### PR TITLE
task-1469: worker-lifecycle probe that survives delegation growth

### DIFF
--- a/Tests/UI/test_ui_responsiveness.py
+++ b/Tests/UI/test_ui_responsiveness.py
@@ -238,45 +238,88 @@ def test_console_transcript_sync_timer_updates_responsiveness_monitor():
     assert stopped == [True]
 
 
+def _make_sync_probe_screen(monitor):
+    """A ChatScreen stand-in for exercising the console-sync recording bracket.
+
+    task-1469: earlier versions hand-stubbed the delegation stages and broke
+    (or silently rotted) every time `_sync_native_console_chat_ui` grew one —
+    it went 12 -> ~25 stages while the test was dormant, and the re-enumerated
+    fix inherits the same treadmill. `MagicMock(spec=ChatScreen)` auto-stubs
+    every CURRENT stage — async defs become AsyncMocks — and keeps tracking
+    the class as it evolves; only the recording bracket itself is real (bound
+    methods + a real monitor), because that bracket is this test's subject.
+    """
+    from functools import partial
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen = MagicMock(spec=ChatScreen)
+    screen._console_sync_in_progress = False
+    screen._console_sync_requested = False
+    screen.app_instance = SimpleNamespace(ui_responsiveness_monitor=monitor)
+    screen._ui_responsiveness_monitor = partial(
+        ChatScreen._ui_responsiveness_monitor, screen
+    )
+    screen._record_ui_worker_started = partial(
+        ChatScreen._record_ui_worker_started, screen
+    )
+    screen._record_ui_worker_finished = partial(
+        ChatScreen._record_ui_worker_finished, screen
+    )
+    return screen
+
+
 @pytest.mark.asyncio
 async def test_console_sync_records_worker_lifecycle():
+    """The sync brackets its stage pipeline in started/finished recording."""
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     monitor = UIResponsivenessMonitor(enabled=True)
-    screen = ChatScreen.__new__(ChatScreen)
-    screen.app_instance = SimpleNamespace(ui_responsiveness_monitor=monitor)
-    screen._console_sync_in_progress = False
-    screen._console_sync_requested = False
-    screen.run_worker = lambda *_args, **_kwargs: None
-    observed_active_worker = False
+    screen = _make_sync_probe_screen(monitor)
 
-    def assert_worker_active():
-        nonlocal observed_active_worker
-        observed_active_worker = True
-        assert monitor.snapshot().active_workers == 1
-
-    async def async_noop():
-        return None
-
-    screen._sync_console_chat_core_state = assert_worker_active
-    screen._sync_console_session_draft = lambda: None
-    screen._warm_console_effective_scope_cache_if_stale = async_noop
-    screen._refresh_active_dictionaries_summary_if_scope_changed = async_noop
-    screen._refresh_active_world_books_summary_if_scope_changed = async_noop
-    screen._refresh_active_character_avatar_if_scope_changed = async_noop
-    screen._current_console_rail_state = lambda: object()
-    screen._sync_console_control_bar = lambda _rail_state: None
-    screen._sync_console_settings_summary = lambda: None
-    screen._sync_console_mode_bar = lambda: None
-    screen._sync_console_native_session_tabs = async_noop
-    screen._sync_console_workspace_context = lambda: None
-    screen._sync_native_console_transcript = async_noop
-    screen._sync_console_rail_visibility_if_changed = lambda _state: None
-    screen._dispatch_console_rail_preference_prune = lambda: None
+    during = []
+    screen._sync_console_chat_core_state = lambda: during.append(
+        monitor.snapshot().active_workers
+    )
 
     await ChatScreen._sync_native_console_chat_ui(screen)
 
-    assert observed_active_worker
+    assert during == [1], "worker not recorded as active while stages ran"
+    assert monitor.snapshot().active_workers == 0
+
+
+@pytest.mark.asyncio
+async def test_console_sync_records_finished_even_when_a_stage_raises():
+    """A failing stage must not leak an active-worker record."""
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    monitor = UIResponsivenessMonitor(enabled=True)
+    screen = _make_sync_probe_screen(monitor)
+    screen._sync_console_chat_core_state = MagicMock(
+        side_effect=RuntimeError("stage boom")
+    )
+
+    with pytest.raises(RuntimeError, match="stage boom"):
+        await ChatScreen._sync_native_console_chat_ui(screen)
+
+    assert monitor.snapshot().active_workers == 0
+
+
+@pytest.mark.asyncio
+async def test_console_sync_reentry_defers_without_recording():
+    """A sync entered while one is in progress defers and records nothing."""
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    monitor = UIResponsivenessMonitor(enabled=True)
+    screen = _make_sync_probe_screen(monitor)
+    screen._console_sync_in_progress = True
+
+    await ChatScreen._sync_native_console_chat_ui(screen)
+
+    assert screen._console_sync_requested is True
     assert monitor.snapshot().active_workers == 0
 
 

