### PR TITLE
task-1600: real vector_store API tests (replaces the deleted stub suite)

### DIFF
--- a/Tests/RAG/simplified/test_vector_store.py
+++ b/Tests/RAG/simplified/test_vector_store.py
@@ -1,0 +1,173 @@
+# test_vector_store.py
+# Description: Real-API tests for RAG_Search.simplified.vector_store
+# (task-1600).
+#
+# Replaces the deleted test_vector_stores.py (plural), which imported a module
+# that never existed, caught the ImportError, and spent ~900 lines testing
+# placeholder classes defined inside the test file itself. Everything here
+# imports the REAL module at top level — if the import breaks, collection
+# breaks, loudly.
+
+import numpy as np
+import pytest
+
+from tldw_chatbook.RAG_Search.simplified.vector_store import (
+    InMemoryVectorStore,
+    SearchResult,
+)
+
+try:
+    import chromadb  # noqa: F401
+
+    CHROMADB_AVAILABLE = True
+except ImportError:
+    CHROMADB_AVAILABLE = False
+
+
+def _embed(*vectors: list[float]) -> np.ndarray:
+    return np.asarray(vectors, dtype=np.float32)
+
+
+def _seeded_store(**kwargs) -> InMemoryVectorStore:
+    store = InMemoryVectorStore(**kwargs)
+    store.add(
+        ids=["a", "b", "c"],
+        embeddings=_embed([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]),
+        documents=["doc about apples", "doc about bees", "doc about cats"],
+        metadata=[
+            {"topic": "fruit", "doc_id": "doc-1"},
+            {"topic": "insects", "doc_id": "doc-1"},
+            {"topic": "animals", "doc_id": "doc-2"},
+        ],
+    )
+    return store
+
+
+class TestInMemoryVectorStore:
+    def test_add_and_search_returns_nearest_document(self):
+        store = _seeded_store()
+
+        results = store.search(_embed([0.9, 0.1, 0.0])[0], top_k=2)
+
+        assert [r.id for r in results][0] == "a"
+        assert isinstance(results[0], SearchResult)
+        assert results[0].document == "doc about apples"
+        assert results[0].metadata == {"topic": "fruit", "doc_id": "doc-1"}
+        assert len(results) == 2
+
+    def test_dimension_mismatch_raises(self):
+        store = _seeded_store()
+
+        with pytest.raises(ValueError, match="dimension"):
+            store.add(
+                ids=["d"],
+                embeddings=_embed([1.0, 0.0]),  # 2-dim into a 3-dim store
+                documents=["wrong width"],
+                metadata=[{}],
+            )
+
+    def test_delete_document_removes_all_its_chunks_from_results(self):
+        store = _seeded_store()
+
+        # delete_document keys on each chunk's `doc_id` METADATA (all chunks
+        # of a document go together), not on chunk ids — chunks a+b belong to
+        # doc-1, c to doc-2.
+        store.delete_document("doc-1")
+        results = store.search(_embed([1.0, 0.0, 0.0])[0], top_k=3)
+
+        assert [r.id for r in results] == ["c"]
+
+    def test_clear_empties_the_store_and_stats_track_counts(self):
+        store = _seeded_store()
+        stats_before = store.get_collection_stats()
+        assert stats_before["count"] == 3
+
+        store.clear()
+
+        assert store.get_collection_stats()["count"] == 0
+        assert store.search(_embed([1.0, 0.0, 0.0])[0], top_k=3) == []
+
+    def test_metadata_allowlist_filters_before_ranking(self):
+        """An in-scope doc must win even when out-of-scope docs rank higher."""
+        store = _seeded_store()
+
+        results = store.search(
+            _embed([1.0, 0.0, 0.0])[0],
+            top_k=1,
+            metadata_allowlist={"topic": {"animals"}},
+        )
+
+        # 'a' (fruit) is the nearest neighbour but out of scope; the allowlist
+        # must exclude it BEFORE top_k truncation so 'c' still surfaces.
+        assert [r.id for r in results] == ["c"]
+
+    def test_lru_eviction_honours_max_documents(self):
+        store = InMemoryVectorStore(max_documents=2)
+        store.add(
+            ids=["a", "b"],
+            embeddings=_embed([1.0, 0.0], [0.0, 1.0]),
+            documents=["first", "second"],
+            metadata=[{}, {}],
+        )
+
+        store.add(
+            ids=["c"],
+            embeddings=_embed([1.0, 1.0]),
+            documents=["third"],
+            metadata=[{}],
+        )
+
+        stats = store.get_collection_stats()
+        assert stats["count"] == 2
+        remaining = {r.id for r in store.search(_embed([1.0, 1.0])[0], top_k=5)}
+        assert "c" in remaining
+        assert len(remaining) == 2
+
+
+@pytest.mark.skipif(not CHROMADB_AVAILABLE, reason="chromadb extra not installed")
+class TestChromaVectorStore:
+    def test_add_search_round_trip(self, tmp_path):
+        from tldw_chatbook.RAG_Search.simplified.vector_store import (
+            ChromaVectorStore,
+        )
+
+        store = ChromaVectorStore(persist_directory=tmp_path / "chroma")
+        try:
+            store.add(
+                ids=["a", "b"],
+                embeddings=_embed([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]),
+                documents=["doc about apples", "doc about bees"],
+                metadata=[{"topic": "fruit"}, {"topic": "insects"}],
+            )
+
+            results = store.search(_embed([0.9, 0.1, 0.0])[0], top_k=1)
+
+            assert [r.id for r in results] == ["a"]
+            assert results[0].document == "doc about apples"
+        finally:
+            store.close()
+
+    def test_data_persists_across_reopen(self, tmp_path):
+        from tldw_chatbook.RAG_Search.simplified.vector_store import (
+            ChromaVectorStore,
+        )
+
+        path = tmp_path / "chroma"
+        store = ChromaVectorStore(persist_directory=path)
+        try:
+            store.add(
+                ids=["a"],
+                embeddings=_embed([1.0, 0.0, 0.0]),
+                documents=["persisted doc"],
+                metadata=[{"topic": "fruit"}],
+            )
+        finally:
+            store.close()
+
+        reopened = ChromaVectorStore(persist_directory=path)
+        try:
+            results = reopened.search(_embed([1.0, 0.0, 0.0])[0], top_k=1)
+            assert [r.id for r in results] == ["a"]
+            assert results[0].document == "persisted doc"
+        finally:
+            reopened.close()

