### PR TITLE
fix(settings): UX critique P2/P3 batch — honest chrome, searchable settings, view badges (tasks 1563-1565)

### DIFF
--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -3829,12 +3829,12 @@ async def test_settings_destination_uses_three_column_workbench_contract():
         await _wait_for_visible_text(
             screen,
             pilot,
-            "Settings | Global preferences, appearance, accounts, storage | Local",
+            "Settings | Global preferences, appearance, storage | Local",
         )
         text = _visible_text(screen)
 
         assert (
-            "Settings | Global preferences, appearance, accounts, storage | Local"
+            "Settings | Global preferences, appearance, storage | Local"
             in text
         )
         assert "Mode: Overview | Runtime controls stay in MCP and ACP" in text

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -2737,7 +2737,8 @@ async def test_settings_active_category_uses_explicit_nav_marker():
         inactive = screen.query_one("#settings-category-diagnostics")
 
         assert str(active.label) == "> Advanced Config"
-        assert str(inactive.label) == "  Diagnostics"
+        # task-1563: view-only categories carry a "(view)" badge in the rail.
+        assert str(inactive.label) == "  Diagnostics (view)"
         assert active.has_class("settings-active-section")
 
 
@@ -6505,9 +6506,9 @@ async def test_settings_storage_privacy_diagnostics_label_unsupported_mutations_
         for button_id, expected in (
             (
                 "#settings-category-privacy-security",
-                "Credential mutation: unavailable/WIP",
+                "Credential mutation: not available yet",
             ),
-            ("#settings-category-diagnostics", "Diagnostics writes: unavailable/WIP"),
+            ("#settings-category-diagnostics", "Diagnostics writes: not available yet"),
         ):
             # Scroll the target into view before clicking: the category
             # rail is taller than the fixed pilot viewport, and Settings >
@@ -6559,7 +6560,7 @@ async def test_settings_privacy_security_renders_guided_redacted_posture(monkeyp
         assert "Provider config secrets: 1 present" in text
         assert "Preferred source: environment variables" in text
         assert (
-            "Credential mutation: unavailable/WIP - password-gated flow required"
+            "Credential mutation: not available yet - password-gated flow required"
             in text
         )
         assert "Open Providers & Models" in text
@@ -7539,4 +7540,48 @@ def test_remote_images_toggle_persists_and_pokes_live_config(monkeypatch):
             "render_remote_images"
         ]
         is True
