### PR TITLE
task-1466: fix deterministic 300s hang killing full runs under webrtcvad

### DIFF
--- a/Tests/Audio/test_recording_service.py
+++ b/Tests/Audio/test_recording_service.py
@@ -441,9 +441,14 @@ class TestAudioRecordingIntegration:
 
                 # Simulate audio data
                 test_audio = b"\x00\x01" * 512
-                mock_stream.read.return_value = test_audio
 
-                service = AudioRecordingService(backend="pyaudio")
+                # use_vad=False: with webrtcvad installed, VAD classifies this
+                # synthetic buffer as non-speech, the callback below never
+                # fires, is_recording never flips, and the loop spins until
+                # pytest-timeout kills the whole run (task-1466). This test
+                # exercises the recording FLOW; VAD behavior is not its
+                # subject.
+                service = AudioRecordingService(backend="pyaudio", use_vad=False)
 
                 # Record for a short time
                 chunks_received = []
@@ -452,6 +457,18 @@ class TestAudioRecordingIntegration:
                     chunks_received.append(chunk)
                     if len(chunks_received) >= 3:
                         service.is_recording = False
+
+                # Belt and braces: bound the loop at the read() source too, so
+                # no future change to chunk handling can make it unbounded.
+                reads = {"n": 0}
+
+                def fake_read(*args, **kwargs):
+                    reads["n"] += 1
+                    if reads["n"] >= 10:
+                        service.is_recording = False
+                    return test_audio
+
+                mock_stream.read.side_effect = fake_read
 
                 service.start_recording(callback=callback)
 
@@ -475,7 +492,14 @@ class TestAudioRecordingIntegration:
                     mock_stream_class.return_value.__enter__.return_value = mock_stream
                     mock_stream_class.return_value.__exit__.return_value = None
 
-                    service = AudioRecordingService(backend="sounddevice")
+                    # use_vad=False for the same reason as the pyaudio flow test
+                    # above (task-1466): the 4-sample chunk below is smaller
+                    # than one 20ms VAD frame, so with VAD on the frame loop
+                    # never executes and nothing reaches the queue — the
+                    # assertion fails whenever webrtcvad is installed.
+                    service = AudioRecordingService(
+                        backend="sounddevice", use_vad=False
+                    )
 
                     # Start recording
                     service.start_recording()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -412,6 +412,48 @@ person who happens to touch that screen.
 
 ---
 
+## A hung test under timeout_method="thread" kills the whole run — and a hang can be an optional-dep condition
+
+**TASK-1466, 2026-07-30.** The full-suite baseline run for the test-suite audit died
+at ~3% progress, twice. `test_pyaudio_recording_flow` stops its recording loop from
+inside the chunk callback, but the callback is gated behind webrtcvad speech
+detection and the test's synthetic buffer is silence: with `webrtcvad` installed
+(it is, locally and in CI), the callback never fires and the loop never exits.
+After the 300s timeout, pytest-timeout's `thread` method — the repo's configured
+method, and the only one that works for threaded/async tests — cannot cancel the
+test, so it dumps stacks and **terminates the entire pytest process**. One hung
+test cost the whole run, every run, on every webrtcvad machine; on machines
+without the extra the callback fires per chunk and the test is green, which is why
+it survived review. Its sibling `test_sounddevice_recording_flow` failed on clean
+dev for the same root cause (a 4-sample chunk is smaller than one 20ms VAD frame,
+so the VAD loop body never executes) — masked because serial runs died at the hang
+before reaching it.
+
+**What to do.** A test that stops its own loop from inside a callback must also
+bound the loop at the *source* (here: the mocked `stream.read` flips the stop flag
+after N reads) so no gating change can make it unbounded. When a test's behavior
+depends on an optional dependency, run it in both installed and absent
+configurations before trusting green. And treat "the run died at N%" as possibly
+ONE test: the timeout stack dump names it.
+
+---
+
+## `--deselect` with a wrong nodeid is silently ignored
+
+**2026-07-30, same audit.** A full baseline attempt was relaunched with
+`--deselect "Tests/Audio/test_recording_service.py::test_pyaudio_recording_flow"` —
+missing the `TestAudioRecordingIntegration::` class qualifier. pytest does not
+error, does not warn, and does not report `1 deselected`; the run simply hung on
+the very test the flag was meant to exclude, and the mistake was only visible ~15
+minutes later when progress stalled at the same file.
+
+**What to do.** After launching a run with `--deselect`, confirm the header line
+says `N deselected` before walking away. Copy nodeids from pytest's own output
+(`--collect-only -q` or a failure line), never reconstruct them by hand — class
+nesting is invisible in the source-file mental model.
+
+---
+
 ## Related
 
 - `lessons-live-verification.md` — why the suite could not see seven of these defects

