### PR TITLE
fix(settings): Theme recompose-storm app freeze + honest footer s/r hints (rescore P1 batch)

### DIFF
--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -188,8 +188,14 @@ async def test_library_registration_updates_the_screens_own_footer():
 @pytest.mark.asyncio
 async def test_settings_registration_updates_the_screens_own_footer():
     """task-264 review Important: Settings' s/r/t hints (previously rendered
-    by the retired Footer) must reach its own footer via registration."""
+    by the retired Footer) must reach its own footer via registration.
+
+    The hints are category-gated (rescore P1): the read-only Overview
+    default advertises none of them, so the check switches to a guided
+    draft category first.
+    """
     from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+    from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
 
     app_instance = _build_test_app()
     host = _DefaultScreenFooterHost(app_instance, SettingsScreen)
@@ -198,6 +204,15 @@ async def test_settings_registration_updates_the_screens_own_footer():
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
         screen = host.screen_stack[-1]
+        screen_footer = screen.query_one(AppFooterStatus)
+        for token in ("save category", "revert category", "test category"):
+            assert token not in screen_footer.shortcut_text
+        screen.active_category = SettingsCategoryId.PROVIDERS_MODELS.value
+        await pilot.pause()
+        screen._register_footer_shortcuts()
+        await pilot.pause()
+        # The category switch recomposes the screen, replacing the footer
+        # widget -- re-query rather than trusting the stale reference.
         screen_footer = screen.query_one(AppFooterStatus)
         for token in ("save category", "revert category", "test category"):
             assert token in screen_footer.shortcut_text

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -7658,3 +7658,36 @@ def test_footer_entries_testable_view_category_keeps_t_without_save_revert():
     assert "t" in keys
     assert "s" not in keys
     assert "r" not in keys
+
+
+@pytest.mark.asyncio
+async def test_theme_user_edit_does_not_remount_editor():
+    """A real color edit must keep the SAME editor instance mounted.
+
+    Qodo review of PR #1125: with theme_editor_modified as a recompose=True
+    reactive, the FIRST user edit posted ThemeModifiedStatus(True), the
+    screen recomposed, and the freshly-mounted editor discarded the
+    in-progress input -- then, storm-fix in place, the dirty flag stuck at
+    True with a clean editor. The dirty state must surface through targeted
+    refreshes instead (the InternalPromptsPanel.Modified idiom).
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-theme")
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#settings-theme-editor", timeout=8.0)
+        for _ in range(6):
+            await pilot.pause()
+        editor = screen.query_one("#settings-theme-editor")
+        target = editor.query_one("#settings-theme-color-primary", Input)
+        target.value = "#123456"
+        for _ in range(6):
+            await pilot.pause()
+        assert screen.query_one("#settings-theme-editor") is editor, (
+            "user edit recomposed the screen and replaced the editor"
+        )
+        assert target.value == "#123456"
+        assert screen.theme_editor_modified is True
+        note = screen.query_one("#settings-theme-unsaved-note", Static)
+        assert "Yes" in str(note.renderable)

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -7557,7 +7557,6 @@ def test_footer_entries_drop_test_hint_where_no_test_action_exists():
     entries = screen._footer_shortcut_entries()
 
     keys = [key for key, _ in entries]
-    assert "s" in keys and "r" in keys
     assert "t" not in keys
 
 
@@ -7585,3 +7584,77 @@ def test_filter_matches_owned_config_keys():
         summary.category is SettingsCategoryId.CONSOLE_BEHAVIOR
         for summary in matches
     )
