### PR TITLE
task-1464 recovery: kokoro HF-offline skip widening + the lost artifacts commit

### DIFF
--- a/Tests/TTS/test_kokoro_validation.py
+++ b/Tests/TTS/test_kokoro_validation.py
@@ -392,8 +392,17 @@ async def test_integration_with_real_kokoro():
     except ImportError:
         pytest.skip("Kokoro dependencies not installed")
     except Exception as e:
-        # Skip only when kokoro/model files are absent; other init failures
-        # now FAIL (task-1464: any exception used to become a skip).
-        if "kokoro" in str(e).lower() or "onnx" in str(e).lower() or isinstance(e, (ImportError, FileNotFoundError)):
-            pytest.skip(f"Kokoro initialization failed: {e}")
+        # Skip only when kokoro/model files are absent — including the
+        # HF-offline shapes (OSError / LocalEntryNotFoundError) that fetching
+        # a missing model produces under the suite's offline-by-default HF
+        # env (task-1451). Other init failures now FAIL (task-1464: any
+        # exception used to become a skip).
+        model_unavailable = (
+            isinstance(e, (ImportError, FileNotFoundError, OSError))
+            or "kokoro" in str(e).lower()
+            or "onnx" in str(e).lower()
+            or "disk cache" in str(e).lower()
+        )
+        if model_unavailable:
+            pytest.skip(f"Kokoro model unavailable: {e}")
         raise