--- a/backlog/tasks/task-1469 - Rewrite-console-sync-worker-lifecycle-test-at-the-recording-seam.md
+++ b/backlog/tasks/task-1469 - Rewrite-console-sync-worker-lifecycle-test-at-the-recording-seam.md
@@ -2,7 +2,7 @@
 id: TASK-1469
 title: >-
   Rewrite test_console_sync_records_worker_lifecycle at the worker-recording seam (xfail-quarantined by task-1457)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-30 19:20'
 labels:
@@ -20,6 +20,27 @@ dependencies: [task-1457]
 
 ## Acceptance Criteria
 
-- [ ] The worker-lifecycle recording behavior is covered by a test that passes on current dev
-- [ ] The test does not enumerate `_sync_native_console_chat_ui`'s delegation stages (adding a stage must not break it)
-- [ ] The `xfail` quarantine on the old test is removed (rewritten or deleted with the coverage moved)
+- [x] The worker-lifecycle recording behavior is covered by a test that passes on current dev
+- [x] The test does not enumerate `_sync_native_console_chat_ui`'s delegation stages (adding a stage must not break it)
+- [x] The `xfail` quarantine on the old test is removed (rewritten or deleted with the coverage moved)
+
+## Implementation Plan
+
+1. Study the recording bracket (`_record_ui_worker_started/finished` around the stage pipeline in `_sync_native_console_chat_ui`)
+2. Replace stage enumeration with `MagicMock(spec=ChatScreen)` (auto-stubs every current stage, async defs become AsyncMocks, tracks the class as it evolves); bind the REAL recording helpers + a real monitor
+3. Cover the bracket's three behaviors: active-during-stages, finished-even-on-stage-failure, re-entry-defers-without-recording
+4. Mutation-check: break the started-recording and confirm the assertion fails
+
+## Implementation Notes
+
+By implementation time a foreign train had already removed the xfail by
+RE-ENUMERATING the stages (15 hand-stubs, updated to the current pipeline) —
+green today, and back on the same rot treadmill this task exists to end.
+Replaced with a spec-mock probe (`_make_sync_probe_screen`): only one
+deliberate anchor remains (`_sync_console_chat_core_state`, the semantic core,
+used as the mid-flight sampling point), so adding a stage cannot break these
+tests. Added the two behaviors the old test never covered: a raising stage
+must not leak an active-worker record (the try/finally), and re-entry must
+defer without recording. Mutation-verified: with the started-recording broken,
+the mid-flight sample reads 0 and the test fails. File: 14 passed.
+Modified: `Tests/UI/test_ui_responsiveness.py`.


### PR DESCRIPTION
## Summary
`test_console_sync_records_worker_lifecycle` kept rotting because every version hand-enumerated `_sync_native_console_chat_ui`'s delegation stages — 12 stubs while it lay dormant (task-1457 found it 13 stages behind), and the recent re-enumeration (15 stubs) is green today but back on the same treadmill. This replaces enumeration with a `MagicMock(spec=ChatScreen)` probe: every current stage is auto-stubbed (async defs become AsyncMocks via spec introspection) and **the spec tracks the class as it evolves — adding a stage cannot break these tests**. Only the recording bracket itself is real (bound helpers + a real `UIResponsivenessMonitor`), because the bracket is the subject. One deliberate anchor remains: `_sync_console_chat_core_state` as the mid-flight sampling point.

Also adds the two bracket behaviors the old test never covered: a **raising stage must not leak an active-worker record** (the `try/finally`), and **re-entry defers without recording**.

## Verification
- File: 14 passed
- Mutation check: with `_record_ui_worker_started` broken, the mid-flight sample reads 0 and the test fails — the guard guards
- Board: task-1469 Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the console-sync worker lifecycle test to use a spec-mocked `ChatScreen` probe that survives delegation growth in `_sync_native_console_chat_ui`. Addresses `task-1469` and keeps worker recording correct during stages, on failure, and on reentry.

- **Refactors**
  - Switched to `MagicMock(spec=ChatScreen)` bound to real `_record_ui_worker_started/_finished` and `UIResponsivenessMonitor`.
  - Mid-flight sample anchored at `_sync_console_chat_core_state`; adding stages no longer breaks the test.
  - Added coverage: a raising stage doesn’t leak an active worker; reentry defers without recording. Removed `xfail`; file passes.

<sup>Written for commit f5abba8664e44077d1fc1618d48a913e7f6a6379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

