### PR TITLE
Establish character authority and conversation provenance

### DIFF
--- a/Docs/superpowers/plans/2026-07-29-character-authority-conversation-provenance.md
+++ b/Docs/superpowers/plans/2026-07-29-character-authority-conversation-provenance.md
@@ -1,0 +1,421 @@
+# Character Authority and Conversation Provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task by task. Every
+> production change below starts with a failing focused test.
+
+**Goal:** Give local and server-backed character conversations a durable,
+source-aware `(source, authority_id, character_id)` identity that can later
+drive exact TTS profile assignment, without changing speech admission,
+assignment mutation, Sync V2, or managed audio.cpp ownership.
+
+**Architecture:** Extend the existing owners instead of introducing a parallel
+identity system. `CharactersRAGDB` exposes its existing durable local authority
+and persists one new nullable conversation column. `ConfiguredServerTarget`
+owns a persisted random authority scope, while
+`RuntimeServerContextProvider` derives the server-user authority through its
+existing authenticated client and runtime revision fence. Native Console
+sessions carry those same fields and construct the existing `CharacterRef`
+only when all character authority is proven.
+
+**Tech Stack:** Python 3.12, SQLite, Pydantic v2, asyncio, Textual 8, pytest,
+Ruff, mypy, Backlog.md.
+
+**Task:** `TASK-617.2`
+
+**Parent:** `TASK-617`
+
+**ADR required:** yes
+
+**ADR path:**
+`backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md`
+
+**Reason:** ADR-037 already governs the local/server authority encoding,
+authenticated-context fencing, one-column conversation migration,
+backup/restore behavior, privacy rules, and the explicit Sync V2 exclusion.
+This task implements only its approved Slice 3A.2 decision, so no second ADR is
+needed.
+
+---
+
+## Scope boundary
+
+This plan implements only approved Slice 3A.2:
+
+- a narrow DB-owned accessor for the existing `local_authority_id`;
+- a persisted canonical UUIDv4 `authority_scope_id` on saved server targets;
+- durable first-use upgrade for legacy targets, with malformed/duplicate scope
+  values failing closed for authority only;
+- the exact `server-user-v1:` authority encoding and revision/auth-context
+  fenced identity lookup;
+- nullable `conversations.assistant_authority_id`, schema v28, local-only
+  legacy backfill, normalized CRUD, and raw database backup/restore coverage;
+- explicit null provenance for current import/Sync-adjacent paths that cannot
+  prove authority;
+- source-aware native Console session identity, persistence, resume, and
+  Roleplay character handoff behavior.
+
+It does **not** implement:
+
+- trusted message speech snapshots or speech admission changes (Slice 3A.3);
+- assignment set/replace/detach operations (Slice 3A.4);
+- assigned-profile resolution, character voice controls, or automatic speech;
+- Persona `CharacterRef` inheritance or Persona-specific TTS;
+- `assistant_authority_id` transport in Sync V2 or portable chatbooks;
+- a generic `AssistantRef` hierarchy or second identity store;
+- managed audio.cpp discovery, launch, supervision, restart, or shutdown.
+
+## Fixed contracts
+
+The server authority frame is exact:
+
+```text
+LP(b"tldw-chatbook.character-authority")
++ LP(b"1")
++ LP(canonical_authority_scope_id_ascii)
++ LP(canonical_user_id_ascii)
+```
+
+`LP(value)` is an unsigned four-byte big-endian length followed by `value`.
+The stored result is:
+
+```text
+server-user-v1:<lowercase sha256 hex digest>
+```
+
+The target scope is an exact lowercase hyphenated UUIDv4. The authenticated
+user ID is an integer from `1` through `2^63 - 1`. URLs, routing `server_id`,
+labels, auth method, tokens, credential fingerprints, and origins do not enter
+the authority frame.
+
+Conversation character identity is:
+
+```text
+(runtime_backend, assistant_authority_id, assistant_id)
+```
+
+- local character: numeric `character_id`, canonical decimal `assistant_id`,
+  and the authority owned by the same database;
+- scoped server character: null `character_id`, bounded opaque `assistant_id`,
+  and encoded server-user authority;
+- unscoped server/imported character: null authority and no `CharacterRef`;
+- Persona/generic: null authority and no `CharacterRef`.
+
+The current Sync V2 message envelope and portable chatbook format remain
+unchanged. They never infer authority from the receiver's active source.
+
+## Supported baseline
+
+Use the repository's existing environment:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python --version
+```
+
+Baseline:
+
+```text
+Python 3.12.11
+```
+
+The focused pre-change suite is green:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/MCP/test_server_target_store.py \
+  Tests/RuntimePolicy/test_server_context_provider.py \
+  Tests/Chat/test_console_chat_store.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/DB/test_chachanotes_citation_provenance_migration.py \
+  Tests/Chat/test_chat_conversation_service.py
+```
+
+Expected baseline:
+
+```text
+257 passed
+```
+
+---
+
+## Task 1: Persist target authority scope without changing server routing
+
+**Files:**
+
+- Modify: `tldw_chatbook/MCP/unified_control_models.py`
+- Modify: `tldw_chatbook/MCP/server_target_store.py`
+- Modify: `Tests/MCP/test_server_target_store.py`
+
+- [x] Add failing tests that prove:
+  - newly bootstrapped configured targets receive a canonical UUIDv4 scope;
+  - JSON round-trip preserves the scope;
+  - target representations never expose the raw scope;
+  - legacy missing scopes are generated, atomically saved, reloaded, and only
+    then returned;
+  - existing scope survives mutable label/URL/auth/status updates and legacy
+    config upsert;
+  - malformed or duplicate scopes fail authority acquisition without making
+    ordinary target loading unusable;
+  - a write/reload failure returns no ephemeral scope.
+- [x] Add `authority_scope_id` to `ConfiguredServerTarget` wire persistence
+  with `repr=False`. Deserialization alone may represent a legacy missing
+  scope as null so ordinary server routing still loads; every newly created
+  target receives a canonical UUIDv4 before its first persistence.
+- [x] Add one store-owned `ensure_authority_scope_id(server_id)` admission
+  method. Serialize same-process upgrades, validate all non-null scope values,
+  persist via the existing temporary-file replacement, reload, and verify
+  exact durability before returning.
+- [x] Preserve an existing scope in `upsert_legacy_config_target`; assign a
+  scope when a genuinely new legacy-config-backed target is created.
+- [x] Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/MCP/test_server_target_store.py
+```
+
+## Task 2: Resolve exact server-user character authority with context fencing
+
+**Files:**
+
+- Modify: `tldw_chatbook/runtime_policy/server_context.py`
+- Modify: `Tests/RuntimePolicy/test_server_context_provider.py`
+
+- [x] Add failing tests for the exact framing/digest vector and validation
+  bounds.
+- [x] Add failing async tests proving the resolver:
+  - requires the expected configured-target ID carried by the caller and
+    rejects a mismatch before identity network I/O;
+  - calls `get_current_user_profile(sections="identity")`;
+  - extracts only a valid positive `user.id`;
+  - remains stable across mutable target metadata and credential rotation when
+    the target scope and returned user are unchanged;
+  - separates two users on the same target;
+  - caches only inside one matching runtime/authenticated client context;
+  - rejects an in-flight response after runtime revision, target, account, or
+    credential/client context changes;
+  - reports bounded `server_identity_unavailable` failure for missing,
+    malformed, ambiguous, or unavailable identity while leaving ordinary
+    `build_client()`/server text operations usable.
+- [x] Implement the encoder as a small pure helper and add one async
+  `RuntimeServerContextProvider` authority resolver that accepts an expected
+  configured-target ID. Before network I/O, capture and validate that exact
+  target, its persisted scope, the bound client/authentication key, and the
+  runtime revision. Revalidate all four after the identity response before
+  caching or returning. Reuse `RuntimePolicyContext.snapshot()` and the
+  existing client cache key; do not create another runtime context service.
+- [x] Clear the one-entry authority cache wherever the existing authenticated
+  client context is invalidated. Never log the scope, encoded authority,
+  endpoint response, token, origin, or routing ID.
+- [x] Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/RuntimePolicy/test_server_context_provider.py
+```
+
+## Task 3: Add schema v28 and normalized conversation provenance
+
+**Files:**
+
+- Add:
+  `tldw_chatbook/DB/migrations/chachanotes_v27_to_v28_character_authority.sql`
+- Modify: `tldw_chatbook/DB/ChaChaNotes_DB.py`
+- Add: `Tests/DB/test_chachanotes_character_authority_migration.py`
+- Modify: `Tests/DB/test_chachanotes_active_leaf_migration.py`
+- Modify: `Tests/DB/test_chachanotes_context_summary_migration.py`
+- Modify: `Tests/DB/test_chachanotes_citation_provenance_migration.py`
+- Modify: `Tests/ChaChaNotesDB/test_message_generation_metadata.py`
+
+- [x] Add failing migration tests that prove:
+  - the DB-owned local authority accessor returns one stable value across
+    close/reopen;
+  - v27→v28 adds only nullable `assistant_authority_id`;
+  - eligible legacy local character rows are backfilled from that database's
+    authority;
+  - legacy server, Persona, and generic rows remain authority-null;
+  - a failed migration rolls back the column/version/backfill together.
+- [x] Add failing CRUD validation tests that prove:
+  - new local character rows use canonical decimal identity and the local
+    authority;
+  - server character rows accept bounded opaque `assistant_id`, keep
+    `character_id` null, and may remain explicitly authority-null;
+  - Persona/generic rows cannot retain character authority;
+  - create/read/update and list normalization round-trip the new field.
+- [x] Advance `CharactersRAGDB` to schema v28, add the migration step, and add
+  the narrow `get_local_authority_id()` accessor.
+- [x] Normalize runtime source and assistant fields jointly. Treat an omitted
+  local authority on an app-owned local-character create as provable from the
+  same DB; preserve an explicitly supplied null for unproven import material.
+- [x] Include the field in application-owned conversation CRUD while leaving
+  existing Sync V2 trigger/envelope payloads unchanged.
+- [x] Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/DB/test_chachanotes_character_authority_migration.py \
+  Tests/DB/test_chachanotes_citation_provenance_migration.py
+```
+
+## Task 4: Carry provenance through services, backup, and unproven import
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py`
+- Modify: `tldw_chatbook/Chat/chat_conversation_service.py`
+- Modify: `tldw_chatbook/Chatbooks/chatbook_importer.py`
+- Modify: `Tests/Chat/test_chat_persistence_service.py`
+- Modify: `Tests/Chat/test_chat_conversation_service.py`
+- Modify: `Tests/Chatbooks/test_chatbook_importer.py`
+- Modify: `Tests/Sync_Interop/test_chat_outbox_producer.py`
+- Modify: `Tests/DB/test_core_sqlite_owner_privacy.py`
+
+- [x] Add failing service tests that pass and normalize
+  `assistant_authority_id` without changing the server conversation wire
+  contract.
+- [x] Add a failing portable-chatbook import test showing imported character
+  identity is explicitly authority-null rather than rebound to the receiving
+  DB merely because a numeric character ID exists.
+- [x] Add a focused Sync V2 regression using a local conversation row that
+  contains `assistant_authority_id`; prove the existing message envelope
+  neither transports that conversation field nor infers any authority from
+  active runtime state. Production Sync V2 code remains unchanged.
+- [x] Add a failing SQLite online-backup round-trip test showing the new column
+  and value survive application-owned backup/reopen.
+- [x] Thread the field through the local persistence facade and normalized
+  local conversation rows. Explicitly pass null at the unproven chatbook
+  import boundary. Do not add the field to chatbook export or Sync V2.
+- [x] Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/Chat/test_chat_conversation_service.py \
+  Tests/Chatbooks/test_chatbook_importer.py \
+  Tests/Sync_Interop/test_chat_outbox_producer.py \
+  Tests/DB/test_core_sqlite_owner_privacy.py
+```
+
+## Task 5: Make native Console session identity source-aware
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_chat_store.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/Chat/test_console_chat_store.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+
+- [x] Add failing store tests for local, scoped-server, unscoped-server,
+  Persona, and generic sessions. Only the two complete character cases may
+  return the existing `CharacterRef`.
+- [x] Add failing persistence and state round-trip tests for
+  `runtime_backend`, `assistant_kind`, `assistant_id`, and
+  `assistant_authority_id`, retaining `character_id` only as the local numeric
+  compatibility projection.
+- [x] Add failing persisted-resume tests showing server opaque IDs restore
+  without consulting or inheriting the active server, and authority-null
+  records stay unscoped.
+- [x] Extend `ConsoleChatSession` and its create/restore/persist seams with the
+  four identity fields and a narrow `character_ref()` projection.
+- [x] Key the direct/plain-provider character gate on trusted
+  `assistant_kind == "character"` rather than local-only `character_id`, while
+  keeping local avatar/dictionary lookups numeric and local.
+- [x] Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_chat_store.py \
+  Tests/UI/test_console_native_chat_flow.py
+```
+
+## Task 6: Produce source-aware Roleplay character handoffs
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/UI/test_personas_workbench.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+
+- [x] Add failing workbench tests showing Start Chat emits the selected
+  runtime source and expected server target instead of hard-coded local
+  metadata.
+- [x] Add failing Console handoff tests showing:
+  - local character authority comes only from the character DB accessor;
+  - server authority comes only from the revision-fenced resolver for the
+    exact target carried by the handoff;
+  - identity endpoint failure still creates an explicitly unscoped server
+    character session that can perform ordinary text chat;
+  - a target mismatch never fetches the same ID from a different active
+    server or assigns that server's authority;
+  - Persona handoffs never produce a `CharacterRef`.
+- [x] Make the existing Personas handoff source-aware. Resolve character card
+  detail through the existing local/server scope service. The current server
+  detail wire DTO remains numeric; opaque server character IDs are accepted
+  at persisted/session identity boundaries and do not require widening that
+  established API client contract in this slice.
+- [x] Populate the Console session identity before seeding/persisting the
+  greeting. Do not invoke profile assignment or alter TTS selection.
+- [x] Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_personas_workbench.py \
+  Tests/UI/test_console_native_chat_flow.py
+```
+
+## Task 7: Focused regression, static checks, and task closeout
+
+**Files:**
+
+- Modify:
+  `backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md`
+- Modify this plan only if implementation deviations must be documented
+
+- [x] Run the union of every focused test file changed by Tasks 1–6.
+- [x] Run existing profile and external audio.cpp regressions to prove this
+  slice did not change selection or synthesis:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/TTS/test_profile_types.py \
+  Tests/TTS/test_profile_repository.py \
+  Tests/TTS/test_profile_service.py \
+  Tests/TTS/test_tts_registry_service.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py \
+  Tests/UI/test_stts_playground_audio_cpp.py
+```
+
+- [x] Run static checks only on changed Python files:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check <changed-python-files>
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m mypy <changed-python-files>
+git diff --check
+```
+
+- [x] Run the repository's required broader gate and distinguish inherited
+  `dev` failures from task regressions; do not fix unrelated baseline debt in
+  this PR.
+- [x] Self-review the diff against every TASK-617.2 acceptance criterion,
+  ADR-037 privacy rules, and the explicit exclusions above.
+- [x] Check all acceptance criteria, add concise implementation notes with
+  commands/results and any documented plan deviation, then set TASK-617.2 to
+  Done only when the repository Definition of Done is actually satisfied.
+
+## Implementation deviations
+
+- Review of Task 6 exposed shared-pane ownership, stale callback, cancellation,
+  and authentication-context races that could publish a character under the
+  wrong source. The handoff files and tests were hardened within the approved
+  provenance contract; no TTS selection, speech, assignment, or managed-server
+  behavior was added.
+- Final whole-slice review found the legacy Tavern/SillyTavern history importer
+  outside the originally listed portable-chatbook boundary. It now explicitly
+  persists null authority, with a real schema-v28 import/reopen regression that
+  proves a same-named local card cannot yield a `CharacterRef`.
+- The repository-wide gate could not collect because current `origin/dev`
+  carries the same `StreamDone` import error. The exact five focused failures,
+  Ruff diagnostics, and production mypy diagnostics were replayed against
+  `origin/dev` and documented in the Backlog task rather than repaired here.

--- a/Tests/ChaChaNotesDB/test_character_persona_runtime_parity.py
+++ b/Tests/ChaChaNotesDB/test_character_persona_runtime_parity.py
@@ -44,7 +44,7 @@ def test_character_conversation_stores_canonical_assistant_id(
         {
             "title": "Character Session",
             "assistant_kind": "character",
-            "assistant_id": "char.local.alice",
+            "assistant_id": str(character_id),
             "character_id": character_id,
             "runtime_backend": "local",
             "discovery_owner": "ccp_character",
@@ -53,7 +53,11 @@ def test_character_conversation_stores_canonical_assistant_id(
     )
 
     conversation = db_instance.get_conversation_by_id(conversation_id)
-    assert conversation["assistant_id"] == "char.local.alice"
+    assert conversation["assistant_id"] == str(character_id)
+    assert (
+        conversation["assistant_authority_id"]
+        == db_instance.get_local_authority_id()
+    )
     assert conversation["runtime_backend"] == "local"
     assert conversation["discovery_owner"] == "ccp_character"
     assert conversation["discovery_entity_id"] == "char.local.alice"
@@ -120,7 +124,7 @@ def test_update_conversation_supports_runtime_and_discovery_metadata(
         {
             "title": "Update Runtime",
             "assistant_kind": "character",
-            "assistant_id": "char.local.updater",
+            "assistant_id": str(character_id),
             "character_id": character_id,
             "runtime_backend": "local",
             "discovery_owner": "ccp_character",
@@ -144,6 +148,8 @@ def test_update_conversation_supports_runtime_and_discovery_metadata(
     updated = db_instance.get_conversation_by_id(conversation_id)
     assert updated is not None
     assert updated["runtime_backend"] == "server"
+    assert updated["character_id"] is None
+    assert updated["assistant_authority_id"] is None
     assert updated["discovery_owner"] == "general_chat"
     assert updated["discovery_entity_id"] == "canonical.updater"
 

--- a/Tests/ChaChaNotesDB/test_message_generation_metadata.py
+++ b/Tests/ChaChaNotesDB/test_message_generation_metadata.py
@@ -25,7 +25,7 @@ def test_fresh_database_reaches_current_schema(db):
         v = cur.execute(
             "SELECT version FROM db_schema_version WHERE schema_name=?",
             ("rag_char_chat_schema",)).fetchone()[0]
-    assert v == 27
+    assert v == 28
 
 def test_set_and_batch_get_roundtrip(db):
     _, mid = _mk_message(db)

--- a/Tests/Character_Chat/test_character_chat.py
+++ b/Tests/Character_Chat/test_character_chat.py
@@ -32,6 +32,7 @@ from tldw_chatbook.Character_Chat.Character_Chat_Lib import (
     post_message_to_conversation,
     retrieve_conversation_messages_for_ui,
 )
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
 
 # Mark all tests in this module as integration tests
 pytestmark = pytest.mark.integration
@@ -310,6 +311,44 @@ class TestCharacterImport:
         assert messages[0]["content"] == "Hello"
         assert messages[1]["content"] == "Hi there"
         assert messages[1]["sender"] == char_name
+
+    def test_imported_tavern_history_stays_authority_unproven_after_reopen(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "tavern-import-v28.sqlite"
+        db = CharactersRAGDB(db_path, client_id="tavern-import")
+        char_name = "SameNameLocalCard"
+        char_id = db.add_character_card({"name": char_name})
+        chat_log = {
+            "char_name": char_name,
+            "history": {"internal": [["Hello", "Imported reply"]]},
+        }
+
+        conv_id, imported_char_id = load_chat_history_from_file_and_save_to_db(
+            db,
+            io.BytesIO(json.dumps(chat_log).encode("utf-8")),
+        )
+
+        assert conv_id is not None
+        assert imported_char_id == char_id
+        assert db._CURRENT_SCHEMA_VERSION == 28
+        db.close_connection()
+
+        reopened = CharactersRAGDB(db_path, client_id="tavern-import")
+        try:
+            imported = reopened.get_conversation_by_id(conv_id)
+            assert imported["assistant_authority_id"] is None
+
+            session = ConsoleChatSession(
+                runtime_backend=imported["runtime_backend"],
+                assistant_kind=imported["assistant_kind"],
+                assistant_id=imported["assistant_id"],
+                assistant_authority_id=imported["assistant_authority_id"],
+                character_id=imported["character_id"],
+            )
+            assert session.character_ref() is None
+        finally:
+            reopened.close_connection()
 
 
 class TestHighLevelChatFlow:

--- a/Tests/Chat/test_chat_conversation_service.py
+++ b/Tests/Chat/test_chat_conversation_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -42,6 +43,12 @@ class FakeDB:
     updates: list[tuple[str, dict[str, Any], int]] = field(default_factory=list)
     deletes: list[tuple[str, int]] = field(default_factory=list)
     restores: list[tuple[str, int]] = field(default_factory=list)
+    created_conversations: list[dict[str, Any]] = field(default_factory=list)
+
+    def add_conversation(self, conversation_data):
+        self.calls.append(("add_conversation", (conversation_data,), {}))
+        self.created_conversations.append(conversation_data)
+        return "conv-created"
 
     def search_conversations_page(self, query, **kwargs):
         self.calls.append(("search_conversations_page", (query,), kwargs))
@@ -231,6 +238,7 @@ def test_normalize_conversation_and_message_rows_preserve_stable_shape():
             "assistant_kind": "character",
             "character_id": 7,
             "assistant_id": "7",
+            "assistant_authority_id": "local-authority-7",
             "persona_memory_mode": None,
             "title": None,
             "state": "Resolved",
@@ -249,6 +257,7 @@ def test_normalize_conversation_and_message_rows_preserve_stable_shape():
     assert conversation["state"] == "resolved"
     assert conversation["topic_label"] == "billing"
     assert conversation["runtime_backend"] == "local"
+    assert conversation["assistant_authority_id"] == "local-authority-7"
     assert conversation["discovery_owner"] == "general_chat"
     assert conversation["discovery_entity_id"] is None
     assert conversation["keywords"] == []
@@ -311,6 +320,42 @@ def test_legacy_character_conversation_defaults_missing_assistant_id_to_characte
     )
 
     assert conversation["assistant_id"] == "9"
+    assert conversation["assistant_authority_id"] is None
+
+
+def test_create_conversation_exposes_and_threads_assistant_authority_id():
+    assert (
+        "assistant_authority_id"
+        in inspect.signature(ChatConversationService.create_conversation).parameters
+    )
+    db = FakeDB()
+    service = ChatConversationService(db)
+
+    conversation_id = service.create_conversation(
+        assistant_kind="character",
+        assistant_id="server-character-7",
+        assistant_authority_id="server-user-v1:" + ("a" * 64),
+        runtime_backend="server",
+    )
+
+    assert conversation_id == "conv-created"
+    assert db.created_conversations[0]["assistant_authority_id"] == (
+        "server-user-v1:" + ("a" * 64)
+    )
+
+
+def test_create_conversation_omits_unspecified_authority_for_database_inference():
+    db = FakeDB()
+    service = ChatConversationService(db)
+
+    service.create_conversation(
+        character_id=7,
+        assistant_kind="character",
+        assistant_id="7",
+        runtime_backend="local",
+    )
+
+    assert "assistant_authority_id" not in db.created_conversations[0]
 
 
 def test_list_conversations_normalizes_pagination_and_enforces_global_defaults():
@@ -506,12 +551,14 @@ def test_mixed_case_assistant_kind_normalizes_on_read_and_write():
 
 
 def test_get_and_update_conversation_metadata_routes_normalized_fields():
+    authority_id = "11111111-1111-4111-8111-111111111111"
     db = FakeDB(
         conversations_by_id={
             "conv-1": {
                 "id": "conv-1",
                 "assistant_kind": "character",
                 "assistant_id": "17",
+                "assistant_authority_id": authority_id,
                 "character_id": 17,
                 "persona_memory_mode": None,
                 "scope_type": "global",
@@ -537,12 +584,21 @@ def test_get_and_update_conversation_metadata_routes_normalized_fields():
     assert metadata["title"] == "Chat with Character 17"
     assert metadata["keywords"] == ["ops", "urgent"]
     assert metadata["topic_label"] == "ops"
+    assert metadata["assistant_authority_id"] == authority_id
+
+    authority_result = service.update_conversation_metadata(
+        "conv-1",
+        {"assistant_authority_id": f"  {authority_id}  "},
+        expected_version=9,
+    )
+    assert authority_result is True
 
     result = service.update_conversation_metadata(
         "conv-1",
         {
             "assistant_kind": None,
             "assistant_id": None,
+            "assistant_authority_id": None,
             "character_id": None,
             "persona_memory_mode": None,
             "scope_type": "workspace",
@@ -560,9 +616,15 @@ def test_get_and_update_conversation_metadata_routes_normalized_fields():
     assert db.updates == [
         (
             "conv-1",
+            {"assistant_authority_id": authority_id},
+            9,
+        ),
+        (
+            "conv-1",
             {
                 "assistant_kind": None,
                 "assistant_id": None,
+                "assistant_authority_id": None,
                 "character_id": None,
                 "persona_memory_mode": None,
                 "scope_type": "workspace",

--- a/Tests/Chat/test_chat_conversation_service.py
+++ b/Tests/Chat/test_chat_conversation_service.py
@@ -10,7 +10,7 @@ import pytest
 
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
 from tldw_chatbook.Chat.citation_legacy_migration import LegacyCitationReadState
-from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, InputError
 
 
 @dataclass
@@ -344,18 +344,34 @@ def test_create_conversation_exposes_and_threads_assistant_authority_id():
     )
 
 
-def test_create_conversation_omits_unspecified_authority_for_database_inference():
-    db = FakeDB()
-    service = ChatConversationService(db)
+def test_create_conversation_preserves_omitted_and_explicit_null_authority(
+    tmp_path,
+):
+    db = CharactersRAGDB(tmp_path / "conversation-authority.sqlite", "test-client")
+    try:
+        character_id = db.add_character_card({"name": "Authority Character"})
+        service = ChatConversationService(db)
 
-    service.create_conversation(
-        character_id=7,
-        assistant_kind="character",
-        assistant_id="7",
-        runtime_backend="local",
-    )
+        inferred_conversation_id = service.create_conversation(
+            character_id=character_id,
+            assistant_kind="character",
+            assistant_id=str(character_id),
+            runtime_backend="local",
+        )
+        unproven_conversation_id = service.create_conversation(
+            character_id=character_id,
+            assistant_kind="character",
+            assistant_id=str(character_id),
+            assistant_authority_id=None,
+            runtime_backend="local",
+        )
 
-    assert "assistant_authority_id" not in db.created_conversations[0]
+        inferred = db.get_conversation_by_id(inferred_conversation_id)
+        unproven = db.get_conversation_by_id(unproven_conversation_id)
+        assert inferred["assistant_authority_id"] == db.get_local_authority_id()
+        assert unproven["assistant_authority_id"] is None
+    finally:
+        db.close_connection()
 
 
 def test_list_conversations_normalizes_pagination_and_enforces_global_defaults():
@@ -616,7 +632,7 @@ def test_get_and_update_conversation_metadata_routes_normalized_fields():
     assert db.updates == [
         (
             "conv-1",
-            {"assistant_authority_id": authority_id},
+            {"assistant_authority_id": f"  {authority_id}  "},
             9,
         ),
         (
@@ -638,6 +654,61 @@ def test_get_and_update_conversation_metadata_routes_normalized_fields():
             9,
         )
     ]
+
+
+def test_update_conversation_authority_leaves_validation_to_database(tmp_path):
+    db = CharactersRAGDB(tmp_path / "authority-update.sqlite", "test-client")
+    try:
+        character_id = db.add_character_card({"name": "Authority Character"})
+        conversation_id = db.add_conversation(
+            {
+                "character_id": character_id,
+                "assistant_kind": "character",
+                "assistant_id": str(character_id),
+                "runtime_backend": "local",
+            }
+        )
+        authority_id = db.get_local_authority_id()
+        service = ChatConversationService(db)
+
+        created = db.get_conversation_by_id(conversation_id)
+        assert service.update_conversation_metadata(
+            conversation_id,
+            {"assistant_authority_id": f"  {authority_id}  "},
+            expected_version=created["version"],
+        )
+        canonical = db.get_conversation_by_id(conversation_id)
+        assert canonical["assistant_authority_id"] == authority_id
+
+        assert service.update_conversation_metadata(
+            conversation_id,
+            {"assistant_authority_id": None},
+            expected_version=canonical["version"],
+        )
+        unproven = db.get_conversation_by_id(conversation_id)
+        assert unproven["assistant_authority_id"] is None
+
+        with pytest.raises(InputError, match="non-empty"):
+            service.update_conversation_metadata(
+                conversation_id,
+                {"assistant_authority_id": "   "},
+                expected_version=unproven["version"],
+            )
+        after_blank = db.get_conversation_by_id(conversation_id)
+        assert after_blank["version"] == unproven["version"]
+
+        with pytest.raises(InputError, match="must be text"):
+            service.update_conversation_metadata(
+                conversation_id,
+                {"assistant_authority_id": 123},
+                expected_version=after_blank["version"],
+            )
+        assert (
+            db.get_conversation_by_id(conversation_id)["version"]
+            == after_blank["version"]
+        )
+    finally:
+        db.close_connection()
 
 
 def test_update_conversation_metadata_merges_scope_from_current_state_before_validation():

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -1656,15 +1656,15 @@ class TestChatHistorySaving:
             == before_messages["msg-assistant-1"]["total_variants"]
         )
 
-    def test_resave_chat_history_preserves_backend_while_normalizing_stale_identity_metadata(
+    def test_resave_server_character_does_not_rebind_to_local_character_context(
         self, db_instance: CharactersRAGDB
     ):
-        char_id = db_instance.add_character_card({"name": "Resaver"})
+        db_instance.add_character_card({"name": "Resaver"})
         conversation_id = db_instance.add_conversation(
             {
-                "character_id": char_id,
                 "assistant_kind": "character",
-                "assistant_id": "Resaver",
+                "assistant_id": "server-character:Resaver",
+                "assistant_authority_id": None,
                 "runtime_backend": "server",
                 "discovery_owner": "general_chat",
                 "discovery_entity_id": "legacy.display.name",
@@ -1684,16 +1684,18 @@ class TestChatHistorySaving:
             "Resaver",
         )
 
-        assert "success" in status.lower()
+        assert "mismatch" in status.lower()
         assert resave_id == conversation_id
 
-        updated_conversation = db_instance.get_conversation_by_id(conversation_id)
-        assert updated_conversation["assistant_kind"] == "character"
-        assert updated_conversation["assistant_id"] == str(char_id)
-        assert updated_conversation["runtime_backend"] == "server"
-        assert updated_conversation["discovery_owner"] == "ccp_character"
-        assert updated_conversation["discovery_entity_id"] == str(char_id)
-        assert updated_conversation["title"] == "Chat with Resaver"
+        unchanged = db_instance.get_conversation_by_id(conversation_id)
+        assert unchanged["assistant_kind"] == "character"
+        assert unchanged["assistant_id"] == "server-character:Resaver"
+        assert unchanged["assistant_authority_id"] is None
+        assert unchanged["character_id"] is None
+        assert unchanged["runtime_backend"] == "server"
+        assert unchanged["discovery_owner"] == "general_chat"
+        assert unchanged["discovery_entity_id"] == "legacy.display.name"
+        assert unchanged["title"] == "Chat with Resaver"
 
     def test_resave_chat_history_rejects_generic_context_for_character_conversation(
         self, db_instance: CharactersRAGDB

--- a/Tests/Chat/test_chat_persistence_service.py
+++ b/Tests/Chat/test_chat_persistence_service.py
@@ -55,17 +55,40 @@ class TestChatPersistenceService:
     ):
         service = ChatPersistenceService(db_instance)
         character_id = db_instance.add_character_card({"name": "Alice"})
+        authority_id = db_instance.get_local_authority_id()
         conversation_id = service.create_conversation(
             character_id=character_id,
             character_name="Alice",
             assistant_kind="character",
-            assistant_id="char.local.alice",
+            assistant_id=str(character_id),
+            assistant_authority_id=authority_id,
             runtime_backend="local",
             discovery_owner="ccp_character",
             discovery_entity_id="char.local.alice",
         )
         conversation = db_instance.get_conversation_by_id(conversation_id)
-        assert conversation["assistant_id"] == "char.local.alice"
+        assert conversation["title"] == "Chat with Alice"
+        assert conversation["assistant_id"] == str(character_id)
+        assert conversation["assistant_id"] != "Alice"
+        assert conversation["assistant_authority_id"] == authority_id
+
+    def test_unspecified_local_authority_is_left_for_database_inference(
+        self, db_instance: CharactersRAGDB
+    ):
+        service = ChatPersistenceService(db_instance)
+        character_id = db_instance.add_character_card({"name": "Bob"})
+
+        conversation_id = service.create_conversation(
+            character_id=character_id,
+            assistant_kind="character",
+            assistant_id=str(character_id),
+            runtime_backend="local",
+        )
+
+        conversation = db_instance.get_conversation_by_id(conversation_id)
+        assert conversation["assistant_authority_id"] == (
+            db_instance.get_local_authority_id()
+        )
 
     def test_canonical_citation_writes_ready_requires_matching_ready_repository(
         self,

--- a/Tests/Chat/test_chat_persistence_service.py
+++ b/Tests/Chat/test_chat_persistence_service.py
@@ -78,17 +78,26 @@ class TestChatPersistenceService:
         service = ChatPersistenceService(db_instance)
         character_id = db_instance.add_character_card({"name": "Bob"})
 
-        conversation_id = service.create_conversation(
+        inferred_conversation_id = service.create_conversation(
             character_id=character_id,
             assistant_kind="character",
             assistant_id=str(character_id),
             runtime_backend="local",
         )
+        unproven_conversation_id = service.create_conversation(
+            character_id=character_id,
+            assistant_kind="character",
+            assistant_id=str(character_id),
+            assistant_authority_id=None,
+            runtime_backend="local",
+        )
 
-        conversation = db_instance.get_conversation_by_id(conversation_id)
-        assert conversation["assistant_authority_id"] == (
+        inferred = db_instance.get_conversation_by_id(inferred_conversation_id)
+        unproven = db_instance.get_conversation_by_id(unproven_conversation_id)
+        assert inferred["assistant_authority_id"] == (
             db_instance.get_local_authority_id()
         )
+        assert unproven["assistant_authority_id"] is None
 
     def test_canonical_citation_writes_ready_requires_matching_ready_repository(
         self,

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -3443,10 +3443,8 @@ class _SpyAgentBridge:
 
 
 @pytest.mark.asyncio
-async def test_character_session_forces_plain_provider():
-    """task-427: a session with character_id set always takes the plain
-    provider branch, even with the global agent runtime enabled and a
-    bridge present."""
+async def test_server_character_session_without_local_projection_forces_plain_provider():
+    """Trusted character kind, not a local numeric projection, owns routing."""
     store = ConsoleChatStore()
     gateway = RecordingStreamingGateway()
     controller = ConsoleChatController(
@@ -3455,7 +3453,11 @@ async def test_character_session_forces_plain_provider():
     bridge = _SpyAgentBridge()
     controller._agent_bridge = bridge
     session = _arm_session(store)
-    session.character_id = 7
+    session.runtime_backend = "server"
+    session.assistant_kind = "character"
+    session.assistant_id = "opaque-character"
+    session.assistant_authority_id = None
+    assert session.character_id is None
 
     result = await controller.submit_draft("Hi")
 
@@ -3465,9 +3467,19 @@ async def test_character_session_forces_plain_provider():
 
 
 @pytest.mark.asyncio
-async def test_normal_session_still_uses_agent_when_enabled():
-    """Control for test_character_session_forces_plain_provider: a session
-    with no character_id keeps using the agent bridge as before."""
+@pytest.mark.parametrize(
+    ("assistant_kind", "assistant_id", "character_id"),
+    [
+        ("generic", "console", None),
+        ("persona", "persona-1", None),
+        ("generic", "console", 7),
+    ],
+    ids=["generic", "persona", "stray-numeric-character-id"],
+)
+async def test_non_character_session_still_uses_agent_when_enabled(
+    assistant_kind, assistant_id, character_id
+):
+    """Generic/Persona sessions do not become direct chat from a stray id."""
     store = ConsoleChatStore()
     gateway = RecordingStreamingGateway()
     controller = ConsoleChatController(
@@ -3483,7 +3495,9 @@ async def test_normal_session_still_uses_agent_when_enabled():
 
     controller._agent_bridge = SimpleNamespace(run_reply=run_reply)
     session = _arm_session(store)
-    assert session.character_id is None
+    session.assistant_kind = assistant_kind
+    session.assistant_id = assistant_id
+    session.character_id = character_id
 
     await controller.submit_draft("Hi")
 

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -44,6 +44,50 @@ def test_session_character_ref_projects_complete_local_and_server_identities():
     )
 
 
+def test_session_local_character_id_requires_canonical_local_character_identity():
+    valid = ConsoleChatSession(
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        character_id=7,
+    )
+    invalid = (
+        ConsoleChatSession(
+            runtime_backend="server",
+            assistant_kind="character",
+            assistant_id="opaque-character",
+            character_id=7,
+        ),
+        ConsoleChatSession(
+            runtime_backend="local",
+            assistant_kind="persona",
+            assistant_id="7",
+            character_id=7,
+        ),
+        ConsoleChatSession(
+            runtime_backend="local",
+            assistant_kind="character",
+            assistant_id="1",
+            character_id=True,
+        ),
+        ConsoleChatSession(
+            runtime_backend="local",
+            assistant_kind="character",
+            assistant_id="0",
+            character_id=0,
+        ),
+        ConsoleChatSession(
+            runtime_backend="local",
+            assistant_kind="character",
+            assistant_id="007",
+            character_id=7,
+        ),
+    )
+
+    assert valid.local_character_id() == 7
+    assert all(session.local_character_id() is None for session in invalid)
+
+
 @pytest.mark.parametrize(
     "session_kwargs",
     [
@@ -1340,6 +1384,63 @@ def test_store_persists_workspace_session_with_real_chat_persistence_service(tmp
         assert persisted_message["content"] == "hello"
         workspace_conversations = registry.list_workspace_conversations("workspace-a")
         assert [item.item_id for item in workspace_conversations] == [conversation_id]
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    "runtime_backend",
+    (
+        pytest.param("", id="missing"),
+        pytest.param(123, id="non-string"),
+        pytest.param("remote", id="unknown"),
+    ),
+)
+def test_invalid_runtime_source_never_reaches_real_chat_persistence(
+    tmp_path,
+    monkeypatch,
+    runtime_backend,
+):
+    """Malformed source provenance cannot become a durable local character."""
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    try:
+        character_id = db.add_character_card({"name": "Existing local card"})
+        assert type(character_id) is int
+        character_count = db.count_character_cards()
+        persistence = ChatPersistenceService(db)
+        create_calls = []
+        real_create = persistence.create_conversation
+
+        def recording_create(**kwargs):
+            create_calls.append(kwargs)
+            return real_create(**kwargs)
+
+        monkeypatch.setattr(persistence, "create_conversation", recording_create)
+        store = ConsoleChatStore(persistence=persistence)
+        session = store.create_session(
+            title="Malformed character",
+            runtime_backend=runtime_backend,
+            assistant_kind="character",
+            assistant_id=str(character_id),
+            assistant_authority_id=db.get_local_authority_id(),
+            character_id=character_id,
+            character_name="Injected local card",
+        )
+
+        conversation_id = store.persist_session_if_needed(session.id)
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Keep this message in memory",
+            persist=True,
+        )
+
+        assert conversation_id is None
+        assert session.persisted_conversation_id is None
+        assert message.persisted_message_id is None
+        assert create_calls == []
+        assert db.get_all_conversation_ids() == []
+        assert db.count_character_cards() == character_count
     finally:
         db.close()
 

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -11,8 +11,91 @@ from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleCha
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.rag_scope import RagScope, ScopeItem, read_conversation_scope
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.TTS.profile_types import CharacterRef
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Workspaces import DEFAULT_WORKSPACE_ID, LocalWorkspaceRegistryService
+
+
+def test_session_character_ref_projects_complete_local_and_server_identities():
+    local = ConsoleChatSession(
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        assistant_authority_id="local-authority",
+        character_id=7,
+    )
+    server = ConsoleChatSession(
+        runtime_backend="server",
+        assistant_kind="character",
+        assistant_id="opaque-character",
+        assistant_authority_id="server-user-v1:" + ("a" * 64),
+        character_id=None,
+    )
+
+    assert local.character_ref() == CharacterRef(
+        source="local",
+        authority_id="local-authority",
+        character_id="7",
+    )
+    assert server.character_ref() == CharacterRef(
+        source="server",
+        authority_id="server-user-v1:" + ("a" * 64),
+        character_id="opaque-character",
+    )
+
+
+@pytest.mark.parametrize(
+    "session_kwargs",
+    [
+        {
+            "runtime_backend": "server",
+            "assistant_kind": "character",
+            "assistant_id": "opaque-character",
+            "assistant_authority_id": None,
+        },
+        {
+            "runtime_backend": "local",
+            "assistant_kind": "persona",
+            "assistant_id": "persona-1",
+            "assistant_authority_id": None,
+        },
+        {},
+        {
+            "runtime_backend": "local",
+            "assistant_kind": "character",
+            "assistant_id": "007",
+            "assistant_authority_id": "local-authority",
+            "character_id": 7,
+        },
+        {
+            "runtime_backend": "server",
+            "assistant_kind": "character",
+            "assistant_id": "opaque-character",
+            "assistant_authority_id": "server-authority",
+            "character_id": 7,
+        },
+        {
+            "runtime_backend": "other",
+            "assistant_kind": "character",
+            "assistant_id": "7",
+            "assistant_authority_id": "local-authority",
+            "character_id": 7,
+        },
+    ],
+    ids=[
+        "unscoped-server",
+        "persona",
+        "generic",
+        "mismatched-local-id",
+        "server-with-local-projection",
+        "unknown-source",
+    ],
+)
+def test_session_character_ref_rejects_unproven_or_inconsistent_identity(
+    session_kwargs,
+):
+    session = ConsoleChatSession(**session_kwargs)
+    assert session.character_ref() is None
 
 
 def test_store_creates_session_and_appends_messages():
@@ -584,21 +667,146 @@ def test_persist_session_if_needed_passes_none_system_prompt_without_settings():
     assert persistence.created_conversations[0]["system_prompt"] is None
 
 
-def test_persist_session_if_needed_passes_character_identity():
+@pytest.mark.parametrize(
+    ("session_kwargs", "expected"),
+    [
+        (
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "character",
+                "assistant_id": "7",
+                "assistant_authority_id": "local-authority",
+                "character_id": 7,
+                "character_name": "Elara",
+            },
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "character",
+                "assistant_id": "7",
+                "assistant_authority_id": "local-authority",
+                "character_id": 7,
+                "character_name": "Elara",
+            },
+        ),
+        (
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "opaque-character",
+                "assistant_authority_id": "server-user-v1:" + ("b" * 64),
+            },
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "opaque-character",
+                "assistant_authority_id": "server-user-v1:" + ("b" * 64),
+                "character_id": None,
+                "character_name": None,
+            },
+        ),
+        (
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "opaque-character",
+                "assistant_authority_id": None,
+            },
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "opaque-character",
+                "assistant_authority_id": None,
+                "character_id": None,
+                "character_name": None,
+            },
+        ),
+        (
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "persona",
+                "assistant_id": "persona-1",
+                "assistant_authority_id": None,
+                "character_id": 99,
+            },
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "persona",
+                "assistant_id": "persona-1",
+                "assistant_authority_id": None,
+                "character_id": None,
+                "character_name": None,
+            },
+        ),
+        (
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "character",
+                "assistant_id": "007",
+                "assistant_authority_id": "local-authority",
+                "character_id": 7,
+                "character_name": "Mismatched",
+            },
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "character",
+                "assistant_id": "007",
+                "assistant_authority_id": "local-authority",
+                "character_id": None,
+                "character_name": None,
+            },
+        ),
+        (
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "character",
+                "assistant_id": "0",
+                "assistant_authority_id": "local-authority",
+                "character_id": 0,
+                "character_name": "Invalid",
+            },
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "character",
+                "assistant_id": "0",
+                "assistant_authority_id": "local-authority",
+                "character_id": None,
+                "character_name": None,
+            },
+        ),
+        (
+            {},
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "generic",
+                "assistant_id": "console",
+                "assistant_authority_id": None,
+                "character_id": None,
+                "character_name": None,
+            },
+        ),
+    ],
+    ids=[
+        "local-character",
+        "scoped-server",
+        "unscoped-server",
+        "persona",
+        "noncanonical-local-id",
+        "nonpositive-local-id",
+        "generic",
+    ],
+)
+def test_persist_session_if_needed_passes_exact_session_identity(
+    session_kwargs, expected
+):
     persistence = FakePersistence()
     store = ConsoleChatStore(persistence=persistence)
-    session = store.create_session(title="Chat with Elara")
-    session.character_id = 7
-    session.character_name = "Elara"
+    session = store.create_session(title="Identity chat", **session_kwargs)
 
     conv_id = store.persist_session_if_needed(session.id)
 
     assert conv_id is not None
     kwargs = persistence.last_create_kwargs
-    assert kwargs["character_id"] == 7
-    assert kwargs["character_name"] == "Elara"
-    assert kwargs["assistant_kind"] == "character"
-    assert kwargs["assistant_id"] == "7"
+    assert {key: kwargs[key] for key in expected} == expected
 
 
 def test_persist_session_if_needed_non_character_stays_generic():
@@ -609,9 +817,11 @@ def test_persist_session_if_needed_non_character_stays_generic():
     store.persist_session_if_needed(session.id)
 
     kwargs = persistence.last_create_kwargs
+    assert kwargs["runtime_backend"] == "local"
     assert kwargs["assistant_kind"] == "generic"
     assert kwargs["assistant_id"] == "console"
-    assert kwargs.get("character_id") is None
+    assert kwargs["assistant_authority_id"] is None
+    assert kwargs["character_id"] is None
 
 
 def test_set_session_system_prompt_updates_settings_without_persisting_when_unsaved():

--- a/Tests/Chatbooks/test_chatbook_importer.py
+++ b/Tests/Chatbooks/test_chatbook_importer.py
@@ -416,6 +416,9 @@ Keywords: test, sample"""
         assert success is True
         assert status.processed_items > 0
         assert len(status.errors) == 0
+        imported_conversation = mock_db_instance.add_conversation.call_args.args[0]
+        assert imported_conversation["character_id"] == 1
+        assert imported_conversation["assistant_authority_id"] is None
 
     @patch("tldw_chatbook.Chatbooks.chatbook_importer.CharactersRAGDB")
     def test_import_chatbook_with_conflicts(

--- a/Tests/DB/test_chachanotes_active_leaf_migration.py
+++ b/Tests/DB/test_chachanotes_active_leaf_migration.py
@@ -5,7 +5,7 @@ def _db(tmp_path):
     return CharactersRAGDB(str(tmp_path / "c.db"), client_id="test-client")
 
 
-def test_fresh_db_is_v27_with_active_leaf_column(tmp_path):
+def test_fresh_db_is_v28_with_active_leaf_column(tmp_path):
     db = _db(tmp_path)
     with db.get_connection() as conn:
         version = conn.execute(
@@ -15,7 +15,7 @@ def test_fresh_db_is_v27_with_active_leaf_column(tmp_path):
     # A fresh DB always migrates to the CURRENT schema version, not the
     # version this column was introduced at -- this assertion moves with
     # each newer migration.
-    assert version == 27
+    assert version == 28
     assert "active_leaf_message_id" in cols
 
 

--- a/Tests/DB/test_chachanotes_character_authority_migration.py
+++ b/Tests/DB/test_chachanotes_character_authority_migration.py
@@ -368,6 +368,120 @@ def test_local_character_explicit_null_stays_unassignable_and_title_update_prese
     assert updated["assistant_authority_id"] is None
 
 
+def test_local_character_omitted_authority_survives_noop_runtime_update(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "local-null-runtime.sqlite", client_id="crud")
+    conversation_id = db.add_conversation(
+        {
+            "character_id": 1,
+            "assistant_kind": "character",
+            "assistant_authority_id": None,
+        }
+    )
+    created = db.get_conversation_by_id(conversation_id)
+
+    assert db.update_conversation(
+        conversation_id,
+        {"runtime_backend": "local"},
+        expected_version=created["version"],
+    )
+    updated = db.get_conversation_by_id(conversation_id)
+    assert updated["assistant_authority_id"] is None
+
+
+def test_local_character_omitted_authority_survives_redundant_identity_update(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "local-null-identity.sqlite", client_id="crud")
+    conversation_id = db.add_conversation(
+        {
+            "character_id": 1,
+            "assistant_kind": "character",
+            "assistant_authority_id": None,
+        }
+    )
+    created = db.get_conversation_by_id(conversation_id)
+
+    assert db.update_conversation(
+        conversation_id,
+        {
+            "runtime_backend": " LOCAL ",
+            "assistant_kind": " CHARACTER ",
+            "character_id": "1",
+            "assistant_id": " 1 ",
+        },
+        expected_version=created["version"],
+    )
+    updated = db.get_conversation_by_id(conversation_id)
+    assert updated["runtime_backend"] == "local"
+    assert updated["assistant_kind"] == "character"
+    assert updated["character_id"] == 1
+    assert updated["assistant_id"] == "1"
+    assert updated["assistant_authority_id"] is None
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "source_id"),
+    [("generic", "console"), ("persona", "persona-1")],
+)
+def test_noncharacter_to_local_character_transition_infers_omitted_authority(
+    tmp_path: Path,
+    source_kind: str,
+    source_id: str,
+) -> None:
+    db = CharactersRAGDB(
+        tmp_path / f"{source_kind}-to-local.sqlite",
+        client_id="crud",
+    )
+    conversation_id = db.add_conversation(
+        {
+            "assistant_kind": source_kind,
+            "assistant_id": source_id,
+        }
+    )
+    source = db.get_conversation_by_id(conversation_id)
+
+    assert db.update_conversation(
+        conversation_id,
+        {
+            "runtime_backend": "local",
+            "assistant_kind": "character",
+            "character_id": 1,
+        },
+        expected_version=source["version"],
+    )
+    local = db.get_conversation_by_id(conversation_id)
+    assert local["assistant_id"] == "1"
+    assert local["assistant_authority_id"] == db.get_local_authority_id()
+
+
+def test_local_character_identity_change_infers_omitted_authority(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "local-character-change.sqlite", client_id="crud")
+    first_character_id = db.add_character_card({"name": "Imported Character"})
+    second_character_id = db.add_character_card({"name": "Replacement Character"})
+    conversation_id = db.add_conversation(
+        {
+            "character_id": first_character_id,
+            "assistant_kind": "character",
+            "assistant_authority_id": None,
+        }
+    )
+    imported = db.get_conversation_by_id(conversation_id)
+
+    assert db.update_conversation(
+        conversation_id,
+        {"character_id": second_character_id},
+        expected_version=imported["version"],
+    )
+    changed = db.get_conversation_by_id(conversation_id)
+    assert changed["character_id"] == second_character_id
+    assert changed["assistant_id"] == str(second_character_id)
+    assert changed["assistant_authority_id"] == db.get_local_authority_id()
+
+
 def test_local_character_rejects_noncanonical_identity_or_wrong_authority(
     tmp_path: Path,
 ) -> None:

--- a/Tests/DB/test_chachanotes_character_authority_migration.py
+++ b/Tests/DB/test_chachanotes_character_authority_migration.py
@@ -1,0 +1,636 @@
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    InputError,
+)
+
+
+SCHEMA_NAME = "rag_char_chat_schema"
+SERVER_AUTHORITY = f"server-user-v1:{'a' * 64}"
+
+
+def _version(connection: sqlite3.Connection) -> int:
+    row = connection.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (SCHEMA_NAME,),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _conversation_columns(connection: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[1])
+        for row in connection.execute("PRAGMA table_info(conversations)").fetchall()
+    }
+
+
+def _seed_v27_database(
+    path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[set[str], str]:
+    """Create a real v27 database without calling v28 conversation CRUD."""
+
+    with monkeypatch.context() as v27_patch:
+        v27_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 27)
+        db = CharactersRAGDB(path, client_id="migration-seed")
+        connection = db.get_connection()
+        before_columns = _conversation_columns(connection)
+        local_authority_id = connection.execute(
+            """
+            SELECT local_authority_id
+            FROM rag_identity_context
+            WHERE context_name = 'default'
+            """
+        ).fetchone()[0]
+        rows = (
+            ("local-proven", "local", "character", "1", 1),
+            ("local-noncanonical", "local", "character", "01", 1),
+            ("server-legacy", "server", "character", "server/opaque:A-7", 1),
+            ("persona-legacy", "local", "persona", "persona-7", 1),
+            ("generic-legacy", "local", "generic", "console", 1),
+        )
+        with db.transaction() as cursor:
+            for conversation_id, source, kind, assistant_id, character_id in rows:
+                cursor.execute(
+                    """
+                    INSERT INTO conversations(
+                        id,
+                        root_id,
+                        character_id,
+                        assistant_kind,
+                        assistant_id,
+                        runtime_backend,
+                        title,
+                        created_at,
+                        last_modified,
+                        deleted,
+                        client_id,
+                        version
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP,
+                              CURRENT_TIMESTAMP, 0, 'migration-seed', 1)
+                    """,
+                    (
+                        conversation_id,
+                        conversation_id,
+                        character_id,
+                        kind,
+                        assistant_id,
+                        source,
+                        conversation_id,
+                    ),
+                )
+            cursor.execute("DELETE FROM sync_log")
+        db.close_connection()
+    return before_columns, str(local_authority_id)
+
+
+def _identity_only_v28_database(
+    path: Path,
+    rows: tuple[tuple[str, object], ...],
+) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.executescript(
+            f"""
+            CREATE TABLE db_schema_version(
+                schema_name TEXT PRIMARY KEY NOT NULL,
+                version INTEGER NOT NULL
+            );
+            INSERT INTO db_schema_version VALUES ('{SCHEMA_NAME}', 28);
+            CREATE TABLE rag_identity_context(
+                context_name TEXT,
+                local_authority_id
+            );
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO rag_identity_context(context_name, local_authority_id)
+            VALUES (?, ?)
+            """,
+            rows,
+        )
+
+
+def test_fresh_database_reaches_v28_and_local_authority_survives_reopen(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "fresh-v28.sqlite"
+    db = CharactersRAGDB(path, client_id="authority-test")
+
+    assert db._CURRENT_SCHEMA_VERSION == 28
+    assert _version(db.get_connection()) == 28
+    authority_id = db.get_local_authority_id()
+    assert 1 <= len(authority_id.encode("utf-8")) <= 256
+    db.close_connection()
+
+    reopened = CharactersRAGDB(path, client_id="authority-test")
+    assert reopened.get_local_authority_id() == authority_id
+    reopened.close_connection()
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        (),
+        (("default", ""),),
+        (("default", " authority-with-whitespace "),),
+        (("default", "x" * 257),),
+        (("default", "authority-one"), ("default", "authority-two")),
+    ],
+)
+def test_local_authority_accessor_fails_closed_for_unavailable_or_ambiguous_state(
+    tmp_path: Path,
+    rows: tuple[tuple[str, object], ...],
+) -> None:
+    path = tmp_path / "invalid-identity.sqlite"
+    _identity_only_v28_database(path, rows)
+    db = CharactersRAGDB(path, client_id="authority-test")
+
+    with pytest.raises(
+        CharactersRAGDBError,
+        match=r"^Local authority identity is unavailable or invalid\.$",
+    ) as exc_info:
+        db.get_local_authority_id()
+
+    assert len(str(exc_info.value).encode("utf-8")) <= 128
+
+
+def test_v27_migration_adds_only_nullable_authority_and_backfills_proven_local_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "v27-to-v28.sqlite"
+    before_columns, expected_authority = _seed_v27_database(path, monkeypatch)
+
+    db = CharactersRAGDB(path, client_id="migration-test")
+    connection = db.get_connection()
+
+    assert _version(connection) == 28
+    after_columns = _conversation_columns(connection)
+    assert after_columns - before_columns == {"assistant_authority_id"}
+    authority_column = next(
+        row
+        for row in connection.execute("PRAGMA table_info(conversations)").fetchall()
+        if row[1] == "assistant_authority_id"
+    )
+    assert authority_column[2] == "TEXT"
+    assert authority_column[3] == 0
+
+    actual = dict(
+        connection.execute(
+            """
+            SELECT id, assistant_authority_id
+            FROM conversations
+            ORDER BY id
+            """
+        ).fetchall()
+    )
+    assert actual == {
+        "generic-legacy": None,
+        "local-noncanonical": None,
+        "local-proven": expected_authority,
+        "persona-legacy": None,
+        "server-legacy": None,
+    }
+    assert connection.execute("SELECT COUNT(*) FROM sync_log").fetchone()[0] == 0
+
+
+def test_v27_migration_rolls_back_column_backfill_and_version_on_late_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "v27-rollback.sqlite"
+    before_columns, expected_authority = _seed_v27_database(path, monkeypatch)
+    original = getattr(
+        CharactersRAGDB,
+        "_update_character_authority_schema_version",
+        None,
+    )
+
+    def fail_after_version_update(self, cursor):
+        if original is not None:
+            original(self, cursor)
+        raise sqlite3.OperationalError("forced character authority failure")
+
+    with monkeypatch.context() as failure_patch:
+        failure_patch.setattr(
+            CharactersRAGDB,
+            "_update_character_authority_schema_version",
+            fail_after_version_update,
+            raising=False,
+        )
+        with pytest.raises(Exception, match="forced character authority failure"):
+            CharactersRAGDB(path, client_id="migration-test")
+
+    with sqlite3.connect(path) as connection:
+        assert _version(connection) == 27
+        assert _conversation_columns(connection) == before_columns
+
+    migrated = CharactersRAGDB(path, client_id="migration-test")
+    row = migrated.get_connection().execute(
+        """
+        SELECT assistant_authority_id
+        FROM conversations
+        WHERE id = 'local-proven'
+        """
+    ).fetchone()
+    assert row["assistant_authority_id"] == expected_authority
+
+
+def test_migration_sql_adds_no_table_index_trigger_or_transaction_owner() -> None:
+    sql_path = (
+        Path(__file__).parents[2]
+        / "tldw_chatbook"
+        / "DB"
+        / "migrations"
+        / "chachanotes_v27_to_v28_character_authority.sql"
+    )
+    executable = "\n".join(
+        line
+        for line in sql_path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("--")
+    ).lower()
+    normalized_sql = re.sub(r"\s+", " ", executable)
+
+    assert normalized_sql.count("alter table conversations add column") == 1
+    assert "assistant_authority_id" in executable
+    assert "create table" not in executable
+    assert "create index" not in executable
+    assert "create trigger" not in executable
+    assert "db_schema_version" not in executable
+    assert "begin" not in executable
+    assert "commit" not in executable
+
+
+def test_authority_column_enforces_nullable_bounded_nonempty_text(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "authority-check.sqlite", client_id="check")
+    conversation_id = db.add_conversation({"title": "Generic"})
+    connection = db.get_connection()
+
+    connection.execute(
+        """
+        UPDATE conversations
+        SET assistant_authority_id = NULL
+        WHERE id = ?
+        """,
+        (conversation_id,),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            UPDATE conversations
+            SET assistant_authority_id = ''
+            WHERE id = ?
+            """,
+            (conversation_id,),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            UPDATE conversations
+            SET assistant_authority_id = ?
+            WHERE id = ?
+            """,
+            ("x" * 257, conversation_id),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            """
+            UPDATE conversations
+            SET assistant_authority_id = ?
+            WHERE id = ?
+            """,
+            (sqlite3.Binary(b"authority"), conversation_id),
+        )
+
+
+def test_local_character_create_read_and_list_infer_same_database_authority(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "local-roundtrip.sqlite", client_id="crud")
+    authority_id = db.get_local_authority_id()
+
+    conversation_id = db.add_conversation(
+        {
+            "title": "Local Character",
+            "character_id": "1",
+            "assistant_kind": " CHARACTER ",
+            "runtime_backend": " LOCAL ",
+        }
+    )
+
+    row = db.get_conversation_by_id(conversation_id)
+    assert row is not None
+    assert row["runtime_backend"] == "local"
+    assert row["assistant_kind"] == "character"
+    assert row["character_id"] == 1
+    assert row["assistant_id"] == "1"
+    assert row["assistant_authority_id"] == authority_id
+    listed = {
+        item["id"]: item for item in db.list_all_active_conversations()
+    }[conversation_id]
+    assert listed["assistant_authority_id"] == authority_id
+    searched = db.search_conversations_page("Local Character")[0][0]
+    assert searched["assistant_authority_id"] == authority_id
+
+
+def test_local_character_explicit_null_stays_unassignable_and_title_update_preserves_it(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "local-null.sqlite", client_id="crud")
+    conversation_id = db.add_conversation(
+        {
+            "title": "Imported Local Character",
+            "character_id": 1,
+            "assistant_kind": "character",
+            "assistant_authority_id": None,
+        }
+    )
+    created = db.get_conversation_by_id(conversation_id)
+    assert created["assistant_authority_id"] is None
+
+    assert db.update_conversation(
+        conversation_id,
+        {"title": "Still Unproven"},
+        expected_version=created["version"],
+    )
+    updated = db.get_conversation_by_id(conversation_id)
+    assert updated["assistant_authority_id"] is None
+
+
+def test_local_character_rejects_noncanonical_identity_or_wrong_authority(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "local-validation.sqlite", client_id="crud")
+
+    with pytest.raises(InputError, match="canonical decimal"):
+        db.add_conversation(
+            {
+                "character_id": 1,
+                "assistant_kind": "character",
+                "assistant_id": "01",
+            }
+        )
+    with pytest.raises(InputError, match="positive"):
+        db.add_conversation(
+            {
+                "character_id": 0,
+                "assistant_kind": "character",
+            }
+        )
+    with pytest.raises(InputError, match="local authority"):
+        db.add_conversation(
+            {
+                "character_id": 1,
+                "assistant_kind": "character",
+                "assistant_authority_id": "authority-from-another-database",
+            }
+        )
+
+
+def test_server_character_accepts_opaque_scoped_or_null_identity_and_clears_character_id(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "server-roundtrip.sqlite", client_id="crud")
+    scoped_id = db.add_conversation(
+        {
+            "title": "Scoped Server",
+            "runtime_backend": " SERVER ",
+            "assistant_kind": "character",
+            "assistant_id": " server/opaque:A-7 ",
+            "assistant_authority_id": SERVER_AUTHORITY,
+            "character_id": 1,
+        }
+    )
+    null_id = db.add_conversation(
+        {
+            "title": "Unscoped Server",
+            "runtime_backend": "server",
+            "assistant_kind": "character",
+            "assistant_id": "server-character-9",
+            "assistant_authority_id": None,
+        }
+    )
+
+    scoped = db.get_conversation_by_id(scoped_id)
+    assert scoped["runtime_backend"] == "server"
+    assert scoped["assistant_id"] == "server/opaque:A-7"
+    assert scoped["character_id"] is None
+    assert scoped["assistant_authority_id"] == SERVER_AUTHORITY
+    assert db.get_conversation_by_id(null_id)["assistant_authority_id"] is None
+
+
+def test_server_character_rejects_empty_or_overlong_identity_text(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "server-validation.sqlite", client_id="crud")
+
+    with pytest.raises(InputError, match="assistant_id"):
+        db.add_conversation(
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": " ",
+            }
+        )
+    with pytest.raises(InputError, match="256 UTF-8 bytes"):
+        db.add_conversation(
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "x" * 257,
+            }
+        )
+    with pytest.raises(InputError, match="256 UTF-8 bytes"):
+        db.add_conversation(
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "opaque",
+                "assistant_authority_id": "x" * 257,
+            }
+        )
+
+
+@pytest.mark.parametrize("assistant_kind", [None, "generic", "persona"])
+def test_persona_and_generic_create_reject_character_authority(
+    tmp_path: Path,
+    assistant_kind: str | None,
+) -> None:
+    db = CharactersRAGDB(
+        tmp_path / f"authority-free-{assistant_kind}.sqlite",
+        client_id="crud",
+    )
+    data = {
+        "assistant_kind": assistant_kind,
+        "assistant_authority_id": SERVER_AUTHORITY,
+    }
+    if assistant_kind in {"generic", "persona"}:
+        data["assistant_id"] = f"{assistant_kind}-assistant"
+
+    with pytest.raises(InputError, match="cannot carry character authority"):
+        db.add_conversation(data)
+
+
+@pytest.mark.parametrize(
+    ("target_kind", "target_id"),
+    [("persona", "persona-1"), ("generic", "console")],
+)
+def test_identity_and_source_conversions_clear_or_infer_authority_jointly(
+    tmp_path: Path,
+    target_kind: str,
+    target_id: str,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "conversions.sqlite", client_id="crud")
+    local_authority = db.get_local_authority_id()
+    conversation_id = db.add_conversation(
+        {
+            "title": "Source Conversion",
+            "character_id": 1,
+            "assistant_kind": "character",
+        }
+    )
+    local = db.get_conversation_by_id(conversation_id)
+
+    assert db.update_conversation(
+        conversation_id,
+        {"runtime_backend": "server"},
+        expected_version=local["version"],
+    )
+    unscoped_server = db.get_conversation_by_id(conversation_id)
+    assert unscoped_server["runtime_backend"] == "server"
+    assert unscoped_server["assistant_id"] == "1"
+    assert unscoped_server["character_id"] is None
+    assert unscoped_server["assistant_authority_id"] is None
+
+    assert db.update_conversation(
+        conversation_id,
+        {
+            "runtime_backend": "local",
+            "character_id": 1,
+        },
+        expected_version=unscoped_server["version"],
+    )
+    local_again = db.get_conversation_by_id(conversation_id)
+    assert local_again["assistant_id"] == "1"
+    assert local_again["assistant_authority_id"] == local_authority
+
+    assert db.update_conversation(
+        conversation_id,
+        {
+            "assistant_kind": target_kind,
+            "assistant_id": target_id,
+        },
+        expected_version=local_again["version"],
+    )
+    authority_free = db.get_conversation_by_id(conversation_id)
+    assert authority_free["assistant_kind"] == target_kind
+    assert authority_free["character_id"] is None
+    assert authority_free["assistant_authority_id"] is None
+
+
+def test_explicit_local_null_update_is_preserved_and_wrong_authority_is_rejected(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "authority-update.sqlite", client_id="crud")
+    conversation_id = db.add_conversation(
+        {"character_id": 1, "assistant_kind": "character"}
+    )
+    created = db.get_conversation_by_id(conversation_id)
+
+    assert db.update_conversation(
+        conversation_id,
+        {"assistant_authority_id": None},
+        expected_version=created["version"],
+    )
+    unproven = db.get_conversation_by_id(conversation_id)
+    assert unproven["assistant_authority_id"] is None
+
+    with pytest.raises(InputError, match="local authority"):
+        db.update_conversation(
+            conversation_id,
+            {"assistant_authority_id": "wrong-authority"},
+            expected_version=unproven["version"],
+        )
+    assert db.get_conversation_by_id(conversation_id)["version"] == unproven["version"]
+
+
+def test_unrelated_update_does_not_repair_degraded_legacy_identity(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "legacy-readable.sqlite", client_id="crud")
+    conversation_id = db.add_conversation({"title": "Legacy"})
+    with db.transaction() as cursor:
+        cursor.execute(
+            """
+            UPDATE conversations
+            SET runtime_backend = 'local',
+                assistant_kind = 'character',
+                assistant_id = 'legacy-display-name',
+                character_id = 1,
+                assistant_authority_id = NULL
+            WHERE id = ?
+            """,
+            (conversation_id,),
+        )
+    legacy = db.get_conversation_by_id(conversation_id)
+
+    assert db.update_conversation(
+        conversation_id,
+        {"title": "Legacy Renamed"},
+        expected_version=legacy["version"],
+    )
+    renamed = db.get_conversation_by_id(conversation_id)
+    assert renamed["assistant_id"] == "legacy-display-name"
+    assert renamed["character_id"] == 1
+    assert renamed["assistant_authority_id"] is None
+
+
+def test_sync_trigger_payloads_never_carry_assistant_authority(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "sync-exclusion.sqlite", client_id="crud")
+    conversation_id = db.add_conversation(
+        {"character_id": 1, "assistant_kind": "character"}
+    )
+    created = db.get_conversation_by_id(conversation_id)
+    db.update_conversation(
+        conversation_id,
+        {"assistant_authority_id": None},
+        expected_version=created["version"],
+    )
+
+    connection = db.get_connection()
+    trigger_sql = connection.execute(
+        """
+        SELECT group_concat(sql, ' ')
+        FROM sqlite_master
+        WHERE type = 'trigger'
+          AND name LIKE 'conversations_sync_%'
+        """
+    ).fetchone()[0]
+    assert "assistant_authority_id" not in trigger_sql
+    payloads = [
+        json.loads(row[0])
+        for row in connection.execute(
+            """
+            SELECT payload
+            FROM sync_log
+            WHERE entity = 'conversations'
+              AND entity_id = ?
+            """,
+            (conversation_id,),
+        ).fetchall()
+    ]
+    assert payloads
+    assert all("assistant_authority_id" not in payload for payload in payloads)

--- a/Tests/DB/test_chachanotes_citation_provenance_migration.py
+++ b/Tests/DB/test_chachanotes_citation_provenance_migration.py
@@ -314,7 +314,13 @@ def _minimal_v24(path: Path) -> None:
                 version INTEGER NOT NULL
             );
             INSERT INTO db_schema_version VALUES ('{SCHEMA_NAME}', 24);
-            CREATE TABLE conversations(id TEXT PRIMARY KEY);
+            CREATE TABLE conversations(
+                id TEXT PRIMARY KEY,
+                character_id INTEGER,
+                assistant_kind TEXT,
+                assistant_id TEXT,
+                runtime_backend TEXT NOT NULL DEFAULT 'local'
+            );
             CREATE TABLE messages(
                 id TEXT PRIMARY KEY,
                 conversation_id TEXT NOT NULL
@@ -391,14 +397,14 @@ def _insert_local_trace_and_snapshot(connection: sqlite3.Connection) -> str:
     return profile_id
 
 
-def test_fresh_database_reaches_v27_with_stable_identity_context(
+def test_fresh_database_reaches_v28_with_stable_identity_context(
     tmp_path: Path,
 ) -> None:
     db = _fresh_db(tmp_path / "fresh.sqlite")
     connection = db.get_connection()
 
-    assert db._CURRENT_SCHEMA_VERSION == 27
-    assert _version(connection) == 27
+    assert db._CURRENT_SCHEMA_VERSION == 28
+    assert _version(connection) == 28
     assert PROVENANCE_TABLES <= _table_names(connection)
     row = connection.execute("SELECT * FROM rag_identity_context").fetchone()
     assert row["context_name"] == "default"
@@ -408,7 +414,7 @@ def test_fresh_database_reaches_v27_with_stable_identity_context(
     assert row["created_at"]
 
 
-def test_v24_upgrade_reaches_v27_and_uses_exact_citation_sql_schema(
+def test_v24_upgrade_reaches_v28_and_uses_exact_citation_sql_schema(
     tmp_path: Path,
 ) -> None:
     path = tmp_path / "upgrade.sqlite"
@@ -417,7 +423,7 @@ def test_v24_upgrade_reaches_v27_and_uses_exact_citation_sql_schema(
     db = _fresh_db(path)
     connection = db.get_connection()
 
-    assert _version(connection) == 27
+    assert _version(connection) == 28
     assert PROVENANCE_TABLES <= _table_names(connection)
     assert "message_generation_metadata" in _table_names(connection)
     conversation_columns = {

--- a/Tests/DB/test_chachanotes_context_summary_migration.py
+++ b/Tests/DB/test_chachanotes_context_summary_migration.py
@@ -5,7 +5,7 @@ def _db(tmp_path):
     return CharactersRAGDB(str(tmp_path / "c.db"), client_id="test-client")
 
 
-def test_fresh_db_is_v27_with_context_summary_columns(tmp_path):
+def test_fresh_db_is_v28_with_context_summary_columns(tmp_path):
     db = _db(tmp_path)
     with db.get_connection() as conn:
         version = conn.execute(
@@ -14,7 +14,7 @@ def test_fresh_db_is_v27_with_context_summary_columns(tmp_path):
         cols = {row[1] for row in conn.execute("PRAGMA table_info(conversations)").fetchall()}
     # Fresh databases always reach the current schema, not merely the version
     # where these columns were introduced.
-    assert version == 27
+    assert version == 28
     assert "context_summary" in cols
     assert "summary_boundary_message_id" in cols
 

--- a/Tests/DB/test_core_sqlite_owner_privacy.py
+++ b/Tests/DB/test_core_sqlite_owner_privacy.py
@@ -550,6 +550,48 @@ BACKUP_CASES = (
 )
 
 
+def test_chachanotes_backup_reopen_preserves_conversation_authority(
+    tmp_path: Path,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir(mode=0o700)
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir(mode=0o700)
+    source_path = source_dir / "chachanotes.sqlite"
+    backup_path = backup_dir / "chachanotes.sqlite"
+    authority_id = "server-user-v1:" + ("d" * 64)
+
+    source_db = ChaChaNotes_DB.CharactersRAGDB(source_path, "source-client")
+    try:
+        conversation_id = source_db.add_conversation(
+            {
+                "assistant_kind": "character",
+                "assistant_id": "opaque-server-character",
+                "assistant_authority_id": authority_id,
+                "runtime_backend": "server",
+                "title": "Backed up character chat",
+            }
+        )
+        assert source_db.backup_database(str(backup_path)) is True
+    finally:
+        source_db.close_connection()
+
+    restored_db = ChaChaNotes_DB.CharactersRAGDB(backup_path, "restored-client")
+    try:
+        columns = {
+            row["name"]
+            for row in restored_db.get_connection()
+            .execute("PRAGMA table_info(conversations)")
+            .fetchall()
+        }
+        restored = restored_db.get_conversation_by_id(conversation_id)
+
+        assert "assistant_authority_id" in columns
+        assert restored["assistant_authority_id"] == authority_id
+    finally:
+        restored_db.close_connection()
+
+
 @pytest.mark.skipif(os.name != "posix", reason="POSIX backup target contract")
 @pytest.mark.parametrize("existing", [False, True], ids=["first-create", "harden"])
 @pytest.mark.parametrize("backup_case", BACKUP_CASES, ids=lambda case: case.name)

--- a/Tests/MCP/test_server_target_store.py
+++ b/Tests/MCP/test_server_target_store.py
@@ -4,7 +4,7 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from datetime import datetime, timezone
-from threading import Barrier, BrokenBarrierError
+from threading import Barrier, BrokenBarrierError, Event
 from uuid import UUID
 
 import pytest
@@ -41,6 +41,25 @@ def _legacy_target_payload(
     if authority_scope_id is not None:
         payload["authority_scope_id"] = authority_scope_id
     return payload
+
+
+def _pause_first_load_after_read(store, monkeypatch) -> Event:
+    first_read_complete = Event()
+    release_first_read = Event()
+    real_load = store.load
+    is_first_load = True
+
+    def paused_load():
+        nonlocal is_first_load
+        targets = real_load()
+        if is_first_load:
+            is_first_load = False
+            first_read_complete.set()
+            release_first_read.wait(timeout=0.25)
+        return targets
+
+    monkeypatch.setattr(store, "load", paused_load)
+    return first_read_complete
 
 
 def test_bootstrap_from_legacy_config_only_when_registry_is_empty(tmp_path):
@@ -212,6 +231,79 @@ def test_ensure_authority_scope_serializes_same_process_store_instances(
     assert ConfiguredServerTargetStore(path).get_target(
         "server-a"
     ).authority_scope_id == scopes[0]
+
+
+def test_status_update_cannot_erase_concurrently_admitted_scope(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(path, [_legacy_target_payload()])
+    status_store = ConfiguredServerTargetStore(path)
+    authority_store = ConfiguredServerTargetStore(path)
+    status_read_complete = _pause_first_load_after_read(status_store, monkeypatch)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        status_future = executor.submit(
+            status_store.update_target_status,
+            "server-a",
+            last_known_reachability="reachable",
+        )
+        assert status_read_complete.wait(timeout=1)
+        scope_future = executor.submit(
+            authority_store.ensure_authority_scope_id,
+            "server-a",
+        )
+        status_future.result(timeout=2)
+        returned_scope = scope_future.result(timeout=2)
+
+    restored = ConfiguredServerTargetStore(path).get_target("server-a")
+    assert restored is not None
+    assert restored.last_known_reachability == "reachable"
+    assert restored.authority_scope_id == returned_scope
+
+
+def test_legacy_upsert_cannot_erase_concurrently_admitted_scope(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(
+        path,
+        [
+            {
+                "server_id": "https://example.com/api",
+                "label": "Legacy",
+                "base_url": "https://example.com/api",
+            }
+        ],
+    )
+    upsert_store = ConfiguredServerTargetStore(path)
+    authority_store = ConfiguredServerTargetStore(path)
+    upsert_read_complete = _pause_first_load_after_read(upsert_store, monkeypatch)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        upsert_future = executor.submit(
+            upsert_store.upsert_legacy_config_target,
+            {
+                "tldw_api": {
+                    "base_url": "https://example.com/api",
+                    "bearer_token": "rotated-token",
+                }
+            },
+        )
+        assert upsert_read_complete.wait(timeout=1)
+        scope_future = executor.submit(
+            authority_store.ensure_authority_scope_id,
+            "https://example.com/api",
+        )
+        upsert_future.result(timeout=2)
+        returned_scope = scope_future.result(timeout=2)
+
+    restored = ConfiguredServerTargetStore(path).get_target(
+        "https://example.com/api"
+    )
+    assert restored is not None
+    assert restored.auth_mode == "bearer"
+    assert restored.authority_scope_id == returned_scope
 
 
 def test_authority_scope_survives_mutable_target_and_status_updates(tmp_path):

--- a/Tests/MCP/test_server_target_store.py
+++ b/Tests/MCP/test_server_target_store.py
@@ -1,10 +1,46 @@
 from __future__ import annotations
 
+import json
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import datetime, timezone
+from threading import Barrier, BrokenBarrierError
+from uuid import UUID
 
+import pytest
 
-from tldw_chatbook.MCP.server_target_store import ConfiguredServerTargetStore
+from tldw_chatbook.MCP.server_target_store import (
+    AuthorityScopeUnavailable,
+    ConfiguredServerTargetStore,
+)
 from tldw_chatbook.MCP.unified_control_models import ConfiguredServerTarget
+
+_CANONICAL_SCOPE = "123e4567-e89b-42d3-a456-426614174000"
+
+
+def _assert_canonical_uuid4(value: str) -> None:
+    parsed = UUID(value)
+    assert parsed.version == 4
+    assert str(parsed) == value
+
+
+def _write_target_payload(path, targets: list[dict[str, object]]) -> None:
+    path.write_text(json.dumps({"targets": targets}), encoding="utf-8")
+
+
+def _legacy_target_payload(
+    *,
+    server_id: str = "server-a",
+    authority_scope_id: object = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "server_id": server_id,
+        "label": f"Label for {server_id}",
+        "base_url": f"https://{server_id}.example/api",
+    }
+    if authority_scope_id is not None:
+        payload["authority_scope_id"] = authority_scope_id
+    return payload
 
 
 def test_bootstrap_from_legacy_config_only_when_registry_is_empty(tmp_path):
@@ -33,6 +69,326 @@ def test_bootstrap_from_legacy_config_only_when_registry_is_empty(tmp_path):
 
     raw_payload = (tmp_path / "server_targets.json").read_text(encoding="utf-8")
     assert "super-secret" not in raw_payload
+
+
+def test_bootstrap_persists_a_canonical_uuid4_authority_scope(tmp_path):
+    path = tmp_path / "server_targets.json"
+    store = ConfiguredServerTargetStore(path)
+
+    imported = store.bootstrap_from_legacy_config(
+        {"tldw_api": {"base_url": "https://example.com/api"}}
+    )
+
+    assert imported is True
+    target = store.list_targets()[0]
+    assert target.authority_scope_id is not None
+    _assert_canonical_uuid4(target.authority_scope_id)
+    assert json.loads(path.read_text(encoding="utf-8"))["targets"][0][
+        "authority_scope_id"
+    ] == target.authority_scope_id
+
+
+def test_authority_scope_round_trips_json_without_appearing_in_target_repr(tmp_path):
+    path = tmp_path / "server_targets.json"
+    target = ConfiguredServerTarget(
+        server_id="server-a",
+        label="Server A",
+        base_url="https://server-a.example/api",
+        authority_scope_id=_CANONICAL_SCOPE,
+    )
+    store = ConfiguredServerTargetStore(path)
+
+    store.save_targets([target])
+    restored = store.list_targets()[0]
+
+    assert restored.authority_scope_id == _CANONICAL_SCOPE
+    assert _CANONICAL_SCOPE not in repr(target)
+    assert _CANONICAL_SCOPE not in repr(restored)
+    assert "authority_scope_id" not in repr(restored)
+
+
+@pytest.mark.parametrize("scope_payload", [{}, {"authority_scope_id": None}])
+def test_plain_deserialization_keeps_legacy_missing_scope_available_for_routing(
+    scope_payload,
+):
+    target = ConfiguredServerTarget.from_dict(
+        {
+            "server_id": "legacy-server",
+            "label": "Legacy",
+            "base_url": "https://legacy.example/api",
+            **scope_payload,
+        }
+    )
+
+    assert target.server_id == "legacy-server"
+    assert target.authority_scope_id is None
+
+
+def test_ensure_authority_scope_durably_upgrades_then_reloads_legacy_target(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(path, [_legacy_target_payload()])
+    store = ConfiguredServerTargetStore(path)
+    events: list[str] = []
+    real_load = store.load
+    real_save = store.save_targets
+
+    def observed_load():
+        events.append("load")
+        return real_load()
+
+    def observed_save(targets):
+        events.append("save")
+        real_save(targets)
+
+    monkeypatch.setattr(store, "load", observed_load)
+    monkeypatch.setattr(store, "save_targets", observed_save)
+
+    scope = store.ensure_authority_scope_id("server-a")
+
+    _assert_canonical_uuid4(scope)
+    assert events == ["load", "save", "load"]
+    assert store.get_target("server-a").authority_scope_id == scope
+    assert not path.with_suffix(".json.tmp").exists()
+
+
+def test_ensure_authority_scope_serializes_same_store_upgrade_calls(tmp_path):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(path, [_legacy_target_payload()])
+    store = ConfiguredServerTargetStore(path)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        scopes = list(
+            executor.map(store.ensure_authority_scope_id, ["server-a"] * 16)
+        )
+
+    assert len(set(scopes)) == 1
+    assert store.get_target("server-a").authority_scope_id == scopes[0]
+    _assert_canonical_uuid4(scopes[0])
+
+
+def test_ensure_authority_scope_serializes_same_process_store_instances(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(path, [_legacy_target_payload()])
+    stores = [ConfiguredServerTargetStore(path), ConfiguredServerTargetStore(path)]
+    first_read_barrier = Barrier(2)
+
+    def synchronize_first_read(real_read_payload):
+        is_first_read = True
+
+        def synchronized_read():
+            nonlocal is_first_read
+            if not is_first_read:
+                return real_read_payload()
+            is_first_read = False
+            payload = real_read_payload()
+            try:
+                first_read_barrier.wait(timeout=0.2)
+            except BrokenBarrierError:
+                pass
+            return payload
+
+        return synchronized_read
+
+    for store in stores:
+        monkeypatch.setattr(
+            store,
+            "_read_payload",
+            synchronize_first_read(store._read_payload),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        scopes = list(
+            executor.map(
+                lambda store: store.ensure_authority_scope_id("server-a"),
+                stores,
+            )
+        )
+
+    assert len(set(scopes)) == 1
+    assert ConfiguredServerTargetStore(path).get_target(
+        "server-a"
+    ).authority_scope_id == scopes[0]
+
+
+def test_authority_scope_survives_mutable_target_and_status_updates(tmp_path):
+    store = ConfiguredServerTargetStore(tmp_path / "server_targets.json")
+    target = ConfiguredServerTarget(
+        server_id="stable-routing-id",
+        label="Old label",
+        base_url="https://old.example/api",
+        auth_mode="api_key",
+        auth_reference="old:key",
+        authority_scope_id=_CANONICAL_SCOPE,
+    )
+    store.save_targets([target])
+
+    mutable_update = replace(
+        target,
+        label="New label",
+        base_url="https://new.example/api",
+        auth_mode="bearer",
+        auth_reference="new:key",
+    )
+    store.save_targets([mutable_update])
+    status_update = store.update_target_status(
+        "stable-routing-id",
+        last_known_reachability="reachable",
+        last_known_auth_state="authenticated",
+    )
+
+    assert status_update.authority_scope_id == _CANONICAL_SCOPE
+    assert store.get_target("stable-routing-id").authority_scope_id == _CANONICAL_SCOPE
+
+
+def test_legacy_config_upsert_preserves_existing_authority_scope(tmp_path):
+    store = ConfiguredServerTargetStore(tmp_path / "server_targets.json")
+    store.save_targets(
+        [
+            ConfiguredServerTarget(
+                server_id="https://example.com/api",
+                label="Old label",
+                base_url="https://example.com/api",
+                auth_mode="api_key",
+                authority_scope_id=_CANONICAL_SCOPE,
+            )
+        ]
+    )
+
+    synced = store.upsert_legacy_config_target(
+        {
+            "tldw_api": {
+                "base_url": "https://example.com/api/",
+                "bearer_token": "rotated-token",
+            }
+        }
+    )
+
+    assert synced is not None
+    assert synced.auth_mode == "bearer"
+    assert synced.authority_scope_id == _CANONICAL_SCOPE
+    assert store.get_target(synced.server_id).authority_scope_id == _CANONICAL_SCOPE
+
+
+def test_new_legacy_config_upsert_persists_a_fresh_authority_scope(tmp_path):
+    store = ConfiguredServerTargetStore(tmp_path / "server_targets.json")
+
+    synced = store.upsert_legacy_config_target(
+        {"tldw_api": {"base_url": "https://new.example/api"}}
+    )
+
+    assert synced is not None
+    assert synced.authority_scope_id is not None
+    _assert_canonical_uuid4(synced.authority_scope_id)
+    assert store.get_target(synced.server_id).authority_scope_id == (
+        synced.authority_scope_id
+    )
+
+
+@pytest.mark.parametrize(
+    "malformed_scope",
+    [
+        "not-a-uuid",
+        "123e4567-e89b-42d3-a456-426614174000".upper(),
+        "123e4567-e89b-12d3-a456-426614174000",
+    ],
+)
+def test_malformed_scope_fails_authority_only_and_remains_routable(
+    tmp_path, malformed_scope
+):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(
+        path,
+        [
+            _legacy_target_payload(
+                server_id="malformed-server",
+                authority_scope_id=malformed_scope,
+            )
+        ],
+    )
+    store = ConfiguredServerTargetStore(path)
+
+    routed = store.resolve_active_target("malformed-server")
+
+    assert routed is not None
+    assert routed.authority_scope_id == malformed_scope
+    with pytest.raises(AuthorityScopeUnavailable) as exc_info:
+        store.ensure_authority_scope_id("malformed-server")
+    assert str(exc_info.value) == "Configured server authority scope is unavailable."
+    assert malformed_scope not in str(exc_info.value)
+
+
+def test_duplicate_scopes_fail_authority_only_and_remain_routable(tmp_path):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(
+        path,
+        [
+            _legacy_target_payload(
+                server_id="server-a", authority_scope_id=_CANONICAL_SCOPE
+            ),
+            _legacy_target_payload(
+                server_id="server-b", authority_scope_id=_CANONICAL_SCOPE
+            ),
+        ],
+    )
+    store = ConfiguredServerTargetStore(path)
+
+    assert store.get_target("server-a") is not None
+    assert store.get_target("server-b") is not None
+    with pytest.raises(AuthorityScopeUnavailable) as exc_info:
+        store.ensure_authority_scope_id("server-a")
+    assert str(exc_info.value) == "Configured server authority scope is unavailable."
+    assert _CANONICAL_SCOPE not in str(exc_info.value)
+
+
+def test_scope_persistence_failure_never_returns_an_ephemeral_scope(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(path, [_legacy_target_payload()])
+    store = ConfiguredServerTargetStore(path)
+
+    def fail_save(_targets):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(store, "save_targets", fail_save)
+
+    with pytest.raises(AuthorityScopeUnavailable) as exc_info:
+        store.ensure_authority_scope_id("server-a")
+
+    assert str(exc_info.value) == "Configured server authority scope is unavailable."
+    assert store.get_target("server-a").authority_scope_id is None
+
+
+def test_scope_reload_failure_never_returns_an_unverified_scope(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "server_targets.json"
+    _write_target_payload(path, [_legacy_target_payload()])
+    store = ConfiguredServerTargetStore(path)
+    real_load = store.load
+    load_count = 0
+
+    def fail_reload():
+        nonlocal load_count
+        load_count += 1
+        if load_count == 1:
+            return real_load()
+        raise OSError("simulated reload failure")
+
+    monkeypatch.setattr(store, "load", fail_reload)
+
+    with pytest.raises(AuthorityScopeUnavailable) as exc_info:
+        store.ensure_authority_scope_id("server-a")
+
+    assert str(exc_info.value) == "Configured server authority scope is unavailable."
+    persisted_scope = json.loads(path.read_text(encoding="utf-8"))["targets"][0][
+        "authority_scope_id"
+    ]
+    _assert_canonical_uuid4(persisted_scope)
 
 
 def test_bootstrap_from_legacy_config_returns_false_for_malformed_url(tmp_path):

--- a/Tests/RuntimePolicy/test_server_context_provider.py
+++ b/Tests/RuntimePolicy/test_server_context_provider.py
@@ -705,6 +705,48 @@ async def test_character_authority_rejects_stale_in_flight_capture(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "same_target_change",
+    ("credential", "credential_aba", "client"),
+)
+async def test_public_character_authority_capture_rejects_same_target_context_change(
+    tmp_path,
+    monkeypatch,
+    same_target_change,
+):
+    client = IdentityClient(_identity_response(42))
+    provider, _, _, _ = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [client],
+    )
+
+    capture = provider.capture_character_authority_context(
+        expected_server_id=_AUTHORITY_SERVER_ID
+    )
+    assert provider.is_character_authority_context_current(capture)
+    authority_id = await provider.resolve_character_authority_id(
+        expected_server_id=_AUTHORITY_SERVER_ID,
+        context_capture=capture,
+    )
+    assert authority_id == server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        42,
+    )
+    assert "access-1" not in repr(capture)
+
+    if same_target_change == "credential":
+        provider.store_auth_tokens(access_token="access-2")
+    elif same_target_change == "credential_aba":
+        provider.store_auth_tokens(access_token="access-2")
+        provider.store_auth_tokens(access_token="access-1")
+    else:
+        await provider.close_cached_client()
+
+    assert not provider.is_character_authority_context_current(capture)
+
+
+@pytest.mark.asyncio
 async def test_character_authority_rejects_older_conflicting_account_response(
     tmp_path,
     monkeypatch,

--- a/Tests/RuntimePolicy/test_server_context_provider.py
+++ b/Tests/RuntimePolicy/test_server_context_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import replace
+from typing import get_args
 
 import pytest
 
@@ -30,6 +31,7 @@ from tldw_chatbook.runtime_policy.server_context import (
 from tldw_chatbook.runtime_policy.types import (
     RuntimeSourceState,
     SERVER_CONTEXT_FAILURE_REASON_CODES,
+    ServerContextFailureReason,
 )
 from tldw_chatbook.tldw_api.auth_user_schemas import UserProfileResponse
 
@@ -785,7 +787,7 @@ def test_rejects_server_mode_without_active_server(tmp_path):
 
 
 def test_server_context_failure_reason_codes_include_stable_contract_values():
-    assert {
+    expected_reason_codes = {
         "server_not_configured",
         "server_profile_missing",
         "server_unavailable",
@@ -794,7 +796,28 @@ def test_server_context_failure_reason_codes_include_stable_contract_values():
         "server_credentials_unavailable",
         "stale_authorization",
         "profile_no_longer_authorized",
-    } <= SERVER_CONTEXT_FAILURE_REASON_CODES
+        "server_identity_unavailable",
+    }
+
+    assert set(get_args(ServerContextFailureReason)) == expected_reason_codes
+    assert SERVER_CONTEXT_FAILURE_REASON_CODES == expected_reason_codes
+
+
+def test_runtime_policy_package_exports_character_authority_apis():
+    import tldw_chatbook.runtime_policy as runtime_policy
+
+    assert (
+        runtime_policy.ServerIdentityUnavailable
+        is server_context_module.ServerIdentityUnavailable
+    )
+    assert (
+        runtime_policy.encode_server_user_character_authority
+        is server_context_module.encode_server_user_character_authority
+    )
+    assert {
+        "ServerIdentityUnavailable",
+        "encode_server_user_character_authority",
+    } <= set(runtime_policy.__all__)
 
 
 def test_context_unavailable_error_exposes_reason_code_and_safe_payload(tmp_path):

--- a/Tests/RuntimePolicy/test_server_context_provider.py
+++ b/Tests/RuntimePolicy/test_server_context_provider.py
@@ -7,7 +7,10 @@ from dataclasses import replace
 import pytest
 
 import tldw_chatbook.runtime_policy.server_context as server_context_module
-from tldw_chatbook.MCP.server_target_store import ConfiguredServerTargetStore
+from tldw_chatbook.MCP.server_target_store import (
+    AuthorityScopeUnavailable,
+    ConfiguredServerTargetStore,
+)
 from tldw_chatbook.MCP.unified_control_models import ConfiguredServerTarget
 from tldw_chatbook.runtime_policy.bootstrap import RuntimePolicyContext
 from tldw_chatbook.runtime_policy.server_credentials import (
@@ -28,6 +31,7 @@ from tldw_chatbook.runtime_policy.types import (
     RuntimeSourceState,
     SERVER_CONTEXT_FAILURE_REASON_CODES,
 )
+from tldw_chatbook.tldw_api.auth_user_schemas import UserProfileResponse
 
 
 class SavingRuntimeStore:
@@ -132,6 +136,607 @@ def _provider(
         credential_store=credential_store or InMemoryServerCredentialStore(),
         app_config=app_config or {},
     )
+
+
+_AUTHORITY_SCOPE = "123e4567-e89b-42d3-a456-426614174000"
+_SECOND_AUTHORITY_SCOPE = "123e4567-e89b-42d3-b456-426614174001"
+_AUTHORITY_SERVER_ID = "https://server.example.com/api"
+
+
+def _identity_response(user_id) -> UserProfileResponse:
+    return UserProfileResponse(
+        profile_version="profile-v1",
+        catalog_version="catalog-v1",
+        user={"id": user_id},
+    )
+
+
+class IdentityClient:
+    def __init__(self, response=None, *, error: BaseException | None = None) -> None:
+        self.response = response
+        self.error = error
+        self.profile_calls: list[dict] = []
+        self.close_calls = 0
+
+    async def get_current_user_profile(self, **kwargs):
+        self.profile_calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class GatedIdentityClient(IdentityClient):
+    def __init__(self, response) -> None:
+        super().__init__(response)
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def get_current_user_profile(self, **kwargs):
+        self.profile_calls.append(kwargs)
+        self.started.set()
+        await self.release.wait()
+        return self.response
+
+
+def _authority_provider(
+    tmp_path,
+    monkeypatch,
+    clients: list[IdentityClient],
+    *,
+    runtime_context: RuntimePolicyContext | None = None,
+    credential_store: InMemoryServerCredentialStore | None = None,
+    target: ConfiguredServerTarget | None = None,
+):
+    runtime_context = runtime_context or _runtime_context()
+    credential_store = credential_store or InMemoryServerCredentialStore()
+    active_server_id = runtime_context.state.active_server_id
+    assert active_server_id is not None
+    if (
+        credential_store.get_secret(
+            active_server_id,
+            SERVER_CREDENTIAL_ACCESS_TOKEN,
+        )
+        is None
+    ):
+        credential_store.set_secret(
+            active_server_id,
+            SERVER_CREDENTIAL_ACCESS_TOKEN,
+            "access-1",
+        )
+    target = target or ConfiguredServerTarget(
+        server_id=active_server_id,
+        label="Primary",
+        base_url="https://server.example.com/api",
+        auth_mode="bearer",
+        is_default=True,
+        authority_scope_id=_AUTHORITY_SCOPE,
+    )
+    target_store = _target_store(tmp_path, [target])
+    remaining_clients = iter(clients)
+    build_calls: list[dict] = []
+
+    def build_client(**kwargs):
+        build_calls.append(kwargs)
+        return next(remaining_clients)
+
+    monkeypatch.setattr(
+        server_context_module,
+        "build_runtime_api_client",
+        build_client,
+    )
+    provider = RuntimeServerContextProvider(
+        runtime_context=runtime_context,
+        target_store=target_store,
+        credential_store=credential_store,
+        app_config={},
+    )
+    return provider, target_store, credential_store, build_calls
+
+
+async def _resolve_authority(provider: RuntimeServerContextProvider) -> str:
+    return await provider.resolve_character_authority_id(
+        expected_server_id=_AUTHORITY_SERVER_ID
+    )
+
+
+def test_server_user_character_authority_encoding_matches_independent_vector():
+    authority_id = server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        42,
+    )
+
+    assert (
+        authority_id == "server-user-v1:"
+        "24e98cf244c628ca3fa628cf0d6a46e79a90864ef5864d3022db18415d5710ed"
+    )
+    assert len(authority_id) == 79
+    assert authority_id.isascii()
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "",
+        "123E4567-E89B-42D3-A456-426614174000",
+        "123e4567e89b42d3a456426614174000",
+        "123e4567-e89b-12d3-a456-426614174000",
+        "123e4567-e89b-42d3-a456-42661417400é",
+        f" {_AUTHORITY_SCOPE}",
+        123,
+    ],
+)
+def test_server_user_character_authority_encoding_rejects_noncanonical_scope(scope):
+    with pytest.raises(ValueError):
+        server_context_module.encode_server_user_character_authority(scope, 1)
+
+
+@pytest.mark.parametrize("user_id", [True, 0, -1, 2**63, "1"])
+def test_server_user_character_authority_encoding_rejects_invalid_user_id(user_id):
+    with pytest.raises(ValueError):
+        server_context_module.encode_server_user_character_authority(
+            _AUTHORITY_SCOPE,
+            user_id,
+        )
+
+
+@pytest.mark.parametrize("user_id", [1, 2**63 - 1])
+def test_server_user_character_authority_encoding_accepts_user_id_boundaries(user_id):
+    authority_id = server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        user_id,
+    )
+
+    assert authority_id.startswith("server-user-v1:")
+    assert len(authority_id) == 79
+    assert authority_id[15:] == authority_id[15:].lower()
+
+
+@pytest.mark.asyncio
+async def test_character_authority_resolver_requests_identity_section_and_caches_same_context(
+    tmp_path,
+    monkeypatch,
+):
+    client = IdentityClient(_identity_response(42))
+    provider, _, _, build_calls = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [client],
+    )
+
+    first = await _resolve_authority(provider)
+    second = await _resolve_authority(provider)
+
+    assert first == server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        42,
+    )
+    assert second == first
+    assert client.profile_calls == [{"sections": "identity"}]
+    assert len(build_calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_server_id",
+    [
+        "",
+        " https://server.example.com/api ",
+        "https://other.example.com/api",
+    ],
+)
+async def test_character_authority_resolver_rejects_expected_target_before_scope_or_network(
+    tmp_path,
+    monkeypatch,
+    expected_server_id,
+):
+    client = IdentityClient(_identity_response(42))
+    provider, target_store, _, build_calls = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [client],
+    )
+    ensure_calls = 0
+    real_ensure = target_store.ensure_authority_scope_id
+
+    def counted_ensure(server_id):
+        nonlocal ensure_calls
+        ensure_calls += 1
+        return real_ensure(server_id)
+
+    monkeypatch.setattr(target_store, "ensure_authority_scope_id", counted_ensure)
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable) as exc_info:
+        await provider.resolve_character_authority_id(
+            expected_server_id=expected_server_id
+        )
+
+    assert str(exc_info.value) == "Server identity unavailable."
+    assert exc_info.value.reason_code == "server_identity_unavailable"
+    assert exc_info.value.recoverable is True
+    assert ensure_calls == 0
+    assert build_calls == []
+    assert client.profile_calls == []
+
+
+@pytest.mark.asyncio
+async def test_character_authority_resolver_uses_only_nested_user_id_from_mapping_fake(
+    tmp_path,
+    monkeypatch,
+):
+    client = IdentityClient({"id": 999, "user": {"id": 42}})
+    provider, _, _, _ = _authority_provider(tmp_path, monkeypatch, [client])
+
+    authority_id = await _resolve_authority(provider)
+
+    assert authority_id == server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        42,
+    )
+
+
+@pytest.mark.asyncio
+async def test_character_authority_resolver_rejects_ambiguous_mapping_and_attribute_response(
+    tmp_path,
+    monkeypatch,
+):
+    class AmbiguousResponse(dict):
+        def __init__(self) -> None:
+            super().__init__(user={"id": 42})
+            self.user = {"id": 43}
+
+    client = IdentityClient(AmbiguousResponse())
+    provider, _, _, _ = _authority_provider(tmp_path, monkeypatch, [client])
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable):
+        await _resolve_authority(provider)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        UserProfileResponse(
+            profile_version="profile-v1",
+            catalog_version="catalog-v1",
+            user=None,
+        ),
+        UserProfileResponse(
+            profile_version="profile-v1",
+            catalog_version="catalog-v1",
+            user={},
+        ),
+        _identity_response(True),
+        _identity_response(0),
+        _identity_response(2**63),
+        _identity_response("42"),
+    ],
+)
+async def test_character_authority_resolver_rejects_invalid_identity_response(
+    tmp_path,
+    monkeypatch,
+    response,
+):
+    client = IdentityClient(response)
+    provider, _, _, _ = _authority_provider(tmp_path, monkeypatch, [client])
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable) as exc_info:
+        await _resolve_authority(provider)
+
+    assert exc_info.value.to_contract() == {
+        "reason_code": "server_identity_unavailable",
+        "message": "Server identity unavailable.",
+        "recoverable": True,
+        "active_server_id": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_character_authority_endpoint_failure_is_bounded_and_client_remains_usable(
+    tmp_path,
+    monkeypatch,
+):
+    sensitive_endpoint_error = "identity-response-sensitive-sentinel"
+    client = IdentityClient(error=RuntimeError(sensitive_endpoint_error))
+    provider, _, _, build_calls = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [client],
+    )
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable) as exc_info:
+        await _resolve_authority(provider)
+
+    assert str(exc_info.value) == "Server identity unavailable."
+    assert sensitive_endpoint_error not in repr(exc_info.value.to_contract())
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True
+    assert provider.build_client() is client
+    assert len(build_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_character_authority_resolver_does_not_swallow_cancellation(
+    tmp_path,
+    monkeypatch,
+):
+    client = IdentityClient(error=asyncio.CancelledError())
+    provider, _, _, _ = _authority_provider(tmp_path, monkeypatch, [client])
+
+    with pytest.raises(asyncio.CancelledError):
+        await _resolve_authority(provider)
+
+
+@pytest.mark.asyncio
+async def test_character_authority_scope_failure_is_bounded_before_client_build(
+    tmp_path,
+    monkeypatch,
+):
+    client = IdentityClient(_identity_response(42))
+    provider, target_store, _, build_calls = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [client],
+    )
+
+    def unavailable_scope(server_id):
+        raise AuthorityScopeUnavailable()
+
+    monkeypatch.setattr(
+        target_store,
+        "ensure_authority_scope_id",
+        unavailable_scope,
+    )
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable) as exc_info:
+        await _resolve_authority(provider)
+
+    assert str(exc_info.value) == "Server identity unavailable."
+    assert exc_info.value.__cause__ is None
+    assert build_calls == []
+    assert provider.build_client() is client
+    assert client.profile_calls == []
+
+
+@pytest.mark.asyncio
+async def test_character_authority_resolver_rejects_malformed_persisted_scope(
+    tmp_path,
+    monkeypatch,
+):
+    target = ConfiguredServerTarget(
+        server_id="https://server.example.com/api",
+        label="Primary",
+        base_url="https://server.example.com/api",
+        auth_mode="bearer",
+        is_default=True,
+        authority_scope_id="not-a-canonical-scope",
+    )
+    client = IdentityClient(_identity_response(42))
+    provider, _, _, build_calls = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [client],
+        target=target,
+    )
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable):
+        await _resolve_authority(provider)
+
+    assert build_calls == []
+    assert client.profile_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("context_change", ["target_metadata", "credential"])
+async def test_character_authority_refetches_and_remains_stable_across_context_changes(
+    tmp_path,
+    monkeypatch,
+    context_change,
+):
+    first_client = IdentityClient(_identity_response(42))
+    second_client = IdentityClient(_identity_response(42))
+    provider, target_store, _, build_calls = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [first_client, second_client],
+    )
+
+    first = await _resolve_authority(provider)
+    if context_change == "target_metadata":
+        original_target = target_store.get_target("https://server.example.com/api")
+        assert original_target is not None
+        target_store.save_targets(
+            [
+                replace(
+                    original_target,
+                    label="Renamed",
+                    base_url="https://moved.example.com/api",
+                    last_known_server_label="Mutable display label",
+                )
+            ]
+        )
+    else:
+        provider.store_auth_tokens(access_token="access-2")
+    second = await _resolve_authority(provider)
+    await asyncio.sleep(0)
+
+    assert second == first
+    assert len(build_calls) == 2
+    assert first_client.profile_calls == [{"sections": "identity"}]
+    assert second_client.profile_calls == [{"sections": "identity"}]
+    assert first_client.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_character_authority_separates_two_users_on_one_target(
+    tmp_path,
+    monkeypatch,
+):
+    first_client = IdentityClient(_identity_response(41))
+    second_client = IdentityClient(_identity_response(42))
+    provider, _, _, _ = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        [first_client, second_client],
+    )
+
+    first = await _resolve_authority(provider)
+    provider.store_auth_tokens(access_token="access-2")
+    second = await _resolve_authority(provider)
+
+    assert first != second
+    assert first == server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        41,
+    )
+    assert second == server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        42,
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_cached_client_clears_character_authority_cache(
+    tmp_path,
+    monkeypatch,
+):
+    client = IdentityClient(_identity_response(42))
+    provider, _, _, _ = _authority_provider(tmp_path, monkeypatch, [client])
+    await _resolve_authority(provider)
+
+    await provider.close_cached_client()
+
+    assert provider._cached_character_authority is None
+    assert client.close_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stale_change",
+    [
+        "runtime_revision",
+        "server_switch",
+        "switch_away_and_back",
+        "target",
+        "scope",
+        "credential",
+        "client",
+    ],
+)
+async def test_character_authority_rejects_stale_in_flight_capture(
+    tmp_path,
+    monkeypatch,
+    stale_change,
+):
+    runtime_context = _runtime_context()
+    credentials = InMemoryServerCredentialStore()
+    credentials.set_secret(
+        "https://server.example.com/api",
+        SERVER_CREDENTIAL_ACCESS_TOKEN,
+        "access-1",
+    )
+    stale_client = GatedIdentityClient(_identity_response(42))
+    replacement_client = IdentityClient(_identity_response(42))
+    clients = (
+        [stale_client, replacement_client]
+        if stale_change == "credential"
+        else [stale_client]
+    )
+    provider, target_store, _, _ = _authority_provider(
+        tmp_path,
+        monkeypatch,
+        clients,
+        runtime_context=runtime_context,
+        credential_store=credentials,
+    )
+    pending = asyncio.create_task(_resolve_authority(provider))
+    await stale_client.started.wait()
+
+    if stale_change == "runtime_revision":
+        _commit_runtime_state(
+            runtime_context,
+            replace(runtime_context.state, last_known_server_label="Changed"),
+        )
+    elif stale_change in {"server_switch", "switch_away_and_back"}:
+        original_state = runtime_context.state
+        _commit_runtime_state(
+            runtime_context,
+            replace(
+                original_state,
+                active_server_id="https://other.example.com/api",
+            ),
+        )
+        if stale_change == "switch_away_and_back":
+            _commit_runtime_state(runtime_context, original_state)
+    elif stale_change in {"target", "scope"}:
+        original_target = target_store.get_target("https://server.example.com/api")
+        assert original_target is not None
+        replacement = (
+            replace(original_target, label="Changed in flight")
+            if stale_change == "target"
+            else replace(
+                original_target,
+                authority_scope_id=_SECOND_AUTHORITY_SCOPE,
+            )
+        )
+        target_store.save_targets([replacement])
+    elif stale_change == "credential":
+        credentials.set_secret(
+            "https://server.example.com/api",
+            SERVER_CREDENTIAL_ACCESS_TOKEN,
+            "access-2",
+        )
+    else:
+        provider._cached_client = replacement_client
+    stale_client.release.set()
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable):
+        await pending
+    assert provider._cached_character_authority is None
+    if stale_change == "credential":
+        assert provider.build_client() is replacement_client
+        await asyncio.sleep(0)
+        assert stale_client.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_character_authority_rejects_older_conflicting_account_response(
+    tmp_path,
+    monkeypatch,
+):
+    old_started = asyncio.Event()
+    release_old = asyncio.Event()
+
+    class SwitchingAccountClient(IdentityClient):
+        async def get_current_user_profile(self, **kwargs):
+            self.profile_calls.append(kwargs)
+            if len(self.profile_calls) == 1:
+                old_started.set()
+                await release_old.wait()
+                return _identity_response(41)
+            return _identity_response(42)
+
+    client = SwitchingAccountClient()
+    provider, _, _, _ = _authority_provider(tmp_path, monkeypatch, [client])
+    old_request = asyncio.create_task(_resolve_authority(provider))
+    await old_started.wait()
+
+    current = await _resolve_authority(provider)
+    release_old.set()
+
+    with pytest.raises(server_context_module.ServerIdentityUnavailable):
+        await old_request
+    assert current == server_context_module.encode_server_user_character_authority(
+        _AUTHORITY_SCOPE,
+        42,
+    )
+    assert client.profile_calls == [
+        {"sections": "identity"},
+        {"sections": "identity"},
+    ]
 
 
 def test_resolves_matching_target_and_credential_store_secret(tmp_path):

--- a/Tests/Sync_Interop/test_chat_outbox_producer.py
+++ b/Tests/Sync_Interop/test_chat_outbox_producer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.Sync_Interop.chat_outbox_producer import ChatSyncV2OutboxProducer
 from tldw_chatbook.Sync_Interop.crypto import decrypt_sync_payload, generate_dataset_key
 from tldw_chatbook.Sync_Interop.sync_state_repository import SyncStateRepository
@@ -131,6 +132,56 @@ def test_chat_producer_skips_without_local_first_profile_or_dataset_key(
         )
         == []
     )
+
+
+def test_chat_producer_does_not_transport_or_infer_local_character_authority(
+    tmp_path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "chat.db", client_id="sync-test")
+    try:
+        character_id = db.add_character_card({"name": "Local Character"})
+        conversation_id = db.add_conversation(
+            {
+                "character_id": character_id,
+                "assistant_kind": "character",
+                "assistant_id": str(character_id),
+                "runtime_backend": "local",
+            }
+        )
+        conversation = db.get_conversation_by_id(conversation_id)
+        authority_id = conversation["assistant_authority_id"]
+        assert authority_id == db.get_local_authority_id()
+
+        dataset_key = generate_dataset_key()
+        repo = _local_first_repo(tmp_path)
+        producer = ChatSyncV2OutboxProducer(
+            state_repository=repo,
+            dataset_keys={"dataset-1": dataset_key},
+        )
+
+        producer.enqueue_chat_message(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope=None,
+            conversation_id=conversation_id,
+            message_id="message-1",
+            role="assistant",
+            content="Local answer",
+        )
+
+        envelope = repo.list_pending_sync_v2_outbox_envelopes(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope=None,
+            dataset_id="dataset-1",
+        )[0]["envelope"]
+        payload = _decrypt_payload(envelope["payload_ciphertext"], dataset_key)
+
+        assert "assistant_authority_id" not in envelope["routing_metadata"]
+        assert "assistant_authority_id" not in payload
+        assert authority_id not in json.dumps(envelope)
+    finally:
+        db.close_connection()
 
 
 def _local_first_repo(tmp_path) -> SyncStateRepository:

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -52,7 +52,14 @@ def _store_with_session(session: ConsoleChatSession) -> ConsoleChatStore:
 
 
 def test_current_console_rail_character_id_reads_active_session():
-    session = ConsoleChatSession(id="session-a", character_id=7, character_name="Ada")
+    session = ConsoleChatSession(
+        id="session-a",
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        character_id=7,
+        character_name="Ada",
+    )
     screen = _bare_console_screen(_store_with_session(session))
 
     assert screen._current_console_rail_character_id() == 7
@@ -75,6 +82,9 @@ def test_p3c_leaves_dictionary_scope_ids_unchanged():
     """
     session = ConsoleChatSession(
         id="session-a",
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
         character_id=7,
         character_name="Ada",
         persisted_conversation_id="conv-1",
@@ -262,6 +272,14 @@ def _set_active_console_character(screen, character_id, character_name) -> None:
     assert session is not None, "no active native Console session"
     session.character_id = character_id
     session.character_name = character_name
+    session.runtime_backend = "local"
+    session.assistant_authority_id = None
+    if type(character_id) is int and character_id > 0:
+        session.assistant_kind = "character"
+        session.assistant_id = str(character_id)
+    else:
+        session.assistant_kind = "generic"
+        session.assistant_id = "console"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -7823,6 +7823,34 @@ def test_native_console_state_round_trip_preserves_source_aware_character_identi
     assert restored_session.character_ref() is not None
 
 
+def test_live_server_session_never_exposes_local_character_projection():
+    """A stray server-side numeric ID cannot drive local rail/card state."""
+    session = ConsoleChatSession(
+        id="session-a",
+        title="Server character",
+        runtime_backend="server",
+        assistant_kind="character",
+        assistant_id="opaque-character",
+        assistant_authority_id="server-user-v1:" + ("f" * 64),
+        character_id=7,
+        character_name="Unrelated local card",
+    )
+    store = ConsoleChatStore()
+    store.restore_state(
+        sessions=[session],
+        messages_by_session={session.id: []},
+        active_session_id=session.id,
+    )
+    screen = _bare_console_screen(store)
+
+    assert screen._current_console_rail_character_id() is None
+
+    payload = screen._serialize_native_console_state()
+    assert payload is not None
+    assert payload["sessions"][0]["character_id"] is None
+    assert session.character_id == 7
+
+
 def test_native_console_state_restore_adapts_legacy_local_character_without_authority():
     """Legacy numeric character state keeps direct-chat kind but stays unproven."""
     payload = {

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -6558,6 +6558,187 @@ async def test_console_workspace_conversation_row_resumes_persisted_conversation
 
 
 @pytest.mark.asyncio
+async def test_console_resume_restores_server_character_identity_without_local_lookup():
+    """Server opaque identity comes only from the selected persisted row."""
+    scoped_authority = "server-user-v1:" + ("c" * 64)
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "server-scoped": {
+                "conversation": {
+                    "id": "server-scoped",
+                    "title": "Scoped server character",
+                    "runtime_backend": "server",
+                    "assistant_kind": "character",
+                    "assistant_id": "opaque-character",
+                    "assistant_authority_id": scoped_authority,
+                    "character_id": None,
+                },
+                "root_threads": [],
+            },
+            "server-unscoped": {
+                "conversation": {
+                    "id": "server-unscoped",
+                    "title": "Unscoped server character",
+                    "runtime_backend": "server",
+                    "assistant_kind": "character",
+                    "assistant_id": "other-opaque-character",
+                    "assistant_authority_id": None,
+                    "character_id": None,
+                },
+                "root_threads": [],
+            },
+            "malformed-local-scalars": {
+                "conversation": {
+                    "id": "malformed-local-scalars",
+                    "title": "Malformed local character",
+                    "runtime_backend": "local",
+                    "assistant_kind": "character",
+                    "assistant_id": 7,
+                    "assistant_authority_id": 123,
+                    "character_id": 7,
+                },
+                "root_threads": [],
+            },
+            "noncanonical-local-id": {
+                "conversation": {
+                    "id": "noncanonical-local-id",
+                    "title": "Noncanonical local character",
+                    "runtime_backend": "local",
+                    "assistant_kind": "character",
+                    "assistant_id": "007",
+                    "assistant_authority_id": "local-authority",
+                    "character_id": 7,
+                },
+                "root_threads": [],
+            },
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        active = store.switch_session(store.active_session_id)
+        active.runtime_backend = "server"
+        active.assistant_kind = "character"
+        active.assistant_id = "active-server-character"
+        active.assistant_authority_id = "server-user-v1:" + ("d" * 64)
+        active.settings = ConsoleSessionSettings(
+            provider="llama_cpp",
+            character_label="Wrong active character",
+        )
+        local_lookup = AsyncMock(
+            side_effect=AssertionError("server identity must not use local cards")
+        )
+        console._resolve_resumed_character_name = local_lookup
+
+        assert (
+            await console._resume_console_workspace_conversation("server-scoped")
+            is True
+        )
+        scoped = store.switch_session(store.active_session_id)
+        assert scoped.runtime_backend == "server"
+        assert scoped.assistant_kind == "character"
+        assert scoped.assistant_id == "opaque-character"
+        assert scoped.assistant_authority_id == scoped_authority
+        assert scoped.character_id is None
+        assert scoped.character_ref() is not None
+        assert scoped.settings is not None
+        assert scoped.settings.character_label == ""
+
+        assert (
+            await console._resume_console_workspace_conversation("server-unscoped")
+            is True
+        )
+        unscoped = store.switch_session(store.active_session_id)
+        assert unscoped.runtime_backend == "server"
+        assert unscoped.assistant_kind == "character"
+        assert unscoped.assistant_id == "other-opaque-character"
+        assert unscoped.assistant_authority_id is None
+        assert unscoped.character_id is None
+        assert unscoped.character_ref() is None
+        assert unscoped.settings is not None
+        assert unscoped.settings.character_label == ""
+
+        assert (
+            await console._resume_console_workspace_conversation(
+                "malformed-local-scalars"
+            )
+            is True
+        )
+        malformed = store.switch_session(store.active_session_id)
+        assert malformed.runtime_backend == "local"
+        assert malformed.assistant_kind == "character"
+        assert malformed.assistant_id is None
+        assert malformed.assistant_authority_id is None
+        assert malformed.character_id is None
+        assert malformed.character_ref() is None
+
+        assert (
+            await console._resume_console_workspace_conversation(
+                "noncanonical-local-id"
+            )
+            is True
+        )
+        noncanonical = store.switch_session(store.active_session_id)
+        assert noncanonical.runtime_backend == "local"
+        assert noncanonical.assistant_kind == "character"
+        assert noncanonical.assistant_id == "007"
+        assert noncanonical.assistant_authority_id == "local-authority"
+        assert noncanonical.character_id is None
+        assert noncanonical.character_ref() is None
+        local_lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_console_resume_rehydrates_local_character_name_from_local_projection():
+    """Only a local character row drives the local card/name lookup."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "local-character": {
+                "conversation": {
+                    "id": "local-character",
+                    "title": "Local character",
+                    "runtime_backend": "local",
+                    "assistant_kind": "character",
+                    "assistant_id": "7",
+                    "assistant_authority_id": "local-authority",
+                    "character_id": 7,
+                },
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        name_lookup = AsyncMock(return_value="Elara")
+        console._resolve_resumed_character_name = name_lookup
+
+        assert (
+            await console._resume_console_workspace_conversation("local-character")
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.runtime_backend == "local"
+        assert session.assistant_kind == "character"
+        assert session.assistant_id == "7"
+        assert session.assistant_authority_id == "local-authority"
+        assert session.character_id == 7
+        assert session.character_name == "Elara"
+        name_lookup.assert_awaited_once_with(7)
+
+
+@pytest.mark.asyncio
 async def test_console_workspace_conversation_resume_restores_system_prompt():
     """Resuming a saved conversation restores its persisted system prompt.
 
@@ -7529,19 +7710,16 @@ def test_native_console_restore_ignores_legacy_identity_without_mutation_or_conf
         callback.assert_not_called()
 
 
-def test_native_console_state_round_trip_preserves_character_identity():
-    """A character-bound session must keep ``character_id``/``character_name``
-    across a native Console screen-state save/restore (task-427).
-
-    Without round-tripping these fields, a screen-state restore silently
-    flips a character session back to a generic one (``character_id=None``),
-    disabling the plain-provider gate and losing the character identity that
-    ``_serialize_native_console_state`` is supposed to preserve.
-    """
+def test_native_console_state_round_trip_preserves_source_aware_character_identity():
+    """Screen state keeps exact assistant provenance and local presentation."""
     store = ConsoleChatStore()
     session = ConsoleChatSession(
         id="session-a",
         title="Chat with Elara",
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        assistant_authority_id="local-authority",
         character_id=7,
         character_name="Elara",
     )
@@ -7554,16 +7732,166 @@ def test_native_console_state_round_trip_preserves_character_identity():
 
     payload = screen._serialize_native_console_state()
     assert payload is not None
-    assert payload["sessions"][0]["character_id"] == 7
-    assert payload["sessions"][0]["character_name"] == "Elara"
+    assert {
+        key: payload["sessions"][0][key]
+        for key in (
+            "runtime_backend",
+            "assistant_kind",
+            "assistant_id",
+            "assistant_authority_id",
+            "character_id",
+            "character_name",
+        )
+    } == {
+        "runtime_backend": "local",
+        "assistant_kind": "character",
+        "assistant_id": "7",
+        "assistant_authority_id": "local-authority",
+        "character_id": 7,
+        "character_name": "Elara",
+    }
 
     restored_store = ConsoleChatStore()
     restored_screen = _bare_console_screen(restored_store)
     restored_screen._restore_native_console_state(payload)
 
     restored_session = restored_store.sessions()[0]
+    assert restored_session.runtime_backend == "local"
+    assert restored_session.assistant_kind == "character"
+    assert restored_session.assistant_id == "7"
+    assert restored_session.assistant_authority_id == "local-authority"
     assert restored_session.character_id == 7
     assert restored_session.character_name == "Elara"
+    assert restored_session.character_ref() is not None
+
+
+def test_native_console_state_restore_adapts_legacy_local_character_without_authority():
+    """Legacy numeric character state keeps direct-chat kind but stays unproven."""
+    payload = {
+        "version": "1.0",
+        "active_session_id": "session-a",
+        "sessions": [
+            {
+                "id": "session-a",
+                "title": "Chat with Elara",
+                "workspace_id": CONSOLE_GLOBAL_WORKSPACE_ID,
+                "persisted_conversation_id": None,
+                "draft": "",
+                "settings": None,
+                "character_id": 7,
+                "character_name": "Elara",
+            }
+        ],
+        "messages_by_session": {"session-a": []},
+    }
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+
+    restored_screen._restore_native_console_state(payload)
+
+    restored_session = restored_store.sessions()[0]
+    assert restored_session.runtime_backend == "local"
+    assert restored_session.assistant_kind == "character"
+    assert restored_session.assistant_id == "7"
+    assert restored_session.assistant_authority_id is None
+    assert restored_session.character_id == 7
+    assert restored_session.character_ref() is None
+
+
+def test_native_console_state_restore_does_not_coerce_identity_scalars():
+    """Malformed scalar types cannot be promoted into proven provenance."""
+    payload = {
+        "version": "1.0",
+        "active_session_id": "session-a",
+        "sessions": [
+            {
+                "id": "session-a",
+                "title": "Malformed identity",
+                "workspace_id": CONSOLE_GLOBAL_WORKSPACE_ID,
+                "persisted_conversation_id": None,
+                "draft": "",
+                "settings": None,
+                "runtime_backend": "local",
+                "assistant_kind": "character",
+                "assistant_id": 7,
+                "assistant_authority_id": 123,
+                "character_id": 7,
+            },
+            {
+                "id": "session-b",
+                "title": "Malformed source",
+                "workspace_id": CONSOLE_GLOBAL_WORKSPACE_ID,
+                "persisted_conversation_id": None,
+                "draft": "",
+                "settings": None,
+                "runtime_backend": 123,
+                "assistant_kind": "character",
+                "assistant_id": "8",
+                "assistant_authority_id": "local-authority",
+                "character_id": 8,
+            },
+        ],
+        "messages_by_session": {"session-a": [], "session-b": []},
+    }
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+
+    restored_screen._restore_native_console_state(payload)
+
+    session = restored_store.sessions()[0]
+    assert session.runtime_backend == "local"
+    assert session.assistant_kind == "character"
+    assert session.assistant_id is None
+    assert session.assistant_authority_id is None
+    assert session.character_id is None
+    assert session.character_ref() is None
+
+    invalid_source = restored_store.sessions()[1]
+    assert invalid_source.runtime_backend == ""
+    assert invalid_source.assistant_kind == "character"
+    assert invalid_source.assistant_id == "8"
+    assert invalid_source.assistant_authority_id == "local-authority"
+    assert invalid_source.character_id is None
+    assert invalid_source.character_ref() is None
+
+
+def test_native_console_state_restore_drops_server_numeric_local_projection():
+    """A server character keeps opaque provenance but no local lookup key."""
+    authority_id = "server-user-v1:" + ("e" * 64)
+    payload = {
+        "version": "1.0",
+        "active_session_id": "session-a",
+        "sessions": [
+            {
+                "id": "session-a",
+                "title": "Server identity",
+                "workspace_id": CONSOLE_GLOBAL_WORKSPACE_ID,
+                "persisted_conversation_id": None,
+                "draft": "",
+                "settings": None,
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "opaque-character",
+                "assistant_authority_id": authority_id,
+                "character_id": 7,
+                "character_name": "Server Card",
+            }
+        ],
+        "messages_by_session": {"session-a": []},
+    }
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+
+    restored_screen._restore_native_console_state(payload)
+
+    session = restored_store.sessions()[0]
+    assert session.runtime_backend == "server"
+    assert session.assistant_kind == "character"
+    assert session.assistant_id == "opaque-character"
+    assert session.assistant_authority_id == authority_id
+    assert session.character_id is None
+    assert session.character_name == "Server Card"
+    assert session.character_ref() is not None
 
 
 def test_native_console_state_restore_tolerates_legacy_payload_without_updated_at():

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -6694,6 +6694,64 @@ async def test_console_resume_restores_server_character_identity_without_local_l
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("include_runtime_backend", "runtime_backend"),
+    (
+        pytest.param(False, None, id="missing"),
+        pytest.param(True, None, id="none"),
+        pytest.param(True, 123, id="non-string"),
+    ),
+)
+async def test_console_resume_rejects_character_identity_without_valid_source(
+    include_runtime_backend,
+    runtime_backend,
+):
+    """A persisted row cannot infer local provenance from its other fields."""
+    conversation = {
+        "id": "invalid-source",
+        "title": "Invalid source",
+        "assistant_kind": "character",
+        "assistant_id": "7",
+        "assistant_authority_id": "local-authority",
+        "character_id": 7,
+    }
+    if include_runtime_backend:
+        conversation["runtime_backend"] = runtime_backend
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "invalid-source": {
+                "conversation": conversation,
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        local_lookup = AsyncMock(return_value="Must not resolve")
+        console._resolve_resumed_character_name = local_lookup
+
+        assert (
+            await console._resume_console_workspace_conversation("invalid-source")
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.runtime_backend == ""
+        assert session.assistant_kind == "character"
+        assert session.assistant_id == "7"
+        assert session.assistant_authority_id == "local-authority"
+        assert session.character_id is None
+        assert session.character_ref() is None
+        local_lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_console_resume_rehydrates_local_character_name_from_local_projection():
     """Only a local character row drives the local card/name lookup."""
     app = _build_test_app()
@@ -7796,6 +7854,53 @@ def test_native_console_state_restore_adapts_legacy_local_character_without_auth
     assert restored_session.assistant_authority_id is None
     assert restored_session.character_id == 7
     assert restored_session.character_ref() is None
+
+
+@pytest.mark.parametrize(
+    ("include_runtime_backend", "runtime_backend"),
+    (
+        pytest.param(False, None, id="missing"),
+        pytest.param(True, None, id="none"),
+        pytest.param(True, 123, id="non-string"),
+    ),
+)
+def test_source_aware_native_console_state_rejects_character_without_valid_source(
+    include_runtime_backend,
+    runtime_backend,
+):
+    """Partial source-aware state cannot infer local character provenance."""
+    raw_session = {
+        "id": "session-a",
+        "title": "Invalid source",
+        "workspace_id": CONSOLE_GLOBAL_WORKSPACE_ID,
+        "persisted_conversation_id": None,
+        "draft": "",
+        "settings": None,
+        "assistant_kind": "character",
+        "assistant_id": "7",
+        "assistant_authority_id": "local-authority",
+        "character_id": 7,
+    }
+    if include_runtime_backend:
+        raw_session["runtime_backend"] = runtime_backend
+    payload = {
+        "version": "1.0",
+        "active_session_id": "session-a",
+        "sessions": [raw_session],
+        "messages_by_session": {"session-a": []},
+    }
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+
+    restored_screen._restore_native_console_state(payload)
+
+    session = restored_store.sessions()[0]
+    assert session.runtime_backend == ""
+    assert session.assistant_kind == "character"
+    assert session.assistant_id == "7"
+    assert session.assistant_authority_id == "local-authority"
+    assert session.character_id is None
+    assert session.character_ref() is None
 
 
 def test_native_console_state_restore_does_not_coerce_identity_scalars():

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -43,6 +43,10 @@ from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Navigation.pending_handoff_store import (
+    HandoffChannel,
+    PendingHandoffStore,
+)
 from tldw_chatbook.UI.Screens.chat_screen import (
     CONSOLE_ACTIVE_RUN_STATUSES,
     CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL,
@@ -3056,7 +3060,7 @@ def _character_start_handoff(
     selected_kind: str = "character",
     source: str = "personas",
     active_server_profile_id: str | None = None,
-    character_id: str = "7",
+    character_id: object = "7",
 ) -> ChatHandoffPayload:
     return ChatHandoffPayload(
         source=source,
@@ -3097,7 +3101,7 @@ def _character_handoff_runtime(
     active_server_id: str | None = None,
     local_authority: str | None = "local-authority",
     card=_DEFAULT_HANDOFF_VALUE,
-    server_authority: str | None = "server-user-v1:" + ("a" * 64),
+    server_authority: object = "server-user-v1:" + ("a" * 64),
 ) -> SimpleNamespace:
     """Build a source-aware handoff runtime with inspectable boundaries."""
     scoped_card = _character_card() if card is _DEFAULT_HANDOFF_VALUE else card
@@ -3165,29 +3169,93 @@ async def _run_character_handoff(monkeypatch, runtime, payload):
 
 
 @pytest.mark.parametrize(
-    ("source", "runtime_backend"),
+    ("field", "value"),
     (
-        pytest.param("library", "local", id="wrong-origin"),
-        pytest.param("personas", "LOCAL", id="non-exact-runtime-source"),
+        pytest.param("source", "library", id="wrong-origin"),
+        pytest.param("item_type", "persona-card", id="wrong-item-type"),
+        pytest.param("runtime_backend", "LOCAL", id="non-exact-runtime-source"),
+        pytest.param("source_owner", "server", id="contradictory-owner"),
+        pytest.param(
+            "source_selector_state",
+            "server",
+            id="contradictory-selector",
+        ),
     ),
 )
-def test_character_start_handoff_requires_personas_and_exact_runtime_source(
-    source,
-    runtime_backend,
+def test_character_start_handoff_requires_exact_coherent_envelope(
+    field,
+    value,
 ):
-    payload = _character_start_handoff(
-        source=source,
-        runtime_backend=runtime_backend,
-    )
+    payload = _character_start_handoff()
+    setattr(payload, field, value)
 
     assert (
         chat_screen_module._character_session_identity_from_handoff(payload) is None
     )
 
 
-@pytest.mark.parametrize("character_id", ("0", "opaque-7", "７"))
-def test_character_start_handoff_requires_positive_numeric_wire_id(character_id):
+@pytest.mark.parametrize(
+    ("metadata_key", "value"),
+    (
+        pytest.param("intent", " start_chat", id="non-exact-intent"),
+        pytest.param("selected_kind", " character", id="non-exact-kind"),
+        pytest.param("backend", "server", id="contradictory-backend"),
+        pytest.param("backend", None, id="missing-backend"),
+    ),
+)
+def test_character_start_handoff_requires_exact_coherent_metadata(
+    metadata_key,
+    value,
+):
+    payload = _character_start_handoff()
+    payload.metadata[metadata_key] = value
+
+    assert (
+        chat_screen_module._character_session_identity_from_handoff(payload) is None
+    )
+
+
+@pytest.mark.parametrize(
+    "character_id",
+    (
+        pytest.param("01", id="leading-zero"),
+        pytest.param(" 7", id="leading-whitespace"),
+        pytest.param("7 ", id="trailing-whitespace"),
+        pytest.param("７", id="unicode-digit"),
+        pytest.param("0", id="zero"),
+        pytest.param("-1", id="negative"),
+        pytest.param(7.0, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(7, id="integer"),
+        pytest.param("9" * 5000, id="overlong"),
+        pytest.param(str(1 << 63), id="signed-64-overflow"),
+    ),
+)
+def test_character_start_handoff_requires_canonical_positive_numeric_wire_id(
+    character_id,
+):
     payload = _character_start_handoff(character_id=character_id)
+
+    assert (
+        chat_screen_module._character_session_identity_from_handoff(payload) is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("record_id", "target_id"),
+    (
+        pytest.param(None, "local:character:7", id="missing-record"),
+        pytest.param("7", None, id="missing-target"),
+        pytest.param("7", "local:character:8", id="conflicting-ids"),
+    ),
+)
+def test_character_start_handoff_requires_matching_record_and_target_ids(
+    record_id,
+    target_id,
+):
+    payload = _character_start_handoff()
+    payload.metadata["selected_record_id"] = record_id
+    payload.metadata["selected_target_id"] = target_id
 
     assert (
         chat_screen_module._character_session_identity_from_handoff(payload) is None
@@ -3273,6 +3341,92 @@ async def test_local_character_handoff_without_scoped_card_falls_back(monkeypatc
     assert store.session is None
 
 
+@pytest.mark.parametrize("runtime_backend", ("local", "server"))
+@pytest.mark.parametrize(
+    "returned_character_id",
+    (
+        pytest.param(_DEFAULT_HANDOFF_VALUE, id="missing-id"),
+        pytest.param("07", id="noncanonical-id"),
+        pytest.param(8, id="mismatched-id"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_character_handoff_requires_exact_returned_card_identity(
+    monkeypatch,
+    runtime_backend,
+    returned_character_id,
+):
+    card = _character_card()
+    if returned_character_id is _DEFAULT_HANDOFF_VALUE:
+        card.pop("id")
+    else:
+        card["id"] = returned_character_id
+    active_server_id = (
+        "configured-target-7" if runtime_backend == "server" else None
+    )
+    runtime = _character_handoff_runtime(
+        active_server_id=active_server_id,
+        card=card,
+    )
+
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend=runtime_backend,
+            active_server_profile_id=active_server_id,
+        ),
+    )
+
+    assert started is False
+    runtime.scope_service.get_character.assert_awaited_once_with(
+        7,
+        mode=runtime_backend,
+    )
+    assert store.session is None
+    assert store.messages == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_character_session_commit_consumes_without_replay(
+    monkeypatch,
+):
+    runtime = _character_handoff_runtime()
+    runtime.app.pending_handoffs = PendingHandoffStore()
+    runtime.app.pending_handoffs.stage(
+        HandoffChannel.CHAT,
+        _character_start_handoff(),
+    )
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+    sync_started = asyncio.Event()
+    hold_sync = asyncio.Event()
+
+    async def _block_post_commit_sync():
+        sync_started.set()
+        await hold_sync.wait()
+
+    monkeypatch.setattr(
+        screen,
+        "_sync_native_console_chat_ui",
+        _block_post_commit_sync,
+    )
+
+    consume_task = asyncio.create_task(screen._consume_pending_chat_handoff())
+    await asyncio.wait_for(sync_started.wait(), timeout=1)
+    consume_task.cancel()
+    await consume_task
+
+    assert store.session is not None
+    assert len(store.messages) == 1
+    assert not runtime.app.pending_handoffs.has_pending(HandoffChannel.CHAT)
+
+    await screen._consume_pending_chat_handoff()
+
+    assert len(store.messages) == 1
+    assert not runtime.app.pending_handoffs.has_pending(HandoffChannel.CHAT)
+
+
 @pytest.mark.asyncio
 async def test_server_character_handoff_scopes_exact_target_without_local_projection(
     monkeypatch,
@@ -3350,6 +3504,62 @@ async def test_server_identity_failure_still_seeds_unscoped_character_session(
     assert [message["content"] for message in store.messages] == [
         "Hello User, I am Elara."
     ]
+
+
+@pytest.mark.parametrize(
+    "resolved_authority_id",
+    (
+        pytest.param(
+            "server-user-v2:" + ("a" * 64),
+            id="wrong-prefix",
+        ),
+        pytest.param(
+            "server-user-v1:" + ("a" * 63),
+            id="short-digest",
+        ),
+        pytest.param(
+            "server-user-v1:" + ("a" * 65),
+            id="long-digest",
+        ),
+        pytest.param(
+            "server-user-v1:" + ("A" * 64),
+            id="uppercase-digest",
+        ),
+        pytest.param(7, id="non-string"),
+        pytest.param(
+            " server-user-v1:" + ("a" * 64),
+            id="leading-whitespace",
+        ),
+        pytest.param(
+            "server-user-v1:" + ("a" * 64) + " ",
+            id="trailing-whitespace",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_server_character_handoff_rejects_malformed_resolver_authority(
+    monkeypatch,
+    resolved_authority_id,
+):
+    expected_server_id = "configured-target-7"
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+        server_authority=resolved_authority_id,
+    )
+
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id=expected_server_id,
+        ),
+    )
+
+    assert started is True
+    assert store.session is not None
+    assert store.session.assistant_authority_id is None
+    assert store.session.character_ref() is None
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.chat_conversation_scope_service import (
     ChatConversationScopeService,
 )
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
@@ -3013,6 +3014,444 @@ async def test_console_workspace_authority_rows_are_structured_for_scanning():
         assert "not configured" in _static_plain_text(
             console.query_one("#console-workspace-server-features-collapsed", Static)
         ).lower()
+
+
+class _CharacterHandoffStore:
+    """Capture character-session identity at greeting persistence time."""
+
+    def __init__(self) -> None:
+        self.create_kwargs: dict | None = None
+        self.session: ConsoleChatSession | None = None
+        self.messages: list[dict] = []
+        self.identity_at_append: dict | None = None
+
+    def create_session(self, **kwargs):
+        self.create_kwargs = dict(kwargs)
+        self.session = ConsoleChatSession(id="handoff-session", **kwargs)
+        return self.session
+
+    def append_message(self, session_id, *, role, content, persist):
+        assert self.session is not None
+        self.identity_at_append = {
+            "runtime_backend": self.session.runtime_backend,
+            "assistant_kind": self.session.assistant_kind,
+            "assistant_id": self.session.assistant_id,
+            "assistant_authority_id": self.session.assistant_authority_id,
+            "character_id": self.session.character_id,
+            "character_ref": self.session.character_ref(),
+        }
+        self.messages.append(
+            {
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+                "persist": persist,
+            }
+        )
+
+
+def _character_start_handoff(
+    *,
+    runtime_backend: str = "local",
+    selected_kind: str = "character",
+    source: str = "personas",
+    active_server_profile_id: str | None = None,
+    character_id: str = "7",
+) -> ChatHandoffPayload:
+    return ChatHandoffPayload(
+        source=source,
+        item_type=f"{selected_kind}-card",
+        title="Elara",
+        body="Character summary",
+        runtime_backend=runtime_backend,
+        source_owner=runtime_backend,
+        source_selector_state=runtime_backend,
+        active_server_profile_id=active_server_profile_id,
+        metadata={
+            "intent": "start_chat",
+            "selected_kind": selected_kind,
+            "selected_record_id": character_id,
+            "selected_name": "Elara",
+            "selected_target_id": (
+                f"{runtime_backend}:{selected_kind}:{character_id}"
+            ),
+            "backend": runtime_backend,
+        },
+    )
+
+
+def _character_card() -> dict:
+    return {
+        "id": 7,
+        "name": "Elara",
+        "first_message": "Hello {{user}}, I am {{char}}.",
+        "system_prompt": "Stay curious.",
+    }
+
+
+_DEFAULT_HANDOFF_VALUE = object()
+
+
+def _character_handoff_runtime(
+    *,
+    active_server_id: str | None = None,
+    local_authority: str | None = "local-authority",
+    card=_DEFAULT_HANDOFF_VALUE,
+    server_authority: str | None = "server-user-v1:" + ("a" * 64),
+) -> SimpleNamespace:
+    """Build a source-aware handoff runtime with inspectable boundaries."""
+    scoped_card = _character_card() if card is _DEFAULT_HANDOFF_VALUE else card
+    db = SimpleNamespace(
+        get_local_authority_id=Mock(return_value=local_authority),
+        # A usable legacy card makes forbidden fallback observable: if the
+        # scoped lookup misses and production consults this seam, the test
+        # would incorrectly create a session instead of failing closed.
+        get_character_card_by_id=Mock(return_value=_character_card()),
+    )
+    scope_service = SimpleNamespace(
+        get_character=AsyncMock(return_value=scoped_card),
+    )
+    resolver = AsyncMock(return_value=server_authority)
+    app = SimpleNamespace(
+        app_config={},
+        active_server_id=active_server_id,
+        chachanotes_db=db,
+        character_persona_scope_service=scope_service,
+        server_context_provider=SimpleNamespace(
+            resolve_character_authority_id=resolver
+        ),
+    )
+    return SimpleNamespace(
+        app=app,
+        db=db,
+        scope_service=scope_service,
+        resolver=resolver,
+    )
+
+
+def _handoff_chat_screen(monkeypatch, app, store: _CharacterHandoffStore) -> ChatScreen:
+    screen = ChatScreen(app)
+    monkeypatch.setattr(
+        ChatScreen,
+        "_ensure_console_chat_store",
+        lambda self: store,
+    )
+    monkeypatch.setattr(
+        ChatScreen,
+        "_default_console_session_settings",
+        lambda self: ConsoleSessionSettings(
+            provider="anthropic",
+            model="claude-3-haiku",
+        ),
+    )
+    monkeypatch.setattr(
+        ChatScreen,
+        "_sync_native_console_chat_ui",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        ChatScreen,
+        "_focus_console_composer_if_needed",
+        lambda self, **kwargs: None,
+    )
+    return screen
+
+
+async def _run_character_handoff(monkeypatch, runtime, payload):
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+    started = await screen._start_character_console_session(payload)
+    return started, store
+
+
+@pytest.mark.parametrize(
+    ("source", "runtime_backend"),
+    (
+        pytest.param("library", "local", id="wrong-origin"),
+        pytest.param("personas", "LOCAL", id="non-exact-runtime-source"),
+    ),
+)
+def test_character_start_handoff_requires_personas_and_exact_runtime_source(
+    source,
+    runtime_backend,
+):
+    payload = _character_start_handoff(
+        source=source,
+        runtime_backend=runtime_backend,
+    )
+
+    assert (
+        chat_screen_module._character_session_identity_from_handoff(payload) is None
+    )
+
+
+@pytest.mark.parametrize("character_id", ("0", "opaque-7", "７"))
+def test_character_start_handoff_requires_positive_numeric_wire_id(character_id):
+    payload = _character_start_handoff(character_id=character_id)
+
+    assert (
+        chat_screen_module._character_session_identity_from_handoff(payload) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_character_handoff_uses_db_authority_and_scoped_card_service(
+    monkeypatch,
+):
+    authority_id = "local-authority"
+    card_model = SimpleNamespace(model_dump=Mock(return_value=_character_card()))
+    runtime = _character_handoff_runtime(
+        local_authority=authority_id,
+        card=card_model,
+    )
+    runtime.resolver.side_effect = AssertionError(
+        "local handoff must not resolve server authority"
+    )
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(runtime_backend="local"),
+    )
+
+    assert started is True
+    runtime.db.get_local_authority_id.assert_called_once_with()
+    runtime.db.get_character_card_by_id.assert_not_called()
+    runtime.scope_service.get_character.assert_awaited_once_with(7, mode="local")
+    card_model.model_dump.assert_called_once_with(mode="json")
+    runtime.resolver.assert_not_awaited()
+    assert store.create_kwargs is not None
+    assert store.create_kwargs["runtime_backend"] == "local"
+    assert store.create_kwargs["assistant_kind"] == "character"
+    assert store.create_kwargs["assistant_id"] == "7"
+    assert store.create_kwargs["assistant_authority_id"] == authority_id
+    assert store.create_kwargs["character_id"] == 7
+    assert store.session is not None
+    assert store.session.local_character_id() == 7
+    assert store.session.character_ref() is not None
+    assert store.session.character_ref().authority_id == authority_id
+    assert store.identity_at_append is not None
+    assert store.identity_at_append["character_ref"] == store.session.character_ref()
+    assert store.messages == [
+        {
+            "session_id": "handoff-session",
+            "role": ConsoleMessageRole.ASSISTANT,
+            "content": "Hello User, I am Elara.",
+            "persist": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_character_handoff_without_db_authority_falls_back(
+    monkeypatch,
+):
+    runtime = _character_handoff_runtime()
+    runtime.db.get_local_authority_id.side_effect = RuntimeError("unavailable")
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(),
+    )
+
+    assert started is False
+    runtime.scope_service.get_character.assert_not_awaited()
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_local_character_handoff_without_scoped_card_falls_back(monkeypatch):
+    runtime = _character_handoff_runtime(card=None)
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(),
+    )
+
+    assert started is False
+    runtime.scope_service.get_character.assert_awaited_once_with(7, mode="local")
+    runtime.db.get_character_card_by_id.assert_not_called()
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_server_character_handoff_scopes_exact_target_without_local_projection(
+    monkeypatch,
+):
+    expected_server_id = "configured-target-7"
+    authority_id = "server-user-v1:" + ("a" * 64)
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+        server_authority=authority_id,
+    )
+    runtime.db.get_local_authority_id.side_effect = AssertionError(
+        "server handoff must not use local authority"
+    )
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id=expected_server_id,
+        )
+    )
+
+    assert started is True
+    runtime.resolver.assert_awaited_once_with(
+        expected_server_id=expected_server_id
+    )
+    runtime.scope_service.get_character.assert_awaited_once_with(7, mode="server")
+    runtime.db.get_local_authority_id.assert_not_called()
+    runtime.db.get_character_card_by_id.assert_not_called()
+    assert store.create_kwargs is not None
+    assert store.create_kwargs["runtime_backend"] == "server"
+    assert store.create_kwargs["assistant_kind"] == "character"
+    assert store.create_kwargs["assistant_id"] == "7"
+    assert store.create_kwargs["assistant_authority_id"] == authority_id
+    assert store.create_kwargs["character_id"] is None
+    assert store.session is not None
+    assert store.session.local_character_id() is None
+    assert store.session.character_ref() is not None
+    assert store.session.character_ref().source == "server"
+    assert store.session.character_ref().authority_id == authority_id
+    assert store.session.character_ref().character_id == "7"
+    assert store.identity_at_append is not None
+    assert store.identity_at_append["character_ref"] == store.session.character_ref()
+
+
+@pytest.mark.asyncio
+async def test_server_identity_failure_still_seeds_unscoped_character_session(
+    monkeypatch,
+):
+    expected_server_id = "configured-target-7"
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+    )
+    runtime.resolver.side_effect = RuntimeError("identity unavailable")
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id=expected_server_id,
+        )
+    )
+
+    assert started is True
+    runtime.resolver.assert_awaited_once_with(
+        expected_server_id=expected_server_id
+    )
+    runtime.scope_service.get_character.assert_awaited_once_with(7, mode="server")
+    assert store.session is not None
+    assert store.session.runtime_backend == "server"
+    assert store.session.assistant_kind == "character"
+    assert store.session.assistant_authority_id is None
+    assert store.session.character_id is None
+    assert store.session.character_ref() is None
+    assert [message["content"] for message in store.messages] == [
+        "Hello User, I am Elara."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_server_target_mismatch_before_resolver_fetches_nothing(monkeypatch):
+    runtime = _character_handoff_runtime(
+        active_server_id="different-target",
+    )
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id="configured-target-7",
+        )
+    )
+
+    assert started is False
+    runtime.resolver.assert_not_awaited()
+    runtime.scope_service.get_character.assert_not_awaited()
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_server_target_switch_during_resolver_discards_authority(monkeypatch):
+    expected_server_id = "configured-target-7"
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+    )
+
+    async def _switch_target(**kwargs):
+        assert kwargs == {"expected_server_id": expected_server_id}
+        runtime.app.active_server_id = "different-target"
+        return "server-user-v1:" + ("b" * 64)
+
+    runtime.resolver.side_effect = _switch_target
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id=expected_server_id,
+        )
+    )
+
+    assert started is False
+    runtime.resolver.assert_awaited_once_with(
+        expected_server_id=expected_server_id
+    )
+    runtime.scope_service.get_character.assert_not_awaited()
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_server_target_switch_during_card_fetch_discards_card(monkeypatch):
+    expected_server_id = "configured-target-7"
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+    )
+
+    async def _fetch_then_switch(character_id, *, mode):
+        assert (character_id, mode) == (7, "server")
+        runtime.app.active_server_id = "different-target"
+        return _character_card()
+
+    runtime.scope_service.get_character.side_effect = _fetch_then_switch
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id=expected_server_id,
+        )
+    )
+
+    assert started is False
+    runtime.resolver.assert_awaited_once_with(
+        expected_server_id=expected_server_id
+    )
+    runtime.scope_service.get_character.assert_awaited_once_with(7, mode="server")
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_does_not_create_character_session(monkeypatch):
+    runtime = _character_handoff_runtime(
+        active_server_id="configured-target-7",
+    )
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            selected_kind="persona",
+            active_server_profile_id="configured-target-7",
+            character_id="p-7",
+        )
+    )
+
+    assert started is False
+    runtime.resolver.assert_not_awaited()
+    runtime.scope_service.get_character.assert_not_awaited()
+    assert store.session is None
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -3116,13 +3116,33 @@ def _character_handoff_runtime(
         get_character=AsyncMock(return_value=scoped_card),
     )
     resolver = AsyncMock(return_value=server_authority)
+    initial_capture = SimpleNamespace(account="A")
+    authority_context_state = {"current": initial_capture}
+    capture_context = Mock(
+        side_effect=lambda *, expected_server_id: authority_context_state["current"]
+    )
+    capture_is_current = Mock(
+        side_effect=lambda capture: capture is authority_context_state["current"]
+    )
+    resolve_captures: list[object | None] = []
+
+    async def resolve_character_authority_id(
+        *,
+        expected_server_id: str,
+        context_capture: object | None = None,
+    ):
+        resolve_captures.append(context_capture)
+        return await resolver(expected_server_id=expected_server_id)
+
     app = SimpleNamespace(
         app_config={},
         active_server_id=active_server_id,
         chachanotes_db=db,
         character_persona_scope_service=scope_service,
         server_context_provider=SimpleNamespace(
-            resolve_character_authority_id=resolver
+            capture_character_authority_context=capture_context,
+            is_character_authority_context_current=capture_is_current,
+            resolve_character_authority_id=resolve_character_authority_id,
         ),
     )
     return SimpleNamespace(
@@ -3130,6 +3150,11 @@ def _character_handoff_runtime(
         db=db,
         scope_service=scope_service,
         resolver=resolver,
+        initial_capture=initial_capture,
+        authority_context_state=authority_context_state,
+        capture_context=capture_context,
+        capture_is_current=capture_is_current,
+        resolve_captures=resolve_captures,
     )
 
 
@@ -3640,6 +3665,122 @@ async def test_server_target_switch_during_card_fetch_discards_card(monkeypatch)
     )
     runtime.scope_service.get_character.assert_awaited_once_with(7, mode="server")
     assert store.session is None
+
+
+@pytest.mark.parametrize(
+    "authenticated_transition",
+    ("a_to_b", "a_to_b_to_a"),
+)
+@pytest.mark.asyncio
+async def test_server_authenticated_context_change_during_card_fetch_aborts_session(
+    monkeypatch,
+    authenticated_transition,
+):
+    expected_server_id = "configured-target-7"
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+    )
+    card_fetch_started = asyncio.Event()
+    release_card_fetch = asyncio.Event()
+
+    async def _blocked_card_fetch(character_id, *, mode):
+        assert (character_id, mode) == (7, "server")
+        card_fetch_started.set()
+        await release_card_fetch.wait()
+        return _character_card()
+
+    runtime.scope_service.get_character.side_effect = _blocked_card_fetch
+    handoff = asyncio.create_task(
+        _run_character_handoff(
+            monkeypatch,
+            runtime,
+            _character_start_handoff(
+                runtime_backend="server",
+                active_server_profile_id=expected_server_id,
+            ),
+        )
+    )
+    await card_fetch_started.wait()
+
+    runtime.authority_context_state["current"] = SimpleNamespace(account="B")
+    if authenticated_transition == "a_to_b_to_a":
+        runtime.authority_context_state["current"] = SimpleNamespace(account="A")
+    assert runtime.app.active_server_id == expected_server_id
+
+    release_card_fetch.set()
+    started, store = await handoff
+
+    assert started is False
+    assert runtime.resolve_captures == [runtime.initial_capture]
+    runtime.scope_service.get_character.assert_awaited_once_with(7, mode="server")
+    assert store.session is None
+    assert store.messages == []
+
+
+@pytest.mark.asyncio
+async def test_server_authenticated_context_change_during_resolver_fetches_no_card(
+    monkeypatch,
+):
+    expected_server_id = "configured-target-7"
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+    )
+
+    async def _resolve_then_change(**kwargs):
+        assert kwargs == {"expected_server_id": expected_server_id}
+        runtime.authority_context_state["current"] = SimpleNamespace(account="B")
+        return "server-user-v1:" + ("b" * 64)
+
+    runtime.resolver.side_effect = _resolve_then_change
+    started, store = await _run_character_handoff(
+        monkeypatch,
+        runtime,
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id=expected_server_id,
+        ),
+    )
+
+    assert started is False
+    assert runtime.resolve_captures == [runtime.initial_capture]
+    runtime.scope_service.get_character.assert_not_awaited()
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_server_authenticated_context_change_immediately_before_commit_aborts(
+    monkeypatch,
+):
+    expected_server_id = "configured-target-7"
+    runtime = _character_handoff_runtime(
+        active_server_id=expected_server_id,
+    )
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    def _settings_then_change_context():
+        runtime.authority_context_state["current"] = SimpleNamespace(account="B")
+        return ConsoleSessionSettings(
+            provider="anthropic",
+            model="claude-3-haiku",
+        )
+
+    monkeypatch.setattr(
+        screen,
+        "_default_console_session_settings",
+        _settings_then_change_context,
+    )
+    started = await screen._start_character_console_session(
+        _character_start_handoff(
+            runtime_backend="server",
+            active_server_profile_id=expected_server_id,
+        )
+    )
+
+    assert started is False
+    assert runtime.resolve_captures == [runtime.initial_capture]
+    assert store.session is None
+    assert store.messages == []
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3266,6 +3266,8 @@ class TestConsoleActions:
             "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
             "api_settings": {"llama_cpp": {"api_url": "http://127.0.0.1:8181"}},
         }
+        mock_app_instance.runtime_backend = "local"
+        mock_app_instance.active_server_id = "configured-but-not-selected"
         app = PersonasTestApp(mock_app_instance)
         app.open_chat_with_handoff = Mock()
         async with app.run_test(size=(160, 50)) as pilot:
@@ -3275,9 +3277,43 @@ class TestConsoleActions:
         app.open_chat_with_handoff.assert_called_once()
         payload = app.open_chat_with_handoff.call_args.args[0]
         assert payload.source == "personas"
+        assert payload.runtime_backend == "local"
+        assert payload.source_owner == "local"
+        assert payload.source_selector_state == "local"
+        assert payload.active_server_profile_id is None
         assert payload.metadata["intent"] == "start_chat"
         assert payload.metadata["selected_target_id"] == "local:character:1"
+        assert payload.metadata["backend"] == "local"
         assert payload.suggested_prompt == "Respond as Detective Sam."
+
+    async def test_server_start_chat_carries_exact_source_and_active_target(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """Server Start Chat captures the selected target in the handoff."""
+        mock_app_instance.app_config = {
+            "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
+            "api_settings": {"llama_cpp": {"api_url": "http://127.0.0.1:8181"}},
+        }
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "configured-target-7"
+        app = PersonasTestApp(mock_app_instance)
+        app.open_chat_with_handoff = Mock()
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            screen.query_one("#personas-start-chat", Button).press()
+            await pilot.pause()
+
+        app.open_chat_with_handoff.assert_called_once()
+        payload = app.open_chat_with_handoff.call_args.args[0]
+        assert payload.source == "personas"
+        assert payload.runtime_backend == "server"
+        assert payload.source_owner == "server"
+        assert payload.source_selector_state == "server"
+        assert payload.active_server_profile_id == "configured-target-7"
+        assert payload.metadata["intent"] == "start_chat"
+        assert payload.metadata["selected_target_id"] == "server:character:1"
+        assert payload.metadata["backend"] == "server"
 
     async def test_start_chat_action_guard_blocks_unready_provider(
         self, mock_app_instance, stub_characters, stub_conversations
@@ -5341,31 +5377,45 @@ class TestPersonaHumanIdentityRemoval:
         server_profile_service.list_persona_profiles = AsyncMock(
             return_value={"items": [dict(PROFILE)], "total": 1}
         )
-
-        class _CardDB:
-            @staticmethod
-            def get_character_card_by_id(character_id):
-                assert character_id == 7
-                return {
-                    "id": 7,
-                    "name": "Elara",
-                    "first_message": "Hello {{user}}, I am {{char}}.",
-                    "system_prompt": "Stay curious.",
-                }
+        server_profile_service.get_character = AsyncMock(
+            return_value={
+                "id": 7,
+                "name": "Elara",
+                "first_message": "Hello {{user}}, I am {{char}}.",
+                "system_prompt": "Stay curious.",
+            }
+        )
+        db = SimpleNamespace(
+            get_local_authority_id=Mock(return_value="local-authority"),
+            get_character_card_by_id=Mock(
+                side_effect=AssertionError(
+                    "Start Chat must use the source-aware scope service"
+                )
+            ),
+        )
+        server_target_id = "configured-target-7"
+        server_authority_id = "server-user-v1:" + ("d" * 64)
+        authority_resolver = AsyncMock(return_value=server_authority_id)
 
         class _CapturingStore:
             def __init__(self):
                 self.session = None
                 self.messages = []
 
-            def create_session(self, *, title, workspace_id, settings):
+            def create_session(
+                self,
+                *,
+                title,
+                workspace_id,
+                settings,
+                **identity,
+            ):
                 self.session = SimpleNamespace(
                     id="session-1",
                     title=title,
                     workspace_id=workspace_id,
                     settings=settings,
-                    character_id=None,
-                    character_name=None,
+                    **identity,
                 )
                 return self.session
 
@@ -5381,10 +5431,15 @@ class TestPersonaHumanIdentityRemoval:
 
         runtime_app = SimpleNamespace(
             app_config=legacy_human_config.mapping,
-            chachanotes_db=_CardDB(),
+            active_server_id=(
+                server_target_id if runtime_source == "server" else None
+            ),
+            chachanotes_db=db,
             character_persona_scope_service=server_profile_service,
             local_character_persona_service=local_profile_service,
-            get_authoritative_runtime_source=lambda: runtime_source,
+            server_context_provider=SimpleNamespace(
+                resolve_character_authority_id=authority_resolver
+            ),
         )
         screen = ChatScreen(runtime_app)
         store = _CapturingStore()
@@ -5418,11 +5473,19 @@ class TestPersonaHumanIdentityRemoval:
             item_type="character-card",
             title="Elara",
             body="Character summary",
+            runtime_backend=runtime_source,
+            source_owner=runtime_source,
+            source_selector_state=runtime_source,
+            active_server_profile_id=(
+                server_target_id if runtime_source == "server" else None
+            ),
             metadata={
                 "intent": "start_chat",
                 "selected_kind": "character",
                 "selected_record_id": "7",
                 "selected_name": "Elara",
+                "selected_target_id": f"{runtime_source}:character:7",
+                "backend": runtime_source,
             },
         )
 
@@ -5434,6 +5497,20 @@ class TestPersonaHumanIdentityRemoval:
         ]
         local_profile_service.list_persona_profiles.assert_not_called()
         server_profile_service.list_persona_profiles.assert_not_awaited()
+        server_profile_service.get_character.assert_awaited_once_with(
+            7, mode=runtime_source
+        )
+        db.get_character_card_by_id.assert_not_called()
+        if runtime_source == "local":
+            db.get_local_authority_id.assert_called_once_with()
+            authority_resolver.assert_not_awaited()
+            assert store.session.assistant_authority_id == "local-authority"
+        else:
+            db.get_local_authority_id.assert_not_called()
+            authority_resolver.assert_awaited_once_with(
+                expected_server_id=server_target_id
+            )
+            assert store.session.assistant_authority_id == server_authority_id
         legacy_human_config.assert_unchanged()
 
     async def test_profile_rename_does_not_follow_legacy_pointer(

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -5067,6 +5067,174 @@ class TestServerCharacterSourceIsolation:
             assert _shared_pane_publication(screen) == newer_publication
             assert getattr(screen, cache_name) == newer_cache
 
+    @pytest.mark.parametrize("valid_mode", ("dictionaries", "lore"))
+    @pytest.mark.parametrize(
+        "stale_callback",
+        ("wrong-mode", "wrong-query"),
+    )
+    @pytest.mark.parametrize("valid_outcome", ("success", "failure"))
+    async def test_invalid_shared_mode_callback_does_not_supersede_valid_owner(
+        self,
+        mock_app_instance,
+        stub_characters,
+        monkeypatch,
+        valid_mode,
+        stale_callback,
+        valid_outcome,
+    ):
+        """Rejected callbacks cannot invalidate an accepted suspended owner."""
+        import asyncio
+
+        fetch_started = asyncio.Event()
+        release_fetch = asyncio.Event()
+        fetch_calls = 0
+        kind = "dictionary" if valid_mode == "dictionaries" else "lore"
+        cache_name = (
+            "_dictionaries_cache"
+            if valid_mode == "dictionaries"
+            else "_lore_books_cache"
+        )
+        entry_count = 2 if valid_mode == "dictionaries" else 3
+        owner_record = {
+            "id": 93,
+            "name": f"Owner {kind.title()} Result",
+            "entry_count": entry_count,
+            "enabled": True,
+        }
+        prior_cache = [
+            {
+                "id": 90,
+                "name": f"Prior {kind.title()} Cache",
+                "entry_count": 1,
+                "enabled": True,
+            }
+        ]
+
+        async def fetch_records() -> list[dict]:
+            nonlocal fetch_calls
+            fetch_calls += 1
+            if fetch_calls != 1:
+                raise AssertionError(f"Unexpected fetch call: {fetch_calls}")
+            fetch_started.set()
+            await release_fetch.wait()
+            if valid_outcome == "failure":
+                raise RuntimeError("accepted owner failed")
+            return [owner_record]
+
+        async def list_dictionaries(*, mode, include_inactive):
+            assert (mode, include_inactive) == ("local", True)
+            return {"dictionaries": await fetch_records()}
+
+        _configure_shared_mode_sources(mock_app_instance, monkeypatch)
+        mock_app_instance.chat_dictionary_scope_service.list_dictionaries = (
+            list_dictionaries
+        )
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                if function is PersonasScreen._list_world_books_with_counts:
+                    return await fetch_records()
+                raise AssertionError(f"Unexpected to_thread function: {function!r}")
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+            library = screen.query_one("#personas-library-pane")
+            screen.state.switch_mode(valid_mode)
+            screen.state.search_query = "owner"
+            library.set_mode(valid_mode)
+            setattr(screen, cache_name, deepcopy(prior_cache))
+
+            valid_render = (
+                screen._render_dictionary_rows
+                if valid_mode == "dictionaries"
+                else screen._render_lore_rows
+            )
+            generation_before = screen._dictionary_lore_request_generation
+            valid_request = asyncio.create_task(valid_render(query="owner"))
+            await fetch_started.wait()
+            accepted_generation = screen._dictionary_lore_request_generation
+
+            if stale_callback == "wrong-mode":
+                invalid_render = (
+                    screen._render_lore_rows
+                    if valid_mode == "dictionaries"
+                    else screen._render_dictionary_rows
+                )
+                await invalid_render(query="owner")
+            else:
+                await valid_render(query="stale")
+            generation_after_invalid = screen._dictionary_lore_request_generation
+
+            release_fetch.set()
+            await valid_request
+            await pilot.pause()
+
+            publication = _shared_pane_publication(screen)
+            recovery_rows = list(
+                screen.query(".personas-library-recovery-row").results()
+            )
+            recovery_copy = (
+                str(recovery_rows[0].query_one(Static).renderable)
+                if recovery_rows
+                else None
+            )
+            if valid_outcome == "success":
+                expected_rows = (
+                    (
+                        f"personas-library-row-{kind}-93",
+                        (
+                            f"Owner {kind.title()} Result",
+                            f"{entry_count} entries · on",
+                        ),
+                    ),
+                )
+                expected_count = (
+                    "1 of 1 dictionary"
+                    if valid_mode == "dictionaries"
+                    else "1 of 1 lore book"
+                )
+                expected_cache = [owner_record]
+                expected_recovery = None
+            else:
+                expected_rows = ()
+                expected_count = (
+                    "Dictionaries unavailable"
+                    if valid_mode == "dictionaries"
+                    else "Lore books unavailable"
+                )
+                expected_cache = prior_cache
+                expected_recovery = (
+                    "Dictionaries could not be loaded.\n"
+                    "Switch modes and back to retry."
+                    if valid_mode == "dictionaries"
+                    else "Lore books could not be loaded.\n"
+                    "Switch modes and back to retry."
+                )
+
+            assert (
+                accepted_generation,
+                generation_after_invalid,
+                fetch_calls,
+                publication["rows"],
+                publication["count"],
+                getattr(screen, cache_name),
+                recovery_copy,
+            ) == (
+                generation_before + 1,
+                accepted_generation,
+                1,
+                expected_rows,
+                expected_count,
+                expected_cache,
+                expected_recovery,
+            )
+
     @pytest.mark.parametrize("older_outcome", ("success", "failure"))
     async def test_server_target_aba_drops_older_request(
         self, mock_app_instance, older_outcome

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4189,6 +4189,82 @@ class TestServerCharacterSourceIsolation:
 
         assert screen._characters == [{"id": 3, "name": "Newer X winner"}]
 
+    async def test_mid_render_invalidation_clears_partial_stale_character_page(
+        self, mock_app_instance, stub_characters, monkeypatch
+    ):
+        """A newer failed reload leaves no older page published after its await."""
+        import asyncio
+
+        mock_app_instance.runtime_backend = "local"
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            library = screen.query_one("#personas-library-pane")
+            original_update_rows = library.update_rows
+            stale_render_started = asyncio.Event()
+            release_stale_render = asyncio.Event()
+            count_calls = 0
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                nonlocal count_calls
+                if function is personas_screen_module.count_character_page:
+                    count_calls += 1
+                    if count_calls == 1:
+                        return 1
+                    raise RuntimeError("newer page failed")
+                return [{"id": 7, "name": "Older X"}]
+
+            async def block_after_row_publication(rows, **kwargs):
+                await original_update_rows(rows, **kwargs)
+                if tuple(row.name for row in rows) == ("Older X",):
+                    stale_render_started.set()
+                    await release_stale_render.wait()
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+            monkeypatch.setattr(library, "update_rows", block_after_row_publication)
+            screen._character_db = lambda: object()
+            screen._count_cache_key = None
+            screen._notify = Mock()
+            screen.state.sort_key = "modified_desc"
+            screen.state.tag_filter = "older-tag"
+
+            stale = asyncio.create_task(screen._reload_character_page())
+            await stale_render_started.wait()
+
+            screen.state.sort_key = "name_asc"
+            screen.state.tag_filter = None
+            await screen._reload_character_page()
+
+            release_stale_render.set()
+            await stale
+            await pilot.pause()
+
+            assert screen._characters == []
+            assert screen._character_total == 0
+            assert not list(screen.query(".personas-library-row"))
+            assert (
+                str(
+                    screen.query_one(
+                        "#personas-library-count",
+                        Static,
+                    ).renderable
+                )
+                == "0 characters"
+            )
+            assert (
+                str(screen.query_one("#personas-library-sort", Button).label)
+                == "Sort: Name"
+            )
+            assert (
+                str(screen.query_one("#personas-library-tag", Button).label)
+                == "Tag: All"
+            )
+
     @pytest.mark.parametrize("older_outcome", ("success", "failure"))
     async def test_server_target_aba_drops_older_request(
         self, mock_app_instance, older_outcome
@@ -6255,6 +6331,17 @@ class TestPersonaHumanIdentityRemoval:
         server_target_id = "configured-target-7"
         server_authority_id = "server-user-v1:" + ("d" * 64)
         authority_resolver = AsyncMock(return_value=server_authority_id)
+        authority_capture = object()
+
+        async def resolve_authority_for_capture(
+            *,
+            expected_server_id,
+            context_capture,
+        ):
+            assert context_capture is authority_capture
+            return await authority_resolver(
+                expected_server_id=expected_server_id
+            )
 
         class _CapturingStore:
             def __init__(self):
@@ -6297,7 +6384,13 @@ class TestPersonaHumanIdentityRemoval:
             character_persona_scope_service=server_profile_service,
             local_character_persona_service=local_profile_service,
             server_context_provider=SimpleNamespace(
-                resolve_character_authority_id=authority_resolver
+                capture_character_authority_context=Mock(
+                    return_value=authority_capture
+                ),
+                is_character_authority_context_current=Mock(
+                    side_effect=lambda capture: capture is authority_capture
+                ),
+                resolve_character_authority_id=resolve_authority_for_capture,
             ),
         )
         screen = ChatScreen(runtime_app)

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3765,6 +3765,7 @@ class TestServerCharacterSourceIsolation:
                 "#personas-library-new",
                 "#personas-library-import",
                 "#personas-library-duplicate",
+                "#personas-library-tag",
                 "#personas-card-edit-character",
                 "#personas-export-json",
                 "#personas-export-png",
@@ -3777,6 +3778,46 @@ class TestServerCharacterSourceIsolation:
                 is False
             )
             assert screen.query_one("#personas-start-chat", Button).disabled is False
+
+    async def test_server_footer_does_not_advertise_local_character_creation(
+        self, mock_app_instance, stub_characters
+    ):
+        """Switching to server Characters removes the unsupported Ctrl+N hint."""
+        mock_app_instance.runtime_backend = "local"
+        mock_app_instance.active_server_id = "server-a"
+        mock_app_instance.character_persona_scope_service = self._server_service()
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            footer = screen.query_one(AppFooterStatus)
+            assert "ctrl+n new" in footer.shortcut_text.lower()
+
+            await screen.handle_runtime_backend_changed("server")
+            await pilot.pause()
+            rendered = screen._shortcut_context().render().lower()
+            footer_copy = footer.shortcut_text.lower()
+
+            assert "ctrl+n new" not in rendered
+            assert "ctrl+n new" not in footer_copy
+
+    async def test_server_tag_request_does_not_schedule_local_worker(
+        self, mock_app_instance
+    ):
+        """A queued Tag event cannot start local tag discovery on the server."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
+            PersonaTagFilterRequested,
+        )
+
+        screen = PersonasScreen(mock_app_instance)
+        screen.state.runtime_source = "server"
+        screen.state.active_mode = "characters"
+        screen.run_worker = Mock()
+
+        await screen._handle_tag_filter(PersonaTagFilterRequested())
+
+        screen.run_worker.assert_not_called()
+        assert screen._io_dialog_active is False
 
     async def test_server_action_dispatch_and_direct_local_seams_fail_closed(
         self, mock_app_instance, stub_characters, monkeypatch
@@ -4013,6 +4054,44 @@ class TestServerCharacterSourceIsolation:
         await load
 
         display.assert_not_awaited()
+
+    async def test_local_page_failure_is_silent_after_source_switch(
+        self, mock_app_instance, monkeypatch
+    ):
+        """A stale local failure cannot notify or restore rows after server switch."""
+        import asyncio
+
+        screen = PersonasScreen(mock_app_instance)
+        screen.state.runtime_source = "local"
+        screen._character_db = lambda: object()
+        screen._characters = [{"id": 1, "name": "Old local row"}]
+        screen._character_total = 1
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def failing_to_thread(function, *args, **kwargs):
+            started.set()
+            await release.wait()
+            raise RuntimeError("stale local failure")
+
+        monkeypatch.setattr(
+            personas_screen_module.asyncio, "to_thread", failing_to_thread
+        )
+        notify = Mock()
+        screen._notify = notify
+
+        load = asyncio.create_task(screen._reload_character_page())
+        await started.wait()
+        await screen.handle_runtime_backend_changed("server")
+        assert screen._characters == []
+        assert screen._character_total == 0
+
+        release.set()
+        await load
+
+        notify.assert_not_called()
+        assert screen._characters == []
+        assert screen._character_total == 0
 
     @pytest.mark.parametrize(
         "changed_dimension",

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -176,6 +176,114 @@ def _row_text(item) -> str:
     return str(item.query_one(Static).renderable)
 
 
+_SHARED_MODE_OWNER_CASES = (
+    pytest.param(
+        "dictionaries",
+        "dictionary",
+        "New Dictionary Owner",
+        "2 entries · on",
+        "1 dictionary",
+        id="dictionaries",
+    ),
+    pytest.param(
+        "lore",
+        "lore",
+        "New Lore Owner",
+        "3 entries · on",
+        "1 lore book",
+        id="lore",
+    ),
+)
+
+
+def _configure_shared_mode_sources(mock_app_instance, monkeypatch) -> None:
+    """Install complete Dictionary/Lore list seams for shared-pane race tests."""
+    mock_app_instance.runtime_backend = "local"
+    mock_app_instance.chat_dictionary_scope_service = SimpleNamespace(
+        list_dictionaries=AsyncMock(
+            return_value={
+                "dictionaries": [
+                    {
+                        "id": 91,
+                        "name": "New Dictionary Owner",
+                        "entry_count": 2,
+                        "enabled": True,
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(
+        PersonasScreen,
+        "_lore_manager",
+        lambda self: object(),
+    )
+
+
+def _shared_pane_publication(screen) -> dict[str, object]:
+    """Snapshot the shared row/count/label fields that establish pane ownership."""
+    library = screen.query_one("#personas-library-pane")
+    rendered_rows = tuple(
+        (
+            str(row.id),
+            tuple(
+                str(static.renderable)
+                for static in row.query(Static).results()
+            ),
+        )
+        for row in library.query(".personas-library-row").results()
+    )
+    return {
+        "mode": screen.state.active_mode,
+        "rows": rendered_rows,
+        "count": str(
+            screen.query_one(
+                "#personas-library-count",
+                Static,
+            ).renderable
+        ),
+        "sort": str(
+            screen.query_one(
+                "#personas-library-sort",
+                Button,
+            ).label
+        ),
+        "tag": str(
+            screen.query_one(
+                "#personas-library-tag",
+                Button,
+            ).label
+        ),
+    }
+
+
+def _observe_shared_mode_render(
+    monkeypatch,
+    screen,
+    mode: str,
+    started,
+) -> tuple[str, str]:
+    """Mark a real mode renderer as started and stamp owner-distinct labels."""
+    library = screen.query_one("#personas-library-pane")
+    method_name = (
+        "_render_dictionary_rows"
+        if mode == "dictionaries"
+        else "_render_lore_rows"
+    )
+    original_render = getattr(screen, method_name)
+    owner_sort = f"Sort: {mode} owner"
+    owner_tag = f"Tag: {mode} owner"
+
+    async def observed_render(*args, **kwargs):
+        started.set()
+        await original_render(*args, **kwargs)
+        library.set_sort_label(owner_sort)
+        library.set_tag_label(owner_tag)
+
+    monkeypatch.setattr(screen, method_name, observed_render)
+    return owner_sort, owner_tag
+
+
 def _right_edge(widget) -> int:
     """Right edge of a mounted widget region."""
     return widget.region.x + widget.region.width
@@ -4301,29 +4409,10 @@ class TestServerCharacterSourceIsolation:
         new_meta,
         new_count,
     ):
-        """A suspended Characters cleanup cannot erase the newer pane owner."""
+        """A mode renderer started after Characters publishes must finish last."""
         import asyncio
 
-        mock_app_instance.runtime_backend = "local"
-        mock_app_instance.chat_dictionary_scope_service = SimpleNamespace(
-            list_dictionaries=AsyncMock(
-                return_value={
-                    "dictionaries": [
-                        {
-                            "id": 91,
-                            "name": "New Dictionary Owner",
-                            "entry_count": 2,
-                            "enabled": True,
-                        }
-                    ]
-                }
-            )
-        )
-        monkeypatch.setattr(
-            PersonasScreen,
-            "_lore_manager",
-            lambda self: object(),
-        )
+        _configure_shared_mode_sources(mock_app_instance, monkeypatch)
         app = PersonasTestApp(mock_app_instance)
 
         async with app.run_test(size=(160, 50)) as pilot:
@@ -4332,6 +4421,13 @@ class TestServerCharacterSourceIsolation:
             original_update_rows = library.update_rows
             stale_render_started = asyncio.Event()
             release_stale_render = asyncio.Event()
+            mode_render_started = asyncio.Event()
+            owner_sort, owner_tag = _observe_shared_mode_render(
+                monkeypatch,
+                screen,
+                new_mode,
+                mode_render_started,
+            )
 
             async def interleaved_to_thread(function, *args, **kwargs):
                 if function is personas_screen_module.count_character_page:
@@ -4360,40 +4456,6 @@ class TestServerCharacterSourceIsolation:
                     stale_render_started.set()
                     await release_stale_render.wait()
 
-            def shared_publication() -> dict[str, object]:
-                rendered_rows = tuple(
-                    (
-                        str(row.id),
-                        tuple(
-                            str(static.renderable)
-                            for static in row.query(Static).results()
-                        ),
-                    )
-                    for row in library.query(".personas-library-row").results()
-                )
-                return {
-                    "mode": screen.state.active_mode,
-                    "rows": rendered_rows,
-                    "count": str(
-                        screen.query_one(
-                            "#personas-library-count",
-                            Static,
-                        ).renderable
-                    ),
-                    "sort": str(
-                        screen.query_one(
-                            "#personas-library-sort",
-                            Button,
-                        ).label
-                    ),
-                    "tag": str(
-                        screen.query_one(
-                            "#personas-library-tag",
-                            Button,
-                        ).label
-                    ),
-                }
-
             monkeypatch.setattr(
                 personas_screen_module.asyncio,
                 "to_thread",
@@ -4412,19 +4474,16 @@ class TestServerCharacterSourceIsolation:
             stale = asyncio.create_task(screen._reload_character_page())
             await stale_render_started.wait()
 
-            await screen._apply_mode(new_mode)
-            owner_sort = f"Sort: {new_mode} owner"
-            owner_tag = f"Tag: {new_mode} owner"
-            library.set_sort_label(owner_sort)
-            library.set_tag_label(owner_tag)
+            newer_mode = asyncio.create_task(screen._apply_mode(new_mode))
+            await mode_render_started.wait()
             await pilot.pause()
-            newer_publication = shared_publication()
 
             release_stale_render.set()
             await stale
+            await newer_mode
             await pilot.pause()
 
-            assert newer_publication == {
+            assert _shared_pane_publication(screen) == {
                 "mode": new_mode,
                 "rows": (
                     (
@@ -4436,10 +4495,366 @@ class TestServerCharacterSourceIsolation:
                 "sort": owner_sort,
                 "tag": owner_tag,
             }
-            assert shared_publication() == newer_publication
             assert screen._characters == []
             assert screen._character_total == 0
             assert screen._count_cache_key is None
+
+    @pytest.mark.parametrize(
+        ("new_mode", "new_kind", "new_name", "new_meta", "new_count"),
+        _SHARED_MODE_OWNER_CASES,
+    )
+    async def test_new_mode_wins_when_stale_character_waits_before_publication(
+        self,
+        mock_app_instance,
+        stub_characters,
+        monkeypatch,
+        new_mode,
+        new_kind,
+        new_name,
+        new_meta,
+        new_count,
+    ):
+        """A mode renderer started behind Characters must publish last."""
+        import asyncio
+
+        _configure_shared_mode_sources(mock_app_instance, monkeypatch)
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            library = screen.query_one("#personas-library-pane")
+            original_update_rows = library.update_rows
+            character_writer_entered = asyncio.Event()
+            release_character_writer = asyncio.Event()
+            mode_render_started = asyncio.Event()
+            owner_sort, owner_tag = _observe_shared_mode_render(
+                monkeypatch,
+                screen,
+                new_mode,
+                mode_render_started,
+            )
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                if function is personas_screen_module.count_character_page:
+                    return 1
+                if function is personas_screen_module.get_character_page_for_ui:
+                    return [{"id": 7, "name": "Older Character Publication"}]
+                if function is PersonasScreen._list_world_books_with_counts:
+                    return [
+                        {
+                            "id": 91,
+                            "name": "New Lore Owner",
+                            "entry_count": 3,
+                            "enabled": True,
+                        }
+                    ]
+                raise AssertionError(f"Unexpected to_thread function: {function!r}")
+
+            async def block_before_character_publication(rows, **kwargs):
+                if tuple(row.name for row in rows) == (
+                    "Older Character Publication",
+                ):
+                    character_writer_entered.set()
+                    await release_character_writer.wait()
+                await original_update_rows(rows, **kwargs)
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+            monkeypatch.setattr(
+                library,
+                "update_rows",
+                block_before_character_publication,
+            )
+            screen._character_db = lambda: object()
+            screen._count_cache_key = None
+
+            stale_character = asyncio.create_task(
+                screen._reload_character_page()
+            )
+            await character_writer_entered.wait()
+
+            newer_mode = asyncio.create_task(screen._apply_mode(new_mode))
+            await mode_render_started.wait()
+            await pilot.pause()
+
+            release_character_writer.set()
+            await stale_character
+            await newer_mode
+            await pilot.pause()
+
+            assert _shared_pane_publication(screen) == {
+                "mode": new_mode,
+                "rows": (
+                    (
+                        f"personas-library-row-{new_kind}-91",
+                        (new_name, new_meta),
+                    ),
+                ),
+                "count": new_count,
+                "sort": owner_sort,
+                "tag": owner_tag,
+            }
+            assert screen._characters == []
+            assert screen._character_total == 0
+
+    @pytest.mark.parametrize(
+        ("new_mode", "new_kind", "new_name", "new_meta", "new_count"),
+        _SHARED_MODE_OWNER_CASES,
+    )
+    async def test_new_mode_wins_when_stale_character_cleanup_is_suspended(
+        self,
+        mock_app_instance,
+        stub_characters,
+        monkeypatch,
+        new_mode,
+        new_kind,
+        new_name,
+        new_meta,
+        new_count,
+    ):
+        """A mode renderer started inside stale cleanup must publish last."""
+        import asyncio
+
+        _configure_shared_mode_sources(mock_app_instance, monkeypatch)
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            library = screen.query_one("#personas-library-pane")
+            original_update_rows = library.update_rows
+            initial_character_published = asyncio.Event()
+            release_initial_character = asyncio.Event()
+            cleanup_writer_entered = asyncio.Event()
+            release_cleanup_writer = asyncio.Event()
+            mode_render_started = asyncio.Event()
+            owner_sort, owner_tag = _observe_shared_mode_render(
+                monkeypatch,
+                screen,
+                new_mode,
+                mode_render_started,
+            )
+            count_calls = 0
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                nonlocal count_calls
+                if function is personas_screen_module.count_character_page:
+                    count_calls += 1
+                    if count_calls == 1:
+                        return 1
+                    raise RuntimeError("newer character page failed")
+                if function is personas_screen_module.get_character_page_for_ui:
+                    return [{"id": 7, "name": "Older Character Publication"}]
+                if function is PersonasScreen._list_world_books_with_counts:
+                    return [
+                        {
+                            "id": 91,
+                            "name": "New Lore Owner",
+                            "entry_count": 3,
+                            "enabled": True,
+                        }
+                    ]
+                raise AssertionError(f"Unexpected to_thread function: {function!r}")
+
+            async def suspend_character_writers(rows, **kwargs):
+                row_names = tuple(row.name for row in rows)
+                if row_names == ("Older Character Publication",):
+                    await original_update_rows(rows, **kwargs)
+                    initial_character_published.set()
+                    await release_initial_character.wait()
+                    return
+                if not rows and kwargs.get("noun") == "characters":
+                    cleanup_writer_entered.set()
+                    await release_cleanup_writer.wait()
+                await original_update_rows(rows, **kwargs)
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+            monkeypatch.setattr(
+                library,
+                "update_rows",
+                suspend_character_writers,
+            )
+            screen._character_db = lambda: object()
+            screen._count_cache_key = None
+            screen.state.tag_filter = "older-tag"
+
+            stale_character = asyncio.create_task(
+                screen._reload_character_page()
+            )
+            await initial_character_published.wait()
+
+            screen.state.tag_filter = None
+            await screen._reload_character_page()
+            release_initial_character.set()
+            await cleanup_writer_entered.wait()
+
+            newer_mode = asyncio.create_task(screen._apply_mode(new_mode))
+            await mode_render_started.wait()
+            await pilot.pause()
+
+            release_cleanup_writer.set()
+            await stale_character
+            await newer_mode
+            await pilot.pause()
+
+            assert _shared_pane_publication(screen) == {
+                "mode": new_mode,
+                "rows": (
+                    (
+                        f"personas-library-row-{new_kind}-91",
+                        (new_name, new_meta),
+                    ),
+                ),
+                "count": new_count,
+                "sort": owner_sort,
+                "tag": owner_tag,
+            }
+            assert screen._characters == []
+            assert screen._character_total == 0
+            assert screen._count_cache_key is None
+
+    @pytest.mark.parametrize(
+        ("source_mode", "owner_change"),
+        (
+            pytest.param("dictionaries", "query", id="dictionaries-query"),
+            pytest.param("dictionaries", "mode", id="dictionaries-mode"),
+            pytest.param("lore", "query", id="lore-query"),
+            pytest.param("lore", "mode", id="lore-mode"),
+        ),
+    )
+    async def test_slow_shared_mode_fetch_cannot_overwrite_changed_owner(
+        self,
+        mock_app_instance,
+        stub_characters,
+        monkeypatch,
+        source_mode,
+        owner_change,
+    ):
+        """Dictionary/Lore results publish only for their captured mode/query."""
+        import asyncio
+
+        fetch_started = asyncio.Event()
+        release_fetch = asyncio.Event()
+        dictionary_calls = 0
+
+        async def list_dictionaries(*, mode, include_inactive):
+            nonlocal dictionary_calls
+            assert (mode, include_inactive) == ("local", True)
+            dictionary_calls += 1
+            if source_mode == "dictionaries" and dictionary_calls == 1:
+                fetch_started.set()
+                await release_fetch.wait()
+                name = "Old Dictionary Result"
+            else:
+                name = "new Dictionary Owner"
+            return {
+                "dictionaries": [
+                    {
+                        "id": 91,
+                        "name": name,
+                        "entry_count": 2,
+                        "enabled": True,
+                    }
+                ]
+            }
+
+        mock_app_instance.runtime_backend = "local"
+        mock_app_instance.chat_dictionary_scope_service = SimpleNamespace(
+            list_dictionaries=list_dictionaries
+        )
+        monkeypatch.setattr(
+            PersonasScreen,
+            "_lore_manager",
+            lambda self: object(),
+        )
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            lore_calls = 0
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                nonlocal lore_calls
+                if function is PersonasScreen._list_world_books_with_counts:
+                    lore_calls += 1
+                    if source_mode == "lore" and lore_calls == 1:
+                        fetch_started.set()
+                        await release_fetch.wait()
+                        name = "Old Lore Result"
+                    else:
+                        name = "new Lore Owner"
+                    return [
+                        {
+                            "id": 91,
+                            "name": name,
+                            "entry_count": 3,
+                            "enabled": True,
+                        }
+                    ]
+                raise AssertionError(f"Unexpected to_thread function: {function!r}")
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+
+            stale_fetch = asyncio.create_task(screen._apply_mode(source_mode))
+            await fetch_started.wait()
+
+            library = screen.query_one("#personas-library-pane")
+            if owner_change == "query":
+                screen.state.search_query = "new"
+                if source_mode == "dictionaries":
+                    await screen._render_dictionary_rows(query="new")
+                    expected_rows = (
+                        (
+                            "personas-library-row-dictionary-91",
+                            ("new Dictionary Owner", "2 entries · on"),
+                        ),
+                    )
+                    expected_count = "1 of 1 dictionary"
+                else:
+                    await screen._render_lore_rows(query="new")
+                    expected_rows = (
+                        (
+                            "personas-library-row-lore-91",
+                            ("new Lore Owner", "3 entries · on"),
+                        ),
+                    )
+                    expected_count = "1 of 1 lore book"
+                expected_mode = source_mode
+            else:
+                await screen._apply_mode("prompts")
+                expected_mode = "prompts"
+                expected_rows = ()
+                expected_count = "0 prompts"
+
+            owner_sort = f"Sort: {expected_mode} current owner"
+            owner_tag = f"Tag: {expected_mode} current owner"
+            library.set_sort_label(owner_sort)
+            library.set_tag_label(owner_tag)
+            await pilot.pause()
+            current_publication = _shared_pane_publication(screen)
+
+            release_fetch.set()
+            await stale_fetch
+            await pilot.pause()
+
+            assert current_publication == {
+                "mode": expected_mode,
+                "rows": expected_rows,
+                "count": expected_count,
+                "sort": owner_sort,
+                "tag": owner_tag,
+            }
+            assert _shared_pane_publication(screen) == current_publication
 
     @pytest.mark.parametrize("older_outcome", ("success", "failure"))
     async def test_server_target_aba_drops_older_request(

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4265,6 +4265,182 @@ class TestServerCharacterSourceIsolation:
                 == "Tag: All"
             )
 
+    @pytest.mark.parametrize(
+        (
+            "new_mode",
+            "new_kind",
+            "new_name",
+            "new_meta",
+            "new_count",
+        ),
+        (
+            (
+                "dictionaries",
+                "dictionary",
+                "New Dictionary Owner",
+                "2 entries · on",
+                "1 dictionary",
+            ),
+            (
+                "lore",
+                "lore",
+                "New Lore Owner",
+                "3 entries · on",
+                "1 lore book",
+            ),
+        ),
+    )
+    async def test_stale_character_render_preserves_newer_shared_mode_publication(
+        self,
+        mock_app_instance,
+        stub_characters,
+        monkeypatch,
+        new_mode,
+        new_kind,
+        new_name,
+        new_meta,
+        new_count,
+    ):
+        """A suspended Characters cleanup cannot erase the newer pane owner."""
+        import asyncio
+
+        mock_app_instance.runtime_backend = "local"
+        mock_app_instance.chat_dictionary_scope_service = SimpleNamespace(
+            list_dictionaries=AsyncMock(
+                return_value={
+                    "dictionaries": [
+                        {
+                            "id": 91,
+                            "name": "New Dictionary Owner",
+                            "entry_count": 2,
+                            "enabled": True,
+                        }
+                    ]
+                }
+            )
+        )
+        monkeypatch.setattr(
+            PersonasScreen,
+            "_lore_manager",
+            lambda self: object(),
+        )
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            library = screen.query_one("#personas-library-pane")
+            original_update_rows = library.update_rows
+            stale_render_started = asyncio.Event()
+            release_stale_render = asyncio.Event()
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                if function is personas_screen_module.count_character_page:
+                    return 1
+                if function is personas_screen_module.get_character_page_for_ui:
+                    return [{"id": 7, "name": "Older Character Publication"}]
+                if (
+                    function
+                    is PersonasScreen._list_world_books_with_counts
+                ):
+                    return [
+                        {
+                            "id": 91,
+                            "name": "New Lore Owner",
+                            "entry_count": 3,
+                            "enabled": True,
+                        }
+                    ]
+                raise AssertionError(f"Unexpected to_thread function: {function!r}")
+
+            async def block_after_character_publication(rows, **kwargs):
+                await original_update_rows(rows, **kwargs)
+                if tuple(row.name for row in rows) == (
+                    "Older Character Publication",
+                ):
+                    stale_render_started.set()
+                    await release_stale_render.wait()
+
+            def shared_publication() -> dict[str, object]:
+                rendered_rows = tuple(
+                    (
+                        str(row.id),
+                        tuple(
+                            str(static.renderable)
+                            for static in row.query(Static).results()
+                        ),
+                    )
+                    for row in library.query(".personas-library-row").results()
+                )
+                return {
+                    "mode": screen.state.active_mode,
+                    "rows": rendered_rows,
+                    "count": str(
+                        screen.query_one(
+                            "#personas-library-count",
+                            Static,
+                        ).renderable
+                    ),
+                    "sort": str(
+                        screen.query_one(
+                            "#personas-library-sort",
+                            Button,
+                        ).label
+                    ),
+                    "tag": str(
+                        screen.query_one(
+                            "#personas-library-tag",
+                            Button,
+                        ).label
+                    ),
+                }
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+            monkeypatch.setattr(
+                library,
+                "update_rows",
+                block_after_character_publication,
+            )
+            screen._character_db = lambda: object()
+            screen._count_cache_key = None
+            screen.state.sort_key = "modified_desc"
+            screen.state.tag_filter = "older-tag"
+
+            stale = asyncio.create_task(screen._reload_character_page())
+            await stale_render_started.wait()
+
+            await screen._apply_mode(new_mode)
+            owner_sort = f"Sort: {new_mode} owner"
+            owner_tag = f"Tag: {new_mode} owner"
+            library.set_sort_label(owner_sort)
+            library.set_tag_label(owner_tag)
+            await pilot.pause()
+            newer_publication = shared_publication()
+
+            release_stale_render.set()
+            await stale
+            await pilot.pause()
+
+            assert newer_publication == {
+                "mode": new_mode,
+                "rows": (
+                    (
+                        f"personas-library-row-{new_kind}-91",
+                        (new_name, new_meta),
+                    ),
+                ),
+                "count": new_count,
+                "sort": owner_sort,
+                "tag": owner_tag,
+            }
+            assert shared_publication() == newer_publication
+            assert screen._characters == []
+            assert screen._character_total == 0
+            assert screen._count_cache_key is None
+
     @pytest.mark.parametrize("older_outcome", ("success", "failure"))
     async def test_server_target_aba_drops_older_request(
         self, mock_app_instance, older_outcome

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4856,6 +4856,217 @@ class TestServerCharacterSourceIsolation:
             }
             assert _shared_pane_publication(screen) == current_publication
 
+    @pytest.mark.parametrize("source_mode", ("dictionaries", "lore"))
+    @pytest.mark.parametrize("older_outcome", ("success", "failure"))
+    async def test_shared_mode_query_aba_drops_older_completion(
+        self,
+        mock_app_instance,
+        stub_characters,
+        monkeypatch,
+        source_mode,
+        older_outcome,
+    ):
+        """Dictionary/Lore X→Y→X keeps the newer X rows and cache."""
+        import asyncio
+
+        fetch_started = asyncio.Event()
+        release_fetch = asyncio.Event()
+        call_count = 0
+        kind = "dictionary" if source_mode == "dictionaries" else "lore"
+        cache_name = (
+            "_dictionaries_cache"
+            if source_mode == "dictionaries"
+            else "_lore_books_cache"
+        )
+        entry_count = 2 if source_mode == "dictionaries" else 3
+
+        def record(item_id: int, name: str) -> dict:
+            return {
+                "id": item_id,
+                "name": name,
+                "entry_count": entry_count,
+                "enabled": True,
+            }
+
+        old_x = record(71, "X older result")
+        y_result = record(72, "Y intermediate result")
+        newer_x = record(73, "X newer winner")
+
+        async def fetch_records() -> list[dict]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fetch_started.set()
+                await release_fetch.wait()
+                if older_outcome == "failure":
+                    raise RuntimeError("older X failed")
+                return [old_x]
+            if call_count == 2:
+                return [y_result]
+            if call_count == 3:
+                return [newer_x]
+            raise AssertionError(f"Unexpected fetch call: {call_count}")
+
+        async def list_dictionaries(*, mode, include_inactive):
+            assert (mode, include_inactive) == ("local", True)
+            return {"dictionaries": await fetch_records()}
+
+        _configure_shared_mode_sources(mock_app_instance, monkeypatch)
+        mock_app_instance.chat_dictionary_scope_service.list_dictionaries = (
+            list_dictionaries
+        )
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                if function is PersonasScreen._list_world_books_with_counts:
+                    return await fetch_records()
+                raise AssertionError(f"Unexpected to_thread function: {function!r}")
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+            library = screen.query_one("#personas-library-pane")
+            screen.state.switch_mode(source_mode)
+            screen.state.search_query = "x"
+            library.set_mode(source_mode)
+            render = (
+                screen._render_dictionary_rows
+                if source_mode == "dictionaries"
+                else screen._render_lore_rows
+            )
+
+            older_x_request = asyncio.create_task(render(query="x"))
+            await fetch_started.wait()
+
+            screen.state.search_query = "y"
+            await render(query="y")
+            screen.state.search_query = "x"
+            await render(query="x")
+            await pilot.pause()
+
+            newer_publication = _shared_pane_publication(screen)
+            newer_cache = deepcopy(getattr(screen, cache_name))
+            assert newer_publication["rows"] == (
+                (
+                    f"personas-library-row-{kind}-73",
+                    ("X newer winner", f"{entry_count} entries · on"),
+                ),
+            )
+            assert newer_cache == [newer_x]
+
+            release_fetch.set()
+            await older_x_request
+            await pilot.pause()
+
+            assert _shared_pane_publication(screen) == newer_publication
+            assert getattr(screen, cache_name) == newer_cache
+
+    @pytest.mark.parametrize("source_mode", ("dictionaries", "lore"))
+    async def test_shared_mode_away_and_back_drops_older_completion(
+        self,
+        mock_app_instance,
+        stub_characters,
+        monkeypatch,
+        source_mode,
+    ):
+        """Dictionary/Lore mode-away→back keeps the newer request owner."""
+        import asyncio
+
+        fetch_started = asyncio.Event()
+        release_fetch = asyncio.Event()
+        call_count = 0
+        kind = "dictionary" if source_mode == "dictionaries" else "lore"
+        cache_name = (
+            "_dictionaries_cache"
+            if source_mode == "dictionaries"
+            else "_lore_books_cache"
+        )
+        entry_count = 2 if source_mode == "dictionaries" else 3
+
+        def record(item_id: int, name: str) -> dict:
+            return {
+                "id": item_id,
+                "name": name,
+                "entry_count": entry_count,
+                "enabled": True,
+            }
+
+        older_result = record(81, "Older before mode return")
+        newer_result = record(82, "Newer after mode return")
+
+        async def fetch_records() -> list[dict]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                fetch_started.set()
+                await release_fetch.wait()
+                return [older_result]
+            if call_count == 2:
+                return [newer_result]
+            raise AssertionError(f"Unexpected fetch call: {call_count}")
+
+        async def list_dictionaries(*, mode, include_inactive):
+            assert (mode, include_inactive) == ("local", True)
+            return {"dictionaries": await fetch_records()}
+
+        _configure_shared_mode_sources(mock_app_instance, monkeypatch)
+        mock_app_instance.chat_dictionary_scope_service.list_dictionaries = (
+            list_dictionaries
+        )
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+
+            async def interleaved_to_thread(function, *args, **kwargs):
+                if function is PersonasScreen._list_world_books_with_counts:
+                    return await fetch_records()
+                raise AssertionError(f"Unexpected to_thread function: {function!r}")
+
+            monkeypatch.setattr(
+                personas_screen_module.asyncio,
+                "to_thread",
+                interleaved_to_thread,
+            )
+            library = screen.query_one("#personas-library-pane")
+            screen.state.switch_mode(source_mode)
+            screen.state.search_query = ""
+            library.set_mode(source_mode)
+            render = (
+                screen._render_dictionary_rows
+                if source_mode == "dictionaries"
+                else screen._render_lore_rows
+            )
+
+            older_request = asyncio.create_task(render())
+            await fetch_started.wait()
+
+            await screen._apply_mode("prompts")
+            await screen._apply_mode(source_mode)
+            await pilot.pause()
+
+            newer_publication = _shared_pane_publication(screen)
+            newer_cache = deepcopy(getattr(screen, cache_name))
+            assert newer_publication["rows"] == (
+                (
+                    f"personas-library-row-{kind}-82",
+                    ("Newer after mode return", f"{entry_count} entries · on"),
+                ),
+            )
+            assert newer_cache == [newer_result]
+
+            release_fetch.set()
+            await older_request
+            await pilot.pause()
+
+            assert _shared_pane_publication(screen) == newer_publication
+            assert getattr(screen, cache_name) == newer_cache
+
     @pytest.mark.parametrize("older_outcome", ("success", "failure"))
     async def test_server_target_aba_drops_older_request(
         self, mock_app_instance, older_outcome

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4093,6 +4093,151 @@ class TestServerCharacterSourceIsolation:
         assert screen._characters == []
         assert screen._character_total == 0
 
+    async def test_stale_local_offset_clamp_cannot_mutate_newer_page(
+        self, mock_app_instance, monkeypatch
+    ):
+        """A stale offset-100 count cannot clamp or render over offset 50."""
+        import asyncio
+
+        screen = PersonasScreen(mock_app_instance)
+        screen.state.runtime_source = "local"
+        screen.state.page_offset = 100
+        screen._character_db = lambda: object()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        count_calls = 0
+
+        async def interleaved_to_thread(function, *args, **kwargs):
+            nonlocal count_calls
+            if function is personas_screen_module.count_character_page:
+                count_calls += 1
+                if count_calls == 1:
+                    started.set()
+                    await release.wait()
+                    return 1
+                return 60
+            if kwargs["offset"] == 50:
+                return [{"id": 50, "name": "Newer offset winner"}]
+            return [{"id": 1, "name": "Stale clamped row"}]
+
+        monkeypatch.setattr(
+            personas_screen_module.asyncio, "to_thread", interleaved_to_thread
+        )
+        notify = Mock()
+        screen._notify = notify
+        display = AsyncMock(wraps=screen._display_character_page)
+        screen._display_character_page = display
+
+        stale = asyncio.create_task(screen._reload_character_page())
+        await started.wait()
+        screen.state.page_offset = 50
+        await screen._reload_character_page()
+        assert screen._characters == [{"id": 50, "name": "Newer offset winner"}]
+
+        release.set()
+        await stale
+
+        assert screen.state.page_offset == 50
+        assert screen._characters == [{"id": 50, "name": "Newer offset winner"}]
+        assert screen._character_total == 60
+        assert display.await_count == 1
+        notify.assert_not_called()
+
+    async def test_local_query_aba_drops_older_success(
+        self, mock_app_instance, monkeypatch
+    ):
+        """Local X→Y→X keeps the newer X page when the older X returns last."""
+        import asyncio
+
+        screen = PersonasScreen(mock_app_instance)
+        screen.state.runtime_source = "local"
+        screen._character_db = lambda: object()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        count_calls = 0
+        x_fetch_calls = 0
+
+        async def interleaved_to_thread(function, *args, **kwargs):
+            nonlocal count_calls, x_fetch_calls
+            if function is personas_screen_module.count_character_page:
+                count_calls += 1
+                if count_calls == 1:
+                    started.set()
+                    await release.wait()
+                return 1
+            if kwargs["search_term"] is not None:
+                return [{"id": 2, "name": "Y page"}]
+            x_fetch_calls += 1
+            if x_fetch_calls == 1:
+                return [{"id": 3, "name": "Newer X winner"}]
+            return [{"id": 1, "name": "Older X result"}]
+
+        monkeypatch.setattr(
+            personas_screen_module.asyncio, "to_thread", interleaved_to_thread
+        )
+
+        older_x = asyncio.create_task(screen._reload_character_page())
+        await started.wait()
+        screen.state.search_query = "y"
+        await screen._reload_character_page()
+        screen.state.search_query = ""
+        await screen._reload_character_page()
+        assert screen._characters == [{"id": 3, "name": "Newer X winner"}]
+
+        release.set()
+        await older_x
+
+        assert screen._characters == [{"id": 3, "name": "Newer X winner"}]
+
+    @pytest.mark.parametrize("older_outcome", ("success", "failure"))
+    async def test_server_target_aba_drops_older_request(
+        self, mock_app_instance, older_outcome
+    ):
+        """Server X→Y→X keeps newer X rows and ignores older X completion."""
+        import asyncio
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+        call_count = 0
+
+        async def list_characters(*, mode, limit, offset):
+            nonlocal call_count
+            assert mode == "server"
+            call_count += 1
+            if call_count == 1:
+                started.set()
+                await release.wait()
+                if older_outcome == "failure":
+                    raise RuntimeError("older X failed")
+                return {"items": [{"id": 1, "name": "Older X"}], "total": 1}
+            if mock_app_instance.active_server_id == "target-y":
+                return {"items": [{"id": 2, "name": "Y page"}], "total": 1}
+            return {"items": [{"id": 3, "name": "Newer X winner"}], "total": 1}
+
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "target-x"
+        mock_app_instance.character_persona_scope_service = SimpleNamespace(
+            list_characters=AsyncMock(side_effect=list_characters)
+        )
+        screen = PersonasScreen(mock_app_instance)
+        notify = Mock()
+        screen._notify = notify
+
+        older_x = asyncio.create_task(screen._reload_server_character_page())
+        await started.wait()
+        mock_app_instance.active_server_id = "target-y"
+        await screen._reload_server_character_page()
+        mock_app_instance.active_server_id = "target-x"
+        await screen._reload_server_character_page()
+        assert screen._characters == [{"id": 3, "name": "Newer X winner"}]
+
+        release.set()
+        await older_x
+
+        assert screen._characters == [{"id": 3, "name": "Newer X winner"}]
+        assert screen._character_total == 1
+        notify.assert_not_called()
+
     @pytest.mark.parametrize(
         "changed_dimension",
         ("source", "target", "mode", "query", "sort", "tag", "offset"),

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3677,6 +3677,501 @@ class TestConsoleActions:
             assert screen._console_action_allowed() is True
 
 
+class TestServerCharacterSourceIsolation:
+    """Server Characters never exposes or crosses into local character seams."""
+
+    @staticmethod
+    def _server_service(
+        *,
+        rows: list[dict] | None = None,
+        detail: dict | None = None,
+    ) -> SimpleNamespace:
+        records = rows if rows is not None else [{"id": 7, "name": "Remote Elara"}]
+        card = (
+            detail
+            if detail is not None
+            else {
+                "id": 7,
+                "name": "Remote Elara",
+                "description": "Server-owned card",
+                "first_message": "Hello from the server.",
+            }
+        )
+        return SimpleNamespace(
+            list_characters=AsyncMock(
+                return_value={
+                    "items": [dict(row) for row in records],
+                    "total": len(records),
+                }
+            ),
+            search_characters=AsyncMock(
+                return_value={
+                    "items": [dict(row) for row in records],
+                    "total": len(records),
+                }
+            ),
+            get_character=AsyncMock(return_value=dict(card)),
+        )
+
+    async def test_source_switch_clears_local_rows_before_server_load_and_gates_actions(
+        self, mock_app_instance, stub_characters
+    ):
+        """A blocked server fetch cannot leave the local page or local controls live."""
+        import asyncio
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+        service = self._server_service()
+
+        async def blocked_list(*, mode, limit, offset):
+            assert mode == "server"
+            started.set()
+            await release.wait()
+            return {"items": [{"id": 7, "name": "Remote Elara"}], "total": 1}
+
+        service.list_characters.side_effect = blocked_list
+        mock_app_instance.runtime_backend = "local"
+        mock_app_instance.active_server_id = "server-a"
+        mock_app_instance.character_persona_scope_service = service
+        mock_app_instance.app_config = {
+            "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
+            "api_settings": {"llama_cpp": {"api_url": "http://127.0.0.1:8181"}},
+        }
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            assert screen.query_one("#personas-library-row-character-1")
+
+            switch = asyncio.create_task(
+                screen.handle_runtime_backend_changed("server")
+            )
+            await started.wait()
+            await pilot.pause()
+
+            assert screen._characters == []
+            assert screen._character_total == 0
+            assert not list(screen.query("#personas-library-row-character-1"))
+
+            release.set()
+            await switch
+            await pilot.pause()
+            await pilot.click("#personas-library-row-character-7")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            for control_id in (
+                "#personas-library-new",
+                "#personas-library-import",
+                "#personas-library-duplicate",
+                "#personas-card-edit-character",
+                "#personas-export-json",
+                "#personas-export-png",
+                "#personas-delete",
+            ):
+                control = screen.query_one(control_id, Button)
+                assert control.disabled or not control.display
+            assert (
+                screen.query_one("#personas-attach-to-console", Button).disabled
+                is False
+            )
+            assert screen.query_one("#personas-start-chat", Button).disabled is False
+
+    async def test_server_action_dispatch_and_direct_local_seams_fail_closed(
+        self, mock_app_instance, stub_characters, monkeypatch
+    ):
+        """Queued events and worker continuations are harmless after a source flip."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+            CharacterSaveRequested,
+            EditCharacterRequested,
+        )
+
+        service = self._server_service()
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "server-a"
+        mock_app_instance.character_persona_scope_service = service
+        app = PersonasTestApp(mock_app_instance)
+
+        local_fetch = Mock(return_value=dict(CHARACTERS[0]))
+        local_create = Mock(return_value=99)
+        local_update = Mock(return_value=True)
+        local_import = Mock(return_value=99)
+        local_delete = Mock(return_value=True)
+        monkeypatch.setattr(
+            character_handler_module, "fetch_character_by_id", local_fetch
+        )
+        monkeypatch.setattr(character_handler_module, "create_character", local_create)
+        monkeypatch.setattr(character_handler_module, "update_character", local_update)
+        monkeypatch.setattr(
+            character_handler_module, "import_character_card", local_import
+        )
+        monkeypatch.setattr(character_handler_module, "delete_character", local_delete)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.click("#personas-library-row-character-7")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            begin_create_impl = screen._begin_create_character
+            open_import_impl = screen._open_import_dialog
+            duplicate_impl = screen._duplicate_selected_character
+            begin_create = AsyncMock()
+            open_import = AsyncMock()
+            duplicate = AsyncMock()
+            screen._begin_create_character = begin_create
+            screen._open_import_dialog = open_import
+            screen._duplicate_selected_character = duplicate
+            for action in ("create", "import", "duplicate"):
+                await screen._handle_action_requested(
+                    PersonaActionRequested(action=action)
+                )
+            begin_create.assert_not_awaited()
+            open_import.assert_not_awaited()
+            duplicate.assert_not_awaited()
+            screen._begin_create_character = begin_create_impl
+            screen._open_import_dialog = open_import_impl
+            screen._duplicate_selected_character = duplicate_impl
+
+            run_worker = Mock()
+            screen.run_worker = run_worker
+            await begin_create_impl()
+            await open_import_impl()
+            await duplicate_impl()
+            assert screen._edit_mode == "view"
+            run_worker.assert_not_called()
+
+            full_record = Mock(return_value=dict(CHARACTERS[0]))
+            save_worker = Mock()
+            screen._full_character_record = full_record
+            screen._save_character_worker = save_worker
+            screen._handle_edit_requested(EditCharacterRequested("7"))
+            screen._handle_save_requested(
+                CharacterSaveRequested({"name": "Must stay remote"})
+            )
+            full_record.assert_not_called()
+            save_worker.assert_not_called()
+
+            await PersonasScreen._save_character_worker.__wrapped__(
+                screen,
+                {"name": "Must stay remote"},
+                "7",
+                "edit",
+            )
+            await screen._import_character_from_path("/tmp/remote-card.json")
+            await screen._export_selected_character("/tmp/remote-card.json", fmt="json")
+            await screen._export_selected_character("/tmp/remote-card.png", fmt="png")
+            await screen._delete_entity("character", "7", 1)
+
+        local_fetch.assert_not_called()
+        local_create.assert_not_called()
+        local_update.assert_not_called()
+        local_import.assert_not_called()
+        local_delete.assert_not_called()
+
+    async def test_server_source_blocks_attachment_and_editor_mutation_messages(
+        self, mock_app_instance, stub_characters, monkeypatch
+    ):
+        """Hidden card/editor controls also fail closed when their messages race."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_character_dictionaries import (
+            CharacterDictionaryAttachRequested,
+            CharacterDictionaryDetachRequested,
+        )
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_character_world_books import (
+            CharacterWorldBookAttachRequested,
+            CharacterWorldBookDetachRequested,
+        )
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+            CharacterAvatarGenerateRequested,
+            CharacterExpressionClearRequested,
+            CharacterExpressionGenerateAllRequested,
+            CharacterExpressionGenerateRequested,
+            CharacterExpressionSetExportRequested,
+            CharacterExpressionSetImportRequested,
+            CharacterExpressionStylePickRequested,
+            CharacterExpressionUploadRequested,
+            CharacterImageRemoveRequested,
+            CharacterImageUploadRequested,
+        )
+
+        dictionary_service = SimpleNamespace(
+            attach_to_character=AsyncMock(),
+            detach_from_character=AsyncMock(),
+        )
+        lore_manager = SimpleNamespace(
+            attach_world_book_to_character=Mock(),
+            detach_world_book_from_character=Mock(),
+        )
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "server-a"
+        mock_app_instance.character_persona_scope_service = self._server_service()
+        mock_app_instance.chat_dictionary_scope_service = dictionary_service
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.click("#personas-library-row-character-7")
+            await pilot.pause()
+            screen.run_worker = Mock()
+            monkeypatch.setattr(
+                PersonasScreen, "_lore_manager", lambda self: lore_manager
+            )
+
+            await screen._handle_character_dictionary_attach(
+                CharacterDictionaryAttachRequested()
+            )
+            await screen._handle_character_dictionary_detach(
+                CharacterDictionaryDetachRequested("facts")
+            )
+            await screen._handle_character_worldbook_attach(
+                CharacterWorldBookAttachRequested()
+            )
+            await screen._handle_character_worldbook_detach(
+                CharacterWorldBookDetachRequested("setting")
+            )
+            for message, handler in (
+                (
+                    CharacterImageUploadRequested(),
+                    screen._handle_character_image_upload_requested,
+                ),
+                (
+                    CharacterImageRemoveRequested(),
+                    screen._handle_character_image_remove,
+                ),
+                (
+                    CharacterExpressionUploadRequested("thinking"),
+                    screen._handle_character_expression_upload_requested,
+                ),
+                (
+                    CharacterExpressionGenerateRequested("thinking"),
+                    screen._handle_character_expression_generate_requested,
+                ),
+                (
+                    CharacterAvatarGenerateRequested(),
+                    screen._handle_character_avatar_generate_requested,
+                ),
+                (
+                    CharacterExpressionGenerateAllRequested(),
+                    screen._handle_character_expression_generate_all_requested,
+                ),
+                (
+                    CharacterExpressionStylePickRequested(),
+                    screen._handle_expression_style_pick_requested,
+                ),
+                (
+                    CharacterExpressionClearRequested("thinking"),
+                    screen._handle_character_expression_clear_requested,
+                ),
+                (
+                    CharacterExpressionSetImportRequested(),
+                    screen._handle_expression_set_import_requested,
+                ),
+                (
+                    CharacterExpressionSetExportRequested(),
+                    screen._handle_expression_set_export_requested,
+                ),
+            ):
+                handler(message)
+
+            screen.run_worker.assert_not_called()
+            dictionary_service.attach_to_character.assert_not_awaited()
+            dictionary_service.detach_from_character.assert_not_awaited()
+            lore_manager.attach_world_book_to_character.assert_not_called()
+            lore_manager.detach_world_book_from_character.assert_not_called()
+
+    async def test_local_page_result_is_dropped_after_source_switch(
+        self, mock_app_instance, monkeypatch
+    ):
+        """A local DB read already in flight cannot publish into server mode."""
+        import asyncio
+
+        screen = PersonasScreen(mock_app_instance)
+        screen.state.runtime_source = "local"
+        screen._character_db = lambda: object()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocked_to_thread(function, *args, **kwargs):
+            if function is personas_screen_module.count_character_page:
+                started.set()
+                await release.wait()
+                return 1
+            return [{"id": 1, "name": "Late local row"}]
+
+        monkeypatch.setattr(
+            personas_screen_module.asyncio, "to_thread", blocked_to_thread
+        )
+        display = AsyncMock()
+        screen._display_character_page = display
+
+        load = asyncio.create_task(screen._reload_character_page())
+        await started.wait()
+        screen.state.runtime_source = "server"
+        release.set()
+        await load
+
+        display.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "changed_dimension",
+        ("source", "target", "mode", "query", "sort", "tag", "offset"),
+    )
+    async def test_server_page_result_is_dropped_after_request_snapshot_changes(
+        self, mock_app_instance, changed_dimension
+    ):
+        """Every source/target/view facet fences an in-flight server result."""
+        import asyncio
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocked_list(*, mode, limit, offset):
+            assert mode == "server"
+            started.set()
+            await release.wait()
+            return {"items": [{"id": 9, "name": "Late server row"}], "total": 1}
+
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "target-a"
+        mock_app_instance.character_persona_scope_service = SimpleNamespace(
+            list_characters=AsyncMock(side_effect=blocked_list)
+        )
+        screen = PersonasScreen(mock_app_instance)
+        screen._characters = [{"id": 1, "name": "Old row"}]
+        screen._character_total = 1
+
+        load = asyncio.create_task(screen._reload_server_character_page())
+        await started.wait()
+        if changed_dimension == "source":
+            screen.state.runtime_source = "local"
+        elif changed_dimension == "target":
+            mock_app_instance.active_server_id = "target-b"
+        elif changed_dimension == "mode":
+            screen.state.active_mode = "personas"
+        elif changed_dimension == "query":
+            screen.state.search_query = "new query"
+        elif changed_dimension == "sort":
+            screen.state.sort_key = "date"
+        elif changed_dimension == "tag":
+            screen.state.tag_filter = "new-tag"
+        else:
+            screen.state.page_offset = (
+                personas_screen_module.PERSONAS_LIBRARY_PAGE_SIZE
+            )
+        release.set()
+        await load
+
+        assert screen._characters == []
+        assert screen._character_total == 0
+
+    async def test_target_b_winner_survives_stale_target_a_failure(
+        self, mock_app_instance
+    ):
+        """A failed A request cannot clear the newer B page."""
+        import asyncio
+
+        started_a = asyncio.Event()
+        release_a = asyncio.Event()
+
+        async def list_characters(*, mode, limit, offset):
+            assert mode == "server"
+            if mock_app_instance.active_server_id == "target-a":
+                started_a.set()
+                await release_a.wait()
+                raise RuntimeError("target A went away")
+            return {"items": [{"id": 2, "name": "Target B"}], "total": 1}
+
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "target-a"
+        mock_app_instance.character_persona_scope_service = SimpleNamespace(
+            list_characters=AsyncMock(side_effect=list_characters)
+        )
+        screen = PersonasScreen(mock_app_instance)
+        screen._characters = [{"id": 1, "name": "Old A"}]
+        screen._character_total = 1
+
+        load_a = asyncio.create_task(screen._reload_server_character_page())
+        await started_a.wait()
+        mock_app_instance.active_server_id = "target-b"
+        await screen._reload_server_character_page()
+        assert screen._characters == [{"id": 2, "name": "Target B"}]
+
+        release_a.set()
+        await load_a
+        assert screen._characters == [{"id": 2, "name": "Target B"}]
+        assert screen._character_total == 1
+
+    @pytest.mark.parametrize(
+        "failure",
+        ("missing-target", "missing-service", "network"),
+    )
+    async def test_server_load_failures_replace_old_rows_with_empty_page(
+        self, mock_app_instance, failure
+    ):
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = (
+            None if failure == "missing-target" else "target-a"
+        )
+        if failure == "missing-service":
+            service = SimpleNamespace()
+        elif failure == "network":
+            service = SimpleNamespace(
+                list_characters=AsyncMock(side_effect=RuntimeError("offline"))
+            )
+        else:
+            service = SimpleNamespace(
+                list_characters=AsyncMock(return_value={"items": [], "total": 0})
+            )
+        mock_app_instance.character_persona_scope_service = service
+        screen = PersonasScreen(mock_app_instance)
+        screen._characters = [{"id": 1, "name": "Stale row"}]
+        screen._character_total = 1
+        screen._count_cache_key = ("stale", None)
+
+        await screen._reload_server_character_page()
+
+        assert screen._characters == []
+        assert screen._character_total == 0
+        assert screen._count_cache_key is None
+
+    async def test_server_search_pages_at_api_limit_without_third_page(
+        self, mock_app_instance
+    ):
+        rows = [{"id": index, "name": f"Remote {index:03d}"} for index in range(1, 121)]
+
+        async def search_characters(query, *, mode, limit):
+            assert query == "remote"
+            assert mode == "server"
+            return {"items": rows[:limit], "total": len(rows)}
+
+        service = self._server_service(rows=[])
+        service.search_characters.side_effect = search_characters
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "target-a"
+        mock_app_instance.character_persona_scope_service = service
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            screen.state.search_query = "remote"
+            await screen._reload_character_page(reset_offset=True)
+            assert [row["id"] for row in screen._characters] == list(range(1, 51))
+
+            await screen._on_page_changed_delta(1)
+            assert [row["id"] for row in screen._characters] == list(range(51, 101))
+            assert screen._character_total == 100
+            assert screen.query_one("#personas-library-next", Button).disabled is True
+
+            await screen._on_page_changed_delta(1)
+            assert screen.state.page_offset == 50
+
+        assert [
+            call.kwargs["limit"] for call in service.search_characters.await_args_list
+        ] == [51, 100]
+
+
 class _FakePreviewGateway:
     """In-memory gateway double: ready resolution + scripted stream.
 

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3287,23 +3287,161 @@ class TestConsoleActions:
         assert payload.suggested_prompt == "Respond as Detective Sam."
 
     async def test_server_start_chat_carries_exact_source_and_active_target(
-        self, mock_app_instance, stub_characters, stub_conversations
+        self,
+        mock_app_instance,
+        stub_characters,
+        stub_conversations,
+        monkeypatch,
     ):
-        """Server Start Chat captures the selected target in the handoff."""
+        """Server browsing, detail, preview, and handoff share one proven card."""
+        local_card = {
+            "id": 1,
+            "name": "Local collision",
+            "description": "Local-only description",
+            "first_message": "Local-only greeting",
+        }
+        server_row = {
+            "id": 1,
+            "name": "Remote Elara",
+            "description": "Server summary",
+        }
+        server_card = {
+            "id": 1,
+            "name": "Remote Elara",
+            "description": "Remote authoritative description",
+            "first_message": "Remote hello from {{char}}.",
+            "system_prompt": "Use the server card.",
+        }
+        local_list = Mock(return_value=[dict(local_card)])
+        local_detail = Mock(return_value=dict(local_card))
+        local_page = Mock(return_value=[dict(local_card)])
+        local_count = Mock(return_value=1)
+        local_conversations = Mock(return_value=[])
+        local_dictionaries = AsyncMock(return_value={"dictionaries": []})
+        local_worldbooks = Mock(return_value=[])
+        local_avatar = AsyncMock()
+        monkeypatch.setattr(
+            character_handler_module,
+            "fetch_all_characters",
+            local_list,
+        )
+        monkeypatch.setattr(
+            character_handler_module,
+            "fetch_character_by_id",
+            local_detail,
+        )
+        monkeypatch.setattr(
+            personas_screen_module,
+            "get_character_page_for_ui",
+            local_page,
+        )
+        monkeypatch.setattr(
+            personas_screen_module,
+            "count_character_page",
+            local_count,
+        )
+        monkeypatch.setattr(
+            conversations_controller_module,
+            "list_character_conversations",
+            local_conversations,
+        )
+        monkeypatch.setattr(
+            PersonasScreen,
+            "_render_inspector_avatar",
+            local_avatar,
+        )
+        monkeypatch.setattr(
+            PersonasScreen,
+            "_lore_manager",
+            lambda self: SimpleNamespace(
+                get_world_books_for_character=local_worldbooks
+            ),
+        )
+
+        row_dto = SimpleNamespace(
+            model_dump=Mock(return_value=dict(server_row))
+        )
+        detail_dto = SimpleNamespace(
+            model_dump=Mock(return_value=dict(server_card))
+        )
+        scope_service = SimpleNamespace(
+            list_characters=AsyncMock(return_value=[row_dto]),
+            search_characters=AsyncMock(
+                return_value={"items": [row_dto], "total": 1}
+            ),
+            get_character=AsyncMock(return_value=detail_dto),
+        )
         mock_app_instance.app_config = {
             "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
             "api_settings": {"llama_cpp": {"api_url": "http://127.0.0.1:8181"}},
         }
         mock_app_instance.runtime_backend = "server"
         mock_app_instance.active_server_id = "configured-target-7"
+        mock_app_instance.character_persona_scope_service = scope_service
+        mock_app_instance.chat_dictionary_scope_service = SimpleNamespace(
+            list_character_dictionaries=local_dictionaries
+        )
         app = PersonasTestApp(mock_app_instance)
         app.open_chat_with_handoff = Mock()
 
         async with app.run_test(size=(160, 50)) as pilot:
-            screen = await self._select_first_character(pilot)
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            row = screen.query_one("#personas-library-row-character-1")
+            assert "Remote Elara" in _row_text(row)
+            assert "Local collision" not in _row_text(row)
+
+            screen.state.search_query = "remote"
+            await screen._reload_character_page(reset_offset=True)
+            await pilot.pause()
+            await pilot.click("#personas-library-row-character-1")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert "Remote Elara" in str(
+                screen.query_one("#personas-character-card-name", Static).renderable
+            )
+            assert "Remote authoritative description" in str(
+                screen.query_one(
+                    "#personas-character-card-description", Static
+                ).renderable
+            )
+            assert "Remote Elara: Remote hello from Remote Elara." in (
+                screen.query_one(PersonasPreviewPane).transcript_text()
+            )
+            assert (
+                screen.query_one("#personas-character-attachments").display is False
+            )
+            assert (
+                screen.query_one("#personas-card-edit-character", Button).disabled
+                is True
+            )
             screen.query_one("#personas-start-chat", Button).press()
             await pilot.pause()
 
+        page_size = personas_screen_module.PERSONAS_LIBRARY_PAGE_SIZE
+        scope_service.list_characters.assert_awaited_once_with(
+            mode="server",
+            limit=page_size + 1,
+            offset=0,
+        )
+        scope_service.search_characters.assert_awaited_once_with(
+            "remote",
+            mode="server",
+            limit=page_size + 1,
+        )
+        scope_service.get_character.assert_awaited_once_with(1, mode="server")
+        row_dto.model_dump.assert_called_with(mode="json")
+        detail_dto.model_dump.assert_called_once_with(mode="json")
+        local_list.assert_not_called()
+        local_page.assert_not_called()
+        local_count.assert_not_called()
+        local_detail.assert_not_called()
+        local_avatar.assert_not_awaited()
+        local_conversations.assert_not_called()
+        local_dictionaries.assert_not_awaited()
+        local_worldbooks.assert_not_called()
         app.open_chat_with_handoff.assert_called_once()
         payload = app.open_chat_with_handoff.call_args.args[0]
         assert payload.source == "personas"
@@ -3314,6 +3452,8 @@ class TestConsoleActions:
         assert payload.metadata["intent"] == "start_chat"
         assert payload.metadata["selected_target_id"] == "server:character:1"
         assert payload.metadata["backend"] == "server"
+        assert "Remote authoritative description" in payload.body
+        assert "Local-only description" not in payload.body
 
     async def test_start_chat_action_guard_blocks_unready_provider(
         self, mock_app_instance, stub_characters, stub_conversations

--- a/backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md
+++ b/backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md
@@ -82,7 +82,7 @@ avatar, dictionary, and lore projections remain local-only; review-driven
 request-generation, ownership, cancellation, authentication, and stale-result
 fences prevent cross-source or superseded UI publication.
 
-Final validation at rebased code revision `00bcdd925` over `origin/dev`
+Full validation at the then-rebased code revision `00bcdd925` over `origin/dev`
 `f3ecd8672`:
 
 - The final 20-file changed-test union produced 1292 passes and 5 inherited
@@ -122,6 +122,12 @@ The final rebase retained `dev`'s non-blocking Personas mount worker and moved
 the source-aware server page reload into that deferred loader. The dedicated
 mount-freeze, exact-server-handoff, and source-switch isolation regressions all
 pass on the rebased history.
+
+Immediately before merge, the branch was rebased without conflict onto the
+newer `origin/dev` revision `13b7f6ee2`. The intervening base changes are
+Watchlists-scoped. The non-blocking Personas mount, exact server handoff,
+source-switch isolation, and legacy Tavern authority regressions passed again
+(4 passed), and `git diff --check origin/dev..HEAD` remained clean.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md
+++ b/backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md
@@ -1,0 +1,136 @@
+---
+id: TASK-617.2
+title: Establish character authority and conversation provenance
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-29 15:43'
+updated_date: '2026-07-30 02:20'
+labels:
+  - roleplay
+  - tts
+  - identity
+dependencies: []
+references:
+  - >-
+    Docs/superpowers/specs/2026-07-28-tts-character-identity-persona-separation-design.md
+  - >-
+    backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md
+parent_task_id: TASK-617
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give local and server-backed character conversations durable, source-aware authority so later TTS assignment resolution can identify the exact character principal without using mutable routing, credentials, paths, or the currently active context. This increment implements approved Slice 3A.2 only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The character database exposes a durable local authority ID that remains stable across restart and is used to identify eligible local character conversations.
+- [x] #2 Each configured server target owns a persisted canonical UUIDv4 authority scope; legacy targets are upgraded atomically before first authority use, and an unpersistable scope is unavailable rather than ephemeral.
+- [x] #3 Server character authority is derived from the persisted target scope and the authenticated positive user ID using the approved versioned encoding, is fenced against target/auth-context changes, remains stable across mutable routing details and credential rotation, separates accounts, and fails closed without blocking ordinary text chat.
+- [x] #4 The main conversation schema adds nullable assistant_authority_id; migration backfills only provable local character provenance, preserves unproven server provenance as null, and supports opaque server character IDs.
+- [x] #5 Application-owned conversation CRUD and backup/restore preserve assistant_authority_id, while current Sync V2 and imports without proven provenance materialize it as null and never infer authority from the receiver's active context.
+- [x] #6 Console character sessions carry source-aware assistant identity sufficient to produce an exact CharacterRef only when authority is proven; generic and Persona sessions remain authority-free.
+- [x] #7 Focused deterministic tests cover authority stability and isolation, stale-context fencing, fail-closed identity errors, schema migration, CRUD, backup/restore, sync/import exclusion, and Console session identity without changing speech admission or TTS selection.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md
+Reason: ADR-037 already governs the authority encoding, authenticated-context fencing, one-column schema migration, backup/restore behavior, privacy rules, and Sync V2 exclusion for Slice 3A.2.
+
+1. Persist redacted canonical UUIDv4 authority scopes on configured targets and durably upgrade legacy missing scopes before authority use.
+2. Add the exact expected-target-bound, runtime/auth-context-fenced server-user authority resolver and encoding.
+3. Add schema v28, the DB-owned local authority accessor, nullable assistant_authority_id, local backfill, and joint conversation identity validation.
+4. Carry provenance through local CRUD/backup while keeping unproven chatbook import and current Sync V2 authority-null.
+5. Make native Console sessions persist and restore source-aware character identity and project CharacterRef only when complete.
+6. Make Roleplay Start Chat handoffs source/target aware without changing speech or assignment behavior.
+7. Run focused regressions/static checks, self-review, and document verification evidence.
+
+Detailed plan: Docs/superpowers/plans/2026-07-29-character-authority-conversation-provenance.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Delivered approved Slice 3A.2. Configured server targets now own persisted,
+redacted UUIDv4 authority scopes with atomic legacy upgrade and fail-closed
+durability checks. The runtime context derives the exact versioned
+`server-user-v1` authority from that scope and the authenticated positive user
+ID, while revision, target, client, credential, and authentication-context
+fences prevent stale or cross-account publication.
+
+Schema v28 adds nullable `assistant_authority_id` and a DB-owned stable local
+authority accessor. Migration backfills only provable local-character rows;
+opaque server characters and unproven records remain authority-null.
+Application-owned CRUD and SQLite backup preserve provenance. Portable
+chatbook, legacy Tavern/SillyTavern, and current Sync V2 boundaries explicitly
+remain authority-null, including when an imported character name or numeric ID
+matches a receiving local card.
+
+Console sessions persist and restore source-aware assistant identity and
+produce `CharacterRef` only for complete, proven local or server character
+principals. Roleplay handoffs preserve the selected source and exact server
+target, fail closed to an unscoped but text-capable session when identity is
+unavailable, and keep generic and Persona sessions authority-free. Local card,
+avatar, dictionary, and lore projections remain local-only; review-driven
+request-generation, ownership, cancellation, authentication, and stale-result
+fences prevent cross-source or superseded UI publication.
+
+Final validation at rebased code revision `00bcdd925` over `origin/dev`
+`f3ecd8672`:
+
+- The final 20-file changed-test union produced 1292 passes and 5 inherited
+  failures. The exact five nodes and failure shapes reproduce on
+  `origin/dev` `f3ecd8672`: four stale module-level `settings` monkeypatches
+  and one existing Personas MagicMock-await import-recovery fixture.
+- The final legacy-import amendment gate passed 156 Character Chat, schema-v28,
+  and Console identity tests. The external audio.cpp/profile regression gate
+  passed 589 tests and did not change synthesis or profile selection.
+- Changed production Python files pass Ruff. The complete changed-file sweep's
+  10 E702 diagnostics are unchanged semicolon lines in
+  `Tests/UI/test_console_character_avatar.py` and reproduce on the same
+  `origin/dev`; the amendment files are clean. `git diff --check` passes.
+- Mypy reports the same 128 errors in the same 7 changed production files on
+  this branch and `origin/dev`; no production typing diagnostic was added.
+  Added/expanded tests remain subject to existing repository typing debt.
+- The required repository-wide gate is blocked during collection by the
+  inherited `StreamDone` import error in
+  `Tests/Event_Handlers/test_worker_events_contract.py`, reproduced on
+  `origin/dev`. A supplemental run excluding that collector reached 654
+  passes and 1 skip with no failures before it was intentionally stopped at
+  2% because the projected runtime was multiple hours.
+
+ADR-037 remains the governing decision. No dependency, speech-admission,
+speech-snapshot, persistent TTS-assignment, managed audio.cpp, production TTS,
+or production Sync V2 change entered this slice.
+
+Two implementation-plan deviations were required by review: Roleplay handoff
+work added narrow shared-pane/authentication race hardening needed to preserve
+the source-provenance contract, and final whole-slice review found the legacy
+Tavern/SillyTavern import boundary outside the originally listed chatbook
+importer. Both were covered by deterministic regressions and stayed within
+AC3, AC5, and AC6. Final independent spec and code review are APPROVED with no
+unresolved Critical or Important finding.
+
+The final rebase retained `dev`'s non-blocking Personas mount worker and moved
+the source-aware server page reload into that deferred loader. The dedicated
+mount-freeze, exact-server-handoff, and source-switch isolation regressions all
+pass on the rebased history.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 All acceptance criteria are checked and implementation notes record the delivered behavior and plan deviations.
+- [x] #2 Deterministic authority, migration, CRUD, backup, import, Sync exclusion, Console, and Roleplay tests cover the new behavior.
+- [x] #3 External audio.cpp and TTS profile regressions pass without selection or synthesis changes.
+- [x] #4 Task-scoped lint, typing comparison, and diff checks pass or exact unchanged `origin/dev` baselines are documented.
+- [x] #5 ADR-037, the approved Slice 3A design, and the detailed implementation plan remain current and linked.
+- [x] #6 Independent specification and code review have no unresolved Critical or Important finding.
+- [x] #7 No speech snapshot, TTS assignment, managed audio.cpp, dependency, production TTS, or production Sync V2 work enters this task.
+<!-- DOD:END -->

--- a/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
+++ b/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
@@ -2900,7 +2900,11 @@ def load_chat_history_from_file_and_save_to_db(
         # Create a new conversation for this imported chat
         conv_title = f"Imported Chat: {actual_char_name_from_db} ({time.strftime('%Y-%m-%d %H:%M')})"
         new_conv_id = db.add_conversation(
-            {"character_id": character_id_from_db, "title": conv_title}
+            {
+                "character_id": character_id_from_db,
+                "title": conv_title,
+                "assistant_authority_id": None,
+            }
         )
 
         if not new_conv_id:

--- a/tldw_chatbook/Chat/chat_conversation_service.py
+++ b/tldw_chatbook/Chat/chat_conversation_service.py
@@ -228,6 +228,9 @@ def normalize_conversation_row(
         "character_id": character_id,
         "assistant_kind": assistant_kind,
         "assistant_id": assistant_id,
+        "assistant_authority_id": _clean_text(
+            conversation_row.get("assistant_authority_id")
+        ),
         "runtime_backend": _normalize_runtime_backend(
             conversation_row.get("runtime_backend")
         ),
@@ -358,6 +361,7 @@ class ChatConversationService:
         character_id: int | None = None,
         assistant_kind: str | None = None,
         assistant_id: str | None = None,
+        assistant_authority_id: str | None = None,
         persona_memory_mode: str | None = None,
         runtime_backend: str | None = None,
         discovery_owner: str | None = None,
@@ -393,6 +397,8 @@ class ChatConversationService:
             "source": source,
             "external_ref": external_ref,
         }
+        if assistant_authority_id is not None:
+            conversation_data["assistant_authority_id"] = assistant_authority_id
         conversation_id = self.db.add_conversation(conversation_data)
         if conversation_id is None:
             raise ValueError("Unable to create chat conversation.")
@@ -515,6 +521,7 @@ class ChatConversationService:
                 normalized_update[key] = _normalize_assistant_kind(value)
             elif key in {
                 "assistant_id",
+                "assistant_authority_id",
                 "persona_memory_mode",
                 "topic_label",
                 "topic_label_source",

--- a/tldw_chatbook/Chat/chat_conversation_service.py
+++ b/tldw_chatbook/Chat/chat_conversation_service.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CONVERSATION_SCOPE_ALL
+
+_ASSISTANT_AUTHORITY_UNSET = cast(str | None, object())
 
 if TYPE_CHECKING:
     from tldw_chatbook.Chat.citation_legacy_migration import (
@@ -361,7 +363,7 @@ class ChatConversationService:
         character_id: int | None = None,
         assistant_kind: str | None = None,
         assistant_id: str | None = None,
-        assistant_authority_id: str | None = None,
+        assistant_authority_id: str | None = _ASSISTANT_AUTHORITY_UNSET,
         persona_memory_mode: str | None = None,
         runtime_backend: str | None = None,
         discovery_owner: str | None = None,
@@ -397,7 +399,7 @@ class ChatConversationService:
             "source": source,
             "external_ref": external_ref,
         }
-        if assistant_authority_id is not None:
+        if assistant_authority_id is not _ASSISTANT_AUTHORITY_UNSET:
             conversation_data["assistant_authority_id"] = assistant_authority_id
         conversation_id = self.db.add_conversation(conversation_data)
         if conversation_id is None:
@@ -519,9 +521,10 @@ class ChatConversationService:
         for key, value in update_data.items():
             if key == "assistant_kind":
                 normalized_update[key] = _normalize_assistant_kind(value)
+            elif key == "assistant_authority_id":
+                normalized_update[key] = value
             elif key in {
                 "assistant_id",
-                "assistant_authority_id",
                 "persona_memory_mode",
                 "topic_label",
                 "topic_label_source",

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -75,6 +75,7 @@ class ChatPersistenceService:
         character_name: Optional[str] = None,
         assistant_kind: Optional[str] = None,
         assistant_id: Optional[str] = None,
+        assistant_authority_id: Optional[str] = None,
         persona_memory_mode: Optional[str] = None,
         runtime_backend: Optional[str] = None,
         discovery_owner: Optional[str] = None,
@@ -94,24 +95,25 @@ class ChatPersistenceService:
             assistant_id=assistant_id,
             explicit_title=conversation_title,
         )
-        conversation_id = self.db.add_conversation(
-            {
-                "character_id": character_id,
-                "assistant_kind": assistant_kind,
-                "assistant_id": assistant_id,
-                "persona_memory_mode": persona_memory_mode,
-                "runtime_backend": runtime_backend,
-                "discovery_owner": discovery_owner,
-                "discovery_entity_id": discovery_entity_id,
-                "scope_type": scope_type,
-                "workspace_id": safe_workspace_id
-                if safe_workspace_id is not None
-                else workspace_id,
-                "title": title,
-                "system_prompt": system_prompt,
-                "client_id": self.db.client_id,
-            }
-        )
+        conversation_data = {
+            "character_id": character_id,
+            "assistant_kind": assistant_kind,
+            "assistant_id": assistant_id,
+            "persona_memory_mode": persona_memory_mode,
+            "runtime_backend": runtime_backend,
+            "discovery_owner": discovery_owner,
+            "discovery_entity_id": discovery_entity_id,
+            "scope_type": scope_type,
+            "workspace_id": safe_workspace_id
+            if safe_workspace_id is not None
+            else workspace_id,
+            "title": title,
+            "system_prompt": system_prompt,
+            "client_id": self.db.client_id,
+        }
+        if assistant_authority_id is not None:
+            conversation_data["assistant_authority_id"] = assistant_authority_id
+        conversation_id = self.db.add_conversation(conversation_data)
         if safe_workspace_id is not None:
             try:
                 self._link_workspace_conversation(

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 from loguru import logger as _logger
 
@@ -13,6 +13,7 @@ from tldw_chatbook.Chat.citation_trace_repository import (
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
 logger = _logger.bind(module="ChatPersistenceService")
+_ASSISTANT_AUTHORITY_UNSET = cast(Optional[str], object())
 
 
 class ChatPersistenceService:
@@ -75,7 +76,7 @@ class ChatPersistenceService:
         character_name: Optional[str] = None,
         assistant_kind: Optional[str] = None,
         assistant_id: Optional[str] = None,
-        assistant_authority_id: Optional[str] = None,
+        assistant_authority_id: Optional[str] = _ASSISTANT_AUTHORITY_UNSET,
         persona_memory_mode: Optional[str] = None,
         runtime_backend: Optional[str] = None,
         discovery_owner: Optional[str] = None,
@@ -111,7 +112,7 @@ class ChatPersistenceService:
             "system_prompt": system_prompt,
             "client_id": self.db.client_id,
         }
-        if assistant_authority_id is not None:
+        if assistant_authority_id is not _ASSISTANT_AUTHORITY_UNSET:
             conversation_data["assistant_authority_id"] = assistant_authority_id
         conversation_id = self.db.add_conversation(conversation_data)
         if safe_workspace_id is not None:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -5552,12 +5552,12 @@ class ConsoleChatController:
             # no-op since nothing will ever read a closed session's state.
             return self._session_closed_result()
         owner = next((s for s in self.store.sessions() if s.id == owner_id), None)
-        # task-427: a character session always takes the plain-provider
+        # A character session always takes the plain-provider
         # path, even with the global agent runtime enabled and a bridge
         # present. Keyed on the message's OWNING session (looked up here,
         # not the controller's active session) so a session switch racing
         # this send can't flip which branch a still-in-flight message uses.
-        force_plain = owner is not None and owner.character_id is not None
+        force_plain = owner is not None and owner.assistant_kind == "character"
         # SP2 /rewind "summarize up to here": at the SINGLE dispatch choke point
         # (agent + direct both flow through here), fold the session's boundary
         # summary into the payload -- but ONLY when the boundary message is

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -34,6 +34,8 @@ from tldw_chatbook.Chat.console_chat_models import (
 )
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.rag_scope import RagScope, SessionScopeHolder
+from tldw_chatbook.TTS.profile_errors import ProfileValidationError
+from tldw_chatbook.TTS.profile_types import CharacterRef
 
 #: Maximum number of attachments a Console session may stage before send.
 MAX_PENDING_ATTACHMENTS = 5
@@ -233,11 +235,48 @@ class ConsoleChatSession:
     #: ``SessionScopeHolder``. ``persist_session_if_needed`` flushes it
     #: through to durable storage exactly once, at first persistence.
     rag_scope_holder: SessionScopeHolder = field(default_factory=SessionScopeHolder)
-    #: When set, this is a character-bound session: it persists with the
-    #: character's id, forces the plain-provider path, and restores as a
-    #: character session (task-427). ``None`` = a normal Console session.
+    #: Durable assistant identity. Authority may be ``None`` for an unscoped
+    #: character; such a session still routes as direct character chat but is
+    #: not eligible for authority-scoped profile assignment.
+    runtime_backend: str = "local"
+    assistant_kind: str | None = "generic"
+    assistant_id: str | None = "console"
+    assistant_authority_id: str | None = None
+    #: Local-only numeric compatibility/display projection. Server character
+    #: IDs remain opaque in ``assistant_id`` and never populate this field.
     character_id: int | None = None
     character_name: str | None = None
+
+    def character_ref(self) -> CharacterRef | None:
+        """Return the complete authority-scoped character identity, if any."""
+        if self.assistant_kind != "character":
+            return None
+        if type(self.assistant_authority_id) is not str:
+            return None
+        if type(self.assistant_id) is not str or not self.assistant_id:
+            return None
+
+        if self.runtime_backend == "local":
+            if (
+                type(self.character_id) is not int
+                or self.character_id < 1
+                or self.assistant_id != str(self.character_id)
+            ):
+                return None
+        elif self.runtime_backend == "server":
+            if self.character_id is not None:
+                return None
+        else:
+            return None
+
+        try:
+            return CharacterRef(
+                source=self.runtime_backend,
+                authority_id=self.assistant_authority_id,
+                character_id=self.assistant_id,
+            )
+        except ProfileValidationError:
+            return None
 
 
 class ConsoleChatStore:
@@ -341,12 +380,24 @@ class ConsoleChatStore:
         title: str = DEFAULT_CONSOLE_SESSION_TITLE,
         workspace_id: str | None = None,
         settings: ConsoleSessionSettings | None = None,
+        runtime_backend: str = "local",
+        assistant_kind: str | None = "generic",
+        assistant_id: str | None = "console",
+        assistant_authority_id: str | None = None,
+        character_id: int | None = None,
+        character_name: str | None = None,
     ) -> ConsoleChatSession:
         """Create and activate a new native Console session."""
         session = ConsoleChatSession(
             title=title,
             workspace_id=workspace_id or self.workspace_context.active_workspace_id,
             settings=settings,
+            runtime_backend=runtime_backend,
+            assistant_kind=assistant_kind,
+            assistant_id=assistant_id,
+            assistant_authority_id=assistant_authority_id,
+            character_id=character_id,
+            character_name=character_name,
         )
         self._sessions[session.id] = session
         self._messages_by_session[session.id] = []
@@ -366,6 +417,12 @@ class ConsoleChatStore:
         all_nodes: Iterable[ConsoleChatMessage],
         active_leaf_persisted_id: str | None = None,
         settings: ConsoleSessionSettings | None = None,
+        runtime_backend: str = "local",
+        assistant_kind: str | None = "generic",
+        assistant_id: str | None = "console",
+        assistant_authority_id: str | None = None,
+        character_id: int | None = None,
+        character_name: str | None = None,
     ) -> ConsoleChatSession:
         """Create and activate a native session from persisted conversation data.
 
@@ -409,6 +466,12 @@ class ConsoleChatStore:
             title=title,
             workspace_id=workspace_id,
             settings=settings,
+            runtime_backend=runtime_backend,
+            assistant_kind=assistant_kind,
+            assistant_id=assistant_id,
+            assistant_authority_id=assistant_authority_id,
+            character_id=character_id,
+            character_name=character_name,
         )
         session.persisted_conversation_id = str(persisted_conversation_id)
         self._ingest_full_tree(
@@ -1900,18 +1963,21 @@ class ConsoleChatStore:
         if self.persistence is None:
             return None
         scope_type, persisted_workspace_id = self._persistence_scope(session)
-        if session.character_id is not None:
-            identity_kwargs = {
-                "assistant_kind": "character",
-                "assistant_id": str(session.character_id),
-                "character_id": session.character_id,
-                "character_name": session.character_name,
-            }
-        else:
-            identity_kwargs = {
-                "assistant_kind": "generic",
-                "assistant_id": "console",
-            }
+        is_local_character = (
+            session.runtime_backend == "local"
+            and session.assistant_kind == "character"
+            and type(session.character_id) is int
+            and session.character_id > 0
+            and session.assistant_id == str(session.character_id)
+        )
+        identity_kwargs = {
+            "runtime_backend": session.runtime_backend,
+            "assistant_kind": session.assistant_kind,
+            "assistant_id": session.assistant_id,
+            "assistant_authority_id": session.assistant_authority_id,
+            "character_id": session.character_id if is_local_character else None,
+            "character_name": session.character_name if is_local_character else None,
+        }
         session.persisted_conversation_id = self.persistence.create_conversation(
             conversation_title=session.title,
             workspace_id=persisted_workspace_id,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -247,6 +247,18 @@ class ConsoleChatSession:
     character_id: int | None = None
     character_name: str | None = None
 
+    def local_character_id(self) -> int | None:
+        """Return the exact validated local character projection, if any."""
+        if (
+            self.runtime_backend != "local"
+            or self.assistant_kind != "character"
+            or type(self.character_id) is not int
+            or self.character_id < 1
+            or self.assistant_id != str(self.character_id)
+        ):
+            return None
+        return self.character_id
+
     def character_ref(self) -> CharacterRef | None:
         """Return the complete authority-scoped character identity, if any."""
         if self.assistant_kind != "character":
@@ -257,11 +269,7 @@ class ConsoleChatSession:
             return None
 
         if self.runtime_backend == "local":
-            if (
-                type(self.character_id) is not int
-                or self.character_id < 1
-                or self.assistant_id != str(self.character_id)
-            ):
+            if self.local_character_id() is None:
                 return None
         elif self.runtime_backend == "server":
             if self.character_id is not None:
@@ -1962,21 +1970,22 @@ class ConsoleChatStore:
             return session.persisted_conversation_id
         if self.persistence is None:
             return None
+        if (
+            type(session.runtime_backend) is not str
+            or session.runtime_backend not in {"local", "server"}
+        ):
+            return None
         scope_type, persisted_workspace_id = self._persistence_scope(session)
-        is_local_character = (
-            session.runtime_backend == "local"
-            and session.assistant_kind == "character"
-            and type(session.character_id) is int
-            and session.character_id > 0
-            and session.assistant_id == str(session.character_id)
-        )
+        local_character_id = session.local_character_id()
         identity_kwargs = {
             "runtime_backend": session.runtime_backend,
             "assistant_kind": session.assistant_kind,
             "assistant_id": session.assistant_id,
             "assistant_authority_id": session.assistant_authority_id,
-            "character_id": session.character_id if is_local_character else None,
-            "character_name": session.character_name if is_local_character else None,
+            "character_id": local_character_id,
+            "character_name": (
+                session.character_name if local_character_id is not None else None
+            ),
         }
         session.persisted_conversation_id = self.persistence.create_conversation(
             conversation_title=session.title,

--- a/tldw_chatbook/Chatbooks/chatbook_importer.py
+++ b/tldw_chatbook/Chatbooks/chatbook_importer.py
@@ -467,6 +467,7 @@ class ChatbookImporter:
                         "updated_at", datetime.now().isoformat()
                     ),
                     "character_id": character_id,
+                    "assistant_authority_id": None,
                     "root_id": f"imported_{conv_data.get('id', 'unknown')}",
                 }
                 # Stage all filesystem work FIRST (attachment byte loads),

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -5927,6 +5927,7 @@ UPDATE db_schema_version
         assistant_authority_id: Any = _UNSET,
         persona_memory_mode: Any = _UNSET,
         runtime_backend: Any = _UNSET,
+        existing_conversation: bool = False,
         existing_character_id: Any = None,
         existing_assistant_kind: Any = None,
         existing_assistant_id: Any = None,
@@ -6041,8 +6042,35 @@ UPDATE db_schema_version
                         "character_id canonical decimal form."
                     )
 
+                existing_kind = self._normalize_nullable_text(
+                    existing_assistant_kind
+                )
+                if existing_kind is not None:
+                    existing_kind = existing_kind.lower()
+                existing_local_identity_unchanged = (
+                    existing_conversation
+                    and self._normalize_runtime_backend(
+                        existing_runtime_backend
+                    )
+                    == "local"
+                    and existing_kind == "character"
+                    and self._normalize_positive_character_id(
+                        existing_character_id
+                    )
+                    == normalized_character_id
+                    and self._normalize_conversation_identity_text(
+                        existing_assistant_id,
+                        field_name="assistant_id",
+                    )
+                    == normalized_assistant_id
+                )
+
                 if authority_was_supplied and supplied_authority is None:
                     normalized_authority = None
+                elif existing_local_identity_unchanged and not authority_was_supplied:
+                    normalized_authority = self._normalize_conversation_authority(
+                        existing_assistant_authority_id
+                    )
                 else:
                     local_authority = self.get_local_authority_id()
                     if (
@@ -7074,6 +7102,7 @@ UPDATE db_schema_version
                             _UNSET,
                         ),
                         runtime_backend=runtime_backend,
+                        existing_conversation=True,
                         existing_character_id=current_state["character_id"],
                         existing_assistant_kind=current_state["assistant_kind"],
                         existing_assistant_id=current_state["assistant_id"],

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -66,6 +66,9 @@ from tldw_chatbook.Utils.private_paths import PrivatePathError, lexical_path
 
 DEFAULT_RUNTIME_BACKEND = "local"
 DEFAULT_DISCOVERY_OWNER = "general_chat"
+_CONVERSATION_IDENTITY_TEXT_MAX_BYTES = 256
+_SQLITE_POSITIVE_INTEGER_MAX = (1 << 63) - 1
+_UNSET = object()
 
 # Sentinel scope for conversation listing that spans every persisted scope
 # ('global' and all workspaces). This is a QUERY-only scope: conversations are
@@ -159,7 +162,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 27  # Adds local-only canonical RAG citation provenance.
+    _CURRENT_SCHEMA_VERSION = 28  # Adds local conversation character authority.
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -2710,6 +2713,50 @@ UPDATE db_schema_version
         """
         return self._get_thread_connection()
 
+    @staticmethod
+    def _local_authority_from_rows(rows: Sequence[sqlite3.Row]) -> str:
+        """Validate the singleton local authority without exposing bad state."""
+
+        if len(rows) != 1:
+            raise CharactersRAGDBError(
+                "Local authority identity is unavailable or invalid."
+            )
+        value = rows[0]["local_authority_id"]
+        if (
+            not isinstance(value, str)
+            or value != value.strip()
+            or not 1
+            <= len(value.encode("utf-8"))
+            <= _CONVERSATION_IDENTITY_TEXT_MAX_BYTES
+        ):
+            raise CharactersRAGDBError(
+                "Local authority identity is unavailable or invalid."
+            )
+        return value
+
+    def get_local_authority_id(self) -> str:
+        """Return this database's stable, bounded local character authority.
+
+        Raises:
+            CharactersRAGDBError: If the default identity is absent, ambiguous,
+                malformed, or cannot be read.
+        """
+
+        try:
+            rows = self.get_connection().execute(
+                """
+                SELECT local_authority_id
+                FROM rag_identity_context
+                WHERE context_name = 'default'
+                LIMIT 2
+                """
+            ).fetchall()
+        except sqlite3.Error as exc:
+            raise CharactersRAGDBError(
+                "Local authority identity is unavailable or invalid."
+            ) from exc
+        return self._local_authority_from_rows(rows)
+
     def close_connection(self):
         """
         Closes the current thread's database connection.
@@ -4018,6 +4065,101 @@ UPDATE db_schema_version
                 f"Migration from V26 to V27 failed for '{self._SCHEMA_NAME}': {exc}"
             ) from exc
 
+    def _execute_character_authority_migration_statement(
+        self,
+        cursor: sqlite3.Cursor,
+        statement: str,
+    ) -> None:
+        """Execute one complete v27→v28 DDL statement."""
+
+        cursor.execute(statement)
+
+    def _backfill_conversation_character_authority(
+        self,
+        cursor: sqlite3.Cursor,
+        local_authority_id: str,
+    ) -> None:
+        """Backfill only legacy rows whose local identity is already provable."""
+
+        cursor.execute(
+            """
+            UPDATE conversations
+               SET assistant_authority_id = ?
+             WHERE runtime_backend = 'local'
+               AND assistant_kind = 'character'
+               AND typeof(character_id) = 'integer'
+               AND character_id > 0
+               AND assistant_id = CAST(character_id AS TEXT)
+            """,
+            (local_authority_id,),
+        )
+
+    def _update_character_authority_schema_version(
+        self,
+        cursor: sqlite3.Cursor,
+    ) -> None:
+        """Advance v27→v28 only after DDL and local backfill succeed."""
+
+        cursor.execute(
+            """
+            UPDATE db_schema_version
+               SET version = 28
+             WHERE schema_name = ?
+               AND version = 27
+            """,
+            (self._SCHEMA_NAME,),
+        )
+        if cursor.rowcount != 1:
+            raise SchemaError(
+                "Character authority schema version update was not applied"
+            )
+
+    def _migrate_from_v27_to_v28(self, conn: sqlite3.Connection) -> None:
+        """Add local conversation authority through one rollback-safe transaction."""
+
+        if self._get_db_version(conn) != 27:
+            raise SchemaError("Character authority migration requires schema version 27")
+        migration_path = (
+            Path(__file__).parent
+            / "migrations"
+            / "chachanotes_v27_to_v28_character_authority.sql"
+        )
+        try:
+            with self.transaction() as cursor:
+                local_authority_id = self.get_local_authority_id()
+                pending = ""
+                for line in migration_path.read_text(encoding="utf-8").splitlines(
+                    keepends=True
+                ):
+                    pending += line
+                    if sqlite3.complete_statement(pending):
+                        self._execute_character_authority_migration_statement(
+                            cursor,
+                            pending,
+                        )
+                        pending = ""
+                if pending.strip():
+                    raise SchemaError(
+                        "Character authority migration contains incomplete SQL"
+                    )
+                self._backfill_conversation_character_authority(
+                    cursor,
+                    local_authority_id,
+                )
+                self._update_character_authority_schema_version(cursor)
+                row = cursor.execute(
+                    "SELECT version FROM db_schema_version WHERE schema_name = ?",
+                    (self._SCHEMA_NAME,),
+                ).fetchone()
+                if row is None or row["version"] != 28:
+                    raise SchemaError(
+                        "Character authority schema version verification failed"
+                    )
+        except (OSError, sqlite3.Error, CharactersRAGDBError) as exc:
+            raise SchemaError(
+                f"Migration from V27 to V28 failed for '{self._SCHEMA_NAME}': {exc}"
+            ) from exc
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -4175,6 +4317,7 @@ UPDATE db_schema_version
                     24: self._migrate_from_v24_to_v25,
                     25: self._migrate_from_v25_to_v26,
                     26: self._migrate_from_v26_to_v27,
+                    27: self._migrate_from_v27_to_v28,
                 }
 
                 if current_db_version == 0:
@@ -5712,63 +5855,248 @@ UPDATE db_schema_version
             return normalized_scope, normalized_workspace_id
         return "global", None
 
-    def _normalize_conversation_assistant_identity(
+    def _normalize_conversation_identity_text(
+        self,
+        value: Any,
+        *,
+        field_name: str,
+    ) -> Optional[str]:
+        normalized = self._normalize_nullable_text(value)
+        if normalized is None:
+            return None
+        if (
+            len(normalized.encode("utf-8"))
+            > _CONVERSATION_IDENTITY_TEXT_MAX_BYTES
+        ):
+            raise InputError(
+                f"{field_name} must not exceed "
+                f"{_CONVERSATION_IDENTITY_TEXT_MAX_BYTES} UTF-8 bytes."
+            )
+        return normalized
+
+    def _normalize_conversation_authority(self, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise InputError("assistant_authority_id must be text or null.")
+        normalized = value.strip()
+        if not normalized:
+            raise InputError(
+                "assistant_authority_id must be non-empty when provided."
+            )
+        if (
+            len(normalized.encode("utf-8"))
+            > _CONVERSATION_IDENTITY_TEXT_MAX_BYTES
+        ):
+            raise InputError(
+                "assistant_authority_id must not exceed "
+                f"{_CONVERSATION_IDENTITY_TEXT_MAX_BYTES} UTF-8 bytes."
+            )
+        return normalized
+
+    @staticmethod
+    def _normalize_positive_character_id(value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise InputError("character_id must be a positive integer.")
+        if isinstance(value, int):
+            normalized = value
+        elif isinstance(value, str) and re.fullmatch(r"[0-9]+", value.strip()):
+            normalized = int(value.strip())
+        else:
+            raise InputError("character_id must be a positive integer.")
+        if not 1 <= normalized <= _SQLITE_POSITIVE_INTEGER_MAX:
+            raise InputError("character_id must be a positive integer.")
+        return normalized
+
+    @staticmethod
+    def _normalize_runtime_backend(runtime_backend: Any) -> str:
+        normalized = CharactersRAGDB._normalize_nullable_text(runtime_backend)
+        runtime_value = (normalized or DEFAULT_RUNTIME_BACKEND).lower()
+        if runtime_value not in {"local", "server"}:
+            return DEFAULT_RUNTIME_BACKEND
+        return runtime_value
+
+    def _normalize_conversation_identity(
         self,
         *,
-        character_id: Any,
-        assistant_kind: Any,
-        assistant_id: Any,
-        persona_memory_mode: Any,
-    ) -> Tuple[Optional[str], Optional[str], Optional[int], Optional[str]]:
-        normalized_kind = self._normalize_nullable_text(assistant_kind)
-        normalized_assistant_id = self._normalize_nullable_text(assistant_id)
-        normalized_memory_mode = self._normalize_nullable_text(persona_memory_mode)
+        character_id: Any = _UNSET,
+        assistant_kind: Any = _UNSET,
+        assistant_id: Any = _UNSET,
+        assistant_authority_id: Any = _UNSET,
+        persona_memory_mode: Any = _UNSET,
+        runtime_backend: Any = _UNSET,
+        existing_character_id: Any = None,
+        existing_assistant_kind: Any = None,
+        existing_assistant_id: Any = None,
+        existing_assistant_authority_id: Any = None,
+        existing_persona_memory_mode: Any = None,
+        existing_runtime_backend: Any = None,
+    ) -> Tuple[
+        str,
+        Optional[str],
+        Optional[str],
+        Optional[int],
+        Optional[str],
+        Optional[str],
+    ]:
+        """Normalize source and assistant provenance as one persisted identity."""
+
+        raw_kind = (
+            existing_assistant_kind
+            if assistant_kind is _UNSET
+            else assistant_kind
+        )
+        raw_assistant_id = (
+            existing_assistant_id if assistant_id is _UNSET else assistant_id
+        )
+        raw_character_id = (
+            existing_character_id if character_id is _UNSET else character_id
+        )
+        raw_memory_mode = (
+            existing_persona_memory_mode
+            if persona_memory_mode is _UNSET
+            else persona_memory_mode
+        )
+        raw_runtime = (
+            existing_runtime_backend
+            if runtime_backend is _UNSET
+            else runtime_backend
+        )
+
+        normalized_runtime = self._normalize_runtime_backend(raw_runtime)
+        normalized_kind = self._normalize_nullable_text(raw_kind)
+        normalized_assistant_id = self._normalize_conversation_identity_text(
+            raw_assistant_id,
+            field_name="assistant_id",
+        )
+        normalized_memory_mode = self._normalize_nullable_text(raw_memory_mode)
 
         if normalized_kind is not None:
             normalized_kind = normalized_kind.lower()
             if normalized_kind not in self._ALLOWED_CONVERSATION_ASSISTANT_KINDS:
                 raise InputError(
-                    f"Invalid assistant_kind '{assistant_kind}'. Allowed: {', '.join(self._ALLOWED_CONVERSATION_ASSISTANT_KINDS)}"
+                    f"Invalid assistant_kind '{raw_kind}'. Allowed: "
+                    f"{', '.join(self._ALLOWED_CONVERSATION_ASSISTANT_KINDS)}"
                 )
-
-        normalized_character_id: Optional[int] = None
-        if character_id is not None:
-            try:
-                normalized_character_id = int(character_id)
-            except (TypeError, ValueError) as exc:
-                raise InputError(
-                    f"character_id must be numeric. Got: {character_id}"
-                ) from exc
-
-        if normalized_kind is None and normalized_character_id is not None:
+        if normalized_kind is None and raw_character_id is not None:
             normalized_kind = "character"
+
+        authority_was_supplied = assistant_authority_id is not _UNSET
+        supplied_authority = (
+            self._normalize_conversation_authority(assistant_authority_id)
+            if authority_was_supplied
+            else None
+        )
 
         if normalized_kind is None:
             if normalized_memory_mode is not None:
                 raise InputError(
                     "persona_memory_mode is only valid for persona-backed conversations."
                 )
-            return None, None, None, None
+            if supplied_authority is not None:
+                raise InputError(
+                    "Generic conversations cannot carry character authority."
+                )
+            return normalized_runtime, None, None, None, None, None
 
         if normalized_kind == "character":
-            if normalized_character_id is None:
-                if normalized_assistant_id is None:
-                    raise InputError(
-                        "Character conversations require 'character_id' or 'assistant_id'."
-                    )
-                try:
-                    normalized_character_id = int(normalized_assistant_id)
-                except (TypeError, ValueError) as exc:
-                    raise InputError(
-                        "Character conversations require 'character_id' when assistant_id is non-numeric."
-                    ) from exc
-            if normalized_assistant_id is None:
-                normalized_assistant_id = str(normalized_character_id)
             if normalized_memory_mode is not None:
                 raise InputError(
                     "persona_memory_mode is only valid for persona-backed conversations."
                 )
-            return "character", normalized_assistant_id, normalized_character_id, None
+
+            if normalized_runtime == "local":
+                normalized_character_id = self._normalize_positive_character_id(
+                    raw_character_id
+                )
+                if normalized_character_id is None:
+                    normalized_character_id = self._normalize_positive_character_id(
+                        normalized_assistant_id
+                    )
+                if normalized_character_id is None:
+                    raise InputError(
+                        "Local character conversations require a positive character_id."
+                    )
+                canonical_assistant_id = str(normalized_character_id)
+                if (
+                    assistant_id is _UNSET
+                    and (
+                        character_id is not _UNSET
+                        or self._normalize_runtime_backend(
+                            existing_runtime_backend
+                        )
+                        != "local"
+                        or self._normalize_nullable_text(existing_assistant_kind)
+                        != "character"
+                    )
+                ):
+                    normalized_assistant_id = canonical_assistant_id
+                elif normalized_assistant_id is None:
+                    normalized_assistant_id = canonical_assistant_id
+                if normalized_assistant_id != canonical_assistant_id:
+                    raise InputError(
+                        "Local character assistant_id must equal the "
+                        "character_id canonical decimal form."
+                    )
+
+                if authority_was_supplied and supplied_authority is None:
+                    normalized_authority = None
+                else:
+                    local_authority = self.get_local_authority_id()
+                    if (
+                        authority_was_supplied
+                        and supplied_authority != local_authority
+                    ):
+                        raise InputError(
+                            "Local character authority must match this "
+                            "database's local authority."
+                        )
+                    normalized_authority = local_authority
+                return (
+                    normalized_runtime,
+                    "character",
+                    normalized_assistant_id,
+                    normalized_character_id,
+                    None,
+                    normalized_authority,
+                )
+
+            if normalized_assistant_id is None and raw_character_id is not None:
+                normalized_assistant_id = str(
+                    self._normalize_positive_character_id(raw_character_id)
+                )
+            if normalized_assistant_id is None:
+                raise InputError(
+                    "Server character conversations require a non-empty assistant_id."
+                )
+            if authority_was_supplied:
+                normalized_authority = supplied_authority
+            elif (
+                self._normalize_runtime_backend(existing_runtime_backend) == "server"
+                and self._normalize_nullable_text(existing_assistant_kind)
+                == "character"
+            ):
+                normalized_authority = self._normalize_conversation_authority(
+                    existing_assistant_authority_id
+                )
+            else:
+                normalized_authority = None
+            return (
+                normalized_runtime,
+                "character",
+                normalized_assistant_id,
+                None,
+                None,
+                normalized_authority,
+            )
+
+        if supplied_authority is not None:
+            raise InputError(
+                f"{normalized_kind.capitalize()} conversations cannot carry "
+                "character authority."
+            )
 
         if normalized_kind == "persona":
             if normalized_assistant_id is None:
@@ -5779,15 +6107,30 @@ UPDATE db_schema_version
                 normalized_memory_mode = normalized_memory_mode.lower()
                 if normalized_memory_mode not in self._ALLOWED_PERSONA_MEMORY_MODES:
                     raise InputError(
-                        f"Invalid persona_memory_mode '{persona_memory_mode}'. Allowed: {', '.join(self._ALLOWED_PERSONA_MEMORY_MODES)}"
+                        f"Invalid persona_memory_mode '{raw_memory_mode}'. Allowed: "
+                        f"{', '.join(self._ALLOWED_PERSONA_MEMORY_MODES)}"
                     )
-            return "persona", normalized_assistant_id, None, normalized_memory_mode
+            return (
+                normalized_runtime,
+                "persona",
+                normalized_assistant_id,
+                None,
+                normalized_memory_mode,
+                None,
+            )
 
         if normalized_memory_mode is not None:
             raise InputError(
                 "persona_memory_mode is only valid for persona-backed conversations."
             )
-        return "generic", normalized_assistant_id, None, None
+        return (
+            normalized_runtime,
+            "generic",
+            normalized_assistant_id,
+            None,
+            None,
+            None,
+        )
 
     def _normalize_conversation_runtime_visibility(
         self,
@@ -5796,13 +6139,10 @@ UPDATE db_schema_version
         discovery_owner: Any,
         discovery_entity_id: Any,
     ) -> Tuple[str, str, Optional[str]]:
-        normalized_runtime = self._normalize_nullable_text(runtime_backend)
         normalized_owner = self._normalize_nullable_text(discovery_owner)
         normalized_entity_id = self._normalize_nullable_text(discovery_entity_id)
 
-        runtime_value = (normalized_runtime or DEFAULT_RUNTIME_BACKEND).strip().lower()
-        if runtime_value not in {"local", "server"}:
-            runtime_value = DEFAULT_RUNTIME_BACKEND
+        runtime_value = self._normalize_runtime_backend(runtime_backend)
 
         owner_value = (normalized_owner or DEFAULT_DISCOVERY_OWNER).strip().lower()
         if owner_value not in {"general_chat", "ccp_character", "ccp_persona"}:
@@ -5850,13 +6190,30 @@ UPDATE db_schema_version
                 "Client ID is required for conversation (either in conv_data or DB instance)."
             )
 
-        assistant_kind, assistant_id, character_id, persona_memory_mode = (
-            self._normalize_conversation_assistant_identity(
-                character_id=conv_data.get("character_id"),
-                assistant_kind=conv_data.get("assistant_kind"),
-                assistant_id=conv_data.get("assistant_id"),
-                persona_memory_mode=conv_data.get("persona_memory_mode"),
+        runtime_backend, discovery_owner, discovery_entity_id = (
+            self._normalize_conversation_runtime_visibility(
+                runtime_backend=conv_data.get("runtime_backend"),
+                discovery_owner=conv_data.get("discovery_owner"),
+                discovery_entity_id=conv_data.get("discovery_entity_id"),
             )
+        )
+        (
+            runtime_backend,
+            assistant_kind,
+            assistant_id,
+            character_id,
+            persona_memory_mode,
+            assistant_authority_id,
+        ) = self._normalize_conversation_identity(
+            character_id=conv_data.get("character_id", _UNSET),
+            assistant_kind=conv_data.get("assistant_kind", _UNSET),
+            assistant_id=conv_data.get("assistant_id", _UNSET),
+            assistant_authority_id=conv_data.get(
+                "assistant_authority_id",
+                _UNSET,
+            ),
+            persona_memory_mode=conv_data.get("persona_memory_mode", _UNSET),
+            runtime_backend=runtime_backend,
         )
         scope_type, workspace_id = self._normalize_scope(
             conv_data.get("scope_type"),
@@ -5876,24 +6233,17 @@ UPDATE db_schema_version
         cluster_id = self._normalize_nullable_text(conv_data.get("cluster_id"))
         source = self._normalize_nullable_text(conv_data.get("source"))
         external_ref = self._normalize_nullable_text(conv_data.get("external_ref"))
-        runtime_backend, discovery_owner, discovery_entity_id = (
-            self._normalize_conversation_runtime_visibility(
-                runtime_backend=conv_data.get("runtime_backend"),
-                discovery_owner=conv_data.get("discovery_owner"),
-                discovery_entity_id=conv_data.get("discovery_entity_id"),
-            )
-        )
         system_prompt = self._normalize_nullable_text(conv_data.get("system_prompt"))
 
         now = self._get_current_utc_timestamp_iso()
         query = """
                 INSERT INTO conversations (id, root_id, forked_from_message_id, parent_conversation_id, \
-                                           character_id, assistant_kind, assistant_id, persona_memory_mode, \
+                                           character_id, assistant_kind, assistant_id, assistant_authority_id, persona_memory_mode, \
                                            scope_type, workspace_id, state, topic_label, topic_label_source, \
                                            topic_last_tagged_at, topic_last_tagged_message_id, cluster_id, source, external_ref, \
                                            runtime_backend, discovery_owner, discovery_entity_id, system_prompt, \
                                            title, rating, created_at, last_modified, client_id, version, deleted) \
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0) \
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0) \
                 """  # created_at added
         params = (
             conv_id,
@@ -5903,6 +6253,7 @@ UPDATE db_schema_version
             character_id,
             assistant_kind,
             assistant_id,
+            assistant_authority_id,
             persona_memory_mode,
             scope_type,
             workspace_id,
@@ -6038,6 +6389,7 @@ UPDATE db_schema_version
                        character_id, \
                        assistant_kind, \
                        assistant_id, \
+                       assistant_authority_id, \
                        runtime_backend, \
                        discovery_owner, \
                        discovery_entity_id, \
@@ -6626,6 +6978,7 @@ UPDATE db_schema_version
                 current_state = conn.execute(
                     """
                     SELECT rowid, title, version, deleted, character_id, assistant_kind, assistant_id,
+                           assistant_authority_id,
                            persona_memory_mode, scope_type, workspace_id, state, topic_label,
                            topic_label_source, topic_last_tagged_at, topic_last_tagged_message_id,
                            cluster_id, source, external_ref,
@@ -6655,19 +7008,21 @@ UPDATE db_schema_version
                         entity_id=conversation_id,
                     )
 
-                assistant_update_requested = any(
+                identity_update_requested = any(
                     field in update_data
                     for field in (
                         "assistant_kind",
                         "assistant_id",
+                        "assistant_authority_id",
                         "character_id",
                         "persona_memory_mode",
+                        "runtime_backend",
                     )
                 )
                 scope_update_requested = (
                     "scope_type" in update_data or "workspace_id" in update_data
                 )
-                runtime_update_requested = any(
+                runtime_visibility_update_requested = any(
                     field in update_data
                     for field in (
                         "runtime_backend",
@@ -6676,27 +7031,66 @@ UPDATE db_schema_version
                     )
                 )
 
-                if assistant_update_requested:
-                    assistant_kind, assistant_id, character_id, persona_memory_mode = (
-                        self._normalize_conversation_assistant_identity(
-                            character_id=update_data.get(
-                                "character_id", current_state["character_id"]
+                if runtime_visibility_update_requested:
+                    runtime_backend, discovery_owner, discovery_entity_id = (
+                        self._normalize_conversation_runtime_visibility(
+                            runtime_backend=update_data.get(
+                                "runtime_backend",
+                                current_state["runtime_backend"],
                             ),
-                            assistant_kind=update_data.get(
-                                "assistant_kind", current_state["assistant_kind"]
+                            discovery_owner=update_data.get(
+                                "discovery_owner",
+                                current_state["discovery_owner"],
                             ),
-                            assistant_id=update_data.get(
-                                "assistant_id", current_state["assistant_id"]
-                            ),
-                            persona_memory_mode=update_data.get(
-                                "persona_memory_mode",
-                                current_state["persona_memory_mode"],
+                            discovery_entity_id=update_data.get(
+                                "discovery_entity_id",
+                                current_state["discovery_entity_id"],
                             ),
                         )
                     )
                 else:
+                    runtime_backend = current_state["runtime_backend"]
+                    discovery_owner = current_state["discovery_owner"]
+                    discovery_entity_id = current_state["discovery_entity_id"]
+
+                if identity_update_requested:
+                    (
+                        runtime_backend,
+                        assistant_kind,
+                        assistant_id,
+                        character_id,
+                        persona_memory_mode,
+                        assistant_authority_id,
+                    ) = self._normalize_conversation_identity(
+                        character_id=update_data.get("character_id", _UNSET),
+                        assistant_kind=update_data.get("assistant_kind", _UNSET),
+                        assistant_id=update_data.get("assistant_id", _UNSET),
+                        assistant_authority_id=update_data.get(
+                            "assistant_authority_id",
+                            _UNSET,
+                        ),
+                        persona_memory_mode=update_data.get(
+                            "persona_memory_mode",
+                            _UNSET,
+                        ),
+                        runtime_backend=runtime_backend,
+                        existing_character_id=current_state["character_id"],
+                        existing_assistant_kind=current_state["assistant_kind"],
+                        existing_assistant_id=current_state["assistant_id"],
+                        existing_assistant_authority_id=current_state[
+                            "assistant_authority_id"
+                        ],
+                        existing_persona_memory_mode=current_state[
+                            "persona_memory_mode"
+                        ],
+                        existing_runtime_backend=current_state["runtime_backend"],
+                    )
+                else:
                     assistant_kind = current_state["assistant_kind"]
                     assistant_id = current_state["assistant_id"]
+                    assistant_authority_id = current_state[
+                        "assistant_authority_id"
+                    ]
                     character_id = current_state["character_id"]
                     persona_memory_mode = current_state["persona_memory_mode"]
 
@@ -6761,26 +7155,6 @@ UPDATE db_schema_version
                         update_data.get("system_prompt")
                     )
 
-                if runtime_update_requested:
-                    runtime_backend, discovery_owner, discovery_entity_id = (
-                        self._normalize_conversation_runtime_visibility(
-                            runtime_backend=update_data.get(
-                                "runtime_backend", current_state["runtime_backend"]
-                            ),
-                            discovery_owner=update_data.get(
-                                "discovery_owner", current_state["discovery_owner"]
-                            ),
-                            discovery_entity_id=update_data.get(
-                                "discovery_entity_id",
-                                current_state["discovery_entity_id"],
-                            ),
-                        )
-                    )
-                else:
-                    runtime_backend = current_state["runtime_backend"]
-                    discovery_owner = current_state["discovery_owner"]
-                    discovery_entity_id = current_state["discovery_entity_id"]
-
                 fields_to_update_sql = []
                 params_for_set_clause = []
 
@@ -6793,11 +7167,12 @@ UPDATE db_schema_version
                 if "metadata" in update_data:  # ADDED (P1e)
                     fields_to_update_sql.append("metadata = ?")  # ADDED
                     params_for_set_clause.append(update_data.get("metadata"))  # ADDED
-                if assistant_update_requested:
+                if identity_update_requested:
                     fields_to_update_sql.extend(
                         [
                             "assistant_kind = ?",
                             "assistant_id = ?",
+                            "assistant_authority_id = ?",
                             "character_id = ?",
                             "persona_memory_mode = ?",
                         ]
@@ -6806,6 +7181,7 @@ UPDATE db_schema_version
                         [
                             assistant_kind,
                             assistant_id,
+                            assistant_authority_id,
                             character_id,
                             persona_memory_mode,
                         ]
@@ -6840,7 +7216,7 @@ UPDATE db_schema_version
                 if "system_prompt" in update_data:
                     fields_to_update_sql.append("system_prompt = ?")
                     params_for_set_clause.append(system_prompt)
-                if runtime_update_requested:
+                if runtime_visibility_update_requested:
                     fields_to_update_sql.extend(
                         [
                             "runtime_backend = ?",

--- a/tldw_chatbook/DB/migrations/chachanotes_v27_to_v28_character_authority.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v27_to_v28_character_authority.sql
@@ -1,0 +1,13 @@
+-- ChaChaNotes v27 -> v28: local conversation character authority.
+-- DDL only. The migration runner owns the transaction, local-only backfill,
+-- and schema-version update. Existing Sync V2 triggers remain unchanged.
+
+ALTER TABLE conversations
+ADD COLUMN assistant_authority_id TEXT
+  CHECK(
+    assistant_authority_id IS NULL
+    OR (
+      typeof(assistant_authority_id) = 'text'
+      AND length(CAST(assistant_authority_id AS BLOB)) BETWEEN 1 AND 256
+    )
+  );

--- a/tldw_chatbook/MCP/server_target_store.py
+++ b/tldw_chatbook/MCP/server_target_store.py
@@ -4,11 +4,25 @@ import json
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import RLock
 from typing import Any, Mapping, Sequence
+from uuid import UUID, uuid4
 
 from .unified_control_models import ConfiguredServerTarget, TargetStatusMetadata
 
 _SERVER_TARGETS_FILENAME = "mcp_server_targets.json"
+_AUTHORITY_SCOPE_UNAVAILABLE_MESSAGE = (
+    "Configured server authority scope is unavailable."
+)
+
+
+class AuthorityScopeUnavailable(RuntimeError):
+    """Raised when a durable configured-target authority scope is unavailable."""
+
+    reason_code = "authority_scope_unavailable"
+
+    def __init__(self) -> None:
+        super().__init__(_AUTHORITY_SCOPE_UNAVAILABLE_MESSAGE)
 
 
 def _default_server_targets_path() -> Path:
@@ -29,6 +43,8 @@ def _default_server_targets_path() -> Path:
 
 
 class ConfiguredServerTargetStore:
+    _authority_scope_lock = RLock()
+
     def __init__(self, path: str | Path | None = None) -> None:
         self.path = Path(path) if path else _default_server_targets_path()
 
@@ -161,6 +177,78 @@ class ConfiguredServerTargetStore:
         self.save_targets(updated_targets)
         return updated_target
 
+    def ensure_authority_scope_id(self, server_id: str) -> str:
+        """Return a validated, durably persisted authority scope for a target.
+
+        Legacy targets without a scope are upgraded under a same-process lock.
+        The generated value is returned only after an atomic save and exact
+        reload verification.
+
+        Args:
+            server_id: Existing configured target routing identifier.
+
+        Returns:
+            The target's canonical lowercase hyphenated UUIDv4 scope.
+
+        Raises:
+            AuthorityScopeUnavailable: If target authority cannot be safely
+                validated, persisted, or reloaded.
+        """
+        normalized_server_id = str(server_id or "").strip()
+        if not normalized_server_id:
+            raise AuthorityScopeUnavailable()
+
+        with self._authority_scope_lock:
+            try:
+                targets = self.list_targets()
+                _validate_authority_scopes(targets)
+                target_indexes = [
+                    index
+                    for index, target in enumerate(targets)
+                    if target.server_id == normalized_server_id
+                ]
+                if len(target_indexes) != 1:
+                    raise AuthorityScopeUnavailable()
+
+                target_index = target_indexes[0]
+                target = targets[target_index]
+                if target.authority_scope_id is not None:
+                    return target.authority_scope_id
+
+                existing_scopes = {
+                    candidate.authority_scope_id
+                    for candidate in targets
+                    if candidate.authority_scope_id is not None
+                }
+                generated_scope = str(uuid4())
+                while generated_scope in existing_scopes:
+                    generated_scope = str(uuid4())
+
+                upgraded_targets = list(targets)
+                upgraded_targets[target_index] = replace(
+                    target,
+                    authority_scope_id=generated_scope,
+                )
+                self.save_targets(upgraded_targets)
+
+                reloaded_targets = self.list_targets()
+                _validate_authority_scopes(reloaded_targets)
+                reloaded_matches = [
+                    candidate
+                    for candidate in reloaded_targets
+                    if candidate.server_id == normalized_server_id
+                ]
+                if (
+                    len(reloaded_matches) != 1
+                    or reloaded_matches[0].authority_scope_id != generated_scope
+                ):
+                    raise AuthorityScopeUnavailable()
+                return generated_scope
+            except AuthorityScopeUnavailable:
+                raise
+            except Exception:
+                raise AuthorityScopeUnavailable() from None
+
     def save_targets(self, targets: Sequence[ConfiguredServerTarget]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
@@ -209,6 +297,7 @@ class ConfiguredServerTargetStore:
             synced_target = replace(
                 legacy_target,
                 is_default=True,
+                authority_scope_id=target.authority_scope_id,
                 last_known_server_label=target.last_known_server_label
                 or legacy_target.last_known_server_label,
                 last_known_reachability=target.last_known_reachability
@@ -263,3 +352,26 @@ def _normalize_optional_text(value: str | None) -> str | None:
         return None
     normalized = str(value).strip()
     return normalized or None
+
+
+def _validate_authority_scopes(
+    targets: Sequence[ConfiguredServerTarget],
+) -> None:
+    seen: set[str] = set()
+    for target in targets:
+        scope = target.authority_scope_id
+        if scope is None:
+            continue
+        if not _is_canonical_uuid4(scope) or scope in seen:
+            raise AuthorityScopeUnavailable()
+        seen.add(scope)
+
+
+def _is_canonical_uuid4(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = UUID(value)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return parsed.version == 4 and str(parsed) == value

--- a/tldw_chatbook/MCP/server_target_store.py
+++ b/tldw_chatbook/MCP/server_target_store.py
@@ -43,7 +43,7 @@ def _default_server_targets_path() -> Path:
 
 
 class ConfiguredServerTargetStore:
-    _authority_scope_lock = RLock()
+    _mutation_lock = RLock()
 
     def __init__(self, path: str | Path | None = None) -> None:
         self.path = Path(path) if path else _default_server_targets_path()
@@ -96,22 +96,23 @@ class ConfiguredServerTargetStore:
         if not normalized_server_id:
             return None
 
-        targets = self.list_targets()
-        updated_targets: list[ConfiguredServerTarget] = []
-        selected_target: ConfiguredServerTarget | None = None
+        with self._mutation_lock:
+            targets = self.list_targets()
+            updated_targets: list[ConfiguredServerTarget] = []
+            selected_target: ConfiguredServerTarget | None = None
 
-        for target in targets:
-            is_default = target.server_id == normalized_server_id
-            updated_target = replace(target, is_default=is_default)
-            updated_targets.append(updated_target)
-            if is_default:
-                selected_target = updated_target
+            for target in targets:
+                is_default = target.server_id == normalized_server_id
+                updated_target = replace(target, is_default=is_default)
+                updated_targets.append(updated_target)
+                if is_default:
+                    selected_target = updated_target
 
-        if selected_target is None:
-            return None
+            if selected_target is None:
+                return None
 
-        self.save_targets(updated_targets)
-        return selected_target
+            self.save_targets(updated_targets)
+            return selected_target
 
     def update_target_status(
         self,
@@ -127,55 +128,60 @@ class ConfiguredServerTargetStore:
         if not normalized_server_id:
             raise KeyError("server_id is required")
 
-        targets = self.list_targets()
-        updated_targets: list[ConfiguredServerTarget] = []
-        updated_target: ConfiguredServerTarget | None = None
+        with self._mutation_lock:
+            targets = self.list_targets()
+            updated_targets: list[ConfiguredServerTarget] = []
+            updated_target: ConfiguredServerTarget | None = None
 
-        for target in targets:
-            if target.server_id != normalized_server_id:
-                updated_targets.append(target)
-                continue
+            for target in targets:
+                if target.server_id != normalized_server_id:
+                    updated_targets.append(target)
+                    continue
 
-            normalized_reachability = _normalize_status_choice(
-                last_known_reachability,
-                valid_values={"unknown", "reachable", "unreachable"},
-            )
-            if normalized_reachability is None:
-                normalized_reachability = target.last_known_reachability
+                normalized_reachability = _normalize_status_choice(
+                    last_known_reachability,
+                    valid_values={"unknown", "reachable", "unreachable"},
+                )
+                if normalized_reachability is None:
+                    normalized_reachability = target.last_known_reachability
 
-            normalized_auth_state = _normalize_status_choice(
-                last_known_auth_state,
-                valid_values={
-                    "unknown",
-                    "authenticated",
-                    "auth_required",
-                    "session_invalid",
-                },
-            )
-            if normalized_auth_state is None:
-                normalized_auth_state = target.last_known_auth_state
+                normalized_auth_state = _normalize_status_choice(
+                    last_known_auth_state,
+                    valid_values={
+                        "unknown",
+                        "authenticated",
+                        "auth_required",
+                        "session_invalid",
+                    },
+                )
+                if normalized_auth_state is None:
+                    normalized_auth_state = target.last_known_auth_state
 
-            normalized_server_label = _normalize_optional_text(last_known_server_label)
-            if normalized_server_label is None:
-                normalized_server_label = target.last_known_server_label
+                normalized_server_label = _normalize_optional_text(
+                    last_known_server_label
+                )
+                if normalized_server_label is None:
+                    normalized_server_label = target.last_known_server_label
 
-            status = TargetStatusMetadata(
-                last_known_server_label=normalized_server_label,
-                last_known_reachability=normalized_reachability,
-                last_known_auth_state=normalized_auth_state,
-                last_connected_at=last_connected_at
-                if last_connected_at is not None
-                else target.last_connected_at,
-                updated_at=updated_at if updated_at is not None else target.updated_at,
-            )
-            updated_target = target.with_status(status)
-            updated_targets.append(updated_target)
+                status = TargetStatusMetadata(
+                    last_known_server_label=normalized_server_label,
+                    last_known_reachability=normalized_reachability,
+                    last_known_auth_state=normalized_auth_state,
+                    last_connected_at=last_connected_at
+                    if last_connected_at is not None
+                    else target.last_connected_at,
+                    updated_at=updated_at
+                    if updated_at is not None
+                    else target.updated_at,
+                )
+                updated_target = target.with_status(status)
+                updated_targets.append(updated_target)
 
-        if updated_target is None:
-            raise KeyError(f"Unknown server_id: {normalized_server_id}")
+            if updated_target is None:
+                raise KeyError(f"Unknown server_id: {normalized_server_id}")
 
-        self.save_targets(updated_targets)
-        return updated_target
+            self.save_targets(updated_targets)
+            return updated_target
 
     def ensure_authority_scope_id(self, server_id: str) -> str:
         """Return a validated, durably persisted authority scope for a target.
@@ -198,7 +204,7 @@ class ConfiguredServerTargetStore:
         if not normalized_server_id:
             raise AuthorityScopeUnavailable()
 
-        with self._authority_scope_lock:
+        with self._mutation_lock:
             try:
                 targets = self.list_targets()
                 _validate_authority_scopes(targets)
@@ -250,30 +256,34 @@ class ConfiguredServerTargetStore:
                 raise AuthorityScopeUnavailable() from None
 
     def save_targets(self, targets: Sequence[ConfiguredServerTarget]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
-        payload = {
-            "targets": [target.to_dict() for target in targets],
-            "updated_at": _datetime_to_iso(datetime.now(timezone.utc)),
-        }
+        with self._mutation_lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            temp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+            payload = {
+                "targets": [target.to_dict() for target in targets],
+                "updated_at": _datetime_to_iso(datetime.now(timezone.utc)),
+            }
 
-        with temp_path.open("w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)
+            with temp_path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
 
-        temp_path.replace(self.path)
+            temp_path.replace(self.path)
 
     def bootstrap_from_legacy_config(
         self, app_config: Mapping[str, Any] | None
     ) -> bool:
-        if self.list_targets():
-            return False
+        with self._mutation_lock:
+            if self.list_targets():
+                return False
 
-        target = ConfiguredServerTarget.from_legacy_tldw_api_config(app_config or {})
-        if target is None:
-            return False
+            target = ConfiguredServerTarget.from_legacy_tldw_api_config(
+                app_config or {}
+            )
+            if target is None:
+                return False
 
-        self.save_targets([target])
-        return True
+            self.save_targets([target])
+            return True
 
     def upsert_legacy_config_target(
         self,
@@ -285,38 +295,39 @@ class ConfiguredServerTargetStore:
         if legacy_target is None:
             return None
 
-        current_targets = self.list_targets()
-        updated_targets: list[ConfiguredServerTarget] = []
-        synced_target: ConfiguredServerTarget | None = None
+        with self._mutation_lock:
+            current_targets = self.list_targets()
+            updated_targets: list[ConfiguredServerTarget] = []
+            synced_target: ConfiguredServerTarget | None = None
 
-        for target in current_targets:
-            if target.server_id != legacy_target.server_id:
-                updated_targets.append(replace(target, is_default=False))
-                continue
+            for target in current_targets:
+                if target.server_id != legacy_target.server_id:
+                    updated_targets.append(replace(target, is_default=False))
+                    continue
 
-            synced_target = replace(
-                legacy_target,
-                is_default=True,
-                authority_scope_id=target.authority_scope_id,
-                last_known_server_label=target.last_known_server_label
-                or legacy_target.last_known_server_label,
-                last_known_reachability=target.last_known_reachability
-                or legacy_target.last_known_reachability,
-                last_known_auth_state=target.last_known_auth_state
-                or legacy_target.last_known_auth_state,
-                last_connected_at=target.last_connected_at
-                or legacy_target.last_connected_at,
-                updated_at=target.updated_at or legacy_target.updated_at,
-            )
-            updated_targets.append(synced_target)
+                synced_target = replace(
+                    legacy_target,
+                    is_default=True,
+                    authority_scope_id=target.authority_scope_id,
+                    last_known_server_label=target.last_known_server_label
+                    or legacy_target.last_known_server_label,
+                    last_known_reachability=target.last_known_reachability
+                    or legacy_target.last_known_reachability,
+                    last_known_auth_state=target.last_known_auth_state
+                    or legacy_target.last_known_auth_state,
+                    last_connected_at=target.last_connected_at
+                    or legacy_target.last_connected_at,
+                    updated_at=target.updated_at or legacy_target.updated_at,
+                )
+                updated_targets.append(synced_target)
 
-        if synced_target is None:
-            synced_target = legacy_target
-            updated_targets.append(synced_target)
+            if synced_target is None:
+                synced_target = legacy_target
+                updated_targets.append(synced_target)
 
-        if updated_targets != current_targets:
-            self.save_targets(updated_targets)
-        return synced_target
+            if updated_targets != current_targets:
+                self.save_targets(updated_targets)
+            return synced_target
 
     def _read_payload(self) -> Any:
         try:

--- a/tldw_chatbook/MCP/unified_control_models.py
+++ b/tldw_chatbook/MCP/unified_control_models.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Mapping
 from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
 
 _VALID_AUTH_MODES = {"api_key", "bearer", "custom_token"}
 _VALID_REACHABILITY_STATES = {"unknown", "reachable", "unreachable"}
@@ -193,6 +194,10 @@ class ConfiguredServerTarget:
     last_known_auth_state: str | None = None
     last_connected_at: datetime | None = None
     updated_at: datetime | None = None
+    authority_scope_id: str | None = field(
+        default_factory=lambda: str(uuid4()),
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         normalized_base_url = self.base_url.rstrip("/")
@@ -232,6 +237,7 @@ class ConfiguredServerTarget:
     def to_dict(self) -> dict[str, Any]:
         return {
             "server_id": self.server_id,
+            "authority_scope_id": self.authority_scope_id,
             "label": self.label,
             "base_url": self.base_url,
             "auth_mode": self.auth_mode,
@@ -247,12 +253,18 @@ class ConfiguredServerTarget:
     @classmethod
     def from_dict(cls, data: Any) -> "ConfiguredServerTarget":
         if not isinstance(data, Mapping):
-            return cls(server_id="", label="", base_url="")
+            return cls(
+                server_id="",
+                label="",
+                base_url="",
+                authority_scope_id=None,
+            )
 
         status = TargetStatusMetadata.from_dict(data.get("status"))
         base_url = _text_or_none(data.get("base_url")) or ""
         return cls(
             server_id=_text_or_none(data.get("server_id")) or "",
+            authority_scope_id=data.get("authority_scope_id"),
             label=_text_or_none(data.get("label")) or "",
             base_url=base_url,
             auth_mode=_coerce_choice(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5723,11 +5723,7 @@ class ChatScreen(BaseAppScreen):
         native_session = self._active_native_console_session()
         if native_session is None:
             return None
-        character_id = getattr(native_session, "character_id", None)
-        try:
-            return int(character_id) if character_id is not None else None
-        except (TypeError, ValueError):
-            return None
+        return native_session.local_character_id()
 
     def _current_console_rail_character_name(self) -> Optional[str]:
         """Active native Console session's character name, or None."""
@@ -11828,7 +11824,7 @@ class ChatScreen(BaseAppScreen):
                     "assistant_kind": session.assistant_kind,
                     "assistant_id": session.assistant_id,
                     "assistant_authority_id": session.assistant_authority_id,
-                    "character_id": session.character_id,
+                    "character_id": session.local_character_id(),
                     "character_name": session.character_name,
                 }
                 for session in store.sessions()

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -987,6 +987,36 @@ def _is_empty_select_value(value: Any) -> bool:
     return value is None or value == Select.BLANK or str(value).startswith("Select.")
 
 
+_MAX_CANONICAL_CHARACTER_ID = (1 << 63) - 1
+_MAX_CANONICAL_CHARACTER_ID_TEXT = str(_MAX_CANONICAL_CHARACTER_ID)
+_CANONICAL_CHARACTER_ID_PATTERN = re.compile(r"[1-9][0-9]{0,18}")
+_SERVER_CHARACTER_AUTHORITY_PATTERN = re.compile(
+    r"server-user-v1:[0-9a-f]{64}"
+)
+
+
+def _canonical_character_id_text(value: Any) -> str | None:
+    """Return an exact signed-64 positive decimal wire ID."""
+    if type(value) is not str:
+        return None
+    if _CANONICAL_CHARACTER_ID_PATTERN.fullmatch(value) is None:
+        return None
+    if (
+        len(value) == len(_MAX_CANONICAL_CHARACTER_ID_TEXT)
+        and value > _MAX_CANONICAL_CHARACTER_ID_TEXT
+    ):
+        return None
+    return value
+
+
+def _canonical_card_character_id(value: Any) -> int | None:
+    """Return a canonical signed-64 positive ID from a card response."""
+    if type(value) is int:
+        return value if 1 <= value <= _MAX_CANONICAL_CHARACTER_ID else None
+    value_text = _canonical_character_id_text(value)
+    return int(value_text) if value_text is not None else None
+
+
 def _character_session_identity_from_handoff(
     payload: ChatHandoffPayload,
 ) -> tuple[str, int, str, str] | None:
@@ -1000,36 +1030,40 @@ def _character_session_identity_from_handoff(
         assistant_id)` when the payload represents a source-aware Personas
         character Start Chat handoff; otherwise `None`.
     """
-    metadata = payload.metadata or {}
+    metadata = payload.metadata
+    if not isinstance(metadata, Mapping):
+        return None
     if (
         payload.source != "personas"
-        or str(metadata.get("intent") or "").strip() != "start_chat"
-        or str(metadata.get("selected_kind") or "").strip() != "character"
+        or payload.item_type != "character-card"
+        or metadata.get("intent") != "start_chat"
+        or metadata.get("selected_kind") != "character"
     ):
         return None
     runtime_backend = payload.runtime_backend
     if runtime_backend not in {"local", "server"}:
         return None
+    if (
+        payload.source_owner != runtime_backend
+        or payload.source_selector_state != runtime_backend
+        or metadata.get("backend") != runtime_backend
+    ):
+        return None
 
-    raw_record_id = metadata.get("selected_record_id")
-    character_id_text = "" if raw_record_id is None else str(raw_record_id).strip()
-    if not character_id_text:
-        target_id = str(metadata.get("selected_target_id") or "").strip()
-        match = re.fullmatch(
-            rf"{re.escape(runtime_backend)}:character:([0-9]+)",
-            target_id,
-        )
-        if match:
-            character_id_text = match.group(1)
-    if not character_id_text.isascii() or not character_id_text.isdecimal():
+    character_id_text = _canonical_character_id_text(
+        metadata.get("selected_record_id")
+    )
+    if character_id_text is None:
+        return None
+    if (
+        metadata.get("selected_target_id")
+        != f"{runtime_backend}:character:{character_id_text}"
+    ):
         return None
 
     character_id = int(character_id_text)
-    if character_id < 1:
-        return None
     character_name = str(metadata.get("selected_name") or payload.title or "").strip()
-    assistant_id = str(character_id)
-    return runtime_backend, character_id, character_name, assistant_id
+    return runtime_backend, character_id, character_name, character_id_text
 
 
 def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
@@ -12235,8 +12269,10 @@ class ChatScreen(BaseAppScreen):
                     resolved_authority_id = None
                 if (
                     type(resolved_authority_id) is str
-                    and resolved_authority_id
-                    and resolved_authority_id == resolved_authority_id.strip()
+                    and _SERVER_CHARACTER_AUTHORITY_PATTERN.fullmatch(
+                        resolved_authority_id
+                    )
+                    is not None
                 ):
                     assistant_authority_id = resolved_authority_id
 
@@ -12263,6 +12299,8 @@ class ChatScreen(BaseAppScreen):
         if not isinstance(card, Mapping) or not card:
             return False
         card = dict(card)
+        if _canonical_card_character_id(card.get("id")) != character_id:
+            return False
 
         if runtime_backend == "server":
             expected_server_id = payload.active_server_profile_id
@@ -12316,6 +12354,10 @@ class ChatScreen(BaseAppScreen):
         try:
             await self._sync_native_console_chat_ui()
             self._focus_console_composer_if_needed(force=True)
+        except asyncio.CancelledError:
+            # The durable commit boundary is above. Report success so the
+            # caller acknowledges this handoff instead of replaying it.
+            return True
         except Exception:
             # The character session (and its greeting) is already durably
             # created above -- a UI-sync/focus failure here must not

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -12225,6 +12225,20 @@ class ChatScreen(BaseAppScreen):
 
         assistant_authority_id: str | None
         local_character_id: int | None
+        server_context_capture: object | None = None
+        server_context_is_current: Callable[[object], bool] | None = None
+
+        def exact_server_context_is_current() -> bool:
+            if (
+                server_context_capture is None
+                or server_context_is_current is None
+            ):
+                return False
+            try:
+                return server_context_is_current(server_context_capture) is True
+            except Exception:
+                return False
+
         if runtime_backend == "local":
             db = getattr(self.app_instance, "chachanotes_db", None)
             get_local_authority_id = getattr(db, "get_local_authority_id", None)
@@ -12257,11 +12271,36 @@ class ChatScreen(BaseAppScreen):
 
             assistant_authority_id = None
             provider = getattr(self.app_instance, "server_context_provider", None)
+            capture_context = getattr(
+                provider,
+                "capture_character_authority_context",
+                None,
+            )
+            server_context_is_current = getattr(
+                provider,
+                "is_character_authority_context_current",
+                None,
+            )
             resolver = getattr(provider, "resolve_character_authority_id", None)
+            if not callable(capture_context) or not callable(
+                server_context_is_current
+            ):
+                return False
+            try:
+                server_context_capture = capture_context(
+                    expected_server_id=expected_server_id
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            if not exact_server_context_is_current():
+                return False
             if callable(resolver):
                 try:
                     resolved_authority_id = await resolver(
-                        expected_server_id=expected_server_id
+                        expected_server_id=expected_server_id,
+                        context_capture=server_context_capture,
                     )
                 except asyncio.CancelledError:
                     raise
@@ -12279,7 +12318,11 @@ class ChatScreen(BaseAppScreen):
             # This is both the post-resolver fence and the immediately
             # pre-card-fetch fence. No card from a newly active target may be
             # used for the ID carried by the handoff.
-            if getattr(self.app_instance, "active_server_id", None) != expected_server_id:
+            if (
+                not exact_server_context_is_current()
+                or getattr(self.app_instance, "active_server_id", None)
+                != expected_server_id
+            ):
                 return False
             local_character_id = None
 
@@ -12304,7 +12347,11 @@ class ChatScreen(BaseAppScreen):
 
         if runtime_backend == "server":
             expected_server_id = payload.active_server_profile_id
-            if getattr(self.app_instance, "active_server_id", None) != expected_server_id:
+            if (
+                not exact_server_context_is_current()
+                or getattr(self.app_instance, "active_server_id", None)
+                != expected_server_id
+            ):
                 return False
 
         # Local import matches this module's existing convention of
@@ -12328,6 +12375,12 @@ class ChatScreen(BaseAppScreen):
             system_prompt=system_prompt,
             character_label=name,
         )
+        if runtime_backend == "server" and (
+            not exact_server_context_is_current()
+            or getattr(self.app_instance, "active_server_id", None)
+            != payload.active_server_profile_id
+        ):
+            return False
         session = store.create_session(
             title=f"Chat with {name}",
             workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -6406,9 +6406,7 @@ class ChatScreen(BaseAppScreen):
             target
         )
         raw_runtime_backend = conversation.get("runtime_backend")
-        if raw_runtime_backend is None:
-            runtime_backend = "local"
-        elif type(raw_runtime_backend) is str:
+        if type(raw_runtime_backend) is str:
             runtime_backend = raw_runtime_backend
         else:
             runtime_backend = ""
@@ -11900,7 +11898,7 @@ class ChatScreen(BaseAppScreen):
                 session_kwargs["runtime_backend"] = (
                     raw_runtime_backend
                     if type(raw_runtime_backend) is str
-                    else ("local" if raw_runtime_backend is None else "")
+                    else ""
                 )
                 for key in (
                     "assistant_kind",

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -6405,6 +6405,37 @@ class ChatScreen(BaseAppScreen):
         active_leaf_id = getattr(db, "get_conversation_active_leaf", lambda _c: None)(
             target
         )
+        raw_runtime_backend = conversation.get("runtime_backend")
+        if raw_runtime_backend is None:
+            runtime_backend = "local"
+        elif type(raw_runtime_backend) is str:
+            runtime_backend = raw_runtime_backend
+        else:
+            runtime_backend = ""
+        raw_assistant_kind = conversation.get("assistant_kind")
+        assistant_kind = (
+            raw_assistant_kind if type(raw_assistant_kind) is str else None
+        )
+        raw_assistant_id = conversation.get("assistant_id")
+        assistant_id = raw_assistant_id if type(raw_assistant_id) is str else None
+        raw_assistant_authority_id = conversation.get("assistant_authority_id")
+        assistant_authority_id = (
+            raw_assistant_authority_id
+            if type(raw_assistant_authority_id) is str
+            else None
+        )
+        raw_character_id = conversation.get("character_id")
+        character_id = (
+            raw_character_id
+            if (
+                runtime_backend == "local"
+                and assistant_kind == "character"
+                and type(raw_character_id) is int
+                and raw_character_id > 0
+                and assistant_id == str(raw_character_id)
+            )
+            else None
+        )
         session = store.restore_persisted_session(
             title=title,
             workspace_id=workspace_id,
@@ -6412,6 +6443,11 @@ class ChatScreen(BaseAppScreen):
             all_nodes=all_nodes,
             active_leaf_persisted_id=active_leaf_id,
             settings=self._console_session_settings_for_resume(conversation),
+            runtime_backend=runtime_backend,
+            assistant_kind=assistant_kind,
+            assistant_id=assistant_id,
+            assistant_authority_id=assistant_authority_id,
+            character_id=character_id,
         )
         # Re-derive display-only agent TOOL markers from AgentRunsDB and overlay
         # them onto the restored active-path VIEW (markers are never tree nodes;
@@ -6423,38 +6459,30 @@ class ChatScreen(BaseAppScreen):
                 store.messages_for_session(session.id), target
             ),
         )
-        # TASK-427: the plain-provider gate (task-3) keys off the active
-        # session's ``character_id`` -- restore it from the persisted
-        # conversation row so a character conversation resumed after an
-        # app restart keeps routing sends off the agent loop.
-        raw_character_id = conversation.get("character_id")
-        if raw_character_id is not None:
-            try:
-                character_id = int(raw_character_id)
-            except (TypeError, ValueError):
-                character_id = None
-            session.character_id = character_id
-            if character_id is not None:
-                # The persisted conversation row carries only the id, so
-                # rehydrate the character name/label from the card. This keeps
-                # the settings identity row reading "Character: <name>" after
-                # resume instead of the Persona fallback. Best-effort: a
-                # missing/failed card leaves ``character_id`` (and the routing
-                # gate) intact.
-                character_name = await self._resolve_resumed_character_name(
-                    character_id
+        # Local presentation remains keyed only by the numeric local
+        # projection. Opaque server identity never enters local card/avatar/
+        # dictionary lookup paths.
+        if (
+            session.runtime_backend == "local"
+            and session.assistant_kind == "character"
+            and session.character_id is not None
+        ):
+            character_name = await self._resolve_resumed_character_name(
+                session.character_id
+            )
+            if character_name:
+                session.character_name = character_name
+            # Always (re)set the label on a local character resume -- to the
+            # resolved name, or clear it when unresolved. ``settings`` are
+            # otherwise inherited from the currently active session, so
+            # leaving an inherited ``character_label`` in place would make
+            # a card-less resume show a *different* character's name.
+            if session.settings is not None:
+                session.settings = replace(
+                    session.settings, character_label=character_name
                 )
-                if character_name:
-                    session.character_name = character_name
-                # Always (re)set the label on a character resume -- to the
-                # resolved name, or clear it when unresolved. ``settings`` are
-                # otherwise inherited from the currently active session, so
-                # leaving an inherited ``character_label`` in place would make
-                # a card-less resume show a *different* character's name.
-                if session.settings is not None:
-                    session.settings = replace(
-                        session.settings, character_label=character_name
-                    )
+        elif session.settings is not None:
+            session.settings = replace(session.settings, character_label="")
         self._set_active_workspace_for_console_session(session.id)
         # task-9/task-13: warm the EFFECTIVE (conversation ∩ workspace)
         # scope cache for this session now (off-loop) so the Inspector row
@@ -11798,9 +11826,10 @@ class ChatScreen(BaseAppScreen):
                     "draft": session.draft,
                     "settings": self._serialize_console_settings(session.settings),
                     "updated_at": session.updated_at,
-                    # task-427: round-trip the character binding so a screen-
-                    # state restore keeps a character session on the plain-
-                    # provider gate instead of reverting it to a generic one.
+                    "runtime_backend": session.runtime_backend,
+                    "assistant_kind": session.assistant_kind,
+                    "assistant_id": session.assistant_id,
+                    "assistant_authority_id": session.assistant_authority_id,
                     "character_id": session.character_id,
                     "character_name": session.character_name,
                 }
@@ -11857,15 +11886,53 @@ class ChatScreen(BaseAppScreen):
             raw_updated_at = raw_session.get("updated_at")
             if raw_updated_at:
                 session_kwargs["updated_at"] = str(raw_updated_at)
-            # task-427: restore the character binding when present. Legacy
-            # payloads (saved before these keys existed) simply omit them and
-            # keep the ConsoleChatSession ``None`` defaults.
+            identity_keys = (
+                "runtime_backend",
+                "assistant_kind",
+                "assistant_id",
+                "assistant_authority_id",
+            )
+            has_source_aware_identity = any(
+                key in raw_session for key in identity_keys
+            )
+            if has_source_aware_identity:
+                raw_runtime_backend = raw_session.get("runtime_backend")
+                session_kwargs["runtime_backend"] = (
+                    raw_runtime_backend
+                    if type(raw_runtime_backend) is str
+                    else ("local" if raw_runtime_backend is None else "")
+                )
+                for key in (
+                    "assistant_kind",
+                    "assistant_id",
+                    "assistant_authority_id",
+                ):
+                    value = raw_session.get(key)
+                    session_kwargs[key] = value if type(value) is str else None
+
             raw_character_id = raw_session.get("character_id")
-            if raw_character_id is not None:
-                try:
-                    session_kwargs["character_id"] = int(raw_character_id)
-                except (TypeError, ValueError):
-                    pass
+            character_id: int | None = None
+            if type(raw_character_id) is int and raw_character_id > 0:
+                if not has_source_aware_identity:
+                    character_id = raw_character_id
+                elif (
+                    session_kwargs.get("runtime_backend") == "local"
+                    and session_kwargs.get("assistant_kind") == "character"
+                    and session_kwargs.get("assistant_id") == str(raw_character_id)
+                ):
+                    character_id = raw_character_id
+            if character_id is not None:
+                session_kwargs["character_id"] = character_id
+            if not has_source_aware_identity and character_id is not None:
+                # Pre-provenance screen state used the numeric local character
+                # projection as its direct-chat routing marker. Preserve that
+                # behavior without inventing a proven authority.
+                session_kwargs.update(
+                    runtime_backend="local",
+                    assistant_kind="character",
+                    assistant_id=str(character_id),
+                    assistant_authority_id=None,
+                )
             raw_character_name = raw_session.get("character_name")
             if raw_character_name is not None:
                 session_kwargs["character_name"] = str(raw_character_name)
@@ -12149,6 +12216,13 @@ class ChatScreen(BaseAppScreen):
             workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
             settings=settings,
         )
+        # This local-only handoff has no proven authority. Record its basic
+        # source/kind/id for direct-chat compatibility while authority-scoped
+        # features continue to fail closed.
+        session.runtime_backend = "local"
+        session.assistant_kind = "character"
+        session.assistant_id = _assistant_id
+        session.assistant_authority_id = None
         session.character_id = character_id
         session.character_name = name
         if greeting:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -989,38 +989,47 @@ def _is_empty_select_value(value: Any) -> bool:
 
 def _character_session_identity_from_handoff(
     payload: ChatHandoffPayload,
-) -> tuple[int, str, str] | None:
+) -> tuple[str, int, str, str] | None:
     """Return character session identity for Personas Start Chat handoffs.
 
     Args:
         payload: Handoff payload staged by a source screen.
 
     Returns:
-        A tuple of `(character_id, character_name, assistant_id)` when the
-        payload represents a Personas character Start Chat handoff; otherwise
-        `None`.
+        A tuple of `(runtime_backend, character_id, character_name,
+        assistant_id)` when the payload represents a source-aware Personas
+        character Start Chat handoff; otherwise `None`.
     """
     metadata = payload.metadata or {}
     if (
-        str(metadata.get("intent") or "").strip() != "start_chat"
+        payload.source != "personas"
+        or str(metadata.get("intent") or "").strip() != "start_chat"
         or str(metadata.get("selected_kind") or "").strip() != "character"
     ):
+        return None
+    runtime_backend = payload.runtime_backend
+    if runtime_backend not in {"local", "server"}:
         return None
 
     raw_record_id = metadata.get("selected_record_id")
     character_id_text = "" if raw_record_id is None else str(raw_record_id).strip()
     if not character_id_text:
         target_id = str(metadata.get("selected_target_id") or "").strip()
-        match = re.search(r"(?:^|:)character:(\d+)$", target_id)
+        match = re.fullmatch(
+            rf"{re.escape(runtime_backend)}:character:([0-9]+)",
+            target_id,
+        )
         if match:
             character_id_text = match.group(1)
-    if not character_id_text.isdecimal():
+    if not character_id_text.isascii() or not character_id_text.isdecimal():
         return None
 
     character_id = int(character_id_text)
+    if character_id < 1:
+        return None
     character_name = str(metadata.get("selected_name") or payload.title or "").strip()
     assistant_id = str(character_id)
-    return character_id, character_name, assistant_id
+    return runtime_backend, character_id, character_name, assistant_id
 
 
 def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
@@ -12170,26 +12179,102 @@ class ChatScreen(BaseAppScreen):
         identity = _character_session_identity_from_handoff(payload)
         if identity is None:
             return False
-        character_id, _name_hint, _assistant_id = identity
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        if db is None:
+        runtime_backend, character_id, name_hint, assistant_id = identity
+        scope_service = getattr(
+            self.app_instance,
+            "character_persona_scope_service",
+            None,
+        )
+        get_character = getattr(scope_service, "get_character", None)
+        if not callable(get_character):
             return False
+
+        assistant_authority_id: str | None
+        local_character_id: int | None
+        if runtime_backend == "local":
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            get_local_authority_id = getattr(db, "get_local_authority_id", None)
+            if not callable(get_local_authority_id):
+                return False
+            try:
+                local_authority_id = get_local_authority_id()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            if (
+                type(local_authority_id) is not str
+                or not local_authority_id
+                or local_authority_id != local_authority_id.strip()
+            ):
+                return False
+            assistant_authority_id = local_authority_id
+            local_character_id = character_id
+        else:
+            expected_server_id = payload.active_server_profile_id
+            if (
+                type(expected_server_id) is not str
+                or not expected_server_id
+                or expected_server_id != expected_server_id.strip()
+            ):
+                return False
+            if getattr(self.app_instance, "active_server_id", None) != expected_server_id:
+                return False
+
+            assistant_authority_id = None
+            provider = getattr(self.app_instance, "server_context_provider", None)
+            resolver = getattr(provider, "resolve_character_authority_id", None)
+            if callable(resolver):
+                try:
+                    resolved_authority_id = await resolver(
+                        expected_server_id=expected_server_id
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    resolved_authority_id = None
+                if (
+                    type(resolved_authority_id) is str
+                    and resolved_authority_id
+                    and resolved_authority_id == resolved_authority_id.strip()
+                ):
+                    assistant_authority_id = resolved_authority_id
+
+            # This is both the post-resolver fence and the immediately
+            # pre-card-fetch fence. No card from a newly active target may be
+            # used for the ID carried by the handoff.
+            if getattr(self.app_instance, "active_server_id", None) != expected_server_id:
+                return False
+            local_character_id = None
+
         try:
-            card = await asyncio.to_thread(db.get_character_card_by_id, character_id)
+            card = await get_character(character_id, mode=runtime_backend)
+            if hasattr(card, "model_dump"):
+                card = card.model_dump(mode="json")
+        except asyncio.CancelledError:
+            raise
         except Exception:
-            logger.opt(exception=True).warning(
-                "Start Chat: character card fetch failed; staging context instead."
+            logger.warning(
+                "Start Chat: character card unavailable; staging context instead "
+                "(source={}).",
+                runtime_backend,
             )
             return False
-        if not card:
+        if not isinstance(card, Mapping) or not card:
             return False
+        card = dict(card)
+
+        if runtime_backend == "server":
+            expected_server_id = payload.active_server_profile_id
+            if getattr(self.app_instance, "active_server_id", None) != expected_server_id:
+                return False
 
         # Local import matches this module's existing convention of
         # deferring Character_Chat submodule imports (they pull in Pillow
         # and CharactersRAGDB) rather than importing them at module scope.
         from ...Character_Chat.Character_Chat_Lib import replace_placeholders
 
-        name = str(card.get("name") or _name_hint or "").strip() or "Character"
+        name = str(card.get("name") or name_hint or "").strip() or "Character"
         parts = [
             str(card.get(key) or "").strip()
             for key in ("system_prompt", "personality", "description", "scenario")
@@ -12209,16 +12294,13 @@ class ChatScreen(BaseAppScreen):
             title=f"Chat with {name}",
             workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
             settings=settings,
+            runtime_backend=runtime_backend,
+            assistant_kind="character",
+            assistant_id=assistant_id,
+            assistant_authority_id=assistant_authority_id,
+            character_id=local_character_id,
+            character_name=name,
         )
-        # This local-only handoff has no proven authority. Record its basic
-        # source/kind/id for direct-chat compatibility while authority-scoped
-        # features continue to fail closed.
-        session.runtime_backend = "local"
-        session.assistant_kind = "character"
-        session.assistant_id = _assistant_id
-        session.assistant_authority_id = None
-        session.character_id = character_id
-        session.character_name = name
         if greeting:
             try:
                 store.append_message(

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1675,6 +1675,10 @@ class PersonasScreen(BaseAppScreen):
         expected_query: str | None = None,
         expected_mode: str | None = None,
     ) -> None:
+        if expected_query is None:
+            expected_query = self.state.search_query
+        if expected_mode is None:
+            expected_mode = "personas"
         if not self._library_render_snapshot_is_current(
             expected_query=expected_query,
             expected_mode=expected_mode,
@@ -1978,31 +1982,37 @@ class PersonasScreen(BaseAppScreen):
 
     async def _render_dictionary_rows(self, query: str = "") -> None:
         """Fetch and render dictionary rows; degrade to recovery copy on failure."""
-        library = self.query_one(PersonasLibraryPane)
+        expected_mode = "dictionaries"
+        expected_query = query
+        if not self._library_render_snapshot_is_current(
+            expected_query=expected_query,
+            expected_mode=expected_mode,
+        ):
+            return
+
         service = self._dictionary_scope_service()
+        recovery_copy: str | None = None
         if service is None:
-            await library.update_rows(
-                (),
-                total=0,
-                noun="dictionaries",
-                recovery_copy="Dictionaries are unavailable: the service is not configured.",
+            records: list[dict] = []
+            recovery_copy = (
+                "Dictionaries are unavailable: the service is not configured."
             )
-            return
-        try:
-            response = await service.list_dictionaries(
-                mode="local", include_inactive=True
-            )
-            records = list(response.get("dictionaries") or [])
-        except Exception:
-            logger.opt(exception=True).warning("Could not list chat dictionaries.")
-            await library.update_rows(
-                (),
-                total=0,
-                noun="dictionaries",
-                recovery_copy="Dictionaries could not be loaded.\nSwitch modes and back to retry.",
-            )
-            return
-        self._dictionaries_cache = records
+        else:
+            try:
+                response = await service.list_dictionaries(
+                    mode="local", include_inactive=True
+                )
+                records = list(response.get("dictionaries") or [])
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not list chat dictionaries."
+                )
+                records = []
+                recovery_copy = (
+                    "Dictionaries could not be loaded.\n"
+                    "Switch modes and back to retry."
+                )
+
         needle = query.strip().lower()
         visible = (
             [r for r in records if needle in str(r.get("name", "")).lower()]
@@ -2010,12 +2020,22 @@ class PersonasScreen(BaseAppScreen):
             else records
         )
         rows = tuple(self._dictionary_row(r) for r in visible)
-        await library.update_rows(
-            rows,
-            total=len(records),
-            noun="dictionaries",
-            filtered=bool(needle),
-        )
+        async with self._render_lock:
+            if not self._library_render_snapshot_is_current(
+                expected_query=expected_query,
+                expected_mode=expected_mode,
+            ):
+                return
+            if recovery_copy is None:
+                self._dictionaries_cache = records
+            library = self.query_one(PersonasLibraryPane)
+            await library.update_rows(
+                rows,
+                total=len(records),
+                noun="dictionaries",
+                filtered=bool(needle),
+                recovery_copy=recovery_copy,
+            )
 
     def _lore_manager(self) -> Any:
         """A ``WorldBookManager`` bound to the app's local DB, or None when absent."""
@@ -2045,30 +2065,34 @@ class PersonasScreen(BaseAppScreen):
 
     async def _render_lore_rows(self, query: str = "") -> None:
         """Fetch and render lore/world-book rows; degrade to recovery copy on failure."""
-        library = self.query_one(PersonasLibraryPane)
+        expected_mode = "lore"
+        expected_query = query
+        if not self._library_render_snapshot_is_current(
+            expected_query=expected_query,
+            expected_mode=expected_mode,
+        ):
+            return
+
         manager = self._lore_manager()
+        recovery_copy: str | None = None
         if manager is None:
-            await library.update_rows(
-                (),
-                total=0,
-                noun="lore books",
-                recovery_copy="Lore is unavailable: the database is not configured.",
+            records: list[dict] = []
+            recovery_copy = (
+                "Lore is unavailable: the database is not configured."
             )
-            return
-        try:
-            records = await asyncio.to_thread(
-                self._list_world_books_with_counts, manager
-            )
-        except Exception:
-            logger.opt(exception=True).warning("Could not list lore books.")
-            await library.update_rows(
-                (),
-                total=0,
-                noun="lore books",
-                recovery_copy="Lore books could not be loaded.\nSwitch modes and back to retry.",
-            )
-            return
-        self._lore_books_cache = records
+        else:
+            try:
+                records = await asyncio.to_thread(
+                    self._list_world_books_with_counts, manager
+                )
+            except Exception:
+                logger.opt(exception=True).warning("Could not list lore books.")
+                records = []
+                recovery_copy = (
+                    "Lore books could not be loaded.\n"
+                    "Switch modes and back to retry."
+                )
+
         needle = query.strip().lower()
         visible = (
             [r for r in records if needle in str(r.get("name", "")).lower()]
@@ -2076,12 +2100,22 @@ class PersonasScreen(BaseAppScreen):
             else records
         )
         rows = tuple(self._lore_row(r) for r in visible)
-        await library.update_rows(
-            rows,
-            total=len(records),
-            noun="lore books",
-            filtered=bool(needle),
-        )
+        async with self._render_lock:
+            if not self._library_render_snapshot_is_current(
+                expected_query=expected_query,
+                expected_mode=expected_mode,
+            ):
+                return
+            if recovery_copy is None:
+                self._lore_books_cache = records
+            library = self.query_one(PersonasLibraryPane)
+            await library.update_rows(
+                rows,
+                total=len(records),
+                noun="lore books",
+                filtered=bool(needle),
+                recovery_copy=recovery_copy,
+            )
 
     # ===== Mode switching =====
 
@@ -2178,7 +2212,12 @@ class PersonasScreen(BaseAppScreen):
             self._show_center(None)
         elif mode == "personas":
             self._profile_lookup_recovery_state = None
-            await library.update_rows((), total=0, noun="personas")
+            async with self._render_lock:
+                if self._library_render_snapshot_is_current(
+                    expected_query="",
+                    expected_mode=mode,
+                ):
+                    await library.update_rows((), total=0, noun="personas")
             self._show_center(None)
             self._refresh_profile_rows_worker()
         elif mode == "dictionaries":
@@ -2188,9 +2227,16 @@ class PersonasScreen(BaseAppScreen):
             await self._render_lore_rows()
             self._show_center(None)
         else:
-            await library.update_rows(
-                (), total=0, noun=MODE_LABELS.get(mode, mode).lower()
-            )
+            async with self._render_lock:
+                if self._library_render_snapshot_is_current(
+                    expected_query="",
+                    expected_mode=mode,
+                ):
+                    await library.update_rows(
+                        (),
+                        total=0,
+                        noun=MODE_LABELS.get(mode, mode).lower(),
+                    )
             self.query_one("#personas-mode-placeholder", Static).update(
                 self._mode_placeholder_text(mode)
             )
@@ -4417,7 +4463,7 @@ class PersonasScreen(BaseAppScreen):
             logger.opt(exception=True).warning("Could not create a dictionary.")
             self._notify(f"Create failed: {exc}", "error")
             return
-        await self._render_dictionary_rows(query="")
+        await self._render_dictionary_rows(query=self.state.search_query)
         await self._select_dictionary(
             str(record.get("id")), str(record.get("name") or name)
         )
@@ -4582,7 +4628,7 @@ class PersonasScreen(BaseAppScreen):
                     f"Duplicated, but the strategy could not be copied ({exc}). Set it in Settings.",
                     "warning",
                 )
-        await self._render_dictionary_rows(query="")
+        await self._render_dictionary_rows(query=self.state.search_query)
         await self._select_dictionary(
             str(record.get("id")), str(record.get("name") or name)
         )
@@ -4614,7 +4660,7 @@ class PersonasScreen(BaseAppScreen):
             logger.opt(exception=True).warning("Could not create a lore book.")
             self._notify(f"Create failed: {exc}", "error")
             return
-        await self._render_lore_rows(query="")
+        await self._render_lore_rows(query=self.state.search_query)
         await self._select_lore_entry(str(book_id), name)
         # Land the user in Settings to rename immediately.
         try:
@@ -4661,7 +4707,7 @@ class PersonasScreen(BaseAppScreen):
             logger.opt(exception=True).warning("Could not duplicate the lore book.")
             self._notify(f"Duplicate failed: {exc}", "error")
             return
-        await self._render_lore_rows(query="")
+        await self._render_lore_rows(query=self.state.search_query)
         await self._select_lore_entry(str(new_id), name)
 
     async def _toggle_dictionary_enabled(self, entity_id: str) -> None:
@@ -6942,7 +6988,7 @@ class PersonasScreen(BaseAppScreen):
         if self.state.active_mode != "lore":
             self._notify(f"Imported '{name}' — open Lore to see it.", "information")
             return
-        await self._render_lore_rows(query="")
+        await self._render_lore_rows(query=self.state.search_query)
         await self._select_lore_entry(str(new_id), name)
         suffix = " Renamed to avoid a name clash." if name != base else ""
         self._notify(f"Imported '{name}'.{suffix}", "information")
@@ -7103,7 +7149,7 @@ class PersonasScreen(BaseAppScreen):
                 "information",
             )
             return
-        await self._render_dictionary_rows(query="")
+        await self._render_dictionary_rows(query=self.state.search_query)
         await self._select_dictionary(
             str(record.get("id")), str(record.get("name") or "")
         )

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -233,6 +233,7 @@ PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 #: Rows per library page. ``page_offset`` is always kept a multiple of this so
 #: the pane's "start-end of N" label math stays exact.
 PERSONAS_LIBRARY_PAGE_SIZE = 50
+_SERVER_CHARACTER_SEARCH_MAX_RESULTS = 100
 _MAX_CHARACTER_ID = (1 << 63) - 1
 #: Display labels for the library sort keys (shared by the character sort cycle
 #: and the persona render path).
@@ -951,6 +952,7 @@ class PersonasScreen(BaseAppScreen):
         self._sync_personas_rails()
         self._set_persona_editor_runtime_source(self.persona_handler.current_mode())
         self.query_one(PersonasLibraryPane).set_mode(self.state.active_mode)
+        self._sync_local_character_actions()
         self._show_center(None)
         self.run_worker(
             self._load_after_mount(),
@@ -1014,7 +1016,22 @@ class PersonasScreen(BaseAppScreen):
         self.character_handler.current_character_data = {}
         self.state.reset_for_runtime_source_change(normalized)
         self._set_persona_editor_runtime_source(normalized)
+        self._count_cache_key = None
+        self._characters = []
+        self._character_total = 0
+        self._update_status_row()
+        self._sync_local_character_actions()
         if self.is_mounted:
+            if active_mode == "characters":
+                await self._display_character_page(
+                    [],
+                    total=0,
+                    offset=0,
+                    sort_label=(
+                        "Sort: Server order" if normalized == "server" else "Sort: Name"
+                    ),
+                    tag_label="Tag: All",
+                )
             await self._apply_mode(active_mode)
 
     async def on_unmount(self) -> None:
@@ -1194,6 +1211,71 @@ class PersonasScreen(BaseAppScreen):
             return value
         return None
 
+    def _local_character_actions_allowed(self) -> bool:
+        """Return whether local character editor/DB seams still own this screen."""
+        return self.state.runtime_source == "local"
+
+    def _sync_local_character_actions(self) -> None:
+        """Disable every local-only character action while browsing the server."""
+        if not self.is_mounted:
+            return
+        server_characters = (
+            self.state.active_mode == "characters"
+            and not self._local_character_actions_allowed()
+        )
+        try:
+            for selector in (
+                "#personas-library-new",
+                "#personas-library-import",
+                "#personas-library-duplicate",
+            ):
+                self.query_one(selector, Button).disabled = server_characters
+
+            edit = self.query_one("#personas-card-edit-character", Button)
+            if server_characters:
+                edit.disabled = True
+            else:
+                edit.disabled = not (
+                    self.state.selected_entity_kind == "character"
+                    and self.state.selected_entity_id is not None
+                )
+
+            inspector = self.query_one(PersonasInspectorPane)
+            if server_characters:
+                for selector in (
+                    "#personas-export-json",
+                    "#personas-export-png",
+                    "#personas-delete",
+                ):
+                    inspector.query_one(selector, Button).disabled = True
+            else:
+                # Restore the inspector's existing selection/unsaved gates after
+                # leaving server Characters mode.
+                inspector.set_unsaved(self.state.has_unsaved_changes)
+        except QueryError:
+            return
+
+    def _server_character_request_is_current(
+        self,
+        *,
+        expected_server_id: str | None,
+        mode: str,
+        query: str,
+        sort_key: str,
+        tag: str | None,
+        offset: int,
+    ) -> bool:
+        """Return whether one server page request still owns the library."""
+        return (
+            self.state.runtime_source == "server"
+            and self._active_server_target() == expected_server_id
+            and self.state.active_mode == mode
+            and self.state.search_query == query
+            and self.state.sort_key == sort_key
+            and self.state.tag_filter == tag
+            and self.state.page_offset == offset
+        )
+
     @staticmethod
     def _character_record_mapping(value: Any) -> dict | None:
         """Return one detached character DTO mapping, if structurally valid."""
@@ -1286,6 +1368,14 @@ class PersonasScreen(BaseAppScreen):
         tag = self.state.tag_filter
         offset = self.state.page_offset
         expected_server_id = self._active_server_target()
+        self._count_cache_key = None
+        await self._display_character_page(
+            [],
+            total=0,
+            offset=offset,
+            sort_label="Sort: Server order",
+            tag_label="Tag: All",
+        )
         if expected_server_id is None:
             return
 
@@ -1301,7 +1391,10 @@ class PersonasScreen(BaseAppScreen):
                 response = await load_characters(
                     query,
                     mode="server",
-                    limit=offset + PERSONAS_LIBRARY_PAGE_SIZE + 1,
+                    limit=min(
+                        offset + PERSONAS_LIBRARY_PAGE_SIZE + 1,
+                        _SERVER_CHARACTER_SEARCH_MAX_RESULTS,
+                    ),
                 )
                 page_start = offset
             else:
@@ -1319,26 +1412,35 @@ class PersonasScreen(BaseAppScreen):
             raise
         except Exception:
             logger.warning("Server character page load failed.")
-            self._notify("Could not load server characters.", "error")
+            if self._server_character_request_is_current(
+                expected_server_id=expected_server_id,
+                mode=mode,
+                query=query,
+                sort_key=sort_key,
+                tag=tag,
+                offset=offset,
+            ):
+                self._notify("Could not load server characters.", "error")
             return
 
-        if (
-            self.state.runtime_source != "server"
-            or self._active_server_target() != expected_server_id
-            or self.state.active_mode != mode
-            or self.state.search_query != query
-            or self.state.sort_key != sort_key
-            or self.state.tag_filter != tag
-            or self.state.page_offset != offset
+        if not self._server_character_request_is_current(
+            expected_server_id=expected_server_id,
+            mode=mode,
+            query=query,
+            sort_key=sort_key,
+            tag=tag,
+            offset=offset,
         ):
             return
 
         inferred_total = offset + len(page_records) + (1 if has_more else 0)
         total = exact_total if exact_total is not None else inferred_total
-        self._count_cache_key = None
+        display_total = max(total, inferred_total)
+        if query:
+            display_total = min(display_total, _SERVER_CHARACTER_SEARCH_MAX_RESULTS)
         await self._display_character_page(
             page_records,
-            total=max(total, inferred_total),
+            total=display_total,
             offset=offset,
             sort_label="Sort: Server order",
             tag_label="Tag: All",
@@ -1355,6 +1457,7 @@ class PersonasScreen(BaseAppScreen):
         if self.state.runtime_source == "server":
             await self._reload_server_character_page()
             return
+        runtime_source = self.state.runtime_source
         mode = self.state.active_mode
         query = self.state.search_query
         sort_key = self.state.sort_key
@@ -1398,7 +1501,8 @@ class PersonasScreen(BaseAppScreen):
         # still False while the initial on-mount refresh runs; teardown is
         # tolerated instead by catching the pane QueryError below.)
         if (
-            self.state.active_mode != mode
+            self.state.runtime_source != runtime_source
+            or self.state.active_mode != mode
             or self.state.search_query != query
             or self.state.sort_key != sort_key
             or self.state.tag_filter != tag
@@ -1943,6 +2047,7 @@ class PersonasScreen(BaseAppScreen):
         )
         library = self.query_one(PersonasLibraryPane)
         library.set_mode(mode)
+        self._sync_local_character_actions()
         is_dictionaries = mode == "dictionaries"
         is_lore = mode == "lore"
         self.query_one(PersonasPreviewPane).display = not (is_dictionaries or is_lore)
@@ -2203,6 +2308,7 @@ class PersonasScreen(BaseAppScreen):
         if server_record is None:
             await self._refresh_character_dictionaries()
             await self._refresh_character_worldbooks()
+        self._sync_local_character_actions()
 
     async def _select_profile(self, entity_id: str, entity_name: str) -> None:
         self.state.select_entity(
@@ -2808,6 +2914,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterDictionaryAttachRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if (
             self.state.selected_entity_kind != "character"
             or not self.state.selected_entity_id
@@ -2820,6 +2928,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _character_dictionary_attach_worker(self) -> None:
         try:
+            if not self._local_character_actions_allowed():
+                return
             entity_id = self.state.selected_entity_id
             service = self._dictionary_scope_service()
             if service is None or not entity_id:
@@ -2843,6 +2953,8 @@ class PersonasScreen(BaseAppScreen):
                 return
             if not picked:
                 return
+            if not self._local_character_actions_allowed():
+                return
             try:
                 await service.attach_to_character(int(picked), char_id, mode="local")
             except ConflictError:
@@ -2863,6 +2975,8 @@ class PersonasScreen(BaseAppScreen):
 
     def _list_attachable_dictionaries(self, character_id: int) -> list[dict]:
         """Local dictionaries NOT already attached to this character (sync DB read)."""
+        if not self._local_character_actions_allowed():
+            return []
         db = getattr(self.app_instance, "chachanotes_db", None)
         if db is None:
             return []
@@ -2885,6 +2999,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _sync_character_editor_dictionaries(self, character_id: int) -> None:
         """Keep the editor's base coherent after an out-of-band attach/detach."""
+        if not self._local_character_actions_allowed():
+            return
         db = getattr(self.app_instance, "chachanotes_db", None)
         if db is None:
             return
@@ -2915,6 +3031,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterDictionaryDetachRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         entity_id = self.state.selected_entity_id
         service = self._dictionary_scope_service()
         if (
@@ -2947,6 +3065,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterWorldBookAttachRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if (
             self.state.selected_entity_kind != "character"
             or not self.state.selected_entity_id
@@ -2959,6 +3079,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _character_worldbook_attach_worker(self) -> None:
         try:
+            if not self._local_character_actions_allowed():
+                return
             entity_id = self.state.selected_entity_id
             manager = self._lore_manager()
             if manager is None or not entity_id:
@@ -2982,6 +3104,8 @@ class PersonasScreen(BaseAppScreen):
                 )
                 return
             if picked is None:
+                return
+            if not self._local_character_actions_allowed():
                 return
             try:
                 await asyncio.to_thread(
@@ -3007,6 +3131,8 @@ class PersonasScreen(BaseAppScreen):
 
     def _list_attachable_world_books(self, character_id: int) -> list[dict]:
         """Standalone world books NOT already attached to this character (sync DB read)."""
+        if not self._local_character_actions_allowed():
+            return []
         manager = self._lore_manager()
         if manager is None:
             return []
@@ -3024,6 +3150,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _sync_character_editor_worldbooks(self, character_id: int) -> None:
         """Keep the editor's base coherent after an out-of-band attach/detach."""
+        if not self._local_character_actions_allowed():
+            return
         db = getattr(self.app_instance, "chachanotes_db", None)
         if db is None:
             return
@@ -3054,6 +3182,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterWorldBookDetachRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         entity_id = self.state.selected_entity_id
         if (
             self.state.selected_entity_kind != "character"
@@ -4077,6 +4207,8 @@ class PersonasScreen(BaseAppScreen):
         message.stop()
         if message.action == "create":
             if self.state.active_mode == "characters":
+                if not self._local_character_actions_allowed():
+                    return
                 await self._run_guarded(self._begin_create_character)
             elif self.state.active_mode == "personas":
                 await self._run_guarded(self._begin_create_profile)
@@ -4087,6 +4219,8 @@ class PersonasScreen(BaseAppScreen):
             # Creation in the remaining modes is wired in follow-up tasks.
         elif message.action == "import":
             if self.state.active_mode == "characters":
+                if not self._local_character_actions_allowed():
+                    return
                 await self._run_guarded(self._open_import_dialog)
             elif self.state.active_mode == "dictionaries":
                 await self._run_guarded(self._open_dictionary_import_dialog)
@@ -4094,6 +4228,8 @@ class PersonasScreen(BaseAppScreen):
                 await self._run_guarded(self._open_lore_import_dialog)
         elif message.action == "duplicate":
             if self.state.active_mode == "characters":
+                if not self._local_character_actions_allowed():
+                    return
                 await self._run_guarded(self._duplicate_selected_character)
             elif self.state.active_mode == "dictionaries":
                 await self._run_guarded(self._duplicate_selected_dictionary)
@@ -4108,6 +4244,8 @@ class PersonasScreen(BaseAppScreen):
         # tasks.
 
     async def _begin_create_character(self) -> None:
+        if not self._local_character_actions_allowed():
+            return
         self._character_editor_generation += 1
         # A picked image-gen style is scoped to the editor session that
         # picked it (fix round 1) - must not bleed into this new one.
@@ -4206,6 +4344,8 @@ class PersonasScreen(BaseAppScreen):
         the same helper Save-as-new-character already calls) rather than a
         new duplication engine.
         """
+        if not self._local_character_actions_allowed():
+            return
         entity_id = self.state.selected_entity_id
         if self.state.selected_entity_kind != "character" or not entity_id:
             self._notify("Select a character to duplicate.", "warning")
@@ -4224,6 +4364,8 @@ class PersonasScreen(BaseAppScreen):
             self._notify(
                 f"Could not load character {entity_id} to duplicate.", "error"
             )
+            return
+        if not self._local_character_actions_allowed():
             return
         base_name = str(source.get("name") or "Character")
         base = f"{base_name} (copy)"
@@ -4253,6 +4395,8 @@ class PersonasScreen(BaseAppScreen):
             "extensions": source.get("extensions"),
         }
         try:
+            if not self._local_character_actions_allowed():
+                return
             new_id = await asyncio.to_thread(
                 ccp_character_handler.create_character, payload
             )
@@ -4265,6 +4409,8 @@ class PersonasScreen(BaseAppScreen):
             return
         if not new_id:
             self._notify("Duplicate failed: character creation returned no id.", "error")
+            return
+        if not self._local_character_actions_allowed():
             return
         await self.character_handler.refresh_character_list()
         await self._select_character(str(new_id), name)
@@ -4494,6 +4640,8 @@ class PersonasScreen(BaseAppScreen):
     @on(EditCharacterRequested)
     def _handle_edit_requested(self, message: EditCharacterRequested) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if str(message.character_id) != (self.state.selected_entity_id or ""):
             self._notify("Selection out of sync; reselect the character.", "warning")
             return
@@ -4639,6 +4787,8 @@ class PersonasScreen(BaseAppScreen):
         return data
 
     async def _stage_character_avatar_from_path(self, path: str) -> None:
+        if not self._local_character_actions_allowed():
+            return
         session_token = self._character_editor_session_token()
         if session_token is None:
             self._notify(
@@ -4662,6 +4812,8 @@ class PersonasScreen(BaseAppScreen):
                 f"changed. path={path!r}, original_session={session_token!r}, "
                 f"current_session={self._character_editor_session_token()!r}"
             )
+            return
+        if not self._local_character_actions_allowed():
             return
         try:
             self.query_one(PersonasCharacterEditorWidget).set_avatar_image(image_data)
@@ -4712,6 +4864,8 @@ class PersonasScreen(BaseAppScreen):
         The field itself is never written here: the editor shows the result and
         the author accepts or discards it.
         """
+        if not self._local_character_actions_allowed():
+            return
         editor = self._editor_or_none()
         if editor is None:
             return
@@ -4750,6 +4904,8 @@ class PersonasScreen(BaseAppScreen):
     def _generate_field_pressed(self, event: Button.Pressed) -> None:
         """Start a generation for the field whose button was pressed."""
         event.stop()
+        if not self._local_character_actions_allowed():
+            return
         field = PersonasCharacterEditorWidget.field_for_generate_button(
             str(event.button.id or "")
         )
@@ -4763,6 +4919,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _run_whole_character_generation(self, concept: str) -> None:
         """Draft a whole character and fill the editor's empty fields."""
+        if not self._local_character_actions_allowed():
+            return
         editor = self._editor_or_none()
         if editor is None:
             return
@@ -4791,6 +4949,8 @@ class PersonasScreen(BaseAppScreen):
     def _concept_run_pressed(self, event: Button.Pressed) -> None:
         """Draft a whole character from the concept the author typed."""
         event.stop()
+        if not self._local_character_actions_allowed():
+            return
         editor = self._editor_or_none()
         concept = editor.concept_text if editor is not None else ""
         if not concept:
@@ -4806,6 +4966,8 @@ class PersonasScreen(BaseAppScreen):
     def _regenerate_pressed(self, event: Button.Pressed) -> None:
         """Re-run the generation for the field currently being previewed."""
         event.stop()
+        if not self._local_character_actions_allowed():
+            return
         editor = self._editor_or_none()
         field = editor.pending_generation_field if editor is not None else None
         if field is None:
@@ -5171,6 +5333,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterImageRemoveRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         try:
             editor = self.query_one(PersonasCharacterEditorWidget)
         except QueryError:
@@ -5218,6 +5382,9 @@ class PersonasScreen(BaseAppScreen):
             apply_expression_images_to_db,
             ExpressionSetApplyResult,
         )
+
+        if not self._local_character_actions_allowed():
+            return ExpressionSetApplyResult(applied=[], skipped=[])
         applied: list[str] = []
         skipped: list = []
         db = getattr(self.app_instance, "chachanotes_db", None)
@@ -5265,6 +5432,8 @@ class PersonasScreen(BaseAppScreen):
             overstated its count even though the user already saw this
             method's own error notify.
         """
+        if not self._local_character_actions_allowed():
+            return False
         db = getattr(self.app_instance, "chachanotes_db", None)
         if db is None:
             self._notify("Database is not available.", "error")
@@ -5287,6 +5456,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _clear_expression_slot(self, character_id: int, state: str) -> None:
         """Soft-delete an expression-state image and clear its slot's thumbnail."""
+        if not self._local_character_actions_allowed():
+            return
         db = getattr(self.app_instance, "chachanotes_db", None)
         if db is None:
             self._notify("Database is not available.", "error")
@@ -5314,6 +5485,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterExpressionUploadRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             self._notify(
                 "Open a character editor before uploading an expression image.",
@@ -5376,6 +5549,8 @@ class PersonasScreen(BaseAppScreen):
         (same check + copy as the Console's ``/generate-image`` command).
         """
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             self._notify(
                 "Open a character editor before generating an expression image.",
@@ -5441,6 +5616,8 @@ class PersonasScreen(BaseAppScreen):
         than requiring it non-``None``.
         """
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             self._notify(
                 "Open a character editor before generating an avatar image.",
@@ -5491,6 +5668,8 @@ class PersonasScreen(BaseAppScreen):
         click is refused independent of any individual slot's own key.
         """
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             self._notify(
                 "Open a character editor before generating expression images.",
@@ -5535,6 +5714,8 @@ class PersonasScreen(BaseAppScreen):
         by the next generation.
         """
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             return
         if self._io_dialog_active:
@@ -5555,6 +5736,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterExpressionClearRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             return
         editor = self.query_one(PersonasCharacterEditorWidget)
@@ -5573,6 +5756,8 @@ class PersonasScreen(BaseAppScreen):
         from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
 
         try:
+            if not self._local_character_actions_allowed():
+                return
             picker = EnhancedFileOpen(
                 title=f"Upload {state.capitalize()} Expression Image",
                 filters=Filters(
@@ -5595,6 +5780,8 @@ class PersonasScreen(BaseAppScreen):
                 )
                 return
             if file_path:
+                if not self._local_character_actions_allowed():
+                    return
                 await self._stage_character_expression_from_path(
                     character_id, state, str(file_path)
                 )
@@ -5604,6 +5791,8 @@ class PersonasScreen(BaseAppScreen):
     async def _stage_character_expression_from_path(
         self, character_id: int, state: str, path: str
     ) -> None:
+        if not self._local_character_actions_allowed():
+            return
         session_token = self._character_editor_session_token()
         if session_token is None:
             self._notify(
@@ -5632,6 +5821,8 @@ class PersonasScreen(BaseAppScreen):
                 f"original_session={session_token!r}, "
                 f"current_session={self._character_editor_session_token()!r}"
             )
+            return
+        if not self._local_character_actions_allowed():
             return
         import mimetypes
 
@@ -5689,6 +5880,8 @@ class PersonasScreen(BaseAppScreen):
         """
         key = (character_id, state)
         try:
+            if not self._local_character_actions_allowed():
+                return False
             editor = self.query_one(PersonasCharacterEditorWidget)
             name = editor._input("name").value
             description = editor._area("description").text
@@ -5728,6 +5921,8 @@ class PersonasScreen(BaseAppScreen):
                     f"state={state!r}, original_session={session_token!r}, "
                     f"current_session={self._character_editor_session_token()!r}"
                 )
+                return False
+            if not self._local_character_actions_allowed():
                 return False
             if state == "avatar":
                 if len(result.content) > PERSONAS_AVATAR_MAX_BYTES:
@@ -5820,6 +6015,9 @@ class PersonasScreen(BaseAppScreen):
         body - this method's behavior is unchanged, only its
         implementation moved).
         """
+        if not self._local_character_actions_allowed():
+            self._expression_generate_inflight.discard((character_id, state))
+            return
         await self._generate_one_slot(
             character_id, state, getattr(self, "_expression_generate_style", None)
         )
@@ -5864,6 +6062,9 @@ class PersonasScreen(BaseAppScreen):
         (which would misleadingly read as an attempt that under-performed
         rather than a request the user actively withdrew).
         """
+        if not self._local_character_actions_allowed():
+            self._expression_generate_inflight.discard((character_id, "all"))
+            return
         style_template = getattr(self, "_expression_generate_style", None)
         succeeded = 0
         cancelled = False
@@ -5911,6 +6112,8 @@ class PersonasScreen(BaseAppScreen):
         (mirrors ``_render_character_expression_slot``'s own read) -
         stopping at the first hit.
         """
+        if not self._local_character_actions_allowed():
+            return True
         if editor.has_avatar_image():
             return True
         db = getattr(self.app_instance, "chachanotes_db", None)
@@ -5977,6 +6180,8 @@ class PersonasScreen(BaseAppScreen):
         exception here only kills this dialog's worker instead of the app.
         """
         try:
+            if not self._local_character_actions_allowed():
+                return
             try:
                 choice = await self.app.push_screen_wait(ConsoleStylePickerModal())
             except Exception:
@@ -6039,6 +6244,8 @@ class PersonasScreen(BaseAppScreen):
     @on(CharacterExpressionSetImportRequested)
     def _handle_expression_set_import_requested(self, message) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             self._notify(
                 "Open a character editor before importing an expression set.",
@@ -6066,6 +6273,8 @@ class PersonasScreen(BaseAppScreen):
         from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
 
         try:
+            if not self._local_character_actions_allowed():
+                return
             picker = EnhancedFileOpen(
                 title="Import Expression Set (.zip / .tldw-persona-vpack)",
                 filters=Filters(
@@ -6081,6 +6290,8 @@ class PersonasScreen(BaseAppScreen):
                 )
                 return
             if file_path:
+                if not self._local_character_actions_allowed():
+                    return
                 await self._import_expression_set_from_path(character_id, str(file_path))
         finally:
             self._io_dialog_active = False
@@ -6098,6 +6309,8 @@ class PersonasScreen(BaseAppScreen):
         delegates to ``_apply_expression_set`` (Task 3) for the actual
         idle-staged/three-immediate application.
         """
+        if not self._local_character_actions_allowed():
+            return
         from ...Character_Chat.expression_set_io import resolve_local_expression_set
 
         try:
@@ -6107,6 +6320,8 @@ class PersonasScreen(BaseAppScreen):
             return
 
         res = await asyncio.to_thread(resolve_local_expression_set, [candidate])
+        if not self._local_character_actions_allowed():
+            return
         if not res.images:
             reason = (
                 "; ".join(n for n, _ in res.skipped[:2])
@@ -6123,6 +6338,8 @@ class PersonasScreen(BaseAppScreen):
     @on(CharacterExpressionSetExportRequested)
     def _handle_expression_set_export_requested(self, message) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             return
         editor = self.query_one(PersonasCharacterEditorWidget)
@@ -6150,6 +6367,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _export_expression_set_worker(self, character_id: int, name: str) -> None:
         try:
+            if not self._local_character_actions_allowed():
+                return
             target = await self._export_expression_set(character_id, name)
             if target:
                 self._notify(f"Expression set exported to {target}.", "information")
@@ -6174,6 +6393,8 @@ class PersonasScreen(BaseAppScreen):
             The written file's path, or ``None`` when there is nothing to
             export (already surfaced via ``_notify``).
         """
+        if not self._local_character_actions_allowed():
+            return None
         from ...Character_Chat.expression_set_io import build_expression_set_zip
 
         images: dict[str, bytes] = {}
@@ -6226,6 +6447,8 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterImageUploadRequested
     ) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if not self._character_editor_is_active():
             self._notify(
                 "Open a character editor before uploading an avatar.", "warning"
@@ -6243,6 +6466,8 @@ class PersonasScreen(BaseAppScreen):
         from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
 
         try:
+            if not self._local_character_actions_allowed():
+                return
             picker = EnhancedFileOpen(
                 title="Upload Character Avatar",
                 filters=Filters(
@@ -6265,12 +6490,16 @@ class PersonasScreen(BaseAppScreen):
                 )
                 return
             if file_path:
+                if not self._local_character_actions_allowed():
+                    return
                 await self._stage_character_avatar_from_path(str(file_path))
         finally:
             self._io_dialog_active = False
 
     async def _open_import_dialog(self) -> None:
         """Continuation for the guarded import action: launch the dialog worker."""
+        if not self._local_character_actions_allowed():
+            return
         if self._active_character_import_worker() is not None:
             self._notify("A character import is already in progress.", "information")
             return
@@ -6289,6 +6518,8 @@ class PersonasScreen(BaseAppScreen):
 
         durable_import_started = False
         try:
+            if not self._local_character_actions_allowed():
+                return
             picker = EnhancedFileOpen(
                 title="Import Character Card",
                 filters=_character_import_filters(),
@@ -6302,13 +6533,16 @@ class PersonasScreen(BaseAppScreen):
                 )
                 return
             if file_path:
+                if not self._local_character_actions_allowed():
+                    return
                 if self._active_character_import_worker() is not None:
                     self._notify(
                         "A character import is already in progress.", "information"
                     )
                     return
-                self._start_character_import(str(file_path))
-                durable_import_started = True
+                durable_import_started = (
+                    self._start_character_import(str(file_path)) is not None
+                )
         finally:
             if not durable_import_started:
                 self._io_dialog_active = False
@@ -6324,7 +6558,7 @@ class PersonasScreen(BaseAppScreen):
                 return worker
         return None
 
-    def _start_character_import(self, path: str) -> Worker[None]:
+    def _start_character_import(self, path: str) -> Worker[None] | None:
         """Launch one durable character import owned by the application.
 
         The worker carries the path in its coroutine; no domain payload or
@@ -6332,6 +6566,8 @@ class PersonasScreen(BaseAppScreen):
         the durable operation alive while ``switch_screen`` unmounts the
         initiating Personas screen.
         """
+        if not self._local_character_actions_allowed():
+            return None
         active_worker = self._active_character_import_worker()
         if active_worker is not None:
             return active_worker
@@ -6343,12 +6579,16 @@ class PersonasScreen(BaseAppScreen):
     async def _run_durable_character_import(self, path: str) -> None:
         """Complete a character import and release the initiating dialog slot."""
         try:
+            if not self._local_character_actions_allowed():
+                return
             await self._import_character_from_path(path)
         finally:
             self._io_dialog_active = False
 
     async def _import_character_from_path(self, path: str) -> None:
         """Import a character card file, then refresh, select, and reveal it."""
+        if not self._local_character_actions_allowed():
+            return
         # On a name conflict the importer returns the EXISTING character's id
         # WITHOUT adding a row; on a new import it creates one. ``_characters``
         # now holds only one page, so decide "existed vs imported" from the
@@ -6363,6 +6603,8 @@ class PersonasScreen(BaseAppScreen):
                 logger.opt(exception=True).debug(
                     "Pre-import character count failed; message will assume new."
                 )
+        if not self._local_character_actions_allowed():
+            return
         try:
             # Sync DB call; see the section comment for the threading choice.
             imported_id = await asyncio.to_thread(
@@ -6389,6 +6631,8 @@ class PersonasScreen(BaseAppScreen):
             )
             return
         imported_id = str(imported_id)
+        if not self._local_character_actions_allowed():
+            return
         if (
             not self.is_mounted
             or self.app.screen is not self
@@ -6404,6 +6648,8 @@ class PersonasScreen(BaseAppScreen):
                 post_import_count = await asyncio.to_thread(count_character_page, db)
             except Exception:
                 logger.opt(exception=True).debug("Post-import character count failed.")
+        if not self._local_character_actions_allowed():
+            return
         existed_before = (
             pre_import_count is not None
             and post_import_count is not None
@@ -6418,6 +6664,8 @@ class PersonasScreen(BaseAppScreen):
         except Exception:
             pass
         await self.character_handler.refresh_character_list()
+        if not self._local_character_actions_allowed():
+            return
         if (
             not self.is_mounted
             or self.app.screen is not self
@@ -6436,6 +6684,8 @@ class PersonasScreen(BaseAppScreen):
             logger.opt(exception=True).debug(
                 "Could not resolve imported character name by id."
             )
+        if not self._local_character_actions_allowed():
+            return
         if (
             not self.is_mounted
             or self.app.screen is not self
@@ -6469,6 +6719,8 @@ class PersonasScreen(BaseAppScreen):
     async def _imported_lorebook_note(self, character_id: str) -> str:
         """Return a " Lorebook 'X' attached (N entries)." suffix, or "" when
         the just-imported character has no embedded world book (task-429)."""
+        if not self._local_character_actions_allowed():
+            return ""
         try:
             record = await asyncio.to_thread(
                 ccp_character_handler.fetch_character_by_id, character_id
@@ -6759,16 +7011,25 @@ class PersonasScreen(BaseAppScreen):
     @on(Button.Pressed, "#personas-export-json")
     async def _handle_export_json_pressed(self, event: Button.Pressed) -> None:
         event.stop()
+        if (
+            self.state.selected_entity_kind == "character"
+            and not self._local_character_actions_allowed()
+        ):
+            return
         self._open_export_dialog("json")
 
     @on(Button.Pressed, "#personas-export-png")
     async def _handle_export_png_pressed(self, event: Button.Pressed) -> None:
         event.stop()
+        if not self._local_character_actions_allowed():
+            return
         self._open_export_dialog("png")
 
     def _open_export_dialog(self, fmt: str) -> None:
         """Validate the selection and launch the save-dialog worker."""
         kind = self.state.selected_entity_kind
+        if kind == "character" and not self._local_character_actions_allowed():
+            return
         if not self.state.selected_entity_id or kind not in (
             "character",
             "persona",
@@ -6793,6 +7054,11 @@ class PersonasScreen(BaseAppScreen):
         from ...Widgets.enhanced_file_picker import EnhancedFileSave, Filters
 
         try:
+            if (
+                self.state.selected_entity_kind == "character"
+                and not self._local_character_actions_allowed()
+            ):
+                return
             name = self.state.selected_entity_name or "export"
             # Filename sanitization mirrors the legacy CCP export route.
             safe_name = "".join(c for c in name if c.isalnum() or c in " -_").rstrip()
@@ -6821,6 +7087,11 @@ class PersonasScreen(BaseAppScreen):
                 )
                 return
             if target_path:
+                if (
+                    self.state.selected_entity_kind == "character"
+                    and not self._local_character_actions_allowed()
+                ):
+                    return
                 await self._export_selected_character(str(target_path), fmt=fmt)
         finally:
             self._io_dialog_active = False
@@ -6829,6 +7100,8 @@ class PersonasScreen(BaseAppScreen):
         """Export the current selection to ``target_path`` as JSON or PNG."""
         kind = self.state.selected_entity_kind
         entity_id = self.state.selected_entity_id
+        if kind == "character" and not self._local_character_actions_allowed():
+            return
         if not entity_id:
             self._notify("Select a saved item before exporting.", "warning")
             return
@@ -6863,6 +7136,8 @@ class PersonasScreen(BaseAppScreen):
 
     def _export_character_json_sync(self, character_id: int, target_path: str) -> None:
         """Sync JSON export; raises on failure (runs off the UI thread)."""
+        if not self._local_character_actions_allowed():
+            raise RuntimeError("Local character export is unavailable in server mode.")
         db = ccp_character_handler._default_character_db()
         content = export_character_card_to_json(db, character_id, include_image=True)
         if content is None:
@@ -6876,6 +7151,8 @@ class PersonasScreen(BaseAppScreen):
         base directory (defaulting to its own exports folder), so the chosen
         path's parent is passed to keep user-selected destinations valid.
         """
+        if not self._local_character_actions_allowed():
+            raise RuntimeError("Local character export is unavailable in server mode.")
         db = ccp_character_handler._default_character_db()
         target = Path(target_path).expanduser()
         ok = export_character_card_to_png(
@@ -6910,6 +7187,11 @@ class PersonasScreen(BaseAppScreen):
     @on(Button.Pressed, "#personas-delete")
     async def _handle_delete_pressed(self, event: Button.Pressed) -> None:
         event.stop()
+        if (
+            self.state.selected_entity_kind == "character"
+            and not self._local_character_actions_allowed()
+        ):
+            return
         # The inspector enables Delete whenever a selection exists, even with
         # unsaved edits - deleting discards them by definition. The flow still
         # routes through the unsaved guard so a dirty session shows the
@@ -6920,6 +7202,8 @@ class PersonasScreen(BaseAppScreen):
     async def _begin_delete_selection(self) -> None:
         """Validate the selection and launch the delete-confirm dialog worker."""
         kind = self.state.selected_entity_kind
+        if kind == "character" and not self._local_character_actions_allowed():
+            return
         entity_id = str(self.state.selected_entity_id or "")
         if not entity_id or kind not in (
             "character",
@@ -6976,7 +7260,11 @@ class PersonasScreen(BaseAppScreen):
         self, kind: str, entity_id: str, name: str, version: int | None
     ) -> None:
         try:
+            if kind == "character" and not self._local_character_actions_allowed():
+                return
             if not await self._confirm_delete(name):
+                return
+            if kind == "character" and not self._local_character_actions_allowed():
                 return
             await self._delete_entity(kind, entity_id, version)
         finally:
@@ -7007,6 +7295,8 @@ class PersonasScreen(BaseAppScreen):
             "Reselect and try again."
         )
         if kind == "character":
+            if not self._local_character_actions_allowed():
+                return
             try:
                 # Sync DB call; same threading choice as import/export.
                 ok = await asyncio.to_thread(
@@ -7134,6 +7424,8 @@ class PersonasScreen(BaseAppScreen):
         await self._after_delete(kind)
 
     async def _after_delete(self, kind: str) -> None:
+        if kind == "character" and not self._local_character_actions_allowed():
+            return
         if kind == "character":
             # The handler still holds the deleted card; drop it so
             # _full_character_record cannot serve stale data.
@@ -7194,6 +7486,8 @@ class PersonasScreen(BaseAppScreen):
     @on(CharacterSaveRequested)
     def _handle_save_requested(self, message: CharacterSaveRequested) -> None:
         message.stop()
+        if not self._local_character_actions_allowed():
+            return
         if self._character_save_inflight:
             # A save for this session is already persisting (re-entrant
             # Save click / Ctrl+S); ignore the duplicate rather than firing
@@ -7225,6 +7519,9 @@ class PersonasScreen(BaseAppScreen):
         self, data: dict, selected_id: str | None, edit_mode: str
     ) -> None:
         """Persist via the legacy module-level helpers off the UI thread."""
+        if not self._local_character_actions_allowed():
+            self._character_save_inflight = False
+            return
         try:
 
             def persist_character() -> str:
@@ -7250,6 +7547,9 @@ class PersonasScreen(BaseAppScreen):
     async def _after_character_save(
         self, saved_id: str, submitted_name: str = ""
     ) -> None:
+        if not self._local_character_actions_allowed():
+            self._character_save_inflight = False
+            return
         if not self.is_mounted or self.state.active_mode != "characters":
             # The save completed after the user left the screen or switched
             # modes; refresh the cached list but leave the selection,
@@ -7945,6 +8245,7 @@ class PersonasScreen(BaseAppScreen):
         """
         self._update_title()
         self._sync_inspector_console_actions()
+        self._sync_local_character_actions()
         try:
             footer = self.query_one("AppFooterStatus")
         except QueryError:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1396,6 +1396,35 @@ class PersonasScreen(BaseAppScreen):
                 page_offset=offset,
                 page_size=PERSONAS_LIBRARY_PAGE_SIZE,
             )
+            if request_is_current is not None and not request_is_current():
+                self._count_cache_key = None
+                self._characters = []
+                self._character_total = 0
+                self._update_status_row()
+                if self.state.runtime_source == "server":
+                    current_sort_label = "Sort: Server order"
+                    current_tag_label = "Tag: All"
+                else:
+                    current_sort_labels = dict(self._character_sort_cycle())
+                    current_sort_label = (
+                        f"Sort: "
+                        f"{current_sort_labels.get(self.state.sort_key, 'Name')}"
+                    )
+                    current_tag_label = (
+                        f"Tag: {self.state.tag_filter}"
+                        if self.state.tag_filter
+                        else "Tag: All"
+                    )
+                library.set_sort_label(current_sort_label)
+                library.set_tag_label(current_tag_label)
+                await library.update_rows(
+                    (),
+                    total=0,
+                    noun="characters",
+                    page_offset=self.state.page_offset,
+                    page_size=PERSONAS_LIBRARY_PAGE_SIZE,
+                )
+                return
             library.set_sort_label(sort_label)
             library.set_tag_label(tag_label)
             if (
@@ -6723,7 +6752,10 @@ class PersonasScreen(BaseAppScreen):
         )
         # Clear any active search (state + Input, as _apply_mode does) and reset
         # paging so the imported character shows on page 0 of the refreshed list.
+        self._cancel_search_debounce()
         self.state.search_query = ""
+        if self.state.sort_key == "relevance":
+            self.state.sort_key = "name_asc"
         self.state.page_offset = 0
         try:
             self.query_one("#personas-library-search", Input).value = ""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -651,6 +651,7 @@ class PersonasScreen(BaseAppScreen):
         # count for the active (search, tag) filter, cached under
         # ``_count_cache_key`` so page-nav/sort reuse it and only a filter
         # change recomputes it.
+        self._character_page_generation: int = 0
         self._characters: list[dict] = []
         self._selected_server_character: tuple[str, dict] | None = None
         self._character_total: int = 0
@@ -1009,6 +1010,7 @@ class PersonasScreen(BaseAppScreen):
         normalized = str(runtime_backend or "").strip().lower()
         if normalized not in {"local", "server"}:
             return
+        self._next_character_page_generation()
         active_mode = self.state.active_mode
         self.runtime_backend = normalized
         self._selected_server_character = None
@@ -1216,6 +1218,11 @@ class PersonasScreen(BaseAppScreen):
         """Return whether local character editor/DB seams still own this screen."""
         return self.state.runtime_source == "local"
 
+    def _next_character_page_generation(self) -> int:
+        """Invalidate older page work and return this request's generation."""
+        self._character_page_generation += 1
+        return self._character_page_generation
+
     def _sync_local_character_actions(self) -> None:
         """Disable every local-only character action while browsing the server."""
         if not self.is_mounted:
@@ -1260,6 +1267,7 @@ class PersonasScreen(BaseAppScreen):
     def _server_character_request_is_current(
         self,
         *,
+        generation: int,
         expected_server_id: str | None,
         mode: str,
         query: str,
@@ -1269,7 +1277,8 @@ class PersonasScreen(BaseAppScreen):
     ) -> bool:
         """Return whether one server page request still owns the library."""
         return (
-            self.state.runtime_source == "server"
+            self._character_page_generation == generation
+            and self.state.runtime_source == "server"
             and self._active_server_target() == expected_server_id
             and self.state.active_mode == mode
             and self.state.search_query == query
@@ -1281,6 +1290,7 @@ class PersonasScreen(BaseAppScreen):
     def _local_character_request_is_current(
         self,
         *,
+        generation: int,
         runtime_source: str,
         mode: str,
         query: str,
@@ -1290,7 +1300,8 @@ class PersonasScreen(BaseAppScreen):
     ) -> bool:
         """Return whether one local page request still owns the library."""
         return (
-            runtime_source == "local"
+            self._character_page_generation == generation
+            and runtime_source == "local"
             and self.state.runtime_source == runtime_source
             and self.state.active_mode == mode
             and self.state.search_query == query
@@ -1358,16 +1369,26 @@ class PersonasScreen(BaseAppScreen):
         offset: int,
         sort_label: str,
         tag_label: str,
+        request_is_current: Callable[[], bool] | None = None,
+        commit_page_offset: bool = False,
+        commit_count_cache: bool = False,
+        count_cache_key: tuple | None = None,
     ) -> None:
         """Commit and render one already-fenced character page."""
-        self._characters = records
-        self._character_total = total
-        self._update_status_row()
-        try:
-            library = self.query_one(PersonasLibraryPane)
-        except QueryError:
-            return
         async with self._render_lock:
+            if request_is_current is not None and not request_is_current():
+                return
+            if commit_page_offset:
+                self.state.page_offset = offset
+            if commit_count_cache:
+                self._count_cache_key = count_cache_key
+            self._characters = records
+            self._character_total = total
+            self._update_status_row()
+            try:
+                library = self.query_one(PersonasLibraryPane)
+            except QueryError:
+                return
             await library.update_rows(
                 self._build_library_rows(records, "character"),
                 total=total,
@@ -1383,22 +1404,43 @@ class PersonasScreen(BaseAppScreen):
             ):
                 library.mark_active_row("character", self.state.selected_entity_id)
 
-    async def _reload_server_character_page(self) -> None:
+    async def _reload_server_character_page(
+        self, *, reset_offset: bool = False
+    ) -> None:
         """Load one server-owned page through the existing character scope service."""
+        generation = self._next_character_page_generation()
+        if reset_offset:
+            self.state.page_offset = 0
         mode = self.state.active_mode
         query = self.state.search_query
         sort_key = self.state.sort_key
         tag = self.state.tag_filter
         offset = self.state.page_offset
         expected_server_id = self._active_server_target()
-        self._count_cache_key = None
+
+        def request_is_current() -> bool:
+            return self._server_character_request_is_current(
+                generation=generation,
+                expected_server_id=expected_server_id,
+                mode=mode,
+                query=query,
+                sort_key=sort_key,
+                tag=tag,
+                offset=offset,
+            )
+
         await self._display_character_page(
             [],
             total=0,
             offset=offset,
             sort_label="Sort: Server order",
             tag_label="Tag: All",
+            request_is_current=request_is_current,
+            commit_count_cache=True,
+            count_cache_key=None,
         )
+        if not request_is_current():
+            return
         if expected_server_id is None:
             return
 
@@ -1434,26 +1476,13 @@ class PersonasScreen(BaseAppScreen):
         except asyncio.CancelledError:
             raise
         except Exception:
+            if not request_is_current():
+                return
             logger.warning("Server character page load failed.")
-            if self._server_character_request_is_current(
-                expected_server_id=expected_server_id,
-                mode=mode,
-                query=query,
-                sort_key=sort_key,
-                tag=tag,
-                offset=offset,
-            ):
-                self._notify("Could not load server characters.", "error")
+            self._notify("Could not load server characters.", "error")
             return
 
-        if not self._server_character_request_is_current(
-            expected_server_id=expected_server_id,
-            mode=mode,
-            query=query,
-            sort_key=sort_key,
-            tag=tag,
-            offset=offset,
-        ):
+        if not request_is_current():
             return
 
         inferred_total = offset + len(page_records) + (1 if has_more else 0)
@@ -1467,6 +1496,7 @@ class PersonasScreen(BaseAppScreen):
             offset=offset,
             sort_label="Sort: Server order",
             tag_label="Tag: All",
+            request_is_current=request_is_current,
         )
 
     async def _reload_character_page(self, *, reset_offset: bool = False) -> None:
@@ -1475,22 +1505,36 @@ class PersonasScreen(BaseAppScreen):
         Local DB count/list work remains off-thread. Server mode delegates to
         the existing source-aware scope service and never consults local rows.
         """
+        if self.state.runtime_source == "server":
+            await self._reload_server_character_page(reset_offset=reset_offset)
+            return
+        generation = self._next_character_page_generation()
         if reset_offset:
             self.state.page_offset = 0
-        if self.state.runtime_source == "server":
-            await self._reload_server_character_page()
-            return
         runtime_source = self.state.runtime_source
         mode = self.state.active_mode
         query = self.state.search_query
         sort_key = self.state.sort_key
         tag = self.state.tag_filter
-        offset = self.state.page_offset
+        requested_offset = self.state.page_offset
+        page_offset = requested_offset
         search = self._fts_match_query()
         db = self._character_db()
         if db is None:
             return
         cache_key = (search, tag)
+
+        def request_is_current() -> bool:
+            return self._local_character_request_is_current(
+                generation=generation,
+                runtime_source=runtime_source,
+                mode=mode,
+                query=query,
+                sort_key=sort_key,
+                tag=tag,
+                offset=requested_offset,
+            )
+
         try:
             if self._count_cache_key == cache_key:
                 total = self._character_total
@@ -1499,31 +1543,23 @@ class PersonasScreen(BaseAppScreen):
                     count_character_page, db, search_term=search, tag=tag
                 )
             # Clamp a now-out-of-range offset back onto the last page.
-            if offset > 0 and offset >= total:
-                offset = max(
+            if page_offset > 0 and page_offset >= total:
+                page_offset = max(
                     0,
                     ((total - 1) // PERSONAS_LIBRARY_PAGE_SIZE)
                     * PERSONAS_LIBRARY_PAGE_SIZE,
                 )
-                self.state.page_offset = offset
             records = await asyncio.to_thread(
                 get_character_page_for_ui,
                 db,
                 limit=PERSONAS_LIBRARY_PAGE_SIZE,
-                offset=offset,
+                offset=page_offset,
                 order_by=sort_key,
                 search_term=search,
                 tag=tag,
             )
         except Exception as exc:
-            if not self._local_character_request_is_current(
-                runtime_source=runtime_source,
-                mode=mode,
-                query=query,
-                sort_key=sort_key,
-                tag=tag,
-                offset=offset,
-            ):
+            if not request_is_current():
                 return
             logger.opt(exception=True).warning("Character page load failed.")
             self._notify(f"Could not load characters: {exc}", "error")
@@ -1532,25 +1568,19 @@ class PersonasScreen(BaseAppScreen):
         # supersedes this render. (is_mounted is deliberately NOT checked: it is
         # still False while the initial on-mount refresh runs; teardown is
         # tolerated instead by catching the pane QueryError below.)
-        if not self._local_character_request_is_current(
-            runtime_source=runtime_source,
-            mode=mode,
-            query=query,
-            sort_key=sort_key,
-            tag=tag,
-            offset=offset,
-        ):
+        if not request_is_current():
             return
-        # Commit shared count state only after the guard passes, so a
-        # superseded reload cannot clobber the winner's cached count.
-        self._count_cache_key = cache_key
         sort_labels = dict(self._character_sort_cycle())
         await self._display_character_page(
             records,
             total=total,
-            offset=offset,
+            offset=page_offset,
             sort_label=f"Sort: {sort_labels.get(sort_key, 'Name')}",
             tag_label=f"Tag: {tag}" if tag else "Tag: All",
+            request_is_current=request_is_current,
+            commit_page_offset=True,
+            commit_count_cache=True,
+            count_cache_key=cache_key,
         )
 
     async def _reload_active_library(self) -> None:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1033,6 +1033,7 @@ class PersonasScreen(BaseAppScreen):
                     tag_label="Tag: All",
                 )
             await self._apply_mode(active_mode)
+            self._sync_title_and_console_actions()
 
     async def on_unmount(self) -> None:
         super().on_unmount()
@@ -1228,6 +1229,7 @@ class PersonasScreen(BaseAppScreen):
                 "#personas-library-new",
                 "#personas-library-import",
                 "#personas-library-duplicate",
+                "#personas-library-tag",
             ):
                 self.query_one(selector, Button).disabled = server_characters
 
@@ -1269,6 +1271,27 @@ class PersonasScreen(BaseAppScreen):
         return (
             self.state.runtime_source == "server"
             and self._active_server_target() == expected_server_id
+            and self.state.active_mode == mode
+            and self.state.search_query == query
+            and self.state.sort_key == sort_key
+            and self.state.tag_filter == tag
+            and self.state.page_offset == offset
+        )
+
+    def _local_character_request_is_current(
+        self,
+        *,
+        runtime_source: str,
+        mode: str,
+        query: str,
+        sort_key: str,
+        tag: str | None,
+        offset: int,
+    ) -> bool:
+        """Return whether one local page request still owns the library."""
+        return (
+            runtime_source == "local"
+            and self.state.runtime_source == runtime_source
             and self.state.active_mode == mode
             and self.state.search_query == query
             and self.state.sort_key == sort_key
@@ -1493,6 +1516,15 @@ class PersonasScreen(BaseAppScreen):
                 tag=tag,
             )
         except Exception as exc:
+            if not self._local_character_request_is_current(
+                runtime_source=runtime_source,
+                mode=mode,
+                query=query,
+                sort_key=sort_key,
+                tag=tag,
+                offset=offset,
+            ):
+                return
             logger.opt(exception=True).warning("Character page load failed.")
             self._notify(f"Could not load characters: {exc}", "error")
             return
@@ -1500,13 +1532,13 @@ class PersonasScreen(BaseAppScreen):
         # supersedes this render. (is_mounted is deliberately NOT checked: it is
         # still False while the initial on-mount refresh runs; teardown is
         # tolerated instead by catching the pane QueryError below.)
-        if (
-            self.state.runtime_source != runtime_source
-            or self.state.active_mode != mode
-            or self.state.search_query != query
-            or self.state.sort_key != sort_key
-            or self.state.tag_filter != tag
-            or self.state.page_offset != offset
+        if not self._local_character_request_is_current(
+            runtime_source=runtime_source,
+            mode=mode,
+            query=query,
+            sort_key=sort_key,
+            tag=tag,
+            offset=offset,
         ):
             return
         # Commit shared count state only after the guard passes, so a
@@ -1704,7 +1736,11 @@ class PersonasScreen(BaseAppScreen):
     async def _handle_tag_filter(self, message: PersonaTagFilterRequested) -> None:
         """Open the tag-filter picker (characters only)."""
         message.stop()
-        if self.state.active_mode != "characters" or self._io_dialog_active:
+        if (
+            self.state.active_mode != "characters"
+            or not self._local_character_actions_allowed()
+            or self._io_dialog_active
+        ):
             return
         self._io_dialog_active = True
         self.run_worker(
@@ -8224,7 +8260,14 @@ class PersonasScreen(BaseAppScreen):
         return ShortcutContext(
             source="personas",
             actions=(
-                ShortcutAction("ctrl+n", "new"),
+                ShortcutAction(
+                    "ctrl+n",
+                    "new",
+                    available=(
+                        self.state.active_mode != "characters"
+                        or self._local_character_actions_allowed()
+                    ),
+                ),
                 ShortcutAction("ctrl+f", "search"),
                 ShortcutAction("ctrl+s", "save", available=editing),
                 ShortcutAction("esc", "back", available=editing or transcript_open),

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3595,16 +3595,28 @@ class PersonasScreen(BaseAppScreen):
     ) -> bool:
         """Single seam for staging Personas context into Console.
 
-        Builds a ``ChatHandoffPayload`` with the workbench's fixed
-        source/runtime identity ("personas" / local) and the selection
-        metadata from ``PersonasWorkbenchState.selected_metadata()``, then
-        hands it to the app's ``open_chat_with_handoff``. Returns ``True``
-        when a payload was staged.
+        Builds a ``ChatHandoffPayload`` with the workbench source/runtime
+        identity and the selection metadata from
+        ``PersonasWorkbenchState.selected_metadata()``, then hands it to the
+        app's ``open_chat_with_handoff``. Returns ``True`` when a payload was
+        staged.
         """
         open_handoff = getattr(self.app_instance, "open_chat_with_handoff", None)
         if not callable(open_handoff):
             self._notify("Console handoff is unavailable.", "warning")
             return False
+        runtime_source = self.state.runtime_source
+        if runtime_source not in {"local", "server"}:
+            runtime_source = (
+                self.runtime_backend
+                if self.runtime_backend in {"local", "server"}
+                else "local"
+            )
+        active_server_profile_id = None
+        if runtime_source == "server":
+            active_server_id = getattr(self.app_instance, "active_server_id", None)
+            if type(active_server_id) is str and active_server_id:
+                active_server_profile_id = active_server_id
         payload = ChatHandoffPayload.from_source_content(
             source="personas",
             item_type=item_type,
@@ -3614,12 +3626,13 @@ class PersonasScreen(BaseAppScreen):
             source_id=source_id,
             suggested_prompt=suggested_prompt,
             display_summary=display_summary,
-            runtime_backend="local",
-            source_owner="local",
-            source_selector_state="local",
+            runtime_backend=runtime_source,
+            source_owner=runtime_source,
+            source_selector_state=runtime_source,
+            active_server_profile_id=active_server_profile_id,
             metadata={
                 **self.state.selected_metadata(),
-                "backend": "local",
+                "backend": runtime_source,
                 **(extra_metadata or {}),
             },
         )

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1983,15 +1983,15 @@ class PersonasScreen(BaseAppScreen):
 
     async def _render_dictionary_rows(self, query: str = "") -> None:
         """Fetch and render dictionary rows; degrade to recovery copy on failure."""
-        self._dictionary_lore_request_generation += 1
-        request_generation = self._dictionary_lore_request_generation
         expected_mode = "dictionaries"
-        expected_query = query
+        expected_query = query.strip()
         if not self._library_render_snapshot_is_current(
             expected_query=expected_query,
             expected_mode=expected_mode,
         ):
             return
+        self._dictionary_lore_request_generation += 1
+        request_generation = self._dictionary_lore_request_generation
 
         service = self._dictionary_scope_service()
         recovery_copy: str | None = None
@@ -2016,7 +2016,7 @@ class PersonasScreen(BaseAppScreen):
                     "Switch modes and back to retry."
                 )
 
-        needle = query.strip().lower()
+        needle = expected_query.lower()
         visible = (
             [r for r in records if needle in str(r.get("name", "")).lower()]
             if needle
@@ -2071,15 +2071,15 @@ class PersonasScreen(BaseAppScreen):
 
     async def _render_lore_rows(self, query: str = "") -> None:
         """Fetch and render lore/world-book rows; degrade to recovery copy on failure."""
-        self._dictionary_lore_request_generation += 1
-        request_generation = self._dictionary_lore_request_generation
         expected_mode = "lore"
-        expected_query = query
+        expected_query = query.strip()
         if not self._library_render_snapshot_is_current(
             expected_query=expected_query,
             expected_mode=expected_mode,
         ):
             return
+        self._dictionary_lore_request_generation += 1
+        request_generation = self._dictionary_lore_request_generation
 
         manager = self._lore_manager()
         recovery_copy: str | None = None
@@ -2101,7 +2101,7 @@ class PersonasScreen(BaseAppScreen):
                     "Switch modes and back to retry."
                 )
 
-        needle = query.strip().lower()
+        needle = expected_query.lower()
         visible = (
             [r for r in records if needle in str(r.get("name", "")).lower()]
             if needle

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -662,6 +662,7 @@ class PersonasScreen(BaseAppScreen):
         self._dictionaries_cache: list[dict] = []
         self._selected_dictionary_version: int | None = None
         self._lore_books_cache: list[dict] = []
+        self._dictionary_lore_request_generation: int = 0
         # Full record + entries for the currently-selected lore book, kept in
         # memory so Try-it can build a WorldInfoProcessor without a re-fetch.
         self._selected_lore_book: dict | None = None
@@ -1982,6 +1983,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _render_dictionary_rows(self, query: str = "") -> None:
         """Fetch and render dictionary rows; degrade to recovery copy on failure."""
+        self._dictionary_lore_request_generation += 1
+        request_generation = self._dictionary_lore_request_generation
         expected_mode = "dictionaries"
         expected_query = query
         if not self._library_render_snapshot_is_current(
@@ -2021,9 +2024,12 @@ class PersonasScreen(BaseAppScreen):
         )
         rows = tuple(self._dictionary_row(r) for r in visible)
         async with self._render_lock:
-            if not self._library_render_snapshot_is_current(
-                expected_query=expected_query,
-                expected_mode=expected_mode,
+            if (
+                request_generation != self._dictionary_lore_request_generation
+                or not self._library_render_snapshot_is_current(
+                    expected_query=expected_query,
+                    expected_mode=expected_mode,
+                )
             ):
                 return
             if recovery_copy is None:
@@ -2065,6 +2071,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _render_lore_rows(self, query: str = "") -> None:
         """Fetch and render lore/world-book rows; degrade to recovery copy on failure."""
+        self._dictionary_lore_request_generation += 1
+        request_generation = self._dictionary_lore_request_generation
         expected_mode = "lore"
         expected_query = query
         if not self._library_render_snapshot_is_current(
@@ -2101,9 +2109,12 @@ class PersonasScreen(BaseAppScreen):
         )
         rows = tuple(self._lore_row(r) for r in visible)
         async with self._render_lock:
-            if not self._library_render_snapshot_is_current(
-                expected_query=expected_query,
-                expected_mode=expected_mode,
+            if (
+                request_generation != self._dictionary_lore_request_generation
+                or not self._library_render_snapshot_is_current(
+                    expected_query=expected_query,
+                    expected_mode=expected_mode,
+                )
             ):
                 return
             if recovery_copy is None:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1401,6 +1401,8 @@ class PersonasScreen(BaseAppScreen):
                 self._characters = []
                 self._character_total = 0
                 self._update_status_row()
+                if self.state.active_mode != "characters":
+                    return
                 if self.state.runtime_source == "server":
                     current_sort_label = "Sort: Server order"
                     current_tag_label = "Tag: All"

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 import dataclasses
 import json
 import re
@@ -232,6 +233,7 @@ PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 #: Rows per library page. ``page_offset`` is always kept a multiple of this so
 #: the pane's "start-end of N" label math stays exact.
 PERSONAS_LIBRARY_PAGE_SIZE = 50
+_MAX_CHARACTER_ID = (1 << 63) - 1
 #: Display labels for the library sort keys (shared by the character sort cycle
 #: and the persona render path).
 _LIBRARY_SORT_LABELS: dict[str, str] = {
@@ -649,6 +651,7 @@ class PersonasScreen(BaseAppScreen):
         # ``_count_cache_key`` so page-nav/sort reuse it and only a filter
         # change recomputes it.
         self._characters: list[dict] = []
+        self._selected_server_character: tuple[str, dict] | None = None
         self._character_total: int = 0
         self._count_cache_key: tuple | None = None
         self._character_tags: list[str] = []
@@ -966,7 +969,10 @@ class PersonasScreen(BaseAppScreen):
             setup_loading = getattr(loading_manager, "setup", None)
             if callable(setup_loading):
                 await setup_loading()
-            await self.character_handler.refresh_character_list()
+            if self.state.runtime_source == "server":
+                await self._reload_character_page()
+            else:
+                await self.character_handler.refresh_character_list()
             self._sync_title_and_console_actions()
             await self._apply_pending_restore()
         except Exception as exc:
@@ -1003,6 +1009,9 @@ class PersonasScreen(BaseAppScreen):
             return
         active_mode = self.state.active_mode
         self.runtime_backend = normalized
+        self._selected_server_character = None
+        self.character_handler.current_character_id = None
+        self.character_handler.current_character_data = {}
         self.state.reset_for_runtime_source_change(normalized)
         self._set_persona_editor_runtime_source(normalized)
         if self.is_mounted:
@@ -1072,8 +1081,12 @@ class PersonasScreen(BaseAppScreen):
         here from the handler's list for compatibility, but the paged reload
         below immediately replaces it with the current page only.
         """
-        self._characters = [dict(record) for record in (characters or [])]
         self._count_cache_key = None
+        if self.state.runtime_source == "server":
+            if self.state.active_mode == "characters":
+                await self._render_library_rows()
+            return
+        self._characters = [dict(record) for record in (characters or [])]
         self._update_status_row()
         if self.state.active_mode != "characters":
             return
@@ -1174,16 +1187,174 @@ class PersonasScreen(BaseAppScreen):
         escaped = term.replace('"', '""')
         return f'"{escaped}"*'
 
-    async def _reload_character_page(self, *, reset_offset: bool = False) -> None:
-        """Load and render one page of characters from the local DB.
+    def _active_server_target(self) -> str | None:
+        """Return the exact active configured-target ID, when usable."""
+        value = getattr(self.app_instance, "active_server_id", None)
+        if type(value) is str and value and value == value.strip():
+            return value
+        return None
 
-        The DB count/list run off-thread; the count is cached under
-        ``(search, tag)`` so page-nav and sort reuse it. After the awaits, a
-        freshness guard re-checks ``(mode, search, sort, tag, offset)`` so a
-        superseded reload never writes stale rows into the pane.
+    @staticmethod
+    def _character_record_mapping(value: Any) -> dict | None:
+        """Return one detached character DTO mapping, if structurally valid."""
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            try:
+                value = model_dump(mode="json")
+            except Exception:
+                return None
+        if not isinstance(value, Mapping):
+            return None
+        return dict(value)
+
+    @staticmethod
+    def _server_character_id(value: Any) -> int | None:
+        """Return one server DTO's canonical positive numeric ID."""
+        if type(value) is not int or not (1 <= value <= _MAX_CHARACTER_ID):
+            return None
+        return value
+
+    @classmethod
+    def _server_character_rows(
+        cls, response: Any
+    ) -> tuple[list[dict], int | None]:
+        """Normalize the existing list/query response shapes without widening them."""
+        response_mapping = cls._character_record_mapping(response)
+        total: int | None = None
+        if response_mapping is not None:
+            raw_items = response_mapping.get(
+                "items", response_mapping.get("characters", [])
+            )
+            raw_total = response_mapping.get("total")
+            if type(raw_total) is int and raw_total >= 0:
+                total = raw_total
+        elif isinstance(response, (list, tuple)):
+            raw_items = response
+        else:
+            raw_items = ()
+
+        rows: list[dict] = []
+        for value in raw_items if isinstance(raw_items, (list, tuple)) else ():
+            record = cls._character_record_mapping(value)
+            if record is None:
+                continue
+            character_id = cls._server_character_id(record.get("id"))
+            if character_id is None:
+                continue
+            record["id"] = character_id
+            rows.append(record)
+        return rows, total
+
+    async def _display_character_page(
+        self,
+        records: list[dict],
+        *,
+        total: int,
+        offset: int,
+        sort_label: str,
+        tag_label: str,
+    ) -> None:
+        """Commit and render one already-fenced character page."""
+        self._characters = records
+        self._character_total = total
+        self._update_status_row()
+        try:
+            library = self.query_one(PersonasLibraryPane)
+        except QueryError:
+            return
+        async with self._render_lock:
+            await library.update_rows(
+                self._build_library_rows(records, "character"),
+                total=total,
+                noun="characters",
+                page_offset=offset,
+                page_size=PERSONAS_LIBRARY_PAGE_SIZE,
+            )
+            library.set_sort_label(sort_label)
+            library.set_tag_label(tag_label)
+            if (
+                self.state.selected_entity_kind == "character"
+                and self.state.selected_entity_id
+            ):
+                library.mark_active_row("character", self.state.selected_entity_id)
+
+    async def _reload_server_character_page(self) -> None:
+        """Load one server-owned page through the existing character scope service."""
+        mode = self.state.active_mode
+        query = self.state.search_query
+        sort_key = self.state.sort_key
+        tag = self.state.tag_filter
+        offset = self.state.page_offset
+        expected_server_id = self._active_server_target()
+        if expected_server_id is None:
+            return
+
+        service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        method_name = "search_characters" if query else "list_characters"
+        load_characters = getattr(service, method_name, None)
+        if not callable(load_characters):
+            return
+        try:
+            if query:
+                response = await load_characters(
+                    query,
+                    mode="server",
+                    limit=offset + PERSONAS_LIBRARY_PAGE_SIZE + 1,
+                )
+                page_start = offset
+            else:
+                response = await load_characters(
+                    mode="server",
+                    limit=PERSONAS_LIBRARY_PAGE_SIZE + 1,
+                    offset=offset,
+                )
+                page_start = 0
+            records, exact_total = self._server_character_rows(response)
+            page_end = page_start + PERSONAS_LIBRARY_PAGE_SIZE
+            page_records = records[page_start:page_end]
+            has_more = len(records) > page_end
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Server character page load failed.")
+            self._notify("Could not load server characters.", "error")
+            return
+
+        if (
+            self.state.runtime_source != "server"
+            or self._active_server_target() != expected_server_id
+            or self.state.active_mode != mode
+            or self.state.search_query != query
+            or self.state.sort_key != sort_key
+            or self.state.tag_filter != tag
+            or self.state.page_offset != offset
+        ):
+            return
+
+        inferred_total = offset + len(page_records) + (1 if has_more else 0)
+        total = exact_total if exact_total is not None else inferred_total
+        self._count_cache_key = None
+        await self._display_character_page(
+            page_records,
+            total=max(total, inferred_total),
+            offset=offset,
+            sort_label="Sort: Server order",
+            tag_label="Tag: All",
+        )
+
+    async def _reload_character_page(self, *, reset_offset: bool = False) -> None:
+        """Load and render one page of characters from the selected source.
+
+        Local DB count/list work remains off-thread. Server mode delegates to
+        the existing source-aware scope service and never consults local rows.
         """
         if reset_offset:
             self.state.page_offset = 0
+        if self.state.runtime_source == "server":
+            await self._reload_server_character_page()
+            return
         mode = self.state.active_mode
         query = self.state.search_query
         sort_key = self.state.sort_key
@@ -1236,32 +1407,15 @@ class PersonasScreen(BaseAppScreen):
             return
         # Commit shared count state only after the guard passes, so a
         # superseded reload cannot clobber the winner's cached count.
-        self._character_total = total
         self._count_cache_key = cache_key
-        self._characters = records
-        self._update_status_row()
-        rows = self._build_library_rows(records, "character")
-        try:
-            library = self.query_one(PersonasLibraryPane)
-        except QueryError:
-            # Screen torn down mid-reload; nothing to render.
-            return
         sort_labels = dict(self._character_sort_cycle())
-        async with self._render_lock:
-            await library.update_rows(
-                rows,
-                total=total,
-                noun="characters",
-                page_offset=offset,
-                page_size=PERSONAS_LIBRARY_PAGE_SIZE,
-            )
-            library.set_sort_label(f"Sort: {sort_labels.get(sort_key, 'Name')}")
-            library.set_tag_label(f"Tag: {tag}" if tag else "Tag: All")
-            if (
-                self.state.selected_entity_kind == "character"
-                and self.state.selected_entity_id
-            ):
-                library.mark_active_row("character", self.state.selected_entity_id)
+        await self._display_character_page(
+            records,
+            total=total,
+            offset=offset,
+            sort_label=f"Sort: {sort_labels.get(sort_key, 'Name')}",
+            tag_label=f"Tag: {tag}" if tag else "Tag: All",
+        )
 
     async def _reload_active_library(self) -> None:
         """Re-render whichever paginated library (characters/personas) is active."""
@@ -1456,6 +1610,8 @@ class PersonasScreen(BaseAppScreen):
     async def _tag_filter_worker(self) -> None:
         """List tags off-thread, prompt for one, and apply the pick."""
         try:
+            if self.state.runtime_source == "server":
+                return
             db = self._character_db()
             if db is None:
                 return
@@ -1762,6 +1918,7 @@ class PersonasScreen(BaseAppScreen):
 
     async def _apply_mode(self, mode: str) -> None:
         self._cancel_search_debounce()
+        self._selected_server_character = None
         # switch_mode resets sort_key/tag_filter/page_offset for a fresh window.
         self.state.switch_mode(mode)
         self._set_persona_editor_runtime_source(self.persona_handler.current_mode())
@@ -1931,9 +2088,69 @@ class PersonasScreen(BaseAppScreen):
         # Prompts are not wired here: prompt management is retired from
         # Personas and lives entirely inside Library (Task 7).
 
+    async def _fetch_server_character(
+        self, entity_id: str
+    ) -> tuple[str, dict] | None:
+        """Fetch one server card and prove its source target and numeric ID."""
+        if (
+            type(entity_id) is not str
+            or re.fullmatch(r"[1-9][0-9]{0,18}", entity_id) is None
+        ):
+            return None
+        character_id = int(entity_id)
+        if character_id > _MAX_CHARACTER_ID:
+            return None
+
+        expected_server_id = self._active_server_target()
+        if expected_server_id is None:
+            return None
+        service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        get_character = getattr(service, "get_character", None)
+        if not callable(get_character):
+            return None
+        try:
+            response = await get_character(character_id, mode="server")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Server character detail load failed.")
+            self._notify("Could not load the server character.", "error")
+            return None
+        if (
+            self.state.runtime_source != "server"
+            or self._active_server_target() != expected_server_id
+        ):
+            return None
+
+        record = self._character_record_mapping(response)
+        if (
+            record is None
+            or self._server_character_id(record.get("id")) != character_id
+        ):
+            return None
+        record["id"] = character_id
+        return expected_server_id, record
+
     async def _select_character(
         self, entity_id: str, entity_name: str, *, restore_preview: dict | None = None
     ) -> None:
+        server_record: dict | None = None
+        if self.state.runtime_source == "server":
+            fetched = await self._fetch_server_character(entity_id)
+            if fetched is None:
+                return
+            server_target, server_record = fetched
+            entity_name = str(server_record.get("name") or entity_name or "Unnamed")
+            server_record["name"] = entity_name
+            self._selected_server_character = (
+                server_target,
+                dict(server_record),
+            )
+        else:
+            self._selected_server_character = None
+
         self.state.select_entity(
             entity_kind="character",
             entity_id=entity_id,
@@ -1942,33 +2159,35 @@ class PersonasScreen(BaseAppScreen):
         self.query_one(PersonasPreviewPane).set_speakers(character=entity_name)
         self._edit_mode = "view"
         self.query_one(PersonasLibraryPane).mark_active_row("character", entity_id)
-        await self.character_handler.load_character(entity_id)
+        if server_record is None:
+            await self.character_handler.load_character(entity_id)
+        else:
+            self.query_one(PersonasCharacterCardWidget).load_character(server_record)
         self._show_center("#ccp-character-card-view")
         inspector = self.query_one(PersonasInspectorPane)
         inspector.show_selection(name=entity_name, kind="character")
         inspector.set_unsaved(False)
         inspector.show_validation(())
         self._sync_inspector_console_actions()
-        # Fire-and-forget, like the conversations list below: the portrait
-        # needs a DB read and an image decode, and awaiting it inline made
-        # selecting a character wait on both. It also yielded control mid
-        # selection, which let the editor's debounced validation run and clear
-        # a footer the save path had just written. The render carries its own
-        # selection-changed guard, so a late result cannot paint the wrong face.
-        self.run_worker(
-            self._render_inspector_avatar(),
-            group="inspector-avatar",
-            exclusive=True,
-        )
-        # Drop any previous character's rows immediately and show a loading
-        # placeholder; the worker fills the panel in once the listing returns
-        # (or replaces the placeholder with the empty-state copy).
+
         self.conversations.reset()
-        await inspector.show_conversations_loading()
-        self.conversations.load_conversations(entity_id)
+        if server_record is None:
+            # Local-only auxiliary data stays behind the local boundary.
+            self.run_worker(
+                self._render_inspector_avatar(),
+                group="inspector-avatar",
+                exclusive=True,
+            )
+            await inspector.show_conversations_loading()
+            self.conversations.load_conversations(entity_id)
+        else:
+            inspector.set_avatar_thumbnail(None)
+            await inspector.show_conversations(())
+            self.query_one(
+                "#personas-card-edit-character", Button
+            ).disabled = True
+
         if restore_preview is not None:
-            # A navigation round-trip (task-434): rebuild the saved preview
-            # transcript instead of reseeding just the greeting.
             await self.preview.restore_conversation(
                 greeting=str(restore_preview.get("greeting") or ""),
                 history=list(restore_preview.get("history") or []),
@@ -1976,21 +2195,14 @@ class PersonasScreen(BaseAppScreen):
                 greeting_index=int(restore_preview.get("greeting_index") or 0),
             )
         else:
-            # Seed the ephemeral preview with the character's greeting. The
-            # list rows are id/name-only summaries and load_character only
-            # SCHEDULES a thread worker, so the full record (with
-            # first_message) is usually not available yet here. Instant
-            # path: when the handler already holds this character's full
-            # card (re-selection), seed now; otherwise clear the preview and
-            # let the CharacterMessage.Loaded handler seed it.
-            record = self._full_character_record(entity_id)
             await self.preview.reset_for_character(
                 character_id=entity_id,
                 character_name=entity_name,
-                record=record,
+                record=server_record or self._full_character_record(entity_id),
             )
-        await self._refresh_character_dictionaries()
-        await self._refresh_character_worldbooks()
+        if server_record is None:
+            await self._refresh_character_dictionaries()
+            await self._refresh_character_worldbooks()
 
     async def _select_profile(self, entity_id: str, entity_name: str) -> None:
         self.state.select_entity(
@@ -2542,6 +2754,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _refresh_character_dictionaries(self) -> None:
         """Re-feed the character dictionaries panel (best-effort)."""
+        if self.state.runtime_source == "server":
+            return
         entity_id = self.state.selected_entity_id
         service = self._dictionary_scope_service()
         if (
@@ -2565,6 +2779,8 @@ class PersonasScreen(BaseAppScreen):
 
     async def _refresh_character_worldbooks(self) -> None:
         """Re-feed the character world-books panel (best-effort)."""
+        if self.state.runtime_source == "server":
+            return
         entity_id = self.state.selected_entity_id
         if self.state.selected_entity_kind != "character" or not entity_id:
             return
@@ -3614,9 +3830,7 @@ class PersonasScreen(BaseAppScreen):
             )
         active_server_profile_id = None
         if runtime_source == "server":
-            active_server_id = getattr(self.app_instance, "active_server_id", None)
-            if type(active_server_id) is str and active_server_id:
-                active_server_profile_id = active_server_id
+            active_server_profile_id = self._active_server_target()
         payload = ChatHandoffPayload.from_source_content(
             source="personas",
             item_type=item_type,
@@ -3805,6 +4019,21 @@ class PersonasScreen(BaseAppScreen):
     @on(CharacterMessage.Loaded)
     async def _handle_character_loaded(self, message: CharacterMessage.Loaded) -> None:
         message.stop()
+        if self.state.runtime_source == "server":
+            cached = self._selected_server_character
+            if cached is not None:
+                target, record = cached
+            else:
+                target, record = None, None
+            if (
+                target == self._active_server_target()
+                and record is not None
+                and str(record.get("id")) == str(self.state.selected_entity_id)
+            ):
+                self.character_handler.current_character_id = record["id"]
+                self.character_handler.current_character_data = dict(record)
+                self.query_one(PersonasCharacterCardWidget).load_character(record)
+            return
         await self.preview.handle_character_loaded(
             character_id=str(message.character_id),
             card_data=message.card_data,
@@ -4346,12 +4575,23 @@ class PersonasScreen(BaseAppScreen):
             pane.set_row_unsaved(None, None, False)
 
     def _full_character_record(self, character_id: str) -> dict | None:
-        """Return the handler's fully-loaded card, or ``None`` when stale.
+        """Return the selected source's fully-loaded card, or ``None`` when stale.
 
         The list rows in ``_characters`` are id/name-only; falling back to
         them would feed the editor (and a later save) empty fields, so a
         mismatch deliberately returns ``None``.
         """
+        if self.state.runtime_source == "server":
+            cached = self._selected_server_character
+            if cached is None:
+                return None
+            target, record = cached
+            if (
+                target == self._active_server_target()
+                and str(record.get("id")) == character_id
+            ):
+                return dict(record)
+            return None
         loaded = self.character_handler.current_character_data
         if loaded and str(self.character_handler.current_character_id) == character_id:
             return dict(loaded)
@@ -4589,6 +4829,9 @@ class PersonasScreen(BaseAppScreen):
             inspector = self.query_one(PersonasInspectorPane)
         except QueryError:
             return
+        if self.state.runtime_source == "server":
+            inspector.set_avatar_thumbnail(None)
+            return
         if self.state.selected_entity_kind != "character":
             inspector.set_avatar_thumbnail(None)
             return
@@ -4635,7 +4878,10 @@ class PersonasScreen(BaseAppScreen):
         # render must not paint another character's face into the rail -- and
         # a late FAILURE must not blank the portrait of whoever is selected
         # now, so the staleness check comes before any clearing.
-        if str(self.state.selected_entity_id or "") != selected_id:
+        if (
+            self.state.runtime_source != "local"
+            or str(self.state.selected_entity_id or "") != selected_id
+        ):
             return
         if not ok or not self.is_mounted:
             inspector.set_avatar_thumbnail(None)
@@ -7374,7 +7620,7 @@ class PersonasScreen(BaseAppScreen):
             dict_panel.display = visible_id in (
                 "#ccp-character-card-view",
                 "#ccp-character-editor-view",
-            )
+            ) and self.state.runtime_source == "local"
         # The docked wrapper that holds BOTH character-attachment panels
         # (Roleplay P2f Task 6 added the world-books panel alongside the
         # P1f dictionaries panel inside #personas-character-attachments)
@@ -7395,7 +7641,7 @@ class PersonasScreen(BaseAppScreen):
             attachments_wrapper.display = visible_id in (
                 "#ccp-character-card-view",
                 "#ccp-character-editor-view",
-            )
+            ) and self.state.runtime_source == "local"
         # The conversation actions row is chrome shown alongside (not instead
         # of) the read-only conversation view.
         try:

--- a/tldw_chatbook/runtime_policy/__init__.py
+++ b/tldw_chatbook/runtime_policy/__init__.py
@@ -110,8 +110,13 @@ _EXPORTS = {
     ),
     "ServerContextUnavailable": (".server_context", "ServerContextUnavailable"),
     "ServerCredentialsUnavailable": (".server_context", "ServerCredentialsUnavailable"),
+    "ServerIdentityUnavailable": (".server_context", "ServerIdentityUnavailable"),
     "SyncIdentityMapEntry": (".server_parity_models", "SyncIdentityMapEntry"),
     "SyncReadinessReport": (".server_parity_models", "SyncReadinessReport"),
+    "encode_server_user_character_authority": (
+        ".server_context",
+        "encode_server_user_character_authority",
+    ),
     "validate_unsupported_capability_report": (
         ".unsupported_capabilities",
         "validate_unsupported_capability_report",
@@ -169,8 +174,10 @@ __all__ = [
     "ServerParityStateRepositories",
     "ServerContextUnavailable",
     "ServerCredentialsUnavailable",
+    "ServerIdentityUnavailable",
     "SyncIdentityMapEntry",
     "SyncReadinessReport",
+    "encode_server_user_character_authority",
     "validate_unsupported_capability_report",
     "validate_registry_completeness",
 ]

--- a/tldw_chatbook/runtime_policy/server_context.py
+++ b/tldw_chatbook/runtime_policy/server_context.py
@@ -236,12 +236,17 @@ class RuntimeServerContextProvider:
         self,
         *,
         expected_server_id: str,
+        context_capture: object | None = None,
     ) -> str:
         """Resolve authority for the expected target's authenticated user.
 
         Args:
             expected_server_id: Configured target identifier already carried
                 by the caller's character context.
+            context_capture: Optional opaque capture returned by
+                :meth:`capture_character_authority_context`. Supplying it
+                binds identity resolution to the caller's exact authenticated
+                context across later operations.
 
         Returns:
             The versioned server-user character authority identifier.
@@ -252,7 +257,18 @@ class RuntimeServerContextProvider:
             asyncio.CancelledError: If the caller cancels the identity lookup.
         """
         try:
-            capture = self._capture_character_authority_context(expected_server_id)
+            if context_capture is None:
+                capture = self._capture_character_authority_context(
+                    expected_server_id
+                )
+            elif (
+                type(context_capture) is _CharacterAuthorityContextCapture
+                and context_capture.expected_server_id == expected_server_id
+                and self._character_authority_capture_matches(context_capture)
+            ):
+                capture = context_capture
+            else:
+                raise ServerIdentityUnavailable()
         except Exception:
             raise ServerIdentityUnavailable() from None
 
@@ -298,6 +314,29 @@ class RuntimeServerContextProvider:
             authority_id=authority_id,
         )
         return authority_id
+
+    def capture_character_authority_context(
+        self,
+        *,
+        expected_server_id: str,
+    ) -> object:
+        """Return an opaque proof of the current authenticated character context.
+
+        The returned object intentionally exposes no public credential or
+        client fields. Callers may only pass it back to the provider's
+        character-authority APIs.
+        """
+        try:
+            return self._capture_character_authority_context(expected_server_id)
+        except Exception:
+            raise ServerIdentityUnavailable() from None
+
+    def is_character_authority_context_current(self, capture: object) -> bool:
+        """Return whether an opaque capture still owns the authenticated client."""
+        return (
+            type(capture) is _CharacterAuthorityContextCapture
+            and self._character_authority_capture_matches(capture)
+        )
 
     async def close_cached_client(self) -> None:
         cached_client = self._cached_client

--- a/tldw_chatbook/runtime_policy/server_context.py
+++ b/tldw_chatbook/runtime_policy/server_context.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Mapping
+from uuid import UUID
 
 from loguru import logger
 
@@ -26,7 +27,60 @@ from .server_credentials import (
     SERVER_CREDENTIAL_REFRESH_TOKEN,
     ServerCredentialStore,
 )
-from .types import ServerContextFailure, ServerContextFailureReason
+from .types import (
+    RuntimeSourceState,
+    ServerContextFailure,
+    ServerContextFailureReason,
+)
+
+_CHARACTER_AUTHORITY_DOMAIN = b"tldw-chatbook.character-authority"
+_CHARACTER_AUTHORITY_VERSION = b"1"
+_MAX_SERVER_USER_ID = 2**63 - 1
+
+
+def encode_server_user_character_authority(
+    authority_scope_id: str,
+    user_id: int,
+) -> str:
+    """Encode one configured-target scope and authenticated user as authority.
+
+    Args:
+        authority_scope_id: Exact canonical lowercase hyphenated UUIDv4 scope.
+        user_id: Exact positive integer server user identifier.
+
+    Returns:
+        The fixed-width version-one server-user authority identifier.
+
+    Raises:
+        ValueError: If either identity component is outside the canonical
+            encoding contract.
+    """
+    if type(authority_scope_id) is not str:
+        raise ValueError("authority_scope_id must be a canonical UUIDv4")
+    try:
+        scope_ascii = authority_scope_id.encode("ascii")
+        parsed_scope = UUID(authority_scope_id)
+    except (UnicodeEncodeError, ValueError):
+        raise ValueError("authority_scope_id must be a canonical UUIDv4") from None
+    if parsed_scope.version != 4 or str(parsed_scope) != authority_scope_id:
+        raise ValueError("authority_scope_id must be a canonical UUIDv4")
+
+    if type(user_id) is not int or not 1 <= user_id <= _MAX_SERVER_USER_ID:
+        raise ValueError("user_id must be a positive signed 64-bit integer")
+    user_id_ascii = str(user_id).encode("ascii")
+
+    def _length_prefix(value: bytes) -> bytes:
+        return len(value).to_bytes(4, byteorder="big", signed=False) + value
+
+    frame = b"".join(
+        (
+            _length_prefix(_CHARACTER_AUTHORITY_DOMAIN),
+            _length_prefix(_CHARACTER_AUTHORITY_VERSION),
+            _length_prefix(scope_ascii),
+            _length_prefix(user_id_ascii),
+        )
+    )
+    return f"server-user-v1:{hashlib.sha256(frame).hexdigest()}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +103,23 @@ class _CachedClientKey:
     auth_method: str
     credential_source: str
     token_fingerprint: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _CharacterAuthorityContextCapture:
+    runtime_state: RuntimeSourceState = field(repr=False)
+    runtime_revision: int
+    expected_server_id: str = field(repr=False)
+    authority_scope_id: str = field(repr=False)
+    active_context: ActiveServerContext = field(repr=False)
+    client_cache_key: _CachedClientKey = field(repr=False)
+    client: TLDWAPIClient = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedCharacterAuthority:
+    capture: _CharacterAuthorityContextCapture = field(repr=False)
+    authority_id: str = field(repr=False)
 
 
 class ServerContextError(RuntimeError):
@@ -84,6 +155,13 @@ class ServerCredentialsUnavailable(ServerContextError):
     reason_code = "server_credentials_unavailable"
 
 
+class ServerIdentityUnavailable(ServerContextError):
+    reason_code = "server_identity_unavailable"
+
+    def __init__(self) -> None:
+        super().__init__("Server identity unavailable.")
+
+
 class RuntimeServerContextProvider:
     def __init__(
         self,
@@ -100,6 +178,7 @@ class RuntimeServerContextProvider:
         self._legacy_cleared_server_ids: set[str] = set()
         self._cached_client_key: _CachedClientKey | None = None
         self._cached_client: TLDWAPIClient | None = None
+        self._cached_character_authority: _CachedCharacterAuthority | None = None
         self._pending_client_close_tasks: set[asyncio.Task[None]] = set()
 
     def get_active_context(self) -> ActiveServerContext:
@@ -153,10 +232,78 @@ class RuntimeServerContextProvider:
         )
         return self._cached_client
 
+    async def resolve_character_authority_id(
+        self,
+        *,
+        expected_server_id: str,
+    ) -> str:
+        """Resolve authority for the expected target's authenticated user.
+
+        Args:
+            expected_server_id: Configured target identifier already carried
+                by the caller's character context.
+
+        Returns:
+            The versioned server-user character authority identifier.
+
+        Raises:
+            ServerIdentityUnavailable: If exact stable target and account
+                authority cannot be proven.
+            asyncio.CancelledError: If the caller cancels the identity lookup.
+        """
+        try:
+            capture = self._capture_character_authority_context(expected_server_id)
+        except Exception:
+            raise ServerIdentityUnavailable() from None
+
+        cached = self._cached_character_authority
+        if cached is not None and self._same_authority_capture(
+            cached.capture,
+            capture,
+        ):
+            return cached.authority_id
+
+        try:
+            response = await capture.client.get_current_user_profile(
+                sections="identity"
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            raise ServerIdentityUnavailable() from None
+
+        if not self._character_authority_capture_matches(capture):
+            raise ServerIdentityUnavailable() from None
+
+        try:
+            user_id = self._extract_identity_user_id(response)
+            authority_id = encode_server_user_character_authority(
+                capture.authority_scope_id,
+                user_id,
+            )
+        except Exception:
+            raise ServerIdentityUnavailable() from None
+
+        cached = self._cached_character_authority
+        if cached is not None and self._same_authority_capture(
+            cached.capture,
+            capture,
+        ):
+            if cached.authority_id != authority_id:
+                raise ServerIdentityUnavailable() from None
+            return cached.authority_id
+
+        self._cached_character_authority = _CachedCharacterAuthority(
+            capture=capture,
+            authority_id=authority_id,
+        )
+        return authority_id
+
     async def close_cached_client(self) -> None:
         cached_client = self._cached_client
         self._cached_client = None
         self._cached_client_key = None
+        self._cached_character_authority = None
         if cached_client is not None:
             await cached_client.close()
         pending_tasks = list(self._pending_client_close_tasks)
@@ -268,6 +415,120 @@ class RuntimeServerContextProvider:
         ):
             return resolved_target
         return None
+
+    def _capture_character_authority_context(
+        self,
+        expected_server_id: str,
+    ) -> _CharacterAuthorityContextCapture:
+        if type(expected_server_id) is not str:
+            raise ServerIdentityUnavailable()
+        if not expected_server_id or expected_server_id != expected_server_id.strip():
+            raise ServerIdentityUnavailable()
+
+        runtime_state, runtime_revision = self.runtime_context.snapshot()
+        if not self._runtime_state_matches_expected_target(
+            runtime_state,
+            expected_server_id,
+        ):
+            raise ServerIdentityUnavailable()
+
+        authority_scope_id = self.target_store.ensure_authority_scope_id(
+            expected_server_id
+        )
+        active_context = self.get_active_context()
+        if (
+            active_context.active_server_id != expected_server_id
+            or active_context.target.server_id != expected_server_id
+            or active_context.target.authority_scope_id != authority_scope_id
+        ):
+            raise ServerIdentityUnavailable()
+
+        client_cache_key = self._client_cache_key(active_context)
+        client = self.build_client()
+        capture = _CharacterAuthorityContextCapture(
+            runtime_state=runtime_state,
+            runtime_revision=runtime_revision,
+            expected_server_id=expected_server_id,
+            authority_scope_id=authority_scope_id,
+            active_context=active_context,
+            client_cache_key=client_cache_key,
+            client=client,
+        )
+        if not self._character_authority_capture_matches(capture):
+            raise ServerIdentityUnavailable()
+        return capture
+
+    def _character_authority_capture_matches(
+        self,
+        capture: _CharacterAuthorityContextCapture,
+    ) -> bool:
+        runtime_state, runtime_revision = self.runtime_context.snapshot()
+        if (
+            runtime_revision != capture.runtime_revision
+            or runtime_state != capture.runtime_state
+            or not self._runtime_state_matches_expected_target(
+                runtime_state,
+                capture.expected_server_id,
+            )
+        ):
+            return False
+
+        try:
+            authority_scope_id = self.target_store.ensure_authority_scope_id(
+                capture.expected_server_id
+            )
+            active_context = self.get_active_context()
+            client_cache_key = self._client_cache_key(active_context)
+        except Exception:
+            return False
+
+        return (
+            authority_scope_id == capture.authority_scope_id
+            and active_context == capture.active_context
+            and client_cache_key == capture.client_cache_key
+            and self._cached_client_key == capture.client_cache_key
+            and self._cached_client is capture.client
+        )
+
+    @staticmethod
+    def _same_authority_capture(
+        left: _CharacterAuthorityContextCapture,
+        right: _CharacterAuthorityContextCapture,
+    ) -> bool:
+        return left == right and left.client is right.client
+
+    @staticmethod
+    def _runtime_state_matches_expected_target(
+        runtime_state: RuntimeSourceState,
+        expected_server_id: str,
+    ) -> bool:
+        active_server_id = runtime_state.active_server_id
+        return (
+            runtime_state.active_source == "server"
+            and runtime_state.server_configured
+            and active_server_id == expected_server_id
+        )
+
+    @staticmethod
+    def _extract_identity_user_id(response: Any) -> int:
+        missing = object()
+        if isinstance(response, Mapping):
+            mapped_user = response.get("user", missing)
+            attribute_user = getattr(response, "user", missing)
+            if attribute_user is not missing and attribute_user != mapped_user:
+                raise ValueError("ambiguous user identity response")
+            user = mapped_user
+        else:
+            user = getattr(response, "user", missing)
+
+        if not isinstance(user, Mapping):
+            raise ValueError("missing user identity")
+        user_id = user.get("id", missing)
+        if user_id is missing:
+            raise ValueError("missing user identifier")
+        if type(user_id) is not int or not 1 <= user_id <= _MAX_SERVER_USER_ID:
+            raise ValueError("invalid user identifier")
+        return user_id
 
     def _require_active_server_id(self) -> str:
         state = self.runtime_context.state
@@ -456,6 +717,7 @@ class RuntimeServerContextProvider:
         cached_client = self._cached_client
         self._cached_client = None
         self._cached_client_key = None
+        self._cached_character_authority = None
         if cached_client is not None:
             self._close_client_sync_safe(cached_client)
 
@@ -565,4 +827,6 @@ __all__ = [
     "ServerContextError",
     "ServerContextUnavailable",
     "ServerCredentialsUnavailable",
+    "ServerIdentityUnavailable",
+    "encode_server_user_character_authority",
 ]

--- a/tldw_chatbook/runtime_policy/types.py
+++ b/tldw_chatbook/runtime_policy/types.py
@@ -18,6 +18,7 @@ ServerContextFailureReason = Literal[
     "server_credentials_unavailable",
     "stale_authorization",
     "profile_no_longer_authorized",
+    "server_identity_unavailable",
 ]
 ActionKind = Literal[
     "browse", "detail", "create", "update", "delete", "launch", "observe"
@@ -36,6 +37,7 @@ SERVER_CONTEXT_FAILURE_REASON_CODES: frozenset[ServerContextFailureReason] = fro
         "server_credentials_unavailable",
         "stale_authorization",
         "profile_no_longer_authorized",
+        "server_identity_unavailable",
     }
 )
 


### PR DESCRIPTION
## Summary

- persist stable, redacted local and configured-server character authority, including atomic legacy target upgrades and revision/auth-context-fenced server-user derivation
- add schema v28 conversation provenance with normalized CRUD/backup behavior, explicit authority-null import and current Sync V2 boundaries, and opaque server character IDs
- carry exact source-aware identity through Console and Roleplay handoffs while keeping Persona/generic sessions authority-free and leaving TTS selection, speech admission, assignment, and managed audio.cpp behavior unchanged

## Verification

- final 20-file TASK-617.2 union: **1292 passed, 5 inherited failures, 2 warnings**
  - all five exact failures reproduce on `origin/dev` `f3ecd8672`
  - four are stale module-level `settings` monkeypatches in `Tests/Chat/test_chat_functions.py`
  - one is the existing MagicMock-await fixture in `TestImportExport::test_import_failure_shows_recovery_copy`
- rebase-conflict overlap: **3 passed** (`dev` non-blocking Personas mount + exact server handoff + source-switch isolation)
- external audio.cpp/profile regression gate: **589 passed, 1 warning**
- legacy Tavern/SillyTavern import amendment gate: **156 passed**
- changed production Ruff: clean
- `git diff --check origin/dev..HEAD`: clean
- production mypy comparison: **128 errors in 7 files** on both branch and exact `origin/dev`; zero task delta
- repository-wide collection remains blocked by the inherited `StreamDone` import error in `Tests/Event_Handlers/test_worker_events_contract.py`, reproduced on exact `origin/dev`

## Architecture and scope

- governed by ADR-037
- no dependency, production TTS, production Sync V2, speech-snapshot, TTS-assignment, or managed audio.cpp changes
- TASK-617.2 acceptance criteria and Definition of Done are complete in the checked-in Backlog task

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable character authority and conversation provenance. Introduces schema v28 with `assistant_authority_id`, persists configured-server authority scopes, and carries source-aware identity across Console, Roleplay, and handoffs without changing TTS, Sync V2, or audio behavior. (Satisfies TASK-617.2)

- **New Features**
  - DB v28: add `assistant_authority_id` to conversations (NULL for unproven), normalize CRUD/backup/imports, and expose local authority lookup; fresh DBs start at v28.
  - MCP/Runtime: `ConfiguredServerTarget` now persists an `authority_scope_id` (UUIDv4); `ConfiguredServerTargetStore` serializes mutations and raises `AuthorityScopeUnavailable`; runtime exports `encode_server_user_character_authority` and reports `server_identity_unavailable` when needed.
  - Chat/Console/UI: sessions persist `(assistant_kind, assistant_id, assistant_authority_id)`; character sessions route via the plain provider keyed on `assistant_kind`; UI projects a `CharacterRef`, rejects character identity without source, and isolates server character actions; Roleplay handoffs include exact authority.
  - Import/Sync: Tavern/SillyTavern and chatbook imports explicitly set authority to `NULL`; Sync V2 outbox does not transport or infer local character authority.

- **Migration**
  - No manual steps; opening the app auto-migrates to v28.
  - For local character chats use `assistant_id=str(character_id)` and `assistant_authority_id=db.get_local_authority_id()` via `CharactersRAGDB`.
  - For server-backed chats set `assistant_kind="character"`, `runtime_backend="server"`, use the opaque server character ID for `assistant_id`, and let runtime resolve `assistant_authority_id` from the configured server target.

<sup>Written for commit 625177b46dc60428158a38d41b81e1590096f279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