+    )
+
+
+# ---- task-1564: footer bindings match reality ----
+
+
+def test_footer_entries_drop_test_hint_where_no_test_action_exists():
+    """Categories without a test action must not advertise "t test category"
+    (the static footer used to over-promise; Image Gen answers the key with
+    a "No test action" toast)."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    screen.active_category = SettingsCategoryId.ARTIFACTS.value
+
+    entries = screen._footer_shortcut_entries()
+
+    keys = [key for key, _ in entries]
+    assert "s" in keys and "r" in keys
+    assert "t" not in keys
+
+
+def test_footer_entries_advertise_test_where_it_acts():
+    """Categories with a real test action keep the t hint."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    screen.active_category = SettingsCategoryId.PROVIDERS_MODELS.value
+
+    entries = screen._footer_shortcut_entries()
+
+    assert ("t", "test category") in entries
+
+
+def test_filter_matches_owned_config_keys():
+    """The "/" filter indexes each category's owned TOML keys: searching a
+    setting name surfaces the category that owns it (task-1564 -- the
+    Owns: data existed but was unsearchable, forcing a 22-category scan)."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+
+    matches = screen._filtered_category_summaries("paste_collapse_threshold")
+
+    assert any(
+        summary.category is SettingsCategoryId.CONSOLE_BEHAVIOR
+        for summary in matches
     )

--- a/Tests/UI/test_unified_shell_phase6_nielsen_closeout.py
+++ b/Tests/UI/test_unified_shell_phase6_nielsen_closeout.py
@@ -138,12 +138,12 @@ async def test_nielsen_closeout_replays_core_heuristic_signals_in_running_app() 
             await _wait_until(
                 pilot,
                 lambda: (
-                    "Global preferences, appearance, accounts, storage"
+                    "Global preferences, appearance, storage"
                     in _screen_text(app)
                 ),
             )
             settings_text = _screen_text(app)
             assert (
-                "Settings | Global preferences, appearance, accounts, storage | Local"
+                "Settings | Global preferences, appearance, storage | Local"
                 in settings_text
             )

--- a/backlog/tasks/task-1563 - Settings-view-only-stub-categories-and-Follow-up-doubling.md
+++ b/backlog/tasks/task-1563 - Settings-view-only-stub-categories-and-Follow-up-doubling.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1563
 title: 'Settings: collapse view-only stub categories; fix Follow-up: doubling'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-31 02:00'
 labels: [settings, ux, P2]
@@ -22,7 +22,21 @@ at settings_screen.py:10433 re-prefixes strings already prefixed at
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 "Follow-up:" renders exactly once per stub page.
-- [ ] #2 View-only categories are visually distinguished in the rail (dimmed and/or badged "view") or collapsed under one "Owned elsewhere" group.
-- [ ] #3 Rail remains navigable to their detail pages.
+- [x] #1 "Follow-up:" renders exactly once per stub page.
+- [x] #2 View-only categories are visually distinguished in the rail (dimmed and/or badged "view") or collapsed under one "Owned elsewhere" group.
+- [x] #3 Rail remains navigable to their detail pages.
 <!-- AC:END -->
+
+## Implementation Notes
+
+- Doubling root cause fixed at the data: seven contract `follow_up` strings
+  carried a literal "Follow-up: " prefix that `_detail_row("Follow-up", ...)`
+  re-labeled; the prefixes are stripped (single render verified live on
+  Schedules).
+- Rail treatment: every category whose ownership record has
+  `writes_allowed=False` now carries a " (view)" badge in its rail label via
+  `_category_button_label` -- honest for the seven Domain Defaults stubs AND
+  the always-view categories (Overview, Diagnostics, Privacy); one exact-label
+  test updated accordingly. Categories stay navigable. Chose badge-only over
+  collapsing into an "Owned elsewhere" group to keep discoverability and the
+  smaller diff; grouping remains open as a future IA change if the rail grows.

--- a/backlog/tasks/task-1564 - Settings-keyboard-promises-match-reality.md
+++ b/backlog/tasks/task-1564 - Settings-keyboard-promises-match-reality.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1564
 title: 'Settings: keyboard promises match reality (footer bindings, setting-level filter)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-31 02:00'
 labels: [settings, ux, P2]
@@ -22,7 +22,21 @@ every owned TOML key per category.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Footer bindings reflect the active category (no advertised key that no-ops).
-- [ ] #2 "/" filter also indexes owned config keys / setting labels and opens the owning category.
-- [ ] #3 Filter status still names the Enter target for the top match.
+- [x] #1 Footer bindings reflect the active category (no advertised key that no-ops).
+- [x] #2 "/" filter also indexes owned config keys / setting labels and opens the owning category.
+- [x] #3 Filter status still names the Enter target for the top match.
 <!-- AC:END -->
+
+## Implementation Notes
+
+- `_footer_shortcut_entries()` (extracted, unit-tested) now derives the hints:
+  `t test category` is advertised ONLY for the six categories whose test
+  action does something (PROVIDERS_MODELS, DIAGNOSTICS, STORAGE,
+  PRIVACY_SECURITY, APPEARANCE, LIBRARY_RAG -- everywhere else the key
+  answers with the "No test action" toast); RAG accelerators appended only on
+  RAG (pre-existing); "Esc, "-prefixed while a text field owns focus
+  (task-1560's honesty rule).
+- The "/" filter gained rank tier 2: each category's
+  `owns_config_sections` keys are searchable, so "paste_collapse_threshold"
+  surfaces Console Behavior directly (live-verified: "1 match | Enter opens
+  Console Behavior"). The status line still names the Enter target.

--- a/backlog/tasks/task-1565 - Settings-chrome-and-copy-minors-batch.md
+++ b/backlog/tasks/task-1565 - Settings-chrome-and-copy-minors-batch.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1565
 title: 'Settings: chrome and copy minors batch'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-31 02:00'
 labels: [settings, ux, P3]
@@ -25,7 +25,27 @@ Grouped P3 findings from the 2026-07-31 critique, each small but shipped:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each listed item fixed or explicitly declined with a reason in notes.
-- [ ] #2 No footer chrome renders dangling separators.
-- [ ] #3 Category names are referenced identically everywhere they appear.
+- [x] #1 Each listed item fixed or explicitly declined with a reason in notes.
+- [x] #2 No footer chrome renders dangling separators.
+- [x] #3 Category names are referenced identically everywhere they appear.
 <!-- AC:END -->
+
+## Implementation Notes
+
+Fixed: idle footer token placeholder "Tokens: -- |" -> "Tokens: --" (live
+format never had the pipe); breadcrumb + docstring drop the nonexistent
+"accounts"; rail auto-scrolls the selected category into view
+(`scroll_visible` after refresh); splash "Duration (s)" / "Animation speed
+(x)" units; RAG read-only guidance comma cadence ("Clone it, then press Set
+active to edit the clone."); Advanced Config guided chips renamed to match
+the sidebar exactly ("Providers & Models", "Console Behavior", "Privacy &
+Security"); duplicate filter-help line removed (the live status line
+carries the same guidance); user-facing "WIP" phrasing replaced
+("read-only here", "not available yet", "Read-only" label) with pinned
+tests updated.
+
+Declined with reasons: splash gallery casing/raw ids (display names are the
+cards' own metadata; normalizing would misrepresent card identity);
+RAG description-flyout overlap and the red Delete on a read-only built-in
+profile (both need RAG-pane layout/state work better scoped with task-1345's
+RAG follow-ups than this chrome batch).

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -380,10 +380,12 @@ CONSOLE_BEHAVIOR_SAVE_ORDER = (
     *CONSOLE_BACKGROUND_EFFECT_SAVE_ORDER,
 )
 ADVANCED_CONFIG_GUIDED_PATHS = (
-    (SettingsCategoryId.PROVIDERS_MODELS, "Providers"),
-    (SettingsCategoryId.CONSOLE_BEHAVIOR, "Console"),
+    # task-1565: labels mirror the sidebar's category names exactly so the
+    # guided chips and the rail never disagree about what a place is called.
+    (SettingsCategoryId.PROVIDERS_MODELS, "Providers & Models"),
+    (SettingsCategoryId.CONSOLE_BEHAVIOR, "Console Behavior"),
     (SettingsCategoryId.STORAGE, "Storage"),
-    (SettingsCategoryId.PRIVACY_SECURITY, "Privacy"),
+    (SettingsCategoryId.PRIVACY_SECURITY, "Privacy & Security"),
     (SettingsCategoryId.DIAGNOSTICS, "Diagnostics"),
 )
 ADVANCED_CONFIG_GUIDED_PATH_BUTTONS = {
@@ -537,7 +539,7 @@ SETTINGS_DOMAIN_CATEGORY_CONTRACTS = (
                 "show defaults/status only; do not move artifact operations here",
             ),
         ),
-        follow_up="Follow-up: add artifact export/default controls only after Artifacts exposes a persisted preference contract.",
+        follow_up="add artifact export/default controls only after Artifacts exposes a persisted preference contract.",
     ),
     SettingsDomainCategoryContract(
         category=SettingsCategoryId.PERSONAS,
@@ -577,7 +579,7 @@ SETTINGS_DOMAIN_CATEGORY_CONTRACTS = (
                 "future defaults can cover trust/display preferences only",
             ),
         ),
-        follow_up="Follow-up: add Skills defaults after import/attach policy has a persisted source contract.",
+        follow_up="add Skills defaults after import/attach policy has a persisted source contract.",
     ),
     SettingsDomainCategoryContract(
         category=SettingsCategoryId.SCHEDULES,
@@ -594,7 +596,7 @@ SETTINGS_DOMAIN_CATEGORY_CONTRACTS = (
                 "future defaults may cover timezone/notification preferences only",
             ),
         ),
-        follow_up="Follow-up: add schedule defaults after Schedules exposes a dedicated settings adapter.",
+        follow_up="add schedule defaults after Schedules exposes a dedicated settings adapter.",
     ),
     SettingsDomainCategoryContract(
         category=SettingsCategoryId.WATCHLISTS,
@@ -608,7 +610,7 @@ SETTINGS_DOMAIN_CATEGORY_CONTRACTS = (
                 "future defaults may cover polling and notification preferences only",
             ),
         ),
-        follow_up="Follow-up: add watchlist defaults after Watchlists exposes persisted polling/notification settings.",
+        follow_up="add watchlist defaults after Watchlists exposes persisted polling/notification settings.",
     ),
     SettingsDomainCategoryContract(
         category=SettingsCategoryId.WORKFLOWS,
@@ -628,7 +630,7 @@ SETTINGS_DOMAIN_CATEGORY_CONTRACTS = (
                 "future defaults may cover execution safety preferences only",
             ),
         ),
-        follow_up="Follow-up: add workflow defaults after Workflows exposes a persisted execution-safety contract.",
+        follow_up="add workflow defaults after Workflows exposes a persisted execution-safety contract.",
     ),
     SettingsDomainCategoryContract(
         category=SettingsCategoryId.MCP_DEFAULTS,
@@ -645,7 +647,7 @@ SETTINGS_DOMAIN_CATEGORY_CONTRACTS = (
                 "show global defaults/status only; server operations stay in MCP",
             ),
         ),
-        follow_up="Follow-up: add MCP defaults only after server-first settings are exposed without flattening tools into Settings.",
+        follow_up="add MCP defaults only after server-first settings are exposed without flattening tools into Settings.",
     ),
     SettingsDomainCategoryContract(
         category=SettingsCategoryId.ACP_DEFAULTS,
@@ -662,7 +664,7 @@ SETTINGS_DOMAIN_CATEGORY_CONTRACTS = (
             ),
             ("Settings role", "show defaults/status only; ACP setup stays in ACP"),
         ),
-        follow_up="Follow-up: add ACP defaults after ACP exposes a persisted runtime/session preference contract.",
+        follow_up="add ACP defaults after ACP exposes a persisted runtime/session preference contract.",
     ),
     SettingsDomainCategoryContract(
         category=SettingsCategoryId.IMAGE_GENERATION,
@@ -1439,7 +1441,7 @@ class RagProfileSwitchConfirmModal(ModalScreen[str]):
 
 
 class SettingsScreen(BaseAppScreen):
-    """Global preferences, appearance, accounts, storage, and app behavior."""
+    """Global preferences, appearance, storage, and app behavior."""
 
     BINDINGS = [
         ("s", "settings_save_category", "Save Settings category"),
@@ -1463,6 +1465,20 @@ class SettingsScreen(BaseAppScreen):
         ("s", "save category"),
         ("r", "revert category"),
         ("t", "test category"),
+    )
+
+    #: task-1564: categories whose `t` binding performs a real test action --
+    #: everywhere else action_settings_test_category answers with the "No
+    #: test action is available" toast, so the footer must not advertise it.
+    TESTABLE_SETTINGS_CATEGORIES = frozenset(
+        {
+            SettingsCategoryId.PROVIDERS_MODELS,
+            SettingsCategoryId.DIAGNOSTICS,
+            SettingsCategoryId.STORAGE,
+            SettingsCategoryId.PRIVACY_SECURITY,
+            SettingsCategoryId.APPEARANCE,
+            SettingsCategoryId.LIBRARY_RAG,
+        }
     )
 
     #: Task 6 (541 AC6): RAG-only accelerator hints, appended to
@@ -1809,7 +1825,22 @@ class SettingsScreen(BaseAppScreen):
         this after a category switch (see `_select_category`) keeps the
         footer in sync without waiting for a recompose.
         """
