### PR TITLE
fix(watchlists): scheduled checks create real run rows (TASK-1383)

### DIFF
--- a/Tests/Scheduling/test_scheduled_watchlist_runs.py
+++ b/Tests/Scheduling/test_scheduled_watchlist_runs.py
@@ -30,6 +30,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from loguru import logger as loguru_logger
 
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler import (
@@ -170,10 +171,29 @@ def _loop(subs_db: SubscriptionsDB, handler: WatchlistCheckHandler) -> Scheduler
 
 
 def _run_rows(subs_db: SubscriptionsDB) -> list[dict]:
-    rows = subs_db.conn.execute(
-        "SELECT * FROM local_watchlist_runs ORDER BY id ASC"
-    ).fetchall()
+    with subs_db.transaction() as conn:
+        rows = conn.execute(
+            "SELECT * FROM local_watchlist_runs ORDER BY id ASC"
+        ).fetchall()
     return [dict(row) for row in rows]
+
+
+def _count_items(subs_db: SubscriptionsDB, subscription_id: int) -> int:
+    with subs_db.transaction() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM subscription_items WHERE subscription_id = ?",
+            (subscription_id,),
+        ).fetchone()
+    return row["n"]
+
+
+def _count_snapshots(subs_db: SubscriptionsDB, subscription_id: int) -> int:
+    with subs_db.transaction() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM url_snapshots WHERE subscription_id = ?",
+            (subscription_id,),
+        ).fetchone()
+    return row["n"]
 
 
 # --- AC#1 + AC#2 -----------------------------------------------------------
