### PR TITLE
fix(notes): restore File Notes compact usability [TASK-1411]

### DIFF
--- a/.impeccable/critique/2026-07-30T16-13-58Z__tldw-chatbook-ui-screens-library-screen-py.md
+++ b/.impeccable/critique/2026-07-30T16-13-58Z__tldw-chatbook-ui-screens-library-screen-py.md
@@ -1,0 +1,160 @@
+---
+target: File Notes full-app UAT
+total_score: 23
+max_score: 40
+na_heuristics:
+p0_count: 2
+p1_count: 0
+timestamp: 2026-07-30T16-13-58Z
+slug: tldw-chatbook-ui-screens-library-screen-py
+---
+Method: dual-agent (A: /root/uat_design_review_a · B: /root/uat_detector_review_b)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key issue |
+|---|---|---:|---|
+| 1 | Visibility of System Status | 2 | Rich state exists, but the Files source, compact status, and primary actions disappear. |
+| 2 | Match System / Real World | 3 | Database, Files, staging, review, and commit fit local-first Git users. |
+| 3 | User Control and Freedom | 2 | Back, unstage, and cancel exist, but compact users cannot advance. |
+| 4 | Consistency and Standards | 2 | The source strip is incomplete and Tab does not produce a usable compact action. |
+| 5 | Error Prevention | 4 | Exact staged-state matching and unrelated-change protection are excellent. |
+| 6 | Recognition Rather Than Recall | 2 | Hidden source and actions require guessing rather than recognition. |
+| 7 | Flexibility and Efficiency | 2 | Pane switching and bulk controls are sound, but the compact keyboard path fails. |
+| 8 | Aesthetic and Minimalist Design | 2 | A diagnostic absolute path displaces task-critical state and actions. |
+| 9 | Error Recovery | 2 | The staged-state mismatch is precise but does not name the safe recovery step. |
+| 10 | Help and Documentation | 2 | Inline keyboard guidance exists, but its compact-mode promise is not fulfilled. |
+| **Total** |  | **23/40** | **Acceptable foundation with blocking reachability failures.** |
+
+## Design Specificity Verdict
+
+**LLM assessment:** The intended information architecture is strongly authored
+for Chatbook: Database/Files authority switching, a disk-backed notes
+workspace, session-scoped staging, and an exact reviewed commit are coherent
+with its local-first control model. The count-and-promise language is unusually
+specific and effective. The rendered layout does not yet uphold that model at
+supported terminal sizes.
+
+**Deterministic scan:** The required detector returned exit code 0 with `[]`
+(zero findings, no rules or locations) for
+`tldw_chatbook/UI/Screens/library_screen.py`. This is a detector coverage limit,
+not evidence against the PTY failures: runtime Textual allocation and compact
+terminal geometry are outside its checks. Source inspection independently
+located both layout causes.
+
+**Visual evidence:** Browser overlays do not apply to a native Textual TUI, so
+no web server or DOM injection was attempted. The fallback evidence is a real
+Chatbook process in a PTY at `160x45`, `120x40`, and `40x20`, preserved under
+`Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/`.
+
+## Overall Impression
+
+The guarded commit interaction inspires confidence once reached: it names
+scope, blocks an unsafe complete index, and finishes with a truthful result.
+The largest opportunity is simpler than a redesign—make that already-good
+workflow visibly enterable and keyboard-reachable at every supported size.
+
+## What's Working
+
+- The review and success states pair an exact note count with “unrelated
+  changes untouched,” which gives high-stakes reassurance without vague claims.
+- Exact-match validation rejects unrelated staged content without moving HEAD
+  or changing the index.
+- Navigator/Editor switching is an appropriate compact workspace model, and
+  wide editing through commit is coherent.
+
+## Cognitive Load
+
+- `Database |` asks users to infer a missing source instead of recognizing it.
+- At `40x20`, the complete linked-root path consumes roughly four rows while
+  status and the next action disappear—a priority inversion.
+- Compact users must remember session state while searching for controls that
+  keyboard traversal does not visibly reveal.
+- The safety detail itself is not excessive; layout allocation, not copy
+  volume, is the failure.
+
+## Emotional Journey
+
+The wide review and commit create a strong confidence peak. Discovery begins
+with a trust-breaking valley when Files is absent, and compact use ends after
+the user has already edited a note but cannot prepare it for commit. That
+abandonment dominates the otherwise reassuring safety model. The unrelated
+staging refusal feels safe, though slightly incomplete without a direct
+recovery instruction.
+
+## Priority Issues
+
+### [P0] The File Notes entry disappears at normal widths
+
+**Why it matters:** At both `120x40` and `160x45`, users cannot discover or
+enter a core workspace through the visible interface.
+
+**Evidence:** `library_screen.py` constrains the two source buttons to automatic
+width, but the intervening `Static("|")` remains flexible and consumes the
+remaining horizontal space, pushing Files outside the strip.
+
+**Fix:** Give the separator a stable class/ID with `width: 1; min-width: 1`.
+Keep both labeled buttons focusable and visibly indicate the selected source.
+
+**Suggested command:** `$impeccable layout`
+
+### [P0] Prepare session becomes a compact-terminal dead end
+
+**Why it matters:** A user can edit and save at `40x20` but cannot reach Stage
+or Commit, so the primary journey fails after work has already been invested.
+Keyboard-only users have no compensating route.
+
+**Evidence:** The complete linked-root path is rendered in auto-height rows
+without elision. The Git surface is a non-scrollable `Vertical`, with status
+and actions after the list, so constrained height clips the actionable tail.
+
+**Fix:** Clamp and middle-elide the persistent root summary to one line while
+retaining the full path on demand, and make the Prepare workflow vertically
+keyboard-scrollable so focusing an action brings it into view. Root clamping
+alone is geometry-dependent and is not sufficient.
+
+**Suggested command:** `$impeccable layout`
+
+### [P2] The safe staged-state refusal omits the recovery step
+
+**Why it matters:** Users know why review was blocked but may not know which
+state must change before retrying.
+
+**Fix:** Preserve the exact safety sentence and add concise recovery copy:
+“Commit or unstage the unrelated staged changes, Refresh, then review this
+session again.”
+
+**Suggested command:** `$impeccable clarify`
+
+## Persona Red Flags
+
+**Alex (power user):** The advertised keyboard path cannot visibly reach Stage
+at `40x20`, turning a fast terminal workflow into a dead end.
+
+**Jordan (first-time File Notes user):** `Database |` gives no recognizable
+evidence that File Notes exists; the staged-state refusal explains policy but
+not the next safe action.
+
+**Sam (keyboard-dependent user):** Focus may move to an off-viewport Files
+button, and compact traversal cannot make a staging action usable, so the
+workflow is not keyboard-operable despite labeled controls.
+
+## Minor Observations
+
+- A disabled selected-source button can read as unavailable; retain a visible
+  selected marker in addition to disabled-state behavior.
+- Keep leading success copy definitive—“Committed 2 session notes”—before the
+  reassurance.
+- The root basename or trailing segments are sufficient for persistent
+  orientation; the complete absolute path can remain available on demand.
+- Existing two-line fixed-region fitting is not the cause; the unbounded outer
+  linked-root status and non-scrollable action surface are.
+
+## Questions to Consider
+
+- What one next action must remain visible or immediately scrollable after
+  editing at every supported terminal size?
+- Is the complete absolute root important enough to displace current status
+  and commit controls?
+- Should every safety refusal name both the protected condition and the exact
+  safe recovery path?

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/README.md
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/README.md
@@ -2,7 +2,8 @@
 
 ## Verdict
 
