### PR TITLE
feat(tts): add trusted Console speech snapshots

### DIFF
--- a/Docs/Development/TTS/TTS_MODULE_GUIDE.md
+++ b/Docs/Development/TTS/TTS_MODULE_GUIDE.md
@@ -228,11 +228,28 @@ save may report **Saved — applying after current speech**; the admitted speech
 continues, only the latest pending generation may become active, and the old
 audio.cpp adapter closes before a replacement can be created.
 
+Console **Speak** does not post caller-supplied message text. The Console store
+issues an ephemeral immutable `TTSMessageSpeechSnapshot` and binds it to the
+store validator. Before the cooldown clock, normalization, or provider work,
+the TTS handler revalidates the active session and branch, native and persisted
+message identity, selected text variant and exact content, process-local speech
+revision, durable row version when present, completed assistant role/status,
+and trusted assistant authorship. A stale, edited, deleted, incomplete,
+non-assistant, or authorship-mismatched snapshot fails closed with bounded retry
+copy asking the user to select **Speak** again.
+
+The snapshot is process-local, is not persisted, and is not a voice-profile
+selection. Once admitted, Console still uses the saved global TTS defaults.
+Direct `TTSRequestEvent` callers outside Console retain their explicit trusted
+global path.
+
 Console **Speak** calls `TTSService.synthesize_default()`. An `audio_cpp`
 selection uses the native adapter with locked WAV, speed `1.0`, and empty
 options. The six retained providers continue through `LegacyTTSAdapter`. The
 native complete WAV is still consumed through `TTSAudioResponse`'s asynchronous
-iterator and closed through the existing artifact/playback lifecycle.
+iterator and closed through the existing artifact/playback lifecycle. Snapshot
+admission neither persists the snapshot nor performs message writes, and it
+does not change ownership of the external audio.cpp process.
 
 ### Native audio.cpp adapter (external mode)
 

--- a/Docs/Features/Speech-Services-Guide.md
+++ b/Docs/Features/Speech-Services-Guide.md
@@ -151,7 +151,16 @@ you start and manage yourself:
 9. Enter text and click **Generate Speech**. After the complete WAV is
    validated, use **Play** or **Export**.
 10. In Console, use **Speak** on a response to synthesize and play it with the
-   same saved defaults.
+    same saved defaults.
+
+Console offers **Speak** only on completed assistant responses. When selected,
+Chatbook captures the exact visible response and selected variant in a
+temporary immutable snapshot, then checks that the same response, conversation
+branch, durable message version when present, and assistant identity are still
+current before starting TTS. If the response changed, Chatbook asks you to
+select **Speak** again instead of speaking stale text. The snapshot is never
+saved and does not select a character voice profile; Console continues to use
+the global defaults configured above.
 
 audio.cpp currently returns one complete WAV per request and supports speed
 `1.0`; the Playground locks both controls while it is selected. This still uses