+
+
+# ---- rescore P1 batch: Theme recompose storm + footer save/revert honesty ----
+
+
+@pytest.mark.asyncio
+async def test_theme_category_settles_without_recompose_storm():
+    """Opening Theme must converge: the mounted editor instance survives.
+
+    Regression (rescore P1): each freshly-mounted editor posted
+    ThemeModifiedStatus(False) at init then (True) after its programmatic
+    load, so theme_editor_modified (recompose=True) flipped forever; every
+    flip replaced the editor and the whole screen -- a busy loop that
+    starved the event loop and froze the app for keyboard AND mouse input.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-theme")
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#settings-theme-editor", timeout=8.0)
+        for _ in range(6):
+            await pilot.pause()
+        first = screen.query_one("#settings-theme-editor")
+        for _ in range(12):
+            await pilot.pause()
+        second = screen.query_one("#settings-theme-editor")
+        assert first is second, "Theme editor was replaced: recompose storm"
+        assert screen.theme_editor_modified is False
+
+
+def test_footer_entries_drop_save_revert_where_no_draft_model_exists():
+    """Categories outside the guided draft model must not advertise
+    "s save category | r revert category": both keys answer with an
+    informational toast there (read-only Artifacts, autosave Splash,
+    immediate-apply Workspaces, editor-owned Theme). Mirrors the task-1564
+    gating that already keeps the ``t`` hint honest."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    for category in (
+        SettingsCategoryId.ARTIFACTS,
+        SettingsCategoryId.SPLASH_SCREEN,
+        SettingsCategoryId.WORKSPACES,
+        SettingsCategoryId.THEME,
+    ):
+        screen.active_category = category.value
+        keys = [key for key, _ in screen._footer_shortcut_entries()]
+        assert "s" not in keys, category
+        assert "r" not in keys, category
+
+
+def test_footer_entries_advertise_save_revert_where_draft_model_acts():
+    """Every guided-mutation category keeps the s/r hints."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    for category in settings_screen_module.GUIDED_SETTINGS_MUTATION_CATEGORIES:
+        screen.active_category = category.value
+        entries = screen._footer_shortcut_entries()
+        assert ("s", "save category") in entries, category
+        assert ("r", "revert category") in entries, category
+
+
+def test_footer_entries_testable_view_category_keeps_t_without_save_revert():
+    """Privacy & Security has a real test action but no draft: t only."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    screen.active_category = SettingsCategoryId.PRIVACY_SECURITY.value
+
+    entries = screen._footer_shortcut_entries()
+
+    keys = [key for key, _ in entries]
+    assert "t" in keys
+    assert "s" not in keys
+    assert "r" not in keys

