### PR TITLE
feat(tts): add exact character assignment mutation service

### DIFF
--- a/Docs/Development/TTS/TTS_MODULE_GUIDE.md
+++ b/Docs/Development/TTS/TTS_MODULE_GUIDE.md
@@ -188,6 +188,21 @@ profile execution, provider connection details, or managed audio.cpp process
 behavior. See
 [ADR-028](../../../backlog/decisions/028-character-tts-generation-profile-ownership.md).
 
+### Slice 3A assignment mutation service
+
+Character assignment identity is the exact
+`(source, authority_id, character_id)` tuple. Set or replace requires the
+caller-held repository generation, selected profile revision, expected current
+assignment (including explicitly unassigned), and a fresh authoritative
+capability check. Detach is idempotent when the assignment is already absent,
+but refuses to remove a different replacement. The repository's final
+transaction checks remain authoritative.
+
+This slice adds no assignment UI, speech resolver, automatic speech, Persona
+inheritance, profile portability, Sync behavior, or managed audio.cpp behavior.
+See
+[ADR-037](../../../backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md).
+
 ### Global defaults and Console request admission
 
 TASK-710 represents global TTS defaults as one immutable

--- a/Docs/superpowers/plans/2026-07-31-tts-assignment-mutation-service.md
+++ b/Docs/superpowers/plans/2026-07-31-tts-assignment-mutation-service.md
@@ -1,0 +1,552 @@
+# Exact Character TTS Assignment Mutation Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete TTS Slice 3A with exact `CharacterRef` assignment set/replace and detach mutations that preserve caller-held repository generation, profile revision, capability authority, and expected-current-assignment state.
+
+**Architecture:** Extend the existing `TTSProfileRepository` mutation methods with mandatory compare-and-set inputs and verify them inside the existing `BEGIN IMMEDIATE` transaction. Add two narrow `TTSProfileService` operations that validate immutable caller-held values, perform fresh audio.cpp capability admission before assignment, and forward every expectation to the repository without adding a second assignment store, UI, or speech resolver.
+
+**Tech Stack:** Python 3.11+, asyncio, SQLite, immutable dataclasses, pytest/pytest-asyncio, Ruff, mypy.
+
+**ADR required:** no
+
+**ADR path:** `backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md`
+
+**Reason:** ADR-037 already requires lifecycle-generation, profile-revision, and expected-current-assignment compare-and-set semantics for Slice 3A.4. This plan implements that accepted boundary without changing schema, ownership, provider/runtime boundaries, or user-facing application structure.
+
+---
+
+## Scope and file map
+
+- `tldw_chatbook/TTS/profile_repository.py`
+  - Make assignment mutation expectations mandatory at the public boundary.
+  - Recheck lifecycle generation, selected profile revision, and current assignment inside the final transaction.
+  - Preserve exact idempotent detach and bounded repository errors.
+- `tldw_chatbook/TTS/profile_service.py`
+  - Extend the repository protocol with the exact mutation contract.
+  - Add service-owned set/replace and detach operations over caller-held immutable values.
+  - Reuse the existing authoritative audio.cpp capability observation.
+- `Tests/TTS/test_profile_repository.py`
+  - Characterize public-input admission, transactional compare-and-set behavior, rollback, lifecycle fencing, and assignment isolation.
+- `Tests/TTS/test_profile_service.py`
+  - Characterize ordering, capability fencing, forwarded expectations, stale-state failures, hostile collaborator results, and bounded diagnostics.
+- `Tests/TTS/test_tts_profile_capabilities.py`
+  - Keep the focused capability-integration repository fake conformant with the runtime-checkable profile-service protocol.
+- `Tests/TTS/test_tts_app_ownership.py`
+  - Keep the focused app-ownership repository fake conformant without adding a lifecycle owner to `TTSProfileService`.
+- `Docs/Development/TTS/TTS_MODULE_GUIDE.md`
+  - Document the completed Slice 3A mutation boundary and explicitly deferred Slice 3B behavior.
+- `backlog/tasks/task-617.4 - Add-exact-character-TTS-assignment-mutation-service.md`
+  - Record the plan, completed acceptance criteria, verification evidence, ADR reuse, and concise implementation notes.
+
+No migration, schema, application composition, Textual UI, Console event, speech resolver, Persona behavior, Sync contract, character-card payload, or managed audio.cpp file belongs in this diff.
+
+### Task 1: Pin the repository compare-and-set contract with failing tests
+
+**Files:**
+- Modify: `Tests/TTS/test_profile_repository.py`
+- Modify: `tldw_chatbook/TTS/profile_repository.py`
+
+- [ ] **Step 1: Update the repository test call sites to supply caller-held expectations**
+
+Use the profile result's exact generation and revision. Creation expects an explicitly unassigned target; replacement expects the exact previously assigned profile:
+
+```python
+created = await repository.create_profile(_draft("Assigned"))
+assigned = await repository.set_assignment(
+    character_ref,
+    created.value.profile_id,
+    expected_generation=created.generation,
+    expected_profile_revision=created.value.revision,
+    expected_current_profile_id=None,
+)
+```
+
+Detach carries the exact profile ID observed by the caller:
+
+```python
+await repository.remove_assignment(
+    character_ref,
+    expected_generation=assigned.generation,
+    expected_profile_id=assigned.value.profile_id,
+)
+```
+
+- [ ] **Step 2: Add public-boundary validation tests**
+
+Extend `test_invalid_public_inputs_fail_before_worker_submission` and the mutated-value tests so exact `int`, `UUID`, and `CharacterRef` values are required for:
+
+```python
+expected_generation
+expected_profile_revision
+expected_current_profile_id
+expected_profile_id
+```
+
+Assert invalid values never submit worker work or create a database path, and errors expose only a bounded code.
+
+- [ ] **Step 3: Add red tests for transactional set/replace compare-and-set**
+
+Cover:
+
+```python
+async def test_set_assignment_requires_expected_unassigned_state() -> None: ...
+async def test_replace_assignment_requires_exact_observed_profile() -> None: ...
+async def test_set_assignment_rejects_stale_selected_profile_revision() -> None: ...
+async def test_assignment_expectations_are_checked_inside_final_transaction() -> None: ...
+```
+
+The transaction test should arrange a queued operation or external committed update before mutation admission completes, then prove the stored assignment is unchanged when either the profile revision or current assignment differs from the caller-held expectation.
+
+Add a separate deterministic lifecycle interleaving: wrap the worker assignment
+entry point with a barrier that is reached after `_worker_operation` preflight
+but before `_worker_set_assignment` opens its transaction. Advance the
+repository generation under `_state_lock`, release the barrier, and assert the
+operation reports `stale` **and the assignment row was never written**. This
+pins the transaction-body generation check rather than relying on admission or
+publication fencing.
+
+- [ ] **Step 4: Add red tests for exact detach**
+
+Cover all three required outcomes:
+
+```python
+# Matching assignment: remove it.
+# No assignment: idempotent success.
+# Different replacement assignment: conflict and preserve it.
+```
+
+Also retain exact authority isolation: the same `character_id` under another authority is untouched.
+
+- [ ] **Step 5: Run the new repository tests and verify they fail for the missing contract**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/TTS/test_profile_repository.py \
+  -q
+```
+
+Expected: failures show that `set_assignment` and `remove_assignment` do not yet accept or enforce the new mandatory expectations; unrelated repository tests remain green.
+
+- [ ] **Step 6: Commit the red repository contract**
+
+```bash
+git add Tests/TTS/test_profile_repository.py
+git commit -m "test(tts): pin assignment mutation compare-and-set contract"
+```
+
+### Task 2: Implement repository-side transactional admission
+
+**Files:**
+- Modify: `tldw_chatbook/TTS/profile_repository.py`
+- Test: `Tests/TTS/test_profile_repository.py`
+
+- [ ] **Step 1: Add mandatory public mutation parameters**
+
+Use these signatures:
+
+```python
+async def set_assignment(
+    self,
+    character_ref: CharacterRef,
+    profile_id: UUID,
+    *,
+    expected_generation: int,
+    expected_profile_revision: int,
+    expected_current_profile_id: UUID | None,
+) -> ProfileStoreResult[CharacterTTSAssignment]: ...
+
+async def remove_assignment(
+    self,
+    character_ref: CharacterRef,
+    *,
+    expected_generation: int,
+    expected_profile_id: UUID,
+) -> ProfileStoreResult[None]: ...
+```
+
+Canonicalize every input before worker submission. Pass `expected_generation` to `_submit_operation` and snapshot all UUID/identity values so caller mutation after enqueue cannot change worker behavior.
+
+- [ ] **Step 2: Recheck lifecycle generation within the final transaction**
+
+Add one private worker helper that acquires `_state_lock`, evaluates `_worker_state_error_locked(expected_generation)`, and raises the existing bounded repository error. Call it from the body of both assignment transactions after `BEGIN IMMEDIATE` and before reading or changing rows.
+
+Do not add a generation column or a second lock. Restore remains the lifecycle owner, and publication retains its existing post-worker generation check.
+
+- [ ] **Step 3: Enforce profile revision and current-assignment CAS for set/replace**
+
+Inside `_worker_set_assignment`:
+
+```python
+stored_profile = self._worker_get_profile(connection, profile_id)
+if stored_profile.revision != expected_profile_revision:
+    raise _repository_error("conflict")
+
+existing = self._worker_get_persisted_assignment(connection, character_ref)
+actual_profile_id = None if existing is None else existing.assignment.profile_id
+if actual_profile_id != expected_current_profile_id:
+    raise _repository_error("conflict")
+```
+
+Only then perform the existing insert/upsert and exact round-trip verification. Preserve the original `created_at` on replacement and monotonic `updated_at`.
+
+- [ ] **Step 4: Enforce exact idempotent detach**
+
+Inside `_worker_remove_assignment`:
+
+```python
+existing = self._worker_get_persisted_assignment(connection, character_ref)
+if existing is None:
+    return
+if existing.assignment.profile_id != expected_profile_id:
+    raise _repository_error("conflict")
+```
+
+Delete with the full identity tuple plus `profile_id` in the `WHERE` clause, require exactly one affected row, and verify the exact assignment is absent before commit.
+
+- [ ] **Step 5: Run the repository suite**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/TTS/test_profile_repository.py \
+  Tests/TTS/test_profile_repository_lifecycle.py \
+  -q
+```
+
+Expected: all tests pass, including rollback, restore-generation, mutation-snapshot, corruption, and interprocess lifecycle regressions.
+
+- [ ] **Step 6: Run static checks for the repository increment**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/TTS/profile_repository.py \
+  Tests/TTS/test_profile_repository.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/TTS/profile_repository.py \
+  Tests/TTS/test_profile_repository.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit the repository implementation**
+
+```bash
+git add tldw_chatbook/TTS/profile_repository.py Tests/TTS/test_profile_repository.py
+git commit -m "feat(tts): fence character assignment mutations"
+```
+
+### Task 3: Pin the profile-service mutation behavior with failing tests
+
+**Files:**
+- Modify: `Tests/TTS/test_profile_service.py`
+- Modify: `Tests/TTS/test_tts_profile_capabilities.py`
+- Modify: `Tests/TTS/test_tts_app_ownership.py`
+- Modify: `tldw_chatbook/TTS/profile_service.py`
+
+- [ ] **Step 1: Extend the fake repository with the exact protocol**
+
+Record every forwarded value:
+
+```python
+async def set_assignment(
+    self,
+    character_ref: CharacterRef,
+    profile_id: UUID,
+    *,
+    expected_generation: int,
+    expected_profile_revision: int,
+    expected_current_profile_id: UUID | None,
+) -> ProfileStoreResult[CharacterTTSAssignment]: ...
+
+async def remove_assignment(
+    self,
+    character_ref: CharacterRef,
+    *,
+    expected_generation: int,
+    expected_profile_id: UUID,
+) -> ProfileStoreResult[None]: ...
+```
+
+Permit deterministic injected conflicts, malformed results, and generation changes before publication.
+
+Also add non-executing `set_assignment` and `remove_assignment` methods to
+`_AvailabilityRepository` in `test_tts_profile_capabilities.py` and
+`FocusedRepository` in `test_tts_app_ownership.py`. Those fakes are passed to
+the runtime-checkable protocol during `TTSProfileService` construction; their
+new methods must raise `AssertionError("not used")` so these tests continue to
+prove capability observation and app composition do not invoke mutations.
+
+- [ ] **Step 2: Add red set/replace service tests**
+
+Define the service boundary as:
+
+```python
+async def set_assignment(
+    self,
+    character_ref: CharacterRef,
+    loaded: LoadedTTSProfile,
+    expected_current: CharacterTTSAssignment | None,
+) -> CharacterTTSAssignment: ...
+```
+
+Test:
+
+- exact `CharacterRef`, loaded generation/revision, and expected current assignment are forwarded;
+- `None` means explicitly unassigned rather than “read current state for me”;
+- an expected assignment must target the same `CharacterRef`;
+- fresh authoritative audio.cpp capability is required for every new assignment;
+- unverified, unavailable, stale-configuration, and stale-repository outcomes perform no repository mutation;
+- generation is checked before capability work, after capability work, and after repository publication;
+- repository conflicts remain bounded conflicts;
+- malformed repository results fail as `operation_failed` without exposing authority, character, endpoint, path, credential, or submitted text.
+
+- [ ] **Step 3: Add red detach service tests**
+
+Define:
+
+```python
+async def detach_assignment(
+    self,
+    assignment: CharacterTTSAssignment,
+    repository_generation: int,
+) -> None: ...
+```
+
+Test that it:
+
+- forwards the exact assignment `CharacterRef`, exact profile UUID, and caller-held generation;
+- does no capability or provider work;
+- treats repository `None` as success;
+- rejects a stale generation before repository work;
+- preserves repository conflict for a replacement assignment;
+- rejects forged or malformed assignment and repository values with bounded errors.
+
+- [ ] **Step 4: Run the service tests and verify they fail for missing methods**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/TTS/test_profile_service.py \
+  -q
+```
+
+Expected: only the new assignment-service cases fail because the service methods and protocol entries do not yet exist.
+
+- [ ] **Step 5: Commit the red service contract**
+
+```bash
+git add \
+  Tests/TTS/test_profile_service.py \
+  Tests/TTS/test_tts_profile_capabilities.py \
+  Tests/TTS/test_tts_app_ownership.py
+git commit -m "test(tts): pin exact assignment service behavior"
+```
+
+### Task 4: Implement the minimal assignment service
+
+**Files:**
+- Modify: `tldw_chatbook/TTS/profile_service.py`
+- Test: `Tests/TTS/test_profile_service.py`
+
+- [ ] **Step 1: Import and canonicalize existing assignment domain values**
+
+Reuse `CharacterRef` and `CharacterTTSAssignment`; do not introduce a generic assistant reference or assignment revision type. Add private exact-copy validators that:
+
+```python
+canonical_ref = CharacterRef(value.source, value.authority_id, value.character_id)
+canonical_assignment = CharacterTTSAssignment(
+    canonical_ref,
+    exact_profile_id,
+)
+```
+
+Require exact built-in/domain types and exact canonical field equality so mutated frozen objects and subclasses fail closed.
+
+- [ ] **Step 2: Extend `_ProfileRepositoryProtocol`**
+
+Add only `set_assignment` and `remove_assignment` with the signatures implemented in Task 2. Do not add repository ownership, UI helpers, resolver APIs, cleanup jobs, or hidden controls.
+
+- [ ] **Step 3: Implement `set_assignment`**
+
+Order the operation exactly:
+
+1. Canonicalize `CharacterRef`, `LoadedTTSProfile`, and optional expected assignment.
+2. Require the expected assignment to target the same canonical reference.
+3. Check the caller-held repository generation.
+4. Build an exact `TTSProfileDraft` from the loaded profile's generation fields.
+5. Call the existing `_require_authoritative_capability` even when the profile was previously available.
+6. Recheck repository generation.
+7. Call the repository with generation, selected revision, and expected current profile ID.
+8. Admit only a result with the exact generation, `CharacterRef`, and selected profile ID.
+9. Recheck generation before returning the canonical assignment.
+
+Never substitute the repository's current generation, reload the current assignment, or select another profile/model/voice.
+
+- [ ] **Step 4: Implement `detach_assignment`**
+
+Canonicalize the caller-held assignment and exact nonnegative generation, reject stale generation before repository work, then call `remove_assignment` with its exact reference/profile ID. Admit only an exact-generation result whose value is `None`.
+
+Detach performs no capability observation because it removes selection rather than authorizing a generation profile.
+
+- [ ] **Step 5: Run focused service and capability tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/TTS/test_profile_service.py \
+  Tests/TTS/test_tts_profile_capabilities.py \
+  -q
+```
+
+Expected: all tests pass and existing profile create/edit/duplicate/preview behavior remains unchanged.
+
+- [ ] **Step 6: Run static checks for the service increment**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/TTS/profile_service.py \
+  Tests/TTS/test_profile_service.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/TTS/profile_service.py \
+  Tests/TTS/test_profile_service.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit the service implementation**
+
+```bash
+git add tldw_chatbook/TTS/profile_service.py Tests/TTS/test_profile_service.py
+git commit -m "feat(tts): add exact character assignment service"
+```
+
+### Task 5: Document the boundary and run the complete slice gate
+
+**Files:**
+- Modify: `Docs/Development/TTS/TTS_MODULE_GUIDE.md`
+- Modify: `backlog/tasks/task-617.4 - Add-exact-character-TTS-assignment-mutation-service.md`
+- Test: `Tests/TTS/test_profile_repository.py`
+- Test: `Tests/TTS/test_profile_repository_lifecycle.py`
+- Test: `Tests/TTS/test_profile_service.py`
+- Test: `Tests/TTS/test_profile_types.py`
+- Test: `Tests/TTS/test_tts_profile_capabilities.py`
+- Test: `Tests/TTS/test_tts_app_ownership.py`
+
+- [ ] **Step 1: Update the developer guide**
+
+Add a short **Slice 3A assignment mutation service** subsection explaining:
+
+- assignment identity remains exact `(source, authority_id, character_id)`;
+- set/replace requires caller-held repository generation, profile revision, expected current assignment, and fresh authoritative capability;
+- detach is absence-idempotent but replacement-safe;
+- repository transaction checks remain final authority;
+- the slice adds no UI, resolver, automatic speech, Persona inheritance, portability, Sync, or managed audio.cpp behavior.
+
+- [ ] **Step 2: Run the task-critical test union**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/TTS/test_profile_types.py \
+  Tests/TTS/test_profile_repository.py \
+  Tests/TTS/test_profile_repository_lifecycle.py \
+  Tests/TTS/test_profile_service.py \
+  Tests/TTS/test_tts_profile_capabilities.py \
+  Tests/TTS/test_tts_app_ownership.py \
+  Tests/TTS/test_console_speech_snapshot_admission.py \
+  Tests/TTS/test_console_audio_cpp_native.py \
+  -q
+```
+
+Expected: all tests pass; snapshot admission and native complete-WAV behavior remain unchanged.
+
+- [ ] **Step 3: Run broader profile and UI regressions**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/TTS/test_profile_schema.py \
+  Tests/TTS/test_profile_store_lock.py \
+  Tests/TTS/test_profile_backup_integration.py \
+  Tests/UI/test_stts_profile_library.py \
+  -q
+```
+
+Expected: all tests pass with only documented pre-existing warnings/skips.
+
+- [ ] **Step 4: Run final static and diff checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/TTS/profile_repository.py \
+  tldw_chatbook/TTS/profile_service.py \
+  Tests/TTS/test_profile_repository.py \
+  Tests/TTS/test_profile_service.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/TTS/profile_repository.py \
+  tldw_chatbook/TTS/profile_service.py \
+  Tests/TTS/test_profile_repository.py \
+  Tests/TTS/test_profile_service.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q \
+  tldw_chatbook/TTS/profile_repository.py \
+  tldw_chatbook/TTS/profile_service.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m mypy \
+  tldw_chatbook/TTS/profile_repository.py \
+  tldw_chatbook/TTS/profile_service.py
+git diff --check origin/dev...HEAD
+```
+
+Expected: all task-owned checks pass. Any broader baseline issue must be reproduced on untouched `origin/dev` and recorded rather than silently attributed to this slice.
+
+- [ ] **Step 5: Confirm scope**
+
+Run:
+
+```bash
+git diff --name-only origin/dev...HEAD
+```
+
+Expected: only the task, plan, guide, two profile modules, two focused mutation
+test files, and the two protocol-fake regression files are changed.
+
+- [ ] **Step 6: Complete the Backlog record**
+
+Check all acceptance criteria only after verification, add concise implementation notes with exact commands/results, retain the ADR-037 link, and set TASK-617.4 to `Done` via the Backlog CLI.
+
+- [ ] **Step 7: Commit documentation and closeout**
+
+```bash
+git add \
+  Docs/Development/TTS/TTS_MODULE_GUIDE.md \
+  Docs/superpowers/plans/2026-07-31-tts-assignment-mutation-service.md \
+  "backlog/tasks/task-617.4 - Add-exact-character-TTS-assignment-mutation-service.md"
+git commit -m "docs(tts): close assignment mutation service slice"
+```
+
+- [ ] **Step 8: Request final code review and prepare the PR**
+
+First run:
+
+```bash
+git status --short
+```
+
+Expected: no output; every task-owned file is committed.
+
+Then use `superpowers:requesting-code-review`, address every valid finding with
+focused regression coverage, rerun the affected and final gates, rebase onto
+latest `origin/dev`, push the branch, and open one PR for TASK-617.4.

--- a/Tests/TTS/test_profile_repository.py
+++ b/Tests/TTS/test_profile_repository.py
@@ -592,11 +592,7 @@ def _spawn_assignment_delete_race(
         try:
             await repository.open()
             opened = True
-            loaded = (
-                await repository.get_profile(UUID(profile_id))
-                if operation == "delete"
-                else None
-            )
+            loaded = await repository.get_profile(UUID(profile_id))
             connection.send(("ready", operation))
             if not release.wait(10.0):
                 raise TimeoutError("parent did not release assignment race")
@@ -609,9 +605,11 @@ def _spawn_assignment_delete_race(
                             character_id="shared-character",
                         ),
                         UUID(profile_id),
+                        expected_generation=loaded.generation,
+                        expected_profile_revision=loaded.value.revision,
+                        expected_current_profile_id=None,
                     )
                 else:
-                    assert loaded is not None
                     result = await repository.delete_profile(
                         UUID(profile_id),
                         expected_generation=loaded.generation,
@@ -774,6 +772,142 @@ def _pause_next_rollback(
     return rolled_back, resume
 
 
+async def _wait_for_barrier_or_task_failure(
+    barrier: asyncio.Event,
+    task: asyncio.Task[Any],
+    *,
+    release: Callable[[], object],
+) -> None:
+    """Wait deterministically for a barrier while surfacing early task failure."""
+
+    barrier_waiter = asyncio.create_task(barrier.wait())
+    try:
+        try:
+            async with asyncio.timeout(10.0):
+                completed, _ = await asyncio.wait(
+                    (barrier_waiter, task),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+        except TimeoutError:
+            release()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise
+        if task in completed:
+            await task
+            raise AssertionError("mutation completed before the test barrier")
+        assert barrier_waiter in completed
+    finally:
+        if not barrier_waiter.done():
+            barrier_waiter.cancel()
+        try:
+            await barrier_waiter
+        except asyncio.CancelledError:
+            pass
+
+
+@asynccontextmanager
+async def _queued_repository_mutation(
+    repository: profile_repository.TTSProfileRepository,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation_factory: Callable[[], Any],
+) -> AsyncIterator[asyncio.Task[Any]]:
+    """Queue one public mutation behind a deterministic worker barrier."""
+
+    worker_entered = threading.Event()
+    worker_resume = threading.Event()
+    blocker: Any = None
+    blocker_publication: asyncio.Task[Any] | None = None
+    mutation: asyncio.Task[Any] | None = None
+    mutation_future: Any = None
+    context_completed = False
+    blocker_error: BaseException | None = None
+    original_admit = repository._admit_operation
+
+    def block_worker(_connection: sqlite3.Connection) -> None:
+        worker_entered.set()
+        if not worker_resume.wait(10.0):
+            raise RuntimeError("test did not resume repository worker")
+
+    mutation_admitted = asyncio.Event()
+
+    def record_mutation_admission(
+        operation: Callable[[sqlite3.Connection], object],
+        *,
+        expected_generation: int | None = None,
+    ) -> Any:
+        nonlocal mutation_future
+        admission = original_admit(
+            operation,
+            expected_generation=expected_generation,
+        )
+        mutation_future = admission.future
+        mutation_admitted.set()
+        return admission
+
+    try:
+        blocker = repository._admit_operation(block_worker)
+        blocker_publication = asyncio.create_task(
+            repository._publish_operation(blocker)
+        )
+        assert await asyncio.to_thread(worker_entered.wait, 10.0)
+        monkeypatch.setattr(
+            repository,
+            "_admit_operation",
+            record_mutation_admission,
+        )
+        mutation = asyncio.create_task(mutation_factory())
+        await _wait_for_barrier_or_task_failure(
+            mutation_admitted,
+            mutation,
+            release=worker_resume.set,
+        )
+        monkeypatch.setattr(repository, "_admit_operation", original_admit)
+        yield mutation
+        context_completed = True
+    finally:
+        monkeypatch.setattr(repository, "_admit_operation", original_admit)
+        worker_resume.set()
+        cleanup_mutation = not context_completed
+        if cleanup_mutation:
+            if blocker is not None:
+                blocker.future.cancel()
+            if blocker_publication is not None:
+                blocker_publication.cancel()
+            if mutation_future is not None:
+                mutation_future.cancel()
+            if mutation is not None:
+                mutation.cancel()
+
+        if blocker_publication is not None:
+            blocker_result = await asyncio.gather(
+                blocker_publication,
+                return_exceptions=True,
+            )
+            if isinstance(blocker_result[0], BaseException):
+                blocker_error = blocker_result[0]
+
+        if blocker_error is not None and not cleanup_mutation:
+            cleanup_mutation = True
+            if mutation_future is not None:
+                mutation_future.cancel()
+            if mutation is not None:
+                mutation.cancel()
+
+        drainables: list[Any] = []
+        if blocker is not None:
+            drainables.append(asyncio.wrap_future(blocker.future))
+        if mutation is not None:
+            drainables.append(mutation)
+        if mutation_future is not None:
+            drainables.append(asyncio.wrap_future(mutation_future))
+        if drainables:
+            await asyncio.gather(*drainables, return_exceptions=True)
+
+    if blocker_error is not None:
+        raise blocker_error
+
+
 def test_private_clock_and_uuid_seams_remain_constructor_pure(
     tmp_path: Path,
 ) -> None:
@@ -807,6 +941,29 @@ def test_profile_mutation_generation_parameters_are_keyword_only() -> None:
     assert update_generation.default is inspect.Parameter.empty
     assert delete_generation.kind is inspect.Parameter.KEYWORD_ONLY
     assert delete_generation.default is inspect.Parameter.empty
+
+
+def test_assignment_mutation_expectations_are_mandatory_keyword_only() -> None:
+    set_parameters = inspect.signature(
+        profile_repository.TTSProfileRepository.set_assignment
+    ).parameters
+    remove_parameters = inspect.signature(
+        profile_repository.TTSProfileRepository.remove_assignment
+    ).parameters
+
+    for parameter_name in (
+        "expected_generation",
+        "expected_profile_revision",
+        "expected_current_profile_id",
+    ):
+        parameter = set_parameters[parameter_name]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is inspect.Parameter.empty
+
+    for parameter_name in ("expected_generation", "expected_profile_id"):
+        parameter = remove_parameters[parameter_name]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is inspect.Parameter.empty
 
 
 @pytest.mark.asyncio
@@ -887,7 +1044,11 @@ def test_profile_mutation_generation_parameters_are_keyword_only() -> None:
         (
             "set_assignment",
             (object(), GENERATED_ID),
-            {},
+            {
+                "expected_generation": 0,
+                "expected_profile_revision": 1,
+                "expected_current_profile_id": None,
+            },
             "",
         ),
         (
@@ -900,7 +1061,11 @@ def test_profile_mutation_generation_parameters_are_keyword_only() -> None:
                 ),
                 GENERATED_ID,
             ),
-            {},
+            {
+                "expected_generation": 0,
+                "expected_profile_revision": 1,
+                "expected_current_profile_id": None,
+            },
             "secret-authority-subclass",
         ),
         (
@@ -913,10 +1078,22 @@ def test_profile_mutation_generation_parameters_are_keyword_only() -> None:
                 ),
                 "secret-assignment-profile",
             ),
-            {},
+            {
+                "expected_generation": 0,
+                "expected_profile_revision": 1,
+                "expected_current_profile_id": None,
+            },
             "secret-assignment-profile",
         ),
-        ("remove_assignment", (object(),), {}, ""),
+        (
+            "remove_assignment",
+            (object(),),
+            {
+                "expected_generation": 0,
+                "expected_profile_id": GENERATED_ID,
+            },
+            "",
+        ),
         (
             "get_assigned_profile",
             (
@@ -946,7 +1123,10 @@ async def test_invalid_public_inputs_fail_before_worker_submission(
 
     async def forbidden_submission(
         _operation: Callable[[sqlite3.Connection], object],
+        *,
+        expected_generation: int | None = None,
     ) -> ProfileStoreResult[object]:
+        del expected_generation
         nonlocal submitted
         submitted = True
         raise AssertionError("invalid input reached worker submission")
@@ -957,6 +1137,110 @@ async def test_invalid_public_inputs_fail_before_worker_submission(
         await getattr(repository, method_name)(*args, **kwargs)
 
     _assert_safe_error(caught.value, "operation_failed", secret)
+    assert submitted is False
+    assert not tmp_path.joinpath("must-not-exist").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["set_assignment", "remove_assignment"])
+async def test_assignment_mutations_require_all_compare_and_set_expectations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+) -> None:
+    character_ref = CharacterRef("local", "authority", "character")
+    args = (
+        (character_ref, GENERATED_ID)
+        if method_name == "set_assignment"
+        else (character_ref,)
+    )
+    repository = profile_repository.TTSProfileRepository(
+        tmp_path / "must-not-exist" / "profiles.sqlite3"
+    )
+    submitted = False
+
+    async def forbidden_submission(
+        _operation: Callable[[sqlite3.Connection], object],
+        *,
+        expected_generation: int | None = None,
+    ) -> ProfileStoreResult[object]:
+        del expected_generation
+        nonlocal submitted
+        submitted = True
+        raise AssertionError("missing expectation reached worker submission")
+
+    monkeypatch.setattr(repository, "_submit_operation", forbidden_submission)
+
+    with pytest.raises(TypeError):
+        await getattr(repository, method_name)(*args)
+
+    assert submitted is False
+    assert not tmp_path.joinpath("must-not-exist").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "parameter_name", "invalid_value"),
+    [
+        ("set_assignment", "expected_generation", True),
+        ("set_assignment", "expected_profile_revision", 0),
+        (
+            "set_assignment",
+            "expected_current_profile_id",
+            _UUIDSubclass(str(CALLER_ID)),
+        ),
+        ("remove_assignment", "expected_generation", -1),
+        (
+            "remove_assignment",
+            "expected_profile_id",
+            _UUIDSubclass(str(GENERATED_ID)),
+        ),
+    ],
+)
+async def test_assignment_mutations_reject_malformed_expectations_before_submission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+    parameter_name: str,
+    invalid_value: object,
+) -> None:
+    character_ref = CharacterRef("local", "authority", "character")
+    if method_name == "set_assignment":
+        args: tuple[object, ...] = (character_ref, GENERATED_ID)
+        kwargs: dict[str, object] = {
+            "expected_generation": 0,
+            "expected_profile_revision": 1,
+            "expected_current_profile_id": None,
+        }
+    else:
+        args = (character_ref,)
+        kwargs = {
+            "expected_generation": 0,
+            "expected_profile_id": GENERATED_ID,
+        }
+    kwargs[parameter_name] = invalid_value
+
+    repository = profile_repository.TTSProfileRepository(
+        tmp_path / "must-not-exist" / "profiles.sqlite3"
+    )
+    submitted = False
+
+    async def forbidden_submission(
+        _operation: Callable[[sqlite3.Connection], object],
+        *,
+        expected_generation: int | None = None,
+    ) -> ProfileStoreResult[object]:
+        del expected_generation
+        nonlocal submitted
+        submitted = True
+        raise AssertionError("malformed expectation reached worker submission")
+
+    monkeypatch.setattr(repository, "_submit_operation", forbidden_submission)
+
+    with pytest.raises(ProfileRepositoryError) as caught:
+        await getattr(repository, method_name)(*args, **kwargs)
+
+    _assert_safe_error(caught.value, "operation_failed")
     assert submitted is False
     assert not tmp_path.joinpath("must-not-exist").exists()
 
@@ -1170,7 +1454,10 @@ async def test_mutated_exact_character_ref_fails_before_worker_submission(
 
     async def forbidden_submission(
         _operation: Callable[[sqlite3.Connection], object],
+        *,
+        expected_generation: int | None = None,
     ) -> ProfileStoreResult[object]:
+        del expected_generation
         nonlocal submitted
         submitted = True
         raise AssertionError("malformed exact CharacterRef reached worker submission")
@@ -1179,9 +1466,22 @@ async def test_mutated_exact_character_ref_fails_before_worker_submission(
     arguments: tuple[object, ...] = (
         (character_ref, GENERATED_ID) if include_profile_id else (character_ref,)
     )
+    if method_name == "set_assignment":
+        kwargs: dict[str, object] = {
+            "expected_generation": 0,
+            "expected_profile_revision": 1,
+            "expected_current_profile_id": None,
+        }
+    elif method_name == "remove_assignment":
+        kwargs = {
+            "expected_generation": 0,
+            "expected_profile_id": GENERATED_ID,
+        }
+    else:
+        kwargs = {}
 
     with pytest.raises(ProfileRepositoryError) as caught:
-        await getattr(repository, method_name)(*arguments)
+        await getattr(repository, method_name)(*arguments, **kwargs)
 
     _assert_safe_error(caught.value, "operation_failed", secret)
     assert not submitted
@@ -1191,6 +1491,7 @@ async def test_mutated_exact_character_ref_fails_before_worker_submission(
 @pytest.mark.asyncio
 async def test_assignment_snapshots_character_ref_before_queued_worker_runs(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     persisted_profile_id = UUID("fd000000-0000-4000-8000-00000000000d")
     caller_profile_id = UUID(str(persisted_profile_id))
@@ -1199,39 +1500,31 @@ async def test_assignment_snapshots_character_ref_before_queued_worker_runs(
         authority_id="admitted-authority",
         character_id="admitted-character",
     )
-    worker_entered = threading.Event()
-    worker_resume = threading.Event()
-
     async with _opened_repository(tmp_path / "queued-snapshot.sqlite3") as repository:
-        await repository.create_profile(
+        created = await repository.create_profile(
             _draft("Queued Snapshot"),
             profile_id=persisted_profile_id,
         )
 
-        def block_worker(_connection: sqlite3.Connection) -> None:
-            worker_entered.set()
-            if not worker_resume.wait(10.0):
-                raise RuntimeError("test did not resume queued worker")
+        async with _queued_repository_mutation(
+            repository,
+            monkeypatch,
+            lambda: repository.set_assignment(
+                admitted_ref,
+                caller_profile_id,
+                expected_generation=created.generation,
+                expected_profile_revision=created.value.revision,
+                expected_current_profile_id=None,
+            ),
+        ) as queued:
+            object.__setattr__(admitted_ref, "authority_id", "mutated-authority")
+            object.__setattr__(admitted_ref, "character_id", "mutated-character")
+            object.__setattr__(
+                caller_profile_id,
+                "int",
+                UUID("fd100000-0000-4000-8000-00000000000d").int,
+            )
 
-        blocker = repository._admit_operation(block_worker)
-        blocker_publication = asyncio.create_task(
-            repository._publish_operation(blocker)
-        )
-        assert await asyncio.to_thread(worker_entered.wait, 10.0)
-        queued = asyncio.create_task(
-            repository.set_assignment(admitted_ref, caller_profile_id)
-        )
-        await asyncio.sleep(0)
-        object.__setattr__(admitted_ref, "authority_id", "mutated-authority")
-        object.__setattr__(admitted_ref, "character_id", "mutated-character")
-        object.__setattr__(
-            caller_profile_id,
-            "int",
-            UUID("fd100000-0000-4000-8000-00000000000d").int,
-        )
-        worker_resume.set()
-
-        await blocker_publication
         assigned = await queued
 
         expected_ref = CharacterRef(
@@ -3339,6 +3632,243 @@ def test_spawned_repositories_resolve_sqlite_constraint_race_safely(
 
 
 @pytest.mark.asyncio
+async def test_set_assignment_requires_expected_unassigned_state(
+    tmp_path: Path,
+) -> None:
+    character_ref = CharacterRef("local", "authority", "unassigned-character")
+
+    async with _opened_repository(
+        tmp_path / "explicit-unassigned.sqlite3"
+    ) as repository:
+        created = await repository.create_profile(
+            _draft("Explicit Unassigned"),
+            profile_id=GENERATED_ID,
+        )
+        assigned = await repository.set_assignment(
+            character_ref,
+            GENERATED_ID,
+            expected_generation=created.generation,
+            expected_profile_revision=created.value.revision,
+            expected_current_profile_id=None,
+        )
+
+        assert assigned.value == CharacterTTSAssignment(character_ref, GENERATED_ID)
+
+
+@pytest.mark.asyncio
+async def test_replace_assignment_requires_exact_observed_profile(
+    tmp_path: Path,
+) -> None:
+    character_ref = CharacterRef("server", "authority", "replace-character")
+
+    async with _opened_repository(
+        tmp_path / "exact-observed-assignment.sqlite3"
+    ) as repository:
+        original = await repository.create_profile(
+            _draft("Original Assignment"),
+            profile_id=GENERATED_ID,
+        )
+        replacement = await repository.create_profile(
+            _draft("Replacement Assignment"),
+            profile_id=CALLER_ID,
+        )
+        assigned = await repository.set_assignment(
+            character_ref,
+            GENERATED_ID,
+            expected_generation=original.generation,
+            expected_profile_revision=original.value.revision,
+            expected_current_profile_id=None,
+        )
+
+        with pytest.raises(ProfileRepositoryError) as conflict:
+            await repository.set_assignment(
+                character_ref,
+                CALLER_ID,
+                expected_generation=assigned.generation,
+                expected_profile_revision=replacement.value.revision,
+                expected_current_profile_id=CALLER_ID,
+            )
+
+        _assert_safe_error(conflict.value, "conflict")
+        preserved = (await repository.get_assigned_profile(character_ref)).value
+        assert preserved is not None
+        assert preserved.assignment.profile_id == GENERATED_ID
+
+        replaced = await repository.set_assignment(
+            character_ref,
+            CALLER_ID,
+            expected_generation=assigned.generation,
+            expected_profile_revision=replacement.value.revision,
+            expected_current_profile_id=assigned.value.profile_id,
+        )
+
+        assert replaced.value.profile_id == CALLER_ID
+
+
+@pytest.mark.asyncio
+async def test_set_assignment_rejects_stale_selected_profile_revision(
+    tmp_path: Path,
+) -> None:
+    character_ref = CharacterRef("local", "authority", "stale-revision-character")
+
+    async with _opened_repository(
+        tmp_path / "stale-selected-revision.sqlite3"
+    ) as repository:
+        created = await repository.create_profile(
+            _draft("Stale Selected Revision"),
+            profile_id=GENERATED_ID,
+        )
+        updated = await repository.update_profile(
+            GENERATED_ID,
+            created.value.revision,
+            _draft("Fresh Selected Revision"),
+            expected_generation=created.generation,
+        )
+
+        with pytest.raises(ProfileRepositoryError) as conflict:
+            await repository.set_assignment(
+                character_ref,
+                GENERATED_ID,
+                expected_generation=updated.generation,
+                expected_profile_revision=created.value.revision,
+                expected_current_profile_id=None,
+            )
+
+        _assert_safe_error(conflict.value, "conflict")
+        assert (await repository.get_assigned_profile(character_ref)).value is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "changed_expectation",
+    ["profile_revision", "current_assignment"],
+)
+async def test_assignment_expectations_are_checked_inside_final_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    changed_expectation: str,
+) -> None:
+    database_path = tmp_path / f"final-transaction-{changed_expectation}.sqlite3"
+    character_ref = CharacterRef(
+        "local",
+        "barrier-authority",
+        f"final-transaction-{changed_expectation}",
+    )
+
+    async with _opened_repository(database_path) as repository:
+        selected = await repository.create_profile(
+            _draft("Transaction Selected"),
+            profile_id=GENERATED_ID,
+        )
+        await repository.create_profile(
+            _draft("Transaction Replacement"),
+            profile_id=CALLER_ID,
+        )
+
+        async with _queued_repository_mutation(
+            repository,
+            monkeypatch,
+            lambda: repository.set_assignment(
+                character_ref,
+                GENERATED_ID,
+                expected_generation=selected.generation,
+                expected_profile_revision=selected.value.revision,
+                expected_current_profile_id=None,
+            ),
+        ) as mutation:
+            if changed_expectation == "profile_revision":
+                await asyncio.to_thread(
+                    _external_execute,
+                    database_path,
+                    (
+                        "UPDATE tts_generation_profiles SET revision = revision + 1 "
+                        "WHERE profile_id = ?"
+                    ),
+                    (str(GENERATED_ID),),
+                )
+            else:
+                await asyncio.to_thread(
+                    _external_insert_assignment,
+                    database_path,
+                    CALLER_ID,
+                    character_ref.character_id,
+                )
+
+        with pytest.raises(ProfileRepositoryError) as conflict:
+            await mutation
+
+        _assert_safe_error(conflict.value, "conflict")
+        snapshot = (await repository.get_assigned_profile(character_ref)).value
+        if changed_expectation == "profile_revision":
+            assert snapshot is None
+        else:
+            assert snapshot is not None
+            assert snapshot.assignment.profile_id == CALLER_ID
+
+
+@pytest.mark.asyncio
+async def test_assignment_generation_is_rechecked_inside_final_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = tmp_path / "generation-final-transaction.sqlite3"
+    character_ref = CharacterRef("server", "authority", "generation-character")
+    worker_entered = asyncio.Event()
+    worker_resume = threading.Event()
+    event_loop = asyncio.get_running_loop()
+
+    async with _opened_repository(database_path) as repository:
+        created = await repository.create_profile(
+            _draft("Generation Barrier"),
+            profile_id=GENERATED_ID,
+        )
+        original_set = cast(
+            Callable[..., CharacterTTSAssignment],
+            repository._worker_set_assignment,
+        )
+
+        def pause_before_assignment_transaction(
+            *args: object,
+            **kwargs: object,
+        ) -> CharacterTTSAssignment:
+            event_loop.call_soon_threadsafe(worker_entered.set)
+            if not worker_resume.wait(10.0):
+                raise RuntimeError("test did not resume assignment transaction")
+            return original_set(*args, **kwargs)
+
+        monkeypatch.setattr(
+            repository,
+            "_worker_set_assignment",
+            pause_before_assignment_transaction,
+        )
+        try:
+            mutation = asyncio.create_task(
+                repository.set_assignment(
+                    character_ref,
+                    GENERATED_ID,
+                    expected_generation=created.generation,
+                    expected_profile_revision=created.value.revision,
+                    expected_current_profile_id=None,
+                )
+            )
+            await _wait_for_barrier_or_task_failure(
+                worker_entered,
+                cast(asyncio.Task[Any], mutation),
+                release=worker_resume.set,
+            )
+            with repository._state_lock:
+                repository._generation += 1
+        finally:
+            worker_resume.set()
+
+        with pytest.raises(ProfileRepositoryError) as stale:
+            await mutation
+
+        _assert_safe_error(stale.value, "stale")
+        assert (await repository.get_assigned_profile(character_ref)).value is None
+
+
+@pytest.mark.asyncio
 async def test_assignments_are_exactly_authority_scoped_and_replace_one_target(
     tmp_path: Path,
 ) -> None:
@@ -3358,20 +3888,25 @@ async def test_assignments_are_exactly_authority_scoped_and_replace_one_target(
         database_path,
         clock=cast(Callable[[], datetime], clock),
     ) as repository:
-        await repository.create_profile(
+        first_profile = await repository.create_profile(
             _draft("First Assignment Profile"),
             profile_id=first_profile_id,
         )
-        await repository.create_profile(
+        second_profile = await repository.create_profile(
             _draft("Second Assignment Profile"),
             profile_id=second_profile_id,
         )
 
+        assignments: list[ProfileStoreResult[CharacterTTSAssignment]] = []
         for character_ref in refs:
             assigned = await repository.set_assignment(
                 character_ref,
                 first_profile_id,
+                expected_generation=first_profile.generation,
+                expected_profile_revision=first_profile.value.revision,
+                expected_current_profile_id=None,
             )
+            assignments.append(assigned)
             assert assigned == ProfileStoreResult(
                 generation=1,
                 value=CharacterTTSAssignment(character_ref, first_profile_id),
@@ -3392,7 +3927,13 @@ async def test_assignments_are_exactly_authority_scoped_and_replace_one_target(
             connection.close()
         assert before is not None
 
-        replaced = await repository.set_assignment(refs[2], second_profile_id)
+        replaced = await repository.set_assignment(
+            refs[2],
+            second_profile_id,
+            expected_generation=assignments[2].generation,
+            expected_profile_revision=second_profile.value.revision,
+            expected_current_profile_id=assignments[2].value.profile_id,
+        )
 
         assert replaced.value == CharacterTTSAssignment(refs[2], second_profile_id)
         assert replaced.generation == 1
@@ -3445,17 +3986,29 @@ async def test_assignment_replacement_is_monotonic_when_clock_moves_backward(
         database_path,
         clock=cast(Callable[[], datetime], clock),
     ) as repository:
-        await repository.create_profile(
+        first_profile = await repository.create_profile(
             _draft("Backward First"),
             profile_id=first_profile_id,
         )
-        await repository.create_profile(
+        second_profile = await repository.create_profile(
             _draft("Backward Second"),
             profile_id=second_profile_id,
         )
-        await repository.set_assignment(character_ref, first_profile_id)
+        assigned = await repository.set_assignment(
+            character_ref,
+            first_profile_id,
+            expected_generation=first_profile.generation,
+            expected_profile_revision=first_profile.value.revision,
+            expected_current_profile_id=None,
+        )
 
-        replaced = await repository.set_assignment(character_ref, second_profile_id)
+        replaced = await repository.set_assignment(
+            character_ref,
+            second_profile_id,
+            expected_generation=assigned.generation,
+            expected_profile_revision=second_profile.value.revision,
+            expected_current_profile_id=assigned.value.profile_id,
+        )
 
         assert replaced.value == CharacterTTSAssignment(
             character_ref,
@@ -3500,16 +4053,23 @@ async def test_assignment_timestamp_rewrite_trigger_rolls_back_and_recovers(
     future_text = FUTURE_AT.isoformat(timespec="microseconds").replace("+00:00", "Z")
 
     async with _opened_repository(database_path) as repository:
-        await repository.create_profile(
+        first_profile = await repository.create_profile(
             _draft("Trigger First"),
             profile_id=first_profile_id,
         )
-        await repository.create_profile(
+        second_profile = await repository.create_profile(
             _draft("Trigger Second"),
             profile_id=second_profile_id,
         )
+        assigned: ProfileStoreResult[CharacterTTSAssignment] | None = None
         if operation == "replace":
-            await repository.set_assignment(character_ref, first_profile_id)
+            assigned = await repository.set_assignment(
+                character_ref,
+                first_profile_id,
+                expected_generation=first_profile.generation,
+                expected_profile_revision=first_profile.value.revision,
+                expected_current_profile_id=None,
+            )
 
         trigger_operation = {"insert": "INSERT", "replace": "UPDATE"}[operation]
         connection = sqlite3.connect(database_path, isolation_level=None)
@@ -3533,8 +4093,18 @@ async def test_assignment_timestamp_rewrite_trigger_rolls_back_and_recovers(
         target_profile_id = (
             first_profile_id if operation == "insert" else second_profile_id
         )
+        target_profile = first_profile if operation == "insert" else second_profile
+        expected_current_profile_id = (
+            None if assigned is None else assigned.value.profile_id
+        )
         with pytest.raises(ProfileRepositoryError) as failed:
-            await repository.set_assignment(character_ref, target_profile_id)
+            await repository.set_assignment(
+                character_ref,
+                target_profile_id,
+                expected_generation=target_profile.generation,
+                expected_profile_revision=target_profile.value.revision,
+                expected_current_profile_id=expected_current_profile_id,
+            )
         _assert_safe_error(
             failed.value,
             "corrupt_data",
@@ -3562,6 +4132,9 @@ async def test_assignment_timestamp_rewrite_trigger_rolls_back_and_recovers(
         recovered = await repository.set_assignment(
             character_ref,
             target_profile_id,
+            expected_generation=target_profile.generation,
+            expected_profile_revision=target_profile.value.revision,
+            expected_current_profile_id=expected_current_profile_id,
         )
         assert recovered.value.profile_id == target_profile_id
 
@@ -3580,12 +4153,19 @@ async def test_assignment_missing_profile_is_missing_not_zero_or_partial(
     async with _opened_repository(
         tmp_path / "missing-assignment.sqlite3"
     ) as repository:
+        current = await repository.list_profiles()
         with pytest.raises(ProfileRepositoryError) as count_missing:
             await repository.assignment_count(missing_profile_id)
         _assert_safe_error(count_missing.value, "missing", str(missing_profile_id))
 
         with pytest.raises(ProfileRepositoryError) as set_missing:
-            await repository.set_assignment(character_ref, missing_profile_id)
+            await repository.set_assignment(
+                character_ref,
+                missing_profile_id,
+                expected_generation=current.generation,
+                expected_profile_revision=1,
+                expected_current_profile_id=None,
+            )
         _assert_safe_error(
             set_missing.value,
             "missing",
@@ -3595,7 +4175,13 @@ async def test_assignment_missing_profile_is_missing_not_zero_or_partial(
         )
 
         assert (await repository.get_assigned_profile(character_ref)).value is None
-        assert (await repository.remove_assignment(character_ref)).value is None
+        assert (
+            await repository.remove_assignment(
+                character_ref,
+                expected_generation=current.generation,
+                expected_profile_id=missing_profile_id,
+            )
+        ).value is None
 
 
 @pytest.mark.asyncio
@@ -3616,8 +4202,17 @@ async def test_orphan_assignment_is_corrupt_while_genuine_unassigned_is_none(
     )
 
     async with _opened_repository(database_path) as repository:
-        await repository.create_profile(_draft("Orphaned"), profile_id=profile_id)
-        await repository.set_assignment(assigned_ref, profile_id)
+        created = await repository.create_profile(
+            _draft("Orphaned"),
+            profile_id=profile_id,
+        )
+        await repository.set_assignment(
+            assigned_ref,
+            profile_id,
+            expected_generation=created.generation,
+            expected_profile_revision=created.value.revision,
+            expected_current_profile_id=None,
+        )
         assert (await repository.get_assigned_profile(unassigned_ref)).value is None
 
         connection = sqlite3.connect(database_path, isolation_level=None)
@@ -3644,7 +4239,7 @@ async def test_orphan_assignment_is_corrupt_while_genuine_unassigned_is_none(
 
 
 @pytest.mark.asyncio
-async def test_remove_assignment_is_exact_idempotent_and_does_not_probe_target(
+async def test_remove_assignment_deletes_exact_matching_assignment(
     tmp_path: Path,
 ) -> None:
     profile_id = UUID("f4000000-0000-4000-8000-000000000004")
@@ -3652,18 +4247,118 @@ async def test_remove_assignment_is_exact_idempotent_and_does_not_probe_target(
     other_ref = CharacterRef("local", "other-database", "same-character")
 
     async with _opened_repository(tmp_path / "detach.sqlite3") as repository:
-        await repository.create_profile(_draft("Detach"), profile_id=profile_id)
-        await repository.set_assignment(exact_ref, profile_id)
-        await repository.set_assignment(other_ref, profile_id)
+        created = await repository.create_profile(
+            _draft("Detach"),
+            profile_id=profile_id,
+        )
+        exact_assignment = await repository.set_assignment(
+            exact_ref,
+            profile_id,
+            expected_generation=created.generation,
+            expected_profile_revision=created.value.revision,
+            expected_current_profile_id=None,
+        )
+        await repository.set_assignment(
+            other_ref,
+            profile_id,
+            expected_generation=created.generation,
+            expected_profile_revision=created.value.revision,
+            expected_current_profile_id=None,
+        )
 
-        first = await repository.remove_assignment(exact_ref)
-        second = await repository.remove_assignment(exact_ref)
+        removed = await repository.remove_assignment(
+            exact_ref,
+            expected_generation=exact_assignment.generation,
+            expected_profile_id=exact_assignment.value.profile_id,
+        )
 
-        assert first == ProfileStoreResult(generation=1, value=None)
-        assert second == ProfileStoreResult(generation=1, value=None)
+        assert removed == ProfileStoreResult(generation=1, value=None)
         assert (await repository.get_assigned_profile(exact_ref)).value is None
         assert (await repository.get_assigned_profile(other_ref)).value is not None
         assert (await repository.assignment_count(profile_id)).value == 1
+
+
+@pytest.mark.asyncio
+async def test_remove_assignment_is_idempotent_when_assignment_is_absent(
+    tmp_path: Path,
+) -> None:
+    character_ref = CharacterRef("local", "authority", "absent-character")
+
+    async with _opened_repository(tmp_path / "idempotent-detach.sqlite3") as repository:
+        created = await repository.create_profile(
+            _draft("Idempotent Detach"),
+            profile_id=GENERATED_ID,
+        )
+
+        removed = await repository.remove_assignment(
+            character_ref,
+            expected_generation=created.generation,
+            expected_profile_id=created.value.profile_id,
+        )
+
+        assert removed == ProfileStoreResult(
+            generation=created.generation,
+            value=None,
+        )
+        assert (await repository.get_assigned_profile(character_ref)).value is None
+
+
+@pytest.mark.asyncio
+async def test_remove_assignment_conflicts_when_observed_assignment_was_replaced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = tmp_path / "replaced-before-detach.sqlite3"
+    character_ref = CharacterRef("server", "authority", "detach-race-character")
+
+    async with _opened_repository(database_path) as repository:
+        observed_profile = await repository.create_profile(
+            _draft("Observed Detach Profile"),
+            profile_id=GENERATED_ID,
+        )
+        await repository.create_profile(
+            _draft("Replacement Detach Profile"),
+            profile_id=CALLER_ID,
+        )
+        observed_assignment = await repository.set_assignment(
+            character_ref,
+            GENERATED_ID,
+            expected_generation=observed_profile.generation,
+            expected_profile_revision=observed_profile.value.revision,
+            expected_current_profile_id=None,
+        )
+
+        async with _queued_repository_mutation(
+            repository,
+            monkeypatch,
+            lambda: repository.remove_assignment(
+                character_ref,
+                expected_generation=observed_assignment.generation,
+                expected_profile_id=observed_assignment.value.profile_id,
+            ),
+        ) as mutation:
+            await asyncio.to_thread(
+                _external_execute,
+                database_path,
+                (
+                    "UPDATE character_tts_assignments SET profile_id = ? "
+                    "WHERE source = ? AND authority_id = ? AND character_id = ?"
+                ),
+                (
+                    str(CALLER_ID),
+                    character_ref.source,
+                    character_ref.authority_id,
+                    character_ref.character_id,
+                ),
+            )
+
+        with pytest.raises(ProfileRepositoryError) as conflict:
+            await mutation
+
+        _assert_safe_error(conflict.value, "conflict")
+        snapshot = (await repository.get_assigned_profile(character_ref)).value
+        assert snapshot is not None
+        assert snapshot.assignment.profile_id == CALLER_ID
 
 
 @pytest.mark.asyncio
@@ -3683,7 +4378,13 @@ async def test_joined_read_returns_immutable_exact_revision_snapshot(
             profile_id=profile_id,
         )
         created = created_result.value
-        await repository.set_assignment(character_ref, profile_id)
+        await repository.set_assignment(
+            character_ref,
+            profile_id,
+            expected_generation=created_result.generation,
+            expected_profile_revision=created.revision,
+            expected_current_profile_id=None,
+        )
 
         joined = await repository.get_assigned_profile(character_ref)
         assert joined == ProfileStoreResult(
@@ -3727,7 +4428,13 @@ async def test_delete_profile_is_blocked_by_repository_assignment(
             profile_id=profile_id,
         )
         profile = profile_result.value
-        await repository.set_assignment(character_ref, profile_id)
+        await repository.set_assignment(
+            character_ref,
+            profile_id,
+            expected_generation=profile_result.generation,
+            expected_profile_revision=profile.revision,
+            expected_current_profile_id=None,
+        )
 
         with pytest.raises(ProfileRepositoryError) as conflict:
             await repository.delete_profile(
@@ -3754,7 +4461,7 @@ async def test_assignment_mutation_commit_failures_roll_back_and_recover(
     )
 
     async with _opened_repository(database_path) as repository:
-        await repository.create_profile(
+        created = await repository.create_profile(
             _draft("Commit Assignment"), profile_id=profile_id
         )
         set_secret = "secret-set-assignment-commit"
@@ -3765,7 +4472,13 @@ async def test_assignment_mutation_commit_failures_roll_back_and_recover(
         )
 
         with pytest.raises(ProfileRepositoryError) as set_failed:
-            await repository.set_assignment(character_ref, profile_id)
+            await repository.set_assignment(
+                character_ref,
+                profile_id,
+                expected_generation=created.generation,
+                expected_profile_revision=created.value.revision,
+                expected_current_profile_id=None,
+            )
         _assert_safe_error(
             set_failed.value,
             "operation_failed",
@@ -3776,7 +4489,13 @@ async def test_assignment_mutation_commit_failures_roll_back_and_recover(
         )
         assert (await repository.get_assigned_profile(character_ref)).value is None
 
-        await repository.set_assignment(character_ref, profile_id)
+        assigned = await repository.set_assignment(
+            character_ref,
+            profile_id,
+            expected_generation=created.generation,
+            expected_profile_revision=created.value.revision,
+            expected_current_profile_id=None,
+        )
         remove_secret = "secret-remove-assignment-commit"
         _fail_next_commit(
             monkeypatch,
@@ -3784,7 +4503,11 @@ async def test_assignment_mutation_commit_failures_roll_back_and_recover(
             sqlite3.OperationalError(remove_secret),
         )
         with pytest.raises(ProfileRepositoryError) as remove_failed:
-            await repository.remove_assignment(character_ref)
+            await repository.remove_assignment(
+                character_ref,
+                expected_generation=assigned.generation,
+                expected_profile_id=assigned.value.profile_id,
+            )
         _assert_safe_error(
             remove_failed.value,
             "operation_failed",
@@ -3794,7 +4517,13 @@ async def test_assignment_mutation_commit_failures_roll_back_and_recover(
             str(database_path),
         )
         assert (await repository.get_assigned_profile(character_ref)).value is not None
-        assert (await repository.remove_assignment(character_ref)).value is None
+        assert (
+            await repository.remove_assignment(
+                character_ref,
+                expected_generation=assigned.generation,
+                expected_profile_id=assigned.value.profile_id,
+            )
+        ).value is None
 
 
 @pytest.mark.asyncio
@@ -3807,7 +4536,7 @@ async def test_unrelated_assignment_foreign_key_trigger_is_not_missing(
     secret = "secret-unrelated-assignment-fk"
 
     async with _opened_repository(database_path) as repository:
-        await repository.create_profile(
+        created = await repository.create_profile(
             _draft("Trigger Assignment"), profile_id=profile_id
         )
         await asyncio.to_thread(
@@ -3837,7 +4566,13 @@ async def test_unrelated_assignment_foreign_key_trigger_is_not_missing(
             connection.close()
 
         with pytest.raises(ProfileRepositoryError) as failed:
-            await repository.set_assignment(character_ref, profile_id)
+            await repository.set_assignment(
+                character_ref,
+                profile_id,
+                expected_generation=created.generation,
+                expected_profile_revision=created.value.revision,
+                expected_current_profile_id=None,
+            )
         _assert_safe_error(
             failed.value,
             "operation_failed",
@@ -3854,7 +4589,13 @@ async def test_unrelated_assignment_foreign_key_trigger_is_not_missing(
             "DROP TRIGGER force_unrelated_assignment_fk",
         )
         assert (
-            await repository.set_assignment(character_ref, profile_id)
+            await repository.set_assignment(
+                character_ref,
+                profile_id,
+                expected_generation=created.generation,
+                expected_profile_revision=created.value.revision,
+                expected_current_profile_id=None,
+            )
         ).value.profile_id == profile_id
 
 
@@ -3872,6 +4613,7 @@ async def test_missing_assignment_target_preflight_returns_missing_before_unrela
     secret = "secret-missing-target-unrelated-fk"
 
     async with _opened_repository(database_path) as repository:
+        current = await repository.list_profiles()
         connection = sqlite3.connect(database_path, isolation_level=None)
         try:
             connection.execute("PRAGMA foreign_keys = ON")
@@ -3896,7 +4638,13 @@ async def test_missing_assignment_target_preflight_returns_missing_before_unrela
             connection.close()
 
         with pytest.raises(ProfileRepositoryError) as failed:
-            await repository.set_assignment(character_ref, missing_profile_id)
+            await repository.set_assignment(
+                character_ref,
+                missing_profile_id,
+                expected_generation=current.generation,
+                expected_profile_revision=1,
+                expected_current_profile_id=None,
+            )
         _assert_safe_error(
             failed.value,
             "missing",
@@ -3924,13 +4672,18 @@ async def test_corrupt_assignment_and_joined_profile_rows_fail_closed(
     profile_secret = "secret-corrupt-joined-profile"
 
     async with _opened_repository(database_path) as repository:
-        profile = (
-            await repository.create_profile(
-                _draft("Corrupt Joined"),
-                profile_id=profile_id,
-            )
-        ).value
-        await repository.set_assignment(character_ref, profile_id)
+        profile_result = await repository.create_profile(
+            _draft("Corrupt Joined"),
+            profile_id=profile_id,
+        )
+        profile = profile_result.value
+        await repository.set_assignment(
+            character_ref,
+            profile_id,
+            expected_generation=profile_result.generation,
+            expected_profile_revision=profile.revision,
+            expected_current_profile_id=None,
+        )
         await asyncio.to_thread(
             _external_execute,
             database_path,
@@ -4010,8 +4763,17 @@ async def test_hostile_joined_codec_failure_is_bounded_without_context(
     secret = "secret-hostile-joined-codec"
 
     async with _opened_repository(database_path) as repository:
-        await repository.create_profile(_draft("Codec Joined"), profile_id=profile_id)
-        await repository.set_assignment(character_ref, profile_id)
+        created = await repository.create_profile(
+            _draft("Codec Joined"),
+            profile_id=profile_id,
+        )
+        await repository.set_assignment(
+            character_ref,
+            profile_id,
+            expected_generation=created.generation,
+            expected_profile_revision=created.value.revision,
+            expected_current_profile_id=None,
+        )
 
         def hostile_decode(_row: object) -> AssignedTTSProfileSnapshot:
             try:

--- a/Tests/TTS/test_profile_service.py
+++ b/Tests/TTS/test_profile_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import traceback
 from collections.abc import Callable, Coroutine, Iterable, Iterator, Sequence
 from dataclasses import FrozenInstanceError, fields
@@ -2700,6 +2701,28 @@ async def test_delete_rejects_stale_loaded_generation_before_repository_work() -
     assert repository.calls == []
     assert tts_service.capability_calls == []
     assert tts_service.revision_decisions == []
+
+
+@pytest.mark.parametrize(
+    ("method_name", "required_sections"),
+    (
+        ("set_assignment", ("Args:", "Returns:", "Raises:")),
+        ("detach_assignment", ("Args:", "Raises:")),
+    ),
+)
+def test_assignment_mutation_methods_document_their_public_contract(
+    method_name: str,
+    required_sections: tuple[str, ...],
+) -> None:
+    method = getattr(TTSProfileService, method_name)
+    docstring = inspect.getdoc(method)
+
+    assert docstring is not None
+    for parameter_name in inspect.signature(method).parameters:
+        if parameter_name != "self":
+            assert f"{parameter_name}:" in docstring
+    for section in required_sections:
+        assert section in docstring
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_profile_service.py
+++ b/Tests/TTS/test_profile_service.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import traceback
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Coroutine, Iterable, Iterator, Sequence
 from dataclasses import FrozenInstanceError, fields
 from datetime import UTC, datetime
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 from uuid import UUID
 
 import pytest
@@ -38,6 +38,8 @@ from tldw_chatbook.TTS.profile_service import (
     TTSProfileService,
 )
 from tldw_chatbook.TTS.profile_types import (
+    CharacterRef,
+    CharacterTTSAssignment,
     ProfileStoreResult,
     TTSGenerationProfile,
     TTSProfileDraft,
@@ -48,6 +50,7 @@ _CREATED_AT = datetime(2026, 7, 27, 12, tzinfo=UTC)
 _PROFILE_ID = UUID("11111111-1111-4111-8111-111111111111")
 _DUPLICATE_ID = UUID("22222222-2222-4222-8222-222222222222")
 _UNSET = object()
+_TaskResult = TypeVar("_TaskResult")
 
 
 def _profile(
@@ -116,6 +119,68 @@ def _forged_loaded_profile(
     return forged
 
 
+def _character_ref(
+    *,
+    source: str = "server",
+    authority_id: str = "server-user-v1:authority",
+    character_id: str = "character-a",
+) -> CharacterRef:
+    return CharacterRef(
+        source=source,  # type: ignore[arg-type]
+        authority_id=authority_id,
+        character_id=character_id,
+    )
+
+
+def _assignment(
+    *,
+    character_ref: CharacterRef | None = None,
+    profile_id: UUID = _PROFILE_ID,
+) -> CharacterTTSAssignment:
+    return CharacterTTSAssignment(
+        character_ref=_character_ref() if character_ref is None else character_ref,
+        profile_id=profile_id,
+    )
+
+
+def _forged_character_ref(
+    character_ref: CharacterRef,
+    **updates: object,
+) -> CharacterRef:
+    """Build an adversarial exact character reference without revalidation."""
+
+    forged = object.__new__(CharacterRef)
+    for reference_field in fields(CharacterRef):
+        object.__setattr__(
+            forged,
+            reference_field.name,
+            updates.get(
+                reference_field.name,
+                getattr(character_ref, reference_field.name),
+            ),
+        )
+    return forged
+
+
+def _forged_assignment(
+    assignment: CharacterTTSAssignment,
+    **updates: object,
+) -> CharacterTTSAssignment:
+    """Build an adversarial exact assignment without revalidation."""
+
+    forged = object.__new__(CharacterTTSAssignment)
+    for assignment_field in fields(CharacterTTSAssignment):
+        object.__setattr__(
+            forged,
+            assignment_field.name,
+            updates.get(
+                assignment_field.name,
+                getattr(assignment, assignment_field.name),
+            ),
+        )
+    return forged
+
+
 def _forged_page_snapshot(
     *,
     repository_generation: object,
@@ -169,6 +234,34 @@ class _AlwaysEqualStr(str):
         return False
 
     __hash__ = str.__hash__
+
+
+def _manufactured_equal_character_ref(
+    character_ref: CharacterRef,
+) -> CharacterRef:
+    hostile_ref = _forged_character_ref(
+        character_ref,
+        authority_id=_AlwaysEqualStr("different-authority"),
+        character_id=_AlwaysEqualStr("different-character"),
+    )
+    assert type(hostile_ref) is CharacterRef
+    assert hostile_ref == character_ref
+    assert str(hostile_ref.authority_id) == "different-authority"
+    assert str(hostile_ref.character_id) == "different-character"
+    return hostile_ref
+
+
+def _manufactured_equal_assignment(
+    assignment: CharacterTTSAssignment,
+) -> CharacterTTSAssignment:
+    hostile_assignment = _forged_assignment(
+        assignment,
+        character_ref=_manufactured_equal_character_ref(assignment.character_ref),
+    )
+    assert type(hostile_assignment) is CharacterTTSAssignment
+    assert type(hostile_assignment.character_ref) is CharacterRef
+    assert hostile_assignment == assignment
+    return hostile_assignment
 
 
 class _GenerationAdvancingMapping(dict[str, Any]):
@@ -318,6 +411,8 @@ class _FakeRepository:
         self.create_error: BaseException | None = None
         self.update_error: BaseException | None = None
         self.delete_error: BaseException | None = None
+        self.set_error: BaseException | None = None
+        self.remove_error: BaseException | None = None
         self.count_value = 0
         self.count_generation: int | None = None
         self.advance_generation_during_count = False
@@ -327,8 +422,12 @@ class _FakeRepository:
         self.create_result: object = _UNSET
         self.update_result: object = _UNSET
         self.delete_result: object = _UNSET
+        self.set_result: object = _UNSET
+        self.remove_result: object = _UNSET
         self.count_result: object = _UNSET
         self.create_boundary: _AsyncBoundary | None = None
+        self.set_boundary: _AsyncBoundary | None = None
+        self.remove_boundary: _AsyncBoundary | None = None
 
     def _record_coordinator_state(self) -> None:
         self.coordinator_active_at_repository_calls.append(
@@ -460,6 +559,73 @@ class _FakeRepository:
             self.generation += 1
         return result
 
+    async def set_assignment(
+        self,
+        character_ref: CharacterRef,
+        profile_id: UUID,
+        *,
+        expected_generation: int,
+        expected_profile_revision: int,
+        expected_current_profile_id: UUID | None,
+    ) -> ProfileStoreResult[CharacterTTSAssignment]:
+        self._record_coordinator_state()
+        self.calls.append(
+            (
+                "set_assignment",
+                (
+                    character_ref,
+                    profile_id,
+                    expected_generation,
+                    expected_profile_revision,
+                    expected_current_profile_id,
+                    self.generation,
+                ),
+            )
+        )
+        if self.set_boundary is not None:
+            await self.set_boundary.wait()
+        if self.set_error is not None:
+            raise self.set_error
+        if self.set_result is not _UNSET:
+            return cast(
+                ProfileStoreResult[CharacterTTSAssignment],
+                self.set_result,
+            )
+        return ProfileStoreResult(
+            generation=self.generation,
+            value=CharacterTTSAssignment(
+                character_ref=character_ref,
+                profile_id=profile_id,
+            ),
+        )
+
+    async def remove_assignment(
+        self,
+        character_ref: CharacterRef,
+        *,
+        expected_generation: int,
+        expected_profile_id: UUID,
+    ) -> ProfileStoreResult[None]:
+        self._record_coordinator_state()
+        self.calls.append(
+            (
+                "remove_assignment",
+                (
+                    character_ref,
+                    expected_generation,
+                    expected_profile_id,
+                    self.generation,
+                ),
+            )
+        )
+        if self.remove_boundary is not None:
+            await self.remove_boundary.wait()
+        if self.remove_error is not None:
+            raise self.remove_error
+        if self.remove_result is not _UNSET:
+            return cast(ProfileStoreResult[None], self.remove_result)
+        return ProfileStoreResult(generation=self.generation, value=None)
+
 
 class _AsyncBoundary:
     def __init__(self) -> None:
@@ -473,6 +639,52 @@ class _AsyncBoundary:
             await self.release.wait()
         finally:
             self.settled.set()
+
+
+async def _wait_for_boundary_or_task_failure(
+    boundary: _AsyncBoundary,
+    operation: asyncio.Task[Any],
+) -> None:
+    entered = asyncio.create_task(boundary.entered.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            (entered, operation),
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if operation in done:
+            await operation
+        await entered
+    finally:
+        if not entered.done():
+            entered.cancel()
+        await asyncio.gather(entered, return_exceptions=True)
+
+
+async def _start_at_boundary(
+    operation: Coroutine[Any, Any, _TaskResult],
+    boundary: _AsyncBoundary,
+) -> asyncio.Task[_TaskResult]:
+    task = asyncio.create_task(operation)
+    try:
+        async with asyncio.timeout(1):
+            await _wait_for_boundary_or_task_failure(boundary, task)
+    except BaseException:
+        boundary.release.set()
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        raise
+    return task
+
+
+async def _settle_boundary_task(
+    boundary: _AsyncBoundary,
+    task: asyncio.Task[Any],
+) -> None:
+    boundary.release.set()
+    if not task.done():
+        task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
 
 
 class _HostileResult:
@@ -2486,6 +2698,741 @@ async def test_delete_rejects_stale_loaded_generation_before_repository_work() -
 
     assert caught.value.code == "stale"
     assert repository.calls == []
+    assert tts_service.capability_calls == []
+    assert tts_service.revision_decisions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_current_profile_id",
+    (None, _DUPLICATE_ID),
+    ids=("unassigned", "replacement"),
+)
+async def test_set_assignment_uses_fresh_loaded_authority_and_exact_expected_state(
+    expected_current_profile_id: UUID | None,
+) -> None:
+    voice = TTSVoiceDiscoveryResult(
+        provider_id="audio_cpp",
+        model_id="model-a",
+        catalog_revision=9,
+        voices=("voice-a",),
+        state="complete",
+    )
+    repository = _FakeRepository()
+    tts_service = _FakeTTSService(
+        _capability_snapshot(
+            models=(_model("model-a"),),
+            voice_results={"model-a": voice},
+        )
+    )
+    service, repository, tts_service = _service(
+        repository=repository,
+        tts_service=tts_service,
+    )
+    character_ref = _character_ref()
+    loaded = LoadedTTSProfile(
+        repository_generation=repository.generation,
+        profile=_profile(voice_id="voice-a", revision=4),
+    )
+    persisted = _assignment(
+        character_ref=character_ref,
+        profile_id=loaded.profile.profile_id,
+    )
+    repository.set_result = ProfileStoreResult(
+        generation=loaded.repository_generation,
+        value=persisted,
+    )
+    page = TTSProfilePageSnapshot(
+        repository_generation=loaded.repository_generation,
+        profiles=(loaded.profile,),
+        total=1,
+    )
+    observed = await service.observe_availability(page)
+    assert observed.profiles[0].state == "available"
+
+    expected_current = (
+        None
+        if expected_current_profile_id is None
+        else _assignment(
+            character_ref=character_ref,
+            profile_id=expected_current_profile_id,
+        )
+    )
+
+    assigned = await service.set_assignment(
+        character_ref,
+        loaded,
+        expected_current,
+    )
+
+    assert assigned == persisted
+    assert type(assigned) is CharacterTTSAssignment
+    assert assigned is not persisted
+    assert assigned.character_ref is not persisted.character_ref
+    assert len(repository.calls) == 1
+    call_name, call_value = repository.calls[0]
+    assert call_name == "set_assignment"
+    (
+        forwarded_ref,
+        forwarded_profile_id,
+        forwarded_generation,
+        forwarded_revision,
+        forwarded_current_profile_id,
+        generation_at_call,
+    ) = call_value  # type: ignore[misc]
+    assert type(forwarded_ref) is CharacterRef
+    assert forwarded_ref == character_ref
+    assert forwarded_ref is not character_ref
+    assert forwarded_profile_id == loaded.profile.profile_id
+    assert forwarded_generation == loaded.repository_generation
+    assert forwarded_revision == loaded.profile.revision
+    assert forwarded_current_profile_id == expected_current_profile_id
+    assert generation_at_call == loaded.repository_generation
+    assert repository.coordinator_active_at_repository_calls == [False]
+
+    assert tts_service.capability_calls == [
+        ("audio_cpp", ("model-a",)),
+        ("audio_cpp", ("model-a",)),
+    ]
+    assert tts_service.revision_decisions == [("audio_cpp", 3)] * 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    (
+        "character-ref-subclass",
+        "character-ref-exploding-field",
+        "character-ref-impostor",
+        "character-ref-manufactured-equality",
+        "loaded-subclass",
+        "loaded-malformed-profile",
+        "loaded-impostor",
+        "expected-current-subclass",
+        "expected-current-malformed-profile-id",
+        "expected-current-impostor",
+        "expected-current-other-character",
+        "expected-current-manufactured-equality",
+    ),
+)
+async def test_set_assignment_rejects_nonexact_domain_inputs_before_work(
+    case: str,
+) -> None:
+    class CharacterRefSubclass(CharacterRef):
+        pass
+
+    class LoadedProfileSubclass(LoadedTTSProfile):
+        pass
+
+    class AssignmentSubclass(CharacterTTSAssignment):
+        pass
+
+    service, repository, tts_service = _service()
+    character_ref = _character_ref()
+    loaded = LoadedTTSProfile(
+        repository_generation=repository.generation,
+        profile=_profile(),
+    )
+    expected_current = _assignment(
+        character_ref=character_ref,
+        profile_id=_DUPLICATE_ID,
+    )
+    secret = "https://user:credential@example.test/private/path"
+    candidate_ref: object = character_ref
+    candidate_loaded: object = loaded
+    candidate_current: object = expected_current
+
+    if case == "character-ref-subclass":
+        candidate_ref = CharacterRefSubclass(
+            source="server",
+            authority_id="server-user-v1:authority",
+            character_id="character-a",
+        )
+    elif case == "character-ref-exploding-field":
+        candidate_ref = _forged_character_ref(
+            character_ref,
+            authority_id=_ExplodingStr(secret),
+        )
+    elif case == "character-ref-impostor":
+        candidate_ref = object()
+    elif case == "character-ref-manufactured-equality":
+        candidate_ref = _manufactured_equal_character_ref(character_ref)
+    elif case == "loaded-subclass":
+        candidate_loaded = LoadedProfileSubclass(
+            repository_generation=repository.generation,
+            profile=_profile(),
+        )
+    elif case == "loaded-malformed-profile":
+        candidate_loaded = _forged_loaded_profile(
+            _forged_profile(
+                _profile(),
+                model_id=_ExplodingStr(secret),
+            ),
+            repository_generation=repository.generation,
+        )
+    elif case == "loaded-impostor":
+        candidate_loaded = object()
+    elif case == "expected-current-subclass":
+        candidate_current = AssignmentSubclass(
+            character_ref=character_ref,
+            profile_id=_DUPLICATE_ID,
+        )
+    elif case == "expected-current-malformed-profile-id":
+        candidate_current = _forged_assignment(expected_current, profile_id=secret)
+    elif case == "expected-current-impostor":
+        candidate_current = object()
+    elif case == "expected-current-other-character":
+        candidate_current = _assignment(
+            character_ref=_character_ref(character_id="different-character"),
+            profile_id=_DUPLICATE_ID,
+        )
+    else:
+        assert case == "expected-current-manufactured-equality"
+        candidate_current = _manufactured_equal_assignment(expected_current)
+
+    with pytest.raises(ProfileValidationError) as caught:
+        await service.set_assignment(
+            cast(CharacterRef, candidate_ref),
+            cast(LoadedTTSProfile, candidate_loaded),
+            cast(CharacterTTSAssignment, candidate_current),
+        )
+
+    expected_code = "profiles" if case.startswith("loaded-") else "assignment"
+    assert caught.value.code == expected_code
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert repository.calls == []
+    assert tts_service.capability_calls == []
+    assert tts_service.revision_decisions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("snapshot", "stale_configuration", "expected_code"),
+    (
+        (_capability_snapshot(models=()), False, "profile_unavailable"),
+        (
+            _capability_snapshot(
+                state="unverified",
+                models=(_model("model-a"),),
+            ),
+            False,
+            "profile_unverified",
+        ),
+        (
+            TTSNativeCapabilitySnapshot(
+                provider_id="audio_cpp",
+                configuration_revision=3,
+                state="unverified",
+                catalog=None,
+                voice_results={},
+            ),
+            False,
+            "profile_unverified",
+        ),
+        (_HostileResult(), False, "operation_failed"),
+        (
+            _capability_snapshot(models=(_model("model-a"),)),
+            True,
+            "stale_configuration",
+        ),
+    ),
+    ids=(
+        "model-unavailable",
+        "catalog-unverified",
+        "missing-catalog-authority",
+        "malformed-capability-success",
+        "stale-configuration",
+    ),
+)
+async def test_set_assignment_rejects_non_authoritative_capability_outcomes(
+    snapshot: object,
+    stale_configuration: bool,
+    expected_code: str,
+) -> None:
+    tts_service = _FakeTTSService(
+        cast(TTSNativeCapabilitySnapshot, snapshot),
+    )
+    tts_service.stale_decision = stale_configuration
+    service, repository, tts_service = _service(tts_service=tts_service)
+    loaded = LoadedTTSProfile(
+        repository_generation=repository.generation,
+        profile=_profile(revision=5),
+    )
+
+    with pytest.raises(ProfileServiceError) as caught:
+        await service.set_assignment(_character_ref(), loaded, None)
+
+    _assert_safe_service_error(
+        caught.value,
+        expected_code,
+        "credential",
+        "example.test",
+        "/private/path",
+        "submitted text",
+    )
+    assert tts_service.capability_calls == [("audio_cpp", ())]
+    assert repository.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("race", "expected_code"),
+    (
+        ("configuration", "stale_configuration"),
+        ("catalog", "profile_unverified"),
+    ),
+)
+async def test_set_assignment_fails_closed_at_capability_authority_barriers(
+    race: str,
+    expected_code: str,
+) -> None:
+    boundary = _AsyncBoundary()
+    tts_service = _FakeTTSService(_capability_snapshot(models=(_model("model-a"),)))
+    if race == "configuration":
+        tts_service.revision_boundary = boundary
+    else:
+        tts_service.capability_boundary = boundary
+    service, repository, tts_service = _service(tts_service=tts_service)
+    loaded = LoadedTTSProfile(
+        repository_generation=repository.generation,
+        profile=_profile(),
+    )
+    operation = await _start_at_boundary(
+        service.set_assignment(_character_ref(), loaded, None),
+        boundary,
+    )
+    try:
+        if race == "configuration":
+            tts_service.revision += 1
+        else:
+            tts_service.snapshot = _capability_snapshot(
+                state="unverified",
+                models=(_model("model-a"),),
+                catalog_revision=10,
+            )
+        boundary.release.set()
+
+        with pytest.raises(ProfileServiceError) as caught:
+            await operation
+    finally:
+        await _settle_boundary_task(boundary, operation)
+
+    _assert_safe_service_error(caught.value, expected_code)
+    assert boundary.settled.is_set()
+    assert repository.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("race_stage", ("before", "capability", "repository"))
+async def test_set_assignment_rechecks_generation_across_lifecycle_barriers(
+    race_stage: str,
+) -> None:
+    boundary = _AsyncBoundary()
+    repository = _FakeRepository()
+    tts_service = _FakeTTSService(_capability_snapshot(models=(_model("model-a"),)))
+    character_ref = _character_ref()
+    loaded = LoadedTTSProfile(
+        repository_generation=repository.generation,
+        profile=_profile(),
+    )
+    repository.set_result = ProfileStoreResult(
+        generation=loaded.repository_generation,
+        value=_assignment(
+            character_ref=character_ref,
+            profile_id=loaded.profile.profile_id,
+        ),
+    )
+    if race_stage == "capability":
+        tts_service.capability_boundary = boundary
+    elif race_stage == "repository":
+        repository.set_boundary = boundary
+    service, repository, tts_service = _service(
+        repository=repository,
+        tts_service=tts_service,
+    )
+    if race_stage == "before":
+        repository.generation += 1
+
+        with pytest.raises(ProfileRepositoryError) as caught:
+            await service.set_assignment(character_ref, loaded, None)
+
+        assert caught.value.code == "stale"
+        assert repository.calls == []
+        assert tts_service.capability_calls == []
+        return
+
+    operation = await _start_at_boundary(
+        service.set_assignment(character_ref, loaded, None),
+        boundary,
+    )
+    try:
+        repository.generation += 1
+        boundary.release.set()
+
+        with pytest.raises(ProfileRepositoryError) as caught:
+            await operation
+    finally:
+        await _settle_boundary_task(boundary, operation)
+
+    assert type(caught.value) is ProfileRepositoryError
+    assert caught.value.code == "stale"
+    assert boundary.settled.is_set()
+    expected_calls = [] if race_stage == "capability" else ["set_assignment"]
+    assert [name for name, _value in repository.calls] == expected_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_code", ("conflict", "stale"))
+async def test_set_assignment_preserves_bounded_repository_race_errors(
+    error_code: str,
+) -> None:
+    boundary = _AsyncBoundary()
+    repository = _FakeRepository()
+    repository.set_boundary = boundary
+    tts_service = _FakeTTSService(_capability_snapshot(models=(_model("model-a"),)))
+    service, repository, _tts_service = _service(
+        repository=repository,
+        tts_service=tts_service,
+    )
+    loaded = LoadedTTSProfile(
+        repository_generation=repository.generation,
+        profile=_profile(),
+    )
+    operation = await _start_at_boundary(
+        service.set_assignment(_character_ref(), loaded, None),
+        boundary,
+    )
+    try:
+        repository.set_error = ProfileRepositoryError(error_code)
+        boundary.release.set()
+
+        with pytest.raises(ProfileRepositoryError) as caught:
+            await operation
+    finally:
+        await _settle_boundary_task(boundary, operation)
+
+    assert type(caught.value) is ProfileRepositoryError
+    assert caught.value.code == error_code
+    assert str(caught.value) == f"TTS profile repository failed: {error_code}"
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert boundary.settled.is_set()
+    assert [name for name, _value in repository.calls] == ["set_assignment"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result_case",
+    (
+        "hostile-envelope",
+        "wrong-generation",
+        "assignment-subclass",
+        "assignment-exploding-nested-ref",
+        "assignment-other-character",
+        "assignment-other-profile",
+        "assignment-manufactured-equality",
+    ),
+)
+async def test_set_assignment_rejects_nonexact_repository_success(
+    result_case: str,
+) -> None:
+    class AssignmentSubclass(CharacterTTSAssignment):
+        pass
+
+    repository = _FakeRepository()
+    character_ref = _character_ref()
+    loaded = LoadedTTSProfile(
+        repository_generation=repository.generation,
+        profile=_profile(),
+    )
+    persisted: object = _assignment(
+        character_ref=character_ref,
+        profile_id=loaded.profile.profile_id,
+    )
+    if result_case == "hostile-envelope":
+        invalid_result: object = _HostileResult()
+    elif result_case == "wrong-generation":
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation + 1,
+            value=persisted,
+        )
+    elif result_case == "assignment-subclass":
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation,
+            value=AssignmentSubclass(
+                character_ref=character_ref,
+                profile_id=loaded.profile.profile_id,
+            ),
+        )
+    elif result_case == "assignment-exploding-nested-ref":
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation,
+            value=_forged_assignment(
+                cast(CharacterTTSAssignment, persisted),
+                character_ref=_forged_character_ref(
+                    character_ref,
+                    authority_id=_ExplodingStr(
+                        "https://user:credential@example.test/private/path"
+                    ),
+                ),
+            ),
+        )
+    elif result_case == "assignment-other-character":
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation,
+            value=_assignment(
+                character_ref=_character_ref(character_id="different-character"),
+                profile_id=loaded.profile.profile_id,
+            ),
+        )
+    elif result_case == "assignment-other-profile":
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation,
+            value=_assignment(
+                character_ref=character_ref,
+                profile_id=_DUPLICATE_ID,
+            ),
+        )
+    else:
+        assert result_case == "assignment-manufactured-equality"
+        hostile_assignment = _manufactured_equal_assignment(
+            cast(CharacterTTSAssignment, persisted),
+        )
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation,
+            value=hostile_assignment,
+        )
+    service, repository, _tts_service = _service(
+        repository=repository,
+        tts_service=_FakeTTSService(_capability_snapshot(models=(_model("model-a"),))),
+    )
+    repository.set_result = invalid_result
+
+    with pytest.raises(ProfileServiceError) as caught:
+        await service.set_assignment(character_ref, loaded, None)
+
+    _assert_safe_service_error(
+        caught.value,
+        "operation_failed",
+        "credential",
+        "example.test",
+        "/private/path",
+        "submitted text",
+        character_ref.authority_id,
+        character_ref.character_id,
+        "different-authority",
+        "different-character",
+    )
+    assert [name for name, _value in repository.calls] == ["set_assignment"]
+
+
+@pytest.mark.asyncio
+async def test_detach_assignment_forwards_exact_state_without_capability_work() -> None:
+    service, repository, tts_service = _service()
+    assignment = _assignment(profile_id=_DUPLICATE_ID)
+
+    result = await service.detach_assignment(
+        assignment,
+        repository.generation,
+    )
+
+    assert result is None
+    assert len(repository.calls) == 1
+    call_name, call_value = repository.calls[0]
+    assert call_name == "remove_assignment"
+    forwarded_ref, forwarded_generation, forwarded_profile_id, generation_at_call = (
+        call_value  # type: ignore[misc]
+    )
+    assert type(forwarded_ref) is CharacterRef
+    assert forwarded_ref == assignment.character_ref
+    assert forwarded_ref is not assignment.character_ref
+    assert forwarded_generation == repository.generation
+    assert forwarded_profile_id == assignment.profile_id
+    assert generation_at_call == repository.generation
+    assert tts_service.capability_calls == []
+    assert tts_service.revision_decisions == []
+    assert tts_service.revision_reads == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    (
+        "assignment-subclass",
+        "assignment-exploding-nested-ref",
+        "assignment-impostor",
+        "generation-bool",
+        "generation-negative",
+        "generation-subclass",
+        "generation-stale",
+    ),
+)
+async def test_detach_assignment_rejects_nonexact_or_stale_caller_state(
+    case: str,
+) -> None:
+    class AssignmentSubclass(CharacterTTSAssignment):
+        pass
+
+    class GenerationSubclass(int):
+        pass
+
+    service, repository, tts_service = _service()
+    assignment = _assignment()
+    secret = "https://user:credential@example.test/private/path"
+    candidate: object = assignment
+    generation: object = repository.generation
+    if case == "assignment-subclass":
+        candidate = AssignmentSubclass(
+            character_ref=assignment.character_ref,
+            profile_id=assignment.profile_id,
+        )
+    elif case == "assignment-exploding-nested-ref":
+        candidate = _forged_assignment(
+            assignment,
+            character_ref=_forged_character_ref(
+                assignment.character_ref,
+                character_id=_ExplodingStr(secret),
+            ),
+        )
+    elif case == "assignment-impostor":
+        candidate = object()
+    elif case == "generation-bool":
+        generation = True
+    elif case == "generation-negative":
+        generation = -1
+    elif case == "generation-subclass":
+        generation = GenerationSubclass(repository.generation)
+    else:
+        assert case == "generation-stale"
+        generation = repository.generation - 1
+
+    expected_error = (
+        ProfileRepositoryError if case == "generation-stale" else ProfileValidationError
+    )
+    with pytest.raises(expected_error) as caught:
+        await service.detach_assignment(
+            cast(CharacterTTSAssignment, candidate),
+            cast(int, generation),
+        )
+
+    expected_code = (
+        "stale"
+        if case == "generation-stale"
+        else "generation"
+        if case.startswith("generation-")
+        else "assignment"
+    )
+    assert caught.value.code == expected_code  # type: ignore[attr-defined]
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    assert repository.calls == []
+    assert tts_service.capability_calls == []
+    assert tts_service.revision_decisions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_code",
+    ("conflict", "stale"),
+)
+async def test_detach_assignment_preserves_bounded_repository_errors(
+    error_code: str,
+) -> None:
+    repository = _FakeRepository()
+    service, repository, tts_service = _service(repository=repository)
+    repository.remove_error = ProfileRepositoryError(error_code)
+
+    with pytest.raises(ProfileRepositoryError) as caught:
+        await service.detach_assignment(
+            _assignment(),
+            repository.generation,
+        )
+
+    assert type(caught.value) is ProfileRepositoryError
+    assert caught.value.code == error_code
+    assert str(caught.value) == f"TTS profile repository failed: {error_code}"
+    assert [name for name, _value in repository.calls] == ["remove_assignment"]
+    assert tts_service.capability_calls == []
+    assert tts_service.revision_decisions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result_case",
+    ("hostile-envelope", "wrong-generation", "unexpected-value"),
+)
+async def test_detach_assignment_rejects_nonexact_repository_success(
+    result_case: str,
+) -> None:
+    repository = _FakeRepository()
+    service, repository, tts_service = _service(repository=repository)
+    assignment = _assignment()
+    if result_case == "hostile-envelope":
+        invalid_result: object = _HostileResult()
+    elif result_case == "wrong-generation":
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation + 1,
+            value=None,
+        )
+    else:
+        assert result_case == "unexpected-value"
+        invalid_result = ProfileStoreResult(
+            generation=repository.generation,
+            value=_HostileResult(),
+        )
+    repository.remove_result = invalid_result
+
+    with pytest.raises(ProfileServiceError) as caught:
+        await service.detach_assignment(
+            assignment,
+            repository.generation,
+        )
+
+    _assert_safe_service_error(
+        caught.value,
+        "operation_failed",
+        "credential",
+        "example.test",
+        "/private/path",
+        "submitted text",
+        assignment.character_ref.authority_id,
+        assignment.character_ref.character_id,
+    )
+    assert [name for name, _value in repository.calls] == ["remove_assignment"]
+    assert tts_service.capability_calls == []
+    assert tts_service.revision_decisions == []
+
+
+@pytest.mark.asyncio
+async def test_detach_assignment_rechecks_generation_after_repository_result() -> None:
+    boundary = _AsyncBoundary()
+    repository = _FakeRepository()
+    repository.remove_boundary = boundary
+    repository.remove_result = ProfileStoreResult(
+        generation=repository.generation,
+        value=None,
+    )
+    service, repository, tts_service = _service(repository=repository)
+    operation = await _start_at_boundary(
+        service.detach_assignment(
+            _assignment(),
+            repository.generation,
+        ),
+        boundary,
+    )
+    try:
+        repository.generation += 1
+        boundary.release.set()
+
+        with pytest.raises(ProfileRepositoryError) as caught:
+            await operation
+    finally:
+        await _settle_boundary_task(boundary, operation)
+
+    assert caught.value.code == "stale"
+    assert boundary.settled.is_set()
+    assert [name for name, _value in repository.calls] == ["remove_assignment"]
     assert tts_service.capability_calls == []
     assert tts_service.revision_decisions == []
 

--- a/Tests/TTS/test_tts_app_ownership.py
+++ b/Tests/TTS/test_tts_app_ownership.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, Mock
+from uuid import UUID
 
 import pytest
 
@@ -715,6 +716,34 @@ def test_profile_service_owns_only_existing_app_dependencies() -> None:
             raise AssertionError("not used")
 
         async def assignment_count(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("not used")
+
+        async def set_assignment(
+            self,
+            character_ref: tts_package.CharacterRef,
+            profile_id: UUID,
+            *,
+            expected_generation: int,
+            expected_profile_revision: int,
+            expected_current_profile_id: UUID | None,
+        ) -> tts_package.ProfileStoreResult[tts_package.CharacterTTSAssignment]:
+            del (
+                character_ref,
+                profile_id,
+                expected_generation,
+                expected_profile_revision,
+                expected_current_profile_id,
+            )
+            raise AssertionError("not used")
+
+        async def remove_assignment(
+            self,
+            character_ref: tts_package.CharacterRef,
+            *,
+            expected_generation: int,
+            expected_profile_id: UUID,
+        ) -> tts_package.ProfileStoreResult[None]:
+            del character_ref, expected_generation, expected_profile_id
             raise AssertionError("not used")
 
     class FocusedTTSService:

--- a/Tests/TTS/test_tts_profile_capabilities.py
+++ b/Tests/TTS/test_tts_profile_capabilities.py
@@ -40,6 +40,9 @@ from tldw_chatbook.TTS.profile_service import (
     TTSProfileService,
 )
 from tldw_chatbook.TTS.profile_types import (
+    CharacterRef,
+    CharacterTTSAssignment,
+    ProfileStoreResult,
     TTSGenerationProfile,
     TTSProfileDraft,
 )
@@ -321,6 +324,34 @@ class _AvailabilityRepository:
 
     async def assignment_count(self, *_args: Any, **_kwargs: Any) -> Any:
         raise AssertionError("availability must not count assignments")
+
+    async def set_assignment(
+        self,
+        character_ref: CharacterRef,
+        profile_id: UUID,
+        *,
+        expected_generation: int,
+        expected_profile_revision: int,
+        expected_current_profile_id: UUID | None,
+    ) -> ProfileStoreResult[CharacterTTSAssignment]:
+        del (
+            character_ref,
+            profile_id,
+            expected_generation,
+            expected_profile_revision,
+            expected_current_profile_id,
+        )
+        raise AssertionError("not used")
+
+    async def remove_assignment(
+        self,
+        character_ref: CharacterRef,
+        *,
+        expected_generation: int,
+        expected_profile_id: UUID,
+    ) -> ProfileStoreResult[None]:
+        del character_ref, expected_generation, expected_profile_id
+        raise AssertionError("not used")
 
 
 def _availability_page(repository_generation: int) -> TTSProfilePageSnapshot:

--- a/backlog/tasks/task-617.4 - Add-exact-character-TTS-assignment-mutation-service.md
+++ b/backlog/tasks/task-617.4 - Add-exact-character-TTS-assignment-mutation-service.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-617.4
 title: Add exact character TTS assignment mutation service
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-31 00:58'
-updated_date: '2026-07-31 01:09'
+updated_date: '2026-07-31 03:39'
 labels:
   - tts
   - profiles
@@ -33,13 +33,13 @@ Complete TTS Slice 3A by exposing exact source-aware character assignment mutati
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A caller can set or replace one exact `CharacterRef` assignment using a caller-held `LoadedTTSProfile` and its repository generation.
-- [ ] #2 A set or replace request validates the exact loaded profile revision against a fresh authoritative capability observation before repository mutation.
-- [ ] #3 The repository's final transaction checks expected lifecycle generation, selected profile revision, and expected current assignment state before mutation.
-- [ ] #4 Detach uses the caller-held assignment generation and exact assigned profile ID; it is idempotent only when already absent and refuses to remove a replacement.
-- [ ] #5 Stale restore, profile edit, catalog movement, assignment races, missing authority, and malformed repository results fail closed with bounded errors and no partial mutation.
-- [ ] #6 Deterministic service and repository tests cover success, replacement, detach, lifecycle races, capability races, and compare-and-set conflicts.
-- [ ] #7 The task adds no assignment UI, speech resolver, automatic speech, Persona TTS, portability, Sync changes, or managed audio.cpp behavior.
+- [x] #1 A caller can set or replace one exact `CharacterRef` assignment using a caller-held `LoadedTTSProfile` and its repository generation.
+- [x] #2 A set or replace request validates the exact loaded profile revision against a fresh authoritative capability observation before repository mutation.
+- [x] #3 The repository's final transaction checks expected lifecycle generation, selected profile revision, and expected current assignment state before mutation.
+- [x] #4 Detach uses the caller-held assignment generation and exact assigned profile ID; it is idempotent only when already absent and refuses to remove a replacement.
+- [x] #5 Stale restore, profile edit, catalog movement, assignment races, missing authority, and malformed repository results fail closed with bounded errors and no partial mutation.
+- [x] #6 Deterministic service and repository tests cover success, replacement, detach, lifecycle races, capability races, and compare-and-set conflicts.
+- [x] #7 The task adds no assignment UI, speech resolver, automatic speech, Persona TTS, portability, Sync changes, or managed audio.cpp behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -58,11 +58,35 @@ Reason: ADR-037 already governs lifecycle generation profile revision expected-c
 Full plan: Docs/superpowers/plans/2026-07-31-tts-assignment-mutation-service.md
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Slice 3A on the existing profile repository and service boundary. The repository now rechecks caller-held lifecycle generation, selected profile revision, and expected current assignment inside the final transaction. The service validates exact immutable caller state, performs a fresh authoritative audio.cpp capability check before set/replace, and forwards exact compare-and-set expectations. Detach forwards the caller-held generation and assigned profile ID, succeeds when already absent, and refuses to remove a replacement.
+
+Files changed: `Docs/superpowers/plans/2026-07-31-tts-assignment-mutation-service.md`; `tldw_chatbook/TTS/profile_repository.py`; `tldw_chatbook/TTS/profile_service.py`; `Tests/TTS/test_profile_repository.py`; `Tests/TTS/test_profile_service.py`; `Tests/TTS/test_tts_profile_capabilities.py`; `Tests/TTS/test_tts_app_ownership.py`; `Docs/Development/TTS/TTS_MODULE_GUIDE.md`; and this Backlog task.
+
+Tradeoffs and exclusions: reused the existing lifecycle generation and repository transaction rather than adding an assignment revision column, second store, schema change, or additional lock. Capability admission precedes mutation, while repository transaction checks remain authoritative. This slice adds no assignment UI, speech resolver, automatic speech, Persona inheritance, portability, Sync behavior, or managed audio.cpp behavior. No implementation-scope deviation occurred; rebase, push, PR creation, and final whole-range review remain parent-owned closeout steps.
+
+ADR required: no. ADR-037 already governs the exact character identity and assignment compare-and-set boundary; the accepted design, ADR, plan, and developer guide remain linked.
+
+Independent review: repository RED contract tests, repository implementation, service RED contract tests, and service implementation were each independently checked for specification compliance and quality. Re-reviews found no unresolved Critical, Important, or Minor issue.
+
+Verification:
+- Task-critical union: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/TTS/test_profile_types.py Tests/TTS/test_profile_repository.py Tests/TTS/test_profile_repository_lifecycle.py Tests/TTS/test_profile_service.py Tests/TTS/test_tts_profile_capabilities.py Tests/TTS/test_tts_app_ownership.py Tests/TTS/test_console_speech_snapshot_admission.py Tests/TTS/test_console_audio_cpp_native.py -q` -> 672 passed, 4 warnings, 0 skipped, exit 0. Warnings were the existing RequestsDependencyWarning, two train-journey invalid-escape SyntaxWarnings, and the webrtcvad pkg_resources deprecation warning.
+- Broader union: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/TTS/test_profile_schema.py Tests/TTS/test_profile_store_lock.py Tests/TTS/test_profile_backup_integration.py Tests/UI/test_stts_profile_library.py -q` -> 292 passed, 10 failed, 1 warning, 0 skipped, exit 1. An untouched detached `origin/dev` at `1e0979c74` reproduced the identical 292 passed, 10 failed, 1 warning result, classifying all failures as an unchanged backup-integration baseline outside this slice. Failing nodes: `test_real_worker_cancellation_before_legacy_publication_leaves_no_artifact`; `test_real_manifest_stage_is_created_exclusively_in_worker_thread`; `test_real_manifest_replace_failure_cleans_stage_and_keeps_values_private`; `test_manifest_cleanup_control_flow_supersedes_ordinary_primary_error`; `test_manifest_cleanup_failure_does_not_mask_base_exception_or_expose_values`; `test_real_backup_all_same_clock_uses_distinct_timestamp_prefixed_directories`; `test_backup_all_awaits_profile_and_manifest_before_success`; `test_backup_all_records_only_legacy_entries_on_profile_partial_failure[unavailable]`; `test_backup_all_records_only_legacy_entries_on_profile_partial_failure[backup_failure]`; and `test_backup_all_worker_failure_is_private_and_never_reports_success[legacy]`.
+- Ruff check: exact task command -> All checks passed, exit 0.
+- Ruff format check: exact task command -> 4 files already formatted, exit 0.
+- Compile: exact `compileall -q` command -> exit 0.
+- Typing: exact mypy command -> Success: no issues found in 2 source files, exit 0.
+- Diff hygiene: `git diff --check origin/dev...HEAD` and `git diff --check` -> exit 0.
+- Scope audit before the documentation commit returned only approved plan, task, production, and test files; the only working-tree additions are the approved developer guide and task closeout.
+<!-- SECTION:NOTES:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 All acceptance criteria are checked and concise implementation notes record the delivered behavior and any plan deviations.
-- [ ] #2 Focused repository, service, lifecycle, capability, ownership, Console snapshot, and native audio.cpp regression tests pass.
-- [ ] #3 Task-scoped Ruff, formatting, compile, typing, and git diff checks pass or exact unchanged baselines are documented.
-- [ ] #4 ADR-037, the approved Slice 3A design, and the TTS developer guide remain current and linked.
-- [ ] #5 Independent review finds no unresolved Critical, Important, or Minor issue before the PR is merged.
+- [x] #1 All acceptance criteria are checked and concise implementation notes record the delivered behavior and any plan deviations.
+- [x] #2 Focused repository, service, lifecycle, capability, ownership, Console snapshot, and native audio.cpp regression tests pass.
+- [x] #3 Task-scoped Ruff, formatting, compile, typing, and git diff checks pass or exact unchanged baselines are documented.
+- [x] #4 ADR-037, the approved Slice 3A design, and the TTS developer guide remain current and linked.
+- [x] #5 Independent review finds no unresolved Critical, Important, or Minor issue before the PR is merged.
 <!-- DOD:END -->

--- a/backlog/tasks/task-617.4 - Add-exact-character-TTS-assignment-mutation-service.md
+++ b/backlog/tasks/task-617.4 - Add-exact-character-TTS-assignment-mutation-service.md
@@ -1,0 +1,68 @@
+---
+id: TASK-617.4
+title: Add exact character TTS assignment mutation service
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-31 00:58'
+updated_date: '2026-07-31 01:09'
+labels:
+  - tts
+  - profiles
+  - roleplay
+dependencies:
+  - TASK-617.2
+  - TASK-617.3
+  - TASK-763
+  - TASK-951
+references:
+  - >-
+    backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-07-28-tts-character-identity-persona-separation-design.md
+parent_task_id: TASK-617
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete TTS Slice 3A by exposing exact source-aware character assignment mutations over the existing profile service and repository so Slice 3B can add visible assignment and assigned-profile speech without weakening lifecycle or capability authority.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A caller can set or replace one exact `CharacterRef` assignment using a caller-held `LoadedTTSProfile` and its repository generation.
+- [ ] #2 A set or replace request validates the exact loaded profile revision against a fresh authoritative capability observation before repository mutation.
+- [ ] #3 The repository's final transaction checks expected lifecycle generation, selected profile revision, and expected current assignment state before mutation.
+- [ ] #4 Detach uses the caller-held assignment generation and exact assigned profile ID; it is idempotent only when already absent and refuses to remove a replacement.
+- [ ] #5 Stale restore, profile edit, catalog movement, assignment races, missing authority, and malformed repository results fail closed with bounded errors and no partial mutation.
+- [ ] #6 Deterministic service and repository tests cover success, replacement, detach, lifecycle races, capability races, and compare-and-set conflicts.
+- [ ] #7 The task adds no assignment UI, speech resolver, automatic speech, Persona TTS, portability, Sync changes, or managed audio.cpp behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md
+Reason: ADR-037 already governs lifecycle generation profile revision expected-current-assignment compare-and-set semantics and the Slice 3B deferrals; this task implements that accepted boundary without a schema or ownership change.
+
+1. Pin mandatory repository assignment expectations and transaction-boundary lifecycle races with failing tests.
+2. Implement transactional generation profile-revision expected-current-assignment and exact-detach checks.
+3. Pin profile-service capability ordering forwarded expectations stale-state handling and bounded failures with failing tests.
+4. Implement minimal exact set/replace and detach service operations over existing domain values.
+5. Update the developer guide run focused and broad verification complete TASK-617.4 request review rebase and open one PR.
+
+Full plan: Docs/superpowers/plans/2026-07-31-tts-assignment-mutation-service.md
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 All acceptance criteria are checked and concise implementation notes record the delivered behavior and any plan deviations.
+- [ ] #2 Focused repository, service, lifecycle, capability, ownership, Console snapshot, and native audio.cpp regression tests pass.
+- [ ] #3 Task-scoped Ruff, formatting, compile, typing, and git diff checks pass or exact unchanged baselines are documented.
+- [ ] #4 ADR-037, the approved Slice 3A design, and the TTS developer guide remain current and linked.
+- [ ] #5 Independent review finds no unresolved Critical, Important, or Minor issue before the PR is merged.
+<!-- DOD:END -->

--- a/tldw_chatbook/TTS/profile_repository.py
+++ b/tldw_chatbook/TTS/profile_repository.py
@@ -1414,58 +1414,91 @@ class TTSProfileRepository:
         self,
         character_ref: CharacterRef,
         profile_id: UUID,
+        *,
+        expected_generation: int,
+        expected_profile_revision: int,
+        expected_current_profile_id: UUID | None,
     ) -> ProfileStoreResult[CharacterTTSAssignment]:
         """Create or replace one exact authority-scoped assignment.
 
         Args:
             character_ref: Exact validated source, authority, and character.
             profile_id: Exact existing profile UUID.
+            expected_generation: Exact nonnegative lifecycle generation loaded
+                with the selected profile and current assignment.
+            expected_profile_revision: Exact positive revision of the selected
+                profile.
+            expected_current_profile_id: Exact currently assigned profile UUID,
+                or ``None`` when the character was observed as unassigned.
 
         Returns:
             The active generation and persisted assignment.
 
         Raises:
-            ProfileRepositoryError: If inputs, state, persistence, foreign-key
-                checks, row decoding, or SQLite access fail safely.
+            ProfileRepositoryError: If inputs, state, optimistic expectations,
+                persistence, foreign-key checks, row decoding, or SQLite
+                access fail safely.
             BaseException: A caller control-flow signal preserved by the
                 serialized operation lane.
         """
 
         validated_character_ref = _validate_character_ref(character_ref)
         validated_profile_id = _validate_exact_profile_id(profile_id)
+        validated_generation = _validate_expected_generation(expected_generation)
+        validated_profile_revision = _validate_expected_revision(
+            expected_profile_revision
+        )
+        validated_current_profile_id = _validate_optional_profile_id(
+            expected_current_profile_id
+        )
         return await self._submit_operation(
             lambda connection: self._worker_set_assignment(
                 connection,
                 validated_character_ref,
                 validated_profile_id,
-            )
+                validated_generation,
+                validated_profile_revision,
+                validated_current_profile_id,
+            ),
+            expected_generation=validated_generation,
         )
 
     async def remove_assignment(
         self,
         character_ref: CharacterRef,
+        *,
+        expected_generation: int,
+        expected_profile_id: UUID,
     ) -> ProfileStoreResult[None]:
         """Remove one exact authority-scoped assignment idempotently.
 
         Args:
             character_ref: Exact validated source, authority, and character.
+            expected_generation: Exact nonnegative lifecycle generation loaded
+                with the assignment.
+            expected_profile_id: Exact profile UUID observed on the assignment.
 
         Returns:
             The active generation paired with ``None``.
 
         Raises:
-            ProfileRepositoryError: If the input, state, persistence, or
-                SQLite access fails safely.
+            ProfileRepositoryError: If an input, state, optimistic expectation,
+                persistence, or SQLite access fails safely.
             BaseException: A caller control-flow signal preserved by the
                 serialized operation lane.
         """
 
         validated_character_ref = _validate_character_ref(character_ref)
+        validated_generation = _validate_expected_generation(expected_generation)
+        validated_profile_id = _validate_exact_profile_id(expected_profile_id)
         return await self._submit_operation(
             lambda connection: self._worker_remove_assignment(
                 connection,
                 validated_character_ref,
-            )
+                validated_generation,
+                validated_profile_id,
+            ),
+            expected_generation=validated_generation,
         )
 
     async def get_assigned_profile(
@@ -2733,18 +2766,35 @@ class TTSProfileRepository:
             immediate=False,
         )
 
+    def _worker_require_generation(self, expected_generation: int) -> None:
+        with self._state_lock:
+            state_error = self._worker_state_error_locked(expected_generation)
+        if state_error is not None:
+            raise _repository_error(state_error)
+
     def _worker_set_assignment(
         self,
         connection: sqlite3.Connection,
         character_ref: CharacterRef,
         profile_id: UUID,
+        expected_generation: int,
+        expected_profile_revision: int,
+        expected_current_profile_id: UUID | None,
     ) -> CharacterTTSAssignment:
         def set_exact() -> CharacterTTSAssignment:
-            self._worker_get_profile(connection, profile_id)
+            self._worker_require_generation(expected_generation)
+            selected_profile = self._worker_get_profile(connection, profile_id)
+            if selected_profile.revision != expected_profile_revision:
+                raise _repository_error("conflict")
             existing = self._worker_get_persisted_assignment(
                 connection,
                 character_ref,
             )
+            current_profile_id = (
+                None if existing is None else existing.assignment.profile_id
+            )
+            if current_profile_id != expected_current_profile_id:
+                raise _repository_error("conflict")
             assignment = CharacterTTSAssignment(
                 character_ref=character_ref,
                 profile_id=profile_id,
@@ -2809,20 +2859,40 @@ class TTSProfileRepository:
         self,
         connection: sqlite3.Connection,
         character_ref: CharacterRef,
+        expected_generation: int,
+        expected_profile_id: UUID,
     ) -> None:
         def remove_exact() -> None:
+            self._worker_require_generation(expected_generation)
+            existing = self._worker_get_persisted_assignment(
+                connection,
+                character_ref,
+            )
+            if existing is None:
+                return
+            if existing.assignment.profile_id != expected_profile_id:
+                raise _repository_error("conflict")
             cursor = connection.execute(
                 """
                 DELETE FROM character_tts_assignments
-                WHERE source = ? AND authority_id = ? AND character_id = ?
+                WHERE source = ?
+                    AND authority_id = ?
+                    AND character_id = ?
+                    AND profile_id = ?
                 """,
                 (
                     character_ref.source,
                     character_ref.authority_id,
                     character_ref.character_id,
+                    encode_uuid(expected_profile_id),
                 ),
             )
-            if cursor.rowcount not in (0, 1):
+            if cursor.rowcount != 1:
+                raise _repository_error("corrupt_data")
+            if (
+                self._worker_get_persisted_assignment(connection, character_ref)
+                is not None
+            ):
                 raise _repository_error("corrupt_data")
 
         self._worker_transaction(

--- a/tldw_chatbook/TTS/profile_service.py
+++ b/tldw_chatbook/TTS/profile_service.py
@@ -1023,7 +1023,28 @@ class TTSProfileService:
         loaded: LoadedTTSProfile,
         expected_current: CharacterTTSAssignment | None,
     ) -> CharacterTTSAssignment:
-        """Set one exact character assignment from caller-held profile state."""
+        """Set one exact character assignment from caller-held profile state.
+
+        Args:
+            character_ref: Exact source, authority, and character identity to
+                assign.
+            loaded: Exact profile and repository generation selected by the
+                caller.
+            expected_current: Exact assignment observed by the caller, or
+                ``None`` when the character was observed as unassigned.
+
+        Returns:
+            The exact persisted character assignment.
+
+        Raises:
+            ProfileValidationError: If caller-held values are invalid,
+                noncanonical, or refer to different characters.
+            ProfileRepositoryError: If repository state is stale or rejects
+                the compare-and-set mutation.
+            ProfileServiceError: If capability authority is unavailable or
+                unverified, configuration changes, or a collaborator returns
+                an invalid result.
+        """
 
         canonical_ref = _canonicalize_exact_character_ref(character_ref)
         profile = self._validate_loaded(loaded)
@@ -1089,7 +1110,21 @@ class TTSProfileService:
         assignment: CharacterTTSAssignment,
         repository_generation: int,
     ) -> None:
-        """Detach one exact caller-held assignment without capability work."""
+        """Detach one exact caller-held assignment without capability work.
+
+        Args:
+            assignment: Exact character and profile assignment observed by the
+                caller.
+            repository_generation: Exact repository lifecycle generation
+                observed with the assignment.
+
+        Raises:
+            ProfileValidationError: If caller-held values are invalid or
+                noncanonical.
+            ProfileRepositoryError: If repository state is stale or the
+                observed assignment has been replaced.
+            ProfileServiceError: If the repository returns an invalid result.
+        """
 
         canonical_assignment = _canonicalize_exact_assignment(assignment)
         expected_generation = _validate_nonnegative_integer(

--- a/tldw_chatbook/TTS/profile_service.py
+++ b/tldw_chatbook/TTS/profile_service.py
@@ -29,6 +29,8 @@ from tldw_chatbook.TTS.profile_errors import (
 from tldw_chatbook.TTS.profile_types import (
     AUDIO_CPP_PROFILE_RESPONSE_FORMAT,
     AUDIO_CPP_PROFILE_SPEED,
+    CharacterRef,
+    CharacterTTSAssignment,
     ProfileStoreResult,
     TTSGenerationProfile,
     TTSProfileDraft,
@@ -44,6 +46,8 @@ ProfileRecoveryAction: TypeAlias = Literal["none", "refresh", "edit"]
 
 _PROFILE_PROVIDER_ID = "audio_cpp"
 _PROFILE_PAGE_LIMIT = 50
+_CHARACTER_REF_TYPE: type[CharacterRef] = CharacterRef
+_CHARACTER_TTS_ASSIGNMENT_TYPE: type[CharacterTTSAssignment] = CharacterTTSAssignment
 _TTS_GENERATION_PROFILE_TYPE: type[TTSGenerationProfile] = TTSGenerationProfile
 _TTS_NATIVE_CAPABILITY_SNAPSHOT_TYPE: type[TTSNativeCapabilitySnapshot] = (
     TTSNativeCapabilitySnapshot
@@ -101,6 +105,24 @@ class _ProfileRepositoryProtocol(Protocol):
         self,
         profile_id: UUID,
     ) -> ProfileStoreResult[int]: ...
+
+    async def set_assignment(
+        self,
+        character_ref: CharacterRef,
+        profile_id: UUID,
+        *,
+        expected_generation: int,
+        expected_profile_revision: int,
+        expected_current_profile_id: UUID | None,
+    ) -> ProfileStoreResult[CharacterTTSAssignment]: ...
+
+    async def remove_assignment(
+        self,
+        character_ref: CharacterRef,
+        *,
+        expected_generation: int,
+        expected_profile_id: UUID,
+    ) -> ProfileStoreResult[None]: ...
 
 
 @runtime_checkable
@@ -219,6 +241,69 @@ def _matches_exact_canonical_value(value: object, canonical: object) -> bool:
             for actual, expected in zip(value_sequence, canonical, strict=True)
         )
     return value == canonical
+
+
+def _canonicalize_exact_character_ref(value: object) -> CharacterRef:
+    """Return a fresh exact character reference or fail closed."""
+
+    if type(value) is not _CHARACTER_REF_TYPE:
+        raise ProfileValidationError("assignment")
+    character_ref = cast(CharacterRef, value)
+    canonical: CharacterRef | None = None
+    valid = False
+    failed = False
+    try:
+        canonical = CharacterRef(
+            source=character_ref.source,
+            authority_id=character_ref.authority_id,
+            character_id=character_ref.character_id,
+        )
+        valid = all(
+            _matches_exact_canonical_value(source, expected)
+            for source, expected in (
+                (character_ref.source, canonical.source),
+                (character_ref.authority_id, canonical.authority_id),
+                (character_ref.character_id, canonical.character_id),
+            )
+        )
+    except Exception:  # noqa: BLE001 - hostile identity values fail closed
+        failed = True
+    if failed or not valid or canonical is None:
+        raise ProfileValidationError("assignment")
+    return canonical
+
+
+def _canonicalize_exact_assignment(value: object) -> CharacterTTSAssignment:
+    """Return a fresh exact character assignment or fail closed."""
+
+    if type(value) is not _CHARACTER_TTS_ASSIGNMENT_TYPE:
+        raise ProfileValidationError("assignment")
+    assignment = cast(CharacterTTSAssignment, value)
+    canonical: CharacterTTSAssignment | None = None
+    valid = False
+    failed = False
+    try:
+        character_ref = _canonicalize_exact_character_ref(assignment.character_ref)
+        profile_id = assignment.profile_id
+        if type(profile_id) is not UUID or type(profile_id.int) is not int:
+            raise TypeError
+        canonical_profile_id = UUID(int=profile_id.int)
+        canonical = CharacterTTSAssignment(
+            character_ref=character_ref,
+            profile_id=canonical_profile_id,
+        )
+        valid = (
+            _matches_exact_canonical_value(
+                assignment.character_ref,
+                canonical.character_ref,
+            )
+            and profile_id.int == canonical_profile_id.int
+        )
+    except Exception:  # noqa: BLE001 - hostile assignment values fail closed
+        failed = True
+    if failed or not valid or canonical is None:
+        raise ProfileValidationError("assignment")
+    return canonical
 
 
 def _canonicalize_exact_profile(value: object) -> TTSGenerationProfile:
@@ -932,6 +1017,109 @@ class TTSProfileService:
             raise ProfileValidationError("assignment_count")
         return value
 
+    async def set_assignment(
+        self,
+        character_ref: CharacterRef,
+        loaded: LoadedTTSProfile,
+        expected_current: CharacterTTSAssignment | None,
+    ) -> CharacterTTSAssignment:
+        """Set one exact character assignment from caller-held profile state."""
+
+        canonical_ref = _canonicalize_exact_character_ref(character_ref)
+        profile = self._validate_loaded(loaded)
+        expected_assignment = (
+            None
+            if expected_current is None
+            else _canonicalize_exact_assignment(expected_current)
+        )
+        if (
+            expected_assignment is not None
+            and expected_assignment.character_ref != canonical_ref
+        ):
+            raise ProfileValidationError("assignment")
+
+        repository_generation = loaded.repository_generation
+        self._require_repository_generation(repository_generation)
+        draft = TTSProfileDraft(
+            display_name=profile.display_name,
+            provider_id=profile.provider_id,
+            model_id=profile.model_id,
+            voice_id=profile.voice_id,
+            response_format=profile.response_format,
+            speed=profile.speed,
+            options=profile.options,
+        )
+        await self._require_authoritative_capability(draft)
+        self._require_repository_generation(repository_generation)
+
+        failed = False
+        result = None
+        try:
+            result = await self._repository.set_assignment(
+                canonical_ref,
+                profile.profile_id,
+                expected_generation=repository_generation,
+                expected_profile_revision=profile.revision,
+                expected_current_profile_id=(
+                    None
+                    if expected_assignment is None
+                    else expected_assignment.profile_id
+                ),
+            )
+        except (ProfileRepositoryError, ProfileValidationError):
+            raise
+        except Exception:  # noqa: BLE001 - hide unexpected repository detail
+            failed = True
+        if failed or result is None:
+            raise ProfileServiceError("operation_failed")
+        value = self._require_admitted_store_result(
+            result,
+            repository_generation,
+        )
+        assignment = self._require_assignment_mutation_result(
+            value,
+            canonical_ref,
+            profile.profile_id,
+        )
+        self._require_repository_generation(repository_generation)
+        return assignment
+
+    async def detach_assignment(
+        self,
+        assignment: CharacterTTSAssignment,
+        repository_generation: int,
+    ) -> None:
+        """Detach one exact caller-held assignment without capability work."""
+
+        canonical_assignment = _canonicalize_exact_assignment(assignment)
+        expected_generation = _validate_nonnegative_integer(
+            repository_generation,
+            "generation",
+        )
+        self._require_repository_generation(expected_generation)
+
+        failed = False
+        result = None
+        try:
+            result = await self._repository.remove_assignment(
+                canonical_assignment.character_ref,
+                expected_generation=expected_generation,
+                expected_profile_id=canonical_assignment.profile_id,
+            )
+        except (ProfileRepositoryError, ProfileValidationError):
+            raise
+        except Exception:  # noqa: BLE001 - hide unexpected repository detail
+            failed = True
+        if failed or result is None:
+            raise ProfileServiceError("operation_failed")
+        value = self._require_admitted_store_result(
+            result,
+            expected_generation,
+        )
+        if value is not None:
+            raise ProfileServiceError("operation_failed")
+        self._require_repository_generation(expected_generation)
+
     async def delete_profile(self, loaded: LoadedTTSProfile) -> None:
         """Delete one loaded profile while retaining repository protection."""
 
@@ -1067,6 +1255,27 @@ class TTSProfileService:
         if failed or not valid or profile is None:
             raise ProfileServiceError("operation_failed")
         return profile
+
+    @staticmethod
+    def _require_assignment_mutation_result(
+        value: object,
+        character_ref: CharacterRef,
+        profile_id: UUID,
+    ) -> CharacterTTSAssignment:
+        assignment: CharacterTTSAssignment | None = None
+        failed = False
+        valid = False
+        try:
+            assignment = _canonicalize_exact_assignment(value)
+            valid = (
+                assignment.character_ref == character_ref
+                and assignment.profile_id == profile_id
+            )
+        except Exception:  # noqa: BLE001 - hostile results fail closed
+            failed = True
+        if failed or not valid or assignment is None:
+            raise ProfileServiceError("operation_failed")
+        return assignment
 
     def _current_configuration_revision(self) -> int:
         failed = False


### PR DESCRIPTION
## Summary

- add mandatory repository compare-and-set fencing for exact character TTS assignment set, replacement, and detach
- add capability-authoritative TTSProfileService assignment mutations with lifecycle-generation checks and fail-closed result admission
- document the Slice 3A boundary and retain explicit deferrals for UI, resolution, automatic speech, Persona TTS, portability, Sync, and managed audio.cpp

## Verification

- task-critical TTS union: 672 passed, 4 existing warnings
- focused repository and service suites: passed
- Ruff check and format check: passed
- compileall and targeted mypy: passed
- git diff check and exact nine-file scope audit: passed
- independent whole-range review: no Critical, Important, or Minor findings

## Known baseline

- broader profile/UI gate: 292 passed, 10 backup-integration failures, 1 warning
- the same 10 failures reproduce unchanged on origin/dev at 1e0979c747090ce21aaa100f34888e7af4495f4e and are outside TASK-617.4

## Tracking

- TASK-617.4
- ADR-037 governs the accepted identity and mutation boundary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an exact character TTS assignment mutation with compare-and-set fencing and fail‑closed capability checks. Completes TASK-617.4 Slice 3A; no UI, speech resolver, or `audio.cpp` management changes.

- **New Features**
  - Added `set_assignment(character_ref, profile_id, *, expected_generation, expected_profile_revision, expected_current_profile_id)` to `TTSProfileService` and repository.
  - Validates authority with a fresh `audio.cpp` capability snapshot; repository enforces final transaction checks and rejects stale inputs.
  - Updated docs with the API and Slice 3A plan; tests pin the service/repository CAS contract and race fences.

- **Migration**
  - Callers must load the current assignment and profile, then pass `expected_generation`, `expected_profile_revision`, and `expected_current_profile_id` (or `None` when unassigned).
  - No changes to assignment UI, Persona TTS, Sync, or speech resolution.

<sup>Written for commit c741e9d108a492e9e139db50d696d7bc92e99d35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