--- a/backlog/docs/test-suite-vacuous-inventory-2026-07-30.md
+++ b/backlog/docs/test-suite-vacuous-inventory-2026-07-30.md
@@ -1,0 +1,192 @@
+# Vacuous-test inventory — 2026-07-30 (task-1464, category 4)
+
+Machine-generated candidates, per the owner ruling: **inventory only, no bulk
+action** — clean up per-file when those files are touched. Read the caveats
+before acting on any row.
+
+## Caveats (why this list is candidates, not verdicts)
+
+- The scanner counts a test as assertion-free when its own body has no
+  `assert`, no `pytest.raises`, no unittest `self.assert*`, and no mock
+  `assert_*` calls. **Assertions living in helper functions or fixtures are
+  invisible to it** — e.g. contract suites that delegate to shared checkers
+  will false-positive here. Verify per file before deleting anything.
+- Mount-smoke tests (build a widget/screen, no explicit assert) still catch
+  compose/crash regressions; assertion-free is not the same as valueless.
+- Mock-only tests pin call graphs across seams: cheap, occasionally useful,
+  prone to rot. The ruling keeps them.
+
+## Assertion-free candidates: 249 tests in 118 files
+
+| Count | File |
+|---|---|
+| 21 | `Tests/UI/test_non_obscuring_focus_contract.py` |
+| 12 | `Tests/UI/test_destination_visual_parity_correction.py` |
+| 11 | `Tests/TTS/test_profile_schema.py` |
+| 9 | `Tests/Image_Generation/test_live_backends.py` |
+| 7 | `Tests/Scheduling/test_watchlist_check_handler.py` |
+| 7 | `Tests/tldw_api/test_notes_workspace_client.py` |
+| 6 | `Tests/UI/test_console_mcp_approval.py` |
+| 6 | `Tests/tldw_api/test_chat_conversation_client.py` |
+| 5 | `Tests/test_enhanced_rag.py` |
+| 5 | `Tests/UI/test_mcp_audit_mode.py` |
+| 5 | `Tests/tldw_api/test_mcp_unified_client.py` |
+| 4 | `Tests/UI/test_destination_shells.py` |
+| 4 | `Tests/UI/test_file_picker_action_tooltips.py` |
+| 4 | `Tests/UI/test_personas_workbench.py` |
+| 4 | `Tests/Scheduling/test_scheduler_loop.py` |
+| 4 | `Tests/RAG/test_rag_ui_integration.py` |
+| 3 | `Tests/UI/test_mcp_workbench.py` |
+| 3 | `Tests/UI/test_chatbook_action_recovery_tooltips.py` |
+| 3 | `Tests/UI/test_settings_configuration_hub.py` |
+| 3 | `Tests/UI/test_console_native_chat_flow.py` |
+| 3 | `Tests/UI/test_disabled_action_recovery_tooltips.py` |
+| 3 | `Tests/Evals/test_eval_runner.py` |
+| 3 | `Tests/Chat/test_message_feedback.py` |
+| 3 | `Tests/Prompts_DB/test_prompts_db_legacy.py` |
+| 3 | `Tests/Character_Chat/test_world_info_regex.py` |
+| 3 | `Tests/DB/test_private_sqlite.py` |
+| 2 | `Tests/UI/test_bulk_selection_tooltips.py` |
+| 2 | `Tests/UI/test_voice_blend_dialog.py` |
+| 2 | `Tests/UI/test_screen_navigation.py` |
+| 2 | `Tests/UI/test_schedules_workbench.py` |
+| 2 | `Tests/Evals/test_eval_orchestrator.py` |
+| 2 | `Tests/Chat/test_console_speech_snapshots.py` |
+| 2 | `Tests/CI/test_textual_runtime_contract.py` |
+| 2 | `Tests/Agents/test_run_log_writer.py` |
+| 2 | `Tests/Utils/test_git_url_validation.py` |
+| 2 | `Tests/Utils/test_config_encryption.py` |
+| 2 | `Tests/MCP/test_control_plane_bridge.py` |
+| 2 | `Tests/Local_Ingestion/test_dictation_window_provider_ids.py` |
+| 2 | `Tests/Diarization/test_diarization_integration.py` |
+| 1 | `Tests/test_minimal_world_book.py` |
+| 1 | `Tests/test_utilities.py` |
+| 1 | `Tests/test_smoke.py` |
+| 1 | `Tests/test_fts5_pattern.py` |
+| 1 | `Tests/Evaluations_Interop/test_evaluation_scope_service.py` |
+| 1 | `Tests/Evaluations_Interop/test_server_evaluations_service.py` |
+| 1 | `Tests/UI/test_evals_empty_states.py` |
+| 1 | `Tests/UI/test_persona_profile_widgets.py` |
+| 1 | `Tests/UI/test_library_file_notes_git.py` |
+| 1 | `Tests/UI/test_file_picker_filters_callable.py` |
+| 1 | `Tests/UI/test_latest_dev_core_app_usability_smoke.py` |
+| 1 | `Tests/UI/test_tools_settings_window.py` |
+| 1 | `Tests/UI/test_console_context_modal.py` |
+| 1 | `Tests/UI/test_notes_unsaved_indicator_removed.py` |
+| 1 | `Tests/UI/test_skill_script_confirm_card.py` |
+| 1 | `Tests/UI/test_product_maturity_phase1_first_run.py` |
+| 1 | `Tests/UI/test_product_maturity_phase1_navigation_smoke.py` |
+| 1 | `Tests/UI/test_study_flashcards_screen.py` |
+| 1 | `Tests/UI/test_tag_action_recovery_tooltips.py` |
+| 1 | `Tests/UI/test_console_character_avatar.py` |
+| 1 | `Tests/UI/test_workbench_pane_focus.py` |
+| 1 | `Tests/UI/test_personas_expression_generate.py` |
+| 1 | `Tests/UI/test_library_shell.py` |
+| 1 | `Tests/UI/test_personas_lore.py` |
+| 1 | `Tests/Media_DB/test_sync_client_integration.py` |
+| 1 | `Tests/Media_DB/test_media_db_v2.py` |
+| 1 | `Tests/Model_Artifacts/test_service.py` |
+| 1 | `Tests/Evals/test_evals_db.py` |
+| 1 | `Tests/Evals/test_eval_integration.py` |
+| 1 | `Tests/Evals/word_bench/test_storage.py` |
+| 1 | `Tests/Chat/test_citation_artifact_ownership.py` |
+| 1 | `Tests/Chat/test_citation_trace_repository.py` |
+| 1 | `Tests/Scheduling/test_schema.py` |
+| 1 | `Tests/Scheduling/test_watchlist_scheduling_end_to_end.py` |
+| 1 | `Tests/Transcription/test_faster_whisper_transcription.py` |
+| 1 | `Tests/Transcription/test_mlx_whisper_transcription.py` |
+| 1 | `Tests/Transcription/test_mlx_parakeet_transcription.py` |
+| 1 | `Tests/Web_Scraping/test_security.py` |
+| 1 | `Tests/Image_Generation/test_http_client.py` |
+| 1 | `Tests/integration/test_file_extraction_integration.py` |
+| 1 | `Tests/integration/test_file_operations_with_validation.py` |
+| 1 | `Tests/Agents/test_run_log_search.py` |
+| 1 | `Tests/Agents/test_builtin_tool_gate.py` |
+| 1 | `Tests/Library/test_library_local_rag_search_service.py` |
+| 1 | `Tests/Library/test_library_ingest_jobs.py` |
+| 1 | `Tests/Utils/test_startup_polish_regressions.py` |
+| 1 | `Tests/MCP/test_control_plane_permissions.py` |
+| 1 | `Tests/MCP/test_unified_context_store.py` |
+| 1 | `Tests/MCP/test_control_plane_lifecycle.py` |
+| 1 | `Tests/RAG/test_scope_store_filtering.py` |
+| 1 | `Tests/RAG/simplified/test_collection_fingerprint.py` |
+| 1 | `Tests/RAG/simplified/test_vector_store_errors.py` |
+| 1 | `Tests/RAG/simplified/test_collection_indexes.py` |
+| 1 | `Tests/Chatbooks/test_chatbook_unit.py` |
+| 1 | `Tests/Notes/test_notes_integration.py` |
+| 1 | `Tests/Notes/test_sync_engine.py` |
+| 1 | `Tests/Notes/test_notes_api_integration.py` |
+| 1 | `Tests/Notes/test_library_notes_sync_integration.py` |
+| 1 | `Tests/Character_Chat/test_world_book_manager.py` |
+| 1 | `Tests/TTS/test_higgs_integration.py` |
+| 1 | `Tests/TTS/test_tts_request_admission.py` |
+| 1 | `Tests/TTS/test_profile_service.py` |
+| 1 | `Tests/TTS/test_audio_cpp_contract.py` |
+| 1 | `Tests/TTS/test_tts_improvements.py` |
+| 1 | `Tests/DB/test_subscriptions_db_watchlists.py` |
+| 1 | `Tests/DB/test_pagination.py` |
+| 1 | `Tests/DB/test_subscriptions_db.py` |
+| 1 | `Tests/DB/test_sql_debug_logging.py` |
+| 1 | `Tests/DB/test_core_sqlite_owner_privacy.py` |
+| 1 | `Tests/Auth_Account/test_server_auth_account_service.py` |
+| 1 | `Tests/Skills/test_skill_trust_service.py` |
+| 1 | `Tests/Skills/test_verify_content_binary.py` |
+| 1 | `Tests/Performance/test_app_startup_performance.py` |
+| 1 | `Tests/LLM_Provider_Catalog/test_llm_provider_catalog_scope_service.py` |
+| 1 | `Tests/Audio_Services/test_server_audio_services_service.py` |
+| 1 | `Tests/Audio_Services/test_audio_services_scope_service.py` |
+| 1 | `Tests/LLM_Management/test_mlx_lm.py` |
+| 1 | `Tests/Diarization/test_diarization_service.py` |
+| 1 | `Tests/RAG_Search/test_embeddings_performance.py` |
+
+## Mock-callgraph-only: 119 tests in 47 files
+
+| Count | File |
+|---|---|
+| 14 | `Tests/Scheduling/test_watchlist_check_handler.py` |
+| 14 | `Tests/tldw_api/test_mcp_unified_client.py` |
+| 9 | `Tests/LLM_Management/test_mlx_lm.py` |
+| 8 | `Tests/UI/test_library_screen.py` |
+| 6 | `Tests/Scheduling/test_reminder_handler.py` |
+| 5 | `Tests/Transcription/test_mlx_whisper_transcription.py` |
+| 4 | `Tests/UI/test_code_repo_copy_paste_window.py` |
+| 4 | `Tests/UI/test_study_screen.py` |
+| 4 | `Tests/UI/test_personas_workbench.py` |
+| 3 | `Tests/UI/test_home_screen.py` |
+| 3 | `Tests/Scheduling/test_scheduling_service.py` |
+| 2 | `Tests/UI/test_chat_search_enhanced.py` |
+| 2 | `Tests/UI/test_media_window_v2_parity.py` |
+| 2 | `Tests/Evals/test_eval_orchestrator.py` |
+| 2 | `Tests/Scheduling/test_scheduler_loop.py` |
+| 2 | `Tests/Watchlists/test_watchlists_collections_screen.py` |
+| 2 | `Tests/Subscriptions/test_notification_dispatch_service.py` |
+| 2 | `Tests/Audio/test_dictation_service.py` |
+| 2 | `Tests/Audio/test_voice_input_widget.py` |
+| 2 | `Tests/TTS/test_tts_app_ownership.py` |
+| 1 | `Tests/UI/test_command_palette_providers.py` |
+| 1 | `Tests/UI/test_console_mcp_approval.py` |
+| 1 | `Tests/UI/test_product_maturity_phase3_knowledge_entry.py` |
+| 1 | `Tests/UI/test_stts_playground_audio_cpp.py` |
+| 1 | `Tests/UI/test_product_maturity_phase3_library_study_context.py` |
+| 1 | `Tests/UI/test_console_context_modal.py` |
+| 1 | `Tests/UI/test_console_skill_commands.py` |
+| 1 | `Tests/UI/test_skill_script_confirm_card.py` |
+| 1 | `Tests/UI/test_command_palette_basic.py` |
+| 1 | `Tests/UI/test_search_rag_window.py` |
+| 1 | `Tests/UI/test_console_skill_install_confirm.py` |
+| 1 | `Tests/UI/test_personas_preview_restore.py` |
+| 1 | `Tests/UI/test_library_shell.py` |
+| 1 | `Tests/Evals/test_specialized_runners.py` |
+| 1 | `Tests/Scheduling/test_sync_engine.py` |
+| 1 | `Tests/Transcription/test_mlx_parakeet_transcription.py` |
+| 1 | `Tests/Web_Scraping/test_security.py` |
+| 1 | `Tests/integration/test_code_repo_integration.py` |
+| 1 | `Tests/Event_Handlers/test_note_ingest_events.py` |
+| 1 | `Tests/RAG/simplified/test_rag_service_basic.py` |
+| 1 | `Tests/Audio/test_recording_service.py` |
+| 1 | `Tests/Audio/test_console_dictation.py` |
+| 1 | `Tests/Notes/test_notes_library_unit.py` |
+| 1 | `Tests/TTS/test_tts_improvements.py` |
+| 1 | `Tests/Wizards/test_first_run_setup_wizard.py` |
+| 1 | `Tests/Widgets/test_chat_message_enhanced.py` |
+| 1 | `Tests/RAG_Search/test_embeddings_unit.py` |

