### PR TITLE
fix: address PR #1096 review findings

### DIFF
--- a/Docs/superpowers/plans/2026-07-30-pr-1096-review-remediation.md
+++ b/Docs/superpowers/plans/2026-07-30-pr-1096-review-remediation.md
@@ -1,0 +1,593 @@
+# PR #1096 Review Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve all six actionable PR #1096 review findings without changing its authority, provenance, TTS, or audio.cpp behavior.
+
+**Architecture:** Keep each amendment at its existing boundary: Console rejects an unclassifiable persistence source, the character DB uses its transaction context, the configured-target store validates its path at construction, and the reviewed public methods document their existing contracts. Regressions exercise the public seams and prove no fallback can assign false local provenance.
+
+**Tech Stack:** Python 3.11+, pytest, Loguru, SQLite, shared `path_validation.py`, Ruff
+
+**Design:** [PR #1096 Review Remediation](../specs/2026-07-30-pr-1096-review-remediation-design.md)
+
+**Related task:** [TASK-617.2](<../../../backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md>)
+
+**ADR required:** no
+
+**ADR path:** N/A; [ADR-037](../../../backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md) remains governing.
+
+**Reason:** The amendments enforce and document existing authority/provenance policy. They add no schema, storage owner, runtime boundary, dependency, or alternative authority rule.
+
+---
+
+## File map
+
+- Modify `tldw_chatbook/Chat/console_chat_store.py`: fail loudly and observably when an invalid runtime backend reaches persistence.
+- Modify `Tests/Chat/test_console_chat_store.py`: prove invalid persistence identity logs, raises, and writes nothing.
+- Modify `tldw_chatbook/DB/ChaChaNotes_DB.py`: use the shared transaction cursor and complete the local-authority docstring.
+- Modify `Tests/DB/test_chachanotes_character_authority_migration.py`: prove transaction-seam use and the docstring contract.
+- Modify `tldw_chatbook/MCP/server_target_store.py`: validate the chosen store path and document constructor failure.
+- Modify `tldw_chatbook/MCP/unified_control_models.py`: document configured-target serialization methods.
+- Modify `Tests/MCP/test_server_target_store.py`: prove dangerous paths fail and serialization docs are complete.
+- Modify `tldw_chatbook/Chat/chat_conversation_service.py`: document conversation creation, including authority provenance.
+- Modify `tldw_chatbook/Chat/chat_persistence_service.py`: document the lower persistence creation boundary.
+- Modify `Tests/Chat/test_chat_conversation_service.py`: enforce the conversation-service public contract documentation.
+- Modify `Tests/Chat/test_chat_persistence_service.py`: enforce the persistence-service public contract documentation.
+- Verify `Tests/MCP/test_store_default_paths.py`: ensure the validated default and explicit paths remain byte-for-byte compatible.
+
+No files are created by the implementation and no existing module is split.
+
+### Task 1: Make invalid Console persistence identity observable
+
+**Files:**
+
+- Modify: `Tests/Chat/test_console_chat_store.py`
+- Modify: `tldw_chatbook/Chat/console_chat_store.py:1966`
+
+- [ ] **Step 1: Write the failing regression**
+
+Add a test beside the existing `persist_session_if_needed` observability tests:
+
+```python
+def test_persist_session_if_needed_rejects_invalid_runtime_backend_observably():
+    from loguru import logger as loguru_logger
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(
+        title="Unscoped restored chat",
+        runtime_backend="invalid",
+    )
+    messages: list[str] = []
+    sink_id = loguru_logger.add(
+        messages.append,
+        level="WARNING",
+        format="{extra[session_id]}|{extra[runtime_backend]}|{message}",
+    )
+    try:
+        with pytest.raises(
+            ValueError,
+            match="runtime_backend must be 'local' or 'server'",
+        ):
+            store.persist_session_if_needed(session.id)
+        with pytest.raises(
+            ValueError,
+            match="runtime_backend must be 'local' or 'server'",
+        ):
+            store.append_message(
+                session.id,
+                role=ConsoleMessageRole.USER,
+                content="Keep this message in memory",
+                persist=True,
+            )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert persistence.created_conversations == []
+    assert persistence.created_messages == []
+    assert any(
+        session.id in message
+        and "invalid" in message
+        and "persist" in message.lower()
+        for message in messages
+    )
+```
+
+- [ ] **Step 2: Update the existing fail-closed provenance expectation**
+
+In the parameterized
+`test_invalid_runtime_source_never_reaches_real_chat_persistence`, replace the
+old `None` expectations with `pytest.raises(ValueError, ...)` around both
+`persist_session_if_needed()` and `append_message(..., persist=True)`. Keep its
+real-DB assertions, and inspect the in-memory message after the raised append:
+
+```python
+with pytest.raises(ValueError, match="runtime_backend must be"):
+    store.persist_session_if_needed(session.id)
+with pytest.raises(ValueError, match="runtime_backend must be"):
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="Keep this message in memory",
+        persist=True,
+    )
+
+message = store.messages_for_session(session.id)[-1]
+assert session.persisted_conversation_id is None
+assert message.persisted_message_id is None
+assert create_calls == []
+assert db.get_all_conversation_ids() == []
+assert db.count_character_cards() == character_count
+```
+
+This preserves the existing proof that malformed provenance cannot be
+materialized as local while changing only the formerly silent failure
+contract.
+
+- [ ] **Step 3: Run the tests and confirm the silent-return defect**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_chat_store.py::test_persist_session_if_needed_rejects_invalid_runtime_backend_observably \
+  Tests/Chat/test_console_chat_store.py::test_invalid_runtime_source_never_reaches_real_chat_persistence
+```
+
+Expected: FAIL because no exception or structured diagnostic is produced.
+
+- [ ] **Step 4: Implement the minimal fail-loud boundary**
+
+Replace the invalid-backend `return None` in
+`ConsoleChatStore.persist_session_if_needed()` with:
+
+```python
+runtime_backend = session.runtime_backend
+if type(runtime_backend) is not str or runtime_backend not in {"local", "server"}:
+    logged_backend = repr(runtime_backend)[:128]
+    logger.bind(
+        session_id=session_id,
+        runtime_backend=logged_backend,
+    ).error("Cannot persist Console session with invalid runtime backend.")
+    raise ValueError(
+        "Cannot persist Console session: "
+        "runtime_backend must be 'local' or 'server'."
+    )
+```
+
+Keep the existing early returns for an already-persisted session and an absent
+persistence adapter. Do not coerce or infer a backend.
+
+- [ ] **Step 5: Run the focused Console tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_chat_store.py::test_persist_session_if_needed_rejects_invalid_runtime_backend_observably \
+  Tests/Chat/test_console_chat_store.py
+```
+
+Expected: the new regression and the complete file PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  Tests/Chat/test_console_chat_store.py \
+  tldw_chatbook/Chat/console_chat_store.py
+git commit -m "fix: reject invalid console persistence backend"
+```
+
+### Task 2: Use the character DB transaction seam
+
+**Files:**
+
+- Modify: `Tests/DB/test_chachanotes_character_authority_migration.py`
+- Modify: `tldw_chatbook/DB/ChaChaNotes_DB.py:2737`
+
+- [ ] **Step 1: Write failing transaction and documentation tests**
+
+Import `contextmanager` and `inspect`, then add:
+
+```python
+def test_local_authority_accessor_uses_shared_transaction_seam(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "authority-transaction.sqlite", "test-client")
+    real_transaction = db.transaction
+    calls = 0
+
+    @contextmanager
+    def recording_transaction():
+        nonlocal calls
+        calls += 1
+        with real_transaction() as cursor:
+            yield cursor
+
+    monkeypatch.setattr(db, "transaction", recording_transaction)
+    try:
+        assert db.get_local_authority_id()
+        assert calls == 1
+    finally:
+        db.close_connection()
+
+
+def test_local_authority_accessor_documents_public_contract() -> None:
+    docstring = inspect.getdoc(CharactersRAGDB.get_local_authority_id)
+
+    assert docstring is not None
+    assert "Returns:" in docstring
+    assert "Raises:" in docstring
+```
+
+- [ ] **Step 2: Run the tests and confirm both review gaps**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/DB/test_chachanotes_character_authority_migration.py::test_local_authority_accessor_uses_shared_transaction_seam \
+  Tests/DB/test_chachanotes_character_authority_migration.py::test_local_authority_accessor_documents_public_contract
+```
+
+Expected: FAIL because the accessor bypasses `transaction()` and lacks
+`Returns:`.
+
+- [ ] **Step 3: Route the lookup through the transaction cursor**
+
+Change the lookup to:
+
+```python
+try:
+    with self.transaction() as cursor:
+        rows = cursor.execute(
+            """
+            SELECT local_authority_id
+            FROM rag_identity_context
+            WHERE context_name = 'default'
+            LIMIT 2
+            """
+        ).fetchall()
+except sqlite3.Error as exc:
+    raise CharactersRAGDBError(
+        "Local authority identity is unavailable or invalid."
+    ) from exc
+```
+
+Add this docstring section before `Raises:`:
+
+```python
+Returns:
+    The database-owned local authority identifier.
+```
+
+- [ ] **Step 4: Run the complete migration/authority test file**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/DB/test_chachanotes_character_authority_migration.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  Tests/DB/test_chachanotes_character_authority_migration.py \
+  tldw_chatbook/DB/ChaChaNotes_DB.py
+git commit -m "fix: use transaction for local authority lookup"
+```
+
+### Task 3: Validate configured-target store paths and document serialization
+
+**Files:**
+
+- Modify: `Tests/MCP/test_server_target_store.py`
+- Modify: `tldw_chatbook/MCP/server_target_store.py:45`
+- Modify: `tldw_chatbook/MCP/unified_control_models.py:237`
+- Verify: `Tests/MCP/test_store_default_paths.py`
+
+- [ ] **Step 1: Write failing path and documentation tests**
+
+Import `inspect`, then add:
+
+```python
+def test_target_store_rejects_dangerous_path() -> None:
+    with pytest.raises(ValueError, match="dangerous pattern"):
+        ConfiguredServerTargetStore("../../mcp_server_targets.json")
+
+
+def test_configured_server_target_serialization_documents_public_contract() -> None:
+    to_dict_doc = inspect.getdoc(ConfiguredServerTarget.to_dict)
+    from_dict_doc = inspect.getdoc(ConfiguredServerTarget.from_dict)
+
+    assert to_dict_doc is not None
+    assert "Returns:" in to_dict_doc
+    assert from_dict_doc is not None
+    assert "Args:" in from_dict_doc
+    assert "Returns:" in from_dict_doc
+```
+
+- [ ] **Step 2: Run the tests and confirm validation/docs are absent**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/MCP/test_server_target_store.py::test_target_store_rejects_dangerous_path \
+  Tests/MCP/test_server_target_store.py::test_configured_server_target_serialization_documents_public_contract
+```
+
+Expected: FAIL because the path is accepted and the methods have no
+docstrings.
+
+- [ ] **Step 3: Validate the constructor boundary**
+
+Import the shared helper:
+
+```python
+from tldw_chatbook.Utils.path_validation import validate_path_simple
+```
+
+Implement:
+
+```python
+def __init__(self, path: str | Path | None = None) -> None:
+    """Initialize a configured-server-target store.
+
+    Args:
+        path: Optional JSON store path. Defaults to the current user data
+            directory.
+
+    Raises:
+        ValueError: If the selected path contains a known security risk.
+    """
+    selected_path = Path(path) if path else _default_server_targets_path()
+    self.path = validate_path_simple(selected_path, require_exists=False)
+```
+
+- [ ] **Step 4: Add minimal Google-style serialization docs**
+
+Add to `ConfiguredServerTarget.to_dict()`:
+
+```python
+"""Serialize this configured target.
+
+Returns:
+    A JSON-compatible mapping containing routing, authority, authentication
+    reference, and status metadata.
+"""
+```
+
+Add to `ConfiguredServerTarget.from_dict()`:
+
+```python
+"""Restore a configured target from serialized data.
+
+Args:
+    data: Serialized mapping. Non-mapping values produce an empty legacy
+        target.
+
+Returns:
+    The normalized configured target.
+"""
+```
+
+- [ ] **Step 5: Run target-store and default-path regressions**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/MCP/test_server_target_store.py \
+  Tests/MCP/test_store_default_paths.py
+```
+
+Expected: PASS, including exact default and explicit path equality.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  Tests/MCP/test_server_target_store.py \
+  tldw_chatbook/MCP/server_target_store.py \
+  tldw_chatbook/MCP/unified_control_models.py
+git commit -m "fix: validate configured server target path"
+```
+
+### Task 4: Document both conversation-creation boundaries
+
+**Files:**
+
+- Modify: `Tests/Chat/test_chat_conversation_service.py`
+- Modify: `Tests/Chat/test_chat_persistence_service.py`
+- Modify: `tldw_chatbook/Chat/chat_conversation_service.py:358`
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py:72`
+
+- [ ] **Step 1: Add failing contract tests**
+
+Add to the conversation-service tests:
+
+```python
+def test_create_conversation_documents_public_contract():
+    docstring = inspect.getdoc(ChatConversationService.create_conversation)
+
+    assert docstring is not None
+    assert "Args:" in docstring
+    assert "assistant_authority_id" in docstring
+    assert "Returns:" in docstring
+    assert "Raises:" in docstring
+```
+
+Add the equivalent assertion for
+`ChatPersistenceService.create_conversation` to its test class.
+
+- [ ] **Step 2: Run the tests and confirm both docstrings are absent**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_chat_conversation_service.py::test_create_conversation_documents_public_contract \
+  Tests/Chat/test_chat_persistence_service.py -k "create_conversation_documents_public_contract"
+```
+
+Expected: FAIL because neither public method has a docstring.
+
+- [ ] **Step 3: Document `ChatConversationService.create_conversation()`**
+
+Add a Google-style docstring covering every named argument and
+`extra_fields`. Its authority entry must state that omission lets the DB apply
+eligible local inference while explicit `None` preserves unproven authority.
+Document the returned string ID and the existing `ValueError` when the DB
+cannot create the conversation.
+
+- [ ] **Step 4: Document `ChatPersistenceService.create_conversation()`**
+
+Add a Google-style docstring covering every named argument. Preserve the same
+authority omission-versus-null distinction, describe workspace linkage, return
+the persisted ID, and document invalid workspace scope/linkage failure without
+changing runtime behavior.
+
+- [ ] **Step 5: Run both complete service test files**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_chat_conversation_service.py \
+  Tests/Chat/test_chat_persistence_service.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  Tests/Chat/test_chat_conversation_service.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  tldw_chatbook/Chat/chat_conversation_service.py \
+  tldw_chatbook/Chat/chat_persistence_service.py
+git commit -m "docs: complete conversation creation contracts"
+```
+
+### Task 5: Verify, review, and open the follow-up PR
+
+**Files:**
+
+- Review all files changed since `origin/dev`
+- Do not add unrelated cleanup
+
+- [ ] **Step 1: Run the complete focused regression union**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/DB/test_chachanotes_character_authority_migration.py \
+  Tests/MCP/test_server_target_store.py \
+  Tests/MCP/test_store_default_paths.py \
+  Tests/Chat/test_chat_conversation_service.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/Chat/test_console_chat_store.py
+```
+
+Expected: PASS. The pre-change five-file baseline was 260 passed; the added
+default-path file and new regressions must remain green.
+
+- [ ] **Step 2: Run task-scoped lint and formatting checks**
+
+Run:
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/Chat/console_chat_store.py \
+  tldw_chatbook/Chat/chat_conversation_service.py \
+  tldw_chatbook/Chat/chat_persistence_service.py \
+  tldw_chatbook/DB/ChaChaNotes_DB.py \
+  tldw_chatbook/MCP/server_target_store.py \
+  tldw_chatbook/MCP/unified_control_models.py \
+  Tests/Chat/test_console_chat_store.py \
+  Tests/Chat/test_chat_conversation_service.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/DB/test_chachanotes_character_authority_migration.py \
+  Tests/MCP/test_server_target_store.py
+
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Chat/console_chat_store.py \
+  tldw_chatbook/Chat/chat_conversation_service.py \
+  tldw_chatbook/Chat/chat_persistence_service.py \
+  tldw_chatbook/DB/ChaChaNotes_DB.py \
+  tldw_chatbook/MCP/server_target_store.py \
+  tldw_chatbook/MCP/unified_control_models.py \
+  Tests/Chat/test_console_chat_store.py \
+  Tests/Chat/test_chat_conversation_service.py \
+  Tests/Chat/test_chat_persistence_service.py \
+  Tests/DB/test_chachanotes_character_authority_migration.py \
+  Tests/MCP/test_server_target_store.py
+```
+
+Expected: PASS, or document an exact unchanged `origin/dev` baseline before
+proceeding.
+
+- [ ] **Step 3: Run repository-wide tests**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q
+```
+
+Expected: PASS. If an inherited failure blocks the suite, reproduce the exact
+node and failure on `origin/dev`; do not repair unrelated baseline failures in
+this PR.
+
+- [ ] **Step 4: Inspect the complete diff**
+
+Run:
+
+```bash
+git diff --check origin/dev...HEAD
+git status --short
+git diff --stat origin/dev...HEAD
+git diff origin/dev...HEAD -- \
+  tldw_chatbook Tests Docs/superpowers
+```
+
+Expected: no whitespace errors, no uncommitted files, and only the reviewed
+remediation.
+
+- [ ] **Step 5: Request independent code review**
+
+Use `superpowers:requesting-code-review` against `origin/dev...HEAD`. Address
+every verified Critical or Important finding and rerun the affected gates.
+
+- [ ] **Step 6: Rebase on the latest `origin/dev`**
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+```
+
+Rerun the focused union and `git diff --check` after the rebase.
+
+- [ ] **Step 7: Push and create a ready follow-up PR**
+
+```bash
+git push -u origin codex/pr-1096-review-fixes
+gh pr create \
+  --base dev \
+  --head codex/pr-1096-review-fixes \
+  --title "fix: address PR #1096 review findings" \
+  --body-file /tmp/pr-1096-review-fixes.md
+```
+
+The PR description must link PR #1096, enumerate all six resolved findings,
+state that ADR-037 remains governing, list verification evidence, and call out
+the explicit non-goals.

--- a/Docs/superpowers/specs/2026-07-30-pr-1096-review-remediation-design.md
+++ b/Docs/superpowers/specs/2026-07-30-pr-1096-review-remediation-design.md
@@ -1,0 +1,134 @@
+# PR #1096 Review Remediation
+
+**Status:** approved in conversation on 2026-07-30; pending written-spec review
+**Date:** 2026-07-30
+**Related task:** [TASK-617.2](<../../../backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md>)
+**Canonical ADR:** [ADR-037](../../../backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md)
+**Source review:** [PR #1096](https://github.com/rmusser01/tldw_chatbook/pull/1096)
+
+## Goal
+
+Resolve every actionable review finding left on merged PR #1096 in one small
+follow-up PR. The changes make invalid Console persistence visible, route the
+local-authority lookup through the database transaction seam, validate the
+configured-server-target store path, and complete the public API
+documentation identified by review.
+
+This remediation does not change the authority model, persistence schema,
+conversation provenance rules, TTS selection, or audio.cpp behavior delivered
+by PR #1096.
+
+## Review disposition
+
+The PR review contains six distinct actionable findings. Qodo repeated these
+findings between its summary and inline threads; each duplicate is one work
+item, not a separate change.
+
+| Finding | Disposition |
+| --- | --- |
+| `CharactersRAGDB.get_local_authority_id()` lacks a Google-style `Returns:` section | Add the missing contract section. |
+| Conversation-service persistence entry points lack complete Google-style documentation | Document both `ChatConversationService.create_conversation()` and `ChatPersistenceService.create_conversation()`, including `assistant_authority_id`. |
+| `ConfiguredServerTarget.to_dict()` and `from_dict()` lack Google-style documentation | Add `Args:` and/or `Returns:` sections appropriate to each method. |
+| Invalid `ConsoleChatSession.runtime_backend` silently prevents conversation and message persistence | Emit structured diagnostics and raise a clear exception before any persistence attempt. |
+| `get_local_authority_id()` bypasses the shared transaction wrapper | Execute the lookup through `self.transaction()`. |
+| `ConfiguredServerTargetStore` accepts an unvalidated caller-provided filesystem path | Validate the selected path at construction with the shared path-validation utility. |
+
+The CodeRabbit path-filter notice, Gemini deprecation notice, Qodo summary
+text, generated GitHub Actions test summary, and previously posted inherited-CI
+evidence do not identify additional code changes.
+
+## Design
+
+### Invalid Console persistence state
+
+`persist_session_if_needed()` continues to accept only the canonical
+`"local"` and `"server"` runtime backends. If a session reaches first
+persistence with any other value, the store:
+
+1. emits a structured Loguru diagnostic containing the session identifier and
+   invalid backend value;
+2. raises `ValueError` with a stable, actionable explanation; and
+3. performs no conversation or message write.
+
+It must not coerce an invalid value to `"local"`. Such coercion could assign
+false local provenance to a restored or malformed session. In-memory restore
+may continue to retain an explicitly unscoped session so text chat can remain
+available; the failure occurs only when code asks to persist an identity it
+cannot classify safely.
+
+### Database transaction seam
+
+`CharactersRAGDB.get_local_authority_id()` obtains a cursor from
+`self.transaction()` and performs its existing single-row lookup through that
+cursor. Existing error translation and cardinality validation remain
+unchanged. This preserves the database's nested-transaction, locking, cleanup,
+and test-instrumentation contract.
+
+### Target-store path boundary
+
+`ConfiguredServerTargetStore.__init__()` selects either the explicit `path` or
+the existing default, then passes it through
+`Utils.path_validation.validate_path_simple(..., require_exists=False)`.
+Validation occurs before any read, directory creation, temporary-file write,
+or replacement. Valid absolute defaults and test `tmp_path` values retain
+their exact paths; dangerous traversal, null-byte, and shell-pattern inputs
+fail with the shared validator's `ValueError`.
+
+This is input hardening only. It does not confine explicit target stores to the
+application data directory or change the on-disk JSON format.
+
+### Public API documentation
+
+The four reviewed API surfaces receive concise Google-style docstrings:
+
+- local-authority lookup documents its return value and existing failure;
+- both conversation-creation layers document their inputs, opaque extra
+  fields, returned conversation ID, and failure behavior;
+- target serialization documents produced data and reconstruction input.
+
+Docstrings describe current behavior only. They do not add runtime branches or
+new validation.
+
+## Verification
+
+Focused regressions will prove:
+
+- an invalid runtime backend raises, logs identifying context, and creates no
+  persisted conversation;
+- the local-authority accessor uses the shared transaction seam;
+- a dangerous target-store path is rejected while existing default and
+  temporary paths still work; and
+- the reviewed public methods expose the required Google-style contract
+  sections.
+
+The pre-change baseline is 260 passing tests across:
+
+- `Tests/DB/test_chachanotes_character_authority_migration.py`
+- `Tests/MCP/test_server_target_store.py`
+- `Tests/Chat/test_chat_conversation_service.py`
+- `Tests/Chat/test_chat_persistence_service.py`
+- `Tests/Chat/test_console_chat_store.py`
+
+After implementation, that focused union, task-scoped lint/static checks, and
+`git diff --check` will be rerun. Any repository-wide inherited failures remain
+out of scope and must be reported rather than silently folded into this PR.
+
+## Architecture and scope
+
+**ADR required:** no
+
+**ADR path:** N/A; existing [ADR-037](../../../backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md) remains governing.
+
+**Reason:** these are documentation, validation, transaction-seam, and
+fail-loud correctness amendments to the existing authority/provenance design.
+They do not introduce a schema, storage owner, runtime boundary, service
+contract, dependency, or alternative authority policy.
+
+Explicit exclusions:
+
+- no database migration or persisted-format change;
+- no new TTS adapter, profile-selection, synthesis, or audio.cpp behavior;
+- no managed audio.cpp launch or supervision;
+- no Persona/User Profile semantic change;
+- no Sync V2 change; and
+- no unrelated CI or repository-wide cleanup.

--- a/Docs/superpowers/specs/2026-07-30-pr-1096-review-remediation-design.md
+++ b/Docs/superpowers/specs/2026-07-30-pr-1096-review-remediation-design.md
@@ -1,6 +1,6 @@
 # PR #1096 Review Remediation
 
-**Status:** approved in conversation on 2026-07-30; pending written-spec review
+**Status:** approved by the user and independent spec review on 2026-07-30
 **Date:** 2026-07-30
 **Related task:** [TASK-617.2](<../../../backlog/tasks/task-617.2 - Establish-character-authority-and-conversation-provenance.md>)
 **Canonical ADR:** [ADR-037](../../../backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md)

--- a/Tests/Chat/test_chat_conversation_service.py
+++ b/Tests/Chat/test_chat_conversation_service.py
@@ -344,6 +344,23 @@ def test_create_conversation_exposes_and_threads_assistant_authority_id():
     )
 
 
+def test_create_conversation_documents_public_contract():
+    method = ChatConversationService.create_conversation
+    doc = inspect.getdoc(method)
+
+    assert doc is not None
+    assert "Args:" in doc
+    for name in inspect.signature(method).parameters:
+        if name != "self":
+            assert f"{name}:" in doc
+    assert "Omitting" in doc
+    assert "``None`` explicitly" in doc
+    assert "conversation_title or title" in doc
+    assert "Raw truthy" in doc
+    assert "Returns:" in doc
+    assert "Raises:" in doc
+
+
 def test_create_conversation_preserves_omitted_and_explicit_null_authority(
     tmp_path,
 ):

--- a/Tests/Chat/test_chat_persistence_service.py
+++ b/Tests/Chat/test_chat_persistence_service.py
@@ -50,6 +50,22 @@ def db_instance(db_path, client_id):
 
 @pytest.mark.integration
 class TestChatPersistenceService:
+    def test_create_conversation_documents_public_contract(self):
+        method = ChatPersistenceService.create_conversation
+        doc = inspect.getdoc(method)
+
+        assert doc is not None
+        assert "Args:" in doc
+        for name in inspect.signature(method).parameters:
+            if name != "self":
+                assert f"{name}:" in doc
+        assert "Omitting" in doc
+        assert "``None`` explicitly" in doc
+        assert "explicit normalized" in doc
+        assert "best-effort" in doc
+        assert "Returns:" in doc
+        assert "Raises:" in doc
+
     def test_persistence_service_never_uses_display_name_as_assistant_id(
         self, db_instance: CharactersRAGDB
     ):

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -751,6 +751,43 @@ def test_persist_session_if_needed_reports_invalid_runtime_backend():
     ), diagnostics
 
 
+def test_persist_session_if_needed_handles_invalid_backend_with_raising_repr():
+    """Diagnostic formatting cannot replace the stable invalid-backend error."""
+    from loguru import logger as loguru_logger
+
+    class ExplodingBackend:
+        def __repr__(self):
+            raise RuntimeError("repr must not run")
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(
+        title="Malformed chat", runtime_backend=ExplodingBackend()
+    )
+    diagnostics: list[str] = []
+    sink_id = loguru_logger.add(
+        diagnostics.append,
+        level="ERROR",
+        format="{extra[session_id]} {extra[runtime_backend]} {message}",
+    )
+    try:
+        with pytest.raises(
+            ValueError, match="runtime_backend must be 'local' or 'server'"
+        ):
+            store.persist_session_if_needed(session.id)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert persistence.created_conversations == []
+    assert persistence.created_messages == []
+    assert any(
+        session.id in diagnostic
+        and "ExplodingBackend" in diagnostic
+        and "persist" in diagnostic.lower()
+        for diagnostic in diagnostics
+    ), diagnostics
+
+
 @pytest.mark.parametrize(
     ("session_kwargs", "expected"),
     [

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -711,6 +711,46 @@ def test_persist_session_if_needed_passes_none_system_prompt_without_settings():
     assert persistence.created_conversations[0]["system_prompt"] is None
 
 
+def test_persist_session_if_needed_reports_invalid_runtime_backend():
+    """Invalid provenance must fail visibly without any durable writes."""
+    from loguru import logger as loguru_logger
+
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Malformed chat", runtime_backend="invalid")
+    diagnostics: list[str] = []
+    sink_id = loguru_logger.add(
+        diagnostics.append,
+        level="ERROR",
+        format="{extra[session_id]} {extra[runtime_backend]} {message}",
+    )
+    try:
+        with pytest.raises(
+            ValueError, match="runtime_backend must be 'local' or 'server'"
+        ):
+            store.persist_session_if_needed(session.id)
+        with pytest.raises(
+            ValueError, match="runtime_backend must be 'local' or 'server'"
+        ):
+            store.append_message(
+                session.id,
+                role=ConsoleMessageRole.USER,
+                content="Keep this message in memory",
+                persist=True,
+            )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert persistence.created_conversations == []
+    assert persistence.created_messages == []
+    assert any(
+        session.id in diagnostic
+        and "'invalid'" in diagnostic
+        and "persist" in diagnostic.lower()
+        for diagnostic in diagnostics
+    ), diagnostics
+
+
 @pytest.mark.parametrize(
     ("session_kwargs", "expected"),
     [
@@ -1427,15 +1467,21 @@ def test_invalid_runtime_source_never_reaches_real_chat_persistence(
             character_name="Injected local card",
         )
 
-        conversation_id = store.persist_session_if_needed(session.id)
-        message = store.append_message(
-            session.id,
-            role=ConsoleMessageRole.USER,
-            content="Keep this message in memory",
-            persist=True,
-        )
+        with pytest.raises(
+            ValueError, match="runtime_backend must be 'local' or 'server'"
+        ):
+            store.persist_session_if_needed(session.id)
+        with pytest.raises(
+            ValueError, match="runtime_backend must be 'local' or 'server'"
+        ):
+            store.append_message(
+                session.id,
+                role=ConsoleMessageRole.USER,
+                content="Keep this message in memory",
+                persist=True,
+            )
 
-        assert conversation_id is None
+        message = store.messages_for_session(session.id)[-1]
         assert session.persisted_conversation_id is None
         assert message.persisted_message_id is None
         assert create_calls == []

--- a/Tests/DB/test_chachanotes_character_authority_migration.py
+++ b/Tests/DB/test_chachanotes_character_authority_migration.py
@@ -1,6 +1,8 @@
+import inspect
 import json
 import re
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -134,6 +136,40 @@ def test_fresh_database_reaches_v28_and_local_authority_survives_reopen(
     reopened = CharactersRAGDB(path, client_id="authority-test")
     assert reopened.get_local_authority_id() == authority_id
     reopened.close_connection()
+
+
+def test_local_authority_accessor_uses_shared_transaction_seam(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = CharactersRAGDB(
+        tmp_path / "authority-transaction.sqlite",
+        client_id="authority-transaction-test",
+    )
+    real_transaction = db.transaction
+    transaction_calls = 0
+
+    @contextmanager
+    def recording_transaction():
+        nonlocal transaction_calls
+        transaction_calls += 1
+        with real_transaction() as cursor:
+            yield cursor
+
+    monkeypatch.setattr(db, "transaction", recording_transaction)
+    try:
+        assert db.get_local_authority_id()
+        assert transaction_calls == 1
+    finally:
+        db.close_connection()
+
+
+def test_local_authority_accessor_documents_public_contract() -> None:
+    doc = inspect.getdoc(CharactersRAGDB.get_local_authority_id)
+
+    assert doc is not None
+    assert "Returns:" in doc
+    assert "Raises:" in doc
 
 
 @pytest.mark.parametrize(

--- a/Tests/DB/test_chachanotes_character_authority_migration.py
+++ b/Tests/DB/test_chachanotes_character_authority_migration.py
@@ -164,6 +164,35 @@ def test_local_authority_accessor_uses_shared_transaction_seam(
         db.close_connection()
 
 
+def test_local_authority_accessor_borrows_caller_owned_sqlite_transaction(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(
+        tmp_path / "authority-caller-transaction.sqlite",
+        client_id="authority-caller-transaction-test",
+    )
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            UPDATE rag_identity_context
+            SET local_authority_id = local_authority_id
+            WHERE context_name = 'default'
+            """
+        )
+        assert conn.in_transaction
+        assert db._local.transaction_depth == 0
+
+        assert db.get_local_authority_id()
+
+        assert conn.in_transaction
+        assert db._local.transaction_depth == 0
+    finally:
+        if conn.in_transaction:
+            conn.rollback()
+        db.close_connection()
+
+
 def test_local_authority_accessor_documents_public_contract() -> None:
     doc = inspect.getdoc(CharactersRAGDB.get_local_authority_id)
 

--- a/Tests/MCP/test_server_target_store.py
+++ b/Tests/MCP/test_server_target_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import inspect
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -16,6 +17,22 @@ from tldw_chatbook.MCP.server_target_store import (
 from tldw_chatbook.MCP.unified_control_models import ConfiguredServerTarget
 
 _CANONICAL_SCOPE = "123e4567-e89b-42d3-a456-426614174000"
+
+
+def test_target_store_rejects_dangerous_path():
+    with pytest.raises(ValueError, match="dangerous pattern"):
+        ConfiguredServerTargetStore("../../mcp_server_targets.json")
+
+
+def test_configured_server_target_serialization_documents_public_contract():
+    to_dict_doc = inspect.getdoc(ConfiguredServerTarget.to_dict)
+    from_dict_doc = inspect.getdoc(ConfiguredServerTarget.from_dict)
+
+    assert to_dict_doc is not None
+    assert "Returns:" in to_dict_doc
+    assert from_dict_doc is not None
+    assert "Args:" in from_dict_doc
+    assert "Returns:" in from_dict_doc
 
 
 def _assert_canonical_uuid4(value: str) -> None:

--- a/tldw_chatbook/Chat/chat_conversation_service.py
+++ b/tldw_chatbook/Chat/chat_conversation_service.py
@@ -376,6 +376,41 @@ class ChatConversationService:
         external_ref: str | None = None,
         **extra_fields: Any,
     ) -> str:
+        """Create and persist a conversation.
+
+        Args:
+            title: Secondary title candidate used only when raw
+                ``conversation_title`` is falsey.
+            conversation_title: Raw truthy value selected by
+                ``conversation_title or title``, including whitespace. Downstream
+                cleaning can discard it and derive an assistant title without
+                falling back to ``title``.
+            character_id: Local character identifier associated with the conversation.
+            assistant_kind: Kind of assistant that owns the conversation.
+            assistant_id: Stable assistant identifier.
+            assistant_authority_id: Provenance authority identifier. Omitting it
+                leaves the field absent so eligible DB-owned local inference may
+                apply; passing ``None`` explicitly preserves unproven authority.
+            persona_memory_mode: Memory behavior for a persona conversation.
+            runtime_backend: Backend selected to run the assistant.
+            discovery_owner: Owner of the assistant discovery record.
+            discovery_entity_id: Discovery record identifier for the assistant.
+            scope_type: Scope classification for the conversation.
+            workspace_id: Workspace identifier when the scope requires one.
+            state: Initial conversation state.
+            topic_label: Optional topic label.
+            source: Origin that created the conversation.
+            external_ref: External source reference.
+            **extra_fields: Additional database-supported fields. Explicit named
+                fields are assigned after this mapping; recognized keyword names
+                bind to the signature rather than this mapping.
+
+        Returns:
+            Persisted conversation ID as a string.
+
+        Raises:
+            ValueError: If the database cannot create the conversation.
+        """
         resolved_title = derive_conversation_title(
             assistant_kind=assistant_kind,
             assistant_name=None,

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -86,6 +86,42 @@ class ChatPersistenceService:
         conversation_title: Optional[str] = None,
         system_prompt: Optional[str] = None,
     ) -> str:
+        """Create a conversation and link it to a workspace when requested.
+
+        Args:
+            character_id: Local character identifier associated with the conversation.
+            character_name: Display name used to derive a title when no explicit
+                title is supplied.
+            assistant_kind: Kind of assistant that owns the conversation.
+            assistant_id: Stable assistant identifier used for title derivation.
+            assistant_authority_id: Provenance authority identifier. Omitting it
+                leaves the field absent so eligible DB-owned local inference may
+                apply; passing ``None`` explicitly preserves unproven authority.
+            persona_memory_mode: Memory behavior for a persona conversation.
+            runtime_backend: Backend selected to run the assistant.
+            discovery_owner: Owner of the assistant discovery record.
+            discovery_entity_id: Discovery record identifier for the assistant.
+            scope_type: Conversation scope. Only an explicit normalized
+                ``scope_type="workspace"`` validates and links workspace
+                membership here.
+            workspace_id: Candidate workspace identifier forwarded to the
+                database and resolved for an explicit workspace scope.
+                Non-workspace/global persistence is normalized by the database
+                and may clear it; omitting scope does not create a link.
+            conversation_title: Explicit title, which takes precedence when
+                truthy; otherwise the character or assistant-derived title is used.
+            system_prompt: Initial system prompt persisted with the conversation.
+
+        Returns:
+            Persisted conversation ID.
+
+        Raises:
+            ValueError: If workspace scope is invalid or its workspace cannot be
+                resolved.
+            Exception: If workspace membership linkage fails after creation. A
+                best-effort soft-delete is attempted; a false result can leave
+                the row, and a cleanup exception may replace the link error.
+        """
         safe_workspace_id = self._require_workspace_scope(
             scope_type=scope_type,
             workspace_id=workspace_id,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1974,7 +1974,14 @@ class ConsoleChatStore:
             type(session.runtime_backend) is not str
             or session.runtime_backend not in {"local", "server"}
         ):
-            return None
+            logger.bind(
+                session_id=session_id,
+                runtime_backend=repr(session.runtime_backend)[:128],
+            ).error("Cannot persist Console session with invalid runtime backend.")
+            raise ValueError(
+                "Cannot persist Console session: runtime_backend must be "
+                "'local' or 'server'."
+            )
         scope_type, persisted_workspace_id = self._persistence_scope(session)
         local_character_id = session.local_character_id()
         identity_kwargs = {

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -218,6 +218,15 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _invalid_runtime_backend_diagnostic(value: Any) -> str:
+    """Return bounded diagnostic context without invoking custom ``repr``."""
+    if type(value) is str:
+        truncated = value[:120]
+        suffix = "..." if len(value) > len(truncated) else ""
+        return f"{truncated!r}{suffix}"
+    return f"<{type(value).__name__[:120]}>"
+
+
 @dataclass
 class ConsoleChatSession:
     """A native Console chat session."""
@@ -1964,7 +1973,16 @@ class ConsoleChatStore:
         return self._snapshot(message)
 
     def persist_session_if_needed(self, session_id: str) -> str | None:
-        """Persist a session once, returning its persisted conversation ID."""
+        """Persist a session once, returning its persisted conversation ID.
+
+        Returns:
+            The persisted conversation ID, or ``None`` when no persistence
+            adapter is configured.
+
+        Raises:
+            ValueError: If ``runtime_backend`` is not exactly ``"local"`` or
+                ``"server"``.
+        """
         session = self._session_or_raise(session_id)
         if session.persisted_conversation_id is not None:
             return session.persisted_conversation_id
@@ -1976,7 +1994,9 @@ class ConsoleChatStore:
         ):
             logger.bind(
                 session_id=session_id,
-                runtime_backend=repr(session.runtime_backend)[:128],
+                runtime_backend=_invalid_runtime_backend_diagnostic(
+                    session.runtime_backend
+                ),
             ).error("Cannot persist Console session with invalid runtime backend.")
             raise ValueError(
                 "Cannot persist Console session: runtime_backend must be "

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -12852,6 +12852,7 @@ class TransactionContextManager:
         self.db = db_instance
         self.conn: Optional[sqlite3.Connection] = None
         self.is_outermost_transaction = False
+        self.borrows_native_transaction = False
 
     def __enter__(self):
         # Ensure transaction_depth is initialized for this thread
@@ -12869,10 +12870,18 @@ class TransactionContextManager:
         else:
             # This is the outermost transaction
             self.conn = self.db.get_connection()
+            if self.conn.in_transaction:
+                self.borrows_native_transaction = True
+                self.db._local.transaction_depth = 1
+                logger.debug(
+                    f"Borrowed caller-owned SQLite transaction on thread {threading.get_ident()}."
+                )
+                return self.conn.cursor()
+
+            # Set depth only after BEGIN succeeds so a failed BEGIN cannot corrupt it.
+            self.conn.execute("BEGIN")
             self.is_outermost_transaction = True
             self.db._local.transaction_depth = 1
-            # SQLite doesn't support nested transactions directly, but we use SAVEPOINTs for nested behavior
-            self.conn.execute("BEGIN")
             logger.debug(
                 f"Started outermost transaction on thread {threading.get_ident()}."
             )
@@ -12946,6 +12955,13 @@ class TransactionContextManager:
                     raise CharactersRAGDBError(
                         f"Rollback failed after exception: {rollback_err}. Original exception: {exc_val}"
                     ) from rollback_err
+        elif self.borrows_native_transaction:
+            if exc_type:
+                logger.debug(
+                    f"Exception in caller-owned transaction block on thread "
+                    f"{threading.get_ident()}: {exc_type.__name__}. Caller retains "
+                    "rollback ownership."
+                )
         elif exc_type:
             # If an exception occurred in a nested block, we don't do anything here.
             # The outermost block will handle the rollback.

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -2737,20 +2737,24 @@ UPDATE db_schema_version
     def get_local_authority_id(self) -> str:
         """Return this database's stable, bounded local character authority.
 
+        Returns:
+            The database-owned local authority identifier.
+
         Raises:
             CharactersRAGDBError: If the default identity is absent, ambiguous,
                 malformed, or cannot be read.
         """
 
         try:
-            rows = self.get_connection().execute(
-                """
-                SELECT local_authority_id
-                FROM rag_identity_context
-                WHERE context_name = 'default'
-                LIMIT 2
-                """
-            ).fetchall()
+            with self.transaction() as cursor:
+                rows = cursor.execute(
+                    """
+                    SELECT local_authority_id
+                    FROM rag_identity_context
+                    WHERE context_name = 'default'
+                    LIMIT 2
+                    """
+                ).fetchall()
         except sqlite3.Error as exc:
             raise CharactersRAGDBError(
                 "Local authority identity is unavailable or invalid."

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -3073,8 +3073,15 @@ UPDATE db_schema_version
         Usage:
             with db.transaction() as conn:
                 # Database operations using conn.execute(...)
-                # Commit is handled automatically on successful exit,
-                # rollback on exception.
+                # A manager-owned outer transaction commits on successful exit
+                # and rolls back on exception.
+
+        At managed depth zero, if the native SQLite connection already has an
+        active transaction, this context borrows that caller-owned transaction.
+        On either successful or exceptional exit, it does not commit or roll
+        back borrowed work; the caller retains transaction ownership. Nested
+        managed contexts only track depth and defer completion to their outer
+        transaction.
 
         Returns:
             TransactionContextManager: An object to be used in a `with` statement.
@@ -12891,9 +12898,14 @@ class TransactionContextManager:
         """
         Handles the exit of the transaction context.
 
-        - If this is the outermost transaction and no exception occurred, commits the transaction.
-        - If this is the outermost transaction and an exception occurred, rolls back the transaction.
-        - If this is a nested transaction, decrements the depth counter and does nothing else.
+        - A manager-owned outermost transaction commits on successful exit and
+          rolls back on exceptional exit.
+        - At managed depth zero, a native SQLite transaction already active on
+          entry is borrowed. On successful or exceptional exit, this context
+          does not commit or roll back that caller-owned work; the caller
+          retains ownership.
+        - A nested managed transaction decrements the depth counter and defers
+          completion to its outer transaction.
 
         Args:
             exc_type: The type of the exception raised in the with block, if any.

--- a/tldw_chatbook/MCP/server_target_store.py
+++ b/tldw_chatbook/MCP/server_target_store.py
@@ -9,7 +9,6 @@ from typing import Any, Mapping, Sequence
 from uuid import UUID, uuid4
 
 from tldw_chatbook.Utils.path_validation import validate_path_simple
-
 from .unified_control_models import ConfiguredServerTarget, TargetStatusMetadata
 
 _SERVER_TARGETS_FILENAME = "mcp_server_targets.json"

--- a/tldw_chatbook/MCP/server_target_store.py
+++ b/tldw_chatbook/MCP/server_target_store.py
@@ -51,7 +51,9 @@ class ConfiguredServerTargetStore:
         """Initialize the configured target store.
 
         Args:
-            path: Optional JSON file path for persisted server targets.
+            path: Optional JSON file path for persisted server targets. ``None``
+                lazily selects ``mcp_server_targets.json`` in the current user
+                data directory.
 
         Raises:
             ValueError: If the selected path contains a dangerous pattern.

--- a/tldw_chatbook/MCP/server_target_store.py
+++ b/tldw_chatbook/MCP/server_target_store.py
@@ -8,6 +8,8 @@ from threading import RLock
 from typing import Any, Mapping, Sequence
 from uuid import UUID, uuid4
 
+from tldw_chatbook.Utils.path_validation import validate_path_simple
+
 from .unified_control_models import ConfiguredServerTarget, TargetStatusMetadata
 
 _SERVER_TARGETS_FILENAME = "mcp_server_targets.json"
@@ -46,7 +48,16 @@ class ConfiguredServerTargetStore:
     _mutation_lock = RLock()
 
     def __init__(self, path: str | Path | None = None) -> None:
-        self.path = Path(path) if path else _default_server_targets_path()
+        """Initialize the configured target store.
+
+        Args:
+            path: Optional JSON file path for persisted server targets.
+
+        Raises:
+            ValueError: If the selected path contains a dangerous pattern.
+        """
+        selected_path = Path(path) if path else _default_server_targets_path()
+        self.path = validate_path_simple(selected_path, require_exists=False)
 
     def load(self) -> list[ConfiguredServerTarget]:
         payload = self._read_payload()

--- a/tldw_chatbook/MCP/unified_control_models.py
+++ b/tldw_chatbook/MCP/unified_control_models.py
@@ -235,6 +235,11 @@ class ConfiguredServerTarget:
         )
 
     def to_dict(self) -> dict[str, Any]:
+        """Return the public JSON-compatible target mapping.
+
+        Returns:
+            Routing, authority, auth-reference, and status data.
+        """
         return {
             "server_id": self.server_id,
             "authority_scope_id": self.authority_scope_id,
@@ -252,6 +257,14 @@ class ConfiguredServerTarget:
 
     @classmethod
     def from_dict(cls, data: Any) -> "ConfiguredServerTarget":
+        """Normalize a configured target mapping.
+
+        Args:
+            data: Serialized target data; a non-mapping yields an empty legacy target.
+
+        Returns:
+            A normalized configured server target.
+        """
         if not isinstance(data, Mapping):
             return cls(
                 server_id="",


### PR DESCRIPTION
## Summary

Follow-up to #1096. This PR resolves every distinct actionable review finding
left on that merged PR:

- document `CharactersRAGDB.get_local_authority_id()` and route its lookup
  through the shared transaction seam;
- document both conversation-creation layers, including the difference between
  omitted `assistant_authority_id` and explicit `None`;
- document `ConfiguredServerTarget.to_dict()` / `from_dict()`;
- reject invalid Console runtime backends visibly before any conversation or
  message write instead of silently dropping persistence; and
- validate the configured-server-target store path with the shared path
  validator before filesystem use.

Review-driven hardening also makes invalid-backend diagnostics safe from
hostile `__repr__` implementations and preserves caller ownership when the
database transaction context borrows an already-active native SQLite
transaction.

## Behavior and safety

- Invalid Console persistence identity logs bounded structured context and
  raises a clear `ValueError`; it is never coerced to local provenance.
- Existing in-memory restored sessions remain available, but an unclassifiable
  source cannot be materialized durably.
- Caller-owned SQLite transactions are neither committed nor rolled back by a
  borrowed managed context, and failed `BEGIN` cannot poison transaction depth.
- Valid explicit/default configured-target paths remain unchanged; dangerous
  traversal and shell-pattern inputs fail at construction.
- Conversation documentation describes current title, workspace linkage,
  cleanup, and authority-sentinel behavior exactly.

ADR-037 remains governing. No new ADR is required because this PR refines
validation, transaction-seam use, observability, tests, and documentation
without changing the authority/provenance architecture.

## Verification

- `275 passed` across the complete focused regression union:
  - character authority migration;
  - configured server target store and default paths;
  - conversation and persistence services; and
  - Console chat store.
- Ruff lint passes on all changed Python files.
- `git diff --check origin/dev...HEAD` passes.
- Ruff formatting reports the same eight whole-file baseline candidates on
  this branch and `origin/dev`; this PR adds no formatter delta.
- Repository-wide pytest collection is blocked by the inherited missing
  `StreamDone` import in
  `Tests/Event_Handlers/test_worker_events_contract.py`. The exact node and
  failure reproduce on the rebased `origin/dev` revision and are outside this
  diff.

The branch is rebased onto `dev` revision
`a39b2fc5f53034dd55984e76915688aa7d18b1af`.

## Explicit non-goals

- no schema or persisted-format change;
- no TTS adapter, synthesis, profile-selection, or audio.cpp behavior;
- no managed audio.cpp launch/supervision;
- no Persona/User Profile or Sync V2 change; and
- no unrelated repository-wide CI repair.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to #1096 that hardens persistence and authority handling, validates configured target paths, and documents key APIs. It also preserves caller-owned SQLite transactions and routes the local-authority lookup through the shared transaction seam.

- **Bug Fixes**
  - `ConsoleChatStore.persist_session_if_needed`: invalid `runtime_backend` now logs structured context and raises `ValueError` before any write; no coercion to local; diagnostics remain safe even if `__repr__` raises.
  - `ConfiguredServerTargetStore`: constructor validates the JSON path with `validate_path_simple`; rejects traversal/shell-pattern inputs; default path unchanged.
  - Transaction manager: borrows caller-owned SQLite transactions without committing or rolling back them; sets depth after `BEGIN` so a failed `BEGIN` can’t corrupt depth.

- **Refactors**
  - `CharactersRAGDB.get_local_authority_id`: routes lookup through `self.transaction()`; docstring adds a clear Returns section.
  - Completed Google-style docs for `ChatConversationService.create_conversation` and `ChatPersistenceService.create_conversation` (covers omitted vs explicit `None` for `assistant_authority_id`, titles, scope/workspace), and for `ConfiguredServerTarget.to_dict` / `from_dict`.
  - `ConsoleChatStore.persist_session_if_needed` doc clarifies the error contract; no schema or format changes; ADR-037 remains governing.

<sup>Written for commit 94e2a72c925896d75dbdbf080fee9f61270a7d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