@@ -241,16 +261,15 @@ async def test_scheduled_check_produces_the_item_and_snapshot(tmp_path, monkeypa
     _serve(monkeypatch, {url: _page("a materially different body")})
     await handler.handle(_task(subscription_id))
 
-    snapshots = subs_db.conn.execute(
-        "SELECT COUNT(*) AS n FROM url_snapshots WHERE subscription_id = ?",
-        (subscription_id,),
-    ).fetchone()["n"]
-    assert snapshots == 2, "the real URLMonitor persists a snapshot per check"
+    assert _count_snapshots(subs_db, subscription_id) == 2, (
+        "the real URLMonitor persists a snapshot per check"
+    )
 
-    items = subs_db.conn.execute(
-        "SELECT * FROM subscription_items WHERE subscription_id = ?",
-        (subscription_id,),
-    ).fetchall()
+    with subs_db.transaction() as conn:
+        items = conn.execute(
+            "SELECT * FROM subscription_items WHERE subscription_id = ?",
+            (subscription_id,),
+        ).fetchall()
     assert len(items) == 1, "the detected change is stored as an item"
     assert items[0]["run_id"] == _run_rows(subs_db)[1]["id"], (
         "the item is attributed to the run that found it"
@@ -343,12 +362,12 @@ async def test_shadow_mode_creates_no_run_row_item_or_snapshot(tmp_path, monkeyp
 
     assert fetched == [url], "shadow mode still performs the fetch"
     assert _run_rows(subs_db) == [], "shadow mode must not create a run row"
-    for table in ("subscription_items", "url_snapshots"):
-        count = subs_db.conn.execute(
-            f"SELECT COUNT(*) AS n FROM {table} WHERE subscription_id = ?",
-            (subscription_id,),
-        ).fetchone()["n"]
-        assert count == 0, f"shadow mode wrote to {table}"
+    assert _count_items(subs_db, subscription_id) == 0, (
+        "shadow mode wrote to subscription_items"
+    )
+    assert _count_snapshots(subs_db, subscription_id) == 0, (
+        "shadow mode wrote to url_snapshots"
+    )
     after = subs_db.get_subscription(subscription_id)["last_checked"]
     assert after == before, "shadow mode must not record a check result"
 
@@ -471,27 +490,130 @@ async def test_failure_recorder_itself_raising_still_records_the_check_error(
     assert row["consecutive_failures"] == 1
 
 
+@pytest.mark.asyncio
+async def test_failed_scheduled_check_is_logged_as_a_warning_with_the_error(
+    tmp_path, monkeypatch
+):
+    """A failed run must say so in the log, with its error text.
+
+    It used to be reported at INFO as "check complete" with no error at all --
+    so an unattended check of a dead source left a metric counter as its only
+    trace, which is the same invisibility the run row was added to fix.
+
+    Captured with a loguru sink rather than `caplog`: this repo logs through
+    loguru, which does not propagate to the stdlib `logging` handlers `caplog`
+    installs, so a `caplog`-based assertion here would pass vacuously.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    subscription_id = _add_due_source(
+        subs_db, name="Dead page", type="url", source="https://example.com/gone"
+    )
+    _serve_failure(monkeypatch, RuntimeError("connection refused"))
+
+    records: list[tuple[str, str]] = []
+    sink_id = loguru_logger.add(
+        lambda message: records.append(
+            (message.record["level"].name, message.record["message"])
+        ),
+        level="INFO",
+    )
+    try:
+        await _handler(subs_db).handle(_task(subscription_id))
+    finally:
+        loguru_logger.remove(sink_id)
+
+    warnings = [text for level, text in records if level in ("WARNING", "ERROR")]
+    assert any("connection refused" in text for text in warnings), (
+        f"the failure's error text must reach the log at WARNING+; got {records}"
+    )
+    assert not any("check complete" in text.lower() for _, text in records), (
+        "a failed run must not also be announced as a completed one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shadow_reports_unsupported_types_distinctly_from_unknown_ones(
+    tmp_path, monkeypatch
+):
+    """Shadow mode must not call a real, checkable source unrecognised.
+
+    Unification made the real path execute `sitemap` and `api`, but the shadow
+    probe cannot reach either. Reporting them as `unknown_type` would have
+    shadow mode -- a diagnostic -- assert that a perfectly valid source is not
+    recognised by the scheduler, which is a false clean bill of health.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    sitemap_id = _add_due_source(
+        subs_db,
+        name="Sitemap source",
+        type="sitemap",
+        source="https://example.com/sitemap.xml",
+    )
+    fetched = _serve(monkeypatch, {}, sitemap=True)
+
+    statuses: list[str] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler.log_counter",
+        lambda name, labels=None: statuses.append((labels or {}).get("status")),
+    )
+
+    handler = _handler(subs_db, shadow_mode=True)
+    await handler.handle(_task(sitemap_id))
+
+    assert statuses == ["shadow_unsupported"], (
+        "an executable type the probe cannot reach is not an unknown type"
+    )
+    assert fetched == [], "shadow mode must not pretend to have checked it"
+    assert _run_rows(subs_db) == [], "shadow mode still writes no run row"
+
+    # A type nothing can execute is still reported as genuinely unknown.
+    statuses.clear()
+    unknown = _subscription_of_unsupported_type(subs_db)
+    await handler.handle(_task(unknown))
+    assert statuses == ["unknown_type"]
+
+
+def _subscription_of_unsupported_type(subs_db: SubscriptionsDB) -> int:
+    """Insert a row whose type no executor handles.
+
+    Written past `add_subscription` deliberately: the `subscriptions.type` CHECK
+    constraint accepts exactly `EXECUTABLE_SOURCE_TYPES`, so a genuinely unknown
+    type cannot be stored through the normal API -- which is itself the
+    invariant `test_executable_types_match_every_type_the_db_accepts` pins.
+    """
+    subscription_id = _add_due_source(
+        subs_db, name="Odd source", type="url", source="https://example.com/odd"
+    )
+    with subs_db.transaction() as conn:
+        conn.execute("PRAGMA ignore_check_constraints = ON")
+        conn.execute(
+            "UPDATE subscriptions SET type = 'gopher' WHERE id = ?",
+            (subscription_id,),
+        )
+        conn.execute("PRAGMA ignore_check_constraints = OFF")
+    return subscription_id
+
+
 # --- guards the handler keeps ----------------------------------------------
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("field", "value"), [("is_paused", 1), ("is_active", 0)]
-)
+@pytest.mark.parametrize("gate", [{"is_paused": 1}, {"is_active": 0}])
 async def test_paused_or_inactive_source_creates_no_run_row(
-    tmp_path, monkeypatch, field, value
+    tmp_path, monkeypatch, gate
 ):
-    """The handler's own gate still short-circuits before anything is launched."""
+    """The handler's own gate still short-circuits before anything is launched.
+
+    The gate goes on through `update_subscription`, whose own allowlist decides
+    which columns may be written, rather than by interpolating a column name
+    into SQL here.
+    """
     subs_db = SubscriptionsDB(tmp_path / "subs.db")
     url = "https://example.com/watched"
     subscription_id = _add_due_source(
         subs_db, name="Watched page", type="url", source=url
     )
-    with subs_db.transaction() as conn:
-        conn.execute(
-            f"UPDATE subscriptions SET {field} = ? WHERE id = ?",
-            (value, subscription_id),
-        )
+    assert subs_db.update_subscription(subscription_id, **gate) is True
     fetched = _serve(monkeypatch, {url: _page("original text")})
 
     await _handler(subs_db).handle(_task(subscription_id))
@@ -510,9 +632,11 @@ def test_executable_types_match_every_type_the_db_accepts(tmp_path):
     to check. Anything storable must be executable.
     """
     subs_db = SubscriptionsDB(tmp_path / "subs.db")
-    schema = subs_db.conn.execute(
-        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'subscriptions'"
-    ).fetchone()["sql"]
+    with subs_db.transaction() as conn:
+        schema = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'subscriptions'"
+        ).fetchone()["sql"]
     constraint = re.search(r"type\s+IN\s*\(([^)]*)\)", schema)
     assert constraint, "the subscriptions.type CHECK constraint moved or vanished"
     accepted = {value.strip().strip("'\"") for value in constraint.group(1).split(",")}

--- a/Tests/Scheduling/test_scheduled_watchlist_runs.py
+++ b/Tests/Scheduling/test_scheduled_watchlist_runs.py
@@ -27,6 +27,7 @@ import json
 import re
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -34,6 +35,8 @@ from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler import (
     WatchlistCheckHandler,
 )
+from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
+from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
 from tldw_chatbook.Subscriptions import LocalWatchlistsService
 from tldw_chatbook.Subscriptions.local_watchlists_service import (
     EXECUTABLE_SOURCE_TYPES,
@@ -153,6 +156,17 @@ def _task(subscription_id: int) -> dict:
 
 def _service(subs_db: SubscriptionsDB) -> LocalWatchlistsService:
     return LocalWatchlistsService(db_factory=lambda: subs_db)
+
+
+def _loop(subs_db: SubscriptionsDB, handler: WatchlistCheckHandler) -> SchedulerLoop:
+    """A real loop whose only source of work is the watchlist projection."""
+    tasks_db = MagicMock()
+    tasks_db.list_reminder_tasks.return_value = []
+    return SchedulerLoop(
+        tasks_db,
+        handlers={"watchlist_job": handler},
+        watchlist_projection=WatchlistProjection(subs_db),
+    )
 
 
 def _run_rows(subs_db: SubscriptionsDB) -> list[dict]:
@@ -352,7 +366,7 @@ async def test_failed_fetch_marks_run_failed_and_bumps_failures_once(
     implementation is `record_check_result`'s error branch,
     `DB/Subscriptions_DB.py:1318-1341`). The handler used to bump that counter
     via `record_check_error`; the service path reaches the identical call from
-    `record_run_failure` (`local_watchlists_service.py:492`), so the counter
+    `record_run_failure` (`local_watchlists_service.py:509`), so the counter
     must still advance -- exactly once, not twice.
     """
     subs_db = SubscriptionsDB(tmp_path / "subs.db")
@@ -413,6 +427,48 @@ async def test_failure_around_execution_still_records_run_and_error(
     row = subs_db.get_subscription(subscription_id)
     assert row["consecutive_failures"] == 1
     assert "source vanished mid-run" in (row["last_error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_failure_recorder_itself_raising_still_records_the_check_error(
+    tmp_path, monkeypatch
+):
+    """The last-resort fallback: even the failure recorder can fail.
+
+    `_record_failure` prefers `record_run_failure` so the launched row is
+    marked, and falls back to `record_check_error` when that call itself
+    raises. Without the fallback the original error reaches no durable surface
+    at all -- the exact swallowed-failure shape this whole path exists to
+    prevent -- and the exception would escape `handle` into the scheduler loop.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    subscription_id = _add_due_source(
+        subs_db, name="Watched page", type="url", source="https://example.com/watched"
+    )
+    service = _service(subs_db)
+
+    async def exploding_execute_run(run_id):
+        raise RuntimeError("source vanished mid-run")
+
+    async def exploding_record_run_failure(run_id, **kwargs):
+        raise RuntimeError("the run table is unwritable")
+
+    monkeypatch.setattr(service, "execute_run", exploding_execute_run)
+    monkeypatch.setattr(service, "record_run_failure", exploding_record_run_failure)
+
+    handler = _handler(subs_db, watchlists_service=service)
+    loop = _loop(subs_db, handler)
+    loop.queue.load()
+
+    # Through the real loop: an escaping exception here is what stops the
+    # scheduler dispatching every later task in the tick.
+    await loop.tick()
+
+    row = subs_db.get_subscription(subscription_id)
+    assert "source vanished mid-run" in (row["last_error"] or ""), (
+        "the ORIGINAL error must survive, not the recorder's own failure"
+    )
+    assert row["consecutive_failures"] == 1
 
 
 # --- guards the handler keeps ----------------------------------------------

--- a/Tests/Scheduling/test_scheduled_watchlist_runs.py
+++ b/Tests/Scheduling/test_scheduled_watchlist_runs.py
@@ -1,0 +1,468 @@
+"""TASK-1383: a scheduled check must produce the run row the Runs pane reads.
+
+The scheduled path used to sink its results into
+`SubscriptionsDB.record_check_result` only, which writes `subscription_stats`
+-- a daily aggregate whose one reader has no callers. The Runs pane reads
+`local_watchlist_runs`, written only by `LocalWatchlistsService.launch_run`.
+So a source checked only by the scheduler produced nothing on the one screen
+built to show what a check did.
+
+These tests drive the REAL `URLMonitor` through the REAL handler with only the
+HTTP fetch faked (AC#2): every pre-existing scheduled-path test passes
+`url_monitor=AsyncMock()`, so none of them ever exercised `check_url`'s actual
+contract -- its return shape, its dispositions, its snapshot writes -- through
+the scheduled caller.
+
+Threading: every test here is same-thread `asyncio` (`await loop.tick()` /
+`await handler.handle(...)`), so an in-memory DB would be safe. They still use
+file-backed DBs under `tmp_path`, matching the rest of `Tests/Scheduling`,
+because `SubscriptionsDB` builds its schema on the constructing thread and
+keeps thread-local connections -- a later thread-hop would otherwise turn
+these into silent no-ops against an empty schema rather than failures.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler import (
+    WatchlistCheckHandler,
+)
+from tldw_chatbook.Subscriptions import LocalWatchlistsService
+from tldw_chatbook.Subscriptions.local_watchlists_service import (
+    EXECUTABLE_SOURCE_TYPES,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- harness ---------------------------------------------------------------
+
+
+def _response(text: str, url: str, *, content_type: str = "text/html"):
+    """Stand in for the `httpx.Response` `guarded_fetch_httpx_async` returns.
+
+    Adapted from `Tests/Subscriptions/test_watchlist_content_kind_producer.py`,
+    with `final_url` following the requested URL so a multi-URL source's
+    responses stay distinguishable.
+    """
+    return SimpleNamespace(
+        status_code=200,
+        headers={"content-type": content_type},
+        text=text,
+        final_url=url,
+        raise_for_status=lambda: None,
+    )
+
+
+def _serve(monkeypatch, pages: dict[str, str], *, sitemap: bool = False) -> list[str]:
+    """Serve `pages` by URL from the real fetch seam. Returns the fetch log.
+
+    Args:
+        monkeypatch: pytest fixture.
+        pages: URL -> body. A URL not present raises, which surfaces as a
+            failed check rather than a silent empty one.
+        sitemap: Also patch `local_watchlists_service`'s own import of the
+            fetch, which is what `_urls_for_sitemap` calls to read the index.
+
+    Returns:
+        The list of URLs fetched, in order -- what "checked every URL" is
+        asserted against.
+    """
+    fetched: list[str] = []
+
+    async def fake_guarded(url, *, client, max_bytes, **kwargs):
+        fetched.append(url)
+        if url not in pages:
+            raise AssertionError(f"unexpected fetch: {url}")
+        content_type = (
+            "application/xml" if sitemap and url.endswith(".xml") else "text/html"
+        )
+        return _response(pages[url], url, content_type=content_type)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+    if sitemap:
+        monkeypatch.setattr(
+            "tldw_chatbook.Subscriptions.local_watchlists_service."
+            "guarded_fetch_httpx_async",
+            fake_guarded,
+        )
+    return fetched
+
+
+def _serve_failure(monkeypatch, error: Exception) -> None:
+    """Make every fetch raise, to drive the failure path."""
+
+    async def fake_guarded(url, *, client, max_bytes, **kwargs):
+        raise error
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+
+
+def _page(body: str) -> str:
+    return f"<html><body><article>{body}</article></body></html>"
+
+
+def _sitemap(urls: list[str]) -> str:
+    entries = "".join(f"<url><loc>{url}</loc></url>" for url in urls)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        f"{entries}</urlset>"
+    )
+
+
+def _add_due_source(subs_db: SubscriptionsDB, **kwargs) -> int:
+    """Add an active source whose cadence has already elapsed."""
+    kwargs.setdefault("check_frequency", 3600)
+    subscription_id = subs_db.add_subscription(**kwargs)
+    stale = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    with subs_db.transaction() as conn:
+        conn.execute(
+            "UPDATE subscriptions SET last_checked = ? WHERE id = ?",
+            (stale, subscription_id),
+        )
+    return subscription_id
+
+
+def _handler(subs_db: SubscriptionsDB, **kwargs) -> WatchlistCheckHandler:
+    return WatchlistCheckHandler(subscriptions_db=subs_db, **kwargs)
+
+
+def _task(subscription_id: int) -> dict:
+    """The projected task shape the scheduler dispatches."""
+    return {
+        "id": f"watchlist:{subscription_id}",
+        "type": "watchlist_job",
+        "title": "Scheduled source",
+        "owner_id": "local",
+    }
+
+
+def _service(subs_db: SubscriptionsDB) -> LocalWatchlistsService:
+    return LocalWatchlistsService(db_factory=lambda: subs_db)
+
+
+def _run_rows(subs_db: SubscriptionsDB) -> list[dict]:
+    rows = subs_db.conn.execute(
+        "SELECT * FROM local_watchlist_runs ORDER BY id ASC"
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+# --- AC#1 + AC#2 -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduled_url_check_creates_a_run_the_runs_pane_can_read(
+    tmp_path, monkeypatch
+):
+    """The whole point: a scheduler-only source becomes a visible run.
+
+    Drives the real `URLMonitor` (AC#2) across two checks so the second one
+    carries a non-trivial disposition -- `changed`, not just the first check's
+    baseline -- and asserts it both in the stored `stats_json` (AC#1) and in
+    the flattened shape `list_runs` hands the Runs pane.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    url = "https://example.com/watched"
+    subscription_id = _add_due_source(
+        subs_db, name="Watched page", type="url", source=url
+    )
+    handler = _handler(subs_db)
+
+    _serve(monkeypatch, {url: _page("original text")})
+    await handler.handle(_task(subscription_id))
+
+    _serve(monkeypatch, {url: _page("completely different text now")})
+    await handler.handle(_task(subscription_id))
+
+    rows = _run_rows(subs_db)
+    assert len(rows) == 2, "each scheduled check must record its own run row"
+    assert [row["source_id"] for row in rows] == [subscription_id] * 2
+
+    first_stats = json.loads(rows[0]["stats_json"])
+    second_stats = json.loads(rows[1]["stats_json"])
+    assert first_stats["dispositions"]["baseline"] == 1, (
+        "the first check of a URL stores a baseline and must say so"
+    )
+    assert second_stats["dispositions"]["changed"] == 1, (
+        "the scheduled path dropped the disposition entirely before TASK-1383"
+    )
+
+    runs = await _service(subs_db).list_runs(source_id=subscription_id)
+    assert len(runs) == 2
+    latest = runs[0]
+    assert latest["status"] == "completed"
+    assert latest["dispositions"]["changed"] == 1, (
+        "the Runs pane reads dispositions off the run's top level"
+    )
+    assert latest["stats"]["new_items_found"] == 1
+
+
+@pytest.mark.asyncio
+async def test_scheduled_check_produces_the_item_and_snapshot(tmp_path, monkeypatch):
+    """The real monitor's side effects reach the DB through the scheduler."""
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    url = "https://example.com/watched"
+    subscription_id = _add_due_source(
+        subs_db, name="Watched page", type="url", source=url
+    )
+    handler = _handler(subs_db)
+
+    _serve(monkeypatch, {url: _page("original text")})
+    await handler.handle(_task(subscription_id))
+    _serve(monkeypatch, {url: _page("a materially different body")})
+    await handler.handle(_task(subscription_id))
+
+    snapshots = subs_db.conn.execute(
+        "SELECT COUNT(*) AS n FROM url_snapshots WHERE subscription_id = ?",
+        (subscription_id,),
+    ).fetchone()["n"]
+    assert snapshots == 2, "the real URLMonitor persists a snapshot per check"
+
+    items = subs_db.conn.execute(
+        "SELECT * FROM subscription_items WHERE subscription_id = ?",
+        (subscription_id,),
+    ).fetchall()
+    assert len(items) == 1, "the detected change is stored as an item"
+    assert items[0]["run_id"] == _run_rows(subs_db)[1]["id"], (
+        "the item is attributed to the run that found it"
+    )
+
+
+# --- the two deleted divergences -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduled_sitemap_source_is_actually_checked(tmp_path, monkeypatch):
+    """Regression: the handler's URL tuple omitted `sitemap` entirely.
+
+    A scheduled sitemap source took the "unknown subscription type" branch and
+    was never checked, while the same source checked by hand worked.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    index = "https://example.com/sitemap.xml"
+    pages = [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+    subscription_id = _add_due_source(
+        subs_db, name="Sitemap source", type="sitemap", source=index
+    )
+    fetched = _serve(
+        monkeypatch,
+        {index: _sitemap(pages), **{url: _page(f"body {url}") for url in pages}},
+        sitemap=True,
+    )
+
+    await _handler(subs_db).handle(_task(subscription_id))
+
+    rows = _run_rows(subs_db)
+    assert len(rows) == 1, "a scheduled sitemap check must record a run"
+    assert rows[0]["status"] == "completed"
+    stats = json.loads(rows[0]["stats_json"])
+    assert sum(stats["dispositions"].values()) == len(pages), (
+        "every URL in the sitemap must be checked"
+    )
+    assert [url for url in fetched if url != index] == pages
+
+
+@pytest.mark.asyncio
+async def test_scheduled_url_list_checks_every_url(tmp_path, monkeypatch):
+    """Regression: `url_list` was handed whole to ONE `check_url` call.
+
+    A scheduled 50-URL source checked a single URL -- and, because the whole
+    subscription was passed through, the one it checked was whatever `source`
+    happened to hold.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    urls = [f"https://example.com/page-{index}" for index in range(4)]
+    subscription_id = _add_due_source(
+        subs_db,
+        name="URL list source",
+        type="url_list",
+        source=urls[0],
+        extraction_rules=json.dumps({"urls": urls}),
+    )
+    fetched = _serve(monkeypatch, {url: _page(f"body {url}") for url in urls})
+
+    await _handler(subs_db).handle(_task(subscription_id))
+
+    rows = _run_rows(subs_db)
+    assert len(rows) == 1
+    stats = json.loads(rows[0]["stats_json"])
+    assert sum(stats["dispositions"].values()) == len(urls), (
+        f"expected one disposition per URL, got {stats['dispositions']}"
+    )
+    assert fetched == urls, "every configured URL must be fetched, in order"
+
+
+# --- shadow mode -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_creates_no_run_row_item_or_snapshot(tmp_path, monkeypatch):
+    """Shadow mode stays a no-mutation probe: it must not join the run table."""
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    url = "https://example.com/watched"
+    subscription_id = _add_due_source(
+        subs_db, name="Watched page", type="url", source=url
+    )
+    before = subs_db.get_subscription(subscription_id)["last_checked"]
+    fetched = _serve(monkeypatch, {url: _page("original text")})
+
+    await _handler(subs_db, shadow_mode=True).handle(_task(subscription_id))
+
+    assert fetched == [url], "shadow mode still performs the fetch"
+    assert _run_rows(subs_db) == [], "shadow mode must not create a run row"
+    for table in ("subscription_items", "url_snapshots"):
+        count = subs_db.conn.execute(
+            f"SELECT COUNT(*) AS n FROM {table} WHERE subscription_id = ?",
+            (subscription_id,),
+        ).fetchone()["n"]
+        assert count == 0, f"shadow mode wrote to {table}"
+    after = subs_db.get_subscription(subscription_id)["last_checked"]
+    assert after == before, "shadow mode must not record a check result"
+
+
+# --- failure path and auto-pause parity ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_marks_run_failed_and_bumps_failures_once(
+    tmp_path, monkeypatch
+):
+    """A dead source records a failed run AND keeps the auto-pause counter.
+
+    Auto-pause is driven by `subscriptions.consecutive_failures` (its only
+    implementation is `record_check_result`'s error branch,
+    `DB/Subscriptions_DB.py:1318-1341`). The handler used to bump that counter
+    via `record_check_error`; the service path reaches the identical call from
+    `record_run_failure` (`local_watchlists_service.py:492`), so the counter
+    must still advance -- exactly once, not twice.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    subscription_id = _add_due_source(
+        subs_db, name="Dead page", type="url", source="https://example.com/gone"
+    )
+    _serve_failure(monkeypatch, RuntimeError("connection refused"))
+    handler = _handler(subs_db)
+
+    await handler.handle(_task(subscription_id))
+
+    rows = _run_rows(subs_db)
+    assert len(rows) == 1, "a failed scheduled check must still record a run"
+    assert rows[0]["status"] == "failed"
+    assert "connection refused" in (rows[0]["error_msg"] or "")
+
+    row = subs_db.get_subscription(subscription_id)
+    assert row["consecutive_failures"] == 1, (
+        "auto-pause input must advance exactly once per failed check"
+    )
+    assert "connection refused" in (row["last_error"] or "")
+
+    await handler.handle(_task(subscription_id))
+    assert subs_db.get_subscription(subscription_id)["consecutive_failures"] == 2, (
+        "repeated failures must keep accumulating toward auto_pause_threshold"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failure_around_execution_still_records_run_and_error(
+    tmp_path, monkeypatch
+):
+    """A failure that escapes `execute_run` must not leave a `queued` orphan.
+
+    `execute_run` resolves the run and its subscription *before* its own
+    `try`, so a source deleted between launch and execution -- or any other
+    fault around the fetch -- raises straight out. This is the TASK-1090
+    shape, now reachable from the scheduler because the scheduler launches
+    runs at all.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    subscription_id = _add_due_source(
+        subs_db, name="Watched page", type="url", source="https://example.com/watched"
+    )
+    service = _service(subs_db)
+
+    async def exploding_execute_run(run_id):
+        raise RuntimeError("source vanished mid-run")
+
+    monkeypatch.setattr(service, "execute_run", exploding_execute_run)
+
+    await _handler(subs_db, watchlists_service=service).handle(_task(subscription_id))
+
+    rows = _run_rows(subs_db)
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed", "the launched run must not stay queued"
+    assert "source vanished mid-run" in (rows[0]["error_msg"] or "")
+    row = subs_db.get_subscription(subscription_id)
+    assert row["consecutive_failures"] == 1
+    assert "source vanished mid-run" in (row["last_error"] or "")
+
+
+# --- guards the handler keeps ----------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"), [("is_paused", 1), ("is_active", 0)]
+)
+async def test_paused_or_inactive_source_creates_no_run_row(
+    tmp_path, monkeypatch, field, value
+):
+    """The handler's own gate still short-circuits before anything is launched."""
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    url = "https://example.com/watched"
+    subscription_id = _add_due_source(
+        subs_db, name="Watched page", type="url", source=url
+    )
+    with subs_db.transaction() as conn:
+        conn.execute(
+            f"UPDATE subscriptions SET {field} = ? WHERE id = ?",
+            (value, subscription_id),
+        )
+    fetched = _serve(monkeypatch, {url: _page("original text")})
+
+    await _handler(subs_db).handle(_task(subscription_id))
+
+    assert fetched == [], "a paused/inactive source must not be fetched"
+    assert _run_rows(subs_db) == [], "a skipped source must not create a run row"
+
+
+def test_executable_types_match_every_type_the_db_accepts(tmp_path):
+    """The handler's executable set must not drift from the schema's, again.
+
+    This is the bug of TASK-1383 stated as an invariant: the handler carried
+    its own `_URL_TYPES = ("url", "url_list")` while the `subscriptions.type`
+    CHECK constraint had long since accepted `sitemap` too, so a row the DB
+    happily stored was one the scheduler declared an unknown type and refused
+    to check. Anything storable must be executable.
+    """
+    subs_db = SubscriptionsDB(tmp_path / "subs.db")
+    schema = subs_db.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'subscriptions'"
+    ).fetchone()["sql"]
+    constraint = re.search(r"type\s+IN\s*\(([^)]*)\)", schema)
+    assert constraint, "the subscriptions.type CHECK constraint moved or vanished"
+    accepted = {value.strip().strip("'\"") for value in constraint.group(1).split(",")}
+
+    assert accepted == set(EXECUTABLE_SOURCE_TYPES), (
+        "every source type the database accepts must have a run executor; "
+        f"unexecutable: {accepted - set(EXECUTABLE_SOURCE_TYPES)}, "
+        f"unstorable: {set(EXECUTABLE_SOURCE_TYPES) - accepted}"
+    )

--- a/Tests/Scheduling/test_watchlist_check_handler.py
+++ b/Tests/Scheduling/test_watchlist_check_handler.py
@@ -299,8 +299,12 @@ async def test_handler_is_callable(handler):
     handler.watchlists_service.execute_run.assert_awaited_once_with(7)
 
 
-@pytest.mark.asyncio
-async def test_default_monitors_are_constructed():
+def test_default_monitors_are_built_lazily_not_at_construction():
+    """The monitors serve the shadow path alone, so the normal path skips them.
+
+    Shadow mode is off by default, so building both at construction meant every
+    handler paid -- at app start -- for two objects it never touched.
+    """
     db = MagicMock()
     with (
         patch(
@@ -311,10 +315,30 @@ async def test_default_monitors_are_constructed():
         ) as url_cls,
     ):
         handler = WatchlistCheckHandler(subscriptions_db=db)
+        feed_cls.assert_not_called()
+        url_cls.assert_not_called()
+
         assert handler.feed_monitor is feed_cls.return_value
         assert handler.url_monitor is url_cls.return_value
         feed_cls.assert_called_once_with()
         url_cls.assert_called_once_with(db=db, persist_snapshots=True)
+
+        # Cached, not rebuilt per access.
+        assert handler.feed_monitor is feed_cls.return_value
+        assert handler.url_monitor is url_cls.return_value
+        feed_cls.assert_called_once_with()
+        url_cls.assert_called_once_with(db=db, persist_snapshots=True)
+
+
+def test_shadow_url_monitor_does_not_persist_snapshots():
+    """`persist_snapshots` follows the mode actually in force at first use."""
+    db = MagicMock()
+    with patch(
+        "tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler.URLMonitor"
+    ) as url_cls:
+        handler = WatchlistCheckHandler(subscriptions_db=db, shadow_mode=True)
+        assert handler.url_monitor is url_cls.return_value
+        url_cls.assert_called_once_with(db=db, persist_snapshots=False)
 
 
 def test_default_service_is_bound_to_the_handlers_db():

--- a/Tests/Scheduling/test_watchlist_check_handler.py
+++ b/Tests/Scheduling/test_watchlist_check_handler.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler import (
     WatchlistCheckHandler,
 )
+from tldw_chatbook.Subscriptions import LocalWatchlistsService
 
 
 def _task(subscription_id: int | str = 42, **overrides) -> dict:
@@ -38,6 +39,24 @@ def _subscription(sub_type: str = "rss", **overrides) -> dict:
     }
 
 
+def _service_mock(*, status: str = "completed", stats: dict | None = None):
+    """A stand-in for `LocalWatchlistsService`'s two-call execution contract.
+
+    TASK-1383: the handler no longer executes checks itself, so these unit
+    tests assert the delegation. What the service then *does* -- run rows,
+    dispositions, per-URL checks -- is covered against real objects in
+    `test_scheduled_watchlist_runs.py`, which is the point of that module.
+    """
+    service = AsyncMock()
+    service.launch_run.return_value = {"run_id": 7, "source_id": 42}
+    service.execute_run.return_value = {
+        "run_id": 7,
+        "status": status,
+        "stats": stats if stats is not None else {"new_items_found": 1},
+    }
+    return service
+
+
 @pytest.fixture
 def handler():
     db = MagicMock()
@@ -48,6 +67,7 @@ def handler():
         feed_monitor=feed_monitor,
         url_monitor=url_monitor,
         shadow_mode=False,
+        watchlists_service=_service_mock(),
     )
 
 
