### PR TITLE
task-1456: repair uncollectable worker_events contract test (unblocks every full run)

### DIFF
--- a/Tests/Event_Handlers/test_worker_events_contract.py
+++ b/Tests/Event_Handlers/test_worker_events_contract.py
@@ -1,24 +1,25 @@
 # test_worker_events_contract.py
 # Description: Regression coverage for worker_events.chat_wrapper_function's
-# error-handling contract (task-634).
+# error-handling contract (task-634, updated for the task-650 contract).
 #
 # A failing LLM call previously fell through to an unconditional
 # `return "STREAMING_HANDLED_BY_EVENTS"` regardless of whether the caller
 # requested streaming. Non-streaming callers (e.g. media analysis) consume
 # the return value directly, so the sentinel string rendered as if it were a
-# valid (and successful) LLM response. Non-streaming failures must now
-# propagate instead. The streaming branch's existing contract (StreamDone
-# posted + sentinel returned) must remain byte-identical.
+# valid (and successful) LLM response. Non-streaming failures must propagate.
+#
+# TASK-650 then removed the legacy streaming branch entirely (StreamDone and
+# the sentinel are gone): native Console's provider gateway owns streaming,
+# and this adapter now rejects streaming requests outright. task-1456 updated
+# this file accordingly — the old streaming-sentinel test asserted removed
+# behavior and its StreamDone import made the whole suite uncollectable.
 #
 # Imports
 from unittest.mock import Mock, patch
 
 import pytest
 
-from tldw_chatbook.Event_Handlers.worker_events import (
-    StreamDone,
-    chat_wrapper_function,
-)
+from tldw_chatbook.Event_Handlers.worker_events import chat_wrapper_function
 
 
 def _mock_app() -> Mock:
@@ -48,25 +49,46 @@ def test_chat_wrapper_function_nonstreaming_failure_raises():
     app.post_message.assert_not_called()
 
 
-def test_chat_wrapper_function_streaming_failure_keeps_sentinel_contract():
-    """The legacy streaming contract (StreamDone posted + sentinel returned) is untouched."""
+def test_chat_wrapper_function_nonstreaming_success_returns_core_result():
+    """The adapter returns the core chat result verbatim and forwards its kwargs."""
     app = _mock_app()
 
     with patch(
         "tldw_chatbook.Event_Handlers.worker_events.core_chat_function",
-        side_effect=RuntimeError("boom"),
-    ):
+        return_value="the-llm-answer",
+    ) as core:
         result = chat_wrapper_function(
             app,
-            streaming=True,
+            strip_thinking_tags=False,
+            streaming=False,
             api_endpoint="test-endpoint",
             model="test-model",
         )
 
-    assert result == "STREAMING_HANDLED_BY_EVENTS"
-    app.post_message.assert_called_once()
-    posted = app.post_message.call_args[0][0]
-    assert isinstance(posted, StreamDone)
-    assert posted.full_text == ""
-    assert posted.error is not None
-    assert "boom" in posted.error
+    assert result == "the-llm-answer"
+    core.assert_called_once_with(
+        strip_thinking_tags=False,
+        streaming=False,
+        api_endpoint="test-endpoint",
+        model="test-model",
+    )
+    app.post_message.assert_not_called()
+
+
+def test_chat_wrapper_function_streaming_request_rejected():
+    """Streaming is owned by native Console; the adapter must refuse, not degrade."""
+    app = _mock_app()
+
+    with patch(
+        "tldw_chatbook.Event_Handlers.worker_events.core_chat_function",
+    ) as core:
+        with pytest.raises(ValueError, match="provider gateway"):
+            chat_wrapper_function(
+                app,
+                streaming=True,
+                api_endpoint="test-endpoint",
+                model="test-model",
+            )
+
+    core.assert_not_called()
+    app.post_message.assert_not_called()

--- a/backlog/tasks/task-1456 - Fix-uncollectable-worker-events-contract-test-blocking-all-full-runs.md
+++ b/backlog/tasks/task-1456 - Fix-uncollectable-worker-events-contract-test-blocking-all-full-runs.md
@@ -2,7 +2,7 @@
 id: TASK-1456
 title: >-
   Fix uncollectable test_worker_events_contract.py (StreamDone import) that aborts every default full-suite run
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 09:05'
 labels:
@@ -20,10 +20,10 @@ dependencies: []
 
 ## Acceptance Criteria
 
