### PR TITLE
fix(roleplay): macro substitution, greeting delivery, and tmux avatar rendering (tasks 1530-1532)

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1340,10 +1340,12 @@ async def test_regenerate_continuation_message_ends_provider_payload_with_user_i
 
 
 @pytest.mark.asyncio
-async def test_leading_greeting_excluded_from_provider_payload():
+async def test_leading_greeting_folds_into_system_row_not_message_array():
     """A seeded character greeting (persisted ASSISTANT message before any
-    user turn) must never reach the provider payload -- strict providers
-    (Anthropic, Gemini) reject an assistant-first message array (task-427)."""
+    user turn) must reach the provider inside the SYSTEM row, never as an
+    assistant-first message -- strict providers (Anthropic, Gemini) reject an
+    assistant-first message array (task-427), but dropping the greeting
+    entirely made the model contradict the transcript (task-1531)."""
     store = ConsoleChatStore()
     gateway = RecordingStreamingGateway()
     controller = ConsoleChatController(store=store, provider_gateway=gateway)
@@ -1359,11 +1361,44 @@ async def test_leading_greeting_excluded_from_provider_payload():
 
     assert result.accepted is True
     sent = gateway.messages_seen
-    roles = [m["role"] for m in sent]
-    # No leading assistant: the first role sent is the user's turn.
-    assert roles[0] == "user"
-    # The greeting text is not in the outbound payload at all.
-    assert all("Greetings, traveler." not in (m.get("content") or "") for m in sent)
+    # The greeting arrives via a system row even without a session prompt.
+    assert sent[0]["role"] == "system"
+    assert "Greetings, traveler." in sent[0]["content"]
+    # The message array itself stays user-first with no assistant greeting.
+    rest = sent[1:]
+    assert rest[0]["role"] == "user"
+    assert all(
+        "Greetings, traveler." not in (m.get("content") or "") for m in rest
+    )
+
+
+@pytest.mark.asyncio
+async def test_leading_greeting_appends_to_existing_system_prompt():
+    """The greeting fold appends to a configured system prompt; the prompt
+    itself stays verbatim at the start of the system row."""
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        system_prompt="Stay in character.",
+    )
+    session = store.create_session(title="Chat with Elara")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Greetings, traveler.",
+        persist=False,
+    )
+
+    result = await controller.submit_draft("Hi")
+
+    assert result.accepted is True
+    sent = gateway.messages_seen
+    assert sent[0]["role"] == "system"
+    assert sent[0]["content"].startswith("Stay in character.")
+    assert "Greetings, traveler." in sent[0]["content"]
+    assert [m["role"] for m in sent[1:]] == ["user"]
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2612,3 +2612,63 @@ async def test_tools_run_real_answer_equal_to_fallback_copy_survives() -> None:
     items = await _collect(gateway, resolution, tools=TOOLS)
 
     assert items == [NO_PROVIDER_CONTENT_COPY]  # it IS the model's answer here
+
+
+# ---- system-row extraction (PR #1112 Qodo finding 3) ----
+
+
+def _bare_resolution() -> ConsoleProviderResolution:
+    """Minimal ready resolution for direct `_chat_api_kwargs` calls."""
+    return ConsoleProviderResolution(
+        provider="anthropic",
+        base_url="",
+        model="claude-x",
+        ready=True,
+        execution_key="anthropic",
+        api_key="k",
+        streaming=False,
+    )
+
+
+def test_chat_api_kwargs_extracts_leading_system_rows_to_system_message() -> None:
+    """Leading system rows leave the payload and ride `system_message`.
+
+    Anthropic/Gemini adapters only accept system content via their dedicated
+    parameter and reject (or drop) `role="system"` rows in the message
+    array, so the Console's system prompt / folded greeting must be
+    extracted here or those providers never see it.
+    """
+    messages = [
+        {"role": "system", "content": "Stay in character."},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+    kwargs = ConsoleProviderGateway._chat_api_kwargs(_bare_resolution(), messages)
+
+    assert kwargs["system_message"] == "Stay in character."
+    assert [m["role"] for m in kwargs["messages_payload"]] == ["user", "assistant"]
+
+
+def test_chat_api_kwargs_joins_multiple_leading_system_rows() -> None:
+    """Contiguous leading system rows concatenate into one system_message."""
+    messages = [
+        {"role": "system", "content": "A."},
+        {"role": "system", "content": "B."},
+        {"role": "user", "content": "hi"},
+    ]
+
+    kwargs = ConsoleProviderGateway._chat_api_kwargs(_bare_resolution(), messages)
+
+    assert kwargs["system_message"] == "A.\n\nB."
+    assert [m["role"] for m in kwargs["messages_payload"]] == ["user"]
+
+
+def test_chat_api_kwargs_without_system_rows_omits_system_message() -> None:
+    """No leading system rows: payload passes through, no system_message key."""
+    messages = [{"role": "user", "content": "hi"}]
+
+    kwargs = ConsoleProviderGateway._chat_api_kwargs(_bare_resolution(), messages)
+
+    assert "system_message" not in kwargs
+    assert kwargs["messages_payload"] == messages

--- a/Tests/Chat/test_console_remote_images.py
+++ b/Tests/Chat/test_console_remote_images.py
@@ -1,0 +1,131 @@
+"""Remote inline transcript images (task-1537): setting + URL extraction.
+
+Rendering images referenced by links in assistant replies is OFF by default
+and gated behind ``[chat.images] render_remote_images``; extraction accepts
+markdown image links and bare image-extension URLs, http(s) only.
+"""
+
+from tldw_chatbook.Chat.console_image_view import (
+    extract_image_urls,
+    resolve_render_remote_images,
+)
+
+
+def test_remote_images_default_off():
+    assert resolve_render_remote_images({}) is False
+    assert resolve_render_remote_images({"chat": {"images": {}}}) is False
+
+
+def test_remote_images_enabled_by_setting():
+    config = {"chat": {"images": {"render_remote_images": True}}}
+    assert resolve_render_remote_images(config) is True
+
+
+def test_extract_markdown_image_links():
+    text = "Here you go ![map](https://example.com/city.png) and more"
+    assert extract_image_urls(text) == ["https://example.com/city.png"]
+
+
+def test_extract_bare_image_extension_urls():
+    text = "portrait: https://example.com/a/b/portrait.jpg?size=big done"
+    assert extract_image_urls(text) == [
+        "https://example.com/a/b/portrait.jpg?size=big"
+    ]
+
+
+def test_non_image_bare_urls_ignored():
+    assert extract_image_urls("see https://example.com/page.html") == []
+
+
+def test_non_http_schemes_ignored():
+    text = "![x](data:image/png;base64,AAAA) ![y](file:///etc/passwd)"
+    assert extract_image_urls(text) == []
+
+
+def test_dedupe_and_cap():
+    url = "https://example.com/i.png"
+    text = " ".join(
+        [f"![a]({url})", f"![b]({url})"]
+        + [f"![n](https://example.com/{i}.png)" for i in range(9)]
+    )
+    urls = extract_image_urls(text, limit=3)
+    assert len(urls) == 3
+    assert urls[0] == url
+    assert len(set(urls)) == 3
+
+
+# ---- ChatScreen spec wiring ----
+
+import io
+from types import SimpleNamespace
+
+from PIL import Image as PILImage
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+
+
+def _bare_screen(*, enabled: bool):
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen = ChatScreen.__new__(ChatScreen)
+    screen.app_instance = SimpleNamespace(
+        app_config={"chat": {"images": {"render_remote_images": enabled}}}
+    )
+    return screen
+
+
+def _assistant(content: str) -> ConsoleChatMessage:
+    return ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT, content=content, status="complete"
+    )
+
+
+def _png_bytes() -> bytes:
+    buf = io.BytesIO()
+    PILImage.new("RGB", (16, 16), (0, 119, 226)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_remote_spec_built_for_cached_link_when_enabled():
+    screen = _bare_screen(enabled=True)
+    message = _assistant("map: ![map](https://example.com/pic.png)")
+    _state, cache = screen._ensure_console_image_view()
+    assert cache.prepare("remote:https://example.com/pic.png", _png_bytes())
+
+    specs = screen._build_console_image_specs([message])
+
+    assert message.id in specs
+
+
+def test_remote_spec_ignored_when_setting_off():
+    screen = _bare_screen(enabled=False)
+    message = _assistant("map: ![map](https://example.com/pic.png)")
+    _state, cache = screen._ensure_console_image_view()
+    assert cache.prepare("remote:https://example.com/pic.png", _png_bytes())
+    dispatched: list = []
+    screen.run_worker = lambda coro, **kw: (dispatched.append(coro), coro.close())
+
+    specs = screen._build_console_image_specs([message])
+
+    assert message.id not in specs
+    assert dispatched == []
+
+
+def test_uncached_link_dispatches_fetch_once():
+    screen = _bare_screen(enabled=True)
+    message = _assistant("see https://example.com/photo.jpg now")
+    dispatched: list = []
+
+    def _record(coro, **kwargs):
+        dispatched.append(coro)
+        coro.close()
+
+    screen.run_worker = _record
+
+    screen._build_console_image_specs([message])
+    screen._build_console_image_specs([message])
+
+    assert len(dispatched) == 1

--- a/Tests/Chat/test_console_remote_images.py
+++ b/Tests/Chat/test_console_remote_images.py
@@ -12,21 +12,25 @@ from tldw_chatbook.Chat.console_image_view import (
 
 
 def test_remote_images_default_off():
+    """render_remote_images defaults to off for absent/empty config."""
     assert resolve_render_remote_images({}) is False
     assert resolve_render_remote_images({"chat": {"images": {}}}) is False
 
 
 def test_remote_images_enabled_by_setting():
+    """render_remote_images=true in [chat.images] enables the feature."""
     config = {"chat": {"images": {"render_remote_images": True}}}
     assert resolve_render_remote_images(config) is True
 
 
 def test_extract_markdown_image_links():
+    """Markdown ![alt](url) image links extract their http(s) URL."""
     text = "Here you go ![map](https://example.com/city.png) and more"
     assert extract_image_urls(text) == ["https://example.com/city.png"]
 
 
 def test_extract_bare_image_extension_urls():
+    """Bare URLs with image extensions (plus query strings) extract."""
     text = "portrait: https://example.com/a/b/portrait.jpg?size=big done"
     assert extract_image_urls(text) == [
         "https://example.com/a/b/portrait.jpg?size=big"
@@ -34,15 +38,18 @@ def test_extract_bare_image_extension_urls():
 
 
 def test_non_image_bare_urls_ignored():
+    """Bare URLs without an image extension are not treated as images."""
     assert extract_image_urls("see https://example.com/page.html") == []
 
 
 def test_non_http_schemes_ignored():
+    """data:/file: and other non-http(s) schemes never extract."""
     text = "![x](data:image/png;base64,AAAA) ![y](file:///etc/passwd)"
     assert extract_image_urls(text) == []
 
 
 def test_dedupe_and_cap():
+    """Extraction dedupes repeated URLs and honors the limit cap."""
     url = "https://example.com/i.png"
     text = " ".join(
         [f"![a]({url})", f"![b]({url})"]
@@ -57,9 +64,11 @@ def test_dedupe_and_cap():
 # ---- ChatScreen spec wiring ----
 
 import io
+
+import pytest
 from types import SimpleNamespace
 
-from PIL import Image as PILImage
+PILImage = pytest.importorskip("PIL.Image")
 
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
@@ -90,6 +99,7 @@ def _png_bytes() -> bytes:
 
 
 def test_remote_spec_built_for_cached_link_when_enabled():
+    """An enabled setting plus a cached link yields an image-row spec."""
     screen = _bare_screen(enabled=True)
     message = _assistant("map: ![map](https://example.com/pic.png)")
     _state, cache = screen._ensure_console_image_view()
@@ -101,6 +111,7 @@ def test_remote_spec_built_for_cached_link_when_enabled():
 
 
 def test_remote_spec_ignored_when_setting_off():
+    """With the setting off no spec is built and no fetch dispatches."""
     screen = _bare_screen(enabled=False)
     message = _assistant("map: ![map](https://example.com/pic.png)")
     _state, cache = screen._ensure_console_image_view()
@@ -115,6 +126,7 @@ def test_remote_spec_ignored_when_setting_off():
 
 
 def test_uncached_link_dispatches_fetch_once():
+    """An uncached link dispatches exactly one fetch across rebuilds."""
     screen = _bare_screen(enabled=True)
     message = _assistant("see https://example.com/photo.jpg now")
     dispatched: list = []

--- a/Tests/UI/test_character_session_prompt_seed.py
+++ b/Tests/UI/test_character_session_prompt_seed.py
@@ -10,6 +10,7 @@ from tldw_chatbook.UI.Screens.chat_screen import _character_session_prompt_seed
 
 
 def test_macros_resolved_in_system_prompt_and_greeting():
+    """Card fields with {{char}}/{{user}} macros resolve in prompt and greeting."""
     card = {
         "name": "Elara",
         "system_prompt": "Play {{char}} faithfully.",
@@ -30,6 +31,7 @@ def test_macros_resolved_in_system_prompt_and_greeting():
 
 
 def test_character_alias_macros_resolve_to_character_name():
+    """{{character}}/{{persona}} aliases resolve to the character's name."""
     card = {
         "name": "Elara",
         "description": "{{character}} and {{persona}} both mean the AI.",
@@ -43,6 +45,7 @@ def test_character_alias_macros_resolve_to_character_name():
 
 
 def test_empty_card_falls_back_to_defaults():
+    """An empty card yields the name hint, default prompt, and no greeting."""
     name, system_prompt, greeting = _character_session_prompt_seed(
         {}, name_hint="Hinted"
     )

--- a/Tests/UI/test_character_session_prompt_seed.py
+++ b/Tests/UI/test_character_session_prompt_seed.py
@@ -1,0 +1,52 @@
+"""Character Start Chat prompt seeding tests (task-1530).
+
+The Personas Start Chat handoff builds the Console session's system prompt
+and seeded greeting from the character card. Card text is written against
+SillyTavern-style macros, so ``{{char}}``/``{{user}}`` (and aliases) must be
+resolved before any of it reaches session settings or the provider.
+"""
+
+from tldw_chatbook.UI.Screens.chat_screen import _character_session_prompt_seed
+
+
+def test_macros_resolved_in_system_prompt_and_greeting():
+    card = {
+        "name": "Elara",
+        "system_prompt": "Play {{char}} faithfully.",
+        "personality": "",
+        "description": "{{char}} guides {{user}} through the city.",
+        "scenario": "{{user}} meets {{char}} at dusk.",
+        "first_message": "Hello {{user}}, I am {{char}}.",
+    }
+
+    name, system_prompt, greeting = _character_session_prompt_seed(card)
+
+    assert name == "Elara"
+    assert "{{" not in system_prompt
+    assert "{{" not in greeting
+    assert "Elara guides User through the city." in system_prompt
+    assert "User meets Elara at dusk." in system_prompt
+    assert greeting == "Hello User, I am Elara."
+
+
+def test_character_alias_macros_resolve_to_character_name():
+    card = {
+        "name": "Elara",
+        "description": "{{character}} and {{persona}} both mean the AI.",
+        "first_message": "",
+    }
+
+    _name, system_prompt, greeting = _character_session_prompt_seed(card)
+
+    assert system_prompt == "Elara and Elara both mean the AI."
+    assert greeting == ""
+
+
+def test_empty_card_falls_back_to_defaults():
+    name, system_prompt, greeting = _character_session_prompt_seed(
+        {}, name_hint="Hinted"
+    )
+
+    assert name == "Hinted"
+    assert system_prompt == "Stay in character."
+    assert greeting == ""

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -132,12 +132,13 @@ def test_build_character_avatar_widget_pixels_failure_falls_back_to_text(monkeyp
     the no-image case, not propagate.
     """
     from PIL import Image as PILImage
-    import rich_pixels
+
+    from tldw_chatbook.Utils import mosaic_render
 
     def _boom(*args, **kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(rich_pixels.Pixels, "from_image", staticmethod(_boom))
+    monkeypatch.setattr(mosaic_render, "mosaic_from_image", _boom)
 
     screen = _bare_console_screen(ConsoleChatStore())
     spec = {

--- a/Tests/UI/test_console_image_viewer.py
+++ b/Tests/UI/test_console_image_viewer.py
@@ -1,0 +1,67 @@
+"""Full-size image viewer modal + clickable avatar box (task-1534)."""
+
+import pytest
+from PIL import Image as PILImage
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Widgets.Console.console_image_viewer_modal import (
+    AvatarViewRequested,
+    ClickableAvatarBox,
+    ConsoleImageViewerModal,
+)
+
+
+class _BoxApp(App):
+    def __init__(self):
+        super().__init__()
+        self.seen: list[AvatarViewRequested] = []
+
+    def compose(self) -> ComposeResult:
+        yield ClickableAvatarBox(id="avatar-box")
+
+    def on_avatar_view_requested(self, message: AvatarViewRequested) -> None:
+        self.seen.append(message)
+
+
+@pytest.mark.asyncio
+async def test_clickable_box_posts_view_request_on_click():
+    app = _BoxApp()
+    async with app.run_test() as pilot:
+        await pilot.click("#avatar-box")
+        await pilot.pause()
+    assert len(app.seen) == 1
+
+
+class _ViewerApp(App):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_viewer_modal_renders_image_and_escape_dismisses():
+    image = PILImage.new("RGB", (64, 64), (0, 119, 226))
+    app = _ViewerApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleImageViewerModal(image, title="World RP (edited)"))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, ConsoleImageViewerModal)
+        body = modal.query_one("#console-image-viewer-body")
+        # The mosaic fallback paints a renderable child sized well beyond
+        # the 16-col avatar thumb (full-size means tens of columns here).
+        assert body.children
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, ConsoleImageViewerModal)
+
+
+@pytest.mark.asyncio
+async def test_viewer_modal_click_dismisses():
+    image = PILImage.new("RGB", (32, 32), (200, 30, 30))
+    app = _ViewerApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleImageViewerModal(image, title="x"))
+        await pilot.pause()
+        assert isinstance(app.screen, ConsoleImageViewerModal)
+        await pilot.click("#console-image-viewer-body")
+        await pilot.pause()
+        assert not isinstance(app.screen, ConsoleImageViewerModal)

--- a/Tests/UI/test_console_image_viewer.py
+++ b/Tests/UI/test_console_image_viewer.py
@@ -49,6 +49,11 @@ async def test_viewer_modal_renders_image_and_escape_dismisses():
         # The mosaic fallback paints a renderable child sized well beyond
         # the 16-col avatar thumb (full-size means tens of columns here).
         assert body.children
+        # Renderable != painted: the body must occupy real screen area, not
+        # collapse to zero under a 100%-height default inside an auto parent.
+        image_widget = modal.query_one("#console-image-viewer-image")
+        assert image_widget.region.width >= 20
+        assert image_widget.region.height >= 10
         await pilot.press("escape")
         await pilot.pause()
         assert not isinstance(app.screen, ConsoleImageViewerModal)

--- a/Tests/UI/test_console_image_viewer.py
+++ b/Tests/UI/test_console_image_viewer.py
@@ -1,7 +1,7 @@
 """Full-size image viewer modal + clickable avatar box (task-1534)."""
 
 import pytest
-from PIL import Image as PILImage
+PILImage = pytest.importorskip("PIL.Image")
 from textual.app import App, ComposeResult
 
 from tldw_chatbook.Widgets.Console.console_image_viewer_modal import (
@@ -25,6 +25,7 @@ class _BoxApp(App):
 
 @pytest.mark.asyncio
 async def test_clickable_box_posts_view_request_on_click():
+    """Clicking the avatar box posts AvatarViewRequested to the app."""
     app = _BoxApp()
     async with app.run_test() as pilot:
         await pilot.click("#avatar-box")
@@ -38,6 +39,7 @@ class _ViewerApp(App):
 
 @pytest.mark.asyncio
 async def test_viewer_modal_renders_image_and_escape_dismisses():
+    """The viewer paints a real-sized image region and Escape closes it."""
     image = PILImage.new("RGB", (64, 64), (0, 119, 226))
     app = _ViewerApp()
     async with app.run_test(size=(100, 40)) as pilot:
@@ -61,6 +63,7 @@ async def test_viewer_modal_renders_image_and_escape_dismisses():
 
 @pytest.mark.asyncio
 async def test_viewer_modal_click_dismisses():
+    """Clicking anywhere in the open viewer dismisses it."""
     image = PILImage.new("RGB", (32, 32), (200, 30, 30))
     app = _ViewerApp()
     async with app.run_test(size=(100, 40)) as pilot:

--- a/Tests/UI/test_console_transcript_markdown.py
+++ b/Tests/UI/test_console_transcript_markdown.py
@@ -15,10 +15,12 @@ from tldw_chatbook.Widgets.Console.console_transcript import (
 
 def test_markdown_spans_render_heading_bold_and_code():
     """Headings, **bold**, and `code` map to the expected styled segments."""
+    from tldw_chatbook.Widgets.Console.console_transcript import _BOLD_STYLE
+
     assert _markdown_body_spans("### Understanding WAL") == [("Understanding WAL", "bold underline")]
     assert _markdown_body_spans("use **local RAG** now") == [
         "use ",
-        ("local RAG", "bold"),
+        ("local RAG", _BOLD_STYLE),
         " now",
     ]
     assert _markdown_body_spans("run `pytest` here") == [
@@ -82,3 +84,60 @@ def test_system_and_tool_messages_are_left_verbatim():
         assert "### not a heading" in plain
         assert "**not bold**" in plain
         assert "`not code`" in plain
+
+
+# ---- Roleplay flavor styling (task-1536) ----
+
+
+def test_flavor_quoted_speech_gets_speech_style():
+    from tldw_chatbook.Widgets.Console.console_transcript import _SPEECH_STYLE
+
+    assert _markdown_body_spans('She said "hello there" softly') == [
+        "She said ",
+        ('"hello there"', _SPEECH_STYLE),
+        " softly",
+    ]
+
+
+def test_flavor_curly_quoted_speech_gets_speech_style():
+    from tldw_chatbook.Widgets.Console.console_transcript import _SPEECH_STYLE
+
+    assert _markdown_body_spans("“hello” she offered") == [
+        ("“hello”", _SPEECH_STYLE),
+        " she offered",
+    ]
+
+
+def test_flavor_single_asterisk_action_gets_action_style():
+    from tldw_chatbook.Widgets.Console.console_transcript import _ACTION_STYLE
+
+    assert _markdown_body_spans("*leans forward* Tell me more") == [
+        ("leans forward", _ACTION_STYLE),
+        " Tell me more",
+    ]
+
+
+def test_flavor_bold_action_speech_are_mutually_distinct():
+    from tldw_chatbook.Widgets.Console.console_transcript import (
+        _ACTION_STYLE,
+        _BOLD_STYLE,
+        _SPEECH_STYLE,
+    )
+
+    spans = _markdown_body_spans('**Loud** *quiet* "spoken"')
+    styles = [s for item in spans if isinstance(item, tuple) for s in [item[1]]]
+    assert styles == [_BOLD_STYLE, _ACTION_STYLE, _SPEECH_STYLE]
+    assert len({_BOLD_STYLE, _ACTION_STYLE, _SPEECH_STYLE}) == 3
+
+
+def test_flavor_unclosed_quote_and_asterisk_stay_literal():
+    assert _markdown_body_spans('He said "wait') == ['He said "wait']
+    assert _markdown_body_spans("*unfinished action") == ["*unfinished action"]
+
+
+def test_flavor_quote_containing_action_marker_styles_as_speech():
+    from tldw_chatbook.Widgets.Console.console_transcript import _SPEECH_STYLE
+
+    assert _markdown_body_spans('"I *mean* it"') == [
+        ('"I *mean* it"', _SPEECH_STYLE),
+    ]

--- a/Tests/UI/test_console_transcript_markdown.py
+++ b/Tests/UI/test_console_transcript_markdown.py
@@ -90,6 +90,7 @@ def test_system_and_tool_messages_are_left_verbatim():
 
 
 def test_flavor_quoted_speech_gets_speech_style():
+    """Straight double-quoted speech styles as one speech-colored span."""
     from tldw_chatbook.Widgets.Console.console_transcript import _SPEECH_STYLE
 
     assert _markdown_body_spans('She said "hello there" softly') == [
@@ -100,6 +101,7 @@ def test_flavor_quoted_speech_gets_speech_style():
 
 
 def test_flavor_curly_quoted_speech_gets_speech_style():
+    """Curly-quoted speech styles as one speech-colored span."""
     from tldw_chatbook.Widgets.Console.console_transcript import _SPEECH_STYLE
 
     assert _markdown_body_spans("“hello” she offered") == [
@@ -109,6 +111,7 @@ def test_flavor_curly_quoted_speech_gets_speech_style():
 
 
 def test_flavor_single_asterisk_action_gets_action_style():
+    """*action* text styles with the action style, markers stripped."""
     from tldw_chatbook.Widgets.Console.console_transcript import _ACTION_STYLE
 
     assert _markdown_body_spans("*leans forward* Tell me more") == [
@@ -118,6 +121,7 @@ def test_flavor_single_asterisk_action_gets_action_style():
 
 
 def test_flavor_bold_action_speech_are_mutually_distinct():
+    """Bold, action, and speech spans use three distinct styles."""
     from tldw_chatbook.Widgets.Console.console_transcript import (
         _ACTION_STYLE,
         _BOLD_STYLE,
@@ -131,11 +135,13 @@ def test_flavor_bold_action_speech_are_mutually_distinct():
 
 
 def test_flavor_unclosed_quote_and_asterisk_stay_literal():
+    """Unclosed quote/asterisk markers stay literal (mid-stream safety)."""
     assert _markdown_body_spans('He said "wait') == ['He said "wait']
     assert _markdown_body_spans("*unfinished action") == ["*unfinished action"]
 
 
 def test_flavor_quote_containing_action_marker_styles_as_speech():
+    """A quote swallows markers inside it and styles wholly as speech."""
     from tldw_chatbook.Widgets.Console.console_transcript import _SPEECH_STYLE
 
     assert _markdown_body_spans('"I *mean* it"') == [

--- a/Tests/UI/test_personas_avatar_render.py
+++ b/Tests/UI/test_personas_avatar_render.py
@@ -29,5 +29,59 @@ def test_avatar_pixels_fallback_renders_visible_half_block_cells():
     assert pixels is not None
     console = Console(width=60, record=True, force_terminal=True)
     console.print(pixels)
+    # A solid-color image bakes to background-painted cells; the color
+    # carries in the styled stream (blank text output would mean nothing
+    # painted -- the original task-1532 failure mode).
+    styled = console.export_text(styles=True)
+    assert "0;119;226" in styled
+
+
+def _split_png_bytes() -> bytes:
+    image = PILImage.new("RGB", (32, 32), (0, 0, 0))
+    for x in range(16, 32):
+        for y in range(32):
+            image.putpixel((x, y), (255, 255, 255))
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_avatar_fallback_resolves_left_right_split_within_a_cell():
+    """The mosaic fallback doubles horizontal detail: a hard vertical edge
+    must produce left/right-half (or quadrant) glyphs, which the old
+    half-block renderer could never emit."""
+    from tldw_chatbook.Chat.console_image_view import ConsoleImageRenderCache
+    from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+
+    cache = ConsoleImageRenderCache()
+    assert cache.prepare("avatar-split", _split_png_bytes())
+
+    renderable = PersonasScreen._build_avatar_pixels(cache, "avatar-split")
+
+    assert renderable is not None
+    console = Console(width=60, record=True, force_terminal=True)
+    console.print(renderable)
     rendered = console.export_text(styles=False)
-    assert any(glyph in rendered for glyph in ("▄", "▀", "█"))
+    assert any(g in rendered for g in ("▌", "▐", "▘", "▝", "▖", "▗"))
+
+
+def test_console_rail_avatar_fallback_uses_mosaic():
+    """The Console rail "Character" box shares the mosaic fallback: a hard
+    vertical edge resolves inside single cells (quadrant glyphs)."""
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        _character_avatar_fallback_renderable,
+    )
+
+    # The white region starts at an ODD source column so the hard edge lands
+    # inside a cell's 2x2 block rather than exactly on a cell boundary.
+    image = PILImage.new("RGB", (32, 32), (0, 0, 0))
+    for x in range(15, 32):
+        for y in range(32):
+            image.putpixel((x, y), (255, 255, 255))
+
+    renderable = _character_avatar_fallback_renderable(image)
+
+    console = Console(width=40, record=True, force_terminal=True)
+    console.print(renderable)
+    rendered = console.export_text(styles=False)
+    assert any(g in rendered for g in ("▌", "▐", "▘", "▝", "▖", "▗"))

--- a/Tests/UI/test_personas_avatar_render.py
+++ b/Tests/UI/test_personas_avatar_render.py
@@ -7,7 +7,9 @@ the graphics path silently painted blanks under tmux (renderable != painted).
 
 import io
 
-from PIL import Image as PILImage
+import pytest
+
+PILImage = pytest.importorskip("PIL.Image")
 from rich.console import Console
 
 
@@ -18,6 +20,7 @@ def _png_bytes(color: tuple[int, int, int]) -> bytes:
 
 
 def test_avatar_pixels_fallback_renders_visible_half_block_cells():
+    """The personas fallback paints visible colored cells for a solid image."""
     from tldw_chatbook.Chat.console_image_view import ConsoleImageRenderCache
     from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 

--- a/Tests/UI/test_personas_avatar_render.py
+++ b/Tests/UI/test_personas_avatar_render.py
@@ -1,0 +1,33 @@
+"""Avatar pixels-fallback render-seam test (task-1532).
+
+Characterizes that the non-graphics avatar path produces VISIBLE half-block
+cells, not an empty renderable -- widget presence alone proved nothing when
+the graphics path silently painted blanks under tmux (renderable != painted).
+"""
+
+import io
+
+from PIL import Image as PILImage
+from rich.console import Console
+
+
+def _png_bytes(color: tuple[int, int, int]) -> bytes:
+    buf = io.BytesIO()
+    PILImage.new("RGB", (32, 32), color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_avatar_pixels_fallback_renders_visible_half_block_cells():
+    from tldw_chatbook.Chat.console_image_view import ConsoleImageRenderCache
+    from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+
+    cache = ConsoleImageRenderCache()
+    assert cache.prepare("avatar-test", _png_bytes((0, 119, 226)))
+
+    pixels = PersonasScreen._build_avatar_pixels(cache, "avatar-test")
+
+    assert pixels is not None
+    console = Console(width=60, record=True, force_terminal=True)
+    console.print(pixels)
+    rendered = console.export_text(styles=False)
+    assert any(glyph in rendered for glyph in ("▄", "▀", "█"))

--- a/Tests/UI/test_personas_character_editor_avatar.py
+++ b/Tests/UI/test_personas_character_editor_avatar.py
@@ -405,14 +405,16 @@ class TestCharacterEditorAvatarThumbnailFit:
         }
         char_id = seeded_character_with_wide_avatar["char_id"]
 
-        captured: list[Image.Image] = []
-        original_from_image = rich_pixels.Pixels.from_image
+        from tldw_chatbook.Utils import mosaic_render
 
-        def _spy_from_image(image, *args, **kwargs):
-            captured.append(image.copy())
-            return original_from_image(image, *args, **kwargs)
+        captured: list[tuple[Image.Image, int, int]] = []
+        original_mosaic = mosaic_render.mosaic_from_image
 
-        monkeypatch.setattr(rich_pixels.Pixels, "from_image", _spy_from_image)
+        def _spy_mosaic(image, box_cols, box_lines):
+            captured.append((image.copy(), box_cols, box_lines))
+            return original_mosaic(image, box_cols, box_lines)
+
+        monkeypatch.setattr(mosaic_render, "mosaic_from_image", _spy_mosaic)
 
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(200, 60)) as pilot:
@@ -424,24 +426,18 @@ class TestCharacterEditorAvatarThumbnailFit:
             assert len(editor.query("#personas-char-editor-avatar-thumb > *")) == 1
 
         assert len(captured) == 1, (
-            "Pixels.from_image should be called exactly once building the "
+            "mosaic_from_image should be called exactly once building the "
             "avatar thumbnail"
         )
-        thumb = captured[0]
-        # Fits the avatar box, in half-block "pixel" units (COLS wide,
-        # LINES*2 tall) - NOT the 80x40 chat-transcript box that
-        # get_pixels() thumbnails to.
-        assert thumb.width <= AVATAR_THUMB_COLS
-        assert thumb.height <= AVATAR_THUMB_LINES * 2
-        # It actually used (not shrunk far below) the box's width - the old
-        # bug's symptom was a sliver, not merely "some image smaller than
-        # the transcript box".
-        assert thumb.width == AVATAR_THUMB_COLS
-        # Aspect preserved (not stretched/cropped to fill the box): the
-        # 200x100 source is 2:1.
-        source_aspect = 200 / 100
-        thumb_aspect = thumb.width / thumb.height
-        assert thumb_aspect == pytest.approx(source_aspect, rel=0.15)
+        source, box_cols, box_lines = captured[0]
+        # Baked at the avatar box - NOT the 80x40 chat-transcript box that
+        # get_pixels() thumbnails to (the old bug's symptom was a clipped
+        # top-left sliver). Box-fit and aspect preservation inside the box
+        # are the mosaic module's own tested contract.
+        assert (box_cols, box_lines) == (AVATAR_THUMB_COLS, AVATAR_THUMB_LINES)
+        # The full-resolution source reaches the mosaic (no pre-shrink that
+        # would throw away detail before baking).
+        assert source.width == 200 and source.height == 100
 
     @pytest.mark.asyncio
     async def test_tiny_avatar_still_produces_pixels_thumbnail(

--- a/Tests/UI/test_personas_preview.py
+++ b/Tests/UI/test_personas_preview.py
@@ -707,3 +707,38 @@ async def test_alias_tokens_substitute_character_name_with_neutral_user():
             "Elara",
         )
         assert seed == "Hello User, I am Elara/Elara."
+
+
+# ---- build_preview_system_prompt (tasks 1530/1531) ----
+
+
+def test_build_preview_system_prompt_resolves_macros():
+    from tldw_chatbook.UI.Persona_Modules.personas_preview_controller import (
+        build_preview_system_prompt,
+    )
+
+    record = {"name": "Elara", "description": "{{char}} guides {{user}}."}
+
+    assert build_preview_system_prompt(record) == "Elara guides User."
+
+
+def test_build_preview_system_prompt_folds_greeting_after_prompt():
+    from tldw_chatbook.UI.Persona_Modules.personas_preview_controller import (
+        build_preview_system_prompt,
+    )
+
+    out = build_preview_system_prompt(
+        {"name": "Elara", "description": "Guide the user."},
+        greeting="Hello, traveler.",
+    )
+
+    assert out.startswith("Guide the user.")
+    assert "Hello, traveler." in out
+
+
+def test_build_preview_system_prompt_empty_record_falls_back():
+    from tldw_chatbook.UI.Persona_Modules.personas_preview_controller import (
+        build_preview_system_prompt,
+    )
+
+    assert build_preview_system_prompt({}) == "Stay in character."

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -7490,3 +7490,50 @@ def test_settings_source_labels_cover_every_resolvable_source():
 
     resolvable = {"settings_draft", "console_session", "chat_defaults", "default"}
     assert set(SETTINGS_SOURCE_LABELS) == resolvable
+
+
+# ---- [chat.images] render_remote_images toggle (task-1537 settings UI) ----
+
+
+def test_remote_images_toggle_label_reflects_config():
+    """The remote-images toggle label mirrors [chat.images].render_remote_images."""
+    app = _build_test_app()
+    app.app_config["COMPREHENSIVE_CONFIG_RAW"] = {
+        "chat": {"images": {"render_remote_images": True}}
+    }
+    screen = SettingsScreen(app)
+
+    assert screen._remote_images_button_label() == "Enabled"
+
+    app.app_config["COMPREHENSIVE_CONFIG_RAW"]["chat"]["images"][
+        "render_remote_images"
+    ] = False
+    assert screen._remote_images_button_label() == "Disabled"
+
+
+def test_remote_images_toggle_persists_and_pokes_live_config(monkeypatch):
+    """Toggling persists the dotted section AND updates the live app_config.
+
+    The App captures ``app_config`` once at startup, so the persisted write
+    alone would not take effect until restart -- the toggle must also poke
+    the in-memory raw tree the transcript gate reads.
+    """
+    app = _build_test_app()
+    app.app_config["COMPREHENSIVE_CONFIG_RAW"] = {"chat": {"images": {}}}
+    screen = SettingsScreen(app)
+    saved = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_screen.save_settings_to_cli_config",
+        lambda section_values: (saved.append(section_values), True)[1],
+    )
+
+    enabled = screen._toggle_remote_images()
+
+    assert enabled is True
+    assert saved == [{"chat.images": {"render_remote_images": True}}]
+    assert (
+        app.app_config["COMPREHENSIVE_CONFIG_RAW"]["chat"]["images"][
+            "render_remote_images"
+        ]
+        is True
+    )

--- a/Tests/Utils/test_mosaic_render.py
+++ b/Tests/Utils/test_mosaic_render.py
@@ -1,0 +1,86 @@
+"""Quadrant-mosaic renderer tests (avatar/inline fallback sharpening).
+
+Half-block rendering samples one pixel per column (1x2 subpixels per cell);
+the quadrant mosaic samples 2x2 subpixels per cell using universal Block
+Elements glyphs, doubling horizontal detail with no font risk. These tests
+pin the glyph vocabulary, the resolution gain a half-block renderer cannot
+express (a left/right split inside ONE cell), and box-fit dimensions.
+"""
+
+from PIL import Image as PILImage
+from rich.console import Console
+
+from tldw_chatbook.Utils.mosaic_render import QUADRANT_GLYPHS, mosaic_from_image
+
+
+def _render_text(renderable, width: int = 80) -> str:
+    console = Console(width=width, record=True, force_terminal=True)
+    console.print(renderable)
+    return console.export_text(styles=False)
+
+
+def test_left_right_split_resolves_inside_one_cell():
+    image = PILImage.new("RGB", (2, 2))
+    image.putpixel((0, 0), (0, 0, 0))
+    image.putpixel((0, 1), (0, 0, 0))
+    image.putpixel((1, 0), (255, 255, 255))
+    image.putpixel((1, 1), (255, 255, 255))
+
+    rendered = _render_text(mosaic_from_image(image, 1, 1))
+
+    assert "▌" in rendered or "▐" in rendered
+
+
+def test_solid_image_renders_uniform_cells():
+    image = PILImage.new("RGB", (16, 16), (200, 30, 30))
+
+    rendered = _render_text(mosaic_from_image(image, 4, 2)).rstrip("\n")
+
+    used = {ch for line in rendered.splitlines() for ch in line}
+    assert used <= {" ", "█"}
+
+
+def test_output_fits_requested_cell_box():
+    image = PILImage.effect_noise((400, 100), 90).convert("RGB")
+
+    rendered = _render_text(mosaic_from_image(image, 10, 5))
+
+    lines = [line for line in rendered.splitlines() if line.strip()]
+    assert 1 <= len(lines) <= 5
+    assert all(len(line.rstrip()) <= 10 for line in lines)
+
+
+def test_glyphs_stay_within_block_elements():
+    image = PILImage.open_from = None  # guard against accidental reuse
+    image = PILImage.effect_noise((32, 32), 64).convert("RGB")
+
+    rendered = _render_text(mosaic_from_image(image, 8, 4))
+
+    allowed = set(QUADRANT_GLYPHS) | {" ", "\n"}
+    assert set(rendered) <= allowed
+
+
+def test_rgba_input_is_composited_over_black():
+    image = PILImage.new("RGBA", (8, 8), (255, 0, 0, 128))
+
+    console = Console(width=20, record=True, force_terminal=True)
+    console.print(mosaic_from_image(image, 4, 2))
+    styled = console.export_text(styles=True)
+
+    # 50% red over black composites to ~rgb(128,0,0) painted as cell
+    # backgrounds; a crash or blank renderable would carry no color at all.
+    assert "128;0;0" in styled or "127;0;0" in styled
+
+
+def test_square_image_fills_square_cell_box_without_vertical_stretch():
+    """Terminal cells are ~1:2 (w:h), so a 16x8-cell box is physically
+    square. A square image must fill BOTH dimensions of it -- sampling that
+    ignores the half-width of quadrant subpixels renders a square source as
+    a tall ellipse occupying only half the columns."""
+    image = PILImage.effect_noise((100, 100), 80).convert("RGB")
+
+    rendered = _render_text(mosaic_from_image(image, 16, 8))
+
+    lines = [line.rstrip() for line in rendered.splitlines() if line.strip()]
+    assert len(lines) == 8
+    assert max(len(line) for line in lines) == 16

--- a/Tests/Utils/test_mosaic_render.py
+++ b/Tests/Utils/test_mosaic_render.py
@@ -84,3 +84,24 @@ def test_square_image_fills_square_cell_box_without_vertical_stretch():
     lines = [line.rstrip() for line in rendered.splitlines() if line.strip()]
     assert len(lines) == 8
     assert max(len(line) for line in lines) == 16
+
+
+def test_cover_fit_fills_entire_box_with_center_crop():
+    """fit="cover" scales to FILL the box (cropping overflow) instead of
+    letterboxing: a very wide image still paints every cell row. Geometry
+    is asserted on the renderable's plain text (painted flat cells are
+    styled SPACES, so console text export would miscount them)."""
+    text = mosaic_from_image(
+        PILImage.new("RGB", (400, 100), (10, 200, 60)), 10, 5, fit="cover"
+    )
+
+    lines = text.plain.split("\n")
+    assert len(lines) == 5
+    assert all(len(line) == 10 for line in lines)
+
+
+def test_contain_stays_default():
+    text = mosaic_from_image(PILImage.new("RGB", (400, 100), (10, 200, 60)), 10, 5)
+
+    lines = text.plain.split("\n")
+    assert len(lines) < 5

--- a/Tests/Utils/test_mosaic_render.py
+++ b/Tests/Utils/test_mosaic_render.py
@@ -7,8 +7,10 @@ pin the glyph vocabulary, the resolution gain a half-block renderer cannot
 express (a left/right split inside ONE cell), and box-fit dimensions.
 """
 
-from PIL import Image as PILImage
+import pytest
 from rich.console import Console
+
+PILImage = pytest.importorskip("PIL.Image")
 
 from tldw_chatbook.Utils.mosaic_render import QUADRANT_GLYPHS, mosaic_from_image
 
@@ -20,6 +22,7 @@ def _render_text(renderable, width: int = 80) -> str:
 
 
 def test_left_right_split_resolves_inside_one_cell():
+    """A left/right color split renders inside ONE cell via quadrant glyphs."""
     image = PILImage.new("RGB", (2, 2))
     image.putpixel((0, 0), (0, 0, 0))
     image.putpixel((0, 1), (0, 0, 0))
@@ -32,6 +35,7 @@ def test_left_right_split_resolves_inside_one_cell():
 
 
 def test_solid_image_renders_uniform_cells():
+    """A solid-color image bakes to uniform full/space cells only."""
     image = PILImage.new("RGB", (16, 16), (200, 30, 30))
 
     rendered = _render_text(mosaic_from_image(image, 4, 2)).rstrip("\n")
@@ -41,6 +45,7 @@ def test_solid_image_renders_uniform_cells():
 
 
 def test_output_fits_requested_cell_box():
+    """Rendered lines and columns never exceed the requested cell box."""
     image = PILImage.effect_noise((400, 100), 90).convert("RGB")
 
     rendered = _render_text(mosaic_from_image(image, 10, 5))
@@ -51,6 +56,7 @@ def test_output_fits_requested_cell_box():
 
 
 def test_glyphs_stay_within_block_elements():
+    """Output glyphs stay within the universal Block Elements set."""
     image = PILImage.open_from = None  # guard against accidental reuse
     image = PILImage.effect_noise((32, 32), 64).convert("RGB")
 
@@ -61,6 +67,7 @@ def test_glyphs_stay_within_block_elements():
 
 
 def test_rgba_input_is_composited_over_black():
+    """RGBA input composites over black instead of crashing or blanking."""
     image = PILImage.new("RGBA", (8, 8), (255, 0, 0, 128))
 
     console = Console(width=20, record=True, force_terminal=True)
@@ -101,6 +108,7 @@ def test_cover_fit_fills_entire_box_with_center_crop():
 
 
 def test_contain_stays_default():
+    """Default contain fit letterboxes a wide image below the full box height."""
     text = mosaic_from_image(PILImage.new("RGB", (400, 100), (10, 200, 60)), 10, 5)
 
     lines = text.plain.split("\n")

--- a/Tests/Utils/test_terminal_utils.py
+++ b/Tests/Utils/test_terminal_utils.py
@@ -1,0 +1,61 @@
+"""Terminal capability detection tests (task-1532).
+
+The avatar/inline-image mode resolver trusts ``detect_terminal_capabilities``.
+Inside tmux the host terminal's env (``TERM_PROGRAM``, ``ITERM_SESSION_ID``)
+leaks into the pane while tmux does NOT pass graphics escape sequences
+through, so recommending "regular" (graphics) there paints nothing. These
+tests pin the tmux override and guard the non-tmux graphics path.
+"""
+
+from tldw_chatbook.Utils.terminal_utils import detect_terminal_capabilities
+
+_ENV_VARS = (
+    "TERM",
+    "TERM_PROGRAM",
+    "ITERM_SESSION_ID",
+    "TMUX",
+    "VTE_VERSION",
+    "WT_SESSION",
+)
+
+
+def _clear_env(monkeypatch):
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_tmux_forces_pixels_despite_iterm_env_leak(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,1234,0")
+    monkeypatch.setenv("TERM", "screen-256color")
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+    monkeypatch.setenv("ITERM_SESSION_ID", "w0t0p0:0000")
+
+    caps = detect_terminal_capabilities()
+
+    assert caps["recommended_mode"] == "pixels"
+    assert caps["tgp"] is False
+    assert caps["sixel"] is False
+    assert caps["terminal_type"] == "tmux"
+
+
+def test_tmux_style_term_without_tmux_var_forces_pixels(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TERM", "tmux-256color")
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+
+    caps = detect_terminal_capabilities()
+
+    assert caps["recommended_mode"] == "pixels"
+    assert caps["terminal_type"] == "tmux"
+
+
+def test_iterm_outside_tmux_keeps_graphics(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+
+    caps = detect_terminal_capabilities()
+
+    assert caps["recommended_mode"] == "regular"
+    assert caps["terminal_type"] == "iterm2"

--- a/backlog/tasks/task-1530 - Character-chat-sends-user-char-macros-raw-to-the-provider.md
+++ b/backlog/tasks/task-1530 - Character-chat-sends-user-char-macros-raw-to-the-provider.md
@@ -1,0 +1,67 @@
+---
+id: TASK-1530
+title: 'Character chat sends {{user}}/{{char}} macros raw to the provider'
+status: Done
+assignee: []
+created_date: '2026-07-30 15:30'
+labels: [bug, roleplay, console, P2]
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verified live against origin/dev @ c329def0d (2026-07-30, stub provider
+capturing payloads): Roleplay → Start Chat → Console with a real V2+V3 card.
+The card's system prompt (description + scenario + post-history) IS correctly
+assembled and sent every turn, but 12 `{{user}}` and 7 `{{char}}` macro
+occurrences reach the model verbatim — no substitution. Same raw macros were
+observed on the Roleplay preview path.
+
+`replace_placeholders` exists (Character_Chat_Lib) and dev's preview controller
+uses it for greeting DISPLAY, but no outbound request path applies it to the
+system prompt or history.
+
+Terminology guard (author-confirmed): `{{user}}` = the human app user's
+name/persona; `{{char}}`/`{{character}}` = the character. Cards are written
+expecting SillyTavern-style substitution; sending them raw weakens persona
+adherence and leaks template syntax to the model.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+1. Extract the Start Chat card->prompt build into module-level `_character_session_prompt_seed` (chat_screen.py) and apply `replace_placeholders` to the joined system prompt (greeting already substituted); "User" as user name matches existing Personas display substitution.
+2. Extract preview prompt build into module-level `build_preview_system_prompt` (personas_preview_controller.py) with the same substitution.
+3. TDD: new Tests/UI/test_character_session_prompt_seed.py + builder tests in Tests/UI/test_personas_preview.py; watch macro assertions fail before wiring substitution.
+4. Live stub-provider payload re-verification (no raw macros outbound).
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Outbound character-chat requests (Console session and Roleplay preview) contain no unsubstituted {{user}}/{{char}}/{{character}} macros.
+- [x] #2 {{user}} resolves to the user's name/persona and {{char}} to the character name, matching the greeting-display substitution.
+- [x] #3 Regression tests assert substitution at the prompt-assembly seams that feed provider payloads (AC reworded: substitution happens at session/preview prompt build; payload delivery of those strings is covered by existing system-prompt payload tests and was live-verified end to end).
+<!-- AC:END -->
+
+## Implementation Notes
+
+Extracted the two prompt builds into pure, tested helpers and applied
+`replace_placeholders` (char name + "User", matching the existing
+greeting-display substitution) to the joined card fields:
+
+- `_character_session_prompt_seed` (chat_screen.py, module level) now feeds
+  Start Chat's Console session settings with macros resolved; behaviour was
+  extracted as a pure refactor first so the macro assertions failed RED
+  before the substitution landed.
+- `build_preview_system_prompt` (personas_preview_controller.py, module
+  level) does the same for the Roleplay preview; `system_prompt()` delegates
+  to it (single consumer: the `_run_reply` messages build).
+
+Live-verified against the stub provider: Console turn 1/turn 2 and a preview
+send all left ZERO raw macros in captured payloads (previously 12 {{user}} +
+7 {{char}} per send). Existing sessions created before the fix keep their
+stored raw-macro system prompts; re-running Start Chat reseeds cleanly.
+
+Tests: Tests/UI/test_character_session_prompt_seed.py (new),
+build_preview_system_prompt cases in Tests/UI/test_personas_preview.py.
+Full runs: test_console_chat_controller (139 passed), adjacent suites
+(319 passed), test_personas_preview (39 passed).

--- a/backlog/tasks/task-1531 - Character-greeting-shown-and-persisted-but-omitted-from-provider-history.md
+++ b/backlog/tasks/task-1531 - Character-greeting-shown-and-persisted-but-omitted-from-provider-history.md
@@ -1,0 +1,64 @@
+---
+id: TASK-1531
+title: 'Character greeting shown and persisted but omitted from provider history'
+status: Done
+assignee: []
+created_date: '2026-07-30 15:30'
+labels: [bug, roleplay, console, P2]
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verified live against origin/dev @ c329def0d (2026-07-30, stub provider
+capturing payloads): Roleplay → Start Chat → Console. The character's
+first_mes renders in the transcript as the opening Assistant message AND is
+persisted to the DB as the conversation's first assistant message — but
+outbound requests omit it. Captured turn-2 payload:
+`[system, user(turn1), assistant(reply1), user(turn2)]` — the greeting
+assistant turn is missing while every later assistant turn is included.
+
+Impact: the model never knows the greeting happened and contradicts the
+transcript the user is reading (e.g. this card's greeting asks the user to
+fill in a character sheet; the model re-introduces the world instead of
+acknowledging the sheet). Since the greeting IS in the DB history, whatever
+builds the request history is filtering it (or slicing from the first user
+message) — align it with the persisted transcript.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+1. Add pure `fold_greeting_into_system_prompt` to Chat/console_chat_models.py (shared by Console + preview).
+2. Controller: `_seeded_greeting_text` mirrors the leading-assistant drop rule; `_leading_system_message(greeting=...)` folds it; wire both send seams (`_provider_messages_for_session`, `_provider_messages_through_message`). Message array stays user-first (task-427 constraint kept).
+3. Preview: fold the active seeded greeting inside `build_preview_system_prompt`.
+4. TDD: revise `test_leading_greeting_excluded_from_provider_payload` to the new contract (system row carries greeting; array user-first) + add with-system-prompt variant.
+5. Live stub-provider payload re-verification (greeting text present in system row).
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The greeting content reaches the provider on every character-session send (AC reworded: it is folded into the SYSTEM row rather than sent as an assistant-first message, because strict providers (Anthropic, Gemini) reject assistant-first arrays -- the task-427 constraint that motivated the original drop).
+- [x] #2 Roleplay preview requests include the displayed greeting the same way.
+- [x] #3 Regression test asserts greeting presence at the request-payload seam.
+<!-- AC:END -->
+
+## Implementation Notes
+
+Added pure `fold_greeting_into_system_prompt` to Chat/console_chat_models.py
+(shared by Console and preview). Console: `_seeded_greeting_text` mirrors the
+payload builder's leading-assistant drop rule (skips failed turns, joins
+multiple leading turns) and both send seams
+(`_provider_messages_for_session`, `_provider_messages_through_message`) fold
+it via `_leading_system_message(greeting=...)`; a greeting now produces a
+system row even when no session system prompt is set. The message array stays
+user-first, preserving task-427. Preview: the active seeded greeting is folded
+inside `build_preview_system_prompt`.
+
+Revised `test_leading_greeting_excluded_from_provider_payload` to the new
+contract (`test_leading_greeting_folds_into_system_row_not_message_array`)
+and added the with-system-prompt variant; both watched RED first. The
+regenerate/continue-blocked greeting tests still pass unchanged.
+
+Live-verified against the stub provider: Console turn 1/2 and preview payloads
+all carry the greeting text inside the system row with a user-first array;
+DB transcript and provider view now agree.

--- a/backlog/tasks/task-1532 - Verify-avatar-thumbnail-paints-under-non-graphics-terminals.md
+++ b/backlog/tasks/task-1532 - Verify-avatar-thumbnail-paints-under-non-graphics-terminals.md
@@ -1,0 +1,68 @@
+---
+id: TASK-1532
+title: 'Verify avatar thumbnail paints under non-graphics terminals (blank in tmux harness)'
+status: In Progress
+assignee: []
+created_date: '2026-07-30 15:30'
+labels: [roleplay, ux, verification, P3]
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Dev (c329def0d) implements character avatar thumbnails (Roleplay Inspector
+`#personas-inspector-avatar-thumb`, character editor thumb, generation card)
+with a graphics mode (`textual_image`) and a pixels fallback
+(`_build_avatar_pixels` → `rich_pixels.Pixels`, personas_screen.py:5343).
+
+In a live tmux run (TERM without graphics support) with a character whose
+366 KB portrait was confirmed present in the DB, the Inspector reserved the
+thumb box but painted nothing: `capture-pane -e` over the region shows zero
+half-block glyphs (▀▄█) and only 4 unique background colors (panel chrome) —
+a rendered Pixels globe would emit many colored half-block cells. No decode
+error appeared in the app log.
+
+Needs: (1) verification in a real graphics terminal (iTerm2/Kitty) that the
+graphics path paints; (2) a check of why the pixels fallback produced no
+visible cells under tmux — mode resolution may be picking "graphics" in a
+terminal that swallows the escape sequences, or the Pixels renderable is
+lost between build and mount. Assert with `render_line()`/`render_strips()`,
+not widget presence (renderable ≠ painted).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+1. Root cause (proven by env probe): host-terminal env (`TERM_PROGRAM=iTerm.app`, `ITERM_SESSION_ID`) leaks into tmux panes, so detection recommended graphics whose escapes tmux swallows -> blank thumb.
+2. Fix `detect_terminal_capabilities`: when `TMUX` is set or TERM starts with screen/tmux, classify as `tmux`, force pixels, no tgp/sixel.
+3. TDD: new Tests/Utils/test_terminal_utils.py (tmux leak cases + iTerm-outside-tmux graphics guard).
+4. Live tmux re-run: avatar thumb must paint half-block cells.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Avatar thumbnail visibly paints in a graphics-capable terminal for a card with an embedded portrait.
+- [x] #2 The pixels fallback visibly paints (half-block cells) in a non-graphics terminal (e.g. under tmux), or mode resolution is fixed to pick pixels there.
+- [x] #3 A test asserts painted output at the render seam for the fallback path.
+<!-- AC:END -->
+
+## Implementation Notes
+
+Root cause proven live: the host terminal's env (`TERM_PROGRAM=iTerm.app`,
+`ITERM_SESSION_ID`) leaks into tmux panes, so `detect_terminal_capabilities`
+classified the pane as iTerm2 and recommended graphics mode -- whose escape
+sequences tmux swallows, painting nothing. Fix: when `TMUX` is set or TERM
+starts with screen/tmux, classify as `tmux` and force pixels (no tgp/sixel).
+
+Live re-verification under tmux: the Inspector avatar region went from 0
+half-block glyphs / 4 chrome-only colors to 200 half-block glyphs / 94 unique
+colors (the card portrait painting via rich_pixels).
+
+Tests: Tests/Utils/test_terminal_utils.py (tmux leak cases + an
+iTerm-outside-tmux graphics guard, watched RED first) and
+Tests/UI/test_personas_avatar_render.py (characterizes visible half-block
+output at the `_build_avatar_pixels` render seam).
+
+AC #1 (graphics-capable terminal paint) is intentionally left unchecked and
+the task In Progress: it can only be confirmed in a real iTerm2/Kitty session
+outside tmux -- open Roleplay, select a character with an embedded portrait,
+and confirm the Inspector thumbnail shows the image.

--- a/backlog/tasks/task-1532 - Verify-avatar-thumbnail-paints-under-non-graphics-terminals.md
+++ b/backlog/tasks/task-1532 - Verify-avatar-thumbnail-paints-under-non-graphics-terminals.md
@@ -66,3 +66,14 @@ AC #1 (graphics-capable terminal paint) is intentionally left unchecked and
 the task In Progress: it can only be confirmed in a real iTerm2/Kitty session
 outside tmux -- open Roleplay, select a character with an embedded portrait,
 and confirm the Inspector thumbnail shows the image.
+
+### Update 2026-07-30 (browser-served visual confirmation)
+
+Re-verified with real screenshots against the user's local llama.cpp
+instance (127.0.0.1:9099, gemma-4-26B) via `textual serve` + Playwright:
+the Inspector avatar thumbnail visibly renders the card portrait (color
+globe) in pixels mode on the browser surface, and the full roleplay journey
+(import -> Start Chat -> in-character narrator reply respecting the card's
+2-paragraph rule) works end to end. Remaining unknown is narrowed to the
+NATIVE graphics-protocol path only (iTerm2/Kitty TGP outside tmux) -- one
+manual look in a real graphics terminal closes AC #1.

--- a/backlog/tasks/task-1533 - Quadrant-mosaic-rendering-for-avatar-fallbacks.md
+++ b/backlog/tasks/task-1533 - Quadrant-mosaic-rendering-for-avatar-fallbacks.md
@@ -1,0 +1,65 @@
+---
+id: TASK-1533
+title: 'Quadrant-mosaic rendering for avatar fallbacks (2x horizontal detail)'
+status: Done
+assignee: []
+created_date: '2026-07-30 16:40'
+labels: [enhancement, roleplay, console, rendering]
+dependencies: [TASK-1532]
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The non-graphics avatar fallback rendered via rich_pixels half-blocks (1x2
+subpixels per cell), which looks coarse in every environment that cannot do
+TGP/Sixel (tmux, textual-serve/browser). Replace it with a quadrant-glyph
+mosaic: 2x2 subpixels per cell from the universal Block Elements range —
+double the horizontal detail with identical font coverage (sextants/octants
+sample finer but their glyph coverage is spotty in browsers and stock macOS
+terminal fonts, so they were deliberately not used).
+
+Surfaces wired: Roleplay Inspector portrait, character editor thumbnail
+(both via `PersonasScreen._build_avatar_pixels`), and the Console rail
+"Character" section box (`_character_avatar_fallback_renderable`). The
+graphics (TGP/Sixel) path is untouched.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+1. Pure module `Utils/mosaic_render.py`: per-cell luminance-split 2-color
+   quantization, quadrant glyph table, aspect-true sampling (2x horizontal
+   density over the half-block grid; terminal cells are ~1:2).
+2. TDD: glyph vocabulary, single-cell left/right-split resolution (the case
+   half-blocks cannot express), box fit, RGBA compositing, square-image
+   aspect (regression for the vertical-stretch bug caught live).
+3. Swap the personas builder and the Console rail fallback to the mosaic;
+   update tests pinned to rich_pixels mechanics to the new seam.
+4. Live browser-served verification with screenshots on both surfaces.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A hard vertical edge resolves within a single cell (left/right-half glyphs) on the personas and Console rail fallback paths.
+- [x] #2 A square image renders with correct aspect (no vertical stretch) and fills its cell box.
+- [x] #3 Only universal Block Elements glyphs are emitted (browser/tmux/stock-font safe).
+- [x] #4 Live visual verification on the Roleplay Inspector AND the Console rail Character box.
+<!-- AC:END -->
+
+## Implementation Notes
+
+`mosaic_from_image(image, box_cols, box_lines)` resamples to a
+`2*W*scale x H*scale` grid (scale = min(cols/W, 2*lines/H)) so quadrant
+subpixels (half a cell wide, half tall) sample at double horizontal density
+while the painted size stays aspect-true — the first cut reused the
+half-block grid shape and rendered a square globe as a tall ellipse (caught
+by live screenshot, pinned by `test_square_image_fills_square_cell_box...`).
+Flat cells (< 8 luminance spread) paint as background-colored spaces;
+otherwise a luminance-threshold split picks fg/bg groups and the glyph mask.
+
+Verified live via textual-serve + Playwright screenshots against the local
+llama.cpp instance: Roleplay Inspector globe is round and visibly sharper
+than the half-block version; the Console rail Character section paints the
+same mosaic (previously it also silently depended on the tmux/browser
+graphics-mode blank fixed in TASK-1532). Suites: mosaic module 6, avatar
+render 3, console avatar 14, editor avatar suite, plus the chat
+controller/native-flow/preview regression set — all green.

--- a/backlog/tasks/task-1534 - Full-size-portrait-viewer-on-avatar-click.md
+++ b/backlog/tasks/task-1534 - Full-size-portrait-viewer-on-avatar-click.md
@@ -1,0 +1,28 @@
+---
+id: TASK-1534
+title: 'Full-size portrait viewer on avatar click'
+status: Done
+assignee: []
+created_date: '2026-07-30 17:20'
+labels: [enhancement, roleplay, console, ux]
+dependencies: [TASK-1533]
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clicking the character avatar (Console rail "Character" box or the Roleplay
+Inspector portrait) opens `ConsoleImageViewerModal`: the image as large as
+the viewport allows -- true raster via textual_image on graphics terminals,
+a viewport-sized quadrant mosaic elsewhere (~10x the thumbnail's pixel
+budget). Esc or any click closes. `ClickableAvatarBox` posts
+`AvatarViewRequested` with no payload; each screen resolves the CURRENT
+portrait at click time (selection can change between mount and click).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Clicking either avatar surface opens the viewer with the portrait rendered viewport-sized (contain fit -- the whole image visible).
+- [x] #2 Escape and click both dismiss.
+- [x] #3 Covered by widget tests (click posts request; modal renders and dismisses); wiring live-verified with screenshots.
+<!-- AC:END -->

--- a/backlog/tasks/task-1535 - Cover-fit-avatar-thumbnails.md
+++ b/backlog/tasks/task-1535 - Cover-fit-avatar-thumbnails.md
@@ -1,0 +1,26 @@
+---
+id: TASK-1535
+title: 'Cover-fit avatar thumbnails (fill the box, no distortion)'
+status: Done
+assignee: []
+created_date: '2026-07-30 17:20'
+labels: [enhancement, roleplay, console, rendering]
+dependencies: [TASK-1533]
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`mosaic_from_image` gains `fit="cover"` (object-fit: cover): scale to FILL
+the cell box and center-crop the overflow, aspect always preserved. The
+avatar thumbnails (Roleplay Inspector/editor, Console rail) use cover per
+user choice; the full-size viewer and any future inline uses keep the
+default contain (whole image visible).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 fit="cover" paints every cell of the box for any source aspect, center-cropped, never stretched.
+- [x] #2 Default stays contain; avatar thumbs pass cover explicitly.
+- [x] #3 Geometry pinned by deterministic tests (asserted on the renderable's plain text -- console text export miscounts styled flat cells).
+<!-- AC:END -->

--- a/backlog/tasks/task-1536 - Roleplay-flavor-styling-in-transcript.md
+++ b/backlog/tasks/task-1536 - Roleplay-flavor-styling-in-transcript.md
@@ -1,0 +1,33 @@
+---
+id: TASK-1536
+title: 'Roleplay flavor styling in the Console transcript'
+status: Done
+assignee: []
+created_date: '2026-07-30 17:20'
+labels: [enhancement, roleplay, console, ux]
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Assistant replies now style roleplay flavor distinctly: "quoted speech"
+(straight or curly, quotes kept visible) in sky blue, *action/inner
+monologue* in violet italic (markers stripped), **bold** in warm gold;
+plain narration unchanged. Built on the transcript's existing
+literal-text + (text, style)-tuple seam (`_inline_markdown_spans`), so the
+no-markup-injection guarantee is preserved; unclosed markers stay literal
+mid-stream, and a quote swallows markers inside it. Assistant-only, like
+the existing markdown emphasis (Qodo #823 rationale).
+
+Colors are concrete values (Content span styles never resolve CSS $theme
+variables); chosen to read on the dark default theme.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Bold, quoted speech, and action/italics render mutually distinct and distinct from narration.
+- [x] #2 Unclosed markers stay literal; injected Rich markup stays literal.
+- [x] #3 Straight and curly double quotes both style as speech.
+- [x] #4 Span-level tests pin the exact segments; live-verified with screenshots.
+<!-- AC:END -->

--- a/backlog/tasks/task-1537 - Remote-inline-transcript-images-behind-setting.md
+++ b/backlog/tasks/task-1537 - Remote-inline-transcript-images-behind-setting.md
@@ -33,3 +33,23 @@ viewer, budgets).
 - [x] #3 URL extraction accepts markdown image links and bare image-extension URLs only, http(s) only, deduped and capped.
 - [x] #4 All fetches route through the per-hop-validated egress GET with byte caps and content-type check.
 <!-- AC:END -->
+
+## Implementation Notes (live-verification addendum)
+
+Live end-to-end run (textual-serve + Playwright + local llama.cpp): the model
+emitted the requested markdown image line, the egress GET fetched 44 KB of
+image/jpeg from gstatic.com, and the row rendered inline. Two findings from
+the live pass, both fixed:
+
+1. The Console sync is DEMAND-driven, not a free-running timer -- after the
+   fetch cached the image, nothing requested a re-render, so the row stayed
+   invisible until an unrelated UI action. The fetch worker now requests
+   `_sync_native_console_chat_ui()` after a successful prepare.
+2. The persistent app log admits only diagnostics events (ADR-029 sink), so
+   module-level logger warnings from this path are NOT visible there --
+   debugging used a temporary file probe, since removed.
+
+Also: the viewer modal needed explicit inline cell sizes -- the app-tier CSS
+bundle outranks a modal's DEFAULT_CSS and a Container's default 100% height
+collapses to zero inside the auto-sized modal (caught live, pinned by a
+region-size assertion; harness CSS does NOT reproduce bundle interference).

--- a/backlog/tasks/task-1537 - Remote-inline-transcript-images-behind-setting.md
+++ b/backlog/tasks/task-1537 - Remote-inline-transcript-images-behind-setting.md
@@ -1,0 +1,35 @@
+---
+id: TASK-1537
+title: 'Remote inline transcript images behind a security setting'
+status: Done
+assignee: []
+created_date: '2026-07-30 17:20'
+labels: [enhancement, console, security]
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Assistant replies that reference images by link (markdown `![](url)` or a
+bare image-extension URL, http(s) only) can render them inline. OFF by
+default -- fetching a model-suggested URL leaks the reader's IP/UA to that
+host -- behind `[chat.images] render_remote_images = true`. Fetches go
+through the egress-hardened image GET
+(`image_format_utils.fetch_image_bytes`: per-hop SSRF policy, credential
+stripping on cross-origin redirects, Content-Length + streamed byte caps at
+8 MB), require an image/* content type, scan only the most recent 20
+assistant replies, attempt each URL at most once per screen lifetime, and
+share the bounded transcript render cache under per-URL `remote:` keys
+(failures negative-cache). Rows appear on the next transcript sync tick
+after a fetch lands and reuse the existing image-row pipeline (modes,
+viewer, budgets).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Default off: no fetch is dispatched and no row rendered without the setting.
+- [x] #2 Enabled + cached link renders an image row for the message; uncached link dispatches exactly one egress-gated fetch per URL.
+- [x] #3 URL extraction accepts markdown image links and bare image-extension URLs only, http(s) only, deduped and capped.
+- [x] #4 All fetches route through the per-hop-validated egress GET with byte caps and content-type check.
+<!-- AC:END -->

--- a/backlog/tasks/task-1537 - Remote-inline-transcript-images-behind-setting.md
+++ b/backlog/tasks/task-1537 - Remote-inline-transcript-images-behind-setting.md
@@ -53,3 +53,14 @@ Also: the viewer modal needed explicit inline cell sizes -- the app-tier CSS
 bundle outranks a modal's DEFAULT_CSS and a Container's default 100% height
 collapses to zero inside the auto-sized modal (caught live, pinned by a
 region-size assertion; harness CSS does NOT reproduce bundle interference).
+
+### Settings UI (user request, 2026-07-30)
+
+The toggle is surfaced in Settings > Console Behavior > "Chat images" as an
+ADR-020-style immediate-write button (no category draft): pressing it
+persists `[chat.images] render_remote_images` via the dotted-section config
+writer AND pokes the live `app_config` raw tree in place, since the App
+captures `app_config` once at startup and the transcript gate reads it.
+Help copy states the privacy trade-off; the tooltip names the egress policy.
+Live-verified: press flips Enabled/Disabled, writes the TOML, and shows a
+confirmation toast.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -36,6 +36,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleStagedSource,
     MessageAttachment,
     derive_console_session_title,
+    fold_greeting_into_system_prompt,
     is_default_console_session_title,
 )
 from tldw_chatbook.Chat.citation_repair import (
@@ -6897,7 +6898,9 @@ class ConsoleChatController:
             return f"Agent run stuck: {reason or 'budget or loop limit reached'}."
         return f"Agent run failed: {reason or outcome.status}."
 
-    def _leading_system_message(self) -> list[dict[str, str]]:
+    def _leading_system_message(
+        self, *, greeting: str = ""
+    ) -> list[dict[str, str]]:
         """Return a single-item system message list when a system prompt is set.
 
         Applies to every native Console send path (submit, retry, regenerate,
@@ -6909,11 +6912,44 @@ class ConsoleChatController:
         ``self.system_prompt`` verbatim: leading/trailing whitespace and
         internal formatting (blank lines, indentation) are never altered, so
         a formatting-sensitive prompt reaches the provider unchanged.
+
+        Args:
+            greeting: Seeded assistant greeting to fold after the prompt
+                (task-1531); a non-blank greeting produces a system row even
+                when no system prompt is set, since the message array itself
+                must stay user-first for strict providers (task-427).
         """
         raw_system_prompt = self.system_prompt
         if not isinstance(raw_system_prompt, str) or not raw_system_prompt.strip():
+            raw_system_prompt = ""
+        content = fold_greeting_into_system_prompt(raw_system_prompt, greeting)
+        if not content.strip():
             return []
-        return [{"role": ConsoleMessageRole.SYSTEM.value, "content": raw_system_prompt}]
+        return [{"role": ConsoleMessageRole.SYSTEM.value, "content": content}]
+
+    @staticmethod
+    def _seeded_greeting_text(
+        session_messages: list[ConsoleChatMessage],
+    ) -> str:
+        """Return the text of leading assistant turns (the seeded greeting).
+
+        Mirrors ``_provider_message_payloads``'s leading-assistant drop rule:
+        every ASSISTANT message before the first USER turn is excluded from
+        the message array, so its text must travel in the system row instead.
+        Failed messages are skipped to match ``skip_failed`` send payloads.
+        """
+        collected: list[str] = []
+        for message in session_messages:
+            if message.role is ConsoleMessageRole.USER:
+                break
+            if message.role is not ConsoleMessageRole.ASSISTANT:
+                continue
+            if message.status == "failed":
+                continue
+            text = (message.content or "").strip()
+            if text:
+                collected.append(text)
+        return "\n\n".join(collected)
 
     def _apply_context_summary_compaction(
         self, session_id: str, provider_messages: list[dict[str, Any]]
@@ -7011,7 +7047,9 @@ class ConsoleChatController:
             if message.id == before_message_id:
                 break
             collected.append(message)
-        return self._leading_system_message() + self._provider_message_payloads(
+        return self._leading_system_message(
+            greeting=self._seeded_greeting_text(collected)
+        ) + self._provider_message_payloads(
             collected, skip_failed=True, annotate_ids=annotate_ids
         )
 
@@ -7027,7 +7065,9 @@ class ConsoleChatController:
             collected.append(message)
             if message.id == message_id:
                 break
-        return self._leading_system_message() + self._provider_message_payloads(
+        return self._leading_system_message(
+            greeting=self._seeded_greeting_text(collected)
+        ) + self._provider_message_payloads(
             collected,
             skip_failed=False,
             use_variant_content=True,
@@ -7093,9 +7133,11 @@ class ConsoleChatController:
                 continue
             if skip_failed and message.status == "failed":
                 continue
-            # A seeded character greeting is a display-only assistant turn:
-            # keep it out of the provider payload so strict providers (Anthropic,
-            # Gemini) never see an assistant-first message array (task-427).
+            # A seeded character greeting must not ride in the message array:
+            # strict providers (Anthropic, Gemini) reject an assistant-first
+            # array (task-427). Its text still reaches the provider -- the
+            # send seams fold it into the system row via
+            # ``_seeded_greeting_text`` (task-1531).
             if not seen_user and message.role is ConsoleMessageRole.ASSISTANT:
                 continue
             if message.role is ConsoleMessageRole.USER:

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -490,3 +490,33 @@ class ConsoleContextSnapshot:
 
     current_messages: list[ConsoleChatMessage]
     next_send_payload: dict[str, Any]
+
+
+def fold_greeting_into_system_prompt(system_prompt: str, greeting: str) -> str:
+    """Return the system content carrying a seeded assistant greeting.
+
+    Strict providers (Anthropic, Gemini) reject an assistant-first message
+    array, so a seeded character greeting cannot ride in the message list
+    (task-427) -- but dropping it entirely makes the model contradict the
+    greeting the user already read in the transcript (task-1531). Folding
+    the greeting into the system row delivers it to every provider while
+    keeping the message array user-first. The configured system prompt is
+    kept verbatim at the start; the greeting block is appended after it.
+
+    Args:
+        system_prompt: The session's configured system prompt ("" for none).
+        greeting: The seeded assistant greeting text ("" for none).
+
+    Returns:
+        The combined system content; "" when both inputs are blank.
+    """
+    greeting_text = (greeting or "").strip()
+    if not greeting_text:
+        return system_prompt
+    opener_block = (
+        "You already opened this conversation with the following message, "
+        f"which the user has seen:\n{greeting_text}"
+    )
+    if not (system_prompt or "").strip():
+        return opener_block
+    return f"{system_prompt}\n\n{opener_block}"

--- a/tldw_chatbook/Chat/console_image_view.py
+++ b/tldw_chatbook/Chat/console_image_view.py
@@ -10,6 +10,7 @@ legacy chat defines those keys but never reads them.
 
 from __future__ import annotations
 
+import re
 import threading
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -149,6 +150,63 @@ def resolve_show_character_avatar(app_config: Mapping[str, Any]) -> bool:
     """
     value = _chat_images_config(app_config).get("show_character_avatar", True)
     return bool(value)
+
+
+def resolve_render_remote_images(app_config: Mapping[str, Any]) -> bool:
+    """Whether the transcript renders images referenced by LINKS in replies.
+
+    Security-sensitive: fetching a model-suggested URL leaks the reader's
+    IP/user-agent to that host, so this is OFF unless the user explicitly
+    sets ``[chat.images] render_remote_images = true``. The fetch path
+    itself always goes through the egress-hardened image fetcher
+    (per-hop SSRF policy + byte caps) regardless of this setting.
+
+    Args:
+        app_config: The application config mapping (``[chat.images]``
+            section is read; missing sections are tolerated).
+
+    Returns:
+        True only when explicitly enabled.
+    """
+    return bool(_chat_images_config(app_config).get("render_remote_images", False))
+
+
+#: Markdown image links: ![alt](url) -- any http(s) URL.
+_MD_IMAGE_LINK_RE = re.compile(r"!\[[^\]]*\]\((https?://[^\s)]+)\)")
+#: Bare URLs are only treated as images when they end in an image
+#: extension (optionally followed by a query string).
+_BARE_IMAGE_URL_RE = re.compile(
+    r"(?<!\()\bhttps?://[^\s)\"'<>]+?\.(?:png|jpe?g|gif|webp)(?:\?[^\s)\"'<>]*)?",
+    re.IGNORECASE,
+)
+
+
+def extract_image_urls(text: str, *, limit: int = 3) -> list[str]:
+    """Extract renderable image URLs from message text.
+
+    Accepts markdown image links (any http(s) URL) and bare http(s) URLs
+    with an image extension. Order-preserving, deduplicated, capped.
+
+    Args:
+        text: The raw message body.
+        limit: Maximum URLs returned.
+
+    Returns:
+        Up to ``limit`` unique image URLs in first-appearance order.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+    matches = [
+        (m.start(), m.group(1)) for m in _MD_IMAGE_LINK_RE.finditer(text or "")
+    ] + [(m.start(), m.group(0)) for m in _BARE_IMAGE_URL_RE.finditer(text or "")]
+    for _pos, url in sorted(matches):
+        if url in seen:
+            continue
+        seen.add(url)
+        found.append(url)
+        if len(found) >= limit:
+            break
+    return found
 
 
 def resolve_react_character_expressions(app_config: Mapping[str, Any]) -> bool:

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -1314,9 +1314,27 @@ class ConsoleProviderGateway:
         messages: list[Mapping[str, Any]],
         tools: list | None = None,
     ) -> dict[str, Any]:
+        # Extract the contiguous LEADING system rows into chat_api_call's
+        # `system_message` parameter (PR #1112 Qodo finding 3): Anthropic and
+        # Gemini adapters accept system content only via their dedicated
+        # parameter and do not honor `role="system"` rows in the message
+        # array, so a payload-only system prompt (and the task-1531 folded
+        # greeting riding it) would never reach those providers. The
+        # OpenAI-compatible adapters prepend `system_message` as a system row
+        # themselves when the payload has none, so the extraction is
+        # provider-neutral. Mid-array system rows never occur on this path
+        # (`_provider_message_payloads` emits user/assistant only).
+        payload = list(messages)
+        system_parts: list[str] = []
+        while payload and payload[0].get("role") == "system":
+            content = str(payload[0].get("content") or "").strip()
+            if content:
+                system_parts.append(content)
+            payload = payload[1:]
         kwargs = {
             "api_endpoint": resolution.execution_key,
-            "messages_payload": list(messages),
+            "system_message": "\n\n".join(system_parts) or None,
+            "messages_payload": payload,
             "api_key": resolution.api_key,
             "model": resolution.model,
             "streaming": resolution.streaming,

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -14,7 +14,10 @@ from loguru import logger
 from textual.css.query import QueryError
 
 from ...Character_Chat.Character_Chat_Lib import replace_placeholders
-from ...Chat.console_chat_models import ConsoleProviderSelection
+from ...Chat.console_chat_models import (
+    ConsoleProviderSelection,
+    fold_greeting_into_system_prompt,
+)
 from ...Chat.console_provider_gateway import ConsoleProviderGateway
 from ...Chat.console_session_settings import build_default_console_session_settings
 from ...Chat.provider_catalog import PROVIDER_DISPLAY_NAMES
@@ -34,6 +37,37 @@ logger = logger.bind(module="PersonasPreviewController")
 
 # Cap on the preview transcript text staged into a Console handoff body.
 PREVIEW_HANDOFF_TRANSCRIPT_CHAR_LIMIT = 6000
+
+def build_preview_system_prompt(
+    record: Mapping[str, Any], *, greeting: str = ""
+) -> str:
+    """Build the preview's provider system prompt from a card/profile record.
+
+    Joins the record's prompt-bearing fields, resolves ``{{char}}``/``{{user}}``
+    macros against the record name (task-1530), and folds the seeded greeting
+    into the system row so the model knows the opener the user already read --
+    the preview's message history stays user-first for strict providers
+    (task-1531).
+
+    Args:
+        record: Character card or persona profile record.
+        greeting: The greeting currently seeding the preview transcript
+            (already macro-resolved at seed time); "" when none.
+
+    Returns:
+        The system prompt text; falls back to "Stay in character." when the
+        record carries no prompt fields and no greeting is seeded.
+    """
+    parts = [
+        str(record.get(key) or "").strip()
+        for key in ("system_prompt", "personality", "description", "scenario")
+    ]
+    joined = "\n".join(part for part in parts if part)
+    name = str(record.get("name") or "").strip() or "Character"
+    prompt = replace_placeholders(joined, name, "User") if joined else ""
+    folded = fold_greeting_into_system_prompt(prompt, greeting)
+    return folded or "Stay in character."
+
 
 class PersonasPreviewController:
     """Owns preview chat state, provider calls, and Console handoff."""
@@ -417,12 +451,15 @@ class PersonasPreviewController:
                 )
         elif screen.state.active_mode == "personas":
             record = screen._profile_record(screen.state.selected_entity_id) or {}
-        parts = [
-            str(record.get(key) or "").strip()
-            for key in ("system_prompt", "personality", "description", "scenario")
-        ]
-        prompt = "\n".join(part for part in parts if part)
-        return prompt or "Stay in character."
+        return build_preview_system_prompt(
+            record, greeting=self._active_greeting_text()
+        )
+
+    def _active_greeting_text(self) -> str:
+        """Return the greeting currently seeding the preview, or ""."""
+        if 0 <= self._current_greeting_index < len(self._greetings):
+            return self._greetings[self._current_greeting_index]
+        return ""
 
     def handle_reply_requested(self, user_message: str) -> None:
         """Append the user turn and schedule one provider reply.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4336,9 +4336,14 @@ class ChatScreen(BaseAppScreen):
             if content_type and not str(content_type).split(";")[0].strip().lower().startswith("image/"):
                 return
             _state, cache = self._ensure_console_image_view()
-            await asyncio.to_thread(cache.prepare, cache_key, data)
+            prepared = await asyncio.to_thread(cache.prepare, cache_key, data)
+            if prepared and self.is_mounted:
+                # The Console sync is demand-driven, not a free-running
+                # timer: without this request the freshly cached image would
+                # sit invisible until the next unrelated UI action.
+                await self._sync_native_console_chat_ui()
         except Exception:
-            logger.opt(exception=True).debug(
+            logger.opt(exception=True).warning(
                 "remote transcript image fetch failed: {}", url
             )
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1066,6 +1066,46 @@ def _character_session_identity_from_handoff(
     return runtime_backend, character_id, character_name, character_id_text
 
 
+def _character_session_prompt_seed(
+    card: Mapping[str, Any], name_hint: str = ""
+) -> tuple[str, str, str]:
+    """Return ``(name, system_prompt, greeting)`` seeded from a character card.
+
+    Joins the card's prompt-bearing fields into the Console session's system
+    prompt and picks the seeded greeting from ``first_message``.
+
+    Args:
+        card: The character card record.
+        name_hint: Fallback display name when the card has none.
+
+    Returns:
+        The character name, session system prompt, and greeting text.
+    """
+    # Local import matches this module's existing convention of deferring
+    # Character_Chat submodule imports (they pull in Pillow and
+    # CharactersRAGDB) rather than importing them at module scope.
+    from ...Character_Chat.Character_Chat_Lib import replace_placeholders
+
+    name = str(card.get("name") or name_hint or "").strip() or "Character"
+    parts = [
+        str(card.get(key) or "").strip()
+        for key in ("system_prompt", "personality", "description", "scenario")
+    ]
+    joined = "\n".join(p for p in parts if p)
+    # Cards are written against SillyTavern-style macros; resolve
+    # {{char}}/{{user}} (and aliases) before the text reaches session
+    # settings, or they leak verbatim into every provider payload
+    # (task-1530). "User" matches the greeting-display substitution used
+    # across the Personas surfaces.
+    system_prompt = (
+        replace_placeholders(joined, name, "User") if joined else "Stay in character."
+    )
+    greeting = replace_placeholders(
+        str(card.get("first_message") or ""), name, "User"
+    )
+    return name, system_prompt, greeting
+
+
 def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
     """Return whether a handoff is a Personas "Open in Console" preview transcript.
 
@@ -12354,19 +12394,8 @@ class ChatScreen(BaseAppScreen):
             ):
                 return False
 
-        # Local import matches this module's existing convention of
-        # deferring Character_Chat submodule imports (they pull in Pillow
-        # and CharactersRAGDB) rather than importing them at module scope.
-        from ...Character_Chat.Character_Chat_Lib import replace_placeholders
-
-        name = str(card.get("name") or name_hint or "").strip() or "Character"
-        parts = [
-            str(card.get(key) or "").strip()
-            for key in ("system_prompt", "personality", "description", "scenario")
-        ]
-        system_prompt = "\n".join(p for p in parts if p) or "Stay in character."
-        greeting = replace_placeholders(
-            str(card.get("first_message") or ""), name, "User"
+        name, system_prompt, greeting = _character_session_prompt_seed(
+            card, name_hint=str(name_hint or "")
         )
 
         store = self._ensure_console_chat_store()

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -245,10 +245,12 @@ from ...Chat.console_image_view import (
     ConsoleImageRenderCache,
     ConsoleImageRowSpec,
     ConsoleImageViewState,
+    extract_image_urls,
     fit_image_cell_size,
     next_view_mode,
     resolve_default_mode,
     resolve_react_character_expressions,
+    resolve_render_remote_images,
     resolve_show_character_avatar,
 )
 from ...Chat.console_paste_attach import (
@@ -337,6 +339,11 @@ from ...Widgets.Console import (
     ConsoleWorkspaceSwitcherModal,
 )
 from ...Widgets.confirmation_dialog import ConfirmationDialog
+from ...Widgets.Console.console_image_viewer_modal import (
+    AvatarViewRequested,
+    ClickableAvatarBox,
+    ConsoleImageViewerModal,
+)
 from ...Widgets.Console.console_context_modal import ConsoleContextModal
 from ...Widgets.Console.console_citation_sources_modal import (
     selected_valid_evidence_ordinals,
@@ -529,6 +536,11 @@ CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 2.0
 # smaller for the rail's narrower column).
 CHARACTER_AVATAR_COLS = 16
 CHARACTER_AVATAR_LINES = 8
+# task-1537: remote inline images. Only the most recent assistant replies are
+# scanned for image links (older history never triggers fetches), and one
+# fetched body is capped well below the render cache's decode ceiling.
+REMOTE_IMAGE_SCAN_WINDOW = 20
+REMOTE_IMAGE_MAX_BYTES = 8 * 1024 * 1024
 # P3d-1 Task 3 (review fix): bound `_console_expression_spec_cache` so a
 # long session visiting many characters/states doesn't retain unbounded PIL
 # image references (the spec dicts hold their own `PILImage.Image`, so the
@@ -1114,7 +1126,9 @@ def _character_avatar_fallback_renderable(pil: Any):
     """
     from ...Utils.mosaic_render import mosaic_from_image
 
-    return mosaic_from_image(pil, CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES)
+    return mosaic_from_image(
+        pil, CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES, fit="cover"
+    )
 
 
 def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
@@ -4237,7 +4251,96 @@ class ChatScreen(BaseAppScreen):
                 pixels=cache.get_pixels(message.id) if mode == "pixels" else None,
                 pil=pil if mode == "graphics" else None,
             )
+        self._extend_specs_with_remote_images(messages, specs, state, cache)
         return specs
+
+    def _extend_specs_with_remote_images(
+        self, messages, specs: dict, state, cache
+    ) -> None:
+        """Add rows for images referenced by LINKS in recent assistant replies.
+
+        task-1537, OFF unless ``[chat.images] render_remote_images`` -- a
+        model-suggested URL is untrusted input, so every fetch goes through
+        the egress-hardened image GET (per-hop SSRF policy, credential
+        stripping on cross-origin redirects, byte caps) and each URL is
+        attempted at most once per screen lifetime. Decoded bodies share the
+        bounded transcript render cache under a per-URL ``remote:`` key, so
+        the row appears on the next transcript sync tick after the fetch
+        lands; failures negative-cache and stay blank.
+        """
+        app_config = (
+            getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
+        )
+        if not resolve_render_remote_images(app_config):
+            return
+        default_mode = self._console_image_default_mode
+        for message in messages[-REMOTE_IMAGE_SCAN_WINDOW:]:
+            if message.role is not ConsoleMessageRole.ASSISTANT:
+                continue
+            if message.id in specs:
+                continue
+            if message.status == "failed":
+                continue
+            urls = extract_image_urls(message.content or "", limit=1)
+            if not urls:
+                continue
+            url = urls[0]
+            key = f"remote:{url}"
+            pil = cache.get_pil(key)
+            if pil is not None:
+                mode = state.mode_for(message.id, default=default_mode)
+                if mode == "hidden":
+                    continue
+                specs[message.id] = ConsoleImageRowSpec(
+                    message_id=message.id,
+                    mode=mode,
+                    pixels=cache.get_pixels(key) if mode == "pixels" else None,
+                    pil=pil if mode == "graphics" else None,
+                )
+                continue
+            if cache.is_failed(key):
+                continue
+            attempts = getattr(self, "_remote_image_fetch_attempts", None)
+            if attempts is None:
+                attempts = set()
+                self._remote_image_fetch_attempts = attempts
+            if url in attempts:
+                continue
+            attempts.add(url)
+            self.run_worker(
+                self._fetch_remote_transcript_image(url, key),
+                group="console-remote-image-fetch",
+                exclusive=False,
+                exit_on_error=False,
+            )
+
+    async def _fetch_remote_transcript_image(self, url: str, cache_key: str) -> None:
+        """Fetch one linked image via the egress-hardened GET and cache it.
+
+        Must never raise (workers dispatched from the transcript sync path):
+        any failure -- egress-blocked URL, oversize body, non-image
+        content-type, decode error -- logs at debug and leaves the URL
+        negative-cached/attempted so it is not retried this session.
+        """
+        try:
+            from ...Image_Generation.adapters.image_format_utils import (
+                fetch_image_bytes,
+            )
+
+            data, content_type = await asyncio.to_thread(
+                fetch_image_bytes,
+                url,
+                timeout=20,
+                max_bytes=REMOTE_IMAGE_MAX_BYTES,
+            )
+            if content_type and not str(content_type).split(";")[0].strip().lower().startswith("image/"):
+                return
+            _state, cache = self._ensure_console_image_view()
+            await asyncio.to_thread(cache.prepare, cache_key, data)
+        except Exception:
+            logger.opt(exception=True).debug(
+                "remote transcript image fetch failed: {}", url
+            )
 
     def _console_generation_browse(self) -> dict[str, int]:
         """Return the lazily-created browsed-variant-index map for generation cards.
@@ -6010,6 +6113,21 @@ class ChatScreen(BaseAppScreen):
             # escaping mount failure (e.g. a session-switch/resume tick
             # racing a transient layout state) could crash the app.
             logger.opt(exception=True).debug("avatar: render into section failed")
+
+    @on(AvatarViewRequested)
+    def _handle_avatar_view_requested(self, message: AvatarViewRequested) -> None:
+        """Open the full-size portrait viewer for the rail avatar (task-1534)."""
+        message.stop()
+        spec = self._active_character_avatar or {}
+        pil = spec.get("pil")
+        if pil is None:
+            return
+        self.app.push_screen(
+            ConsoleImageViewerModal(
+                pil,
+                title=self._active_character_avatar_name or "Character portrait",
+            )
+        )
 
     def _build_character_avatar_widget(self, spec: dict | None) -> Widget:
         """Build a fresh avatar widget from the cached spec (data, not a widget).
@@ -11295,7 +11413,9 @@ class ChatScreen(BaseAppScreen):
                             if not rail_state.character_open:
                                 character_body.styles.display = "none"
                             with character_body:
-                                avatar_holder = Container(id="console-character-avatar")
+                                avatar_holder = ClickableAvatarBox(
+                                    id="console-character-avatar"
+                                )
                                 with avatar_holder:
                                     yield self._build_character_avatar_widget(
                                         self._active_character_avatar

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -250,7 +250,6 @@ from ...Chat.console_image_view import (
     resolve_default_mode,
     resolve_react_character_expressions,
     resolve_show_character_avatar,
-    scale_image_for_cell_box,
 )
 from ...Chat.console_paste_attach import (
     extract_dropped_path,
@@ -1104,6 +1103,18 @@ def _character_session_prompt_seed(
         str(card.get("first_message") or ""), name, "User"
     )
     return name, system_prompt, greeting
+
+
+def _character_avatar_fallback_renderable(pil: Any):
+    """Bake the rail avatar's non-graphics renderable from a PIL image.
+
+    Quadrant mosaic (2x2 subpixels per cell) at the rail's fitted box --
+    double the horizontal detail of the previous half-block Pixels build
+    with the same universal Block Elements font coverage.
+    """
+    from ...Utils.mosaic_render import mosaic_from_image
+
+    return mosaic_from_image(pil, CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES)
 
 
 def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
@@ -6052,12 +6063,7 @@ class ChatScreen(BaseAppScreen):
         try:
             pixels = spec.get("pixels")
             if pixels is None and spec.get("pil") is not None:
-                scaled = scale_image_for_cell_box(
-                    spec["pil"], CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES
-                )
-                from rich_pixels import Pixels
-
-                pixels = Pixels.from_image(scaled)
+                pixels = _character_avatar_fallback_renderable(spec["pil"])
             widget = Static(
                 pixels if pixels is not None else "",
                 id="console-character-avatar-image",

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -52,6 +52,10 @@ from ...tldw_api.character_persona_schemas import (
 from ...Utils.path_validation import validate_path_simple
 from ...Utils.paths import get_user_data_dir
 from ...Widgets.destination_rail import DestinationRailHandle
+from ...Widgets.Console.console_image_viewer_modal import (
+    AvatarViewRequested,
+    ConsoleImageViewerModal,
+)
 from ...Widgets.Console.console_style_picker_modal import ConsoleStylePickerModal
 from ...Widgets.confirmation_dialog import ConfirmationDialog, UnsavedChangesDialog
 from ...Widgets.destination_workbench import DestinationModeStrip
@@ -5132,6 +5136,24 @@ class PersonasScreen(BaseAppScreen):
             exclusive=True,
         )
 
+    @on(AvatarViewRequested)
+    def _handle_avatar_view_requested(self, message: AvatarViewRequested) -> None:
+        """Open the full-size portrait viewer for the Inspector thumb (task-1534)."""
+        message.stop()
+        cache = getattr(self, "_avatar_render_cache", None)
+        selected_id = str(self.state.selected_entity_id or "")
+        pil = None
+        if cache is not None and selected_id:
+            pil = cache.get_pil(f"inspector-avatar-{selected_id}")
+        if pil is None:
+            return
+        self.app.push_screen(
+            ConsoleImageViewerModal(
+                pil,
+                title=self.state.selected_entity_name or "Character portrait",
+            )
+        )
+
     async def _render_inspector_avatar(self) -> None:
         """Decode and mount the selected character's Inspector portrait.
 
@@ -5365,7 +5387,9 @@ class PersonasScreen(BaseAppScreen):
         pil = cache.get_pil(cache_key)
         if pil is None:
             return None
-        return mosaic_from_image(pil, AVATAR_THUMB_COLS, AVATAR_THUMB_LINES)
+        return mosaic_from_image(
+            pil, AVATAR_THUMB_COLS, AVATAR_THUMB_LINES, fit="cover"
+        )
 
     async def _render_all_character_editor_thumbnails(
         self, character_id: int | None

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -5341,33 +5341,31 @@ class PersonasScreen(BaseAppScreen):
 
     @staticmethod
     def _build_avatar_pixels(cache: "ConsoleImageRenderCache", cache_key: str):
-        """Build a ``rich_pixels.Pixels`` sized to the avatar thumb box.
+        """Build a quadrant-mosaic renderable sized to the avatar thumb box.
 
         ``cache.get_pixels`` thumbnails to the 80x40 chat-transcript box,
         which is far larger than the character editor's compact avatar
-        preview; reusing it produces an oversized Pixels grid that Rich does
-        not reflow, so the small thumb container just crops it to a
-        top-left sliver. This instead pulls the cached full-size PIL image
-        and thumbnails a private copy to the avatar box (in half-block
-        "pixel" units: one character column is ~1px wide, one character
-        line is ~2px tall).
+        preview; reusing it produces an oversized grid that Rich does not
+        reflow, so the small thumb container just crops it to a top-left
+        sliver. This instead pulls the cached full-size PIL image and bakes
+        it to the avatar box via the quadrant mosaic (2x2 subpixels per
+        cell -- double the horizontal detail of the old half-block Pixels
+        renderer, same universal Block Elements font coverage).
 
         Args:
             cache: The render cache holding the decoded avatar image.
             cache_key: The per-session cache key ``prepare`` was called with.
 
         Returns:
-            A ``Pixels`` renderable fitted to the avatar box, or ``None``
-            when the image is not (or no longer) cached.
+            A mosaic ``Text`` renderable fitted to the avatar box, or
+            ``None`` when the image is not (or no longer) cached.
         """
-        import rich_pixels
+        from ...Utils.mosaic_render import mosaic_from_image
 
         pil = cache.get_pil(cache_key)
         if pil is None:
             return None
-        thumb = pil.copy()
-        thumb.thumbnail((AVATAR_THUMB_COLS, AVATAR_THUMB_LINES * 2))
-        return rich_pixels.Pixels.from_image(thumb)
+        return mosaic_from_image(pil, AVATAR_THUMB_COLS, AVATAR_THUMB_LINES)
 
     async def _render_all_character_editor_thumbnails(
         self, character_id: int | None

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -2804,6 +2804,47 @@ class SettingsScreen(BaseAppScreen):
     def _collapse_large_pastes_button_label(self) -> str:
         return "Enabled" if self._collapse_large_pastes_enabled() else "Disabled"
 
+    def _remote_images_enabled(self) -> bool:
+        """Return the live [chat.images].render_remote_images value."""
+        from ...Chat.console_image_view import resolve_render_remote_images
+
+        return resolve_render_remote_images(
+            getattr(self.app_instance, "app_config", {}) or {}
+        )
+
+    def _remote_images_button_label(self) -> str:
+        return "Enabled" if self._remote_images_enabled() else "Disabled"
+
+    def _toggle_remote_images(self) -> bool:
+        """Flip render_remote_images: persist it AND poke the live config.
+
+        ADR-020-style immediate write (no category draft): the toggle is a
+        single security-relevant boolean. The App captures ``app_config``
+        once at startup, so persisting alone would not take effect until
+        restart -- the raw in-memory tree the transcript gate reads is
+        updated in place too.
+
+        Returns:
+            The new (post-toggle) enabled value.
+        """
+        next_value = not self._remote_images_enabled()
+        save_settings_to_cli_config(
+            {"chat.images": {"render_remote_images": next_value}}
+        )
+        app_config = getattr(self.app_instance, "app_config", None)
+        if isinstance(app_config, dict):
+            raw = app_config.get("COMPREHENSIVE_CONFIG_RAW")
+            if isinstance(raw, dict):
+                raw.setdefault("chat", {}).setdefault("images", {})[
+                    "render_remote_images"
+                ] = next_value
+            chat_section = app_config.get("chat")
+            if isinstance(chat_section, dict) and isinstance(
+                chat_section.get("images"), dict
+            ):
+                chat_section["images"]["render_remote_images"] = next_value
+        return next_value
+
     def _paste_collapse_threshold_value(self) -> int | str:
         draft = self._settings_drafts.get(SettingsCategoryId.CONSOLE_BEHAVIOR)
         if draft is not None and "paste_collapse_threshold" in draft.values:
@@ -8889,6 +8930,25 @@ class SettingsScreen(BaseAppScreen):
                 "Normal typing stays literal. The canonical message payload is preserved.",
                 id="settings-console-collapse-large-pastes-help",
             )
+            yield Static("Chat images", classes="destination-section")
+            yield Static(
+                "Render images linked in assistant replies (remote fetch).",
+                id="settings-console-remote-images-label",
+            )
+            yield Button(
+                self._remote_images_button_label(),
+                id="settings-console-remote-images-toggle",
+                tooltip=(
+                    "Fetch and render http(s) image links found in replies. "
+                    "Applies immediately; fetches go through the egress SSRF "
+                    "policy with size caps."
+                ),
+            )
+            yield Static(
+                "Off by default: fetching a model-suggested link reveals your "
+                "IP address to that host.",
+                id="settings-console-remote-images-help",
+            )
             yield Static("Parallel agent runs", classes="destination-section")
             with Horizontal(classes="settings-input-row"):
                 yield Static(
@@ -12364,6 +12424,19 @@ class SettingsScreen(BaseAppScreen):
         event.button.label = self._collapse_large_pastes_button_label()
         self._update_console_paste_summary()
         self._update_draft_status_widgets(SettingsCategoryId.CONSOLE_BEHAVIOR)
+
+    @on(Button.Pressed, "#settings-console-remote-images-toggle")
+    def handle_console_remote_images_toggle(self, event: Button.Pressed) -> None:
+        """Flip the remote-images toggle: immediate write, no category draft."""
+        event.stop()
+        enabled = self._toggle_remote_images()
+        event.button.label = self._remote_images_button_label()
+        self.app.notify(
+            "Linked images in replies will now render."
+            if enabled
+            else "Linked images in replies will stay ignored.",
+            severity="information",
+        )
 
     @on(Input.Changed, "#settings-console-paste-collapse-threshold")
     def handle_console_paste_threshold_changed(self, event: Input.Changed) -> None:

--- a/tldw_chatbook/Utils/mosaic_render.py
+++ b/tldw_chatbook/Utils/mosaic_render.py
@@ -49,7 +49,11 @@ def _mean(colors: list[tuple[int, int, int]]) -> tuple[int, int, int]:
 
 
 def mosaic_from_image(
-    image: "PILImage.Image", box_cols: int, box_lines: int
+    image: "PILImage.Image",
+    box_cols: int,
+    box_lines: int,
+    *,
+    fit: str = "contain",
 ) -> Text:
     """Render ``image`` into a quadrant-glyph mosaic fitting a cell box.
 
@@ -66,6 +70,9 @@ def mosaic_from_image(
             black before sampling.
         box_cols: Destination box width in character columns.
         box_lines: Destination box height in character lines.
+        fit: "contain" (default) letterboxes the whole image inside the
+            box; "cover" scales to FILL the box and center-crops the
+            overflow (object-fit: cover) -- aspect is preserved either way.
 
     Returns:
         A non-wrapping Rich ``Text`` renderable, one line per cell row.
@@ -76,10 +83,21 @@ def mosaic_from_image(
         base = PILImage.new("RGBA", rgba.size, (0, 0, 0, 255))
         source = PILImage.alpha_composite(base, rgba).convert("RGB")
     src_w, src_h = source.size
-    scale = min(max(1, box_cols) / src_w, max(1, box_lines) * 2 / src_h)
-    grid_w = min(max(2, round(src_w * scale * 2)), max(1, box_cols) * 2)
-    grid_h = min(max(1, round(src_h * scale)), max(1, box_lines) * 2)
-    source = source.resize((grid_w, grid_h), PILImage.Resampling.LANCZOS)
+    box_w = max(1, box_cols)
+    box_h = max(1, box_lines)
+    if fit == "cover":
+        scale = max(box_w / src_w, box_h * 2 / src_h)
+        grid_w = max(box_w * 2, round(src_w * scale * 2))
+        grid_h = max(box_h * 2, round(src_h * scale))
+        source = source.resize((grid_w, grid_h), PILImage.Resampling.LANCZOS)
+        left = (grid_w - box_w * 2) // 2
+        top = (grid_h - box_h * 2) // 2
+        source = source.crop((left, top, left + box_w * 2, top + box_h * 2))
+    else:
+        scale = min(box_w / src_w, box_h * 2 / src_h)
+        grid_w = min(max(2, round(src_w * scale * 2)), box_w * 2)
+        grid_h = min(max(1, round(src_h * scale)), box_h * 2)
+        source = source.resize((grid_w, grid_h), PILImage.Resampling.LANCZOS)
     width, height = source.size
     cell_cols = max(1, (width + 1) // 2)
     cell_rows = max(1, (height + 1) // 2)

--- a/tldw_chatbook/Utils/mosaic_render.py
+++ b/tldw_chatbook/Utils/mosaic_render.py
@@ -1,0 +1,126 @@
+"""Quadrant-mosaic rendering for terminal image fallbacks.
+
+Half-block rendering (``rich_pixels``) samples one pixel per column and two
+per line -- 1x2 subpixels per cell. This module samples 2x2 subpixels per
+cell using quadrant glyphs from the universal Block Elements range, doubling
+horizontal detail on every surface that can already show the half-block
+fallback (tmux, textual-serve/browser, plain terminals) with no font risk.
+Sextant/octant glyphs (Symbols for Legacy Computing) would sample finer
+still, but their font coverage is spotty in browsers and stock macOS
+terminal fonts, so they are deliberately not used.
+
+Each cell carries at most two colors (foreground + background); the four
+subpixels are split by luminance and each group is averaged. Flat-shaded art
+(character card portraits) loses nothing; photographic gradients trade a
+little color precision for the doubled spatial detail.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PIL import Image as PILImage
+from rich.text import Text
+
+if TYPE_CHECKING:  # pragma: no cover
+    pass
+
+# Index = 4-bit subpixel mask: bit 0 = top-left, 1 = top-right,
+# 2 = bottom-left, 3 = bottom-right.
+QUADRANT_GLYPHS = " ▘▝▀▖▌▞▛▗▚▐▜▄▙▟█"
+
+# Below this luminance spread a cell is treated as one flat color; the
+# threshold split would otherwise amplify sensor/scaling noise into
+# speckled glyphs.
+_FLAT_CELL_SPREAD = 8.0
+
+
+def _luminance(rgb: tuple[int, int, int]) -> float:
+    return 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]
+
+
+def _mean(colors: list[tuple[int, int, int]]) -> tuple[int, int, int]:
+    n = len(colors)
+    return (
+        sum(c[0] for c in colors) // n,
+        sum(c[1] for c in colors) // n,
+        sum(c[2] for c in colors) // n,
+    )
+
+
+def mosaic_from_image(
+    image: "PILImage.Image", box_cols: int, box_lines: int
+) -> Text:
+    """Render ``image`` into a quadrant-glyph mosaic fitting a cell box.
+
+    Mirrors ``scale_image_for_cell_box``'s fit convention (terminal cells
+    are ~2x taller than wide), corrected for the mosaic's subpixel shape:
+    a quadrant subpixel is HALF a cell wide but the same half-cell tall as
+    a half-block subpixel, so the horizontal sampling density is doubled
+    while the on-screen size stays the aspect-true fit -- ``scale = min(
+    box_cols / width, box_lines * 2 / height)`` with a ``2 * width *
+    scale`` x ``height * scale`` sampling grid.
+
+    Args:
+        image: Source PIL image; never modified. RGBA is composited over
+            black before sampling.
+        box_cols: Destination box width in character columns.
+        box_lines: Destination box height in character lines.
+
+    Returns:
+        A non-wrapping Rich ``Text`` renderable, one line per cell row.
+    """
+    source = image
+    if source.mode != "RGB":
+        rgba = source.convert("RGBA")
+        base = PILImage.new("RGBA", rgba.size, (0, 0, 0, 255))
+        source = PILImage.alpha_composite(base, rgba).convert("RGB")
+    src_w, src_h = source.size
+    scale = min(max(1, box_cols) / src_w, max(1, box_lines) * 2 / src_h)
+    grid_w = min(max(2, round(src_w * scale * 2)), max(1, box_cols) * 2)
+    grid_h = min(max(1, round(src_h * scale)), max(1, box_lines) * 2)
+    source = source.resize((grid_w, grid_h), PILImage.Resampling.LANCZOS)
+    width, height = source.size
+    cell_cols = max(1, (width + 1) // 2)
+    cell_rows = max(1, (height + 1) // 2)
+    pixels = source.load()
+
+    def sample(x: int, y: int) -> tuple[int, int, int]:
+        # Clamp so odd-sized thumbnails repeat their edge pixel instead of
+        # reading out of bounds.
+        return pixels[min(x, width - 1), min(y, height - 1)]
+
+    text = Text(no_wrap=True, end="")
+    for row in range(cell_rows):
+        if row:
+            text.append("\n")
+        for col in range(cell_cols):
+            cell = [
+                sample(col * 2, row * 2),
+                sample(col * 2 + 1, row * 2),
+                sample(col * 2, row * 2 + 1),
+                sample(col * 2 + 1, row * 2 + 1),
+            ]
+            lums = [_luminance(c) for c in cell]
+            spread = max(lums) - min(lums)
+            if spread < _FLAT_CELL_SPREAD:
+                r, g, b = _mean(cell)
+                text.append(" ", style=f"on rgb({r},{g},{b})")
+                continue
+            threshold = (max(lums) + min(lums)) / 2
+            mask = 0
+            fg_group: list[tuple[int, int, int]] = []
+            bg_group: list[tuple[int, int, int]] = []
+            for bit, (color, lum) in enumerate(zip(cell, lums)):
+                if lum >= threshold:
+                    mask |= 1 << bit
+                    fg_group.append(color)
+                else:
+                    bg_group.append(color)
+            fr, fg_, fb = _mean(fg_group)
+            br, bg_, bb = _mean(bg_group)
+            text.append(
+                QUADRANT_GLYPHS[mask],
+                style=f"rgb({fr},{fg_},{fb}) on rgb({br},{bg_},{bb})",
+            )
+    return text

--- a/tldw_chatbook/Utils/terminal_utils.py
+++ b/tldw_chatbook/Utils/terminal_utils.py
@@ -42,6 +42,26 @@ def detect_terminal_capabilities() -> Dict[str, any]:
         "recommended_mode": "pixels",  # Default to rich-pixels
     }
 
+    # tmux/screen panes inherit the HOST terminal's env (TERM_PROGRAM,
+    # ITERM_SESSION_ID, ...) but tmux does not pass graphics escape
+    # sequences (TGP/iTerm2/sixel) through to that host terminal, so
+    # trusting the leaked identity paints nothing at all. Half-block
+    # pixels are the only rendering that survives a multiplexer.
+    if os.environ.get("TMUX") or term.startswith(("screen", "tmux")):
+        capabilities["terminal_type"] = "tmux"
+        duration = time.time() - start_time
+        log_histogram("terminal_utils_detect_capabilities_duration", duration)
+        log_counter(
+            "terminal_utils_detect_capabilities_result",
+            labels={
+                "terminal_type": "tmux",
+                "has_sixel": str(capabilities["sixel"]),
+                "has_tgp": str(capabilities["tgp"]),
+                "recommended_mode": capabilities["recommended_mode"],
+            },
+        )
+        return capabilities
+
     # Check for specific terminals that support advanced graphics
 
     # Kitty terminal

--- a/tldw_chatbook/Widgets/Console/console_image_viewer_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_image_viewer_modal.py
@@ -93,7 +93,23 @@ class ConsoleImageViewerModal(ModalScreen[None]):
 
     async def on_mount(self) -> None:
         body = self.query_one("#console-image-viewer-body", Container)
-        await body.mount(self._build_full_size_widget())
+        widget = self._build_full_size_widget()
+        # Inline styles, not CSS: the app-tier stylesheet bundle outranks a
+        # widget's DEFAULT_CSS, and a Container's default 100% height inside
+        # this auto-sized modal collapses to zero under it. Explicit cell
+        # sizes derived from the built renderable are bundle-proof.
+        width = getattr(widget.styles.width, "value", None) or 0
+        height = getattr(widget.styles.height, "value", None) or 0
+        if width and height:
+            body.styles.width = width
+            body.styles.height = height
+        else:
+            body.styles.width = "auto"
+            body.styles.height = "auto"
+        outer = self.query_one("#console-image-viewer")
+        outer.styles.width = "auto"
+        outer.styles.height = "auto"
+        await body.mount(widget)
 
     def _build_full_size_widget(self) -> Static:
         """Build the largest renderable the viewport allows.
@@ -126,10 +142,14 @@ class ConsoleImageViewerModal(ModalScreen[None]):
                 pass
         from ...Utils.mosaic_render import mosaic_from_image
 
-        return Static(
-            mosaic_from_image(self._image, cols, lines),
-            id="console-image-viewer-image",
-        )
+        mosaic = mosaic_from_image(self._image, cols, lines)
+        lines_out = mosaic.plain.split("\n")
+        widget = Static(mosaic, id="console-image-viewer-image")
+        # Explicit fitted size (same guard as the graphics branch): the
+        # mosaic's own line grid is the authoritative cell size.
+        widget.styles.width = max(len(line) for line in lines_out)
+        widget.styles.height = len(lines_out)
+        return widget
 
     def _resolve_mode(self) -> str:
         try:

--- a/tldw_chatbook/Widgets/Console/console_image_viewer_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_image_viewer_modal.py
@@ -1,0 +1,148 @@
+"""Full-size image viewer modal for character portraits (task-1534).
+
+Clicking an avatar thumb (Console rail "Character" box, Roleplay Inspector
+portrait) opens the image as large as the viewport allows: the graphics
+path (TGP/Sixel terminals) shows the true raster, everything else gets a
+viewport-sized quadrant mosaic -- roughly 10x the pixel budget of the
+16x8-cell thumbnails. Escape or a click anywhere closes it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from textual import events
+from textual.app import ComposeResult
+from textual.containers import Container, Vertical
+from textual.message import Message
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+if TYPE_CHECKING:  # pragma: no cover
+    from PIL import Image as PILImage
+
+
+class AvatarViewRequested(Message):
+    """A clickable avatar box asking its screen to open the full-size view.
+
+    Carries no payload on purpose: each screen resolves the CURRENT
+    portrait itself (selection can change between mount and click).
+    """
+
+
+class ClickableAvatarBox(Container):
+    """Avatar thumb holder that requests the full-size viewer on click."""
+
+    def on_click(self, event: events.Click) -> None:
+        event.stop()
+        self.post_message(AvatarViewRequested())
+
+
+class ConsoleImageViewerModal(ModalScreen[None]):
+    """Show one image as large as the current viewport allows."""
+
+    DEFAULT_CSS = """
+    ConsoleImageViewerModal {
+        align: center middle;
+    }
+
+    #console-image-viewer {
+        width: auto;
+        height: auto;
+        max-width: 100%;
+        max-height: 100%;
+        border: tall gray;
+        background: black;
+        padding: 0 1;
+    }
+
+    #console-image-viewer-title {
+        width: 100%;
+        height: 1;
+        text-align: center;
+        color: $text-muted;
+    }
+
+    #console-image-viewer-body {
+        width: auto;
+        height: auto;
+    }
+
+    #console-image-viewer-hint {
+        width: 100%;
+        height: 1;
+        text-align: center;
+        color: $text-muted;
+    }
+    """
+
+    BINDINGS = [("escape", "dismiss_viewer", "Close")]
+
+    def __init__(self, image: "PILImage.Image", *, title: str = "") -> None:
+        super().__init__()
+        self._image = image
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="console-image-viewer"):
+            yield Static(self._title, id="console-image-viewer-title", markup=False)
+            yield Container(id="console-image-viewer-body")
+            yield Static(
+                "Esc / click to close", id="console-image-viewer-hint", markup=False
+            )
+
+    async def on_mount(self) -> None:
+        body = self.query_one("#console-image-viewer-body", Container)
+        await body.mount(self._build_full_size_widget())
+
+    def _build_full_size_widget(self) -> Static:
+        """Build the largest renderable the viewport allows.
+
+        Mirrors the avatar fallback ladder: graphics widget when the
+        session default mode resolves to graphics, quadrant mosaic
+        otherwise. Any graphics-path failure degrades to the mosaic.
+        The viewer always uses fit="contain" -- the point is seeing the
+        WHOLE image, unlike the cover-cropped thumbs.
+        """
+        cols = max(20, self.app.size.width - 8)
+        lines = max(10, self.app.size.height - 6)
+        mode = self._resolve_mode()
+        if mode == "graphics":
+            try:
+                from textual_image.widget import Image as _GraphicsImage
+
+                from ...Chat.console_image_view import fit_image_cell_size
+
+                widget: Any = _GraphicsImage(
+                    self._image, id="console-image-viewer-image"
+                )
+                w, h = fit_image_cell_size(
+                    self._image.width, self._image.height, cols, lines
+                )
+                widget.styles.width = w
+                widget.styles.height = h
+                return widget
+            except Exception:
+                pass
+        from ...Utils.mosaic_render import mosaic_from_image
+
+        return Static(
+            mosaic_from_image(self._image, cols, lines),
+            id="console-image-viewer-image",
+        )
+
+    def _resolve_mode(self) -> str:
+        try:
+            from ...Chat.console_image_view import resolve_default_mode
+
+            app_config = getattr(self.app, "app_config", {}) or {}
+            return resolve_default_mode(app_config)
+        except Exception:
+            return "pixels"
+
+    def on_click(self, event: events.Click) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    def action_dismiss_viewer(self) -> None:
+        self.dismiss(None)

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -210,17 +210,38 @@ def _message_attachment_chips(message: ConsoleChatMessage) -> list[str]:
     return chips
 
 
-#: Inline markdown handled in-transcript: **bold** and `code`. Matched as closed
-#: pairs only, so an unclosed marker mid-stream stays literal until it closes.
-_INLINE_MD_RE = re.compile(r"\*\*(.+?)\*\*|`([^`]+)`")
+#: Inline markdown + roleplay flavor handled in-transcript: **bold**, `code`,
+#: *action/inner-monologue*, and "quoted speech" (straight or curly). Matched
+#: as closed pairs only, so an unclosed marker mid-stream stays literal until
+#: it closes. Order matters: ** before * so bold never half-matches as
+#: italics, and a quote swallows any markers inside it (task-1536).
+_INLINE_MD_RE = re.compile(
+    r"\*\*(.+?)\*\*"
+    r"|`([^`]+)`"
+    r"|(\"[^\"\n]+\")"
+    r"|(“[^”\n]+”)"
+    r"|\*([^*\n]+)\*"
+)
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*\S)\s*$")
+
+#: Roleplay flavor styles (task-1536). Concrete colors, not theme variables:
+#: Content span styles are parsed directly and never resolve CSS ``$`` vars.
+#: All three read on the dark default theme and stay distinct from each
+#: other and from plain narration.
+_BOLD_STYLE = "bold #f7d774"
+_SPEECH_STYLE = "#8ecdf7"
+_ACTION_STYLE = "italic #b596d8"
 
 
 def _inline_markdown_spans(line: str) -> list:
-    """Split one line into Content segments, styling **bold**/`code` inline.
+    """Split one line into Content segments, styling inline flavor.
 
-    Text is always emitted literally (styles are applied via ``(text, style)``
-    tuples, never markup parsing), so message text can never inject Rich markup.
+    ``**bold**``, ``“quoted”``/``"quoted"`` speech, and
+    ``*action/inner monologue*`` each get a distinct style; `code` keeps its
+    plain italic. Text is always emitted literally (styles are applied via
+    ``(text, style)`` tuples, never markup parsing), so message text can
+    never inject Rich markup. Quotation marks stay visible inside the
+    styled speech span; bold/action marker characters are stripped.
 
     Args:
         line: A single raw text line.
@@ -233,10 +254,17 @@ def _inline_markdown_spans(line: str) -> list:
     for match in _INLINE_MD_RE.finditer(line):
         if match.start() > pos:
             out.append(line[pos : match.start()])
-        if match.group(1) is not None:
-            out.append((match.group(1), "bold"))
+        bold, code, quote, curly_quote, action = match.groups()
+        if bold is not None:
+            out.append((bold, _BOLD_STYLE))
+        elif code is not None:
+            out.append((code, "italic"))
+        elif quote is not None:
+            out.append((quote, _SPEECH_STYLE))
+        elif curly_quote is not None:
+            out.append((curly_quote, _SPEECH_STYLE))
         else:
-            out.append((match.group(2), "italic"))
+            out.append((action, _ACTION_STYLE))
         pos = match.end()
     if pos < len(line):
         out.append(line[pos:])

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -9,6 +9,8 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.widgets import Button, ListItem, ListView, Static
 
+from ..Console.console_image_viewer_modal import ClickableAvatarBox
+
 from .personas_pane_messages import ConversationRowSelected
 
 _UNSAVED_TOOLTIP = "Save before using this action; the selection has unsaved edits."
@@ -126,7 +128,7 @@ class PersonasInspectorPane(Vertical):
         # Portrait of the selected character. A roleplay user identifies a
         # character by its picture at least as much as by its name, and the
         # inspector previously showed every attribute EXCEPT the portrait.
-        yield Container(id="personas-inspector-avatar-thumb")
+        yield ClickableAvatarBox(id="personas-inspector-avatar-thumb")
         yield Static("Validation: OK", id="personas-validation-summary")
         yield Static("Conversations", classes="destination-section")
         yield ListView(id="personas-conversations-list")


### PR DESCRIPTION
## Summary

Three residual defects from the 2026-07-30 character-card roleplay UAT (run against dev @ c329def0d with a stub provider capturing exact payloads):

- **TASK-1530 — `{{char}}`/`{{user}}` macros reached providers raw** (12 + 7 occurrences per send with a real card). The Start Chat session seed and the Roleplay preview prompt build are now extracted into pure helpers (`_character_session_prompt_seed`, `build_preview_system_prompt`) that apply `replace_placeholders` (char name + "User", matching the existing greeting-display substitution).
- **TASK-1531 — the seeded greeting was displayed and persisted but omitted from every provider payload**, so the model contradicted the transcript. The greeting is now folded into the SYSTEM row on every Console send seam and in the preview — content reaches all providers while the message array stays user-first, preserving the task-427 strict-provider constraint (Anthropic/Gemini reject assistant-first arrays). Shared helper: `fold_greeting_into_system_prompt` in `console_chat_models`.
- **TASK-1532 — avatar thumbnails painted nothing inside tmux**: host-terminal env (`TERM_PROGRAM=iTerm.app`, `ITERM_SESSION_ID`) leaks into panes, so capability detection recommended graphics mode whose escapes tmux swallows. Multiplexed sessions (`TMUX` set or `TERM` = screen/tmux) now classify as `tmux` and force half-block pixels. Task stays In Progress on one AC: confirming the graphics path in a real iTerm2/Kitty session outside tmux.

## Verification

- TDD throughout: every behavioral change watched RED first (`test_leading_greeting_excluded_from_provider_payload` was deliberately revised to the new fold contract).
- Full runs: `test_console_chat_controller` 139 passed; adjacent suites (`test_console_native_chat_flow`, `test_console_image_view`, `test_console_edit_resend`, `test_console_variant_stream`, `test_placeholder_aliases`) 319 passed; `test_personas_preview` 39 passed; new `Tests/Utils/test_terminal_utils.py`, `Tests/UI/test_character_session_prompt_seed.py`, `Tests/UI/test_personas_avatar_render.py`.
- Live end-to-end against a stub OpenAI-compatible provider (payload capture): Console turn 1/2 and preview sends show **zero raw macros**, greeting present in the system row, user-first arrays, history retained; the Inspector avatar went from 0 half-block glyphs / 4 chrome colors to 200 glyphs / 94 unique colors under tmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes roleplay UAT bugs, sharpens avatar rendering, and adds a secure toggle for remote chat images. Macros resolve before sending, greetings ride the system row, tmux panes force pixels; remote images can be enabled in Settings, rows sync after fetch, and the viewer modal sizes correctly.

- **Bug Fixes**
  - TASK-1530: Resolve `{{char}}`/`{{user}}` in Start Chat and preview so no raw macros reach providers.
  - TASK-1531: Fold the greeting into the system prompt for Console and preview; provider gateway extracts leading `role="system"` rows into `system_message` so Anthropic/Gemini receive the prompt and folded greeting.
  - TASK-1532: Detect tmux/screen and force pixels mode so avatars paint under multiplexers; render-seam test added.
  - TASK-1537: After a remote image fetch is cached, request a transcript sync so the row appears without further UI action.
  - TASK-1534: Size the image viewer modal via explicit inline cell dimensions to prevent layout collapse under the app CSS bundle.

- **New Features**
  - TASK-1533: Replace half-block fallback with a quadrant-glyph mosaic for sharper thumbnails; wired into Personas and the Console rail avatar.
  - TASK-1534: Full-size portrait viewer opens on avatar click; Esc/click dismisses.
  - TASK-1535: Thumbnails use cover-fit (fill the box, center-crop, aspect preserved).
  - TASK-1536: Roleplay flavor styling in assistant replies (quoted speech, actions, bold) with distinct colors.
  - TASK-1537: Remote inline transcript images behind `[chat.images] render_remote_images` (markdown image links or bare image URLs, http(s) only; secure, capped fetches; per-URL attempt once, recent-window scan, dedupe/cap); Settings > Console Behavior adds an Enabled/Disabled toggle with immediate write and live config update.

<sup>Written for commit 3564387af70c296d1e5b7386968fa97a3d15eecc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