@@ -82,69 +102,46 @@ def _assert_metrics(counter, histogram, *, status, subscription_type, shadow=Non
         assert "shadow" not in histogram_kwargs["labels"]
 
 
+@pytest.mark.parametrize(
+    "sub_type", ["rss", "atom", "json_feed", "podcast", "url", "url_list", "sitemap", "api"]
+)
 @pytest.mark.asyncio
-async def test_feed_check_records_result(handler):
-    items = [{"title": "New post", "url": "http://example.com/1"}]
-    handler.feed_monitor.check_feed.return_value = items
-    handler.subscriptions_db.get_subscription.return_value = _subscription("rss")
+async def test_every_executable_type_is_launched_as_a_run(handler, sub_type):
+    """TASK-1383: every storable type goes through the run seam, `sitemap` included.
 
-    await handler.handle(_task())
-
-    handler.feed_monitor.check_feed.assert_awaited_once_with(
-        handler.subscriptions_db.get_subscription.return_value
-    )
-    handler.url_monitor.check_url.assert_not_awaited()
-    handler.subscriptions_db.record_check_result.assert_called_once()
-    call_args = handler.subscriptions_db.record_check_result.call_args
-    assert call_args.args[0] == 42
-    assert call_args.kwargs["items"] == items
-    assert call_args.kwargs["stats"]["new_items_found"] == 1
-    assert isinstance(call_args.kwargs["stats"]["response_time_ms"], int)
-
-
-@pytest.mark.asyncio
-async def test_url_check_records_result(handler):
-    # TASK-1362: `check_url` returns `(item, disposition)`. This handler writes
-    # through `record_check_result`, whose stats carry no disposition field, so
-    # it takes the item and drops the disposition.
-    result = {"changed": True, "url": "http://example.com/page"}
-    handler.url_monitor.check_url.return_value = (
-        result,
-        {"kind": "changed", "reason": None, "withheld_percentage": None},
-    )
-    handler.subscriptions_db.get_subscription.return_value = _subscription("url")
-
-    await handler.handle(_task())
-
-    handler.url_monitor.check_url.assert_awaited_once_with(
-        handler.subscriptions_db.get_subscription.return_value
-    )
-    handler.feed_monitor.check_feed.assert_not_awaited()
-    handler.subscriptions_db.record_check_result.assert_called_once()
-    call_args = handler.subscriptions_db.record_check_result.call_args
-    assert call_args.args[0] == 42
-    assert call_args.kwargs["items"] == [result]
-
-
-@pytest.mark.asyncio
-async def test_url_check_with_none_result(handler):
-    """A check that produced no item must still record a successful check.
-
-    The disposition (here `unchanged`) is what distinguishes this from the
-    three other reasons a check produces nothing; the handler's own stats
-    schema does not carry it, so it is dropped rather than invented.
+    `sitemap` is listed here deliberately: the handler's own `_URL_TYPES` tuple
+    omitted it, so a scheduled sitemap source was declared an unknown type and
+    never checked at all.
     """
-    handler.url_monitor.check_url.return_value = (
-        None,
-        {"kind": "unchanged", "reason": None, "withheld_percentage": None},
-    )
+    handler.subscriptions_db.get_subscription.return_value = _subscription(sub_type)
+
+    await handler.handle(_task())
+
+    handler.watchlists_service.launch_run.assert_awaited_once_with(source_id=42)
+    handler.watchlists_service.execute_run.assert_awaited_once_with(7)
+    # The service records the check; a second write here would double-count it
+    # into `subscription_stats` and re-bump the auto-pause counter.
+    handler.subscriptions_db.record_check_result.assert_not_called()
+    handler.subscriptions_db.record_check_error.assert_not_called()
+    # The handler's own monitors belong to the shadow path now.
+    handler.feed_monitor.check_feed.assert_not_awaited()
+    handler.url_monitor.check_url.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_run_is_reported_without_a_second_error_record(handler):
+    """`execute_run` handles its own fetch failures and does not re-raise."""
+    handler.watchlists_service.execute_run.return_value = {
+        "run_id": 7,
+        "status": "failed",
+        "stats": {"error_msg": "boom"},
+    }
     handler.subscriptions_db.get_subscription.return_value = _subscription("url")
 
     await handler.handle(_task())
 
-    handler.subscriptions_db.record_check_result.assert_called_once()
-    call_args = handler.subscriptions_db.record_check_result.call_args
-    assert call_args.kwargs["items"] == []
+    handler.watchlists_service.record_run_failure.assert_not_awaited()
+    handler.subscriptions_db.record_check_error.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -157,6 +154,7 @@ async def test_paused_subscription_is_skipped(handler):
 
     handler.feed_monitor.check_feed.assert_not_awaited()
     handler.url_monitor.check_url.assert_not_awaited()
+    handler.watchlists_service.launch_run.assert_not_awaited()
     handler.subscriptions_db.record_check_result.assert_not_called()
     handler.subscriptions_db.record_check_error.assert_not_called()
 
@@ -171,20 +169,43 @@ async def test_inactive_subscription_is_skipped(handler):
 
     handler.feed_monitor.check_feed.assert_not_awaited()
     handler.url_monitor.check_url.assert_not_awaited()
+    handler.watchlists_service.launch_run.assert_not_awaited()
     handler.subscriptions_db.record_check_result.assert_not_called()
     handler.subscriptions_db.record_check_error.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_monitor_error_records_check_error(handler):
-    handler.feed_monitor.check_feed.side_effect = RuntimeError("feed unreachable")
+async def test_failure_escaping_execute_run_marks_the_launched_run_failed(handler):
+    """A fault around execution must not leave the launched row at `queued`.
+
+    `record_run_failure` also calls `SubscriptionsDB.record_check_error`, which
+    is the same call this handler used to make itself -- so the auto-pause
+    counter still advances, exactly once.
+    """
+    error = RuntimeError("feed unreachable")
+    handler.watchlists_service.execute_run.side_effect = error
     handler.subscriptions_db.get_subscription.return_value = _subscription("rss")
 
     await handler.handle(_task())
 
+    handler.watchlists_service.record_run_failure.assert_awaited_once_with(
+        7, source_id=42, error=error
+    )
     handler.subscriptions_db.record_check_result.assert_not_called()
+    handler.subscriptions_db.record_check_error.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failure_before_a_run_exists_falls_back_to_record_check_error(handler):
+    """With no run row to fail, the error still reaches the subscription."""
+    handler.watchlists_service.launch_run.side_effect = RuntimeError("launch failed")
+    handler.subscriptions_db.get_subscription.return_value = _subscription("rss")
+
+    await handler.handle(_task())
+
+    handler.watchlists_service.record_run_failure.assert_not_awaited()
     handler.subscriptions_db.record_check_error.assert_called_once_with(
-        42, "feed unreachable"
+        42, "launch failed"
     )
 
 
@@ -216,10 +237,18 @@ async def test_shadow_mode_does_not_record_errors(handler):
 
 @pytest.mark.asyncio
 async def test_unknown_subscription_type_logs_and_returns(handler):
-    handler.subscriptions_db.get_subscription.return_value = _subscription("sitemap")
+    """A type with no executor is reported, not launched into a failed run.
+
+    `sitemap` used to be this test's example; it is a real, executable type and
+    the handler was simply refusing to check it (TASK-1383). No type the schema
+    accepts reaches this branch any more -- see
+    `test_executable_types_match_every_type_the_db_accepts`.
+    """
+    handler.subscriptions_db.get_subscription.return_value = _subscription("gopher")
 
     await handler.handle(_task())
 
+    handler.watchlists_service.launch_run.assert_not_awaited()
     handler.feed_monitor.check_feed.assert_not_awaited()
     handler.url_monitor.check_url.assert_not_awaited()
     handler.subscriptions_db.record_check_result.assert_not_called()
@@ -262,13 +291,12 @@ async def test_missing_subscription_logs_and_returns(handler):
 
 @pytest.mark.asyncio
 async def test_handler_is_callable(handler):
-    handler.feed_monitor.check_feed.return_value = []
     handler.subscriptions_db.get_subscription.return_value = _subscription("rss")
 
     await handler(_task())
 
-    handler.feed_monitor.check_feed.assert_awaited_once()
-    handler.subscriptions_db.record_check_result.assert_called_once()
+    handler.watchlists_service.launch_run.assert_awaited_once_with(source_id=42)
+    handler.watchlists_service.execute_run.assert_awaited_once_with(7)
 
 
 @pytest.mark.asyncio
@@ -289,10 +317,17 @@ async def test_default_monitors_are_constructed():
         url_cls.assert_called_once_with(db=db, persist_snapshots=True)
 
 
+def test_default_service_is_bound_to_the_handlers_db():
+    """Production wiring stays zero-config: `app.py` passes only the db."""
+    db = MagicMock()
+    handler = WatchlistCheckHandler(subscriptions_db=db)
+    assert isinstance(handler.watchlists_service, LocalWatchlistsService)
+    assert handler.watchlists_service.db_factory() is db
+
+
 @pytest.mark.asyncio
 async def test_metrics_success_path(handler, metrics_patch):
     counter, histogram = metrics_patch
-    handler.feed_monitor.check_feed.return_value = [{"title": "Post"}]
     handler.subscriptions_db.get_subscription.return_value = _subscription("rss")
 
     await handler.handle(_task())
@@ -343,7 +378,7 @@ async def test_metrics_skipped_subscription(handler, metrics_patch):
 @pytest.mark.asyncio
 async def test_metrics_unknown_type(handler, metrics_patch):
     counter, histogram = metrics_patch
-    handler.subscriptions_db.get_subscription.return_value = _subscription("sitemap")
+    handler.subscriptions_db.get_subscription.return_value = _subscription("gopher")
 
     await handler.handle(_task())
 
@@ -351,8 +386,24 @@ async def test_metrics_unknown_type(handler, metrics_patch):
         counter,
         histogram,
         status="unknown_type",
-        subscription_type="sitemap",
+        subscription_type="gopher",
     )
+
+
+@pytest.mark.asyncio
+async def test_metrics_error_path_for_a_failed_run(handler, metrics_patch):
+    """A run the service marked failed is an errored check, not a successful one."""
+    counter, histogram = metrics_patch
+    handler.watchlists_service.execute_run.return_value = {
+        "run_id": 7,
+        "status": "failed",
+        "stats": {},
+    }
+    handler.subscriptions_db.get_subscription.return_value = _subscription("url")
+
+    await handler.handle(_task())
+
+    _assert_metrics(counter, histogram, status="error", subscription_type="url")
 
 
 @pytest.mark.asyncio
@@ -372,7 +423,7 @@ async def test_metrics_missing_task_id(handler, metrics_patch):
 @pytest.mark.asyncio
 async def test_metrics_error_path(handler, metrics_patch):
     counter, histogram = metrics_patch
-    handler.feed_monitor.check_feed.side_effect = RuntimeError("feed unreachable")
+    handler.watchlists_service.execute_run.side_effect = RuntimeError("feed unreachable")
     handler.subscriptions_db.get_subscription.return_value = _subscription("rss")
 
     await handler.handle(_task())

--- a/Tests/Scheduling/test_watchlist_scheduling_end_to_end.py
+++ b/Tests/Scheduling/test_watchlist_scheduling_end_to_end.py
@@ -21,6 +21,7 @@ from tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler import 
 )
 from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
 from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
+from tldw_chatbook.Subscriptions import LocalWatchlistsService
 
 pytestmark = pytest.mark.unit
 
@@ -55,33 +56,52 @@ def _loop(subs_db: SubscriptionsDB, handler: WatchlistCheckHandler) -> Scheduler
 
 @pytest.mark.asyncio
 async def test_due_watchlist_is_dispatched_and_persisted(tmp_path):
-    """A due subscription is checked and its result written back to the DB."""
+    """A due subscription is checked and its result written back to the DB.
+
+    TASK-1383: the handler now executes through ``LocalWatchlistsService``, so
+    the stub goes in at the service's ``run_executor`` seam rather than at the
+    handler's monitors -- which keeps the real ``launch_run``/``execute_run``
+    persistence in the loop and lets this test assert the run row the Runs pane
+    reads, which is what was missing.
+    """
     subs_db = SubscriptionsDB(tmp_path / "subs.db")
     subscription_id = _due_subscription(subs_db)
     before = subs_db.get_subscription(subscription_id)["last_checked"]
 
-    feed_monitor = AsyncMock()
-    feed_monitor.check_feed.return_value = [
-        {
-            "url": "https://example.com/post-1",
-            "title": "Post 1",
-            "content": "hello",
-        }
-    ]
+    checked: list[str] = []
+
+    def fake_executor(subscription):
+        checked.append(subscription["name"])
+        return [
+            {
+                "url": "https://example.com/post-1",
+                "title": "Post 1",
+                "content": "hello",
+            }
+        ]
+
     handler = WatchlistCheckHandler(
         subscriptions_db=subs_db,
-        feed_monitor=feed_monitor,
-        url_monitor=AsyncMock(),
         shadow_mode=False,
+        watchlists_service=LocalWatchlistsService(
+            db_factory=lambda: subs_db, run_executor=fake_executor
+        ),
     )
 
     loop = _loop(subs_db, handler)
     loop.queue.load()
     await loop.tick()
 
-    feed_monitor.check_feed.assert_awaited_once()
+    assert checked == ["Due feed"], "the due subscription was not checked"
     after = subs_db.get_subscription(subscription_id)["last_checked"]
     assert after != before, "the check result was not persisted to Subscriptions_DB"
+
+    runs = await LocalWatchlistsService(db_factory=lambda: subs_db).list_runs(
+        source_id=subscription_id
+    )
+    assert len(runs) == 1, "a scheduled check must be visible to the Runs pane"
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["stats"]["new_items_found"] == 1
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-1383 - Scheduled-watchlist-checks-never-create-a-run-row-so-the-Runs-pane-cannot-see-them.md
+++ b/backlog/tasks/task-1383 - Scheduled-watchlist-checks-never-create-a-run-row-so-the-Runs-pane-cannot-see-them.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1383
 title: Scheduled watchlist checks never create a run row, so the Runs pane cannot see them
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-30 02:01'
 labels:
@@ -52,7 +52,82 @@ only through the manual path's tests.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A watchlist source checked only via the scheduler produces a run record the Runs pane displays, including its check disposition(s)
-- [ ] #2 At least one scheduled-path test drives the real `URLMonitor` (not a mock), covering its actual `check_url` contract
-- [ ] #3 A deliberately broken disposition on the scheduled path (e.g. dropped or miscounted) fails a test, proving the coverage discriminates it
+- [x] #1 A watchlist source checked only via the scheduler produces a run record the Runs pane displays, including its check disposition(s)
+- [x] #2 At least one scheduled-path test drives the real `URLMonitor` (not a mock), covering its actual `check_url` contract
+- [x] #3 A deliberately broken disposition on the scheduled path (e.g. dropped or miscounted) fails a test, proving the coverage discriminates it
 <!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Establish what the handler's fork diverged on, and whether the service path preserves its
+   failure/auto-pause behaviour.
+2. Route non-shadow checks through `LocalWatchlistsService.launch_run` + `execute_run`, deleting
+   the fork's own dispatch and `record_check_result` block.
+3. Keep shadow mode as a separate, documented no-mutation probe.
+4. Cover with tests that drive the real `URLMonitor` with only the HTTP fetch faked.
+5. Mutation-check that the new coverage discriminates each behaviour it claims.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+**Unified rather than extended.** `WatchlistCheckHandler` was a parallel reimplementation of the
+service's execution path. Non-shadow checks now call `launch_run(source_id=...)` +
+`execute_run(run_id)`, which yields the run row, `stats_json` dispositions, per-URL baselines
+(TASK-1361), filters and alerts for free. The handler's own dispatch and `record_check_result`
+block are gone; it keeps the guards that are genuinely its job (task-id parse, missing
+subscription, paused/inactive skip, metrics in `finally`).
+
+**Two divergences fixed by deletion, not patching.** The fork's `_URL_TYPES = ("url", "url_list")`
+omitted `sitemap`, so every scheduled sitemap source hit the "unknown subscription type" branch and
+was never checked — while the `subscriptions.type` CHECK constraint had accepted `sitemap` all
+along. And `url_list` passed the whole subscription to ONE `check_url` call, so a scheduled 50-URL
+source checked a single URL. `EXECUTABLE_SOURCE_TYPES` (`local_watchlists_service.py`) is now the
+one definition both the executor and the handler's guard read;
+`test_executable_types_match_every_type_the_db_accepts` pins it against the schema's own CHECK
+constraint, so "storable but not executable" cannot recur.
+
+**Auto-pause: parity is exact, because there is none.** The task brief assumed the old path
+auto-paused via `record_check_error`. It does not. Auto-pause's only implementation is the `if
+error:` branch of `record_check_result` (`DB/Subscriptions_DB.py:1318-1341`), and that branch has
+no caller — the sole production caller (`local_watchlists_service.py:448`) never passes `error`.
+`record_check_error` (`:1391-1411`) bumps `consecutive_failures` but writes `is_paused = 1 if
+should_pause else 0`, defaulting to `False`. The old handler called
+`record_check_error(subscription_id, str(exc))`; the service reaches the *identical* call from
+`record_run_failure` (`local_watchlists_service.py:492`). So the counter advances exactly as
+before — and adding a compensating call in the handler's `except` would have double-bumped it.
+The latent bug (nothing ever auto-pauses; every failure actively clears `is_paused`) is out of
+scope here and filed as TASK-1410.
+
+**No double-write.** `execute_run` calls `record_check_result` itself, and it does not re-raise a
+fetch failure — so the handler neither records a second time nor expects an exception for the
+ordinary failure case. Its `except` now only sees faults *around* execution (`launch_run` raising,
+or `execute_run` failing before its own `try`), and routes them to `record_run_failure` so the
+just-inserted row cannot be orphaned at `queued` — the TASK-1090 shape, newly reachable from the
+scheduler because the scheduler launches runs at all.
+
+**Shadow mode** keeps the direct-monitor probe, isolated in `_check_in_shadow` and documented as
+the deliberate fork: it cannot use the run seam because that seam exists to write. It stays
+deliberately coarser (one URL for a `url_list`, no sitemap enumeration) — a diagnostic's fidelity,
+safe only because nothing it returns is persisted.
+
+**Tests.** `Tests/Scheduling/test_scheduled_watchlist_runs.py` (10 tests) drives the real
+`URLMonitor` through the real handler with only `guarded_fetch_httpx_async` faked (AC#2); every
+pre-existing scheduled-path test passed `url_monitor=AsyncMock()`. All same-thread asyncio, but
+file-backed DBs under `tmp_path` so a later thread-hop fails loudly rather than finding an empty
+schema. The handler's unit tests moved to the delegation contract; the end-to-end feed test stubs
+at the service's `run_executor` seam so real persistence stays in the loop.
+
+**Mutation checks** (AC#3), each restored afterwards:
+- bare `check_url` + `record_check_result` -> 5 failed (both AC#1 tests and the `url_list` count);
+- the old type tuples -> only the sitemap regression failed, 1 failed / 9 passed;
+- shadow guard dropped -> 2 failed (both shadow tests);
+- `_record_failure` no-op -> 3 failed;
+- `record_run_failure`'s `record_check_error` removed -> 2 failed (both auto-pause tests).
+
+`Tests/Scheduling/ Tests/Subscriptions/ Tests/Watchlists/`: **587 passed**, 0 failed.
+
+Modified: `Scheduling/scheduler/handlers/watchlist_check_handler.py`,
+`Subscriptions/local_watchlists_service.py`, `Tests/Scheduling/test_watchlist_check_handler.py`,
+`Tests/Scheduling/test_watchlist_scheduling_end_to_end.py`. Added:
+`Tests/Scheduling/test_scheduled_watchlist_runs.py`, `backlog/tasks/task-1410`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1383 - Scheduled-watchlist-checks-never-create-a-run-row-so-the-Runs-pane-cannot-see-them.md
+++ b/backlog/tasks/task-1383 - Scheduled-watchlist-checks-never-create-a-run-row-so-the-Runs-pane-cannot-see-them.md
@@ -93,10 +93,18 @@ no caller — the sole production caller (`local_watchlists_service.py:448`) nev
 `record_check_error` (`:1391-1411`) bumps `consecutive_failures` but writes `is_paused = 1 if
 should_pause else 0`, defaulting to `False`. The old handler called
 `record_check_error(subscription_id, str(exc))`; the service reaches the *identical* call from
-`record_run_failure` (`local_watchlists_service.py:492`). So the counter advances exactly as
+`record_run_failure` (`local_watchlists_service.py:509`). So the counter advances exactly as
 before — and adding a compensating call in the handler's `except` would have double-bumped it.
 The latent bug (nothing ever auto-pauses; every failure actively clears `is_paused`) is out of
 scope here and filed as TASK-1410.
+
+**Intended behaviour change.** Scheduled checks now also run filter and content-alert
+*evaluation*, because that is part of `execute_run` and unifying onto it is the point — a
+scheduled check and a manual one should not disagree about which items survive filtering or which
+alert rules matched. No notification is *dispatched*: the handler's service is constructed with
+`notification_dispatcher=None`, so evaluation results are recorded against the run and nothing is
+sent. Wiring a dispatcher into the scheduled path is a separate decision, not a side effect of
+this one.
 
 **No double-write.** `execute_run` calls `record_check_result` itself, and it does not re-raise a
 fetch failure — so the handler neither records a second time nor expects an exception for the

--- a/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
+++ b/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
@@ -18,39 +18,68 @@ Found while implementing TASK-1383, which required establishing whether routing 
 through `LocalWatchlistsService` preserved the auto-pause behaviour of the path it replaced. It
 does — exactly — because **neither path has ever auto-paused anything.**
 
-`subscriptions.auto_pause_threshold` (default 10, `DB/Subscriptions_DB.py:195`) is compared against
-`consecutive_failures` in exactly one place: the `if error:` branch of
+`subscriptions.auto_pause_threshold` (schema default 10, `DB/Subscriptions_DB.py:195`) is compared
+against `consecutive_failures` in exactly one place: the `if error:` branch of
 `SubscriptionsDB.record_check_result` (`DB/Subscriptions_DB.py:1318-1341`), which sets
 `is_paused = 1` and logs "Auto-paused subscription N after M failures".
 
-That branch has no caller. After TASK-1383, `record_check_result` has a single production caller,
-`Subscriptions/local_watchlists_service.py:448`, and it passes `items=None, stats=stats` with no
-`error` argument at all — so the success branch is the only one ever taken. (Before TASK-1383 the
-scheduled handler was the second caller, and it likewise only ever called it on success.)
+**That branch has no caller.** After TASK-1383, `record_check_result` has a single production
+caller — `Subscriptions/local_watchlists_service.py:448` — and it passes `items=None, stats=stats`
+with no `error` argument, so only the success branch is ever taken. (Before TASK-1383 the scheduled
+handler was the second caller and likewise only called it on success.) `DB/Subscriptions_DB.py:1333`
+is consequently the only `is_paused = 1` write in the codebase, and it is dead.
 
 Failures instead go to `SubscriptionsDB.record_check_error` (`DB/Subscriptions_DB.py:1391-1411`)
-via `LocalWatchlistsService.record_run_failure` (`local_watchlists_service.py:492`). That method
-bumps `consecutive_failures`, but it does **not** consult `auto_pause_threshold`; it writes
-`is_paused = 1 if should_pause else 0`, and `should_pause` defaults to `False` and is never passed
-by any caller. So every recorded failure writes `is_paused = 0` — a permanently failing source is
-not merely left running, it is actively **un-paused** on each failure, which would also silently
-clear a pause the user set by hand.
+via `LocalWatchlistsService.record_run_failure` (`local_watchlists_service.py:509`). That method
+bumps `consecutive_failures` but never consults `auto_pause_threshold`; it writes
+`is_paused = 1 if should_pause else 0`, and `should_pause` defaults to `False` and is passed by no
+caller. So every recorded failure writes `is_paused = 0`.
 
-Net effect: `consecutive_failures` climbs forever, `auto_pause_threshold` is a setting the UI can
-show and store but nothing reads, and a dead feed is retried on its cadence indefinitely.
+Net effect: `consecutive_failures` climbs forever, nothing reads `auto_pause_threshold`, and a dead
+source is retried on its cadence indefinitely.
+
+### Scope of the un-pause write, precisely
+
+The `is_paused = 0` write is **not reachable from the scheduler**, and is **currently vacuous** —
+both facts matter for how this is fixed:
+
+- The scheduled path skips paused sources before any check runs, at
+  `Scheduling/scheduler/handlers/watchlist_check_handler.py:132` and in the projection's status
+  mapping, `Scheduling/services/watchlist_projection.py:60`. A paused source is never checked on a
+  schedule and so never reaches `record_check_error`.
+- `launch_run`/`execute_run` have **no** paused guard, so the write is reachable via a **manual
+  re-check** of a paused source.
+- But nothing in production ever writes `is_paused = 1` in the first place: the auto-pause branch
+  above is dead, and there is no pause UI or CLI. (`is_paused` sits in `update_subscription`'s
+  field allowlist at `DB/Subscriptions_DB.py:1072`, so the write surface exists, but no caller
+  passes it.) There is therefore no pause for this to clear today — the bug is latent, and becomes
+  live the moment anything starts setting `is_paused = 1`.
+
+That ordering is the point: **AC#2 is a hard prerequisite of AC#1.** Landing auto-pause on its own
+produces a pause that the next manual re-check of that source silently erases, which is worse than
+today's honest do-nothing.
+
+### The config surface is separately named and equally unread
+
+The user-facing setting is **`auto_pause_after_failures`** (`config.py:3553`, documented at
+`Docs/Features/SUBSCRIPTION_IMPLEMENTATION_PLAN.md:1052`), not `auto_pause_threshold`. It is read
+by nothing. `auto_pause_threshold` is a per-subscription column with **no Settings UI at all** — it
+appears only in the schema (`:195`) and in field allowlists (`DB/Subscriptions_DB.py:969,1085`,
+`Subscriptions/local_watchlists_service.py:840`). Whichever direction this task takes, it must name
+both and decide — or explicitly defer — whether the global config key and the per-source column
+unify, and which wins when they disagree.
 
 Same failure class as TASK-1210/1212/1383: the machinery is present and looks live to a grep — a
-threshold column, a comparison, a warning log — but no execution path reaches it.
+threshold column, a config key, a comparison, a warning log — but no execution path reaches it.
 
-Deciding which way to close it is part of the work: either make the failure path honour
-`auto_pause_threshold` (the behaviour the schema and Settings already advertise), or remove the
-threshold and the dead branch so the app stops promising a feature it does not have. The
-`is_paused = 0` write on failure is a bug under either choice.
+Deciding which way to close it is part of the work: either make the failure path honour the
+threshold (the behaviour the schema and config already advertise), or remove the dead branch and
+both settings so the app stops promising a feature it does not have.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A source that fails `auto_pause_threshold` times in a row reaches the documented outcome, and a test drives it through the real failure path rather than calling the DB method directly
-- [ ] #2 Recording a check failure never clears an existing `is_paused`, whether the pause was automatic or set by the user
-- [ ] #3 `auto_pause_threshold` is either read by a live code path or removed from the schema, the Settings UI and the docs together, so no setting is shown that nothing consumes
+- [ ] #1 Recording a check failure never clears an existing `is_paused`; landed BEFORE #2, because auto-pause without it produces a pause the next manual re-check erases
+- [ ] #2 A source that fails the configured number of times in a row reaches the documented outcome, driven in a test through the real failure path rather than by calling the DB method directly
+- [ ] #3 `auto_pause_threshold` (column) and `auto_pause_after_failures` (`config.py:3553`) are reconciled: either both are read by a live path with a stated precedence, or both are removed together with the dead branch and the docs that advertise them
 <!-- AC:END -->

--- a/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
+++ b/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
@@ -1,0 +1,56 @@
+---
+id: TASK-1410
+title: Watchlist auto-pause never fires; its only implementation is unreachable
+status: To Do
+assignee: []
+created_date: '2026-07-30 08:20'
+labels:
+  - watchlists
+  - correctness
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while implementing TASK-1383, which required establishing whether routing scheduled checks
+through `LocalWatchlistsService` preserved the auto-pause behaviour of the path it replaced. It
+does — exactly — because **neither path has ever auto-paused anything.**
+
+`subscriptions.auto_pause_threshold` (default 10, `DB/Subscriptions_DB.py:195`) is compared against
+`consecutive_failures` in exactly one place: the `if error:` branch of
+`SubscriptionsDB.record_check_result` (`DB/Subscriptions_DB.py:1318-1341`), which sets
+`is_paused = 1` and logs "Auto-paused subscription N after M failures".
+
+That branch has no caller. After TASK-1383, `record_check_result` has a single production caller,
+`Subscriptions/local_watchlists_service.py:448`, and it passes `items=None, stats=stats` with no
+`error` argument at all — so the success branch is the only one ever taken. (Before TASK-1383 the
+scheduled handler was the second caller, and it likewise only ever called it on success.)
+
+Failures instead go to `SubscriptionsDB.record_check_error` (`DB/Subscriptions_DB.py:1391-1411`)
+via `LocalWatchlistsService.record_run_failure` (`local_watchlists_service.py:492`). That method
+bumps `consecutive_failures`, but it does **not** consult `auto_pause_threshold`; it writes
+`is_paused = 1 if should_pause else 0`, and `should_pause` defaults to `False` and is never passed
+by any caller. So every recorded failure writes `is_paused = 0` — a permanently failing source is
+not merely left running, it is actively **un-paused** on each failure, which would also silently
+clear a pause the user set by hand.
+
+Net effect: `consecutive_failures` climbs forever, `auto_pause_threshold` is a setting the UI can
+show and store but nothing reads, and a dead feed is retried on its cadence indefinitely.
+
+Same failure class as TASK-1210/1212/1383: the machinery is present and looks live to a grep — a
+threshold column, a comparison, a warning log — but no execution path reaches it.
+
+Deciding which way to close it is part of the work: either make the failure path honour
+`auto_pause_threshold` (the behaviour the schema and Settings already advertise), or remove the
+threshold and the dead branch so the app stops promising a feature it does not have. The
+`is_paused = 0` write on failure is a bug under either choice.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A source that fails `auto_pause_threshold` times in a row reaches the documented outcome, and a test drives it through the real failure path rather than calling the DB method directly
+- [ ] #2 Recording a check failure never clears an existing `is_paused`, whether the pause was automatic or set by the user
+- [ ] #3 `auto_pause_threshold` is either read by a live code path or removed from the schema, the Settings UI and the docs together, so no setting is shown that nothing consumes
+<!-- AC:END -->

--- a/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
@@ -9,11 +9,18 @@ from loguru import logger
 
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+from tldw_chatbook.Subscriptions.local_watchlists_service import (
+    EXECUTABLE_SOURCE_TYPES,
+    LocalWatchlistsService,
+)
 from tldw_chatbook.Subscriptions.monitoring_engine import FeedMonitor, URLMonitor
 
 _WATCHLIST_TASK_PREFIX = "watchlist"
-_FEED_TYPES = ("rss", "atom", "json_feed", "podcast")
-_URL_TYPES = ("url", "url_list")
+
+# Shadow mode only -- see `_check_in_shadow`. The real path asks
+# `EXECUTABLE_SOURCE_TYPES` instead.
+_SHADOW_FEED_TYPES = ("rss", "atom", "json_feed", "podcast")
+_SHADOW_URL_TYPES = ("url", "url_list")
 
 _STATUS_SUCCESS = "success"
 _STATUS_ERROR = "error"
@@ -23,11 +30,36 @@ _STATUS_UNKNOWN_TYPE = "unknown_type"
 
 
 class WatchlistCheckHandler:
-    """Execute a watchlist check by delegating to feed or URL monitors.
+    """Execute a scheduled watchlist check as a real, visible watchlist run.
 
     The handler is stateless: all persistent subscription state lives in
-    ``SubscriptionsDB``. When ``shadow_mode`` is ``True`` checks are executed
-    and metrics/logs are emitted, but the database is not mutated.
+    ``SubscriptionsDB``.
+
+    TASK-1383. This used to be a parallel reimplementation of
+    ``LocalWatchlistsService``'s execution path, and it sank its results
+    exclusively into ``SubscriptionsDB.record_check_result`` -- which writes
+    ``subscription_stats``, a daily aggregate whose only reader
+    (``get_subscription_health``) has no callers at all. The Watchlists Runs
+    pane reads ``local_watchlist_runs``, and only ``launch_run`` ever wrote to
+    that table, so a source checked *only* by the scheduler -- the normal
+    unattended case this feature exists for -- produced no record on the one
+    screen built to show what a check did.
+
+    Being a second implementation, it had also drifted into two outright bugs
+    that are fixed here by deletion rather than by patching:
+
+    * its URL type tuple omitted ``sitemap``, so scheduled sitemap sources hit
+      the "unknown subscription type" branch and were never checked at all;
+    * ``url_list`` was passed whole to a single ``check_url`` call, so a
+      scheduled 50-URL source checked exactly one URL.
+
+    Routing through ``launch_run`` + ``execute_run`` yields the run row, its
+    ``stats_json`` dispositions (TASK-1362), per-URL baselines (TASK-1361),
+    filters and alerts for free, and leaves this class with the job that is
+    genuinely its own: parsing the task id, resolving and gating the
+    subscription, and reporting scheduler metrics.
+
+    ``shadow_mode`` keeps a deliberate, separate fork; see ``_check_in_shadow``.
     """
 
     def __init__(
@@ -36,19 +68,23 @@ class WatchlistCheckHandler:
         feed_monitor: FeedMonitor | None = None,
         url_monitor: URLMonitor | None = None,
         shadow_mode: bool = False,
+        watchlists_service: LocalWatchlistsService | None = None,
     ) -> None:
         """Initialize the handler.
 
         Args:
             subscriptions_db: Persistent subscription store used to read
-                subscriptions and record check results/errors.
-            feed_monitor: Monitor for RSS/Atom/JSON feed checks. A default
-                ``FeedMonitor`` instance is created when ``None``.
-            url_monitor: Monitor for URL change checks. A default
-                ``URLMonitor`` instance bound to ``subscriptions_db`` is
+                subscriptions and record run results/errors.
+            feed_monitor: Monitor for RSS/Atom/JSON feed checks, used by the
+                shadow path only. A default ``FeedMonitor`` is created when
+                ``None``.
+            url_monitor: Monitor for URL change checks, used by the shadow path
+                only. A default ``URLMonitor`` bound to ``subscriptions_db`` is
                 created when ``None``.
             shadow_mode: When ``True``, execute checks without mutating
                 ``subscriptions_db`` and emit metrics with a ``shadow`` label.
+            watchlists_service: The service that owns run execution. A default
+                bound to ``subscriptions_db`` is created when ``None``.
         """
         self.subscriptions_db = subscriptions_db
         self.feed_monitor = feed_monitor if feed_monitor is not None else FeedMonitor()
@@ -58,6 +94,16 @@ class WatchlistCheckHandler:
             else URLMonitor(db=subscriptions_db, persist_snapshots=not shadow_mode)
         )
         self.shadow_mode = shadow_mode
