### PR TITLE
task-1451: gate RAG_Search autouse HF model warm-up, default HuggingFace offline in tests

### DIFF
--- a/Tests/RAG_Search/conftest.py
+++ b/Tests/RAG_Search/conftest.py
@@ -17,8 +17,20 @@ import sys
 # This must happen before importing any modules that use optional_deps
 os.environ.pop("PYTEST_CURRENT_TEST", None)  # Remove pytest env var temporarily
 
-# Set environment variables to prevent meta tensors in transformers
-os.environ["TRANSFORMERS_OFFLINE"] = "0"  # Allow downloading if needed
+# HuggingFace stays offline unless a suite explicitly opts into real model
+# downloads (TLDW_RUN_REAL_EMBEDDINGS gates the real-integration suite;
+# TLDW_TEST_ALLOW_HF_DOWNLOADS is the general escape hatch). setdefault so an
+# externally-set value always wins.
+_TRUTHY = {"1", "true", "yes", "on"}
+_ALLOW_HF_DOWNLOADS = (
+    os.environ.get("TLDW_RUN_REAL_EMBEDDINGS", "").strip().lower() in _TRUTHY
+    or os.environ.get("TLDW_TEST_ALLOW_HF_DOWNLOADS", "").strip().lower() in _TRUTHY
+)
+if _ALLOW_HF_DOWNLOADS:
+    os.environ.setdefault("TRANSFORMERS_OFFLINE", "0")
+else:
+    os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+    os.environ.setdefault("HF_HUB_OFFLINE", "1")
 os.environ["HF_HUB_DISABLE_EXPERIMENTAL_WARNING"] = "1"  # Disable warnings
 os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Avoid tokenizer warnings in tests
 