--- a/backlog/tasks/task-1464 - Dead-and-vacuous-test-decision-table-owner-signoff.md
+++ b/backlog/tasks/task-1464 - Dead-and-vacuous-test-decision-table-owner-signoff.md
@@ -2,7 +2,7 @@
 id: TASK-1464
 title: >-
   Decision table for dead/vacuous tests: rotted skips, swallowed assertions, assertion-free and mock-only tests (owner sign-off)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-30 08:55'
 labels:
@@ -20,7 +20,46 @@ The audit (`backlog/docs/test-suite-audit-2026-07-30.md` §5) found ~416 tests t
 
 ## Acceptance Criteria
 
-- [ ] Decision table covers: 27 exception-swallowed tests; ~174 assertion-free; ~99 trivial-assert (incl. the 3 placeholder security tests in Tests/Web_Scraping/test_security.py); 143 mock-callgraph-only; module-level skips with contradicted reasons; test_vector_stores.py (delete vs rewrite); @slow policy (proposal: scheduled --run-slow job)
-- [ ] Each category has an owner decision recorded before any deletion lands
-- [ ] The xfail(strict=False) quarantine convention is documented in Tests/README.md
-- [ ] Approved subset implemented with itemized collect-only deltas
+- [x] Decision table covers: 27 exception-swallowed tests; ~174 assertion-free; ~99 trivial-assert (incl. the 3 placeholder security tests in Tests/Web_Scraping/test_security.py); 143 mock-callgraph-only; module-level skips with contradicted reasons; test_vector_stores.py (delete vs rewrite); @slow policy (proposal: scheduled --run-slow job)
+- [x] Each category has an owner decision recorded before any deletion lands
+- [x] The xfail(strict=False) quarantine convention is documented in Tests/README.md
+- [x] Approved subset implemented with itemized collect-only deltas
+
+## Implementation Plan
+
+1. Refresh every inventory on current dev before asking for rulings (audit data was 15 PRs stale; one whole category had self-resolved via foreign deletions)
+2. Present four category rulings via the decision table; implement the approved subset
+3. Verify per file; attribute any surrounding failures against the unmodified base tip
+
+## Implementation Notes
+
+Owner rulings (all four recommended options): un-swallow all; delete all
+placeholders; delete the stub suite + follow-up; inventory-only for bulk.
+
+Deleted: `test_worldbook_ui.py` + `test_chat_dictionaries_ui.py` (whole files —
+assert-True checklists, commented-out example bodies, a prose-dict
+"documentation test"); the 3 placeholder security tests (+ the emptied
+`TestSecureDefaults`); `test_vector_stores.py` (stub suite; real coverage filed
+as task-1600); the legacy AppTest block in `test_tools_settings_window.py`
+(guard + always-skip fixture + its 16 permanently-skipped consumers).
+
+Un-swallowed: of 16 flagged sites, 4 were verified-legitimate on inspection
+(collect-then-assert, known-type handler asserts, hypothesis assume) and left
+alone; 12 genuine swallows narrowed to the domain-error classes each contract
+permits, so crash classes now bite. The flagship
+`test_budget_monitoring_integration` immediately surfaced what its swallow hid:
+BudgetMonitor raises EAGERLY from update_cost and the old API
+(`is_budget_exceeded`/`check_budget`) is gone — the feature was integrated all
+along; the test was skipping itself. Rewritten to the real contract. The
+kokoro narrowing needed one widening round: under the suite's HF-offline
+default (task-1451) a missing model surfaces as OSError/LocalEntryNotFoundError,
+matched by class now.
+
+Category 4: `backlog/docs/test-suite-vacuous-inventory-2026-07-30.md` (249
+assertion-free / 119 mock-only candidates, with the helper-assert
+false-positive caveat front and center).
+
+Also observed, NOT from this change (identical on unmodified base): 11
+pre-existing failures in `Tests/TTS/test_profile_backup_integration.py` +
+`test_tts_preferences.py` — the in-flight speech workstream's area; reported in
+the PR rather than filed over their active work.

