### PR TITLE
task-1453: pytest-xdist adoption with per-worker config sandboxes

### DIFF
--- a/Tests/UI/conftest.py
+++ b/Tests/UI/conftest.py
@@ -16,6 +16,8 @@ _existing_test_config_root = os.environ.get(_TEST_CONFIG_ROOT_ENV)
 # (task-1453). Needed here too for runs rooted at Tests/UI, where the root
 # conftest is not loaded.
 _XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER")
+if _XDIST_WORKER and not __import__("re").fullmatch(r"[A-Za-z0-9_-]+", _XDIST_WORKER):
+    _XDIST_WORKER = None  # never join an unexpected id into a path
 if _existing_test_config_root:
     _BOOTSTRAP_CONFIG_ROOT = Path(_existing_test_config_root)
     if _XDIST_WORKER and _BOOTSTRAP_CONFIG_ROOT.name != _XDIST_WORKER:

--- a/Tests/UI/conftest.py
+++ b/Tests/UI/conftest.py
@@ -12,8 +12,16 @@ from pathlib import Path
 _TEST_CONFIG_ROOT_ENV = "TLDW_TEST_CONFIG_ROOT"
 _TEST_CONFIG_OWNER_ENV = "TLDW_TEST_CONFIG_ROOT_OWNER"
 _existing_test_config_root = os.environ.get(_TEST_CONFIG_ROOT_ENV)
+# Per-xdist-worker sandbox subtree; see Tests/conftest.py for the rationale
+# (task-1453). Needed here too for runs rooted at Tests/UI, where the root
+# conftest is not loaded.
+_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER")
 if _existing_test_config_root:
     _BOOTSTRAP_CONFIG_ROOT = Path(_existing_test_config_root)
+    if _XDIST_WORKER and _BOOTSTRAP_CONFIG_ROOT.name != _XDIST_WORKER:
+        _BOOTSTRAP_CONFIG_ROOT = _BOOTSTRAP_CONFIG_ROOT / _XDIST_WORKER
+        _BOOTSTRAP_CONFIG_ROOT.mkdir(parents=True, exist_ok=True)
+        os.environ[_TEST_CONFIG_ROOT_ENV] = str(_BOOTSTRAP_CONFIG_ROOT)
     _OWNS_BOOTSTRAP_CONFIG_ROOT = False
 else:
     _BOOTSTRAP_CONFIG_ROOT = Path(tempfile.mkdtemp(prefix="tldw_test_config_"))

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -21,8 +21,19 @@ _SANDBOXED_ENV_NAMES = (
 )
 _PREVIOUS_TEST_ENV = {name: os.environ.get(name) for name in _SANDBOXED_ENV_NAMES}
 _existing_test_config_root = os.environ.get(_TEST_CONFIG_ROOT_ENV)
+# Under pytest-xdist the controller creates the sandbox root and workers
+# inherit it via the env; give each worker its own subtree so concurrent
+# workers never share a config/home/data dir (task-1453). The name guard keeps
+# re-entrant loads (Tests/UI/conftest.py, subprocess children) from suffixing
+# twice — the suffixed path is republished to the env below. The controller
+# owns the unsuffixed root and its sessionfinish rmtree removes the worker
+# subtrees with it.
+_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER")
 if _existing_test_config_root:
     _BOOTSTRAP_CONFIG_ROOT = Path(_existing_test_config_root)
+    if _XDIST_WORKER and _BOOTSTRAP_CONFIG_ROOT.name != _XDIST_WORKER:
+        _BOOTSTRAP_CONFIG_ROOT = _BOOTSTRAP_CONFIG_ROOT / _XDIST_WORKER
+        _BOOTSTRAP_CONFIG_ROOT.mkdir(mode=0o700, parents=True, exist_ok=True)
     _OWNS_BOOTSTRAP_CONFIG_ROOT = False
 else:
     _BOOTSTRAP_CONFIG_ROOT = Path(tempfile.mkdtemp(prefix="tldw_test_config_"))

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -28,7 +28,13 @@ _existing_test_config_root = os.environ.get(_TEST_CONFIG_ROOT_ENV)
 # twice — the suffixed path is republished to the env below. The controller
 # owns the unsuffixed root and its sessionfinish rmtree removes the worker
 # subtrees with it.
+# The worker id is only ever xdist's own "gw<N>"; the strict pattern makes the
+# env-derived path join traversal-proof without pulling app-level path
+# validation into this pre-sys.path bootstrap (an id that fails the pattern is
+# ignored, falling back to the shared root).
 _XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER")
