### PR TITLE
task-1454: periodic gc instead of double-collect per test; fd-leak sentinel

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -50,6 +50,7 @@ import asyncio  # noqa: E402
 import sqlite3  # noqa: E402
 import sys  # noqa: E402
 import gc  # noqa: E402
+from typing import Iterator  # noqa: E402
 import warnings  # noqa: E402
 
 # Add project root to Python path for consistent imports
@@ -190,17 +191,49 @@ def cleanup_loguru_handlers():
 # above and the fd_leak_sentinel below; periodic collection plus the
 # requires_cleanup marker covers the rest. TLDW_TEST_GC_EVERY=1 restores
 # per-test collection as an escape hatch.
-_GC_EVERY = max(1, int(os.environ.get("TLDW_TEST_GC_EVERY", "25")))
+def _env_int(name: str, default: int) -> int:
+    """Parse an integer environment knob without letting a typo abort the run.
+
+    Args:
+        name: Environment variable name.
+        default: Value used when the variable is unset or malformed.
+
+    Returns:
+        The parsed integer, or ``default`` (with a UserWarning) when the value
+        is not a valid integer — a malformed escape-hatch value must degrade to
+        the default, not kill conftest import for the whole suite.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        warnings.warn(
+            f"{name}={raw!r} is not an integer; using default {default}",
+            UserWarning,
+            stacklevel=2,
+        )
+        return default
+
+
+_GC_EVERY = max(1, _env_int("TLDW_TEST_GC_EVERY", 25))
 _gc_test_counter = 0
 
 
 @pytest.fixture(autouse=True)
-def cleanup_file_descriptors(request):
+def cleanup_file_descriptors(request: pytest.FixtureRequest) -> Iterator[None]:
     """Garbage-collect leaked file objects periodically (or per-test on request).
 
     Tests that genuinely need a collection pass right after they run (e.g. they
     open many files and assert on fd state) mark themselves
     ``@pytest.mark.requires_cleanup``.
+
+    Args:
+        request: The pytest fixture request, used to read the test's markers.
+
+    Yields:
+        None. Collection (if due) happens in teardown, after the test body.
     """
     yield
 
@@ -217,13 +250,18 @@ def cleanup_file_descriptors(request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def fd_leak_sentinel():
+def fd_leak_sentinel() -> Iterator[None]:
     """Warn when the session's open-fd count grows past a leak threshold.
 
     Replacement leak detection for the per-test gc.collect() this file used to
     do: cheap (two directory listings per session), and unlike the gc pass it
     produces an actionable signal instead of silently papering over leaks.