--- a/backlog/tasks/task-1600 - Real-vector-store-API-tests-replacing-deleted-stub-suite.md
+++ b/backlog/tasks/task-1600 - Real-vector-store-API-tests-replacing-deleted-stub-suite.md
@@ -1,0 +1,25 @@
+---
+id: TASK-1600
+title: >-
+  Write real vector_store.py API tests replacing the deleted stub suite
+status: To Do
+assignee: []
+created_date: '2026-07-30 23:20'
+labels:
+  - testing
+  - rag
+priority: medium
+dependencies: [task-1464]
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+task-1464 deleted `Tests/RAG/simplified/test_vector_stores.py` (~900 lines): it imported `tldw_chatbook.RAG_Search.simplified.vector_stores` — plural, a module that never existed — caught the ImportError, defined placeholder classes inside the test file, and tested those stubs. Permanently green, testing nothing. The real module (`vector_store.py`, singular — InMemory/Chroma vector stores) deserves a small, real test file: construction, add/query/delete round-trips, persistence behavior where applicable, and the skip-gating for the chromadb extra. Keep it modest — the stub suite's 900 lines are not the bar; a few dozen real assertions beat them.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [ ] A test file imports the REAL `vector_store` module (no fallback stubs) and fails collection if the import breaks
+- [ ] Round-trip coverage for the in-memory store; chromadb-backed coverage gated on the extra
+- [ ] Tests pass on a machine without the chromadb extra (gated skips) and with it