@@ -641,15 +653,18 @@ requires_numpy = pytest.mark.skipif(
 
 
 # ===========================================
-# Session-scoped fixture to ensure dependencies are initialized
+# Session-scoped fixture for suites that load REAL transformers models.
+# Deliberately NOT autouse (task-1451): as an autouse fixture it ran
+# transformers.utils.move_cache() plus a tiny-bert download/load for every
+# session that touched Tests/RAG_Search — including fully-mocked ones — and
+# hit the network on cold caches. Suites that load real models request it
+# explicitly (see test_embeddings_real_integration.py).
 # ===========================================
 
 
-@pytest.fixture(scope="session", autouse=True)
-def initialize_test_dependencies():
-    """Ensure dependencies are initialized before any tests run."""
-    # Dependencies should already be initialized at module import time
-    # This fixture just ensures they stay initialized
+@pytest.fixture(scope="session")
+def real_transformers_session():
+    """Warm torch/transformers for suites that load real models (meta-tensor guard)."""
     print(f"[Session Start] Dependencies available: {DEPENDENCIES_AVAILABLE}")
 
     # Force proper model initialization for transformers

--- a/Tests/RAG_Search/conftest.py
+++ b/Tests/RAG_Search/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import tempfile
 import shutil
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, Iterator, List, Any, Optional
 from unittest.mock import MagicMock, Mock
 import threading
 import time
@@ -663,7 +663,7 @@ requires_numpy = pytest.mark.skipif(
 
 
 @pytest.fixture(scope="session")
-def real_transformers_session():
+def real_transformers_session() -> Iterator[None]:
     """Warm torch/transformers for suites that load real models (meta-tensor guard)."""
     print(f"[Session Start] Dependencies available: {DEPENDENCIES_AVAILABLE}")
 

--- a/Tests/RAG_Search/test_embeddings_performance.py
+++ b/Tests/RAG_Search/test_embeddings_performance.py
@@ -150,9 +150,17 @@ class TestEmbeddingPerformance:
             service.close()
 
     @requires_embeddings
-    def test_real_model_performance(self):
-        """Benchmark performance with real embedding model"""
+    def test_real_model_performance(self, request):
+        """Benchmark performance with real embedding model.
+
+        Args:
+            request: The pytest fixture request, used to pull the session-scoped
+                ``real_transformers_session`` warm-up (torch cpu default +
+                tiny-bert preload) before a real model load — the guard the old
+                autouse fixture provided implicitly (task-1451 review).
+        """
         # This test uses actual model if available
+        request.getfixturevalue("real_transformers_session")
         try:
             service = EmbeddingsServiceWrapper(
                 model_name="sentence-transformers/all-MiniLM-L6-v2"

--- a/Tests/RAG_Search/test_embeddings_real_integration.py
+++ b/Tests/RAG_Search/test_embeddings_real_integration.py
@@ -39,6 +39,10 @@ def _warm_transformers(request):
     The warm-up (torch cpu default + tiny-bert preload) is the meta-tensor guard the
     old autouse conftest fixture provided; it is only needed when
     TLDW_RUN_REAL_EMBEDDINGS actually enables real model loads (task-1451).
+
+    Args:
+        request: The pytest fixture request, used to lazily resolve the
+            session-scoped ``real_transformers_session`` fixture.
     """
     if RUN_REAL_EMBEDDINGS:
         request.getfixturevalue("real_transformers_session")

--- a/Tests/RAG_Search/test_embeddings_real_integration.py
+++ b/Tests/RAG_Search/test_embeddings_real_integration.py
@@ -33,6 +33,18 @@ RUN_REAL_EMBEDDINGS = os.environ.get(
 
 
 @pytest.fixture(autouse=True)
+def _warm_transformers(request):
+    """Pull the session-scoped transformers warm-up only when real models will load.
+
+    The warm-up (torch cpu default + tiny-bert preload) is the meta-tensor guard the
+    old autouse conftest fixture provided; it is only needed when
+    TLDW_RUN_REAL_EMBEDDINGS actually enables real model loads (task-1451).
+    """
+    if RUN_REAL_EMBEDDINGS:
+        request.getfixturevalue("real_transformers_session")
+
+
+@pytest.fixture(autouse=True)
 def reset_circuit_breakers():
     """Reset all circuit breakers before each test."""
     # Clear the global circuit breaker registry before each test

--- a/backlog/tasks/task-1451 - Gate-RAG-Search-autouse-HF-model-fixture-and-default-offline.md
+++ b/backlog/tasks/task-1451 - Gate-RAG-Search-autouse-HF-model-fixture-and-default-offline.md
@@ -2,7 +2,7 @@
 id: TASK-1451
 title: >-
   Gate the RAG_Search autouse HF-model warm-up fixture and default HuggingFace to offline in tests
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 09:05'
 labels:
@@ -20,9 +20,9 @@ dependencies: []
 
 ## Acceptance Criteria
 
-- [ ] The transformers warm-up fixture no longer runs for sessions that only use mocked embeddings; suites that load real models request it explicitly
-- [ ] HuggingFace env defaults to offline in tests; enabling `TLDW_RUN_REAL_EMBEDDINGS` (or `TLDW_TEST_ALLOW_HF_DOWNLOADS`) restores downloads; an externally-set value always wins
-- [ ] `pytest Tests/RAG_Search` outcome set is unchanged vs the serial baseline (junit diff)
+- [x] The transformers warm-up fixture no longer runs for sessions that only use mocked embeddings; suites that load real models request it explicitly
+- [x] HuggingFace env defaults to offline in tests; enabling `TLDW_RUN_REAL_EMBEDDINGS` (or `TLDW_TEST_ALLOW_HF_DOWNLOADS`) restores downloads; an externally-set value always wins
+- [x] `pytest Tests/RAG_Search` outcome set is unchanged vs the serial baseline (junit diff)
 
 ## Implementation Plan
 
@@ -38,4 +38,6 @@ Offline-by-default via `setdefault` (external env always wins); the warm-up fixt
 `real_transformers_session`, requested lazily from the real-integration module only
 when `TLDW_RUN_REAL_EMBEDDINGS` is on, so chromadb-only tests in that file don't pay
 it either. Grep confirms no other module referenced the old fixture name. Modified:
-`Tests/RAG_Search/conftest.py`, `Tests/RAG_Search/test_embeddings_real_integration.py`.
+`Tests/RAG_Search/conftest.py`, `Tests/RAG_Search/test_embeddings_real_integration.py`,
+`Tests/RAG_Search/test_embeddings_performance.py` (review: the real-model benchmark now
+pulls the warm-up too).

--- a/backlog/tasks/task-1451 - Gate-RAG-Search-autouse-HF-model-fixture-and-default-offline.md
+++ b/backlog/tasks/task-1451 - Gate-RAG-Search-autouse-HF-model-fixture-and-default-offline.md
@@ -1,0 +1,41 @@
+---
+id: TASK-1451
+title: >-
+  Gate the RAG_Search autouse HF-model warm-up fixture and default HuggingFace to offline in tests
+status: In Progress
+assignee: []
+created_date: '2026-07-30 09:05'
+labels:
+  - testing
+  - performance
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/RAG_Search/conftest.py` carried a session-scoped **autouse** fixture that, whenever transformers is installed (CI installs it for every job), ran `transformers.utils.move_cache()` and downloaded/loaded `hf-internal-testing/tiny-bert` — network-touching work paid by every session that touches the directory, including fully-mocked ones, and multiplied per worker once pytest-xdist lands. The conftest also force-set `TRANSFORMERS_OFFLINE=0` at import, making test runs network-dependent by default. Found by the 2026-07-30 test-suite audit (driver #10).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [ ] The transformers warm-up fixture no longer runs for sessions that only use mocked embeddings; suites that load real models request it explicitly
+- [ ] HuggingFace env defaults to offline in tests; enabling `TLDW_RUN_REAL_EMBEDDINGS` (or `TLDW_TEST_ALLOW_HF_DOWNLOADS`) restores downloads; an externally-set value always wins
+- [ ] `pytest Tests/RAG_Search` outcome set is unchanged vs the serial baseline (junit diff)
+
+## Implementation Plan
+
+1. Replace the forced `TRANSFORMERS_OFFLINE=0` with offline-by-default `setdefault`s keyed off the existing real-embeddings env gate
+2. Drop `autouse=True` from the session fixture; rename to `real_transformers_session`
+3. Have `test_embeddings_real_integration.py` (the only real-model suite in the directory) request it via a lazy autouse shim gated on `TLDW_RUN_REAL_EMBEDDINGS`
+4. Verify: `pytest Tests/RAG_Search` before/after, junit outcome diff empty
+
+## Implementation Notes
+
+Offline-by-default via `setdefault` (external env always wins); the warm-up fixture
+(torch cpu default + move_cache + tiny-bert preload — the meta-tensor guard) is now
+`real_transformers_session`, requested lazily from the real-integration module only
+when `TLDW_RUN_REAL_EMBEDDINGS` is on, so chromadb-only tests in that file don't pay
+it either. Grep confirms no other module referenced the old fixture name. Modified:
+`Tests/RAG_Search/conftest.py`, `Tests/RAG_Search/test_embeddings_real_integration.py`.


### PR DESCRIPTION
## Summary
`Tests/RAG_Search/conftest.py` ran a session-scoped **autouse** fixture that called `transformers.utils.move_cache()` and downloaded/loaded `hf-internal-testing/tiny-bert` for every session touching the directory — mocked or not — and force-set `TRANSFORMERS_OFFLINE=0` at import (network-dependent test runs by default; multiplied per worker under xdist). Now: HF env defaults offline via `setdefault` (an externally-set value always wins; `TLDW_RUN_REAL_EMBEDDINGS` or `TLDW_TEST_ALLOW_HF_DOWNLOADS` re-enables), and the warm-up is a plain session fixture requested lazily by the real-integration suite only when real models will actually load.

## Verification
- `pytest Tests/RAG_Search`: 66 passed, 12 skipped (the expected env-gated suites) in 25s, fully offline
- No other module references the old fixture name (grep)
- Audit driver #10 (`backlog/docs/test-suite-audit-2026-07-30.md`, PR #1102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the RAG_Search HuggingFace warm-up so it only runs for real-model tests, and default HF to offline for deterministic, faster test runs. This completes task-1451 and removes the session-wide autouse warm-up; downloads are now opt-in.

- **Refactors**
  - Default `TRANSFORMERS_OFFLINE` and `HF_HUB_OFFLINE` to `1` via `setdefault`; external env wins. `TLDW_RUN_REAL_EMBEDDINGS` or `TLDW_TEST_ALLOW_HF_DOWNLOADS` re-enables downloads.
  - Replace the autouse session fixture with `real_transformers_session`; requested only when real models load via a lazy autouse shim in the real-integration suite. The real-model performance test now pulls this warm-up before benchmarking.
  - Avoid running `transformers.utils.move_cache()` and preloading `hf-internal-testing/tiny-bert` for mocked suites; reduces network work and xdist duplication.

- **Migration**
  - Tests run offline by default. Set `TLDW_RUN_REAL_EMBEDDINGS=1` (or `TLDW_TEST_ALLOW_HF_DOWNLOADS=1`) to run real-embedding integration tests.

<sup>Written for commit a047a689e2131cdfa2d4706cdf89b96c3641d067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