-- [ ] `pytest Tests --collect-only` completes with no collection error from this module
-- [ ] task-634's regression (non-streaming failures propagate; no sentinel, no message posts) remains covered
-- [ ] The current task-650 contract is covered: streaming requests are rejected with `ValueError` and never reach the core chat function
-- [ ] The file's own tests pass
+- [x] `pytest Tests --collect-only` completes with no collection error from this module
+- [x] task-634's regression (non-streaming failures propagate; no sentinel, no message posts) remains covered
+- [x] The current task-650 contract is covered: streaming requests are rejected with `ValueError` and never reach the core chat function
+- [x] The file's own tests pass
 
 ## Implementation Plan
 

--- a/backlog/tasks/task-1456 - Fix-uncollectable-worker-events-contract-test-blocking-all-full-runs.md
+++ b/backlog/tasks/task-1456 - Fix-uncollectable-worker-events-contract-test-blocking-all-full-runs.md
@@ -1,0 +1,42 @@
+---
+id: TASK-1456
+title: >-
+  Fix uncollectable test_worker_events_contract.py (StreamDone import) that aborts every default full-suite run
+status: In Progress
+assignee: []
+created_date: '2026-07-30 09:05'
+labels:
+  - testing
+  - bug
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Event_Handlers/test_worker_events_contract.py` (task-634's regression coverage) imports `StreamDone` from `tldw_chatbook.Event_Handlers.worker_events`. TASK-650 removed the legacy streaming branch and `StreamDone` with it, so the module no longer imports — and because pytest interrupts on collection errors by default, **every plain `pytest Tests` run on dev dies before running a single test**. Found by the 2026-07-30 test-suite audit's baseline run (`backlog/docs/test-suite-audit-2026-07-30.md` §4.2). The non-streaming error-propagation contract task-634 actually guards is still real and must stay covered; the streaming-sentinel half of the file asserts behavior that was deliberately removed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [ ] `pytest Tests --collect-only` completes with no collection error from this module
+- [ ] task-634's regression (non-streaming failures propagate; no sentinel, no message posts) remains covered
+- [ ] The current task-650 contract is covered: streaming requests are rejected with `ValueError` and never reach the core chat function
+- [ ] The file's own tests pass
+
+## Implementation Plan
+
+1. Drop the `StreamDone` import and the streaming-sentinel test (removed behavior)
+2. Keep the non-streaming failure-propagation test unchanged
+3. Add coverage for the current contract: non-streaming success returns the core result verbatim with kwargs forwarded; streaming requests raise `ValueError` without calling the core function
+4. Verify: run the file; run full-tree `--collect-only`
+
+## Implementation Notes
+
+Rewrote the module against the current `worker_events.py` contract. Kept
+`test_chat_wrapper_function_nonstreaming_failure_raises` byte-identical (task-634's
+actual regression guard). Replaced the streaming-sentinel test with
+`test_chat_wrapper_function_streaming_request_rejected` (ValueError, core never
+called) and added `..._nonstreaming_success_returns_core_result` to pin kwarg
+forwarding. Modified: `Tests/Event_Handlers/test_worker_events_contract.py` only.


### PR DESCRIPTION
## Summary
`Tests/Event_Handlers/test_worker_events_contract.py` imports `StreamDone`, which TASK-650 removed — the collection error makes **every default `pytest Tests` run abort before running a single test** ("Interrupted: 1 error during collection"). Keeps task-634's non-streaming failure-propagation guard byte-identical; replaces the removed-behavior streaming-sentinel test with the current contract (streaming requests raise `ValueError` and never reach `core_chat_function`; non-streaming success forwards kwargs verbatim).

## Verification
- File: 3 passed (was uncollectable)
- Full-tree collection on the combined quick-wins branch: **23,796 collected, 0 errors** (dev: 23,793 + 1 error); the +3 are this file's tests
- Found by the 2026-07-30 test-suite audit (see `backlog/docs/test-suite-audit-2026-07-30.md` §4.2, PR #1102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs an uncollectable test in `Tests/Event_Handlers/test_worker_events_contract.py` that stopped default `pytest Tests` runs. Updates the contract per TASK-650 while preserving task-634’s non‑streaming failure guard, unblocking full-suite runs.

- **Bug Fixes**
  - Removed `StreamDone` import and legacy streaming-sentinel assertions; adapter now rejects streaming (TASK-650).
  - Kept the non‑streaming failure-propagation test unchanged (task-634).
  - Added tests: non‑streaming success returns core result and forwards kwargs; streaming requests raise `ValueError` and never call `core_chat_function`.
  - Verified: `pytest Tests --collect-only` reports 0 collection errors; the file’s 3 tests pass.

<sup>Written for commit 3bf439b26796735aab009228be99b9f232096b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