+if _XDIST_WORKER and not __import__("re").fullmatch(r"[A-Za-z0-9_-]+", _XDIST_WORKER):
+    _XDIST_WORKER = None
 if _existing_test_config_root:
     _BOOTSTRAP_CONFIG_ROOT = Path(_existing_test_config_root)
     if _XDIST_WORKER and _BOOTSTRAP_CONFIG_ROOT.name != _XDIST_WORKER:
@@ -352,7 +358,16 @@ def pytest_configure(config):
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    """Restore caller config variables and remove only an owned sandbox."""
+    """Restore caller config variables and remove only an owned sandbox.
+
+    In xdist workers the pre-suffix snapshot points at the controller's SHARED
+    sandbox, so restoring it here would aim HOME/XDG/TLDW_* back at shared
+    directories for the late-shutdown window (atexit hooks) — exactly the
+    isolation this sandboxing exists to provide. Workers are about to exit and
+    own nothing; skip both the restore and the (already owner-gated) cleanup.
+    """
+    if _XDIST_WORKER:
+        return
     for name, previous in _PREVIOUS_TEST_ENV.items():
         if previous is None:
             os.environ.pop(name, None)

--- a/backlog/tasks/task-1453 - Adopt-pytest-xdist-per-worker-config-sandbox-parallel-runs.md
+++ b/backlog/tasks/task-1453 - Adopt-pytest-xdist-per-worker-config-sandbox-parallel-runs.md
@@ -1,0 +1,44 @@
+---
+id: TASK-1453
+title: >-
+  Adopt pytest-xdist: per-worker config sandboxes and parallel local runs
+status: In Progress
+assignee: []
+created_date: '2026-07-30 09:05'
+labels:
+  - testing
+  - performance
+priority: high
+dependencies: [task-1450, task-1451, task-1452]
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The suite (~11,600 tests, 23,793 collected items, 1+ hour) runs fully serially: pytest-xdist is not installed, not declared in any extra, and no CI job or config passes `-n`. The dominant cost (Textual app mounts) is CPU-bound and parallelizes near-linearly. Compatibility prerequisites landed separately: the RAG_Search session autouse model fixture is gated (task-1451), Hypothesis profiles no longer depend on collection order (task-1452). Remaining blocker fixed here: all xdist workers inherited `TLDW_TEST_CONFIG_ROOT` from the controller and would share one sandbox (one HOME/XDG/config.toml — a write-race). Real test servers all bind port 0 (verified — no fixed-port binds in Tests/), so no port work is needed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [ ] `pytest-xdist` installable via both `.[dev]` and `requirements-test.txt` (plus `pytest-mock`/`pytest-cov`, which the docs and tests already assume)
+- [ ] Each xdist worker gets its own config sandbox subtree (own HOME/XDG/TLDW_CONFIG_PATH); the controller still owns and removes the root
+- [ ] Works for both rootdirs: repo root and `pytest Tests/UI`
+- [ ] A full `-n auto --dist loadscope` run completes; its junit outcome set diffed against the serial baseline shows no unexplained regressions (new failures get fix-or-`xfail(strict=False)`+task, never silent skips)
+- [ ] Serial behavior is unchanged when xdist is not used (no `-n` in addopts — opt-in via CLI/CI)
+
+## Implementation Plan
+
+1. Add deps to `[dev]` extra + `requirements-test.txt`
+2. Per-worker sandbox suffix (`PYTEST_XDIST_WORKER`) in both conftest bootstrap blocks, guarded against double-suffixing (root conftest republishes the suffixed path; Tests/UI conftest and subprocess children must not suffix again)
+3. Verify: fixed-port grep (clean), parallel full run + junit diff vs baseline
+4. Recommended invocation: `pytest -n auto --dist loadscope --max-worker-restart=3` (loadscope preserves module-scoped fixtures and intra-module ordering; worker restarts bound the blast radius of pytest-timeout's thread-method process kills)
+
+## Implementation Notes
+
+Sandbox suffixing: controller creates the root (unsuffixed, owner) → workers see
+`PYTEST_XDIST_WORKER` and nest `<root>/<worker>` with their own home/data/config
+dirs; the name-guard makes re-entrant conftest loads idempotent. `-n` is
+deliberately NOT in addopts yet — serial stays the default until the parallel
+outcome diff has soaked; CI adoption is task-1465.
+Modified: `pyproject.toml`, `requirements-test.txt`, `Tests/conftest.py`,
+`Tests/UI/conftest.py`.

--- a/backlog/tasks/task-1453 - Adopt-pytest-xdist-per-worker-config-sandbox-parallel-runs.md
+++ b/backlog/tasks/task-1453 - Adopt-pytest-xdist-per-worker-config-sandbox-parallel-runs.md
@@ -2,7 +2,7 @@
 id: TASK-1453
 title: >-
   Adopt pytest-xdist: per-worker config sandboxes and parallel local runs
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 09:05'
 labels:
@@ -20,11 +20,11 @@ The suite (~11,600 tests, 23,793 collected items, 1+ hour) runs fully serially: 
 
 ## Acceptance Criteria
 
-- [ ] `pytest-xdist` installable via both `.[dev]` and `requirements-test.txt` (plus `pytest-mock`/`pytest-cov`, which the docs and tests already assume)
-- [ ] Each xdist worker gets its own config sandbox subtree (own HOME/XDG/TLDW_CONFIG_PATH); the controller still owns and removes the root
-- [ ] Works for both rootdirs: repo root and `pytest Tests/UI`
-- [ ] A full `-n auto --dist loadscope` run completes; its junit outcome set diffed against the serial baseline shows no unexplained regressions (new failures get fix-or-`xfail(strict=False)`+task, never silent skips)
-- [ ] Serial behavior is unchanged when xdist is not used (no `-n` in addopts — opt-in via CLI/CI)
+- [x] `pytest-xdist` installable via both `.[dev]` and `requirements-test.txt` (plus `pytest-mock`/`pytest-cov`, which the docs and tests already assume)
+- [x] Each xdist worker gets its own config sandbox subtree (own HOME/XDG/TLDW_CONFIG_PATH); the controller still owns and removes the root
+- [x] Works for both rootdirs: repo root and `pytest Tests/UI`
+- [x] A full `-n auto --dist loadscope` run completes; its junit outcome set diffed against the serial baseline shows no unexplained regressions (new failures get fix-or-`xfail(strict=False)`+task, never silent skips)
+- [x] Serial behavior is unchanged when xdist is not used (no `-n` in addopts — opt-in via CLI/CI)
 
 ## Implementation Plan
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,9 @@ ocr_docext = [
 dev = [
     "pytest",
     "pytest-timeout",  # For handling hanging tests
+    "pytest-xdist",  # Parallel test execution: pytest -n auto --dist loadscope
+    "pytest-mock",  # Used throughout Tests/; was only in requirements-test.txt
+    "pytest-cov",  # Coverage runs documented in Tests/README.md
     "textual-dev", # For Textual development tools
     "hypothesis",
     "pytest-asyncio",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,8 @@ pytest
 pytest-asyncio
 pytest-mock
 pytest-timeout
+pytest-xdist
+pytest-cov
 hypothesis
 aiohttp
 build


### PR DESCRIPTION
## Summary
The suite runs fully serially; its dominant cost (Textual app mounts) is CPU-bound and parallelizes near-linearly. Adds `pytest-xdist` (+`pytest-mock`/`pytest-cov`, already assumed by docs and tests) to the `[dev]` extra and `requirements-test.txt`, and gives each xdist worker its own config-sandbox subtree (own HOME/XDG/`TLDW_CONFIG_PATH`) — previously all workers inherited the controller's `TLDW_TEST_CONFIG_ROOT` and would share one sandbox. Works for both rootdirs (repo root and `Tests/UI`); re-entrant conftest loads and subprocess children are suffix-idempotent. Real test servers all bind port 0 (verified — no fixed-port binds). Serial stays the default (`-n` is NOT in addopts); recommended invocation: `pytest -n auto --dist loadscope --max-worker-restart=3`. CI adoption is task-1465.

## Verification
- Full-suite `-n 8 --dist loadscope` on the combined quick-wins branch: **13:56 vs dev's 1:10:32** with the identical command; junit outcome diff fully triaged — zero regressions attributable (7 flips are pre-existing order-dependent tests, confirmed by identical isolation failure sets on both trees; filed as task-1467). Audit §8, PR #1102.
- Smoke: `Tests/Notes -n 2` → 701 passed, outcomes identical to serial

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable parallel test runs with `pytest-xdist` and isolate each worker in its own config sandbox to prevent shared HOME/XDG writes. On 8 workers, the full suite dropped from ~1h10 to ~14m while keeping serial as the default.

- **New Features**
  - Opt-in parallel execution: `pytest -n auto --dist loadscope --max-worker-restart=3`.
  - Per-worker sandboxing under `TLDW_TEST_CONFIG_ROOT` via `PYTEST_XDIST_WORKER` (separate HOME/XDG/`TLDW_CONFIG_PATH`); safe for repo-root and `Tests/UI` runs, idempotent for re-entrant conftests/subprocesses; real test servers bind port 0 (no conflicts).
  - Hardening: worker id is pattern-checked before joining into paths; xdist workers skip env restore at session finish to avoid late writes to the shared root (controller owns cleanup).
  - Implements Linear task-1453.

- **Dependencies**
  - Added `pytest-xdist`, `pytest-mock`, and `pytest-cov` to `[dev]` and `requirements-test.txt`.

<sup>Written for commit 95e7b38b494ba89ad8c58d61a82d314f7c853e66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