+        # A constructor parameter rather than a lookup inside `handle`, for the
+        # same reason `feed_monitor`/`url_monitor` are: a test can hand in a
+        # service wired to a stub `run_executor` without monkeypatching a
+        # module-level name, and production wiring (`app.py`) stays zero-config
+        # because the default binds to the db it was already given.
+        self.watchlists_service = (
+            watchlists_service
+            if watchlists_service is not None
+            else LocalWatchlistsService(db_factory=lambda: self.subscriptions_db)
+        )
 
     async def handle(self, task: dict[str, Any]) -> None:
         """Process a single watchlist check task.
@@ -69,6 +115,7 @@ class WatchlistCheckHandler:
         subscription_id: int | None = None
         subscription_type = "unknown"
         status = _STATUS_MISSING
+        run_id: Any = None
 
         try:
             subscription_id = self._parse_subscription_id(task.get("id"))
@@ -92,45 +139,45 @@ class WatchlistCheckHandler:
                 f"(ID: {subscription_id})"
             )
 
-            items: list[dict[str, Any]] = []
-            if subscription_type in _FEED_TYPES:
-                items = await self.feed_monitor.check_feed(subscription)
-            elif subscription_type in _URL_TYPES:
-                # TASK-1362: `check_url` returns `(item, disposition)`. The
-                # disposition is recorded per run by
-                # `LocalWatchlistsService._default_run_executor`; this handler
-                # writes through `record_check_result`, whose stats have no
-                # disposition field, so it is deliberately dropped here rather
-                # than invented into a schema that does not carry it.
-                result, _disposition = await self.url_monitor.check_url(subscription)
-                if result is not None:
-                    items = [result]
-            else:
+            if self.shadow_mode:
+                if not await self._check_in_shadow(subscription, subscription_type):
+                    status = _STATUS_UNKNOWN_TYPE
+                    return
+                status = _STATUS_SUCCESS
+                return
+
+            if subscription_type not in EXECUTABLE_SOURCE_TYPES:
+                # Kept as an early return rather than letting `execute_run`
+                # raise, so the scheduler metric still distinguishes "this type
+                # has no executor" from "the check failed" -- the TASK-1212
+                # distinction. `sitemap` is inside this set now; it never was
+                # in the tuple this replaced.
                 logger.warning(f"Unknown subscription type: {subscription_type}")
                 status = _STATUS_UNKNOWN_TYPE
                 return
 
-            if not self.shadow_mode:
-                self.subscriptions_db.record_check_result(
-                    subscription_id,
-                    items=items,
-                    stats={
-                        "new_items_found": len(items),
-                        "response_time_ms": int((time.time() - start_time) * 1000),
-                    },
-                )
-
-            status = _STATUS_SUCCESS
+            launched = await self.watchlists_service.launch_run(
+                source_id=subscription_id
+            )
+            run_id = launched["run_id"]
+            # `execute_run` records its own result -- including
+            # `record_check_result` -- and does not re-raise a fetch failure, so
+            # this handler must neither record a second time nor expect an
+            # exception for the ordinary failure case.
+            executed = await self.watchlists_service.execute_run(run_id)
+            run_status = str(executed.get("status") or "")
+            status = _STATUS_ERROR if run_status == "failed" else _STATUS_SUCCESS
+            stats = executed.get("stats") or {}
             logger.info(
                 f"Subscription check complete: '{subscription.get('name')}' - "
-                f"{len(items)} new items"
+                f"run {run_id} {run_status or 'completed'}, "
+                f"{stats.get('new_items_found', 0)} new items"
             )
 
         except Exception as exc:
             status = _STATUS_ERROR
             logger.error(f"Error checking subscription {subscription_id}: {exc}")
-            if not self.shadow_mode and subscription_id is not None:
-                self.subscriptions_db.record_check_error(subscription_id, str(exc))
+            await self._record_failure(subscription_id, run_id, exc)
 
         finally:
             duration = time.time() - start_time
@@ -142,6 +189,78 @@ class WatchlistCheckHandler:
                 labels["shadow"] = "true"
             log_counter("watchlist_checks", labels=labels)
             log_histogram("watchlist_check_duration", duration, labels=labels)
+
+    async def _record_failure(
+        self, subscription_id: int | None, run_id: Any, exc: BaseException
+    ) -> None:
+        """Persist a failure that escaped ``execute_run``'s own handling.
+
+        Only failures *around* execution reach here -- ``launch_run`` raising,
+        or ``execute_run`` failing before its internal ``try`` (a subscription
+        deleted between the two calls). A fetch failure is already recorded by
+        ``execute_run``.
+
+        Auto-pause parity: the run-failure path ends in
+        ``SubscriptionsDB.record_check_error`` (``local_watchlists_service.py``
+        ``:492``), which is the exact call this handler used to make itself, so
+        ``consecutive_failures`` is bumped identically either way. Calling it
+        again here would double-count it, so the ``run_id`` branch does not.
+        """
+        if self.shadow_mode or subscription_id is None:
+            return
+        if run_id is not None:
+            # A row already exists at `queued`/`running`; leaving it there is
+            # the TASK-1090 failure. `record_run_failure` marks it failed *and*
+            # calls `record_check_error`.
+            try:
+                await self.watchlists_service.record_run_failure(
+                    run_id, source_id=subscription_id, error=exc
+                )
+                return
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Watchlists: could not mark scheduled run {run_id} failed; "
+                    f"falling back to recording the error on the subscription."
+                )
+        self.subscriptions_db.record_check_error(subscription_id, str(exc))
+
+    async def _check_in_shadow(
+        self, subscription: dict[str, Any], subscription_type: str
+    ) -> bool:
+        """Probe a subscription without writing anything. The deliberate fork.
+
+        Shadow mode (``[scheduling] watchlist_checks_shadow``) exists to prove
+        the scheduler wiring end to end -- projection, queue, dispatch, fetch --
+        on an installation where a real check must not touch the database. It
+        therefore cannot go through ``launch_run``/``execute_run`` at all: those
+        exist precisely to write a run row, items and snapshots.
+
+        So this stays a direct-monitor call, and stays deliberately coarser than
+        the real path: it probes one URL for a ``url_list`` and does not
+        enumerate a ``sitemap``. That is a diagnostic's fidelity, not a check's,
+        and it is safe here only because nothing it returns is persisted.
+
+        Args:
+            subscription: The subscription row to probe.
+            subscription_type: Its ``type``.
+
+        Returns:
+            ``True`` when the type was probed, ``False`` when it has no shadow
+            arm (reported as ``unknown_type``).
+        """
+        if subscription_type in _SHADOW_FEED_TYPES:
+            items = await self.feed_monitor.check_feed(subscription)
+        elif subscription_type in _SHADOW_URL_TYPES:
+            result, _disposition = await self.url_monitor.check_url(subscription)
+            items = [result] if result is not None else []
+        else:
+            logger.warning(f"Unknown subscription type: {subscription_type}")
+            return False
+        logger.info(
+            f"Shadow check complete: '{subscription.get('name')}' - "
+            f"{len(items)} item(s) observed, nothing written"
+        )
+        return True
 
     def _parse_subscription_id(self, task_id: Any) -> int | None:
         """Extract the numeric subscription id from a ``watchlist:<id>`` task id."""

--- a/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
@@ -76,23 +76,24 @@ class WatchlistCheckHandler:
             subscriptions_db: Persistent subscription store used to read
                 subscriptions and record run results/errors.
             feed_monitor: Monitor for RSS/Atom/JSON feed checks, used by the
-                shadow path only. A default ``FeedMonitor`` is created when
-                ``None``.
+                shadow path only. Built on first use when ``None``.
             url_monitor: Monitor for URL change checks, used by the shadow path
-                only. A default ``URLMonitor`` bound to ``subscriptions_db`` is
-                created when ``None``.
+                only. Built on first use, bound to ``subscriptions_db``, when
+                ``None``.
             shadow_mode: When ``True``, execute checks without mutating
                 ``subscriptions_db`` and emit metrics with a ``shadow`` label.
             watchlists_service: The service that owns run execution. A default
                 bound to ``subscriptions_db`` is created when ``None``.
         """
         self.subscriptions_db = subscriptions_db