-**UX acceptance blocked; guarded commit behavior passed.**
+**Accepted after TASK-1411 remediation; guarded commit behavior remains
+passed.**
 
 The test launched the real Chatbook Textual application in a PTY and exercised
 the Library navigation, native folder picker, process-only Git trust prompt,
@@ -10,7 +11,7 @@ File Notes editor, autosave, session staging, commit review, commit execution,
 and unrelated-staged-content block against a disposable Git repository and
 SQLite replica.
 
-Two reachability defects prevent full UX acceptance:
+The initial run found two reachability defects:
 
 1. At `120x40` and `160x45`, Library > Notes rendered the source strip as
    `Database |`; the Files choice was not visible or operable.
@@ -21,8 +22,24 @@ Two reachability defects prevent full UX acceptance:
 
 The focused remediation is tracked by
 [TASK-1411](../../../../backlog/tasks/task-1411%20-%20Restore-File-Notes-entry-and-compact-terminal-Prepare-usability.md).
-Guarded push remains subsequent work; it should not be added on top of an
-unreachable commit workflow.
+TASK-1411 repaired both defects. A second full-app PTY run used the current
+application directly, with no diagnostic launcher or runtime override:
+
+- At `120x40`, Library > Notes rendered
+  `Database (selected) | Files`; selecting Files changed it to
+  `Database | Files (selected)` and mounted the retained workspace.
+- At `40x20`, the linked-root summary stayed on one line as
+  `Linked —...o/notes`. The visible Details action opened the exact root and
+  warning text in a keyboard-focused, read-only dialog.
+- Prepare session for commit scrolled from status to the selected-path,
+  Stage/Unstage, Stage All/Unstage All, and Commit staged controls.
+- In an actionless Prepare state, Shift+Tab focused the scroll surface and End
+  revealed `Commit staged (0)` plus the “Stage at least one…” guidance.
+- A new autosaved session edit was staged from the compact UI. After
+  `unrelated.txt` was staged externally, review remained fail-closed and
+  displayed the safe recovery instruction.
+
+Guarded push remains subsequent work.
 
 ## Build and environment
 
@@ -51,7 +68,7 @@ not missing feature registration.
 
 | Scenario | Result | Evidence |
 |---|---|---|
-| Open Library > Notes and select Files at normal width | **Fail** | Only `Database |` was visible at `120x40` and `160x45`. |
+| Open Library > Notes and select Files at normal width | **Pass after remediation** | Direct full-app retest passed at `120x40`; mounted geometry and keyboard coverage passed at both `120x40` and `160x45`. |
 | Select root through the native picker | Pass after entry-only diagnostic bypass | The disposable `notes` folder was linked. |
 | Decline/reopen/accept process-only Git trust | Pass | Cancel remained the safe default; `Trust and check status` enabled Session Git for this process only. |
 | Edit Markdown body and autosave | Pass | Both notes reached `Saved`; disk bytes and replica hashes matched. |
@@ -61,8 +78,8 @@ not missing feature registration.
 | Review and commit current-session paths | Pass | Commit `540f5e02da489216a3b9bc1bd87c538b03d67c21` contains only the two session notes. |
 | Promise plus count after success | Pass | `Committed 2 session notes; unrelated changes untouched.` remained explicit. |
 | Navigator/editor switching at `40x20` | Pass | The selected note could be opened, edited, saved, and returned to Navigator. |
-| Prepare session actions at `40x20` with long root | **Fail** | Status/actions were clipped; keyboard traversal did not expose a usable staging action. |
-| Block commit when unrelated staged content exists | Pass | Review was refused; HEAD and the complete staged state were unchanged. |
+| Prepare session actions at `40x20` with long root | **Pass after remediation** | The one-line root summary preserved content height; the Prepare surface scrolled to every staging and commit action. |
+| Block commit when unrelated staged content exists | Pass | Review was refused; HEAD and the complete staged state were unchanged; the UI explained how to recover safely. |
 
 ## Git proof
 
@@ -81,7 +98,9 @@ After externally staging `unrelated.txt` and staging one changed session note,
 Chatbook refused review with:
 
 ```text
-The complete staged state does not exactly match this session.
+The complete staged state does not exactly match this session. If Git has
+unrelated staged changes, commit or unstage them outside Chatbook; then
+Refresh and review this session again.
 ```
 
 HEAD remained `540f5e02da489216a3b9bc1bd87c538b03d67c21`,
@@ -99,16 +118,30 @@ The disk and SQLite `raw_bytes` SHA-256 values matched after autosave:
 
 The corresponding raw-byte lengths were 77 and 50 bytes.
 
-## Focused automated check
+## Focused remediation checks
 
-The existing mounted source-switch regression passed before any remediation:
+After the no-bypass full-app retest, the affected mounted UI files passed:
 
 ```text
-Tests/UI/test_library_file_notes_workspace.py::test_library_database_files_switch_retains_workspace_and_database_canvas
-1 passed in 6.02s
+Tests/UI/test_library_file_notes_workspace.py
+Tests/UI/test_library_file_notes_git.py
+169 passed, 1 dependency warning in 69.38s
 ```
 