--- a/Tests/UI/test_settings_rag_profile_region.py
+++ b/Tests/UI/test_settings_rag_profile_region.py
@@ -3518,8 +3518,10 @@ async def test_rag_category_footer_advertises_the_new_accelerators(
         overview_footer = screen.query_one(AppFooterStatus)
         for token in ("a set active", "c clone", "b backfill"):
             assert token not in overview_footer.shortcut_text
+        # Overview is read-only and untestable: the category-gated footer
+        # (rescore P1) advertises no settings keys there at all.
         for token in ("s save category", "r revert category", "t test category"):
-            assert token in overview_footer.shortcut_text
+            assert token not in overview_footer.shortcut_text
 
         await _open_settings_category(pilot, "#settings-category-library-rag")
         screen = _active_destination_screen(host)

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -49,3 +49,64 @@ async def test_settings_theme_editor_mounts_without_error():
         await pilot.app.mount(editor)
         await pilot.pause()
         assert editor.is_mounted
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_mount_does_not_mark_modified():
+    """Mounting and initializing the editor must leave is_modified False.
+
+    load_theme writes Input values programmatically; the resulting
+    Input.Changed events must not count as user edits. A spurious True here
+    recomposes SettingsScreen, which mounts a fresh editor, which posts
+    again -- the infinite recompose storm that froze the whole app
+    (rescore P1: Theme traps keyboard navigation).
+    """
+    app = _build_test_app()
+    editor = SettingsThemeEditor()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.app.mount(editor)
+        for _ in range(8):
+            await pilot.pause()
+        assert editor.is_modified is False
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_mount_posts_no_modified_status():
+    """A clean mount must not emit ThemeModifiedStatus at all.
+
+    Textual calls watch methods with the initial value during mount when the
+    reactive keeps init=True; that ThemeModifiedStatus(False) is one half of
+    the False/True oscillation that drove the recompose storm.
+    """
+    app = _build_test_app()
+    editor = SettingsThemeEditor()
+    posted = []
+    original = editor.post_message
+
+    def record(message):
+        if isinstance(message, SettingsThemeEditor.ThemeModifiedStatus):
+            posted.append(message.is_modified)
+        return original(message)
+
+    editor.post_message = record
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.app.mount(editor)
+        for _ in range(8):
+            await pilot.pause()
+        assert posted == []
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_user_edit_still_marks_modified():
+    """A real user edit (a color value differing from the loaded theme)
+    still flips is_modified True -- the no-op guard must not eat real edits."""
+    app = _build_test_app()
+    editor = SettingsThemeEditor()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.app.mount(editor)
+        for _ in range(8):
+            await pilot.pause()
+        target = editor.query_one("#settings-theme-color-primary", Input)
+        target.value = "#123456"
+        await pilot.pause()
+        assert editor.is_modified is True

--- a/backlog/tasks/task-1580 - Settings-footer-s-r-hints-gated-to-draft-model-categories.md
+++ b/backlog/tasks/task-1580 - Settings-footer-s-r-hints-gated-to-draft-model-categories.md
@@ -1,0 +1,60 @@
+---
+id: task-1580
+title: 'Settings: footer s/r hints gated to draft-model categories'
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-07-31'
+labels:
+  - settings
+  - ux
+  - rescore-p1
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+The 2026-07-31 Settings critique rescore (29 → 30/40) found the footer
+advertising "s save category | r revert category" on every category,
+including the six read-only view pages (Writes allowed: No), the autosaving
+Splash Screen, and immediate-apply Workspaces — where both keys answer with
+an informational toast. The footer is the keyboard contract; advertising
+inert keys breaks it. task-1564 already gates the `t` hint the same way.
+
+## Acceptance Criteria (the what)
+
+- [x] Categories outside the guided draft model (read-only pages, Splash,
+      Workspaces, Theme) do not advertise s/r in the footer
+- [x] Every guided-mutation category still advertises s/r
+- [x] Testable non-draft categories (e.g. Privacy & Security) keep `t`
+      without gaining s/r
+- [x] Existing footer behaviors (Esc-prefix under input focus, RAG
+      accelerators) unchanged
+- [x] Live verification at the real surface confirms the gated footer
+
+## Implementation Plan (the how)
+
+1. RED tests: non-draft categories drop s/r; guided categories keep them;
+   Privacy & Security shows t only.
+2. Gate `_footer_shortcut_entries` on GUIDED_SETTINGS_MUTATION_CATEGORIES,
+   mirroring the TESTABLE_SETTINGS_CATEGORIES gate for `t`.
+3. Update the two tests that pinned the old always-on contract.
+4. Live tmux verification.
+
+## Implementation Notes
+
+Added a s/r gate in `_footer_shortcut_entries` keyed on
+`GUIDED_SETTINGS_MUTATION_CATEGORIES` — the exact set where
+`action_settings_save_category` acts instead of toasting. On categories with
+no active settings keys (e.g. Theme, Overview) the settings registration is
+empty and the footer falls back to the app default hints, which is honest.
+Updated `test_settings_registration_updates_the_screens_own_footer` (now
+switches to a guided category first, re-querying the footer after the
+recompose) and the Overview assertion in
+`test_settings_rag_profile_region.py`. Live-verified in tmux: Theme shows
+default hints, Storage shows s|r|t, Console Behavior shows s|r.
+Files: `tldw_chatbook/UI/Screens/settings_screen.py`,
+`Tests/UI/test_settings_configuration_hub.py`,
+`Tests/UI/test_screen_footer_hints.py`,
+`Tests/UI/test_settings_rag_profile_region.py`.

--- a/backlog/tasks/task-1581 - Theme-category-recompose-storm-freezes-the-whole-app.md
+++ b/backlog/tasks/task-1581 - Theme-category-recompose-storm-freezes-the-whole-app.md
@@ -1,0 +1,70 @@
+---
+id: task-1581
+title: 'Theme category recompose storm freezes the whole app'
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-07-31'
+labels:
+  - settings
+  - theme
+  - bug
+  - rescore-p1
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+Opening Settings → Theme froze the ENTIRE app: every keystroke and mouse
+click (including nav tabs) dead, process spinning at ~60% CPU until killed.
+Found live during the critique rescore capture ("Theme traps keyboard
+navigation"); py-spy-less diagnosis via `sample`, SIGABRT faulthandler dump,
+and a temp compose probe. Mechanism: `SettingsThemeEditor.is_modified` is a
+watched reactive whose init-time watch call posts ThemeModifiedStatus(False)
+on every mount, and the editor's programmatic `load_theme` Input writes
+queue Input.Changed events that flip it True — so the screen's
+`theme_editor_modified` (recompose=True) oscillated False/True forever, each
+flip recomposing the screen and mounting a fresh editor that emitted the
+next pair. Pre-existing since the Theme category was wired in (a94f84a94),
+not introduced by the remediation PRs.
+
+## Acceptance Criteria (the what)
+
+- [x] Opening the Theme category converges: the mounted editor instance
+      survives settling (no recompose storm)
+- [x] A clean editor mount emits no ThemeModifiedStatus posts and leaves
+      is_modified False
+- [x] Real user edits (color value change, dark-mode toggle) still mark the
+      editor modified
+- [x] Live verification: Theme opens at idle CPU, the category filter and
+      all navigation remain usable, and leaving Theme via the filter works
+
+## Implementation Plan (the how)
+
+1. Reproduce live (textual-serve + Playwright, then tmux), capture the spin
+   with `sample`/faulthandler, isolate the oscillating reactive with a
+   compose-entry probe.
+2. RED tests: editor-level (no posts on mount, is_modified stays False,
+   user edits still flip it) and screen-level (editor instance identity
+   survives settling).
+3. Fix in the editor: `is_modified = reactive(False, init=False)`; treat
+   programmatic-load no-op Changed events (value equal to stored data) as
+   non-edits; same guard for the dark-mode switch sync.
+4. GREEN + full affected suites + live tmux verification.
+
+## Implementation Notes
+
+Three-line-class fix in `settings_theme_editor.py`: init=False on the
+reactive (kills the False half of the oscillation), an equality guard in
+`on_color_input_changed` (load_theme sets `current_theme_data` before
+writing Input values, so reload events arrive value-equal and are skipped),
+and an equality guard in `on_dark_mode_changed`. No screen-side change
+needed — with honest posts the recompose reactive converges. Also fixes the
+cosmetic lie where merely opening Theme could report unsaved theme changes.
+Live-verified: CPU 0.0% with Theme open (was 56-62%), Theme → Storage →
+Theme → Console Behavior round-trips via the filter, all input responsive.
+The screen-level regression test pins editor identity across 12 settle
+pauses. Files: `tldw_chatbook/Widgets/settings_theme_editor.py`,
+`Tests/UI/test_settings_theme_editor.py`,
+`Tests/UI/test_settings_configuration_hub.py`.

--- a/backlog/tasks/task-1581 - Theme-category-recompose-storm-freezes-the-whole-app.md
+++ b/backlog/tasks/task-1581 - Theme-category-recompose-storm-freezes-the-whole-app.md
@@ -65,6 +65,19 @@ cosmetic lie where merely opening Theme could report unsaved theme changes.
 Live-verified: CPU 0.0% with Theme open (was 56-62%), Theme → Storage →
 Theme → Console Behavior round-trips via the filter, all input responsive.
 The screen-level regression test pins editor identity across 12 settle
-pauses. Files: `tldw_chatbook/Widgets/settings_theme_editor.py`,
+pauses.
+
+Qodo review follow-up (confirmed real, TDD RED-first): with the editor
+posts honest, the screen's `theme_editor_modified` recompose=True reactive
+became the next defect — the FIRST real user edit remounted the editor,
+discarding the in-progress input and leaving the flag stale-True. Dropped
+recompose on that reactive; the two dependents (rail dirty marker,
+inspector "Unsaved theme changes" row, now id'd) refresh in place via
+`_refresh_theme_modified_widgets`, mirroring the InternalPromptsPanel
+targeted-refresh idiom. Live-verified: typed #123456 survives, inspector
+flips to Yes, rail shows `Theme *`, CPU idle.
+
+Files: `tldw_chatbook/Widgets/settings_theme_editor.py`,
+`tldw_chatbook/UI/Screens/settings_screen.py`,
 `Tests/UI/test_settings_theme_editor.py`,
 `Tests/UI/test_settings_configuration_hub.py`.

--- a/backlog/tasks/task-1582 - Settings-interactive-elements-indistinguishable-from-prose.md
+++ b/backlog/tasks/task-1582 - Settings-interactive-elements-indistinguishable-from-prose.md
@@ -1,0 +1,35 @@
+---
+id: task-1582
+title: 'Settings: interactive elements indistinguishable from prose'
+status: To Do
+assignee: []
+created_date: '2026-07-31'
+labels:
+  - settings
+  - ux
+  - rescore-p2
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+Critique rescore P2: in Console Behavior (and elsewhere), toggle words
+("Enabled"), editable inputs ("Threshold 50"), and explanation prose render
+at near-identical weight and background, so finding "the thing I can
+change" requires tabbing blindly or reading everything. Disabled controls
+(Save/Revert, Clear saved key, Save Raw TOML) differ from enabled ones only
+by luminance — low-vision users lose the affordance entirely. Theme's
+"Dark theme" switch is an empty rectangle with no text state at all (the
+only control-without-text-state found in the evidence pass).
+
+## Acceptance Criteria (the what)
+
+- [ ] One consistent visual convention distinguishes interactive controls
+      from prose across Settings categories (e.g. bracketed toggles,
+      bordered inputs)
+- [ ] Disabled Save/Revert (and other disabled buttons) carry a text
+      annotation or contrast treatment beyond dimming alone
+- [ ] The Theme "Dark theme" switch shows a text state (On/Off) like the
+      Splash Screen switches do
+- [ ] A visible focus indicator exists on center-pane fields

--- a/backlog/tasks/task-1583 - Scope-Inspector-bottom-clipping-and-mid-token-wraps.md
+++ b/backlog/tasks/task-1583 - Scope-Inspector-bottom-clipping-and-mid-token-wraps.md
@@ -1,0 +1,31 @@
+---
+id: task-1583
+title: 'Scope Inspector: bottom clipping and mid-token wraps'
+status: To Do
+assignee: []
+created_date: '2026-07-31'
+labels:
+  - settings
+  - ux
+  - rescore-p2
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+Critique rescore P2: in 8 of 20 evidence captures the Scope Inspector's
+last visible line is cut mid-sentence ("Saves apply to your local",
+"…Nothing is sent to", "Recovery: use each prompt's") — reassurance copy
+that reads worse truncated than absent. The 34-char column also breaks
+tokens mid-word ("crede/ntial_source", "config.tom/l"). A scrollbar exists
+but the default viewport reliably clips the standing local-scope note.
+
+## Acceptance Criteria (the what)
+
+- [ ] The inspector's default viewport does not cut the standing
+      local-scope note mid-sentence on common category/terminal sizes
+      (shorten the copy, reflow, or reserve a fold indicator row)
+- [ ] Config paths and TOML key names wrap at token boundaries or are
+      ellipsized, not split mid-word
+- [ ] Overflow remains reachable (scrollbar/fold indicator preserved)

--- a/backlog/tasks/task-1584 - Settings-filter-correctness-ranking-refocus-placeholder.md
+++ b/backlog/tasks/task-1584 - Settings-filter-correctness-ranking-refocus-placeholder.md
@@ -1,0 +1,35 @@
+---
+id: task-1584
+title: 'Settings filter correctness: ranking, refocus, placeholder'
+status: To Do
+assignee: []
+created_date: '2026-07-31'
+labels:
+  - settings
+  - ux
+  - rescore-p2
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+Three filter defects found live during the critique rescore capture:
+(1) typing "rag" and pressing Enter opens Storage, not Library/RAG — the
+substring match on "sto-RAG-e" ties on rank tier and wins on list index;
+(2) refocusing the filter (via "/" or click) retains stale text with no
+select-all, so a second "/" press types a literal slash into the focused
+input and stale terms silently poison the next search;
+(3) the placeholder says "Filter settings (/)" but results resolve to
+categories (task-1564 made owned keys searchable, which helps, but the
+Enter target is always a category).
+
+## Acceptance Criteria (the what)
+
+- [ ] A whole-word/prefix rank tier beats bare substring matches: "rag"
+      opens Library/RAG, not Storage
+- [ ] Refocusing the filter selects the existing text (typing replaces it)
+      or clears it, so repeat searches never concatenate
+- [ ] Placeholder copy matches behavior (e.g. "Filter categories (/)")
+- [ ] Existing rank tiers (id/title, description, owned keys) keep their
+      relative order

--- a/backlog/tasks/task-1585 - Settings-hygiene-batch-empty-states-casing-repeated-modeline.md
+++ b/backlog/tasks/task-1585 - Settings-hygiene-batch-empty-states-casing-repeated-modeline.md
@@ -1,0 +1,41 @@
+---
+id: task-1585
+title: 'Settings hygiene batch: empty states, casing, repeated mode line'
+status: To Do
+assignee: []
+created_date: '2026-07-31'
+labels:
+  - settings
+  - ux
+  - rescore-p3
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+Critique rescore P3 leftovers, batched: Theme's collapsed "Themes" tree
+leaves a large blank region and Workspaces' center pane is nearly empty
+(both need empty-state copy); "Runtime controls stay in MCP and ACP"
+repeats verbatim on all 17 categories; snake_case leaf content
+(rag_reranker (6), tech_pulse, trust_uninitialized) sits against Title Case
+chrome; Internal Prompts center-aligns row labels and embeds a second
+search idiom ("Search prompts…") beside the global "/" filter; Privacy's
+"Provider env vars: 0 present / 19 missing / 19 configured" reads as
+contradictory; Workspaces alone omits the Save/Revert buttons entirely
+while other non-draft categories show them disabled. The five view-only
+Domain Defaults placeholder pages are a KNOWN accepted WIP state (owner
+review 2026-07-31) and are out of scope here.
+
+## Acceptance Criteria (the what)
+
+- [ ] Theme tree and Workspaces center pane have empty-state copy
+- [ ] The mode-line disclaimer is not repeated verbatim on every category
+      (category-specific or shown once)
+- [ ] User-facing group headers and enum values render in consistent casing
+      (raw config ids stay raw only where they name config keys)
+- [ ] Internal Prompts rows left-align and its search idiom is reconciled
+      with the global filter
+- [ ] The provider env-var counts read unambiguously
+- [ ] Non-draft categories are consistent about showing vs hiding the
+      Save/Revert button pair

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -1831,13 +1831,22 @@ class SettingsScreen(BaseAppScreen):
     def _footer_shortcut_entries(self) -> tuple[tuple[str, str], ...]:
         """Category- and focus-aware footer hints (task-1564/1560).
 
-        Drops the ``t`` hint for categories whose test action is the "No
-        test action is available" toast, appends the RAG accelerators only
-        where they act, and prefixes keys with "Esc, " while a text-entry
-        widget owns focus (printable keys feed the field until Esc).
+        Drops the ``s``/``r`` hints for categories outside the guided draft
+        model (read-only pages, autosave Splash, immediate-apply Workspaces,
+        the editor-owned Theme -- everywhere action_settings_save_category
+        answers with an informational toast), drops the ``t`` hint for
+        categories whose test action is the "No test action is available"
+        toast, appends the RAG accelerators only where they act, and
+        prefixes keys with "Esc, " while a text-entry widget owns focus
+        (printable keys feed the field until Esc).
         """
         shortcuts = self.SETTINGS_SHORTCUTS
-        if self._active_category_id() not in self.TESTABLE_SETTINGS_CATEGORIES:
+        active = self._active_category_id()
+        if active not in GUIDED_SETTINGS_MUTATION_CATEGORIES:
+            shortcuts = tuple(
+                entry for entry in shortcuts if entry[0] not in {"s", "r"}
+            )
+        if active not in self.TESTABLE_SETTINGS_CATEGORIES:
             shortcuts = tuple(
                 entry for entry in shortcuts if entry[0] != "t"
             )

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -1509,7 +1509,13 @@ class SettingsScreen(BaseAppScreen):
     category_search_query = reactive("")
     server_sync_workspace_handoff_rows = reactive((), recompose=True)
     manual_sync_rows = reactive((), recompose=True)
-    theme_editor_modified = reactive(False, recompose=True)
+    # Deliberately NOT recompose=True (Qodo review of PR #1125): a recompose
+    # here remounts the theme editor on the FIRST real user edit, discarding
+    # the in-progress input and leaving the flag stale-True against a clean
+    # editor. The two displays that read it (rail dirty marker, inspector
+    # row) refresh in place via _refresh_theme_modified_widgets, mirroring
+    # the InternalPromptsPanel.Modified idiom.
+    theme_editor_modified = reactive(False)
 
     #: TASK-366: sentinel copies for the provider Test result row.
     _PROVIDER_TEST_NOT_RUN_COPY = "Provider test has not run."
@@ -11391,7 +11397,11 @@ class SettingsScreen(BaseAppScreen):
             yield self._detail_row("Save target", "~/.config/tldw_cli/themes/")
             yield self._detail_row("Note", "Use the editor's own Apply/Save/Reset buttons.")
             modified = "Yes" if self.theme_editor_modified else "No"
-            yield self._detail_row("Unsaved theme changes", modified)
+            yield self._detail_row(
+                "Unsaved theme changes",
+                modified,
+                identifier="settings-theme-unsaved-note",
+            )
         elif summary.category is SettingsCategoryId.SPLASH_SCREEN:
             yield Static("Affects startup splash screen behavior.", classes="destination-section")
             yield Static("Focused field guide", classes="destination-section")
@@ -12037,7 +12047,26 @@ class SettingsScreen(BaseAppScreen):
     def handle_theme_modified_status(
         self, event: SettingsThemeEditor.ThemeModifiedStatus
     ) -> None:
+        if self.theme_editor_modified == event.is_modified:
+            return
         self.theme_editor_modified = event.is_modified
+        self._refresh_theme_modified_widgets()
+
+    def _refresh_theme_modified_widgets(self) -> None:
+        """In-place refresh of the Theme dirty displays (rail marker, inspector row).
+
+        Targeted updates, never a recompose -- a recompose would remount the
+        theme editor and wipe the very in-progress edit that raised this
+        notification (see the theme_editor_modified reactive's comment).
+        """
+        self._refresh_category_button_label(SettingsCategoryId.THEME)
+        try:
+            row = self.query_one("#settings-theme-unsaved-note", Static)
+        except QueryError:
+            pass
+        else:
+            modified = "Yes" if self.theme_editor_modified else "No"
+            row.update(f"Unsaved theme changes: {modified}")
 
     @on(InternalPromptsPanel.Modified)
     def _on_internal_prompts_modified(self, event: InternalPromptsPanel.Modified) -> None:

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -415,7 +415,13 @@ class SettingsThemeEditor(Vertical):
 
     @on(Input.Changed)
     def on_color_input_changed(self, event: Input.Changed) -> None:
-        """Handle color input changes."""
+        """Handle color input changes.
+
+        Args:
+            event: The Input.Changed event from a color field; events whose
+                value matches the stored theme data are programmatic reloads
+                and do not mark the editor modified.
+        """
         if event.input.id and event.input.id.startswith("settings-theme-color-"):
             color_name = event.input.id[len("settings-theme-color-") :]
             color_value = event.value.strip()
@@ -437,7 +443,13 @@ class SettingsThemeEditor(Vertical):
 
     @on(Switch.Changed, "#settings-theme-dark-mode")
     def on_dark_mode_changed(self, event: Switch.Changed) -> None:
-        """Handle dark mode switch changes."""
+        """Handle dark mode switch changes.
+
+        Args:
+            event: The Switch.Changed event; an event whose value already
+                matches the loaded theme's dark flag is a programmatic sync
+                and does not mark the editor modified.
+        """
         if event.value == self.is_dark_theme:
             # _update_dark_mode_switch syncing the widget to the loaded
             # theme -- not a user edit.

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -35,7 +35,12 @@ class SettingsThemeEditor(Vertical):
     current_theme_name = reactive("textual-dark")
     current_theme_data: reactive[dict[str, str]] = reactive({}, layout=False)
     is_dark_theme = reactive(True)
-    is_modified = reactive(False)
+    # init=False: the init-time watch call would post ThemeModifiedStatus(False)
+    # on every mount, and SettingsScreen recomposes on that reactive -- paired
+    # with the load-time True post below, each recompose mounted an editor
+    # whose posts forced the next recompose (an event-loop-starving storm
+    # that froze the whole app while Theme was open).
+    is_modified = reactive(False, init=False)
 
     BASE_COLORS = [
         "primary",
@@ -418,8 +423,13 @@ class SettingsThemeEditor(Vertical):
             if color_value:
                 if self._validate_color_input(color_value):
                     self._update_color_swatch(color_name, color_value)
-                    self.current_theme_data[color_name] = color_value
-                    self.is_modified = True
+                    # load_theme sets current_theme_data before writing the
+                    # Input values, so the Changed events it queues arrive
+                    # carrying values equal to the stored ones: a programmatic
+                    # reload, not a user edit.
+                    if self.current_theme_data.get(color_name) != color_value:
+                        self.current_theme_data[color_name] = color_value
+                        self.is_modified = True
                     event.input.remove_class("invalid-color")
                 else:
                     event.input.add_class("invalid-color")
@@ -428,6 +438,10 @@ class SettingsThemeEditor(Vertical):
     @on(Switch.Changed, "#settings-theme-dark-mode")
     def on_dark_mode_changed(self, event: Switch.Changed) -> None:
         """Handle dark mode switch changes."""
+        if event.value == self.is_dark_theme:
+            # _update_dark_mode_switch syncing the widget to the loaded
+            # theme -- not a user edit.
+            return
         self.is_dark_theme = event.value
         self.is_modified = True
 


### PR DESCRIPTION
## Summary

First fix batch from the Settings critique rescore (29 → 30/40, snapshot `2026-07-31T03-47-38Z`). Both P1s here were verified live before and after.

### 1. Theme category froze the entire app (task-1581)
Opening Settings → Theme spun the process at ~60% CPU and killed ALL input — keyboard, mouse, and nav tabs — until restart. Root cause: `SettingsThemeEditor.is_modified` posted `ThemeModifiedStatus(False)` from its init-time watch call on every mount, then flipped True when `load_theme`'s programmatic Input writes echoed back as `Input.Changed`; the screen's `theme_editor_modified` reactive (recompose=True) oscillated forever, each flip mounting a fresh editor that emitted the next pair. Diagnosed with `sample`, a SIGABRT faulthandler dump (100 frames of mount→compose cycle), and a compose-entry probe showing the alternation. **Pre-existing since the Theme category was wired in (a94f84a94)** — not from the recent remediation PRs.

Fix: `init=False` on the reactive plus no-op guards so programmatic reloads never count as user edits. Side benefit: Theme no longer claims unsaved changes the moment it opens.

### 2. Footer advertised save/revert where they don't act (task-1580)
`s save category | r revert category` rendered on all six read-only view categories, autosaving Splash, and immediate-apply Workspaces — both keys just toast there. Now gated on `GUIDED_SETTINGS_MUTATION_CATEGORIES`, mirroring task-1564's `t` gate. Categories with no active keys fall back to the app default hints.

Also files rescore P2/P3 follow-up tasks 1582-1585.

## Testing
- TDD RED-first: editor posts observed as `[False, True]` before the fix; storm test pinned editor-instance identity across settles.
- Affected suites: **406 passed, 1 failed** — the failure (`test_library_registration_updates_the_screens_own_footer`) fails identically on pristine dev @ 1e0979c74 (pre-existing, unrelated).
- Live tmux verification: Theme opens at 0.0% CPU (was 56-62%), filter round-trips Theme → Storage → Theme → Console Behavior, footer shows `s|r|t` on Storage, `s|r` on Console Behavior, default hints on Theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Settings Theme freeze and keeps the editor mounted during real edits. Also makes footer save/revert hints honest by showing them only where drafts exist.

- **Bug Fixes**
  - Theme: stopped the recompose storm with `is_modified = reactive(False, init=False)` and guards that ignore programmatic reload events; dropped `recompose=True` on `theme_editor_modified` and refresh the rail/inspector in place so real edits don’t remount the editor. Opening Theme no longer marks modified or locks input, and typed values persist (task-1581).
  - Footer: gated `s`/`r` hints on `GUIDED_SETTINGS_MUTATION_CATEGORIES`; read-only pages, Splash, Workspaces, and Theme drop save/revert while testable categories still show `t` (task-1580).

<sup>Written for commit e05c186623cb73f37e3a035e62ca76b2bdee7b27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