+        shortcuts = self._footer_shortcut_entries()
+        self.register_footer_shortcuts(source="settings", shortcuts=shortcuts)
+
+    def _footer_shortcut_entries(self) -> tuple[tuple[str, str], ...]:
+        """Category- and focus-aware footer hints (task-1564/1560).
+
+        Drops the ``t`` hint for categories whose test action is the "No
+        test action is available" toast, appends the RAG accelerators only
+        where they act, and prefixes keys with "Esc, " while a text-entry
+        widget owns focus (printable keys feed the field until Esc).
+        """
         shortcuts = self.SETTINGS_SHORTCUTS
+        if self._active_category_id() not in self.TESTABLE_SETTINGS_CATEGORIES:
+            shortcuts = tuple(
+                entry for entry in shortcuts if entry[0] != "t"
+            )
         if self._text_entry_focused():
             # task-1560: s/r/t are real bindings and therefore inert while an
             # Input/TextArea consumes printable keys -- advertising the bare
@@ -1820,11 +1851,15 @@ class SettingsScreen(BaseAppScreen):
             )
         if self._active_category_id() is SettingsCategoryId.LIBRARY_RAG:
             shortcuts = shortcuts + self.LIBRARY_RAG_SHORTCUTS
-        self.register_footer_shortcuts(source="settings", shortcuts=shortcuts)
+        return shortcuts
 
     def _text_entry_focused(self) -> bool:
         """Whether a printable-key-consuming widget owns focus right now."""