-That test proves direct widget switching, but not that both source controls are
-rendered and reachable in the full application. TASK-1411 therefore requires
-rendered-geometry and keyboard-operation coverage. No full suite or broad CI
-run was performed.
+The complete-staged-state integration regression passed:
+
+```text
+Tests/Notes/test_file_notes_git_commit_integration.py::test_complete_commit_proof_blocks_unrelated_staged_without_disclosure
+1 passed in 0.69s
+```
+
+Targeted Ruff and Python compilation passed. The Impeccable layout detector
+reported `[]` for the three changed UI modules. The rendered source-choice
+test uses real Tab/Shift+Tab/Enter input, asserts viewport containment at
+`120x40` and `160x45`, and verifies the explicit selected state in both
+directions. The compact Prepare regression uses real Tab/Enter input at
+`40x20`, verifies focus-driven scrolling in both actionable and actionless
+states, and traverses Stage, Unstage, and guarded commit entry. The exact
+linked-root state is also opened and closed entirely through keyboard input.
+
+No full suite or broad CI run was performed.

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/README.md
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/README.md
@@ -1,0 +1,114 @@
+# File Notes full-app UAT — 2026-07-30
+
+## Verdict
+
+**UX acceptance blocked; guarded commit behavior passed.**
+
+The test launched the real Chatbook Textual application in a PTY and exercised
+the Library navigation, native folder picker, process-only Git trust prompt,
+File Notes editor, autosave, session staging, commit review, commit execution,
+and unrelated-staged-content block against a disposable Git repository and
+SQLite replica.
+
+Two reachability defects prevent full UX acceptance:
+
+1. At `120x40` and `160x45`, Library > Notes rendered the source strip as
+   `Database |`; the Files choice was not visible or operable.
+2. At `40x20`, a realistic linked-root path consumed enough vertical space
+   that Prepare session for commit clipped its status and staging/commit
+   actions below the viewport. Keyboard traversal did not make a usable Stage
+   action available.
+
+The focused remediation is tracked by
+[TASK-1411](../../../../backlog/tasks/task-1411%20-%20Restore-File-Notes-entry-and-compact-terminal-Prepare-usability.md).
+Guarded push remains subsequent work; it should not be added on top of an
+unreachable commit workflow.
+
+## Build and environment
+
+- Feature source HEAD:
+  `c07fef609f9b6eec0732b8ab28ec13d086515f1d`
+- Merged by PR #1098 into `dev`:
+  `665ef1c01a48130b8da3bd80eea17054de54e976`
+- App launch: real `python -m tldw_chatbook.app` process in a tmux PTY
+- App configuration, user data, Git repository, and SQLite replica were
+  isolated under `/private/tmp/chatbook-fullapp-uat.z0StBm`
+- Git fixture:
+  `/private/tmp/chatbook-fullapp-uat.z0StBm/repo`
+- Notes root:
+  `/private/tmp/chatbook-fullapp-uat.z0StBm/repo/notes`
+- SQLite replica:
+  `/private/tmp/chatbook-fullapp-uat.z0StBm/data/uat_operator/file_notes.sqlite`
+
+The first run used the unmodified full app and exposed the missing Files
+choice. A process-local launcher then applied only a diagnostic source-strip
+layout override and selected Files at startup so the remaining workflow could
+be tested. It did not modify repository source. The override made
+`Database | Files` visible, confirming that the blocker was presentational,
+not missing feature registration.
+
+## Acceptance matrix
+
+| Scenario | Result | Evidence |
+|---|---|---|
+| Open Library > Notes and select Files at normal width | **Fail** | Only `Database |` was visible at `120x40` and `160x45`. |
+| Select root through the native picker | Pass after entry-only diagnostic bypass | The disposable `notes` folder was linked. |
+| Decline/reopen/accept process-only Git trust | Pass | Cancel remained the safe default; `Trust and check status` enabled Session Git for this process only. |
+| Edit Markdown body and autosave | Pass | Both notes reached `Saved`; disk bytes and replica hashes matched. |
+| Preserve frontmatter exactly while editing body separately | Pass | `one.md` retained its original frontmatter bytes and received only the intended body edit. |
+| Stage all current-session paths | Pass | Exactly two notes were staged; unrelated worktree content remained unstaged. |
+| Review and cancel back to the form | Pass | Subject/body and staging state were preserved. |
+| Review and commit current-session paths | Pass | Commit `540f5e02da489216a3b9bc1bd87c538b03d67c21` contains only the two session notes. |
+| Promise plus count after success | Pass | `Committed 2 session notes; unrelated changes untouched.` remained explicit. |
+| Navigator/editor switching at `40x20` | Pass | The selected note could be opened, edited, saved, and returned to Navigator. |
+| Prepare session actions at `40x20` with long root | **Fail** | Status/actions were clipped; keyboard traversal did not expose a usable staging action. |
+| Block commit when unrelated staged content exists | Pass | Review was refused; HEAD and the complete staged state were unchanged. |
+
+## Git proof
+
+Successful Chatbook commit:
+
+```text
+commit  540f5e02da489216a3b9bc1bd87c538b03d67c21
+parent  a6dac2e9bdc19b0db0c9e0a0dfc549b4b09d48a7
+subject UAT: update two session notes
+author  Chatbook UAT <chatbook-uat@example.invalid>
+files   notes/one.md
+        notes/study/two.md
+```
+
+After externally staging `unrelated.txt` and staging one changed session note,
+Chatbook refused review with:
+
+```text
+The complete staged state does not exactly match this session.
+```
+
+HEAD remained `540f5e02da489216a3b9bc1bd87c538b03d67c21`,
+and the index still contained both `notes/one.md` and `unrelated.txt`. The
+commit subject draft remained available.
+
+## Disk and replica proof
+
+The disk and SQLite `raw_bytes` SHA-256 values matched after autosave:
+
+| Path | SHA-256 |
+|---|---|
+| `notes/one.md` | `c740cfaca39684b68a49d9085a7b903cd097e66f8416c457531e7c312ed6fdad` |
+| `notes/study/two.md` | `1f7c3a6f8b2b7dbcbd1a5f6ebd4d0ea19a2abc028a38388d49c03737d9a2526f` |
+
+The corresponding raw-byte lengths were 77 and 50 bytes.
+
+## Focused automated check
+
+The existing mounted source-switch regression passed before any remediation:
+
+```text
+Tests/UI/test_library_file_notes_workspace.py::test_library_database_files_switch_retains_workspace_and_database_canvas
+1 passed in 6.02s
+```
+
+That test proves direct widget switching, but not that both source controls are
+rendered and reachable in the full application. TASK-1411 therefore requires
+rendered-geometry and keyboard-operation coverage. No full suite or broad CI
+run was performed.

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/evidence.json
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/evidence.json
@@ -1,0 +1,40 @@
+{
+  "date": "2026-07-30",
+  "verdict": "ux_acceptance_blocked_core_guarded_commit_passed",
+  "feature_source_head": "c07fef609f9b6eec0732b8ab28ec13d086515f1d",
+  "dev_merge_commit": "665ef1c01a48130b8da3bd80eea17054de54e976",
+  "method": {
+    "application": "python -m tldw_chatbook.app",
+    "terminal": "tmux PTY",
+    "headless_textual_harness": false,
+    "disposable_environment": "/private/tmp/chatbook-fullapp-uat.z0StBm",
+    "runtime_entry_probe_modified_repository": false
+  },
+  "fixture": {
+    "repository": "/private/tmp/chatbook-fullapp-uat.z0StBm/repo",
+    "notes_root": "/private/tmp/chatbook-fullapp-uat.z0StBm/repo/notes",
+    "replica": "/private/tmp/chatbook-fullapp-uat.z0StBm/data/uat_operator/file_notes.sqlite",
+    "baseline_commit": "a6dac2e9bdc19b0db0c9e0a0dfc549b4b09d48a7",
+    "successful_commit": "540f5e02da489216a3b9bc1bd87c538b03d67c21"
+  },
+  "checks": {
+    "visible_files_source_120x40": "fail",
+    "visible_files_source_160x45": "fail",
+    "native_folder_picker": "pass_after_entry_only_runtime_probe",
+    "process_only_trust": "pass_after_entry_only_runtime_probe",
+    "body_edit_and_autosave": "pass",
+    "exact_frontmatter_preservation": "pass",
+    "session_only_stage_all": "pass",
+    "commit_review_cancel_preserves_draft": "pass",
+    "guarded_commit_two_notes_only": "pass",
+    "success_count_and_promise": "pass",
+    "narrow_navigator_editor_switch": "pass",
+    "narrow_prepare_actions_reachable_40x20": "fail",
+    "unrelated_staged_content_blocks_commit": "pass"
+  },
+  "hashes": {
+    "notes/one.md": "c740cfaca39684b68a49d9085a7b903cd097e66f8416c457531e7c312ed6fdad",
+    "notes/study/two.md": "1f7c3a6f8b2b7dbcbd1a5f6ebd4d0ea19a2abc028a38388d49c03737d9a2526f"
+  },
+  "next_task": "TASK-1411"
+}

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/evidence.json
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/evidence.json
@@ -1,6 +1,6 @@
 {
   "date": "2026-07-30",
-  "verdict": "ux_acceptance_blocked_core_guarded_commit_passed",
+  "verdict": "accepted_after_task_1411_remediation",
   "feature_source_head": "c07fef609f9b6eec0732b8ab28ec13d086515f1d",
   "dev_merge_commit": "665ef1c01a48130b8da3bd80eea17054de54e976",
   "method": {
@@ -8,7 +8,8 @@
     "terminal": "tmux PTY",
     "headless_textual_harness": false,
     "disposable_environment": "/private/tmp/chatbook-fullapp-uat.z0StBm",
-    "runtime_entry_probe_modified_repository": false
+    "runtime_entry_probe_modified_repository": false,
+    "remediation_retest_used_runtime_probe": false
   },
   "fixture": {
     "repository": "/private/tmp/chatbook-fullapp-uat.z0StBm/repo",
@@ -18,8 +19,8 @@
     "successful_commit": "540f5e02da489216a3b9bc1bd87c538b03d67c21"
   },
   "checks": {
-    "visible_files_source_120x40": "fail",
-    "visible_files_source_160x45": "fail",
+    "visible_files_source_120x40": "pass_after_remediation_full_app",
+    "visible_files_source_160x45": "pass_after_remediation_mounted",
     "native_folder_picker": "pass_after_entry_only_runtime_probe",
     "process_only_trust": "pass_after_entry_only_runtime_probe",
     "body_edit_and_autosave": "pass",
@@ -29,12 +30,25 @@
     "guarded_commit_two_notes_only": "pass",
     "success_count_and_promise": "pass",
     "narrow_navigator_editor_switch": "pass",
-    "narrow_prepare_actions_reachable_40x20": "fail",
+    "narrow_prepare_actions_reachable_40x20": "pass_after_remediation_full_app",
+    "explicit_selected_source_state": "pass",
+    "compact_linked_root_one_line": "pass",
+    "keyboard_exact_root_details": "pass",
+    "actionless_prepare_keyboard_scroll": "pass",
+    "actionable_unrelated_stage_recovery": "pass",
     "unrelated_staged_content_blocks_commit": "pass"
+  },
+  "remediation_verification": {
+    "affected_ui_tests": "169 passed in 69.38s",
+    "guarded_commit_integration": "1 passed in 0.69s",
+    "targeted_ruff": "pass",
+    "changed_module_compile": "pass",
+    "layout_detector_findings": 0,
+    "full_suite_or_broad_ci_run": false
   },
   "hashes": {
     "notes/one.md": "c740cfaca39684b68a49d9085a7b903cd097e66f8416c457531e7c312ed6fdad",
     "notes/study/two.md": "1f7c3a6f8b2b7dbcbd1a5f6ebd4d0ea19a2abc028a38388d49c03737d9a2526f"
   },
-  "next_task": "TASK-1411"
+  "remediation_task": "TASK-1411"
 }

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/guarded-commit-transcript.txt
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/guarded-commit-transcript.txt
@@ -1,0 +1,25 @@
+Full-app PTY transcript excerpts
+
+Review promise:
+
+    2 session notes will be committed; unrelated changes untouched.
+
+Success:
+
+    Committed 2 session notes; unrelated changes untouched.
+
+    Committed 2 session notes as 540f5e02da48; unrelated changes untouched.
+
+Unrelated staged-content block:
+
+    The complete staged state does not exactly match this session.
+
+After the block:
+
+    HEAD: 540f5e02da489216a3b9bc1bd87c538b03d67c21
+    M  notes/one.md
+    M  unrelated.txt
+
+Result: PASS. The successful commit contained only the two session notes, and
+the later unsafe complete-index state was rejected without moving HEAD or
+altering the staged set.

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/narrow-prepare-transcript.txt
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/narrow-prepare-transcript.txt
@@ -1,0 +1,15 @@
+Full-app PTY transcript excerpt, 40x20
+
+Observed Prepare session for commit:
+
+- The linked-root value wrapped across approximately four terminal rows.
+- The current-status line was visible only through:
+
+    Status: CURRENT · READY — 1 can...
+
+- Stage and commit actions were below the visible viewport.
+- Keyboard traversal followed by activation did not stage the eligible note.
+- Resizing the same running app to 120x40 exposed the expected actions.
+
+Result: FAIL. The supported compact layout did not keep the primary workflow
+reachable with a realistic path.

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/remediation-uat-transcript.txt
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/remediation-uat-transcript.txt
@@ -1,0 +1,63 @@
+TASK-1411 REMEDIATION RETEST — 2026-07-30
+
+Method
+------
+Real `python -m tldw_chatbook.app` process in a tmux PTY.
+Current branch source loaded directly through PYTHONPATH.
+No diagnostic launcher, monkeypatch, runtime layout override, or headless
+Textual harness.
+
+120x40 — visible source entry
+--------------------------------
+Library | Local
+  Database (selected)  |  Files
+
+After selecting Files:
+
+Library | Local
+  Database  |  Files (selected)
+Linked — /private/tmp/chatbook-fullapp-uat.z0StBm/repo/notes
+
+40x20 — linked-root and Prepare reachability
+---------------------------------------------
+Library | Local
+  Database  |  Files (selected)
+Linked —...o/notes  Details    Change…
+
+Activating Details opened a read-only, keyboard-focused dialog containing:
+
+Linked — /private/tmp/chatbook-fullapp-uat.z0StBm/repo/notes
+
+After a new autosaved edit:
+
+Session Git (1)
+
+Prepare initially showed the current path and status. Scrolling the same
+surface revealed:
+
+  Unstage
+  Stage all (0)    Unstage all (1)
+  Commit staged (1)
+
+The action result reported one staged session note and retained the
+session-only safety promise.
+
+40x20 — actionless keyboard scrolling
+-------------------------------------
+With no current-session changes, Shift+Tab focused the Prepare scroll surface.
+Pressing End revealed:
+
+  Commit staged (0)
+Stage at least one session note to commit
+
+40x20 — unrelated staged recovery
+----------------------------------
+After staging `unrelated.txt` outside Chatbook and entering review:
+
+The complete staged state does not exactly match this session. If Git
+has unrelated staged changes, commit or unstage them outside Chatbook;
+then Refresh and review this session again.
+
+No commit was executed during the remediation retest. The earlier full-app
+UAT had already proven the unchanged guarded commit-success path. The
+disposable fixture was returned to an unstaged worktree-only state.

