### PR TITLE
task-1468: per-test gc restored for app-mounting test dirs (fixes rotating-victim flaps from task-1454)

### DIFF
--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -267,6 +267,25 @@ def _env_int(name: str, default: int) -> int:
 _GC_EVERY = max(1, _env_int("TLDW_TEST_GC_EVERY", 25))
 _gc_test_counter = 0
 
+# Directories whose tests mount Textual apps (run_test() call-site census from
+# the 2026-07-30 audit). A Textual App is a reference CYCLE that only
+# gc.collect() reclaims, and an uncollected app from the previous test
+# interferes with the next app-mounting test — with periodic-only collection
+# the victim rotates with heap state (task-1468: a 10-test batch failed a
+# DIFFERENT UI test on consecutive runs, and passed 10/10 with
+# TLDW_TEST_GC_EVERY=1). These dirs keep per-test collection; everything else
+# stays periodic, which is where the task-1454 win lives.
+_APP_MOUNTING_DIR_PARTS = (
+    f"{os.sep}Tests{os.sep}UI{os.sep}",
+    f"{os.sep}Tests{os.sep}Widgets{os.sep}",
+    f"{os.sep}Tests{os.sep}Watchlists{os.sep}",
+    f"{os.sep}Tests{os.sep}Skills{os.sep}",
+    f"{os.sep}Tests{os.sep}Library{os.sep}",
+    f"{os.sep}Tests{os.sep}Event_Handlers{os.sep}",
+    f"{os.sep}Tests{os.sep}integration{os.sep}",
+    f"{os.sep}Tests{os.sep}Chat{os.sep}",
+)
+
 
 @pytest.fixture(autouse=True)
 def cleanup_file_descriptors(request: pytest.FixtureRequest) -> Iterator[None]:
@@ -274,10 +293,13 @@ def cleanup_file_descriptors(request: pytest.FixtureRequest) -> Iterator[None]:
 
     Tests that genuinely need a collection pass right after they run (e.g. they
     open many files and assert on fd state) mark themselves
-    ``@pytest.mark.requires_cleanup``.
+    ``@pytest.mark.requires_cleanup``. Tests in app-mounting directories
+    (``_APP_MOUNTING_DIR_PARTS``) always collect, so a torn-down Textual app's
+    reference cycle never lingers into the next app's lifetime.
 
     Args:
-        request: The pytest fixture request, used to read the test's markers.
+        request: The pytest fixture request, used to read the test's markers
+            and path.
 
     Yields:
         None. Collection (if due) happens in teardown, after the test body.
@@ -286,8 +308,10 @@ def cleanup_file_descriptors(request: pytest.FixtureRequest) -> Iterator[None]:
 
     global _gc_test_counter
     _gc_test_counter += 1
+    _node_path = str(getattr(request.node, "path", "") or "")
     if (
         request.node.get_closest_marker("requires_cleanup")
+        or any(part in _node_path for part in _APP_MOUNTING_DIR_PARTS)
         or _gc_test_counter % _GC_EVERY == 0
     ):
         # Suppress ResourceWarnings emitted for unclosed files reclaimed here.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -454,6 +454,30 @@ nesting is invisible in the source-file mental model.
 
 ---
 
+## Removing a per-test gc.collect() can unmask cross-test coupling — with a rotating victim
+
+**TASK-1468, 2026-07-30.** task-1454 replaced the double `gc.collect()` after every
+test with a periodic collect (every 25). A 10-test batch then started failing ONE
+UI test — a *different* one on consecutive identical runs (first the Skills trust
+panel test, then a Library git-notes test). Alone, each test passed. With
+`TLDW_TEST_GC_EVERY=1` the batch passed 10/10; on pre-change dev it passed 10/10.
+
+The mechanism: a Textual `App` is a reference cycle that refcounting never frees —
+only the cycle collector does. Per-test collection had been silently guaranteeing
+each app-mounting test a garbage-free predecessor; without it, the previous app's
+remains (timers, context vars, screen state) linger into the next app's lifetime,
+and which test breaks depends on heap state at the time. A rotating victim is the
+tell that you are looking at ambient-state interference, not a broken test.
+
+**What to do.** When narrowing global per-test cleanup, ask what CLASS of object it
+was silently reclaiming, and scope the cleanup to the tests that produce that class
+(here: per-test collection in app-mounting dirs, periodic elsewhere) rather than
+tuning frequency — no interval above 1 protects adjacent producers. And triage any
+"deterministic" batch failure by rerunning the identical batch twice before
+believing determinism: the rotating victim only shows on the second run.
+
+---
+
 ## Related
 
 - `lessons-live-verification.md` — why the suite could not see seven of these defects