### PR DESCRIPTION
## Summary
PR #1128 merged **missing its last two commits**: the push in the final command chain silently delivered the branch at an earlier commit (during one of yesterday's TCC access flaps, after a worktree removal invalidated the shell's cwd), and the local branch was then deleted during cleanup. Both commits were recovered from dangling objects (`git fsck --lost-found`) and cherry-pick cleanly:

1. **Kokoro skip widening**: under the suite's offline-by-default HF env (task-1451), a missing model surfaces as `OSError`/`LocalEntryNotFoundError` about the disk cache; the narrowed handler now matches model-unavailable by exception class, not just message — without it, `Tests/RAG_Search` running before `test_kokoro_validation.py` turns the skip into a failure.
2. **The task-1464 artifacts**: task file → Done with full notes, `backlog/docs/test-suite-vacuous-inventory-2026-07-30.md` (the category-4 inventory: 249 assertion-free / 119 mock-only candidates with caveats), and the task-1600 filing.

## Verification
- Trigger pair (`test_embeddings_real_integration` then `test_kokoro_validation`): 13 passed / 12 skipped — the cross-file failure is gone
- Cherry-picks applied conflict-free onto current dev; parent chain verified (`2c2ee93f8` → `f56f87254` → the two commits #1128 did merge)
- Process note: chained `git add && commit && push && pr-create` swallowed the partial-push state; future chains verify the pushed tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores two commits lost in a partial push. Fixes Kokoro validation test skips under the offline-by-default HF env (task-1451) and lands TASK-1464 artifacts (decision table marked Done, vacuous-test inventory doc, and TASK-1600 to replace the deleted stub vector-store suite with real tests).

- **Bug Fixes**
  - Kokoro “model unavailable” now skips by exception class (ImportError/FileNotFoundError/OSError) and common messages; real init errors still fail. Prevents the cross-file failure when `Tests/RAG_Search` runs before `test_kokoro_validation.py`.

<sup>Written for commit d0b3a3f012a87785548a61b2a6bc28ba3cb915ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