--- a/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/wide-entry-transcript.txt
+++ b/Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/wide-entry-transcript.txt
@@ -1,0 +1,16 @@
+Full-app PTY transcript excerpt, 120x40 and 160x45
+
+Library > Notes source strip:
+
+    Database |
+
+Expected second source choice:
+
+    Files
+
+Result: FAIL. File Notes was not reachable through the visible interface.
+
+With a process-local diagnostic layout override (no repository edit), the same
+strip rendered:
+
+    Database | Files

--- a/Tests/Notes/test_file_notes_git_commit_integration.py
+++ b/Tests/Notes/test_file_notes_git_commit_integration.py
@@ -1145,6 +1145,11 @@ async def test_complete_commit_proof_blocks_unrelated_staged_without_disclosure(
     assert result.state == "blocked"
     assert result.handle is None
     assert result.projection is None
+    assert result.message == (
+        "The complete staged state does not exactly match this session. "
+        "If Git has unrelated staged changes, commit or unstage them outside "
+        "Chatbook; then Refresh and review this session again."
+    )
     assert "unrelated-secret" not in repr(result)
     assert "unrelated-secret" not in repr(service._owner.snapshot(binding))
     assert "unrelated-secret" not in repr(service._commit_review_snapshots)

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -4569,6 +4569,199 @@ async def test_narrow_git_navigation_retains_editor_search_tree_and_row_selectio
 
 
 @pytest.mark.asyncio
+async def test_40x20_prepare_scrolls_actions_below_a_long_linked_root(
+    tmp_path: Path,
+) -> None:
+    nested = (
+        tmp_path
+        / "management-notes-with-a-realistically-long-root"
+        / "projects-and-study"
+    )
+    root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        nested
+    )
+    workspace.styles.height = 14
+
+    async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        root_row = workspace.query_one("#file-notes-root-row")
+        root_status = workspace.query_one("#file-notes-root-status", Static)
+        full_status = f"Linked — {root.resolve()}"
+        assert root_row.region.height == 1
+        assert root_status.region.height == 1
+        assert _text(root_status) != full_status
+        assert "..." in _text(root_status)
+        assert str(root_status.tooltip) == full_status
+        details = workspace.query_one("#file-notes-root-details", Button)
+        assert details.display
+        workspace_screen = pilot.app.screen
+        details.focus()
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: bool(
+                pilot.app.screen.query("#file-notes-root-details-text")
+            ),
+            "Keyboard root-details disclosure did not open",
+        )
+        assert (
+            pilot.app.screen.query_one(
+                "#file-notes-root-details-text",
+                TextArea,
+            ).text
+            == full_status
+        )
+        await pilot.press("escape")
+        await _wait_until(
+            pilot,
+            lambda: pilot.app.screen is workspace_screen,
+            "Root-details disclosure did not close",
+        )
+
+        entry = workspace.query_one("#file-notes-session-changes", Button)
+        entry.focus()
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: (
+                len(git_service.status_calls) == 1
+                and len(workspace._git_panel_widget.rows) == 2
+            ),
+            "Prepare session did not render current rows",
+        )
+        await _wait_for_current_git_row_projection(workspace)
+
+        panel = workspace._git_panel_widget
+        list_surface = panel.query_one(
+            "#file-notes-git-list-surface",
+            VerticalScroll,
+        )
+        assert list_surface.can_focus
+        stage_all = panel.query_one("#file-notes-git-stage-all", Button)
+        for _ in range(20):
+            if stage_all.has_focus:
+                break
+            await pilot.press("tab")
+        assert stage_all.has_focus
+        assert list_surface.content_region.contains_region(stage_all.region)
+        assert cell_len(str(stage_all.label)) <= stage_all.content_region.width
+
+        git_service.rows = (
+            _row("owned", group_id=1, unstage_eligible=True),
+            _row("owned", group_id=2, unstage_eligible=True),
+        )
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: (
+                git_service.stage_calls == [(1, 2)]
+                and len(git_service.status_calls) == 2
+            ),
+            "Keyboard activation did not stage the eligible session notes",
+        )
+
+        async def focus_action(selector: str) -> Button:
+            button = panel.query_one(selector, Button)
+            for _ in range(30):
+                if button.has_focus:
+                    break
+                await pilot.press("tab")
+            assert button.has_focus
+            assert list_surface.content_region.contains_region(button.region)
+            return button
+
+        await focus_action("#file-notes-git-unstage-selected")
+        await focus_action("#file-notes-git-unstage-all")
+        await focus_action("#file-notes-git-commit-staged")
+
+        git_service.rows = (
+            _row("unstaged", group_id=1, stage_action="stage"),
+            _row("unstaged", group_id=2, stage_action="stage"),
+        )
+        await focus_action("#file-notes-git-unstage-all")
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: (
+                git_service.unstage_calls == [(1, 2)]
+                and len(git_service.status_calls) == 3
+            ),
+            "Keyboard activation did not unstage the session notes",
+        )
+
+        git_service.rows = (
+            _row("owned", group_id=1, unstage_eligible=True),
+            _row("owned", group_id=2, unstage_eligible=True),
+        )
+        await focus_action("#file-notes-git-stage-all")
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: (
+                git_service.stage_calls == [(1, 2), (1, 2)]
+                and len(git_service.status_calls) == 4
+            ),
+            "Keyboard activation did not restage the session notes",
+        )
+
+        await focus_action("#file-notes-git-commit-staged")
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: panel.commit_phase == "form",
+            "Keyboard activation did not open the guarded commit form",
+        )
+
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_40x20_actionless_prepare_surface_is_keyboard_scrollable(
+    tmp_path: Path,
+) -> None:
+    _root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
+        tmp_path
+    )
+    git_service.rows = ()
+    workspace.styles.height = 14
+
+    async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        entry = workspace.query_one("#file-notes-session-changes", Button)
+        entry.focus()
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: (
+                len(git_service.status_calls) == 1
+                and not workspace._git_panel_widget.rows
+            ),
+            "Actionless Prepare state did not render",
+        )
+
+        panel = workspace._git_panel_widget
+        list_surface = panel.query_one(
+            "#file-notes-git-list-surface",
+            VerticalScroll,
+        )
+        assert list_surface.can_focus
+        await pilot.press("shift+tab")
+        assert list_surface.has_focus
+
+        await pilot.press("end")
+        await pilot.pause()
+        commit_zero = panel.query_one("#file-notes-git-commit-zero", Static)
+        assert list_surface.scroll_y > 0
+        assert list_surface.content_region.contains_region(commit_zero.region)
+
+    await workspace.shutdown()
+    owner.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
 async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_remount(
     tmp_path: Path,
 ) -> None:

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -1793,6 +1793,134 @@ async def test_poll_and_narrow_navigation_retain_the_text_area(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(120, 40), (160, 45)])
+async def test_library_notes_source_choices_render_and_switch_by_keyboard(
+    tmp_path: Path,
+    size: tuple[int, int],
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "library.md").write_text("library file", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "owned.sqlite",
+        poll_interval=10,
+        autosave_delay=10,
+    )
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=[{"title": "Database note", "id": "db-note-1"}],
+    )
+    screen = LibraryScreen(
+        app,
+        file_notes_workspace_factory=lambda: workspace,
+    )
+
+    async with LibraryHarness(app, screen=screen).run_test(size=size) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-strip")),
+            "Notes source strip did not compose",
+        )
+
+        strip = screen.query_one("#library-notes-source-strip")
+        separator = screen.query_one("#library-notes-source-separator")
+        database = screen.query_one("#library-notes-source-database", Button)
+        files = screen.query_one("#library-notes-source-files", Button)
+        await _wait_until(
+            pilot,
+            lambda: (
+                separator.region.width == 1
+                and database.region.width > 0
+                and files.region.width > 0
+            ),
+            "Notes source choices did not receive visible geometry",
+        )
+        assert strip.content_region.contains_region(database.region)
+        assert strip.content_region.contains_region(separator.region)
+        assert strip.content_region.contains_region(files.region)
+        assert separator.region.width == 1
+        assert str(database.label) == "Database (selected)"
+        assert database.has_class("-selected")
+        assert not database.disabled
+        assert database.can_focus
+        assert str(files.label) == "Files"
+        assert not files.disabled
+        assert files.can_focus
+
+        for _ in range(60):
+            if database.has_focus:
+                break
+            await pilot.press("tab")
+        assert database.has_focus
+        assert strip.content_region.contains_region(database.region)
+        await pilot.press("tab")
+        await _wait_until(
+            pilot,
+            lambda: files.has_focus,
+            "Tab did not move from Database to the visible Files source",
+        )
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: (
+                screen._library_notes_source == "files"
+                and workspace.initialized
+                and bool(screen.query("#library-file-notes-workspace"))
+            ),
+            "Files source did not open from the keyboard",
+        )
+
+        strip = screen.query_one("#library-notes-source-strip")
+        database = screen.query_one("#library-notes-source-database", Button)
+        files = screen.query_one("#library-notes-source-files", Button)
+        assert strip.content_region.contains_region(database.region)
+        assert strip.content_region.contains_region(files.region)
+        assert str(database.label) == "Database"
+        assert not database.disabled
+        assert str(files.label) == "Files (selected)"
+        assert files.has_class("-selected")
+        assert not files.disabled
+
+        for _ in range(60):
+            if files.has_focus:
+                break
+            await pilot.press("tab")
+        assert files.has_focus
+        assert strip.content_region.contains_region(files.region)
+        await pilot.press("shift+tab")
+        await _wait_until(
+            pilot,
+            lambda: database.has_focus,
+            "Shift+Tab did not move from Files to the visible Database source",
+        )
+        await pilot.press("enter")
+        await _wait_until(
+            pilot,
+            lambda: (
+                screen._library_notes_source == "database"
+                and bool(screen.query("#library-notes-canvas"))
+            ),
+            "Database source did not reopen from the keyboard",
+        )
+        assert (
+            str(
+                screen.query_one(
+                    "#library-notes-source-database",
+                    Button,
+                ).label
+            )
+            == "Database (selected)"
+        )
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_library_database_files_switch_retains_workspace_and_database_canvas(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/backlog/tasks/task-1350 - Add-guarded-session-commit-to-File-Notes.md
+++ b/backlog/tasks/task-1350 - Add-guarded-session-commit-to-File-Notes.md
@@ -105,4 +105,18 @@ draft/editor leases, and the panel remains presentation-only.
   duplicate every injected edge case. Newer-edit blocking, uncertainty,
   `Check again`, and exact convergence are covered by the focused automated
   boundary.
+
+Post-merge full-app UAT correction (2026-07-30):
+
+- The earlier `/tmp/task1350-live-uat.O2BJB7` run was a mounted Textual
+  `WorkspaceHarness`, not a launch and traversal of the complete Chatbook
+  application. Its Git, SQLite, autosave, staging, review, commit, and safety
+  evidence remains valid automated end-to-end coverage.
+- A subsequent real `python -m tldw_chatbook.app` PTY walkthrough proved the
+  guarded two-note commit and unrelated-staged-content block, but found that
+  the Files source choice is not rendered at normal widths and Prepare actions
+  are unreachable at `40x20` with a realistic linked-root path. Full UX
+  acceptance is therefore blocked pending TASK-1411.
+- Durable evidence:
+  `Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/README.md`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1411 - Restore-File-Notes-entry-and-compact-terminal-Prepare-usability.md
+++ b/backlog/tasks/task-1411 - Restore-File-Notes-entry-and-compact-terminal-Prepare-usability.md
@@ -1,0 +1,53 @@
+---
+id: TASK-1411
+title: Restore File Notes entry and compact-terminal Prepare usability
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-07-30 16:06'
+updated_date: '2026-07-30 16:14'
+labels:
+  - notes
+  - git
+  - library
+  - ux
+  - accessibility
+dependencies:
+  - TASK-1350
+references:
+  - Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/README.md
+  - >-
+    .impeccable/critique/2026-07-30T16-13-58Z__tldw-chatbook-ui-screens-library-screen-py.md
+documentation:
+  - backlog/decisions/038-file-notes-guarded-session-commit.md
+  - backlog/decisions/035-file-notes-session-git-index-controls.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Full-app acceptance testing found that File Notes cannot be reached through the visible Library Notes source switch at normal terminal widths and that Prepare session for commit hides essential status and actions at 40x20 when the linked-root path is realistically long. Restore a discoverable path into File Notes and make the existing guarded staging/commit workflow operable at the supported compact viewport without weakening its session-only Git safety promises.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Library > Notes visibly exposes both Database and Files as focusable, keyboard-operable source choices at 120x40 and 160x45, and selecting Files reaches the retained File Notes workspace.
+- [ ] #2 At 40x20 with a realistic long linked-root and repository path, Prepare session for commit keeps current status and every required staging/commit action reachable through a visible or keyboard-scrollable layout without clipping labels or depending on pointer input.
+- [ ] #3 Wide and compact layouts preserve the existing count-and-promise copy, editor/Navigator switching, focus return, and unrelated-change safety behavior defined by ADR-035 and ADR-038.
+- [ ] #4 A real full-app disposable-repository walkthrough covers source selection, root selection, process-only trust, body editing with exact frontmatter preservation, autosave, session-only staging, review, commit success, and unrelated-staged blocking.
+- [ ] #5 Focused mounted regressions assert rendered reachability and keyboard operation at 160x45, 120x40, and 40x20 rather than relying only on direct widget method calls; targeted lint and diff checks pass.
+<!-- AC:END -->
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A; conform to
+`backlog/decisions/035-file-notes-session-git-index-controls.md` and
+`backlog/decisions/038-file-notes-guarded-session-commit.md`.
+
+Reason: this task repairs presentation and keyboard reachability within the
+existing File Notes ownership, staging, and guarded-commit contracts. It does
+not change storage, schema, sync policy, Git authority, service boundaries,
+security policy, dependencies, or long-lived application structure.

--- a/backlog/tasks/task-1411 - Restore-File-Notes-entry-and-compact-terminal-Prepare-usability.md
+++ b/backlog/tasks/task-1411 - Restore-File-Notes-entry-and-compact-terminal-Prepare-usability.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-1411
 title: Restore File Notes entry and compact-terminal Prepare usability
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 16:06'
-updated_date: '2026-07-30 16:14'
+updated_date: '2026-07-30 17:03'
 labels:
   - notes
   - git
@@ -32,22 +32,37 @@ Full-app acceptance testing found that File Notes cannot be reached through the 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Library > Notes visibly exposes both Database and Files as focusable, keyboard-operable source choices at 120x40 and 160x45, and selecting Files reaches the retained File Notes workspace.
-- [ ] #2 At 40x20 with a realistic long linked-root and repository path, Prepare session for commit keeps current status and every required staging/commit action reachable through a visible or keyboard-scrollable layout without clipping labels or depending on pointer input.
-- [ ] #3 Wide and compact layouts preserve the existing count-and-promise copy, editor/Navigator switching, focus return, and unrelated-change safety behavior defined by ADR-035 and ADR-038.
-- [ ] #4 A real full-app disposable-repository walkthrough covers source selection, root selection, process-only trust, body editing with exact frontmatter preservation, autosave, session-only staging, review, commit success, and unrelated-staged blocking.
-- [ ] #5 Focused mounted regressions assert rendered reachability and keyboard operation at 160x45, 120x40, and 40x20 rather than relying only on direct widget method calls; targeted lint and diff checks pass.
+- [x] #1 Library > Notes visibly exposes both Database and Files as focusable, keyboard-operable source choices at 120x40 and 160x45, and selecting Files reaches the retained File Notes workspace.
+- [x] #2 At 40x20 with a realistic long linked-root and repository path, Prepare session for commit keeps current status and every required staging/commit action reachable through a visible or keyboard-scrollable layout without clipping labels or depending on pointer input.
+- [x] #3 Wide and compact layouts preserve the existing count-and-promise copy, editor/Navigator switching, focus return, and unrelated-change safety behavior defined by ADR-035 and ADR-038.
+- [x] #4 A real full-app disposable-repository walkthrough covers source selection, root selection, process-only trust, body editing with exact frontmatter preservation, autosave, session-only staging, review, commit success, and unrelated-staged blocking.
+- [x] #5 Focused mounted regressions assert rendered reachability and keyboard operation at 160x45, 120x40, and 40x20 rather than relying only on direct widget method calls; targeted lint and diff checks pass.
+- [x] #6 Database and Files retain an explicit visible selected-source state instead of relying only on a disabled control, and keyboard focus is never moved to an off-viewport source choice.
+- [x] #7 The complete-staged-state mismatch keeps its exact fail-closed safety statement and adds a concise, accurate recovery instruction to commit or unstage unrelated staged changes, refresh, and review the session again.
+- [x] #8 Keyboard users can open the exact unelided linked-root and runtime-warning text, and can scroll actionless Prepare states to their complete status and guidance at 40x20.
 <!-- AC:END -->
 
-## ADR Check
+## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 ADR required: no
+ADR path: N/A; conform to backlog/decisions/035-file-notes-session-git-index-controls.md and backlog/decisions/038-file-notes-guarded-session-commit.md.
+Reason: this is a presentation, keyboard-reachability, and recovery-copy repair within the existing File Notes ownership and guarded-commit contracts.
 
-ADR path: N/A; conform to
-`backlog/decisions/035-file-notes-session-git-index-controls.md` and
-`backlog/decisions/038-file-notes-guarded-session-commit.md`.
+1. Add failing mounted Textual regressions for visible source choices and selected state at normal widths, compact linked-root behavior, keyboard-scrollable Prepare actions, and actionable unrelated-staging recovery copy.
+2. Give the source separator bounded geometry and preserve a visible selected-source marker.
+3. Bound the compact linked-root summary, expose the exact detail in a keyboard-operated read-only dialog, and make actionable and actionless Prepare states vertically keyboard-scrollable.
+4. Add the concise safe recovery instruction to the existing complete-staged-state refusal without weakening its exact-match block.
+5. Run only focused affected tests, targeted static checks, the layout detector, and a real full-app wide/40x20 UAT; then self-review and record the result.
+<!-- SECTION:PLAN:END -->
 
-Reason: this task repairs presentation and keyboard reachability within the
-existing File Notes ownership, staging, and guarded-commit contracts. It does
-not change storage, schema, sync policy, Git authority, service boundaries,
-security policy, dependencies, or long-lived application structure.
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Bounded the Library Notes source separator, kept both choices enabled, and added explicit selected-source labels so Database and Files stay visible and keyboard-operable.
+- Kept the linked-root summary to one row, added a visible keyboard-operated Details dialog for the exact root/runtime warning, and made Prepare a keyboard-scrollable surface in both actionable and actionless states.
+- Preserved the fail-closed complete-stage proof while adding accurate recovery steps for unrelated staged content.
+- Added rendered geometry and real-key regressions at 160x45, 120x40, and 40x20. The affected UI files passed 169 tests; the exact guarded-commit integration regression, targeted Ruff, compilation, diff/JSON checks, and layout detector passed.
+- Repeated the real full-app PTY walkthrough with no runtime bypass and recorded the accepted remediation evidence under `Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/`.
+- ADR required: no. The implementation conforms to ADR-035 and ADR-038 without changing storage, synchronization, or Git authority.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Notes/file_notes_git_service.py
+++ b/tldw_chatbook/Notes/file_notes_git_service.py
@@ -3582,7 +3582,9 @@ class FileNotesGitService:
         )
         if proof is None:
             return _blocked_commit_review(
-                "The complete staged state does not exactly match this session."
+                "The complete staged state does not exactly match this session. "
+                "If Git has unrelated staged changes, commit or unstage them "
+                "outside Chatbook; then Refresh and review this session again."
             )
         identities = await self._resolve_commit_identities(repository)
         if identities is None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1036,6 +1036,19 @@ class LibraryScreen(BaseAppScreen):
         border: none;
         background: transparent;
     }