-        focused = getattr(self.app, "focused", None)
+        try:
+            focused = getattr(self.app, "focused", None)
+        except Exception:
+            # No active app (bare-screen tests / teardown) -- nothing focused.
+            return False
         return isinstance(focused, (Input, TextArea))
 
     def on_descendant_focus(self, event) -> None:
@@ -3656,7 +3691,7 @@ class SettingsScreen(BaseAppScreen):
         }
         if category in DOMAIN_SETTINGS_CATEGORY_IDS:
             contract = self._domain_category_contract(category)
-            return f"Guided edits: read-only/WIP; open {contract.owner_destination}."
+            return f"Guided edits: read-only here; open {contract.owner_destination}."
         return messages.get(category, "Guided edits: read-only.")
 
     def _guided_actions_enabled(self, category: SettingsCategoryId) -> bool:
@@ -3704,7 +3739,16 @@ class SettingsScreen(BaseAppScreen):
             dirty_marker = " *"
         elif summary.category == SettingsCategoryId.THEME and self.theme_editor_modified:
             dirty_marker = " *"
-        return f"{'> ' if active else '  '}{summary.title}{dirty_marker}"
+        # task-1563: view-only stub categories are full nav peers whose whole
+        # page says "edit elsewhere" -- badge them in the rail so a third of
+        # the navigation stops masquerading as editable surface.
+        view_marker = ""
+        try:
+            if not self._ownership_record(summary.category).writes_allowed:
+                view_marker = " (view)"
+        except Exception:
+            view_marker = ""
+        return f"{'> ' if active else '  '}{summary.title}{view_marker}{dirty_marker}"
 
     def _refresh_category_button_label(self, category: SettingsCategoryId) -> None:
         try:
@@ -3805,6 +3849,17 @@ class SettingsScreen(BaseAppScreen):
         ).lower()
         if query in secondary_haystack:
             return 1
+        # task-1564: rank 2 -- the category's owned config keys. The Scope
+        # Inspector already publishes them; indexing them lets "/" find the
+        # category that OWNS a setting instead of forcing a 22-item scan.
+        try:
+            owned = " ".join(
+                self._ownership_record(summary.category).owns_config_sections
+            ).lower()
+        except Exception:
+            owned = ""
+        if owned and query in owned:
+            return 2
         return None
 
     def _category_matches_search(
@@ -9737,7 +9792,7 @@ class SettingsScreen(BaseAppScreen):
                 classes="settings-library-rag-profile-delete-button",
             )
         readonly_banner = Static(
-            "Built-in profile — read-only. Clone it, then Set active, to edit.",
+            "Built-in profile — read-only. Clone it, then press Set active to edit the clone.",
             id="settings-library-rag-profile-readonly-banner",
             classes="settings-status-row settings-library-rag-readonly-banner",
         )
@@ -10992,7 +11047,7 @@ class SettingsScreen(BaseAppScreen):
                 yield self._detail_row("Server tokens", posture.server_boundary)
                 yield self._detail_row(
                     "Credential mutation",
-                    "unavailable/WIP - password-gated flow required",
+                    "not available yet - password-gated flow required",
                 )
                 yield Static(
                     self._privacy_check_text(),
@@ -11019,7 +11074,7 @@ class SettingsScreen(BaseAppScreen):
                 yield self._detail_row("Write safety", "validation is read-only")
                 yield self._detail_row(
                     "Diagnostics writes",
-                    "unavailable/WIP - raw edits remain gated in Advanced Config",
+                    "not available yet - raw edits remain gated in Advanced Config",
                 )
                 with Horizontal(
                     id="settings-diagnostics-actions", classes="settings-action-row"
@@ -11385,7 +11440,7 @@ class SettingsScreen(BaseAppScreen):
                 "\n".join(ownership.owns_config_sections),
             )
         if ownership.read_only_reason:
-            yield self._detail_row("Read-only/WIP", ownership.read_only_reason)
+            yield self._detail_row("Read-only", ownership.read_only_reason)
         for label, value in self._inspector_guidance(summary.category):
             yield self._detail_row(
                 label,
@@ -11410,7 +11465,7 @@ class SettingsScreen(BaseAppScreen):
         active_summary = self._active_summary()
         with Vertical(id="settings-shell"):
             yield Static(
-                "Settings | Global preferences, appearance, accounts, storage | Local",
+                "Settings | Global preferences, appearance, storage | Local",
                 id="settings-title",
                 classes="ds-destination-header",
             )
@@ -11437,11 +11492,6 @@ class SettingsScreen(BaseAppScreen):
                         placeholder="Filter settings (/)",
                         id="settings-category-search",
                         classes="settings-category-search",
-                    )
-                    yield Static(
-                        "/ filter | Enter open | Esc clear",
-                        id="settings-category-search-help",
-                        classes="settings-category-search-help",
                     )
                     yield Static(
                         self._category_search_status_text(),
@@ -11728,6 +11778,19 @@ class SettingsScreen(BaseAppScreen):
             # not even show (e.g. after an archive elsewhere).
             self._settings_selected_workspace_id = None
         self.active_category = category_value
+        # task-1565: keep the selection visible -- the rail does not follow
+        # the active category on its own, so deep categories (Schedules,
+        # Image Gen) could be selected while entirely off-viewport.
+        def _reveal_active_button() -> None:
+            try:
+                self.query_one(
+                    f"#settings-category-{category_value}", Button
+                ).scroll_visible(animate=False)
+            except Exception:
+                pass
+
+        if getattr(self, "is_mounted", False):
+            self.call_after_refresh(_reveal_active_button)
         # Task 6 (541 AC6): keep the footer's a/c/b hint in sync with a
         # live in-session category switch (on_mount's call alone only
         # covers the initial/restored-state paint -- see

--- a/tldw_chatbook/Widgets/AppFooterStatus.py
+++ b/tldw_chatbook/Widgets/AppFooterStatus.py
@@ -89,7 +89,7 @@ class AppFooterStatus(Widget):
         self._shortcut_display = Static(self._shortcut_text, id="footer-key-quit")
         self._word_count_display: Static = Static("", id="footer-word-count")
         self._token_count_display: Static = Static(
-            "Tokens: -- | ", id="footer-token-count"
+            "Tokens: --", id="footer-token-count"
         )
         self._db_status_display: Static = Static("", id="internal-db-size-indicator")
         # The stats read as cryptic single letters (P: / C/N: / M:); a hover

--- a/tldw_chatbook/Widgets/settings_splash_screen_viewer.py
+++ b/tldw_chatbook/Widgets/settings_splash_screen_viewer.py
@@ -166,7 +166,7 @@ class SettingsSplashScreenViewer(Vertical):
                     classes="settings-toggle-state",
                 )
             with Horizontal(classes="settings-input-row"):
-                yield Static("Duration", classes="settings-input-label")
+                yield Static("Duration (s)", classes="settings-input-label")
                 yield Input(
                     value=str(self._config.get("duration", 2.5)),
                     id="settings-splash-duration",
@@ -175,7 +175,7 @@ class SettingsSplashScreenViewer(Vertical):
                     restrict=r"^[0-9]*\.?[0-9]*$",
                 )
             with Horizontal(classes="settings-input-row"):
-                yield Static("Animation speed", classes="settings-input-label")
+                yield Static("Animation speed (x)", classes="settings-input-label")
                 yield Input(
                     value=str(self._config.get("animation_speed", 1.0)),
                     id="settings-splash-animation-speed",


### PR DESCRIPTION
## Summary

Completes the Settings UX critique remediation (P1 batch merged as #1117). Tasks 1563–1565, all live-verified with screenshots on the served build.

- **TASK-1563**: the shipped `Follow-up: Follow-up:` doubling is fixed at its root (seven self-prefixed contract strings); every `writes_allowed=False` category now carries a **" (view)"** rail badge — a third of the navigation stops masquerading as editable surface while staying navigable.
- **TASK-1564**: footer hints are now derived per category and focus state — `t test category` is only advertised where the test action does something (six categories; elsewhere the key produced a "No test action" toast contradicting the chrome), with the Esc-prefix honesty from #1117. The `/` filter indexes each category's **owned config keys**: typing `paste_collapse_threshold` surfaces Console Behavior directly ("1 match | Enter opens Console Behavior").
- **TASK-1565** chrome/copy minors: dangling `Tokens: -- |` pipe, phantom "accounts" breadcrumb, rail auto-scroll to the selected category, splash units, RAG copy cadence, guided-path chips renamed to match the sidebar exactly, duplicate filter-help line removed, user-facing "WIP" phrasing replaced. Two RAG-pane layout items and the splash gallery casing are declined with reasons in the task file.

## Verification

Settings hub + splash + destination shells + nielsen closeout suites: **370 passed, 1 pre-existing skip**. Pinned-string tests updated alongside the copy they pin. Live screenshots: key-indexed filter match, "(view)" badges, single Follow-up prefix, honest per-category footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Settings UX: view-only categories show a "(view)" badge, footer shortcuts reflect real actions, and the "/" filter finds categories by owned config keys. Also cleans up copy and chrome, auto-scrolls the rail selection, and fixes the "Follow-up:" double label (TASK-1563/1564/1565).

- **New Features**
  - "(view)" badge on categories with `writes_allowed=False`; still navigable (TASK-1563).
  - Footer hints derive per category/focus; `t test category` only where it acts; Esc-prefixed while typing (TASK-1564).
  - "/" filter indexes owned TOML keys; status still names the Enter target (TASK-1564).

- **Bug Fixes**
  - Removed hardcoded "Follow-up: " prefixes to stop "Follow-up: Follow-up:" (TASK-1563).
  - Replaced "WIP" phrasing with clear, user-facing text; updated Diagnostics/Privacy labels and read-only messaging (TASK-1565).
  - Dropped "accounts" from the Settings title; removed dangling "Tokens: -- |" pipe (TASK-1565).
  - Rail auto-scrolls the selected category into view; added splash units "(s)" and "(x)" (TASK-1565).
  - Guided-path chips now match sidebar names; removed redundant filter-help line (TASK-1565).

<sup>Written for commit 5e50d238ab676e447f6eb1ac0af46b2085b12606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