-        self.feed_monitor = feed_monitor if feed_monitor is not None else FeedMonitor()
-        self.url_monitor = (
-            url_monitor
-            if url_monitor is not None
-            else URLMonitor(db=subscriptions_db, persist_snapshots=not shadow_mode)
-        )
+        # Held unbuilt: since TASK-1383 the monitors serve the shadow path
+        # alone, and shadow mode is off by default, so the normal path used to
+        # construct -- on every handler, at app start -- two objects it never
+        # touched. `URLMonitor.__init__` in particular takes the db and builds
+        # per-subscription circuit-breaker state. The properties below build
+        # them on first use, which is the shadow path or an injected test.
+        self._feed_monitor = feed_monitor
+        self._url_monitor = url_monitor
         self.shadow_mode = shadow_mode
         # A constructor parameter rather than a lookup inside `handle`, for the
         # same reason `feed_monitor`/`url_monitor` are: a test can hand in a
@@ -104,6 +105,26 @@ class WatchlistCheckHandler:
             if watchlists_service is not None
             else LocalWatchlistsService(db_factory=lambda: self.subscriptions_db)
         )
+
+    @property
+    def feed_monitor(self) -> FeedMonitor:
+        """The shadow path's feed monitor, built on first use."""
+        if self._feed_monitor is None:
+            self._feed_monitor = FeedMonitor()
+        return self._feed_monitor
+
+    @property
+    def url_monitor(self) -> URLMonitor:
+        """The shadow path's URL monitor, built on first use.
+
+        ``persist_snapshots`` is read from ``shadow_mode`` here rather than at
+        construction, so it cannot disagree with the mode actually in force.
+        """
+        if self._url_monitor is None:
+            self._url_monitor = URLMonitor(
+                db=self.subscriptions_db, persist_snapshots=not self.shadow_mode
+            )
+        return self._url_monitor
 
     async def handle(self, task: dict[str, Any]) -> None:
         """Process a single watchlist check task.
@@ -202,7 +223,7 @@ class WatchlistCheckHandler:
 
         Auto-pause parity: the run-failure path ends in
         ``SubscriptionsDB.record_check_error`` (``local_watchlists_service.py``
-        ``:492``), which is the exact call this handler used to make itself, so
+        ``:509``), which is the exact call this handler used to make itself, so
         ``consecutive_failures`` is bumped identically either way. Calling it
         again here would double-count it, so the ``run_id`` branch does not.
         """