+
+    #library-notes-source-strip Button.-selected {
+        text-style: bold;
+    }
+
+    #library-notes-source-separator {
+        width: 1;
+        min-width: 1;
+        max-width: 1;
+        height: 1;
+        min-height: 1;
+        content-align: center middle;
+    }
     """
 
     def __init__(
@@ -3761,20 +3774,30 @@ class LibraryScreen(BaseAppScreen):
         )
         if shell.canvas_kind == "notes":
             with Horizontal(id="library-notes-source-strip"):
+                database_selected = self._library_notes_source == "database"
                 database_source = Button(
-                    "Database",
+                    (
+                        "Database (selected)"
+                        if database_selected
+                        else "Database"
+                    ),
                     id="library-notes-source-database",
                     compact=True,
                 )
-                database_source.disabled = self._library_notes_source == "database"
+                database_source.set_class(database_selected, "-selected")
                 yield database_source
-                yield Static("|", markup=False)
+                yield Static(
+                    "|",
+                    id="library-notes-source-separator",
+                    markup=False,
+                )
+                files_selected = self._library_notes_source == "files"
                 files_source = Button(
-                    "Files",
+                    "Files (selected)" if files_selected else "Files",
                     id="library-notes-source-files",
                     compact=True,
                 )
-                files_source.disabled = self._library_notes_source == "files"
+                files_source.set_class(files_selected, "-selected")
                 yield files_source
             if self._library_notes_source == "files":
                 workspace = self._library_file_notes_workspace

--- a/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_git_panel.py
@@ -472,7 +472,7 @@ class _CommitIncludedNoteListItem(ListItem):
 
 
 class _CommitWorkflowScroll(VerticalScroll):
-    """Keyboard-scrollable focus target for actionless workflow states."""
+    """Keyboard-scrollable focus target for constrained workflow states."""
 
     can_focus = True
 
@@ -891,7 +891,7 @@ class LibraryFileNotesGitPanel(Vertical):
         return self._commit_phase
 
     def compose(self) -> ComposeResult:
-        with Vertical(id="file-notes-git-list-surface"):
+        with VerticalScroll(id="file-notes-git-list-surface"):
             with Horizontal(id="file-notes-git-header"):
                 yield Button(
                     "Back to navigator",

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -16,7 +16,9 @@ from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.events import Resize
+from textual.screen import ModalScreen
 from textual.timer import Timer
 from textual.worker import Worker
 from textual.widgets import Button, Input, ListView, Static, TextArea, Tree
@@ -68,6 +70,7 @@ from tldw_chatbook.Widgets.Library.library_file_notes_git_panel import (
     CommitReviewNoteProjection,
     LibraryFileNotesGitPanel,
     SessionGitTrustDialog,
+    _middle_elide_cells,
 )
 
 SaveState = Literal["idle", "dirty", "saving", "saved", "conflict", "error"]
@@ -200,6 +203,76 @@ class _SessionGitService(Protocol):
     ) -> asyncio.Task[CommitOutcome]: ...
 
 
+class FileNotesRootDetailsDialog(ModalScreen[None]):
+    """Show the exact linked-root state through a keyboard-readable surface."""
+
+    BINDINGS = [("escape", "dismiss", "Close")]
+
+    DEFAULT_CSS = """
+    FileNotesRootDetailsDialog {
+        align: center middle;
+    }
+
+    #file-notes-root-details-dialog {
+        width: 76;
+        max-width: 95%;
+        height: 12;
+        max-height: 85%;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #file-notes-root-details-title {
+        height: 1;
+        text-style: bold;
+    }
+
+    #file-notes-root-details-text {
+        height: 1fr;
+        min-height: 3;
+    }
+
+    #file-notes-root-details-close {
+        width: auto;
+        height: 1;
+        min-height: 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(id="file-notes-root-details-dialog-screen")
+        self._detail = detail
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="file-notes-root-details-dialog"):
+            yield Static(
+                "File Notes folder details",
+                id="file-notes-root-details-title",
+                markup=False,
+            )
+            yield TextArea(
+                self._detail,
+                id="file-notes-root-details-text",
+                read_only=True,
+                soft_wrap=True,
+            )
+            yield Button(
+                "Close",
+                id="file-notes-root-details-close",
+                compact=True,
+            )
+
+    def on_mount(self) -> None:
+        self.query_one("#file-notes-root-details-text", TextArea).focus()
+
+    @on(Button.Pressed, "#file-notes-root-details-close")
+    def _close(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+
 class LibraryFileNotesWorkspace(Vertical):
     """Browse and edit one disk-authoritative Markdown/text root."""
 
@@ -211,16 +284,22 @@ class LibraryFileNotesWorkspace(Vertical):
     }
 
     #file-notes-root-row {
