### PR TITLE
task-1452: env-scaled central Hypothesis profile; stop module-level profile leaks

### DIFF
--- a/Tests/ChaChaNotesDB/test_chachanotes_db_properties.py
+++ b/Tests/ChaChaNotesDB/test_chachanotes_db_properties.py
@@ -30,9 +30,17 @@ from tldw_chatbook.DB.ChaChaNotes_DB import (
 # Functions:
 # --- Hypothesis Tests ---
 
+# Child of the central 'tldw' profile (Tests/conftest.py, task-1452): inherits
+# deadline=None and the env-scaled max_examples, adds the fixture suppression
+# these DB tests need. This module previously registered "db_friendly" TWICE —
+# the second registration silently dropped the function_scoped_fixture
+# suppression this comment called "THE FIX"; consolidated to one.
+# The central profile is restored at the END of this module — Hypothesis binds
+# settings at decoration time, so an unrestored load_profile leaks into every
+# module imported after this one.
 settings.register_profile(
     "db_friendly",
-    deadline=1000,
+    parent=settings.default,
     suppress_health_check=[
         HealthCheck.too_slow,
         HealthCheck.function_scoped_fixture,  # <--- THIS IS THE FIX
@@ -67,12 +75,6 @@ st_character_card_data = st.tuples(
 # Define a strategy for a non-zero integer to add to the version
 st_version_offset = st.integers().filter(lambda x: x != 0)
 
-# To prevent tests from being too slow on complex data, we can set a deadline.
-# We also disable the 'too_slow' health check as DB operations can sometimes be slow.
-settings.register_profile(
-    "db_friendly", deadline=1000, suppress_health_check=[HealthCheck.too_slow]
-)
-settings.load_profile("db_friendly")
 
 # --- Fixtures (Copied from your existing test file for a self-contained example) ---
 
@@ -1229,6 +1231,11 @@ class TestDBOperations:
 
         backup_db.close_connection()
 
+
+# Restore the central profile: everything above bound "db_friendly" at
+# decoration time; without this, every module imported after this one binds
+# "db_friendly" too (task-1452).
+settings.load_profile("tldw")
 
 #
 # End of test_chachanotes_db_properties.py

--- a/Tests/Media_DB/test_media_db_properties.py
+++ b/Tests/Media_DB/test_media_db_properties.py
@@ -28,12 +28,14 @@ from tldw_chatbook.DB.Client_Media_DB_v2 import (
 #
 # --- Hypothesis Settings ---
 
-# A custom profile for database-intensive tests.
-# It increases the deadline and suppresses health checks that are common
-# but expected in I/O-heavy testing scenarios.
+# Child of the central 'tldw' profile (Tests/conftest.py, task-1452): inherits
+# deadline=None and the env-scaled max_examples, adds the health-check
+# suppressions these I/O-heavy tests need. The central profile is restored at
+# the END of this module — Hypothesis binds settings at decoration time, so an
+# unrestored load_profile leaks into every module imported after this one.
 settings.register_profile(
     "db_test_suite",
-    deadline=2000,
+    parent=settings.default,
     suppress_health_check=[
         HealthCheck.too_slow,
         HealthCheck.function_scoped_fixture,
@@ -616,6 +618,11 @@ class TestLargeMediaIdsFilterUsesJsonEach:
         assert captured_sql, "expected search_media_db to execute at least one query"
         assert all("json_each" not in q for q in captured_sql)
 
+
+# Restore the central profile: everything above bound "db_test_suite" at
+# decoration time; without this, every module imported after this one binds
+# "db_test_suite" too (task-1452).
+settings.load_profile("tldw")
 
 #
 # End of test_media_db_properties.py

--- a/Tests/Prompts_DB/tests_prompts_db_properties.py
+++ b/Tests/Prompts_DB/tests_prompts_db_properties.py
@@ -22,10 +22,15 @@ from tldw_chatbook.DB.Prompts_DB import PromptsDatabase, DatabaseError, Conflict
 #
 # Hypothesis Setup:
 
-# A custom profile for DB tests to avoid timeouts on complex operations.
+# Child of the central 'tldw' profile (Tests/conftest.py, task-1452): inherits
+# deadline=None and the env-scaled max_examples, adds the fixture suppression
+# these DB tests need. NOTE: this file is currently named tests_* and is never
+# collected (task-1463 tracks enabling it); the profile hygiene is applied now
+# so enabling it does not reintroduce a profile leak. The central profile is
+# restored at the end of the module.
 settings.register_profile(
     "db_friendly",
-    deadline=1500,  # Increased deadline for potentially slow DB I/O
+    parent=settings.default,
     suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
 )
 settings.load_profile("db_friendly")
@@ -653,3 +658,9 @@ class TestPromptLifecycleAsTest(PromptLifecycleMachine):
     def inject_db(self, db_instance):
         """Injects the clean db_instance fixture into the state machine."""
         self.db = db_instance
+
+
+# Restore the central profile: everything above bound "db_friendly" at
+# decoration time; without this, every module imported after this one binds
+# "db_friendly" too (task-1452).
+settings.load_profile("tldw")

--- a/Tests/RAG_Search/test_embeddings_properties.py
+++ b/Tests/RAG_Search/test_embeddings_properties.py
@@ -17,14 +17,10 @@ from tldw_chatbook.RAG_Search.simplified import (
 # Import test utilities from conftest
 
 
-# Hypothesis settings for embeddings tests
-settings.register_profile(
-    "embeddings",
-    deadline=5000,  # 5 seconds for complex operations
-    max_examples=50,
-    suppress_health_check=[HealthCheck.too_slow],
-)
-settings.load_profile("embeddings")
+# Hypothesis settings come from the central 'tldw' profile (Tests/conftest.py,
+# task-1452): deadline=None and env-scaled max_examples supersede the old
+# module-level "embeddings" profile (deadline=5000, max_examples=50), whose
+# import-time load_profile() also leaked into every later-imported module.
 
 
 # Custom strategies for embeddings domain

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -74,12 +74,29 @@ if str(PROJECT_ROOT) not in sys.path:
 try:  # pragma: no cover - hypothesis is a test-only dependency
     from hypothesis import HealthCheck, settings as _hypothesis_settings
 
+    # Example counts are env-scaled (task-1452): 'dev' keeps routine runs fast,
+    # CI sets TLDW_HYPOTHESIS_PROFILE=ci, and the scheduled deep run uses
+    # 'thorough' so the reduced dev depth has a compensating control.
+    # Hypothesis binds settings.default at DECORATION time, so this profile
+    # must be active whenever a test module is imported. Property modules that
+    # need extra health-check suppressions register a child profile with
+    # parent=settings.default and MUST restore this one at end of module —
+    # a leaked load_profile() silently reconfigures every later-imported
+    # module's unannotated @given tests (the pre-task-1452 state).
+    _pt_profile = os.environ.get("TLDW_HYPOTHESIS_PROFILE", "dev")
+    _pt_scale = {
+        "dev": {"max_examples": 25, "stateful_step_count": 20},
+        "ci": {"max_examples": 50, "stateful_step_count": 30},
+        "thorough": {"max_examples": 300, "stateful_step_count": 100},
+    }.get(_pt_profile, {"max_examples": 25, "stateful_step_count": 20})
+
     _hypothesis_settings.register_profile(
         "tldw",
         deadline=None,
         # `too_slow` fires for the same reason the deadline does: machine load,
         # not a slow strategy.
         suppress_health_check=[HealthCheck.too_slow],
+        **_pt_scale,
     )
     _hypothesis_settings.load_profile("tldw")
 except ImportError:

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -83,12 +83,25 @@ try:  # pragma: no cover - hypothesis is a test-only dependency
     # parent=settings.default and MUST restore this one at end of module —
     # a leaked load_profile() silently reconfigures every later-imported
     # module's unannotated @given tests (the pre-task-1452 state).
-    _pt_profile = os.environ.get("TLDW_HYPOTHESIS_PROFILE", "dev")
-    _pt_scale = {
+    _HYPOTHESIS_SCALES = {
         "dev": {"max_examples": 25, "stateful_step_count": 20},
         "ci": {"max_examples": 50, "stateful_step_count": 30},
         "thorough": {"max_examples": 300, "stateful_step_count": 100},
-    }.get(_pt_profile, {"max_examples": 25, "stateful_step_count": 20})
+    }
+    _pt_profile = os.environ.get("TLDW_HYPOTHESIS_PROFILE", "dev")
+    if _pt_profile not in _HYPOTHESIS_SCALES:
+        # A typo'd profile silently running at dev depth is exactly the kind of
+        # quiet configuration rot this suite has been burned by — warn loudly
+        # (pytest surfaces it in the warnings summary) but do not brick every
+        # local run over it.
+        warnings.warn(
+            f"Unknown TLDW_HYPOTHESIS_PROFILE={_pt_profile!r}; expected one of "
+            f"{sorted(_HYPOTHESIS_SCALES)} — falling back to 'dev' scale",
+            UserWarning,
+            stacklevel=1,
+        )
+        _pt_profile = "dev"
+    _pt_scale = _HYPOTHESIS_SCALES[_pt_profile]
 
     _hypothesis_settings.register_profile(
         "tldw",

--- a/backlog/tasks/task-1452 - Central-env-scaled-Hypothesis-profile-stop-module-level-profile-leaks.md
+++ b/backlog/tasks/task-1452 - Central-env-scaled-Hypothesis-profile-stop-module-level-profile-leaks.md
@@ -2,7 +2,7 @@
 id: TASK-1452
 title: >-
   Central env-scaled Hypothesis profile; stop module-level load_profile() leaks that made example counts collection-order-dependent
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 09:05'
 labels:
@@ -20,11 +20,11 @@ Hypothesis binds `settings.default` at decoration time (verified by probe on ins
 
 ## Acceptance Criteria
 
-- [ ] The central profile scales `max_examples`/`stateful_step_count` via `TLDW_HYPOTHESIS_PROFILE` (dev=25/20 default, ci=50/30, thorough=300/100), keeping TASK-1260's `deadline=None` policy
-- [ ] No module leaves a non-central profile active after import: property modules needing extra health-check suppressions register a child profile (`parent=settings.default`) and restore `tldw` at end of module
-- [ ] Redundant module profiles (RAG_Search "embeddings") are removed rather than inherited
-- [ ] The ChaChaNotesDB double-registration is consolidated with the fixture suppression retained
-- [ ] Affected property suites (ChaChaNotesDB, Media_DB, RAG_Search, Utils path-validation) pass; junit outcome diff vs baseline shows no regressions
+- [x] The central profile scales `max_examples`/`stateful_step_count` via `TLDW_HYPOTHESIS_PROFILE` (dev=25/20 default, ci=50/30, thorough=300/100), keeping TASK-1260's `deadline=None` policy
+- [x] No module leaves a non-central profile active after import: property modules needing extra health-check suppressions register a child profile (`parent=settings.default`) and restore `tldw` at end of module
+- [x] Redundant module profiles (RAG_Search "embeddings") are removed rather than inherited
+- [x] The ChaChaNotesDB double-registration is consolidated with the fixture suppression retained
+- [x] Affected property suites (ChaChaNotesDB, Media_DB, RAG_Search, Utils path-validation) pass; junit outcome diff vs baseline shows no regressions
 
 ## Implementation Plan
 

--- a/backlog/tasks/task-1452 - Central-env-scaled-Hypothesis-profile-stop-module-level-profile-leaks.md
+++ b/backlog/tasks/task-1452 - Central-env-scaled-Hypothesis-profile-stop-module-level-profile-leaks.md
@@ -1,0 +1,49 @@
+---
+id: TASK-1452
+title: >-
+  Central env-scaled Hypothesis profile; stop module-level load_profile() leaks that made example counts collection-order-dependent
+status: In Progress
+assignee: []
+created_date: '2026-07-30 09:05'
+labels:
+  - testing
+  - performance
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Hypothesis binds `settings.default` at decoration time (verified by probe on installed 6.152.3), and four test modules call `settings.load_profile()` at import with no restore — so every module imported after one of them binds *that* module's profile instead of the central `tldw` profile TASK-1260 added. In a full run, `Tests/Utils/test_path_validation_properties.py` and the other 30+ unannotated `@given` sites run under `RAG_Search`'s "embeddings" profile; in a directory run they run under `tldw`. Effective example counts and deadlines depended on which files happened to be collected. Also: the suite had no example-count scaling at all (default 100 everywhere), part of audit driver #7, and `test_chachanotes_db_properties.py` registered "db_friendly" twice, with the second registration silently dropping the `function_scoped_fixture` suppression the first called "THE FIX".
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [ ] The central profile scales `max_examples`/`stateful_step_count` via `TLDW_HYPOTHESIS_PROFILE` (dev=25/20 default, ci=50/30, thorough=300/100), keeping TASK-1260's `deadline=None` policy
+- [ ] No module leaves a non-central profile active after import: property modules needing extra health-check suppressions register a child profile (`parent=settings.default`) and restore `tldw` at end of module
+- [ ] Redundant module profiles (RAG_Search "embeddings") are removed rather than inherited
+- [ ] The ChaChaNotesDB double-registration is consolidated with the fixture suppression retained
+- [ ] Affected property suites (ChaChaNotesDB, Media_DB, RAG_Search, Utils path-validation) pass; junit outcome diff vs baseline shows no regressions
+
+## Implementation Plan
+
+1. Probe decoration-time vs run-time binding on the installed Hypothesis (decides the mechanism)
+2. Extend the central `tldw` profile with env-scaled example counts
+3. Media_DB + ChaChaNotesDB + Prompts_DB properties: child profile via `parent=settings.default`, restore `tldw` at end of module; consolidate the ChaChaNotes double-registration
+4. RAG_Search properties: delete the module profile (fully superseded by the central one)
+5. Verify affected directories + junit diff
+
+## Implementation Notes
+
+Mechanism chosen after probing: decoration-time binding means each module's own
+tests keep their intended settings while the *leak* is what harmed everyone else,
+so per-module child profiles + end-of-module restore preserves current per-module
+behavior exactly while making every other module's binding deterministic.
+Deadline overrides (1000/1500/2000/5000) were dropped in favor of the central
+deadline=None per TASK-1260's policy (deadlines measure the machine, not the
+code). `tests_prompts_db_properties.py` is not currently collected (task-1463)
+but got the same hygiene so enabling it later cannot reintroduce the leak.
+Modified: `Tests/conftest.py`, `Tests/ChaChaNotesDB/test_chachanotes_db_properties.py`,
+`Tests/Media_DB/test_media_db_properties.py`, `Tests/RAG_Search/test_embeddings_properties.py`,
+`Tests/Prompts_DB/tests_prompts_db_properties.py`.


### PR DESCRIPTION
## Summary
Hypothesis binds `settings.default` at **decoration time** (probe-verified on 6.152.3), and four modules called `load_profile()` at import with no restore — every module imported after one of them bound *that* module's profile, so effective example counts and deadlines depended on collection order. The existing guard `Tests/test_hypothesis_profile::test_per_example_deadline_is_disabled` was **failing on clean dev because of exactly this leak** (it appears in RECOVERED in the parallel outcome diff).

Central `tldw` profile now scales `max_examples`/`stateful_step_count` via `TLDW_HYPOTHESIS_PROFILE` (dev=25/20 default, ci=50/30, thorough=300/100), keeping TASK-1260's `deadline=None` policy. DB property modules register child profiles (`parent=settings.default`) preserving their health-check suppressions and restore `tldw` at end of module. The redundant RAG_Search module profile is deleted; the ChaChaNotesDB double-registration (whose second copy silently dropped the `function_scoped_fixture` suppression labeled "THE FIX") is consolidated.

## Verification
- Child-profile inheritance + restore probe-verified; affected suites green: ChaChaNotesDB + Utils path-validation properties 37 passed / 6.3s; RAG_Search + Media_DB properties 26 passed / 13.2s
- Parallel A/B: the profile-guard test moves fail→pass (audit §8, PR #1102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes `hypothesis` settings with an env‑scaled `tldw` profile and stops module‑level `load_profile()` leaks so example counts no longer depend on import order. Adds a warning and safe fallback when `TLDW_HYPOTHESIS_PROFILE` is invalid to satisfy TASK-1452.

- **Bug Fixes**
  - Restored `tldw` at the end of DB property modules to prevent profile leaks; the deadline guard test now passes.

- **Refactors**
  - Added central `tldw` in `Tests/conftest.py` with `deadline=None`, `HealthCheck.too_slow` suppressed, and env‑scaled `max_examples`/`stateful_step_count` via `TLDW_HYPOTHESIS_PROFILE` (dev 25/20, ci 50/30, thorough 300/100). Scales are defined in `_HYPOTHESIS_SCALES`; unknown profiles emit a `UserWarning` and fall back to `dev`.
  - Updated DB property modules to register child profiles with `parent=settings.default` for needed suppressions, then restore `tldw` on module exit.
  - Removed RAG_Search `"embeddings"` profile and consolidated ChaChaNotesDB’s double registration, preserving `HealthCheck.function_scoped_fixture` suppression.

<sup>Written for commit e19437dd6629055f6fa3c17083579a3cb156b232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