--- a/backlog/tasks/task-1466 - Fix-deterministic-300s-hang-in-test_pyaudio_recording_flow.md
+++ b/backlog/tasks/task-1466 - Fix-deterministic-300s-hang-in-test_pyaudio_recording_flow.md
@@ -1,0 +1,42 @@
+---
+id: TASK-1466
+title: >-
+  Fix deterministic 300s hang in test_pyaudio_recording_flow that kills every full-suite run when webrtcvad is installed
+status: In Progress
+assignee: []
+created_date: '2026-07-30 09:20'
+labels:
+  - testing
+  - bug
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Audio/test_recording_service.py::test_pyaudio_recording_flow` stops its recording loop from inside the chunk callback — but `_process_audio_chunk` only invokes the callback for frames VAD classifies as speech, and the test's synthetic buffer (`b"\\x00\\x01" * 512`) is non-speech. With the optional `webrtcvad` extra installed (it is, locally and in CI via requirements-test.txt), the callback never fires, `is_recording` never flips, and the loop spins for the full 300s pytest timeout — after which `timeout_method="thread"` **terminates the entire pytest process**. Every full-suite run on a webrtcvad machine dies at ~3% progress. Found by the 2026-07-30 audit's baseline run (stack captured in the timeout dump); with webrtcvad absent the callback fires per chunk and the test passes, which is why it ever looked green.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [x] The test cannot hang regardless of whether webrtcvad is installed
+- [x] It still exercises the pyaudio recording flow end to end (chunks delivered to the callback, loop exits via `is_recording`)
+- [x] `test_sounddevice_recording_flow` — same VAD root cause, unmasked once the hang stopped killing the run (its 4-sample chunk is smaller than one 20ms VAD frame, so the frame loop never executes and the queue stays empty; fails on clean dev) — also passes
+- [x] `pytest Tests/Audio/test_recording_service.py` passes on a machine with webrtcvad installed (34 passed, 1.4s; previously 300s hang + process kill)
+
+## Implementation Plan
+
+1. Construct the service with `use_vad=False` — VAD is not this test's subject, and it is what routes the callback away from silence
+2. Bound the mock `stream.read` as a second guard so no chunk-handling change can make the loop unbounded again
+3. Verify on this machine (webrtcvad installed — previously the hanging configuration)
+
+## Implementation Notes
+
+`use_vad=False` restores the intended flow (every chunk reaches the callback, the
+callback's counter stops the loop at 3); a read-side counter also flips
+`is_recording` after 10 reads as a hard bound. The sounddevice flow test had the
+same root cause in a different costume — sub-frame chunks are silently dropped by
+the VAD loop — verified pre-existing on clean `origin/dev` before fixing, and
+fixed the same way. No production code changed.
+Modified: `Tests/Audio/test_recording_service.py`.

--- a/backlog/tasks/task-1466 - Fix-deterministic-300s-hang-in-test_pyaudio_recording_flow.md
+++ b/backlog/tasks/task-1466 - Fix-deterministic-300s-hang-in-test_pyaudio_recording_flow.md
@@ -2,7 +2,7 @@
 id: TASK-1466
 title: >-
   Fix deterministic 300s hang in test_pyaudio_recording_flow that kills every full-suite run when webrtcvad is installed
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 09:20'
 labels:


### PR DESCRIPTION
## Summary
`test_pyaudio_recording_flow` stops its loop from inside the chunk callback, but VAD (on by default; webrtcvad installed locally and in CI) classifies the silent mock buffer as non-speech — the callback never fires, the loop spins for the 300s timeout, and `timeout_method="thread"` then **kills the entire pytest process at ~3% of a full run**. `use_vad=False` (VAD is not these tests' subject) plus a bounded mock `read()` so the loop can never be unbounded again. `test_sounddevice_recording_flow` had the same root cause unmasked (its 4-sample chunk is smaller than one 20ms VAD frame — verified failing on clean origin/dev before fixing).

Also adds two lessons entries (`backlog/docs/lessons-testing-evidence.md`): a hung test under thread-method timeout kills the whole run, and `--deselect` silently ignores non-matching nodeids (both cost baseline attempts during the audit).

## Verification
- `Tests/Audio/test_recording_service.py`: **34 passed in 1.4s** (was: 300s hang → process kill; the audit's serial baseline died here twice)
- Parallel A/B outcome diff shows the sounddevice test in RECOVERED (audit report §8, PR #1102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deterministic 300s hang in audio recording flow tests when `webrtcvad` is installed by disabling VAD in these tests and bounding the mock read loop, preventing full runs from being killed. Adds audit notes to the lessons doc. Addresses TASK-1466.

- **Bug Fixes**
  - `Tests/Audio/test_recording_service.py::test_pyaudio_recording_flow`: create service with `use_vad=False`; set `mock_stream.read.side_effect` to return test audio and flip `is_recording` after 10 reads to hard-bound the loop.
  - `::test_sounddevice_recording_flow`: create service with `use_vad=False` to avoid sub-frame chunks being dropped by VAD; test now passes.

<sup>Written for commit fa3b09b6ec3ff2cca45af974fd770c3db74f5d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