-        height: auto;
+        height: 1;
         min-height: 1;
+        max-height: 1;
     }
 
     #file-notes-root-status {
         width: 1fr;
-        height: auto;
+        height: 1;
+        min-height: 1;
+        max-height: 1;
         color: $text-muted;
+        text-wrap: nowrap;
+        overflow: hidden hidden;
     }
 
+    #file-notes-root-details,
     #file-notes-choose-root {
         width: auto;
         min-width: 0;
@@ -229,6 +308,10 @@ class LibraryFileNotesWorkspace(Vertical):
         padding: 0 1;
         border: none;
         background: transparent;
+    }
+
+    #file-notes-root-details {
+        display: none;
     }
 
     #file-notes-body {
@@ -381,6 +464,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._session_binding: SessionBinding | None = None
         self._service: FileNotesService | None = None
         self._runtime_warning = ""
+        self._root_status_detail = "Choose a notes folder."
 
         self._poll_interval = max(0.02, poll_interval)
         self._autosave_delay = max(0.01, autosave_delay)
@@ -556,6 +640,11 @@ class LibraryFileNotesWorkspace(Vertical):
                 markup=False,
             )
             yield Button(
+                "Details",
+                id="file-notes-root-details",
+                compact=True,
+            )
+            yield Button(
                 "Choose folder…",
                 id="file-notes-choose-root",
                 compact=True,
@@ -715,6 +804,7 @@ class LibraryFileNotesWorkspace(Vertical):
     def on_resize(self, event: Resize) -> None:
         """Choose wide or narrow panes from the mounted workspace width."""
         self._apply_responsive_layout(event.size.width)
+        self.call_after_refresh(self._fit_root_status)
 
     async def _initialize(self) -> None:
         generation = self._root_generation
@@ -1021,9 +1111,13 @@ class LibraryFileNotesWorkspace(Vertical):
     def _update_root_surface(self, *, offline: bool | None = None) -> None:
         if not self._active or not self.is_mounted or not self.children:
             return
-        status = self.query_one("#file-notes-root-status", Static)
-        body = self.query_one("#file-notes-body")
-        choose = self.query_one("#file-notes-choose-root", Button)
+        try:
+            status = self.query_one("#file-notes-root-status", Static)
+            body = self.query_one("#file-notes-body")
+            details = self.query_one("#file-notes-root-details", Button)
+            choose = self.query_one("#file-notes-choose-root", Button)
+        except NoMatches:
+            return
         binding = self._session_binding
         mutation_active = (
             binding is not None
@@ -1035,8 +1129,12 @@ class LibraryFileNotesWorkspace(Vertical):
             or mutation_active
         )
         if self._root is None:
-            status.update("Choose a notes folder.")
+            self._root_status_detail = "Choose a notes folder."
+            status.tooltip = None
+            status.update(self._root_status_detail)
             body.display = False
+            details.display = False
+            choose.label = "Choose folder…"
             choose.display = True
             return
         is_offline = self._root_offline if offline is None else offline
@@ -1048,10 +1146,27 @@ class LibraryFileNotesWorkspace(Vertical):
         detail = f"{state} — {self._root}"
         if self._runtime_warning:
             detail = f"{detail} · {self._runtime_warning}"
+        self._root_status_detail = detail
+        status.tooltip = Text(detail)
         status.update(detail)
         body.display = True
+        details.display = True
+        choose.label = "Change…"
         choose.display = True
         self._apply_responsive_layout(self.size.width)
+        self.call_after_refresh(self._fit_root_status)
+
+    def _fit_root_status(self) -> None:
+        """Keep the linked-root summary to one row and retain exact detail."""
+        if not self._active or not self.is_mounted or not self.children:
+            return
+        try:
+            status = self.query_one("#file-notes-root-status", Static)
+        except NoMatches:
+            return
+        width = status.content_region.width
+        if width > 0:
+            status.update(_middle_elide_cells(self._root_status_detail, width))
 
     def _apply_responsive_layout(self, width: int) -> None:
         if not self._active or not self.is_mounted:
@@ -2715,6 +2830,12 @@ class LibraryFileNotesWorkspace(Vertical):
             SelectDirectory(location, title="Choose File Notes Folder"),
             callback=self._root_selected,
         )