-    Warn-only for now; threshold via TLDW_TEST_FD_GROWTH_LIMIT.
+    Warn-only for now; threshold via TLDW_TEST_FD_GROWTH_LIMIT. The signal is
+    a UserWarning (never in default ignore filters, unlike ResourceWarning)
+    plus a stderr line, so it survives any warning-filter configuration.
+
+    Yields:
+        None. The fd count comparison happens at session teardown.
     """
     fd_dir = "/dev/fd" if sys.platform == "darwin" else "/proc/self/fd"
 
@@ -233,21 +271,25 @@ def fd_leak_sentinel():
         except OSError:
             return None
 
-    limit = int(os.environ.get("TLDW_TEST_FD_GROWTH_LIMIT", "200"))
+    limit = _env_int("TLDW_TEST_FD_GROWTH_LIMIT", 200)
     start = _count_fds()
     yield
     if start is None:
         return
     end = _count_fds()
     if end is not None and end - start > limit:
-        warnings.warn(
+        message = (
             f"open file descriptors grew by {end - start} over the test session "
             f"(start={start}, end={end}, limit={limit}) — possible fd leak; "
             "bisect with TLDW_TEST_GC_EVERY=1 and mark offending tests "
-            "@pytest.mark.requires_cleanup",
-            ResourceWarning,
-            stacklevel=0,
+            "@pytest.mark.requires_cleanup"
         )
+        # UserWarning (not ResourceWarning): ResourceWarning sits in Python's
+        # default ignore filters, so the sentinel's only signal could vanish
+        # under filter configurations that don't re-enable it. The stderr echo
+        # survives even -W ignore.
+        warnings.warn(message, UserWarning, stacklevel=0)
+        print(f"[fd_leak_sentinel] {message}", file=sys.stderr)
 
 
 # ========== Async Cleanup Fixtures ==========

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -182,18 +182,72 @@ def cleanup_loguru_handlers():
                 pass
 
 
+# Full gc passes after EVERY test cost real wall-clock at suite scale: the old
+# version of this fixture ran TWO gc.collect() per test, ~23,000 full-heap
+# collections per run with torch/transformers-sized heaps (2026-07-30 audit,
+# driver #3). The FD-leak incidents that motivated it (loguru handlers, fds
+# under Textual's redirected streams) are guarded by cleanup_loguru_handlers
+# above and the fd_leak_sentinel below; periodic collection plus the
+# requires_cleanup marker covers the rest. TLDW_TEST_GC_EVERY=1 restores
+# per-test collection as an escape hatch.
+_GC_EVERY = max(1, int(os.environ.get("TLDW_TEST_GC_EVERY", "25")))
+_gc_test_counter = 0
+
+
 @pytest.fixture(autouse=True)
-def cleanup_file_descriptors():
-    """Force garbage collection and close any leaked file descriptors after each test."""
+def cleanup_file_descriptors(request):
+    """Garbage-collect leaked file objects periodically (or per-test on request).
+
+    Tests that genuinely need a collection pass right after they run (e.g. they
+    open many files and assert on fd state) mark themselves
+    ``@pytest.mark.requires_cleanup``.
+    """
     yield
 
-    # Force garbage collection to cleanup any unclosed files
-    gc.collect()
+    global _gc_test_counter
+    _gc_test_counter += 1
+    if (
+        request.node.get_closest_marker("requires_cleanup")
+        or _gc_test_counter % _GC_EVERY == 0
+    ):
+        # Suppress ResourceWarnings emitted for unclosed files reclaimed here.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ResourceWarning)
+            gc.collect()
 
-    # Suppress ResourceWarnings during test cleanup
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", ResourceWarning)
-        gc.collect()
+
+@pytest.fixture(scope="session", autouse=True)
+def fd_leak_sentinel():
+    """Warn when the session's open-fd count grows past a leak threshold.
+
+    Replacement leak detection for the per-test gc.collect() this file used to
+    do: cheap (two directory listings per session), and unlike the gc pass it
+    produces an actionable signal instead of silently papering over leaks.
+    Warn-only for now; threshold via TLDW_TEST_FD_GROWTH_LIMIT.
+    """
+    fd_dir = "/dev/fd" if sys.platform == "darwin" else "/proc/self/fd"
+
+    def _count_fds():
+        try:
+            return len(os.listdir(fd_dir))
+        except OSError:
+            return None
+
+    limit = int(os.environ.get("TLDW_TEST_FD_GROWTH_LIMIT", "200"))
+    start = _count_fds()
+    yield
+    if start is None:
+        return
+    end = _count_fds()
+    if end is not None and end - start > limit:
+        warnings.warn(
+            f"open file descriptors grew by {end - start} over the test session "
+            f"(start={start}, end={end}, limit={limit}) — possible fd leak; "
+            "bisect with TLDW_TEST_GC_EVERY=1 and mark offending tests "
+            "@pytest.mark.requires_cleanup",
+            ResourceWarning,
+            stacklevel=0,
+        )
 
 
 # ========== Async Cleanup Fixtures ==========

--- a/backlog/tasks/task-1454 - Narrow-per-test-double-gc.collect-autouse-fixture-add-fd-leak-sentinel.md
+++ b/backlog/tasks/task-1454 - Narrow-per-test-double-gc.collect-autouse-fixture-add-fd-leak-sentinel.md
@@ -2,7 +2,7 @@
 id: TASK-1454
 title: >-
   Narrow the per-test double gc.collect() autouse fixture to periodic/marked collection and add an fd-leak sentinel
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 09:05'
 labels:
@@ -20,10 +20,10 @@ dependencies: []
 
 ## Acceptance Criteria
 
-- [ ] gc.collect() runs every N tests (`TLDW_TEST_GC_EVERY`, default 25) or immediately after tests marked `requires_cleanup`; `TLDW_TEST_GC_EVERY=1` restores per-test collection
-- [ ] `cleanup_loguru_handlers` is unchanged
-- [ ] A session-scoped fd sentinel warns (warn-only initially) when open-fd count grows past a configurable threshold, with actionable guidance in the message
-- [ ] Full-suite run completes without fd exhaustion; junit outcome diff vs baseline shows no regressions
+- [x] gc.collect() runs every N tests (`TLDW_TEST_GC_EVERY`, default 25) or immediately after tests marked `requires_cleanup`; `TLDW_TEST_GC_EVERY=1` restores per-test collection
+- [x] `cleanup_loguru_handlers` is unchanged
+- [x] A session-scoped fd sentinel warns (warn-only initially) when open-fd count grows past a configurable threshold, with actionable guidance in the message
+- [x] Full-suite run completes without fd exhaustion; junit outcome diff vs baseline shows no regressions
 
 ## Implementation Plan
 

--- a/backlog/tasks/task-1454 - Narrow-per-test-double-gc.collect-autouse-fixture-add-fd-leak-sentinel.md
+++ b/backlog/tasks/task-1454 - Narrow-per-test-double-gc.collect-autouse-fixture-add-fd-leak-sentinel.md
@@ -1,0 +1,41 @@
+---
+id: TASK-1454
+title: >-
+  Narrow the per-test double gc.collect() autouse fixture to periodic/marked collection and add an fd-leak sentinel
+status: In Progress
+assignee: []
+created_date: '2026-07-30 09:05'
+labels:
+  - testing
+  - performance
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/conftest.py`'s autouse `cleanup_file_descriptors` ran **two full `gc.collect()` passes after every test** — ~23,000 full-heap collections per ~11,600-test run, in a process whose heap includes Textual and (in CI) torch/transformers/chromadb. The 2026-07-30 audit ranks this the #3 wall-clock driver (est. 10–40 min/run). The fixture exists because of real FD-leak incidents (loguru handlers; fds under Textual's redirected streams), so it must be narrowed with a replacement leak-detection story, not deleted: the targeted `cleanup_loguru_handlers` fixture stays untouched, collection becomes periodic (every N tests) or per-test via the already-registered-but-unused `requires_cleanup` marker, and a session-scoped fd-count sentinel warns on suspicious growth.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [ ] gc.collect() runs every N tests (`TLDW_TEST_GC_EVERY`, default 25) or immediately after tests marked `requires_cleanup`; `TLDW_TEST_GC_EVERY=1` restores per-test collection
+- [ ] `cleanup_loguru_handlers` is unchanged
+- [ ] A session-scoped fd sentinel warns (warn-only initially) when open-fd count grows past a configurable threshold, with actionable guidance in the message
+- [ ] Full-suite run completes without fd exhaustion; junit outcome diff vs baseline shows no regressions
+
+## Implementation Plan
+
+1. Replace the double per-test collect with a counter-gated single collect (ResourceWarnings suppressed during the pass) + `requires_cleanup` marker path
+2. Add `fd_leak_sentinel` (session, autouse): count `/dev/fd` (darwin) / `/proc/self/fd` entries at session start/end, warn past `TLDW_TEST_FD_GROWTH_LIMIT` (default 200)
+3. Verify: full run, junit diff, no ResourceWarning storms
+
+## Implementation Notes
+
+Counter-gated single `gc.collect()` (the second bare collect added nothing the
+warnings-suppressed one doesn't do), `requires_cleanup` marker honored per test,
+env escape hatch for CI conservatism, and the fd sentinel as the leak-detection
+replacement — it produces an actionable signal (bisect with TLDW_TEST_GC_EVERY=1,
+mark offenders) instead of silently papering over leaks per test.
+Modified: `Tests/conftest.py`.


### PR DESCRIPTION
## Summary
The autouse `cleanup_file_descriptors` fixture ran **two full `gc.collect()` passes after every test** — ~23,000 full-heap collections per ~11,600-test run in a process whose heap includes Textual and (in CI) torch/transformers (audit driver #3). Now: a single warnings-suppressed collect every `TLDW_TEST_GC_EVERY` tests (default 25; `=1` restores per-test) or immediately for `@pytest.mark.requires_cleanup` tests, plus a session fd-count sentinel (warn-only, `TLDW_TEST_FD_GROWTH_LIMIT`) as the leak-detection replacement. `cleanup_loguru_handlers` — the targeted fix for the original FD-leak incidents — is untouched.

## Verification
- A/B on `Tests/Notes` (701 tests, same command, same machine): **111.7s (every-25) vs 131.9s (per-test)** — ~15% on this dir alone, identical outcomes; the saving vs dev is larger (dev double-collects)
- Contributes to the parallel A/B's 5.1× (1:10:32 → 13:56; audit §8, PR #1102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce test runtime by replacing per-test double `gc.collect()` with periodic collection and adding a session FD-leak sentinel. Addresses TASK-1454; keeps `cleanup_loguru_handlers` unchanged and supports per-test cleanup via `@pytest.mark.requires_cleanup`.

- **Refactors**
  - Run `gc.collect()` every `TLDW_TEST_GC_EVERY` tests (default 25) or immediately for tests marked `@pytest.mark.requires_cleanup`; set `TLDW_TEST_GC_EVERY=1` to restore per-test.
  - Add session-scoped `fd_leak_sentinel` that warns if open FDs grow beyond `TLDW_TEST_FD_GROWTH_LIMIT` (default 200), signaling via `UserWarning` plus a stderr echo.
  - Parse `TLDW_TEST_GC_EVERY` and `TLDW_TEST_FD_GROWTH_LIMIT` with a robust `_env_int` (malformed values warn and fall back); suppress `ResourceWarning` during GC; fixtures are typed; no changes to `cleanup_loguru_handlers`.

<sup>Written for commit c9f3615cef81b4ee424af62705edb74249c4d78e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