--- a/Docs/superpowers/plans/2026-07-30-trusted-console-speech-snapshots.md
+++ b/Docs/superpowers/plans/2026-07-30-trusted-console-speech-snapshots.md
@@ -1,0 +1,545 @@
+# Trusted Console Speech Snapshots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind Console **Speak** to the exact completed assistant message and selected text variant the user clicked, rejecting stale or mismatched requests before cooldown or provider work while preserving the existing global TTS and complete-WAV path.
+
+**Architecture:** Add one immutable, privacy-safe `TTSMessageSpeechSnapshot` value and make `ConsoleChatStore` the sole authority that issues and validates it. Console posts a dedicated snapshot request event carrying the snapshot and the issuing store's validator; the application and TTS handler validate it before normalization or cooldown, while the existing `TTSRequestEvent` remains the explicit trusted global-speech path for callers with no Console message. Persisted messages additionally compare the captured optimistic-lock row version through a narrow `ChatPersistenceService` read.
+
+**Tech Stack:** Python 3.11+, dataclasses, Textual messages/events, SQLite optimistic versions, pytest/pytest-asyncio, Ruff, mypy.
+
+---
+
+## Scope and governing decision
+
+- Implement only approved Slice **3A.3** from
+  `Docs/superpowers/specs/2026-07-28-tts-character-identity-persona-separation-design.md`.
+- Preserve global provider/model/voice/format/speed selection and the existing
+  `TTSService.synthesize_default()` complete-WAV lifecycle.
+- Do not add profile assignment mutation, assignment UI, assigned-profile
+  resolution, automatic speech, Persona voice inheritance, portability, or
+  managed audio.cpp behavior.
+
+ADR required: yes
+ADR path: `backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md`
+Reason: ADR-037 already governs immutable Console speech snapshots, authorship validation, pre-cooldown rejection, privacy, and the deferral of assigned-profile resolution. This task implements that accepted decision and requires no new ADR.
+
+## File responsibility map
+
+- Create `tldw_chatbook/Chat/console_speech.py`: immutable snapshot and bounded
+  rejection-code contract only.
+- Modify `tldw_chatbook/Chat/console_chat_store.py`: process-local speech
+  revisions plus snapshot issuance and validation.
+- Modify `tldw_chatbook/Chat/chat_persistence_service.py`: narrow current
+  message-version lookup.
+- Modify `tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py`: dedicated
+  Console snapshot event and validation before any cooldown mutation.
+- Modify `tldw_chatbook/UI/Screens/chat_screen.py`: issue snapshots from the
+  store instead of copying caller-visible text into a global request.
+- Modify `tldw_chatbook/app.py`: route the dedicated event without logging
+  synthesis text.
+- Modify `tldw_chatbook/Chat/console_message_actions.py`: offer **Speak** only
+  for completed assistant text, matching admission.
+- Create `Tests/Chat/test_console_speech_snapshots.py`: store issuance,
+  revisions, authorship, variants, persistence-version, and privacy tests.
+- Create `Tests/TTS/test_console_speech_snapshot_admission.py`: handler ordering,
+  cooldown isolation, and valid global-flow tests.
+- Modify `Tests/Chat/test_console_generation_actions.py`,
+  `Tests/Chat/test_console_message_actions.py`, and
+  `Tests/UI/test_console_native_chat_flow.py`: Console event wiring and
+  user-visible regression coverage.
+- Modify `Docs/Development/TTS/TTS_MODULE_GUIDE.md` and
+  `Docs/Features/Speech-Services-Guide.md`: document trusted Console admission
+  and unchanged global synthesis selection.
+- Update `backlog/tasks/task-617.3 - Add-trusted-Console-speech-snapshots.md`
+  only after implementation and verification evidence exists.
+
+### Task 1: Define the immutable privacy-safe snapshot contract
+
+**Files:**
+- Create: `tldw_chatbook/Chat/console_speech.py`
+- Create: `Tests/Chat/test_console_speech_snapshots.py`
+
+- [ ] **Step 1: Write failing snapshot-value tests**
+
+Add tests that construct the desired frozen value and assert:
+
+```python
+snapshot = TTSMessageSpeechSnapshot(
+    session_id="session-1",
+    message_id="message-1",
+    persisted_conversation_id=None,
+    persisted_message_id=None,
+    raw_content="private response",
+    selected_variant_id="message-1",
+    speech_revision=0,
+    persisted_message_version=None,
+    role=ConsoleMessageRole.ASSISTANT,
+    status="complete",
+    assistant_kind="generic",
+    character_ref=None,
+)
+with pytest.raises(FrozenInstanceError):
+    snapshot.raw_content = "changed"  # type: ignore[misc]
+assert "private response" not in repr(snapshot)
+```
+
+Also assert `character_ref` is omitted from `repr`, rejection codes are from a
+closed set, and the exception exposes only its safe code and generic
+retry-facing copy.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_speech_snapshots.py
+```
+
+Expected: collection fails because `tldw_chatbook.Chat.console_speech` does not
+exist.
+
+- [ ] **Step 3: Implement the minimal snapshot module**
+
+Add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class TTSMessageSpeechSnapshot:
+    session_id: str
+    message_id: str
+    persisted_conversation_id: str | None
+    persisted_message_id: str | None
+    raw_content: str = field(repr=False)
+    selected_variant_id: str
+    speech_revision: int
+    persisted_message_version: int | None
+    role: ConsoleMessageRole
+    status: ConsoleMessageStatus
+    assistant_kind: str | None
+    character_ref: CharacterRef | None = field(repr=False)
+```
+
+Define `ConsoleSpeechSnapshotRejected` with a validated bounded code and one
+generic user-facing message. Do not add serialization or a generic assistant
+identity abstraction.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the Task 1 command again. Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_speech.py \
+  Tests/Chat/test_console_speech_snapshots.py
+git commit -m "feat(tts): define trusted Console speech snapshot"
+```
+
+### Task 2: Make the Console store issue and validate snapshots
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py:299-380`
+- Modify: `tldw_chatbook/Chat/console_chat_store.py:1352-1974`
+- Modify: `tldw_chatbook/Chat/console_chat_store.py:2717-2775`
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py:19-60`
+- Test: `Tests/Chat/test_console_speech_snapshots.py`
+- Test: `Tests/Chat/test_console_chat_store.py`
+
+- [ ] **Step 1: Write failing issuance and validation tests**
+
+Cover:
+
+- a completed assistant snapshot carries its owning session, message,
+  persisted IDs, exact raw selected content, linear-or-selected variant ID,
+  revision, role/status, assistant kind, and scoped `CharacterRef`;
+- generic, Persona, and authority-null character sessions carry no
+  `CharacterRef`;
+- user, system, tool, blank, pending, streaming, stopped, and failed messages
+  cannot issue a snapshot;
+- switching the active session, moving the message off the active path,
+  deleting it, or changing session authorship rejects an already-issued
+  snapshot;
+- edit then restore identical content remains stale;
+- adding, streaming, finalizing, or selecting a text variant makes the old
+  snapshot stale;
+- an unchanged snapshot validates to its exact raw content.
+
+- [ ] **Step 2: Write failing persisted-version tests**
+
+Add a real `ChatPersistenceService` test proving
+`get_message_version(message_id)` returns the current positive row version and
+returns `None` for a missing/deleted row. Add a store test that issues a
+snapshot, changes the persisted row through a second writer, and confirms
+validation rejects it even when visible text is restored to the original.
+
+- [ ] **Step 3: Run the store tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_speech_snapshots.py \
+  Tests/Chat/test_console_chat_store.py
+```
+
+Expected: snapshot issuance, revision, validation, and message-version APIs are
+missing.
+
+- [ ] **Step 4: Implement process-local revision ownership**
+
+In `ConsoleChatStore`:
+
+- initialize `_message_speech_revisions: dict[str, int]`;
+- initialize a node's revision to zero only in `_register_tree_node`;
+- remove revisions during subtree deletion and session close;
+- add `_bump_message_speech_revision(message_id)` and
+  `_selected_speech_variant_id(message)`;
+- bump after every content/status/text-variant mutation, including stream
+  chunks, reset, provisional-body replacement, edit, retry preparation,
+  terminal transitions, variant add/begin/finalize/select;
+- do not serialize the map or place the revision on `ConsoleChatMessage`.
+
+No exact increment count is externally meaningful; only monotonic inequality is
+part of admission.
+
+- [ ] **Step 5: Implement the persisted-version seam**
+
+Add `ChatPersistenceService.get_message_version(message_id) -> int | None`,
+backed by `db.get_message_by_id`, accepting only a non-deleted exact positive
+integer version. Declare the narrow method on `ConsoleChatPersistence`.
+
+Snapshot issuance and validation call this seam only for a persisted message.
+If persistence or a trustworthy version is unavailable, fail closed with a
+bounded rejection code rather than assuming the current version.
+
+- [ ] **Step 6: Implement store issuance and validation**
+
+Add:
+
+```python
+def issue_tts_message_speech_snapshot(
+    self, message_id: str
+) -> TTSMessageSpeechSnapshot:
+    ...
+
+def validate_tts_message_speech_snapshot(
+    self, snapshot: TTSMessageSpeechSnapshot
+) -> str:
+    ...
+```
+
+Issuance requires the message to be on the active session's active path and to
+be a complete nonblank assistant message. Validation re-resolves all state from
+the store and compares active session, owning session, active path, native and
+persisted identity, exact selected variant, raw content, revision, role/status,
+assistant kind, `CharacterRef`, and current durable row version. It returns the
+captured raw content only after every check succeeds.
+
+- [ ] **Step 7: Run the store tests and verify GREEN**
+
+Run the Task 2 command. Expected: all tests pass with only the existing
+dependency warning.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_store.py \
+  tldw_chatbook/Chat/chat_persistence_service.py \
+  Tests/Chat/test_console_speech_snapshots.py \
+  Tests/Chat/test_console_chat_store.py
+git commit -m "feat(console): issue and validate speech snapshots"
+```
+
+### Task 3: Validate snapshot requests before cooldown
+
+**Files:**
+- Modify: `tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py:46-59`
+- Modify: `tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py:317-400`
+- Create: `Tests/TTS/test_console_speech_snapshot_admission.py`
+- Test: `Tests/TTS/test_tts_improvements.py`
+
+- [ ] **Step 1: Write failing event-admission tests**
+
+Create a recording handler and assert:
+
+- `TTSMessageSpeechRequestEvent` accepts an exact snapshot plus validator and
+  exposes the native message ID without a caller-supplied text field;
+- the validator runs before service availability checks, normalization,
+  cooldown cleanup, cooldown insertion, active-task creation, or synthesis;
+- a bounded rejection posts one `TTSCompleteEvent`, leaves the cooldown mapping
+  byte-for-byte unchanged, performs no provider call, and logs no raw content
+  or authority;
+- an unexpected validator failure also fails closed without exception detail;
+- a valid snapshot passes its exact text into the unchanged synthesis path;
+- legacy/non-Console `TTSRequestEvent` behavior remains unchanged.
+
+- [ ] **Step 2: Run the event tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/TTS/test_console_speech_snapshot_admission.py \
+  Tests/TTS/test_tts_improvements.py
+```
+
+Expected: the dedicated event and pre-cooldown admission path are absent.
+
+- [ ] **Step 3: Add the dedicated event and shared admitted-request path**
+
+Add `TTSMessageSpeechRequestEvent` with the snapshot and issuing store's bound
+validator. Refactor `handle_tts_request` only enough to resolve either:
+
+- the explicit global event's trusted `text`, `message_id`, and optional
+  `voice`; or
+- the Console snapshot event's validator-returned exact text, snapshot message
+  ID, and no voice override.
+
+For a Console event, call the validator before reading the clock or mutating
+cooldown state. Catch only the bounded rejection separately; convert unexpected
+validator exceptions into a generic safe outcome without logging exception
+values. After admission, reuse the existing length, whitespace, cooldown,
+task, synthesis, complete-WAV, playback, and error code unchanged.
+
+- [ ] **Step 4: Register the Textual event entry point**
+
+Add `on_tts_message_speech_request_event` beside
+`on_tts_request_event`, both calling `handle_tts_request`.
+
+- [ ] **Step 5: Run the event tests and verify GREEN**
+
+Run the Task 3 command. Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py \
+  Tests/TTS/test_console_speech_snapshot_admission.py \
+  Tests/TTS/test_tts_improvements.py
+git commit -m "feat(tts): admit Console snapshots before cooldown"
+```
+
+### Task 4: Wire Console and application routing
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_message_actions.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py:15607-15725`
+- Modify: `tldw_chatbook/app.py:228-241`
+- Modify: `tldw_chatbook/app.py:6450-6470`
+- Modify: `Tests/Chat/test_console_message_actions.py:548-637`
+- Modify: `Tests/Chat/test_console_generation_actions.py:528-575`
+- Modify: `Tests/UI/test_console_native_chat_flow.py:2460-2515`
+
+- [ ] **Step 1: Write failing action and wiring tests**
+
+Update action tests to require **Speak** only for complete nonblank assistant
+messages. Update screen tests to assert the posted object is
+`TTSMessageSpeechRequestEvent`, contains the store-issued snapshot, contains no
+caller text field, and its validator rejects a mutation performed after the
+button press. Update the repaired-response test to inspect
+`event.snapshot.raw_content`.
+
+Add an application routing test that confirms the dedicated handler does not
+log the snapshot text and delegates to the app-owned `TTSEventHandler`.
+
+- [ ] **Step 2: Run the wiring tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_message_actions.py \
+  Tests/Chat/test_console_generation_actions.py \
+  Tests/UI/test_console_native_chat_flow.py
+```
+
+Expected: Console still posts caller-copied `TTSRequestEvent` text and offers
+Speak for user messages.
+
+- [ ] **Step 3: Wire the store-issued event**
+
+In `ChatScreen.handle_console_message_action`, replace:
+
+```python
+TTSRequestEvent(text=message.content, message_id=message.id)
+```
+
+with store issuance followed by
+`TTSMessageSpeechRequestEvent(snapshot, store.validate_tts_message_speech_snapshot)`.
+If issuance fails, show the generic retry copy and do not set speaking state.
+
+In `app.py`, register a separate `@on(TTSMessageSpeechRequestEvent)` handler
+that logs only a static safe message, ensures the TTS handler, and delegates.
+Do not route the snapshot event through the legacy handler that logs
+`event.text`.
+
+- [ ] **Step 4: Align the action availability**
+
+Change `ConsoleMessageActionService` so **Speak** is available only for a
+complete nonblank assistant message. Preserve stop-toggle order and all
+existing playback plumbing.
+
+- [ ] **Step 5: Run the wiring tests and verify GREEN**
+
+Run the Task 4 command. Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_message_actions.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  tldw_chatbook/app.py \
+  Tests/Chat/test_console_message_actions.py \
+  Tests/Chat/test_console_generation_actions.py \
+  Tests/UI/test_console_native_chat_flow.py
+git commit -m "feat(console): post trusted speech requests"
+```
+
+### Task 5: Prove unchanged native/global synthesis and document the boundary
+
+**Files:**
+- Modify: `Tests/TTS/test_console_audio_cpp_native.py`
+- Modify: `Tests/TTS/test_console_speak_autoplay.py`
+- Modify: `Docs/Development/TTS/TTS_MODULE_GUIDE.md`
+- Modify: `Docs/Features/Speech-Services-Guide.md`
+
+- [ ] **Step 1: Add the valid-snapshot native audio.cpp regression**
+
+Extend the native Console audio.cpp test to pass a real store-issued snapshot
+through `TTSMessageSpeechRequestEvent`. Assert the native adapter receives the
+same exact `TTSRequest`, the legacy generator remains unused, the response is
+closed, the artifact is a complete WAV, and playback/autoplay behavior is
+unchanged.
+
+- [ ] **Step 2: Run the native regression and verify RED/GREEN**
+
+First run before the test-support implementation is complete and confirm it
+fails at the new event path. After wiring the shared fixtures, run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/TTS/test_console_audio_cpp_native.py \
+  Tests/TTS/test_console_speak_autoplay.py \
+  Tests/TTS/test_console_speech_snapshot_admission.py
+```
+
+Expected final result: all tests pass.
+
+- [ ] **Step 3: Update user and developer documentation**
+
+Document that Console **Speak** now:
+
+- issues an ephemeral immutable snapshot from the Console store;
+- validates the exact completed assistant message, selected text variant,
+  revision, durable row version, and trusted authorship before cooldown;
+- asks the user to click Speak again when the message changed;
+- keeps global TTS selection and native/legacy complete-WAV behavior unchanged;
+- never persists the snapshot or manages the external audio.cpp process.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/TTS/test_console_audio_cpp_native.py \
+  Tests/TTS/test_console_speak_autoplay.py \
+  Docs/Development/TTS/TTS_MODULE_GUIDE.md \
+  Docs/Features/Speech-Services-Guide.md
+git commit -m "docs(tts): describe trusted Console speech admission"
+```
+
+### Task 6: Full focused verification and task closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-617.3 - Add-trusted-Console-speech-snapshots.md`
+
+- [ ] **Step 1: Run the complete focused regression union**
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Chat/test_console_speech_snapshots.py \
+  Tests/Chat/test_console_chat_store.py \
+  Tests/Chat/test_console_message_actions.py \
+  Tests/Chat/test_console_generation_actions.py \
+  Tests/TTS/test_console_speech_snapshot_admission.py \
+  Tests/TTS/test_console_audio_cpp_native.py \
+  Tests/TTS/test_console_speak_autoplay.py \
+  Tests/TTS/test_tts_improvements.py \
+  Tests/UI/test_console_native_chat_flow.py
+```
+
+Expected: all task-focused tests pass. Record inherited warnings separately.
+
+- [ ] **Step 2: Run broader TTS and Console regression suites**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/TTS Tests/Chat
+```
+
+If a failure occurs, reproduce the exact node on untouched current `origin/dev`
+before classifying it as inherited.
+
+- [ ] **Step 3: Run static and hygiene checks**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/Chat/console_speech.py \
+  tldw_chatbook/Chat/console_chat_store.py \
+  tldw_chatbook/Chat/chat_persistence_service.py \
+  tldw_chatbook/Chat/console_message_actions.py \
+  tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  tldw_chatbook/app.py
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Chat/console_speech.py \
+  Tests/Chat/test_console_speech_snapshots.py \
+  Tests/TTS/test_console_speech_snapshot_admission.py
+../../.venv/bin/python -m compileall -q \
+  tldw_chatbook/Chat/console_speech.py \
+  tldw_chatbook/Chat/console_chat_store.py \
+  tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+../../.venv/bin/python -m mypy \
+  tldw_chatbook/Chat/console_speech.py \
+  tldw_chatbook/Chat/console_chat_store.py \
+  tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+git diff --check origin/dev...HEAD
+```
+
+Compare any pre-existing whole-file formatter or mypy diagnostics against
+exact `origin/dev`; do not broaden this task into repository-wide cleanup.
+
+- [ ] **Step 4: Run privacy and scope guards**
+
+Verify the production diff contains no snapshot serialization, text-bearing
+log, assignment resolver, assignment UI, Persona TTS inheritance, or managed
+audio.cpp process code:
+
+```bash
+git diff origin/dev...HEAD -- tldw_chatbook \
+  | rg -n "raw_content|logger|assignment|managed|subprocess|server\\.json"
+```
+
+Review each match manually; the snapshot field and comparisons are expected,
+but logging it is forbidden.
+
+- [ ] **Step 5: Request independent code review**
+
+Use `superpowers:requesting-code-review` against the complete
+`origin/dev...HEAD` range. Address every verified issue and re-run affected
+tests.
+
+- [ ] **Step 6: Complete Backlog evidence**
+
+Only after all gates pass:
+
+- check all acceptance criteria and Definition of Done items;
+- add concise implementation notes with test counts, static evidence,
+  inherited baselines, review outcome, ADR-037 linkage, and any plan deviation;
+- set `TASK-617.3` to Done.
+
+- [ ] **Step 7: Commit closeout**
+
+```bash
+git add "backlog/tasks/task-617.3 - Add-trusted-Console-speech-snapshots.md"
+git commit -m "docs: close trusted Console speech snapshot task"
+```

--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -38,9 +38,10 @@ from tldw_chatbook.Chat.console_generate_image import (
 )
 from tldw_chatbook.Chat.console_message_actions import ConsoleMessageActionService
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_speech import ConsoleSpeechSnapshotRejected
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    TTSMessageSpeechRequestEvent,
     TTSPlaybackEvent,
-    TTSRequestEvent,
 )
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
@@ -529,10 +530,8 @@ async def test_handle_console_message_action_routes_regenerate_for_generation_me
 
 
 @pytest.mark.asyncio
-async def test_handle_console_message_action_routes_speak_to_tts_request_event():
-    """Speak posts the app's existing ``TTSRequestEvent`` -- no new TTS
-    machinery, no worker (spec §1a). Captured via a monkeypatched
-    ``post_message`` on the bare screen's stub ``app_instance``."""
+async def test_handle_console_message_action_posts_store_issued_speech_snapshot():
+    """Speak posts a store-issued snapshot and its bound validator."""
     store = ConsoleChatStore()
     session = store.ensure_session(title="Chat 1")
     message = store.append_message(
@@ -551,9 +550,15 @@ async def test_handle_console_message_action_routes_speak_to_tts_request_event()
     assert handled is True
     assert len(posted) == 1
     event = posted[0]
-    assert isinstance(event, TTSRequestEvent)
-    assert event.text == "The sky is blue today."
+    assert isinstance(event, TTSMessageSpeechRequestEvent)
+    assert event.snapshot.raw_content == "The sky is blue today."
     assert event.message_id == message.id
+    assert not hasattr(event, "text")
+    assert event.validator(event.snapshot) == "The sky is blue today."
+
+    store.update_message_content(message.id, "Changed after click.")
+    with pytest.raises(ConsoleSpeechSnapshotRejected):
+        event.validator(event.snapshot)
 
 
 @pytest.mark.asyncio
@@ -571,8 +576,40 @@ async def test_handle_console_message_action_routes_speak_for_generation_message
 
     assert handled is True
     assert len(posted) == 1
-    assert posted[0].text == "[image] a red dragon"
+    assert isinstance(posted[0], TTSMessageSpeechRequestEvent)
+    assert posted[0].snapshot.raw_content == "[image] a red dragon"
     assert posted[0].message_id == message.id
+
+
+@pytest.mark.asyncio
+async def test_handle_console_message_action_does_not_forge_user_speech_snapshot():
+    store = ConsoleChatStore()
+    session = store.ensure_session(title="Chat 1")
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="User-authored text.",
+        persist=False,
+    )
+    screen = _bare_generation_screen(store)
+    posted: list = []
+    notified: list[tuple[tuple, dict]] = []
+    screen.app_instance.post_message = posted.append
+    screen.app_instance.notify = lambda *args, **kwargs: notified.append((args, kwargs))
+    button = Button("speak", id=f"console-message-action-speak-{message.id}")
+
+    handled = await screen.handle_console_message_action(Button.Pressed(button))
+
+    assert handled is True
+    assert posted == []
+    assert getattr(screen, "_console_speaking_message_id", None) is None
+    screen._sync_native_console_chat_ui.assert_not_awaited()
+    assert notified == [
+        (
+            ("Message changed before speech started; select Speak again.",),
+            {"severity": "warning"},
+        )
+    ]
 
 
 # --- task-559 unit 2: Console TTS stop toggle dispatch ------------------------

--- a/Tests/Chat/test_console_message_actions.py
+++ b/Tests/Chat/test_console_message_actions.py
@@ -59,7 +59,6 @@ def test_streaming_assistant_message_shows_completed_actions_disabled_with_reaso
 
     assert [action.label for action in actions] == [
         "Copy",
-        "🔊",
         "Edit",
         "Save as...",
         "♻",
@@ -548,25 +547,51 @@ def test_continue_action_targets_selected_variant_content():
 # --- TASK-1: speak (TTS) action ------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "role", [ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT]
-)
-def test_speak_action_present_for_completed_text_message_any_role(
-    role: ConsoleMessageRole,
-):
-    """Spec §1a: speak is available for any COMPLETED message with
-    non-empty text -- both roles, not just assistant responses."""
+def test_speak_action_present_for_completed_assistant_text():
     service = ConsoleMessageActionService()
-    message = ConsoleChatMessage(role=role, content="hello there")
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="hello there",
+    )
 
     action_ids = [action.action_id for action in service.available_actions(message)]
 
     assert "speak" in action_ids
 
 
+@pytest.mark.parametrize(
+    "role",
+    [
+        ConsoleMessageRole.USER,
+        ConsoleMessageRole.SYSTEM,
+        ConsoleMessageRole.TOOL,
+    ],
+)
+def test_speak_action_absent_for_non_assistant_text(role: ConsoleMessageRole):
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(role=role, content="hello there")
+
+    action_ids = [action.action_id for action in service.available_actions(message)]
+
+    assert "speak" not in action_ids
+
+
+@pytest.mark.parametrize("status", ["pending", "streaming", "stopped", "failed"])
+def test_speak_action_absent_for_incomplete_assistant_status(status):
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="partial answer",
+        status=status,
+    )
+
+    action_ids = [action.action_id for action in service.available_actions(message)]
+
+    assert "speak" not in action_ids
+
+
 def test_speak_action_present_for_generation_card_marker_text():
-    """Spec §1a: a generation-card message's ``[image] ...`` marker text is
-    harmless input to TTS -- speak is offered for it like any other text."""
+    """A completed assistant generation card remains trusted assistant text."""
     service = ConsoleMessageActionService()
     message = ConsoleChatMessage(
         role=ConsoleMessageRole.ASSISTANT, content="[image] a red dragon"

--- a/Tests/Chat/test_console_speech_snapshots.py
+++ b/Tests/Chat/test_console_speech_snapshots.py
@@ -1,0 +1,86 @@
+"""Trusted Console speech snapshot contracts."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_speech import (
+    ConsoleSpeechSnapshotRejected,
+    ConsoleSpeechSnapshotRejectionCode,
+    TTSMessageSpeechSnapshot,
+)
+from tldw_chatbook.TTS.profile_types import CharacterRef
+
+
+def _snapshot(
+    *,
+    raw_content: str = "private response",
+    character_ref: CharacterRef | None = None,
+) -> TTSMessageSpeechSnapshot:
+    return TTSMessageSpeechSnapshot(
+        session_id="session-1",
+        message_id="message-1",
+        persisted_conversation_id=None,
+        persisted_message_id=None,
+        raw_content=raw_content,
+        selected_variant_id="message-1",
+        speech_revision=0,
+        persisted_message_version=None,
+        role=ConsoleMessageRole.ASSISTANT,
+        status="complete",
+        assistant_kind="character" if character_ref is not None else "generic",
+        character_ref=character_ref,
+    )
+
+
+def test_snapshot_is_frozen_and_redacts_content_and_authority_from_repr():
+    character_ref = CharacterRef(
+        source="local",
+        authority_id="authority-secret",
+        character_id="17",
+    )
+    snapshot = _snapshot(
+        raw_content="do not log this response",
+        character_ref=character_ref,
+    )
+
+    rendered = repr(snapshot)
+
+    assert "do not log this response" not in rendered
+    assert "authority-secret" not in rendered
+    assert snapshot.raw_content == "do not log this response"
+    assert snapshot.character_ref == character_ref
+    with pytest.raises(FrozenInstanceError):
+        snapshot.raw_content = "changed"  # type: ignore[misc]
+
+
+def test_snapshot_rejects_invalid_structural_values():
+    with pytest.raises(ValueError, match="speech_revision"):
+        TTSMessageSpeechSnapshot(
+            session_id="session-1",
+            message_id="message-1",
+            persisted_conversation_id=None,
+            persisted_message_id=None,
+            raw_content="response",
+            selected_variant_id="message-1",
+            speech_revision=-1,
+            persisted_message_version=None,
+            role=ConsoleMessageRole.ASSISTANT,
+            status="complete",
+            assistant_kind="generic",
+            character_ref=None,
+        )
+
+
+def test_snapshot_rejection_exposes_only_bounded_code_and_safe_retry_copy():
+    error = ConsoleSpeechSnapshotRejected(
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+    )
+
+    assert error.code is ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+    assert str(error) == "Message changed before speech started; select Speak again."
+    assert "private response" not in repr(error)
+
+    with pytest.raises(ValueError, match="rejection code"):
+        ConsoleSpeechSnapshotRejected("unbounded-detail")  # type: ignore[arg-type]

--- a/Tests/Chat/test_console_speech_snapshots.py
+++ b/Tests/Chat/test_console_speech_snapshots.py
@@ -4,12 +4,15 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_speech import (
     ConsoleSpeechSnapshotRejected,
     ConsoleSpeechSnapshotRejectionCode,
     TTSMessageSpeechSnapshot,
 )
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.TTS.profile_types import CharacterRef
 
 
@@ -84,3 +87,525 @@ def test_snapshot_rejection_exposes_only_bounded_code_and_safe_retry_copy():
 
     with pytest.raises(ValueError, match="rejection code"):
         ConsoleSpeechSnapshotRejected("unbounded-detail")  # type: ignore[arg-type]
+
+
+def _assert_rejected(
+    store: ConsoleChatStore,
+    snapshot: TTSMessageSpeechSnapshot,
+    code: ConsoleSpeechSnapshotRejectionCode,
+) -> None:
+    with pytest.raises(ConsoleSpeechSnapshotRejected) as caught:
+        store.validate_tts_message_speech_snapshot(snapshot)
+    assert caught.value.code is code
+
+
+def _revision(store: ConsoleChatStore, message_id: str) -> int:
+    return store._message_speech_revisions[message_id]
+
+
+def test_store_issues_and_validates_exact_scoped_character_snapshot():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        assistant_authority_id="local-authority",
+        character_id=7,
+    )
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="  Exact visible response.\n",
+    )
+
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    assert snapshot.session_id == session.id
+    assert snapshot.message_id == message.id
+    assert snapshot.persisted_conversation_id is None
+    assert snapshot.persisted_message_id is None
+    assert snapshot.raw_content == "  Exact visible response.\n"
+    assert snapshot.selected_variant_id == message.id
+    assert snapshot.speech_revision == 0
+    assert snapshot.persisted_message_version is None
+    assert snapshot.role is ConsoleMessageRole.ASSISTANT
+    assert snapshot.status == "complete"
+    assert snapshot.assistant_kind == "character"
+    assert snapshot.character_ref == CharacterRef(
+        source="local",
+        authority_id="local-authority",
+        character_id="7",
+    )
+    assert (
+        store.validate_tts_message_speech_snapshot(snapshot)
+        == "  Exact visible response.\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "session_kwargs, expected_kind",
+    [
+        ({}, "generic"),
+        (
+            {
+                "runtime_backend": "local",
+                "assistant_kind": "persona",
+                "assistant_id": "persona-1",
+            },
+            "persona",
+        ),
+        (
+            {
+                "runtime_backend": "server",
+                "assistant_kind": "character",
+                "assistant_id": "character-1",
+                "assistant_authority_id": None,
+            },
+            "character",
+        ),
+    ],
+    ids=["generic", "persona", "authority-null-character"],
+)
+def test_store_snapshot_does_not_invent_character_authority(
+    session_kwargs,
+    expected_kind,
+):
+    store = ConsoleChatStore()
+    session = store.create_session(**session_kwargs)
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="response",
+    )
+
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    assert snapshot.assistant_kind == expected_kind
+    assert snapshot.character_ref is None
+    assert store.validate_tts_message_speech_snapshot(snapshot) == "response"
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "user",
+        "system",
+        "tool",
+        "blank",
+        "pending",
+        "streaming",
+        "stopped",
+        "failed",
+    ],
+)
+def test_store_refuses_non_assistant_incomplete_or_blank_messages(scenario):
+    store = ConsoleChatStore()
+    session = store.create_session()
+    if scenario in {"user", "system", "tool"}:
+        role = {
+            "user": ConsoleMessageRole.USER,
+            "system": ConsoleMessageRole.SYSTEM,
+            "tool": ConsoleMessageRole.TOOL,
+        }[scenario]
+        message = store.append_message(session.id, role=role, content="text")
+    elif scenario == "blank":
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content=" \n ",
+        )
+    else:
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+        )
+        if scenario == "streaming":
+            store.append_stream_chunk(message.id, "partial")
+        elif scenario == "stopped":
+            store.mark_message_stopped(message.id)
+        elif scenario == "failed":
+            store.mark_message_failed(message.id)
+
+    with pytest.raises(ConsoleSpeechSnapshotRejected):
+        store.issue_tts_message_speech_snapshot(message.id)
+
+
+def test_edit_then_restore_identical_content_still_invalidates_snapshot():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="original",
+    )
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    store.update_message_content(message.id, "edited")
+    store.update_message_content(message.id, "original")
+
+    assert store.get_message(message.id).content == snapshot.raw_content
+    _assert_rejected(
+        store,
+        snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED,
+    )
+
+
+def test_session_switch_rejects_snapshot_without_mutating_message():
+    store = ConsoleChatStore()
+    first = store.create_session()
+    message = store.append_message(
+        first.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="response",
+    )
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    store.create_session(title="Second")
+
+    _assert_rejected(
+        store,
+        snapshot,
+        ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED,
+    )
+    assert store.get_message(message.id).content == "response"
+
+
+def test_message_moved_off_active_path_rejects_snapshot():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="first branch",
+    )
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    store.create_sibling(
+        message.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="second branch",
+    )
+
+    _assert_rejected(
+        store,
+        snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED,
+    )
+
+
+def test_delete_rejects_snapshot_and_releases_process_local_revision():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="response",
+    )
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    store.delete_message(message.id)
+
+    _assert_rejected(
+        store,
+        snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MISSING_MESSAGE,
+    )
+    assert message.id not in store._message_speech_revisions
+
+
+def test_close_session_releases_all_process_local_revisions():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    first = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="question",
+    )
+    second = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="response",
+    )
+
+    store.close_session(session.id)
+
+    assert first.id not in store._message_speech_revisions
+    assert second.id not in store._message_speech_revisions
+
+
+def test_authorship_change_rejects_snapshot():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        assistant_authority_id="local-authority",
+        character_id=7,
+    )
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="response",
+    )
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    session.assistant_authority_id = "different-authority"
+
+    _assert_rejected(
+        store,
+        snapshot,
+        ConsoleSpeechSnapshotRejectionCode.AUTHORSHIP_CHANGED,
+    )
+
+
+def test_selected_text_variant_identity_and_content_are_revalidated():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="first",
+    )
+    linear_snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    with_variant = store.add_variant(message.id, "second")
+    second_snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    assert with_variant.variants is not None
+    assert second_snapshot.selected_variant_id == with_variant.variants.current.id
+    assert second_snapshot.raw_content == "second"
+    _assert_rejected(
+        store,
+        linear_snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED,
+    )
+
+    store.select_variant(message.id, 0)
+    first_variant_snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    assert first_variant_snapshot.selected_variant_id == (
+        with_variant.variants.variants[0].id
+    )
+    assert first_variant_snapshot.raw_content == "first"
+    _assert_rejected(
+        store,
+        second_snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED,
+    )
+
+    store.update_message_content(message.id, "changed first")
+    _assert_rejected(
+        store,
+        first_variant_snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED,
+    )
+
+
+def test_variant_stream_lifecycle_invalidates_pre_stream_snapshot():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="base",
+    )
+    snapshot = store.issue_tts_message_speech_snapshot(message.id)
+
+    before_begin = _revision(store, message.id)
+    store.begin_variant_stream(message.id)
+    assert _revision(store, message.id) > before_begin
+    _assert_rejected(
+        store,
+        snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_NOT_SPEAKABLE,
+    )
+
+    before_chunk = _revision(store, message.id)
+    store.append_stream_chunk(message.id, "new")
+    assert _revision(store, message.id) > before_chunk
+
+    before_finalize = _revision(store, message.id)
+    store.finalize_variant_stream(message.id)
+    assert _revision(store, message.id) > before_finalize
+    _assert_rejected(
+        store,
+        snapshot,
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED,
+    )
+
+
+def test_speech_revision_bumps_for_content_status_and_variant_mutations():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    assert _revision(store, message.id) == 0
+
+    before = _revision(store, message.id)
+    store.append_stream_chunk(message.id, "partial")
+    assert _revision(store, message.id) > before
+
+    before = _revision(store, message.id)
+    store.get_message(message.id)
+    assert _revision(store, message.id) > before
+
+    before = _revision(store, message.id)
+    store.reset_stream_content(message.id)
+    assert _revision(store, message.id) > before
+
+    store.append_stream_chunk(message.id, "answer")
+    before = _revision(store, message.id)
+    store.mark_message_complete(message.id)
+    assert _revision(store, message.id) > before
+
+    before = _revision(store, message.id)
+    store.update_message_content(message.id, "edited")
+    assert _revision(store, message.id) > before
+
+    before = _revision(store, message.id)
+    store.add_variant(message.id, "variant")
+    assert _revision(store, message.id) > before
+
+    before = _revision(store, message.id)
+    store.select_variant(message.id, 0)
+    assert _revision(store, message.id) > before
+
+    before = _revision(store, message.id)
+    store.update_message_content(message.id, "edited variant")
+    assert _revision(store, message.id) > before
+
+
+def test_speech_revision_bumps_for_provisional_retry_and_terminal_mutations():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    provisional = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        defer_terminal_persistence=True,
+    )
+
+    before = _revision(store, provisional.id)
+    store.replace_deferred_terminal_body(provisional.id, "selected")
+    assert _revision(store, provisional.id) > before
+
+    before = _revision(store, provisional.id)
+    store.mark_message_complete(provisional.id)
+    assert _revision(store, provisional.id) > before
+
+    failed = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    before = _revision(store, failed.id)
+    store.mark_message_failed(failed.id)
+    assert _revision(store, failed.id) > before
+
+    before = _revision(store, failed.id)
+    store.prepare_message_retry(failed.id)
+    assert _revision(store, failed.id) > before
+
+    stopped = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    before = _revision(store, stopped.id)
+    store.mark_message_stopped(stopped.id)
+    assert _revision(store, stopped.id) > before
+
+    blocked = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="not sent",
+    )
+    before = _revision(store, blocked.id)
+    store.mark_message_send_blocked(blocked.id)
+    assert _revision(store, blocked.id) > before
+
+
+def test_persistence_service_reads_only_current_positive_message_version(tmp_path):
+    database = CharactersRAGDB(tmp_path / "speech-version.sqlite", "speech-test")
+    try:
+        service = ChatPersistenceService(database)
+        conversation_id = service.create_conversation()
+        message_id = service.create_message(
+            conversation_id=conversation_id,
+            sender="assistant",
+            content="response",
+            image_data=None,
+            image_mime_type=None,
+        )
+
+        assert service.get_message_version(message_id) == 1
+        assert service.get_message_version("missing") is None
+
+        database.soft_delete_message(message_id, expected_version=1)
+
+        assert service.get_message_version(message_id) is None
+    finally:
+        database.close_connection()
+
+
+def test_persisted_snapshot_rejects_external_edit_then_restore(tmp_path):
+    database = CharactersRAGDB(tmp_path / "speech-stale.sqlite", "speech-test")
+    try:
+        persistence = ChatPersistenceService(database)
+        store = ConsoleChatStore(persistence=persistence)
+        session = store.create_session()
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="original",
+            persist=True,
+        )
+        snapshot = store.issue_tts_message_speech_snapshot(message.id)
+        assert snapshot.persisted_conversation_id is not None
+        assert snapshot.persisted_message_id is not None
+        assert snapshot.persisted_message_version == 1
+
+        for content in ("external edit", "original"):
+            assert persistence.update_message_content(
+                message_id=snapshot.persisted_message_id,
+                content=content,
+                image_data=None,
+                image_mime_type=None,
+            )
+
+        assert store.get_message(message.id).content == snapshot.raw_content
+        _assert_rejected(
+            store,
+            snapshot,
+            ConsoleSpeechSnapshotRejectionCode.PERSISTED_VERSION_CHANGED,
+        )
+    finally:
+        database.close_connection()
+
+
+def test_persisted_message_without_version_reader_fails_closed():
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="response",
+    )
+    session.persisted_conversation_id = "conversation-1"
+    store._nodes_by_session[session.id][
+        message.id
+    ].persisted_message_id = "persisted-message-1"
+    store.persistence = object()  # type: ignore[assignment]
+
+    with pytest.raises(ConsoleSpeechSnapshotRejected) as caught:
+        store.issue_tts_message_speech_snapshot(message.id)
+
+    assert (
+        caught.value.code
+        is ConsoleSpeechSnapshotRejectionCode.PERSISTED_VERSION_UNAVAILABLE
+    )

--- a/Tests/TTS/test_console_audio_cpp_native.py
+++ b/Tests/TTS/test_console_audio_cpp_native.py
@@ -10,10 +10,13 @@ from typing import Any
 
 import pytest
 
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Event_Handlers.TTS_Events import tts_events as tts_events_module
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSCompleteEvent,
     TTSEventHandler,
+    TTSMessageSpeechRequestEvent,
     TTSProgressEvent,
     TTSRequestEvent,
     TTSStreamingEvent,
@@ -304,7 +307,7 @@ def _external_preferences() -> dict[str, Any]:
 
 
 @pytest.mark.asyncio
-async def test_console_audio_cpp_request_uses_native_default_without_rewriting_ids() -> (
+async def test_console_audio_cpp_snapshot_uses_native_default_without_rewriting_ids() -> (
     None
 ):
     timeline: list[str] = []
@@ -345,12 +348,26 @@ async def test_console_audio_cpp_request_uses_native_default_without_rewriting_i
     handler = _Handler(timeline)
     handler._request_cooldown = {}
     handler._tts_service = service
+    store = ConsoleChatStore()
+    session = store.create_session(
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        assistant_authority_id="local-authority",
+        character_id=7,
+        character_name="Mira",
+    )
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Character response",
+    )
     artifact: Path | None = None
     try:
         await handler.handle_tts_request(
-            TTSRequestEvent(
-                text="Character response",
-                message_id="console-native-1",
+            TTSMessageSpeechRequestEvent(
+                store.issue_tts_message_speech_snapshot(message.id),
+                store.validate_tts_message_speech_snapshot,
             )
         )
         await asyncio.wait_for(
@@ -364,6 +381,7 @@ async def test_console_audio_cpp_request_uses_native_default_without_rewriting_i
         )
         artifact = completion.audio_file
 
+        assert completion.message_id == message.id
         assert adapter.requests == [
             TTSRequest(
                 provider_id="audio_cpp",
@@ -397,6 +415,52 @@ async def test_console_audio_cpp_request_uses_native_default_without_rewriting_i
         await handler.cleanup_tts_resources()
         await service.close()
         await service.wait_closed()
+
+    assert artifact is not None
+    assert not artifact.exists()
+
+
+@pytest.mark.asyncio
+async def test_non_console_tts_request_event_keeps_global_default_path(
+    tmp_path: Path,
+) -> None:
+    timeline: list[str] = []
+    response = _Response(_RecordingStream(_WAV_CHUNKS, timeline))
+    service = _DefaultService(response)
+    handler = _Handler()
+    handler._tts_service = service
+    handler._temp_manager = _RecordingTempManager(tmp_path)
+    artifact: Path | None = None
+    try:
+        await handler.handle_tts_request(
+            TTSRequestEvent(
+                text="Global caller response",
+                message_id="global-native-1",
+                voice="Global voice override",
+            )
+        )
+        await asyncio.wait_for(
+            handler.completion_posted.wait(),
+            timeout=_WAIT_SECONDS,
+        )
+        completion = next(
+            message
+            for message in handler.messages
+            if isinstance(message, TTSCompleteEvent)
+        )
+        artifact = completion.audio_file
+
+        assert len(service.calls) == 1
+        text, voice, progress_sink = service.calls[0]
+        assert text == "Global caller response"
+        assert voice == "Global voice override"
+        assert callable(progress_sink)
+        assert artifact is not None
+        assert artifact.read_bytes() == b"".join(_WAV_CHUNKS)
+        assert response.close_calls == 1
+        assert response.byte_stream.close_calls == 1
+    finally:
+        await handler.cleanup_tts_resources()
 
     assert artifact is not None
     assert not artifact.exists()

--- a/Tests/TTS/test_console_speak_autoplay.py
+++ b/Tests/TTS/test_console_speak_autoplay.py
@@ -96,6 +96,46 @@ async def test_app_routes_snapshot_event_without_logging_private_snapshot_data()
 
 
 @pytest.mark.asyncio
+async def test_app_snapshot_handler_unavailable_logs_only_safe_context():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        assistant_authority_id="PRIVATE_AUTHORITY",
+        character_id=7,
+    )
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="PRIVATE_RESPONSE_TEXT",
+    )
+    event = TTSMessageSpeechRequestEvent(
+        store.issue_tts_message_speech_snapshot(message.id),
+        store.validate_tts_message_speech_snapshot,
+    )
+    fake_app = _FakeApp()
+    fake_app._ensure_tts_handler = AsyncMock(return_value=None)
+    fake_app.post_message = AsyncMock()
+
+    await TldwCli.handle_tts_message_speech_request_event(fake_app, event)
+
+    fake_app.loguru_logger.error.assert_called_once_with(
+        "TTS handler not initialized "
+        "(operation=trusted_console_speech, outcome_code=handler_unavailable)"
+    )
+    rendered_logs = repr(fake_app.loguru_logger.method_calls)
+    assert "PRIVATE_RESPONSE_TEXT" not in rendered_logs
+    assert "PRIVATE_AUTHORITY" not in rendered_logs
+    assert message.id not in rendered_logs
+    fake_app.post_message.assert_awaited_once()
+    completion = fake_app.post_message.await_args.args[0]
+    assert isinstance(completion, TTSCompleteEvent)
+    assert completion.message_id == message.id
+    assert completion.error == "TTS service not available"
+
+
+@pytest.mark.asyncio
 async def test_console_speak_autoplay_when_no_legacy_widget_claims_message(tmp_path):
     """No legacy widget claims the message id (the Console case) -> the
     handler must post TTSPlaybackEvent(action="play") itself after the native

--- a/Tests/TTS/test_console_speak_autoplay.py
+++ b/Tests/TTS/test_console_speak_autoplay.py
@@ -31,13 +31,16 @@ path the legacy play button drives today), not new logic introduced here.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.app import TldwCli
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSCompleteEvent,
+    TTSMessageSpeechRequestEvent,
     TTSPlaybackEvent,
 )
 from tldw_chatbook.Widgets.Chat_Widgets.chat_message import ChatMessage
@@ -58,6 +61,38 @@ class _FakeApp:
     def post_message(self, message) -> bool:
         self.posted.append(message)
         return True
+
+
+@pytest.mark.asyncio
+async def test_app_routes_snapshot_event_without_logging_private_snapshot_data():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        runtime_backend="local",
+        assistant_kind="character",
+        assistant_id="7",
+        assistant_authority_id="PRIVATE_AUTHORITY",
+        character_id=7,
+    )
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="PRIVATE_RESPONSE_TEXT",
+    )
+    event = TTSMessageSpeechRequestEvent(
+        store.issue_tts_message_speech_snapshot(message.id),
+        store.validate_tts_message_speech_snapshot,
+    )
+    handler = MagicMock()
+    handler.handle_tts_request = AsyncMock()
+    fake_app = _FakeApp()
+    fake_app._ensure_tts_handler = AsyncMock(return_value=handler)
+
+    await TldwCli.handle_tts_message_speech_request_event(fake_app, event)
+
+    handler.handle_tts_request.assert_awaited_once_with(event)
+    rendered_logs = repr(fake_app.loguru_logger.method_calls)
+    assert "PRIVATE_RESPONSE_TEXT" not in rendered_logs
+    assert "PRIVATE_AUTHORITY" not in rendered_logs
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_console_speech_snapshot_admission.py
+++ b/Tests/TTS/test_console_speech_snapshot_admission.py
@@ -1,0 +1,219 @@
+"""Pre-cooldown admission tests for trusted Console speech snapshots."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+
+import pytest
+from loguru import logger
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_speech import (
+    ConsoleSpeechSnapshotRejected,
+    ConsoleSpeechSnapshotRejectionCode,
+    TTSMessageSpeechSnapshot,
+)
+from tldw_chatbook.Event_Handlers.TTS_Events import tts_events as tts_events_module
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    TTSCompleteEvent,
+    TTSEventHandler,
+    TTSMessageSpeechRequestEvent,
+    TTSRequestEvent,
+)
+
+
+class _RecordingHandler(TTSEventHandler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[object] = []
+        self.generated: list[tuple[str, str | None, str | None]] = []
+        self._request_cooldown = {}
+
+    async def post_message(self, message: object) -> None:
+        self.messages.append(message)
+
+    async def _generate_tts_with_rate_limit(
+        self,
+        text: str,
+        message_id: str | None,
+        voice: str | None,
+    ) -> None:
+        self.generated.append((text, message_id, voice))
+
+
+def _issued_snapshot() -> tuple[
+    ConsoleChatStore,
+    TTSMessageSpeechSnapshot,
+]:
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="  Exact   Console response.\n",
+    )
+    return store, store.issue_tts_message_speech_snapshot(message.id)
+
+
+def test_message_speech_event_carries_snapshot_and_validator_without_text_field():
+    store, snapshot = _issued_snapshot()
+    validator = store.validate_tts_message_speech_snapshot
+
+    event = TTSMessageSpeechRequestEvent(snapshot, validator)
+
+    assert event.snapshot is snapshot
+    assert event.validator is validator
+    assert event.message_id == snapshot.message_id
+    assert not hasattr(event, "text")
+    assert not hasattr(event, "voice")
+
+
+@pytest.mark.asyncio
+async def test_bounded_rejection_happens_before_clock_service_or_cooldown(
+    monkeypatch,
+):
+    store, snapshot = _issued_snapshot()
+    store.update_message_content(snapshot.message_id, "changed")
+    handler = _RecordingHandler()
+    handler._tts_service = None
+    handler._request_cooldown = {"old-message": -1000.0}
+    handler._last_cooldown_cleanup = -1000.0
+    cooldown_before = deepcopy(handler._request_cooldown)
+    cleanup_before = handler._last_cooldown_cleanup
+
+    def forbidden_clock():
+        raise AssertionError("clock must not be read before snapshot admission")
+
+    def forbidden_mutation(*_args, **_kwargs):
+        raise AssertionError("cooldown must not mutate before snapshot admission")
+
+    monkeypatch.setattr(tts_events_module.asyncio, "get_event_loop", forbidden_clock)
+    monkeypatch.setattr(handler, "_cleanup_cooldown_dict", forbidden_mutation)
+    monkeypatch.setattr(handler, "_enforce_cooldown_limit", forbidden_mutation)
+
+    await handler.handle_tts_request(
+        TTSMessageSpeechRequestEvent(
+            snapshot,
+            store.validate_tts_message_speech_snapshot,
+        )
+    )
+
+    completions = [
+        message for message in handler.messages if isinstance(message, TTSCompleteEvent)
+    ]
+    assert len(completions) == 1
+    assert completions[0].message_id == snapshot.message_id
+    assert (
+        completions[0].error
+        == "Message changed before speech started; select Speak again."
+    )
+    assert handler._request_cooldown == cooldown_before
+    assert handler._last_cooldown_cleanup == cleanup_before
+    assert handler.generated == []
+    assert handler._active_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_validator_failure_is_generic_and_privacy_safe(monkeypatch):
+    _store, snapshot = _issued_snapshot()
+    handler = _RecordingHandler()
+    handler._tts_service = object()
+    private_values = (
+        snapshot.raw_content,
+        "PRIVATE_AUTHORITY_COMPONENT",
+        "PRIVATE_EXCEPTION_DETAIL",
+    )
+    log_messages: list[str] = []
+
+    def fail_closed(_snapshot: TTSMessageSpeechSnapshot) -> str:
+        raise RuntimeError(" ".join(private_values))
+
+    monkeypatch.setattr(
+        tts_events_module.asyncio,
+        "get_event_loop",
+        lambda: pytest.fail("clock read before validator rejection"),
+    )
+    sink_id = logger.add(log_messages.append, level="DEBUG", format="{message}")
+    try:
+        await handler.handle_tts_request(
+            TTSMessageSpeechRequestEvent(snapshot, fail_closed)
+        )
+    finally:
+        logger.remove(sink_id)
+
+    completions = [
+        message for message in handler.messages if isinstance(message, TTSCompleteEvent)
+    ]
+    assert len(completions) == 1
+    assert (
+        completions[0].error
+        == "Message changed before speech started; select Speak again."
+    )
+    rendered = "\n".join(log_messages) + repr(completions)
+    for private_value in private_values:
+        assert private_value not in rendered
+    assert handler._request_cooldown == {}
+    assert handler.generated == []
+    assert handler._active_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_valid_snapshot_uses_existing_normalization_and_global_voice_path():
+    store, snapshot = _issued_snapshot()
+    handler = _RecordingHandler()
+    handler._tts_service = object()
+
+    await handler.handle_tts_request(
+        TTSMessageSpeechRequestEvent(
+            snapshot,
+            store.validate_tts_message_speech_snapshot,
+        )
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert handler.generated == [("Exact Console response.", snapshot.message_id, None)]
+    assert snapshot.message_id in handler._request_cooldown
+
+
+@pytest.mark.asyncio
+async def test_explicit_global_request_path_remains_available():
+    handler = _RecordingHandler()
+    handler._tts_service = object()
+
+    await handler.handle_tts_request(
+        TTSRequestEvent(
+            text="  Trusted   global speech. ",
+            message_id="global-message",
+            voice="alloy",
+        )
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert handler.generated == [("Trusted global speech.", "global-message", "alloy")]
+
+
+def test_snapshot_event_rejects_non_snapshot_or_non_callable_validator():
+    store, snapshot = _issued_snapshot()
+
+    with pytest.raises(ValueError, match="snapshot"):
+        TTSMessageSpeechRequestEvent(
+            object(),  # type: ignore[arg-type]
+            store.validate_tts_message_speech_snapshot,
+        )
+    with pytest.raises(ValueError, match="validator"):
+        TTSMessageSpeechRequestEvent(
+            snapshot,
+            object(),  # type: ignore[arg-type]
+        )
+
+
+def test_bounded_snapshot_rejection_has_no_unbounded_exception_data():
+    error = ConsoleSpeechSnapshotRejected(
+        ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+    )
+
+    assert str(error) == "Message changed before speech started; select Speak again."

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -2486,7 +2486,7 @@ async def test_console_original_attempt_preview_toggles_without_changing_selecte
             spoken_event = next(
                 call.args[0]
                 for call in app.post_message.call_args_list
-                if call.args[0].__class__.__name__ == "TTSRequestEvent"
+                if call.args[0].__class__.__name__ == "TTSMessageSpeechRequestEvent"
             )
 
             assert selected.content == repaired
@@ -2494,14 +2494,14 @@ async def test_console_original_attempt_preview_toggles_without_changing_selecte
             assert repaired in plain_export
             assert save_payload == repaired
             assert repaired in provider_contents
-            assert spoken_event.text == repaired
+            assert spoken_event.snapshot.raw_content == repaired
             for output in (
                 selected.content,
                 copied_text,
                 plain_export,
                 save_payload,
                 *provider_contents,
-                spoken_event.text,
+                spoken_event.snapshot.raw_content,
             ):
                 assert original not in str(output)
 

--- a/backlog/tasks/task-1495 - Wizard-step-compose-crash-policy-from-spec-§5-unimplemented.md
+++ b/backlog/tasks/task-1495 - Wizard-step-compose-crash-policy-from-spec-§5-unimplemented.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-1266
+id: TASK-1495
 title: Wizard step compose() crash policy from spec §5 unimplemented
 status: To Do
 assignee: []

--- a/backlog/tasks/task-617.3 - Add-trusted-Console-speech-snapshots.md
+++ b/backlog/tasks/task-617.3 - Add-trusted-Console-speech-snapshots.md
@@ -1,0 +1,66 @@
+---
+id: TASK-617.3
+title: Add trusted Console speech snapshots
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-30 19:28'
+updated_date: '2026-07-30 19:32'
+labels:
+  - tts
+  - console
+  - security
+dependencies: []
+references:
+  - >-
+    backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-28-tts-character-identity-persona-separation-design.md
+parent_task_id: TASK-617
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Bind Console Speak to an immutable app-issued message snapshot and reject stale or mismatched requests before normalization, cooldown, profile lookup, or provider work while preserving existing global TTS selection and playback.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Console store issues a frozen snapshot containing native and optional persisted identity, exact visible content, selected variant and monotonic speech revision, persisted row version, role, completion state, assistant kind, and a CharacterRef only when authority is complete.
+- [ ] #2 Speech revisions advance on every content, status, variant-addition, variant-selection, and variant-content mutation so edit-then-revert remains stale; revisions are never serialized across process restart.
+- [ ] #3 Admission rejects deleted, moved, incomplete, non-assistant, stale-variant, stale-revision, stale-persisted-version, and mismatched-authorship snapshots before normalization, cooldown, or provider work.
+- [ ] #4 An unchanged valid Console snapshot follows the existing global TTS provider, model, voice, format, speed, complete-WAV playback, and error behavior without assigned-profile resolution.
+- [ ] #5 Non-Console callers retain a distinct explicit trusted global-speech request path and do not construct Console snapshots.
+- [ ] #6 Diagnostics use bounded outcome codes and never log snapshot text, authority, credentials, origins, routing IDs, or paths.
+- [ ] #7 Deterministic store, event-handler, UI, and native audio.cpp regression tests cover valid and rejected requests including controlled post-click mutations.
+- [ ] #8 The task adds no profile assignment mutation, assignment UI, character-specific resolver, automatic speech, Persona voice inheritance, portability, or managed audio.cpp behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md
+Reason: ADR-037 already governs immutable Console speech snapshots, authorship validation, pre-cooldown rejection, privacy, and deferral of assigned-profile resolution; no new ADR is required.
+
+1. Define the immutable privacy-safe snapshot and bounded rejection contract with TDD.
+2. Add Console-owned process-local speech revisions, persisted-version reads, snapshot issuance, and exact validation with TDD.
+3. Add the dedicated snapshot event and validate it before any cooldown mutation while preserving the explicit global request path.
+4. Wire Console and application routing and align Speak availability to completed assistant messages.
+5. Prove unchanged native audio.cpp and legacy/global synthesis and document the boundary.
+6. Run focused and broader verification, independent review, and Backlog closeout.
+
+Full plan: Docs/superpowers/plans/2026-07-30-trusted-console-speech-snapshots.md
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 All acceptance criteria are checked and concise Implementation Notes record the delivered behavior and deviations.
+- [ ] #2 Focused store, event-handler, Console UI, native audio.cpp, complete-WAV, and legacy TTS tests pass.
+- [ ] #3 Task-scoped Ruff, formatting, compile, typing, and git diff checks pass or exact unchanged baselines are documented.
+- [ ] #4 ADR-037 and the approved Slice 3A design remain current and are linked from the task and plan.
+- [ ] #5 Independent review finds no unresolved Critical, Important, or Minor issue before merge.
+<!-- DOD:END -->

--- a/backlog/tasks/task-617.3 - Add-trusted-Console-speech-snapshots.md
+++ b/backlog/tasks/task-617.3 - Add-trusted-Console-speech-snapshots.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-617.3
 title: Add trusted Console speech snapshots
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 19:28'
-updated_date: '2026-07-30 19:32'
+updated_date: '2026-07-30 20:27'
 labels:
   - tts
   - console
@@ -29,14 +29,14 @@ Bind Console Speak to an immutable app-issued message snapshot and reject stale 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The Console store issues a frozen snapshot containing native and optional persisted identity, exact visible content, selected variant and monotonic speech revision, persisted row version, role, completion state, assistant kind, and a CharacterRef only when authority is complete.
-- [ ] #2 Speech revisions advance on every content, status, variant-addition, variant-selection, and variant-content mutation so edit-then-revert remains stale; revisions are never serialized across process restart.
-- [ ] #3 Admission rejects deleted, moved, incomplete, non-assistant, stale-variant, stale-revision, stale-persisted-version, and mismatched-authorship snapshots before normalization, cooldown, or provider work.
-- [ ] #4 An unchanged valid Console snapshot follows the existing global TTS provider, model, voice, format, speed, complete-WAV playback, and error behavior without assigned-profile resolution.
-- [ ] #5 Non-Console callers retain a distinct explicit trusted global-speech request path and do not construct Console snapshots.
-- [ ] #6 Diagnostics use bounded outcome codes and never log snapshot text, authority, credentials, origins, routing IDs, or paths.
-- [ ] #7 Deterministic store, event-handler, UI, and native audio.cpp regression tests cover valid and rejected requests including controlled post-click mutations.
-- [ ] #8 The task adds no profile assignment mutation, assignment UI, character-specific resolver, automatic speech, Persona voice inheritance, portability, or managed audio.cpp behavior.
+- [x] #1 The Console store issues a frozen snapshot containing native and optional persisted identity, exact visible content, selected variant and monotonic speech revision, persisted row version, role, completion state, assistant kind, and a CharacterRef only when authority is complete.
+- [x] #2 Speech revisions advance on every content, status, variant-addition, variant-selection, and variant-content mutation so edit-then-revert remains stale; revisions are never serialized across process restart.
+- [x] #3 Admission rejects deleted, moved, incomplete, non-assistant, stale-variant, stale-revision, stale-persisted-version, and mismatched-authorship snapshots before normalization, cooldown, or provider work.
+- [x] #4 An unchanged valid Console snapshot follows the existing global TTS provider, model, voice, format, speed, complete-WAV playback, and error behavior without assigned-profile resolution.
+- [x] #5 Non-Console callers retain a distinct explicit trusted global-speech request path and do not construct Console snapshots.
+- [x] #6 Diagnostics use bounded outcome codes and never log snapshot text, authority, credentials, origins, routing IDs, or paths.
+- [x] #7 Deterministic store, event-handler, UI, and native audio.cpp regression tests cover valid and rejected requests including controlled post-click mutations.
+- [x] #8 The task adds no profile assignment mutation, assignment UI, character-specific resolver, automatic speech, Persona voice inheritance, portability, or managed audio.cpp behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -56,11 +56,21 @@ Reason: ADR-037 already governs immutable Console speech snapshots, authorship v
 Full plan: Docs/superpowers/plans/2026-07-30-trusted-console-speech-snapshots.md
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented immutable trusted Console speech snapshots with store-owned issuance and validation across active session/path, exact selected content and variant, monotonic process-local revision, persisted row version, completed-assistant state, and assistant authorship. Added a dedicated snapshot event that validates before cooldown, normalization, or provider work; Console Speak now posts only store-issued snapshots and remains limited to completed assistant messages. Preserved the explicit non-Console global request path, saved global TTS selection, native audio.cpp complete-WAV lifecycle, legacy bridge, autoplay, and external-process ownership. Added deterministic store, handler, UI, privacy, native audio.cpp, and global-path regressions plus user/developer documentation. ADR-037 remains the governing decision; no new ADR was required.
+
+Verification: 294 task-critical tests passed in the final green run. The complete focused union recorded 561 passes and three unrelated mounted workspace-browser timing failures; two passed immediately when rerun serially and the remaining stale-search assertion reproduced on untouched base dev. The broader Tests/TTS + Tests/Chat union recorded 4,681 passes and 74 skips; two socket errors disappeared outside the sandbox and every remaining failing node reproduced on untouched base dev. Ruff, scoped format, compileall, and diff checks passed. The new snapshot module passes mypy; three TTSEventHandler.notify diagnostics are unchanged from base dev. Independent review found no Critical, Important, or Minor issues.
+
+Plan deviation: the native snapshot integration regression passed on first execution because the dedicated event support had already been completed and verified in the preceding plan step; no additional production change was needed.
+<!-- SECTION:NOTES:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 All acceptance criteria are checked and concise Implementation Notes record the delivered behavior and deviations.
-- [ ] #2 Focused store, event-handler, Console UI, native audio.cpp, complete-WAV, and legacy TTS tests pass.
-- [ ] #3 Task-scoped Ruff, formatting, compile, typing, and git diff checks pass or exact unchanged baselines are documented.
-- [ ] #4 ADR-037 and the approved Slice 3A design remain current and are linked from the task and plan.
-- [ ] #5 Independent review finds no unresolved Critical, Important, or Minor issue before merge.
+- [x] #1 All acceptance criteria are checked and concise Implementation Notes record the delivered behavior and deviations.
+- [x] #2 Focused store, event-handler, Console UI, native audio.cpp, complete-WAV, and legacy TTS tests pass.
+- [x] #3 Task-scoped Ruff, formatting, compile, typing, and git diff checks pass or exact unchanged baselines are documented.
+- [x] #4 ADR-037 and the approved Slice 3A design remain current and are linked from the task and plan.
+- [x] #5 Independent review finds no unresolved Critical, Important, or Minor issue before merge.
 <!-- DOD:END -->

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -43,6 +43,26 @@ class ChatPersistenceService:
             and repository.local_citation_writes_ready
         )
 
+    def get_message_version(self, message_id: str) -> int | None:
+        """Return the current positive version for one non-deleted message.
+
+        Args:
+            message_id: Persisted Chat message identifier.
+
+        Returns:
+            The exact positive integer row version, or ``None`` when the row
+            is missing, deleted, or carries an untrustworthy version value.
+        """
+        if type(message_id) is not str or not message_id:
+            return None
+        message = self.db.get_message_by_id(message_id)
+        if message is None or message.get("deleted"):
+            return None
+        version = message.get("version")
+        if type(version) is not int or version < 1:
+            return None
+        return version
+
     @staticmethod
     def derive_conversation_title(
         *,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -127,7 +127,15 @@ class ConsoleChatPersistence(Protocol):
         """
 
     def get_message_version(self, message_id: str) -> int | None:
-        """Return the current positive durable row version, if trustworthy."""
+        """Return the current positive durable row version, if trustworthy.
+
+        Args:
+            message_id: Persisted Chat message identifier.
+
+        Returns:
+            The exact positive integer row version, or ``None`` when the row
+            cannot provide a trustworthy version fence.
+        """
 
     def update_conversation_system_prompt(
         self,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -33,6 +33,11 @@ from tldw_chatbook.Chat.console_chat_models import (
     MessageAttachment,
 )
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_speech import (
+    ConsoleSpeechSnapshotRejected,
+    ConsoleSpeechSnapshotRejectionCode,
+    TTSMessageSpeechSnapshot,
+)
 from tldw_chatbook.Chat.rag_scope import RagScope, SessionScopeHolder
 from tldw_chatbook.TTS.profile_errors import ProfileValidationError
 from tldw_chatbook.TTS.profile_types import CharacterRef
@@ -120,6 +125,9 @@ class ConsoleChatPersistence(Protocol):
         passes this) leaves attachments untouched. Optional: fakes used in
         tests may omit this parameter entirely.
         """
+
+    def get_message_version(self, message_id: str) -> int | None:
+        """Return the current positive durable row version, if trustworthy."""
 
     def update_conversation_system_prompt(
         self,
@@ -376,6 +384,9 @@ class ConsoleChatStore:
         self._stream_materialized_counts: dict[str, int] = {}
         self._sync_v2_message_versions: dict[str, str] = {}
         self._variant_stream_bases: dict[str, _VariantStreamBase] = {}
+        # Ephemeral fence for issued speech snapshots. It deliberately lives
+        # outside ConsoleChatMessage so it is neither persisted nor restored.
+        self._message_speech_revisions: dict[str, int] = {}
 
     def ensure_session(
         self,
@@ -667,6 +678,7 @@ class ConsoleChatStore:
             self._stream_materialized_counts.pop(message_id, None)
             self._pending_persistence_message_ids.discard(message_id)
             self._variant_stream_bases.pop(message_id, None)
+            self._message_speech_revisions.pop(message_id, None)
             self._native_parent_by_message.pop(message_id, None)
 
         self._messages_by_session.pop(session_id, None)
@@ -874,6 +886,7 @@ class ConsoleChatStore:
         # Pre-existing bug fixed while here: the regenerate base snapshots were
         # never cleared on restore, leaking across a state replacement.
         self._variant_stream_bases.clear()
+        self._message_speech_revisions.clear()
         self._nodes_by_session.clear()
         self._children_by_parent.clear()
         self._native_parent_by_message.clear()
@@ -1355,6 +1368,181 @@ class ConsoleChatStore:
         self._materialize_stream_buffer(message)
         return self._snapshot(message)
 
+    def issue_tts_message_speech_snapshot(
+        self,
+        message_id: str,
+    ) -> TTSMessageSpeechSnapshot:
+        """Issue a trusted snapshot for one speakable active-path message.
+
+        Args:
+            message_id: Native Console message selected by the user.
+
+        Returns:
+            An immutable snapshot bound to the exact selected text and
+            current trusted session authorship.
+
+        Raises:
+            ConsoleSpeechSnapshotRejected: If the message is missing,
+                inactive, incomplete, non-assistant, blank, or cannot be
+                durably version-fenced.
+        """
+        session_id = self._message_session_index.get(message_id)
+        if session_id is None:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MISSING_MESSAGE
+            )
+        if session_id != self.active_session_id:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED
+            )
+        session = self._sessions.get(session_id)
+        message = self._nodes_by_session.get(session_id, {}).get(message_id)
+        if session is None or message is None:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MISSING_MESSAGE
+            )
+        if (
+            message.persisted_message_id is not None
+            and session.persisted_conversation_id is None
+        ):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        if message_id not in self.active_path_message_ids(session_id):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        raw_content, selected_variant_id = self._speech_selection(message)
+        if (
+            message.role is not ConsoleMessageRole.ASSISTANT
+            or message.status != "complete"
+            or not raw_content.strip()
+        ):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_NOT_SPEAKABLE
+            )
+        speech_revision = self._message_speech_revisions.get(message_id)
+        if type(speech_revision) is not int or speech_revision < 0:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        if (
+            session.assistant_kind is not None
+            and type(session.assistant_kind) is not str
+        ):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.AUTHORSHIP_CHANGED
+            )
+        persisted_version = self._persisted_message_version_or_reject(message)
+        return TTSMessageSpeechSnapshot(
+            session_id=session_id,
+            message_id=message.id,
+            persisted_conversation_id=session.persisted_conversation_id,
+            persisted_message_id=message.persisted_message_id,
+            raw_content=raw_content,
+            selected_variant_id=selected_variant_id,
+            speech_revision=speech_revision,
+            persisted_message_version=persisted_version,
+            role=message.role,
+            status=message.status,
+            assistant_kind=session.assistant_kind,
+            character_ref=session.character_ref(),
+        )
+
+    def validate_tts_message_speech_snapshot(
+        self,
+        snapshot: TTSMessageSpeechSnapshot,
+    ) -> str:
+        """Revalidate an issued Console speech snapshot against live state.
+
+        Args:
+            snapshot: Immutable snapshot previously issued by this store.
+
+        Returns:
+            The captured exact raw content after every identity, state,
+            authorship, and durable-version check succeeds.
+
+        Raises:
+            ConsoleSpeechSnapshotRejected: If any captured fact is stale or
+                cannot be re-established.
+        """
+        if type(snapshot) is not TTSMessageSpeechSnapshot:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        if snapshot.session_id != self.active_session_id:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED
+            )
+        session = self._sessions.get(snapshot.session_id)
+        if session is None:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED
+            )
+        owner_session_id = self._message_session_index.get(snapshot.message_id)
+        if owner_session_id is None:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MISSING_MESSAGE
+            )
+        if owner_session_id != snapshot.session_id:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        message = self._nodes_by_session.get(snapshot.session_id, {}).get(
+            snapshot.message_id
+        )
+        if message is None:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MISSING_MESSAGE
+            )
+        if (
+            message.persisted_message_id is not None
+            and session.persisted_conversation_id is None
+        ):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        if snapshot.message_id not in self.active_path_message_ids(snapshot.session_id):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        raw_content, selected_variant_id = self._speech_selection(message)
+        if (
+            message.role is not ConsoleMessageRole.ASSISTANT
+            or message.status != "complete"
+            or not raw_content.strip()
+        ):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_NOT_SPEAKABLE
+            )
+        if (
+            message.id != snapshot.message_id
+            or message.role is not snapshot.role
+            or message.status != snapshot.status
+            or selected_variant_id != snapshot.selected_variant_id
+            or raw_content != snapshot.raw_content
+            or self._message_speech_revisions.get(message.id)
+            != snapshot.speech_revision
+            or session.persisted_conversation_id != snapshot.persisted_conversation_id
+            or message.persisted_message_id != snapshot.persisted_message_id
+        ):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        if (
+            session.assistant_kind != snapshot.assistant_kind
+            or session.character_ref() != snapshot.character_ref
+        ):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.AUTHORSHIP_CHANGED
+            )
+        current_version = self._persisted_message_version_or_reject(message)
+        if current_version != snapshot.persisted_message_version:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.PERSISTED_VERSION_CHANGED
+            )
+        return snapshot.raw_content
+
     def replace_deferred_terminal_body(
         self,
         message_id: str,
@@ -1390,6 +1578,7 @@ class ConsoleChatStore:
         else:
             buffer[:] = [selected_body]
         self._stream_materialized_counts[message.id] = 1
+        self._bump_message_speech_revision(message.id)
         return self._snapshot(message)
 
     def set_citation_presentation(
@@ -1440,6 +1629,7 @@ class ConsoleChatStore:
                 content=content,
             )
             message.content = message.variants.current.content
+        self._bump_message_speech_revision(message.id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -1475,6 +1665,7 @@ class ConsoleChatStore:
             self._stream_materialized_counts.pop(node_id, None)
             self._pending_persistence_message_ids.discard(node_id)
             self._variant_stream_bases.pop(node_id, None)
+            self._message_speech_revisions.pop(node_id, None)
         # Only when the deleted branch was on the active path does the leaf move
         # (up to the deleted node's parent); an off-path delete leaves it alone.
         if on_active_path:
@@ -1639,6 +1830,7 @@ class ConsoleChatStore:
         )
         buffer.append(chunk)
         message.status = "streaming"
+        self._bump_message_speech_revision(message.id)
         return self._snapshot(message)
 
     def reset_stream_content(self, message_id: str) -> ConsoleChatMessage:
@@ -1684,6 +1876,7 @@ class ConsoleChatStore:
         self._stream_chunks_by_message.pop(message.id, None)
         self._stream_materialized_counts.pop(message.id, None)
         message.status = "streaming"
+        self._bump_message_speech_revision(message.id)
         return self._snapshot(message)
 
     def mark_message_complete(self, message_id: str) -> ConsoleChatMessage:
@@ -1699,12 +1892,14 @@ class ConsoleChatStore:
         self.clear_terminal_citation_state(message.id)
         if not terminal_persistence:
             message.status = "complete"
+            self._bump_message_speech_revision(message.id)
             self._persist_existing_message(message)
             return self._snapshot(message)
 
         try:
             if not message.content:
                 message.status = "complete"
+                self._bump_message_speech_revision(message.id)
                 self._persist_existing_message(message)
                 return self._snapshot(message)
 
@@ -1715,6 +1910,7 @@ class ConsoleChatStore:
                 except Exception:
                     logger.warning("terminal_finalizer_unavailable")
             message.status = "complete"
+            self._bump_message_speech_revision(message.id)
             session_id = self._message_session_index[message.id]
             try:
                 self._persist_new_message(
@@ -1761,6 +1957,7 @@ class ConsoleChatStore:
             message.status = base.prior_status
         else:
             message.status = "stopped"
+        self._bump_message_speech_revision(message.id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -1792,6 +1989,7 @@ class ConsoleChatStore:
             message.status = base.prior_status
         else:
             message.status = "failed"
+        self._bump_message_speech_revision(message.id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -1833,6 +2031,7 @@ class ConsoleChatStore:
                 "not one that is mid-stream."
             )
         message.status = "failed"
+        self._bump_message_speech_revision(message.id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -1874,6 +2073,7 @@ class ConsoleChatStore:
         message.status = "pending"
         self._stream_chunks_by_message.pop(message.id, None)
         self._stream_materialized_counts.pop(message.id, None)
+        self._bump_message_speech_revision(message.id)
         return self._snapshot(message)
 
     def add_variant(self, message_id: str, content: str) -> ConsoleChatMessage:
@@ -1892,6 +2092,7 @@ class ConsoleChatStore:
             message.variants.variants.append(ConsoleVariant(content=content))
             message.variants.selected_index = len(message.variants.variants) - 1
         message.content = message.variants.current.content
+        self._bump_message_speech_revision(message.id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -1922,6 +2123,7 @@ class ConsoleChatStore:
         self._stream_chunks_by_message.pop(message.id, None)
         self._stream_materialized_counts.pop(message.id, None)
         message.status = "streaming"
+        self._bump_message_speech_revision(message.id)
         return self._snapshot(message)
 
     def finalize_variant_stream(self, message_id: str) -> ConsoleChatMessage:
@@ -1954,6 +2156,7 @@ class ConsoleChatStore:
             message.variants.selected_index = len(message.variants.variants) - 1
         message.content = message.variants.current.content
         message.status = "complete"
+        self._bump_message_speech_revision(message.id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -1969,6 +2172,7 @@ class ConsoleChatStore:
             raise ValueError("selected_index must reference an existing variant")
         message.variants.selected_index = selected_index
         message.content = message.variants.current.content
+        self._bump_message_speech_revision(message.id)
         self._persist_existing_message(message)
         return self._snapshot(message)
 
@@ -2732,6 +2936,85 @@ class ConsoleChatStore:
             return node
         raise KeyError(f"Unknown Console message: {message_id}")
 
+    @staticmethod
+    def _selected_speech_variant_id(message: ConsoleChatMessage) -> str:
+        """Return the native linear id or exact selected text-variant id."""
+        if message.variants is None:
+            return message.id
+        try:
+            selected_id = message.variants.current.id
+        except (AttributeError, IndexError):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            ) from None
+        if type(selected_id) is not str or not selected_id:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        return selected_id
+
+    @classmethod
+    def _speech_selection(
+        cls,
+        message: ConsoleChatMessage,
+    ) -> tuple[str, str]:
+        """Return exact visible text and its selected text-variant identity."""
+        selected_variant_id = cls._selected_speech_variant_id(message)
+        if type(message.content) is not str:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+            )
+        if message.variants is not None:
+            try:
+                selected_content = message.variants.current.content
+            except (AttributeError, IndexError):
+                raise ConsoleSpeechSnapshotRejected(
+                    ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+                ) from None
+            if type(selected_content) is not str or message.content != selected_content:
+                raise ConsoleSpeechSnapshotRejected(
+                    ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
+                )
+        return message.content, selected_variant_id
+
+    def _persisted_message_version_or_reject(
+        self,
+        message: ConsoleChatMessage,
+    ) -> int | None:
+        """Read the durable version fence or reject an unverifiable row."""
+        persisted_message_id = message.persisted_message_id
+        if persisted_message_id is None:
+            return None
+        if type(persisted_message_id) is not str or not persisted_message_id:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.PERSISTED_VERSION_UNAVAILABLE
+            )
+        persistence = self.persistence
+        reader = (
+            getattr(persistence, "get_message_version", None)
+            if persistence is not None
+            else None
+        )
+        if not callable(reader):
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.PERSISTED_VERSION_UNAVAILABLE
+            )
+        try:
+            version = reader(persisted_message_id)
+        except Exception:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.PERSISTED_VERSION_UNAVAILABLE
+            ) from None
+        if type(version) is not int or version < 1:
+            raise ConsoleSpeechSnapshotRejected(
+                ConsoleSpeechSnapshotRejectionCode.PERSISTED_VERSION_UNAVAILABLE
+            )
+        return version
+
+    def _bump_message_speech_revision(self, message_id: str) -> None:
+        """Advance one registered node's process-local speech fence."""
+        self._message_speech_revisions[message_id] += 1
+
     def _register_tree_node(
         self,
         session_id: str,
@@ -2753,6 +3036,7 @@ class ConsoleChatStore:
             parent_native_id, []
         ).append(message.id)
         self._message_session_index[message.id] = session_id
+        self._message_speech_revisions[message.id] = 0
 
     def _ingest_linear_messages(
         self, session_id: str, messages: Iterable[ConsoleChatMessage]
@@ -3213,6 +3497,7 @@ class ConsoleChatStore:
         message.content = "".join(buffer)
         buffer[:] = [message.content]
         self._stream_materialized_counts[message.id] = 1
+        self._bump_message_speech_revision(message.id)
         return True
 
     def _materialize_stream_buffer(self, message: ConsoleChatMessage) -> None:

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -85,11 +85,12 @@ class ConsoleMessageActionService:
 
     @staticmethod
     def _speak_visible(message: ConsoleChatMessage) -> bool:
-        """Spec §1a: speak is offered for any completed message with
-        non-empty text (any role, generation-card marker text included) --
-        absent (not merely disabled) for a failed message or one with no
-        text yet (e.g. a still-pending assistant turn)."""
-        return message.status != "failed" and bool(message.content.strip())
+        """Offer speech only for trusted completed assistant text."""
+        return (
+            message.role is ConsoleMessageRole.ASSISTANT
+            and message.status == "complete"
+            and bool(message.content.strip())
+        )
 
     def __init__(
         self,

--- a/tldw_chatbook/Chat/console_speech.py
+++ b/tldw_chatbook/Chat/console_speech.py
@@ -1,0 +1,91 @@
+"""Trusted, process-local Console speech request contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleMessageStatus,
+)
+from tldw_chatbook.TTS.profile_types import CharacterRef
+
+
+class ConsoleSpeechSnapshotRejectionCode(str, Enum):
+    """Bounded reasons an issued Console speech snapshot can be rejected."""
+
+    MISSING_MESSAGE = "missing_message"
+    SESSION_CHANGED = "session_changed"
+    MESSAGE_CHANGED = "message_changed"
+    MESSAGE_NOT_SPEAKABLE = "message_not_speakable"
+    PERSISTED_VERSION_UNAVAILABLE = "persisted_version_unavailable"
+    PERSISTED_VERSION_CHANGED = "persisted_version_changed"
+    AUTHORSHIP_CHANGED = "authorship_changed"
+
+
+class ConsoleSpeechSnapshotRejected(ValueError):
+    """Reject a stale or unverifiable snapshot without carrying private data."""
+
+    USER_COPY = "Message changed before speech started; select Speak again."
+
+    def __init__(self, code: ConsoleSpeechSnapshotRejectionCode) -> None:
+        if type(code) is not ConsoleSpeechSnapshotRejectionCode:
+            raise ValueError("rejection code must be bounded")
+        self.code = code
+        super().__init__(self.USER_COPY)
+
+
+@dataclass(frozen=True, slots=True)
+class TTSMessageSpeechSnapshot:
+    """Immutable identity and content captured for one Console Speak action."""
+
+    session_id: str
+    message_id: str
+    persisted_conversation_id: str | None
+    persisted_message_id: str | None
+    raw_content: str = field(repr=False)
+    selected_variant_id: str
+    speech_revision: int
+    persisted_message_version: int | None
+    role: ConsoleMessageRole
+    status: ConsoleMessageStatus
+    assistant_kind: str | None
+    character_ref: CharacterRef | None = field(repr=False)
+
+    def __post_init__(self) -> None:
+        """Reject malformed snapshots at their sole construction boundary."""
+        for name in ("session_id", "message_id", "selected_variant_id"):
+            value = getattr(self, name)
+            if type(value) is not str or not value:
+                raise ValueError(name)
+        for name in ("persisted_conversation_id", "persisted_message_id"):
+            value = getattr(self, name)
+            if value is not None and (type(value) is not str or not value):
+                raise ValueError(name)
+        if type(self.raw_content) is not str:
+            raise ValueError("raw_content")
+        if type(self.speech_revision) is not int or self.speech_revision < 0:
+            raise ValueError("speech_revision")
+        if self.persisted_message_version is not None and (
+            type(self.persisted_message_version) is not int
+            or self.persisted_message_version < 1
+        ):
+            raise ValueError("persisted_message_version")
+        if type(self.role) is not ConsoleMessageRole:
+            raise ValueError("role")
+        if self.status not in {
+            "complete",
+            "pending",
+            "streaming",
+            "stopped",
+            "failed",
+        }:
+            raise ValueError("status")
+        if self.assistant_kind is not None and type(self.assistant_kind) is not str:
+            raise ValueError("assistant_kind")
+        if (
+            self.character_ref is not None
+            and type(self.character_ref) is not CharacterRef
+        ):
+            raise ValueError("character_ref")

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -15,6 +15,10 @@ from loguru import logger
 from textual.message import Message
 
 # Local imports
+from tldw_chatbook.Chat.console_speech import (
+    ConsoleSpeechSnapshotRejected,
+    TTSMessageSpeechSnapshot,
+)
 from tldw_chatbook.TTS import get_tts_service
 from tldw_chatbook.TTS.adapter_types import (
     TTSConfigurationRevisionError,
@@ -47,7 +51,7 @@ class _TTSArtifactIOTimeout(RuntimeError):
 
 
 class TTSRequestEvent(Message):
-    """Event to request TTS generation"""
+    """Explicit trusted global-speech request without a Console message."""
 
     def __init__(
         self, text: str, message_id: Optional[str] = None, voice: Optional[str] = None
@@ -56,6 +60,28 @@ class TTSRequestEvent(Message):
         self.text = text
         self.message_id = message_id  # ID of the chat message
         self.voice = voice  # Optional voice override
+
+
+class TTSMessageSpeechRequestEvent(Message):
+    """Request speech for one store-issued immutable Console snapshot."""
+
+    def __init__(
+        self,
+        snapshot: TTSMessageSpeechSnapshot,
+        validator: Callable[[TTSMessageSpeechSnapshot], str],
+    ) -> None:
+        super().__init__()
+        if type(snapshot) is not TTSMessageSpeechSnapshot:
+            raise ValueError("snapshot must be TTSMessageSpeechSnapshot")
+        if not callable(validator):
+            raise ValueError("validator must be callable")
+        self.snapshot = snapshot
+        self.validator = validator
+
+    @property
+    def message_id(self) -> str:
+        """Expose the native message id without duplicating caller text."""
+        return self.snapshot.message_id
 
 
 class TTSStreamingEvent(Message):
@@ -314,8 +340,57 @@ class TTSEventHandler:
             if asyncio.iscoroutine(result):
                 await result
 
-    async def handle_tts_request(self, event: TTSRequestEvent) -> None:
-        """Handle TTS generation request"""
+    async def handle_tts_request(
+        self,
+        event: TTSRequestEvent | TTSMessageSpeechRequestEvent,
+    ) -> None:
+        """Admit a trusted request, then run the shared TTS generation path."""
+        if isinstance(event, TTSMessageSpeechRequestEvent):
+            try:
+                request_text = event.validator(event.snapshot)
+            except ConsoleSpeechSnapshotRejected as error:
+                logger.warning(
+                    "Console speech snapshot rejected (outcome_code={})",
+                    error.code.value,
+                )
+                await self._post_tts_message(
+                    TTSCompleteEvent(
+                        message_id=event.message_id,
+                        error=str(error),
+                    )
+                )
+                return
+            except Exception:
+                logger.warning(
+                    "Console speech snapshot rejected "
+                    "(outcome_code=validator_failure)"
+                )
+                await self._post_tts_message(
+                    TTSCompleteEvent(
+                        message_id=event.message_id,
+                        error=ConsoleSpeechSnapshotRejected.USER_COPY,
+                    )
+                )
+                return
+            if type(request_text) is not str:
+                logger.warning(
+                    "Console speech snapshot rejected "
+                    "(outcome_code=invalid_validator_result)"
+                )
+                await self._post_tts_message(
+                    TTSCompleteEvent(
+                        message_id=event.message_id,
+                        error=ConsoleSpeechSnapshotRejected.USER_COPY,
+                    )
+                )
+                return
+            request_message_id: str | None = event.message_id
+            request_voice: str | None = None
+        else:
+            request_text = event.text
+            request_message_id = event.message_id
+            request_voice = event.voice
+
         current_time = asyncio.get_event_loop().time()
         if current_time - self._last_cooldown_cleanup > self.COOLDOWN_CLEANUP_INTERVAL:
             self._cleanup_cooldown_dict(current_time)
@@ -326,17 +401,17 @@ class TTSEventHandler:
             logger.error("TTS service not initialized")
             await self._post_tts_message(
                 TTSCompleteEvent(
-                    message_id=event.message_id or "unknown",
+                    message_id=request_message_id or "unknown",
                     error="TTS service not available",
                 )
             )
             return
 
         # Validate input text
-        if not event.text:
+        if not request_text:
             await self._post_tts_message(
                 TTSCompleteEvent(
-                    message_id=event.message_id or "unknown",
+                    message_id=request_message_id or "unknown",
                     error="No text provided for TTS generation",
                 )
             )
@@ -344,29 +419,29 @@ class TTSEventHandler:
 
         # Check text length limits
         MAX_TTS_LENGTH = 5000  # Maximum characters for TTS
-        if len(event.text) > MAX_TTS_LENGTH:
-            logger.warning(f"TTS text too long: {len(event.text)} characters")
+        if len(request_text) > MAX_TTS_LENGTH:
+            logger.warning(f"TTS text too long: {len(request_text)} characters")
             await self._post_tts_message(
                 TTSCompleteEvent(
-                    message_id=event.message_id or "unknown",
+                    message_id=request_message_id or "unknown",
                     error=f"Text is too long for TTS. Maximum {MAX_TTS_LENGTH} characters allowed.",
                 )
             )
             return
 
         # Basic sanitization - remove excessive whitespace
-        text = " ".join(event.text.split())
+        text = " ".join(request_text.split())
         if len(text) < 1:
             await self._post_tts_message(
                 TTSCompleteEvent(
-                    message_id=event.message_id or "unknown",
+                    message_id=request_message_id or "unknown",
                     error="Text contains only whitespace",
                 )
             )
             return
 
         # Check rate limiting for this message
-        message_id = event.message_id or "adhoc"
+        message_id = request_message_id or "adhoc"
 
         if message_id in self._request_cooldown:
             time_since_last = current_time - self._request_cooldown[message_id]
@@ -393,7 +468,7 @@ class TTSEventHandler:
             self._generate_tts_with_rate_limit(
                 text,  # Use sanitized text
                 message_id,
-                event.voice,
+                request_voice,
             )
         )
         # Track the task
@@ -1084,6 +1159,14 @@ class TTSEventHandler:
         """Handle TTS request event"""
         task = asyncio.create_task(self.handle_tts_request(event))
         # Use create_task to add task safely
+        asyncio.create_task(self._add_active_task(task))
+
+    def on_tts_message_speech_request_event(
+        self,
+        event: TTSMessageSpeechRequestEvent,
+    ) -> None:
+        """Handle one trusted Console message speech request event."""
+        task = asyncio.create_task(self.handle_tts_request(event))
         asyncio.create_task(self._add_active_task(task))
 
     def on_tts_playback_event(self, event: TTSPlaybackEvent) -> None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -15673,15 +15673,23 @@ class ChatScreen(BaseAppScreen):
             if callable(copy_to_clipboard):
                 copy_to_clipboard(result.clipboard_text)
         if action_id == "speak" and result.status == "completed":
-            # No new TTS machinery -- hand off to the app's existing
-            # pipeline (validation, synthesis, playback, failure toast) the
-            # same way legacy chat does (spec §1a).
+            from tldw_chatbook.Chat.console_speech import (
+                ConsoleSpeechSnapshotRejected,
+            )
             from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
-                TTSRequestEvent,
+                TTSMessageSpeechRequestEvent,
             )
 
+            try:
+                speech_snapshot = store.issue_tts_message_speech_snapshot(message.id)
+            except ConsoleSpeechSnapshotRejected as error:
+                self.app_instance.notify(str(error), severity="warning")
+                return True
             self.app_instance.post_message(
-                TTSRequestEvent(text=message.content, message_id=message.id)
+                TTSMessageSpeechRequestEvent(
+                    speech_snapshot,
+                    store.validate_tts_message_speech_snapshot,
+                )
             )
             # task-559 unit 2: track this message as "speaking" so the
             # action row swaps 🔊 -> ⏹ (a fresh speak always supersedes

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -6527,7 +6527,11 @@ class TldwCli(
         if handler:
             await handler.handle_tts_request(event)
         else:
-            self.loguru_logger.error("TTS handler not initialized")
+            self.loguru_logger.error(
+                "TTS handler not initialized "
+                "(operation=trusted_console_speech, "
+                "outcome_code=handler_unavailable)"
+            )
             await self.post_message(
                 TTSCompleteEvent(
                     message_id=event.message_id,

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -232,6 +232,7 @@ from .config import (
 )
 from .Event_Handlers import worker_events
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    TTSMessageSpeechRequestEvent,
     TTSRequestEvent,
     TTSCompleteEvent,
     TTSPlaybackEvent,
@@ -6511,6 +6512,25 @@ class TldwCli(
             await self.post_message(
                 TTSCompleteEvent(
                     message_id=event.message_id or "unknown",
+                    error="TTS service not available",
+                )
+            )
+
+    @on(TTSMessageSpeechRequestEvent)
+    async def handle_tts_message_speech_request_event(
+        self,
+        event: TTSMessageSpeechRequestEvent,
+    ) -> None:
+        """Route a trusted Console snapshot without logging private content."""
+        self.loguru_logger.info("Trusted Console speech request received")
+        handler = await self._ensure_tts_handler()
+        if handler:
+            await handler.handle_tts_request(event)
+        else:
+            self.loguru_logger.error("TTS handler not initialized")
+            await self.post_message(
+                TTSCompleteEvent(
+                    message_id=event.message_id,
                     error="TTS service not available",
                 )
             )


### PR DESCRIPTION
## Summary

- Add a frozen, privacy-safe `TTSMessageSpeechSnapshot` issued and revalidated by the Console store.
- Reject stale session/path, content, variant, revision, persisted-version, completion, role, or authorship state before cooldown, normalization, or provider work.
- Route completed assistant-only Console Speak actions through the dedicated trusted event while preserving the explicit non-Console global request path.
- Preserve native audio.cpp complete-WAV behavior, global TTS selection, autoplay, and the temporary legacy bridge; update user/developer documentation and close TASK-617.3.

## Scope boundaries

- External, user-managed audio.cpp servers only.
- No audio.cpp binary or `server.json` launch/supervision.
- No voice-profile assignment or resolver.
- No Persona TTS inheritance, portability, or automatic speech.

## Verification

- `294 passed` in the post-rebase task-critical store, handler, UI, native audio.cpp, complete-WAV, autoplay, and legacy/global suite.
- All seven patches are range-diff identical after rebasing onto current `dev`.
- Ruff, scoped formatting, compileall, privacy review, and `git diff --check` pass.
- The new snapshot module passes mypy. Three existing `TTSEventHandler.notify` diagnostics are unchanged from the base branch.
- Independent production-readiness review found no Critical, Important, or Minor issues.

## Baseline diagnostics

The broad `Tests/TTS Tests/Chat` run recorded 4,681 passes and 74 skips. Two local-socket errors disappeared when rerun outside the sandbox; every remaining failing node reproduced unchanged on the clean base branch. In the mounted Console union, two workspace-browser timing failures passed immediately in serial, while the stale-search failure reproduced on clean base `dev`.

## References

- TASK-617.3
- ADR-037
- `Docs/superpowers/specs/2026-07-28-tts-character-identity-persona-separation-design.md`
- `Docs/superpowers/plans/2026-07-30-trusted-console-speech-snapshots.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trusted Console speech snapshots so Speak plays exactly the clicked assistant response and variant with strict pre-cooldown validation, and routes snapshots without logging private content. Preserves global TTS and native `audio.cpp` behavior; implements TASK-617.3.

- **New Features**
  - Added immutable `TTSMessageSpeechSnapshot` issued by `ConsoleChatStore`; rejects stale session/message, content/variant, revision, persisted version, role, or authorship with a clear warning.
  - Speak is shown only for completed assistant responses; snapshots are process-local, not persisted, and do not select a character voice profile.
  - Routed `TTSMessageSpeechRequestEvent` through the app and TTS handler without logging private snapshot data; kept complete-WAV `audio.cpp` flow, global TTS defaults, and autoplay; updated docs, added admission/integration tests, and a durable row-version lookup.

- **Migration**
  - Extensions/tests that intercept Console Speak should handle `TTSMessageSpeechRequestEvent`; `TTSRequestEvent` remains for non-Console/global speech.
  - Speak is no longer available for user/system/tool or incomplete messages.

<sup>Written for commit 724b77e6c42fbe773b88b61731902fac51276a30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