+
+    @on(Button.Pressed, "#file-notes-root-details")
+    def _show_root_details(self, event: Button.Pressed) -> None:
+        """Open the exact root state without depending on pointer hover."""
+        event.stop()
+        self.app.push_screen(FileNotesRootDetailsDialog(self._root_status_detail))
 
     def _root_selected(self, path: Path | None) -> None:
         if path is None or not self._active:

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -242,10 +242,20 @@ class FileNotesRootDetailsDialog(ModalScreen[None]):
     """
 
     def __init__(self, detail: str) -> None:
+        """Initialize the dialog with the exact linked-root detail.
+
+        Args:
+            detail: Full linked-root path or warning text to display.
+        """
         super().__init__(id="file-notes-root-details-dialog-screen")
         self._detail = detail
 
     def compose(self) -> ComposeResult:
+        """Compose the read-only detail surface and close control.
+
+        Returns:
+            The widgets that make up the dialog.
+        """
         with Vertical(id="file-notes-root-details-dialog"):
             yield Static(
                 "File Notes folder details",
@@ -265,6 +275,7 @@ class FileNotesRootDetailsDialog(ModalScreen[None]):
             )
 
     def on_mount(self) -> None:
+        """Focus the detail text when the dialog opens."""
         self.query_one("#file-notes-root-details-text", TextArea).focus()
 
     @on(Button.Pressed, "#file-notes-root-details-close")


### PR DESCRIPTION
## Summary

- restore visible, focusable Database and Files source choices at supported terminal widths with an explicit selected state
- keep the linked-root row compact while exposing exact details to keyboard users, and make actionable and actionless Prepare states keyboard-scrollable at 40x20
- preserve guarded Git behavior while adding accurate unrelated-stage recovery guidance and durable full-app UAT evidence

## Verification

- affected File Notes UI files: 169 passed, 1 existing dependency warning
- post-rebase acceptance subset: 5 passed, 1 existing dependency warning
- exact guarded-commit integration regression: passed
- targeted Ruff, compilation, diff/JSON checks, and Impeccable layout detector: passed
- real Chatbook PTY walkthrough at 120x40 and 40x20 with no runtime bypass: accepted
- two independent focused reviewers approved all remediated findings

No full suite or broad CI run was performed.

## Architecture

ADR required: no. This conforms to ADR-035 and ADR-038 without changing storage, synchronization, or Git authority.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores visible File Notes entry at normal widths and makes Prepare usable at 40x20 with keyboard-scrollable actions and an explicit selected source. Satisfies TASK-1411 and preserves guarded commit safety with clear recovery guidance.

- **Bug Fixes**
  - Show both Database and Files with a fixed-width `|` separator; keep both focusable and label the active one as “(selected)” for clear keyboard switching at 120x40 and 160x45.
  - Compact layout: clamp the linked-root summary to one line with middle elision and tooltip; add a keyboard “Details” dialog for the exact path and warnings.
  - Make Prepare vertically keyboard-scrollable so status and Stage/Unstage/Commit are reachable at 40x20, including actionless states.
  - Keep existing guarded commit behavior; add a concise recovery tip when unrelated staged changes block review.
  - Add focused UI regressions and an integration assertion; record a full-app PTY UAT run and document the root “Details” dialog under `Docs/superpowers/qa/file-notes-full-app-uat-2026-07-30/`.

<sup>Written for commit 8e5d80e5f2c441159d309e2d3dc51d5ea173eddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