--- a/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
@@ -22,11 +22,22 @@ _WATCHLIST_TASK_PREFIX = "watchlist"
 _SHADOW_FEED_TYPES = ("rss", "atom", "json_feed", "podcast")
 _SHADOW_URL_TYPES = ("url", "url_list")
 
+#: What the shadow probe can actually reach. Deliberately narrower than
+#: `EXECUTABLE_SOURCE_TYPES`: `sitemap` and `api` need the service's own URL and
+#: payload enumeration, which lives on the path shadow mode exists to avoid.
+_SHADOW_COVERED_TYPES = frozenset(_SHADOW_FEED_TYPES) | frozenset(_SHADOW_URL_TYPES)
+
 _STATUS_SUCCESS = "success"
 _STATUS_ERROR = "error"
 _STATUS_SKIPPED = "skipped"
 _STATUS_MISSING = "missing"
 _STATUS_UNKNOWN_TYPE = "unknown_type"
+#: A source the app can really check, but that the shadow probe cannot. Distinct
+#: from `_STATUS_UNKNOWN_TYPE` because conflating them makes shadow mode lie
+#: about scheduler health: it would report a perfectly valid `sitemap` source as
+#: an unknown type, which is exactly the "nothing is wrong" reading that hid
+#: TASK-1210 and TASK-1212.
+_STATUS_SHADOW_UNSUPPORTED = "shadow_unsupported"
 
 
 class WatchlistCheckHandler:
@@ -161,10 +172,7 @@ class WatchlistCheckHandler:
             )
 
             if self.shadow_mode:
-                if not await self._check_in_shadow(subscription, subscription_type):
-                    status = _STATUS_UNKNOWN_TYPE
-                    return
-                status = _STATUS_SUCCESS
+                status = await self._check_in_shadow(subscription, subscription_type)
                 return
 
             if subscription_type not in EXECUTABLE_SOURCE_TYPES:
@@ -187,13 +195,33 @@ class WatchlistCheckHandler:
             # exception for the ordinary failure case.
             executed = await self.watchlists_service.execute_run(run_id)
             run_status = str(executed.get("status") or "")
-            status = _STATUS_ERROR if run_status == "failed" else _STATUS_SUCCESS
             stats = executed.get("stats") or {}
-            logger.info(
-                f"Subscription check complete: '{subscription.get('name')}' - "
-                f"run {run_id} {run_status or 'completed'}, "
-                f"{stats.get('new_items_found', 0)} new items"
-            )
+            if run_status == "failed":
+                status = _STATUS_ERROR
+                # A failed run used to be logged at INFO as "check complete",
+                # with no error text at all -- so the most common failure, an
+                # unattended scheduled check of a dead source, left the metric
+                # counter as its only trace. `error_msg` is read from the run's
+                # own top-level field, which `record_run_result` writes to the
+                # `local_watchlist_runs.error_msg` column; the `stats` copy is
+                # a mirror it makes only when the column is set, so the column
+                # is the one to trust and the mirror is the fallback.
+                error_text = (
+                    executed.get("error_msg")
+                    or stats.get("error_msg")
+                    or "no error message recorded"
+                )
+                logger.warning(
+                    f"Scheduled check FAILED: '{subscription.get('name')}' "
+                    f"(ID: {subscription_id}), run {run_id}: {error_text}"
+                )
+            else:
+                status = _STATUS_SUCCESS
+                logger.info(
+                    f"Subscription check complete: '{subscription.get('name')}' - "
+                    f"run {run_id} {run_status or 'completed'}, "
+                    f"{stats.get('new_items_found', 0)} new items"
+                )
 
         except Exception as exc:
             status = _STATUS_ERROR