--- a/backlog/tasks/task-1468 - Per-test-gc-for-app-mounting-test-dirs-periodic-gc-exposed-app-cycle-interference.md
+++ b/backlog/tasks/task-1468 - Per-test-gc-for-app-mounting-test-dirs-periodic-gc-exposed-app-cycle-interference.md
@@ -1,0 +1,39 @@
+---
+id: TASK-1468
+title: >-
+  Restore per-test gc for app-mounting test dirs — periodic-only gc exposed Textual app-cycle interference between adjacent tests
+status: Done
+assignee: []
+created_date: '2026-07-30 12:55'
+labels:
+  - testing
+  - bug
+priority: high
+dependencies: [task-1454]
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+task-1454's periodic gc (every 25 tests) surfaced a latent coupling the old per-test double-collect had been masking: a Textual `App` is a reference cycle that only `gc.collect()` reclaims, and an uncollected app from the previous test interferes with the next app-mounting test. Post-merge evidence: a 10-test batch (TestChatApiCall + one Skills UI test + two Library git UI tests) failed a **different** UI test on consecutive runs — the victim rotates with heap state — passed 10/10 with `TLDW_TEST_GC_EVERY=1`, and passed 10/10 on pre-task-1454 dev. Interval tuning cannot fix adjacency (any interval >1 leaves neighboring app tests unprotected), so per-test collection is restored for exactly the directories the audit's `run_test()` census shows mount apps; everything else keeps periodic collection, which is where task-1454's measured win (Tests/Notes 131.9s→111.7s) lives.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [x] The rotating-victim batch passes repeatedly (3×) under default settings
+- [x] Tests in app-mounting dirs (UI, Widgets, Watchlists, Skills, Library, Event_Handlers, integration, Chat) collect per test; other dirs remain periodic
+- [x] Non-app dirs keep the task-1454 speedup (no behavior change for them)
+
+## Implementation Plan
+
+1. Confirm the mechanism: batch A/B with `TLDW_TEST_GC_EVERY=1` vs default, and against pre-task-1454 dev
+2. Add an app-dir path predicate to `cleanup_file_descriptors` alongside the marker and counter
+3. Verify the batch 3× and record the lesson
+
+## Implementation Notes
+
+`_APP_MOUNTING_DIR_PARTS` (from the audit's run_test call-site census) added as a
+third trigger in `cleanup_file_descriptors`. The old behavior was TWO collects per
+test everywhere; the new steady state is ONE collect per test in ~8 app dirs and
+one per 25 tests elsewhere. Lesson recorded in lessons-testing-evidence.md.
+Modified: `Tests/conftest.py`.


### PR DESCRIPTION
## Summary
Post-merge verification of the test-suite quick wins caught a regression class introduced by #1107 (task-1454): with periodic-only gc, an uncollected Textual app (a reference cycle refcounting never frees) lingers into the next app-mounting test and interferes — a 10-test batch failed a **different** UI test on consecutive identical runs (rotating victim), passed 10/10 with `TLDW_TEST_GC_EVERY=1`, and passed 10/10 on pre-#1107 dev. No collection interval above 1 protects adjacent app tests, so this restores per-test collection for exactly the directories the audit's `run_test()` census shows mount apps (UI, Widgets, Watchlists, Skills, Library, Event_Handlers, integration, Chat); all other directories keep periodic collection — which is where #1107's measured win (Tests/Notes 131.9s→111.7s) lives. Net steady state vs old dev is still a large reduction: one collect per test in ~8 dirs and one per 25 tests elsewhere, versus two collects per test everywhere.

## Verification
- The rotating-victim batch: 3× 10-passed under default settings (was: 1 failure per run, different test each time)
- Mechanism triple-confirmed: fails on merged dev default / passes with `GC_EVERY=1` / passes on pre-#1107 dev
- Lesson recorded with the incident in `backlog/docs/lessons-testing-evidence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-test GC for tests that mount `Textual` apps to stop cross-test interference exposed by task-1454’s periodic-only GC. Fixes rotating-victim UI flakiness while keeping the suite-wide speedup elsewhere. Addresses task-1468.

- **Bug Fixes**
  - Force gc after each test in app-mounting dirs: UI, Widgets, Watchlists, Skills, Library, Event_Handlers, integration, Chat (via `_APP_MOUNTING_DIR_PARTS` in `Tests/conftest.py`).
  - Keep periodic collection elsewhere (every `TLDW_TEST_GC_EVERY` tests; default 25) to preserve task-1454’s performance gains.
  - Verified the previously flaky 10-test batch passes 3×; added a short lesson to `backlog/docs/lessons-testing-evidence.md`.

<sup>Written for commit 2fc4798405b43c9c3c10bedd9d7a2965a48c5ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