--- a/backlog/tasks/task-1600 - Real-vector-store-API-tests-replacing-deleted-stub-suite.md
+++ b/backlog/tasks/task-1600 - Real-vector-store-API-tests-replacing-deleted-stub-suite.md
@@ -2,7 +2,7 @@
 id: TASK-1600
 title: >-
   Write real vector_store.py API tests replacing the deleted stub suite
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-30 23:20'
 labels:
@@ -20,6 +20,24 @@ task-1464 deleted `Tests/RAG/simplified/test_vector_stores.py` (~900 lines): it 
 
 ## Acceptance Criteria
 
-- [ ] A test file imports the REAL `vector_store` module (no fallback stubs) and fails collection if the import breaks
-- [ ] Round-trip coverage for the in-memory store; chromadb-backed coverage gated on the extra
-- [ ] Tests pass on a machine without the chromadb extra (gated skips) and with it
+- [x] A test file imports the REAL `vector_store` module (no fallback stubs) and fails collection if the import breaks
+- [x] Round-trip coverage for the in-memory store; chromadb-backed coverage gated on the extra
+- [x] Tests pass on a machine without the chromadb extra (gated skips) and with it
+
+## Implementation Plan
+
+1. Map the real module API (Protocol, InMemoryVectorStore, ChromaVectorStore, SearchResult)
+2. In-memory: add/search round-trip, dimension-mismatch ValueError, delete_document by doc_id metadata, clear+stats, metadata_allowlist filters BEFORE top_k truncation, LRU eviction
+3. Chroma (gated on the extra): round-trip + persistence across reopen on tmp_path
+
+## Implementation Notes
+
+`Tests/RAG/simplified/test_vector_store.py` (singular, mirroring the module):
+8 tests, all passing with the chromadb extra installed; the Chroma class gates
+on the extra. Real-API contracts the stub suite could never have caught, and
+this authoring DID catch as corrections: `delete_document` keys on the chunk's
+`doc_id` METADATA (all chunks of a document), not chunk ids; stats expose
+`count`, not `document_count`. Deliberately pinned: `metadata_allowlist`
+excludes out-of-scope candidates BEFORE ranking/top_k truncation (an in-scope
+doc is never starved by higher-ranked out-of-scope ones — the scoping
+behavior's security property). Added: `Tests/RAG/simplified/test_vector_store.py`.


### PR DESCRIPTION
## Summary
The stub suite deleted in task-1464 imported a nonexistent module, silently fell back to placeholder classes defined in the test file, and spent ~900 lines testing those. This replaces it with **8 tests against the real `vector_store.py`** — top-level import, so a broken import breaks collection loudly:

- In-memory: add/search round-trip, dimension-mismatch `ValueError`, `delete_document`'s **doc_id-metadata contract** (deletes all of a document's chunks, not by chunk id), clear + stats, LRU eviction at `max_documents`
- **`metadata_allowlist` filters BEFORE ranking/top_k truncation** — an in-scope document is never starved out by higher-ranked out-of-scope ones (the scoping behavior's security property, pinned)
- Chroma (gated on the extra): round-trip + persistence across reopen

Writing against the real API immediately surfaced two contract facts the stubs would have hidden (delete-by-doc_id; stats key is `count`) — which is the whole point.

## Verification
- 8 passed with the chromadb extra installed (both gated tests exercised for real)
- Pushed tip verified equal to local HEAD before this PR (the #1128 partial-push lesson)
- Board: task-1600 Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the deleted stub suite with 8 real API tests for `tldw_chatbook.RAG_Search.simplified.vector_store`, covering in-memory round trips, delete-by-`doc_id`, `metadata_allowlist` pre-ranking filtering, stats `count`, LRU at `max_documents`, and optional Chroma persistence. Satisfies TASK-1600 and gates `chromadb` tests behind the extra so the suite passes with or without it.

<sup>Written for commit 09987732286401950f79dfe554d5294f35690d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