@@ -247,7 +275,7 @@ class WatchlistCheckHandler:
 
     async def _check_in_shadow(
         self, subscription: dict[str, Any], subscription_type: str
-    ) -> bool:
+    ) -> str:
         """Probe a subscription without writing anything. The deliberate fork.
 
         Shadow mode (``[scheduling] watchlist_checks_shadow``) exists to prove
@@ -257,31 +285,49 @@ class WatchlistCheckHandler:
         exist precisely to write a run row, items and snapshots.
 
         So this stays a direct-monitor call, and stays deliberately coarser than
-        the real path: it probes one URL for a ``url_list`` and does not
-        enumerate a ``sitemap``. That is a diagnostic's fidelity, not a check's,
-        and it is safe here only because nothing it returns is persisted.
+        the real path: it probes one URL for a ``url_list``, and it cannot reach
+        ``sitemap`` or ``api`` at all, because enumerating those means the
+        service methods that live on the path shadow mode avoids.
+
+        That gap is reported rather than disguised. Before TASK-1383 the real
+        path was equally narrow, so the tuples above happened to match it; now
+        that the real path executes every type in ``EXECUTABLE_SOURCE_TYPES``,
+        folding the uncovered ones into ``unknown_type`` would have shadow mode
+        report a perfectly valid `sitemap` source as unrecognised -- a false
+        clean bill of health, which is the failure mode this stream exists to
+        remove. They get their own status instead.
 
         Args:
             subscription: The subscription row to probe.
             subscription_type: Its ``type``.
 
         Returns:
-            ``True`` when the type was probed, ``False`` when it has no shadow
-            arm (reported as ``unknown_type``).
+            The handler status for this check: ``success`` when probed,
+            ``shadow_unsupported`` when the type is genuinely executable but
+            out of the probe's reach, ``unknown_type`` when nothing can execute
+            it at all.
         """
         if subscription_type in _SHADOW_FEED_TYPES:
             items = await self.feed_monitor.check_feed(subscription)
         elif subscription_type in _SHADOW_URL_TYPES:
             result, _disposition = await self.url_monitor.check_url(subscription)
             items = [result] if result is not None else []
+        elif subscription_type in EXECUTABLE_SOURCE_TYPES:
+            logger.warning(
+                f"Shadow mode cannot probe '{subscription_type}' sources "
+                f"(subscription {subscription.get('id')}); it is checked normally "
+                f"when shadow mode is off. Shadow coverage: "
+                f"{', '.join(sorted(_SHADOW_COVERED_TYPES))}."
+            )
+            return _STATUS_SHADOW_UNSUPPORTED
         else:
             logger.warning(f"Unknown subscription type: {subscription_type}")
-            return False
+            return _STATUS_UNKNOWN_TYPE
         logger.info(
             f"Shadow check complete: '{subscription.get('name')}' - "
             f"{len(items)} item(s) observed, nothing written"
         )
-        return True
+        return _STATUS_SUCCESS
 
     def _parse_subscription_id(self, task_id: Any) -> int | None:
         """Extract the numeric subscription id from a ``watchlist:<id>`` task id."""

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -44,6 +44,23 @@ _ALERT_CONDITION_TYPES = frozenset(
     }
 )
 
+#: The source types `_default_run_executor`'s feed arm handles.
+_FEED_SOURCE_TYPES = frozenset({"rss", "atom", "json_feed", "podcast"})
+
+#: Every source type a local run can execute, i.e. exactly the arms of
+#: `_default_run_executor` below.
+#:
+#: TASK-1383. Exported because the scheduled-check handler
+#: (`Scheduling/scheduler/handlers/watchlist_check_handler.py`) has to decide
+#: whether a subscription is executable *before* it launches a run, and it
+#: used to answer that question from its own private tuples. Those tuples had
+#: drifted: they omitted `sitemap` entirely, so every scheduled sitemap source
+#: took an "unknown subscription type" branch and was never checked. One
+#: definition, read by both callers, is what stops that recurring.
+EXECUTABLE_SOURCE_TYPES = _FEED_SOURCE_TYPES | frozenset(
+    {"url", "url_list", "sitemap", "api"}
+)
+
 #: Every counter `_disposition_counts` can return, in the order the Runs pane
 #: renders them. Named here rather than inline so the zero-fill and the
 #: binding below cannot disagree about which counters exist.
@@ -885,7 +902,7 @@ class LocalWatchlistsService:
         # `None` for the feed and API arms, which have no dispositions at all
         # (spec §4) -- distinguished from `[]`, which would record four zeros.
         dispositions: list[dict[str, Any]] | None = None
-        if source_type in {"rss", "atom", "json_feed", "podcast"}:
+        if source_type in _FEED_SOURCE_TYPES:
             items = await FeedMonitor().check_feed(subscription_config)
         elif source_type == "url":
             result, disposition = await URLMonitor(db).check_url(subscription_config)

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2336,7 +2336,11 @@ reminder_catchup_hours = 24
 # That scheduler is gone, so shadow mode has nothing to compare against and leaving
 # these at their staging values meant nothing ever checked a watchlist (TASK-1210).
 watchlist_checks_enabled = true   # Run watchlist checks on their configured cadence
-watchlist_checks_shadow = false   # Diagnostics only: fetch but DISCARD results, ignoring cadence
+# Diagnostics only: fetch but DISCARD results, ignoring cadence. Shadow mode probes
+# feed and url/url_list sources directly; it CANNOT probe sitemap or api sources,
+# which need the execution path it exists to avoid, and reports those as
+# "shadow_unsupported" rather than pretending they were checked (TASK-1383).
+watchlist_checks_shadow = false
 
 [media_cleanup]
 # Media cleanup settings for automatic hard deletion of soft-deleted items


### PR DESCRIPTION
## What this does

**TASK-1383**: scheduled watchlist checks never created a run row — the Runs pane was structurally blind to the most common, most invisible check path, and the dispositions shipped by TASK-1362 could never reach it.

The scheduled handler previously reimplemented the service's execution path in parallel, and its divergences were live bugs:
- `sitemap` sources hit the "unknown type" branch — never checked on a schedule at all
- a `url_list` source was passed whole to ONE `check_url` call — a 50-URL source checked a single URL
- results sank into `subscription_stats`, a fixed-column daily aggregate with **zero readers anywhere**

**The fix is unification, not extension**: in normal mode the handler now routes through the real `launch_run` + `execute_run`, deleting its parallel dispatch. Scheduled checks get run rows, `stats_json` dispositions, per-URL baselines, and filter/alert evaluation identically to manual checks. Shadow mode keeps its deliberate no-mutation fork (documented in-code). The handler's genuine job — id parsing, missing-subscription and paused/inactive guards (ordered *before* any run row), metrics — is preserved and pinned.

## The finding worth reading

The dispatch asked the implementer to "preserve auto-pause parity" on the failure path. The finding: **no path has ever auto-paused.** The only implementation lives in a branch with no production caller; the function every failure actually uses bumps `consecutive_failures`, never reads `auto_pause_threshold`, and writes `is_paused = 0` — and the codebase's only `is_paused = 1` write is that same dead branch. Parity was therefore preserved exactly: at zero, with no compensating call (it would have double-bumped). Filed as **TASK-1410**, with the review-established facts: the un-pause is reachable only via a manual re-check and currently vacuous; fixing the `is_paused = 0` write is a **hard prerequisite** of ever making auto-pause fire; and the real config surface is the separately-named, equally-unread `auto_pause_after_failures`.

## Review record

One implementer + one full review + one fix round, every claim probed: single-writing verified by counting writes end to end (×1 record, ×1 stats bump, 1 run row); the injection seam pinned to bind the handler's own DB (one thread-local connection family); shadow non-mutation pinned including `persist_snapshots`; five mutations each red for exactly the tests they should redden (the sitemap regression reds precisely one). Tests drive the real `URLMonitor` with only the HTTP fetch faked — every prior scheduled-path test mocked the monitor entirely, which is how the divergences survived.

## Testing

`Tests/Scheduling/ Tests/Subscriptions/ Tests/Watchlists/` — **589 passed, 0 failed**. New module `Tests/Scheduling/test_scheduled_watchlist_runs.py` (12 tests), file-backed `tmp_path` DBs with the thread-locality reasoning stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes scheduled watchlist checks through the real run path (`launch_run`/`execute_run`) so they create `local_watchlist_runs` rows and show up in Runs. Fixes `sitemap`/`url_list` scheduling gaps, improves failure logging, and tightens shadow-mode diagnostics to fully meet TASK-1383.

- **Bug Fixes**
  - Scheduled checks now create run rows via `LocalWatchlistsService.launch_run` + `execute_run`, with dispositions in `stats_json` and per-URL baselines.
  - `sitemap` sources are executed; `url_list` iterates every URL.
  - Failed runs are marked failed, bump `consecutive_failures` once, and log at WARNING with the error; if run-failure recording raises, we fall back to `record_check_error`.
  - Shadow mode still fetches but writes nothing; now reports `shadow_unsupported` for `sitemap`/`api` instead of mislabeling them as unknown.
  - Tests: new `Tests/Scheduling/test_scheduled_watchlist_runs.py` drives the real `URLMonitor`; added invariant to keep `EXECUTABLE_SOURCE_TYPES` aligned with the DB `subscriptions.type` CHECK; E2E updated.

- **Refactors**
  - Handler delegates execution to `LocalWatchlistsService` and drops its parallel dispatch and success-path `record_check_result` write (prevents double-write).
  - Exported `EXECUTABLE_SOURCE_TYPES` from `local_watchlists_service` and use it as the single executability gate.
  - Lazily build `FeedMonitor`/`URLMonitor` (shadow-only) with `persist_snapshots` derived at first use; default service binds to the handler’s DB.

<sup>Written for commit 0ca0be93e317f404f14732371968d6700c7b0307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

