### PR TITLE
fix(tts): close external audio.cpp Console UAT gaps

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -349,7 +349,7 @@
     },
     {
       "call_count": 15,
-      "diagnostic_digest": "18c0ccd17c530994bf29",
+      "diagnostic_digest": "a261ed24e24438c9cd40",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Evals_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1868,7 +1868,7 @@
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "d2a4ec2f8e19eb0e66f8",
+      "diagnostic_digest": "ac6fccf5d4ccb7bd5887",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Evals/sample_bench.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1986,8 +1986,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 4,
-      "diagnostic_digest": "f5bb24af8529f2c11c1d",
+      "call_count": 6,
+      "diagnostic_digest": "753face4b9ef467c6f6b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/evals_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2085,7 +2085,7 @@
     },
     {
       "call_count": 24,
-      "diagnostic_digest": "cc0e689d0a9a0397d10a",
+      "diagnostic_digest": "7207991b01343d312c08",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3143,6 +3143,6 @@
     "owner_files": 427,
     "persistent_sink_files": 4,
     "task_492_calls": 1067,
-    "task_494_calls": 6601
+    "task_494_calls": 6603
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -608,7 +608,7 @@
     },
     {
       "call_count": 24,
-      "diagnostic_digest": "c12f310dc57265e34532",
+      "diagnostic_digest": "f523d31c21726d9931ec",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -621,8 +621,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 34,
-      "diagnostic_digest": "adb95115a98acfbbd571",
+      "call_count": 36,
+      "diagnostic_digest": "5fbfa938ca7045a0d89d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1615,6 +1615,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "0d7578c0bec60f1e2308",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/TTS/character_request_resolver.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 5,
       "diagnostic_digest": "63385d1cf26d021dfa5f",
       "owner": "TASK-494",
@@ -1882,7 +1889,7 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "86d3b958727e904b7f16",
+      "diagnostic_digest": "8ab3390b39e2eb6f803f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/MCP_Modules/mcp_inspector.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1945,7 +1952,7 @@
     },
     {
       "call_count": 83,
-      "diagnostic_digest": "91c3b673d2be7a8a35d5",
+      "diagnostic_digest": "15fbd378f495dbd1e477",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/STTS_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2029,7 +2036,7 @@
     },
     {
       "call_count": 148,
-      "diagnostic_digest": "05c62b267adc1b60a2d5",
+      "diagnostic_digest": "53b46fca922c2017d48a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/personas_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2099,7 +2106,7 @@
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "e27dbdd0c832acfa6688",
+      "diagnostic_digest": "17abae3da75ce1eb6ff7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/stts_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2154,8 +2161,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 47,
-      "diagnostic_digest": "ee81e46363fb9b2f6199",
+      "call_count": 49,
+      "diagnostic_digest": "11eaf592f11ac78e747b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Speech/speech_playback_mixin.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2952,8 +2959,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 281,
-      "diagnostic_digest": "6e1cff04bfdccbbc35b7",
+      "call_count": 283,
+      "diagnostic_digest": "3db63caba3147e44f962",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3101,13 +3108,13 @@
         {
           "digest": "567455f2495e9603",
           "kind": "addHandler",
-          "line": 5737,
+          "line": 5739,
           "method": "addHandler"
         },
         {
           "digest": "928f6c554daaf493",
           "kind": "addHandler",
-          "line": 5791,
+          "line": 5793,
           "method": "addHandler"
         }
       ]
@@ -3133,9 +3140,9 @@
   "schema_version": 1,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 426,
+    "owner_files": 427,
     "persistent_sink_files": 4,
     "task_492_calls": 1067,
-    "task_494_calls": 6594
+    "task_494_calls": 6601
   }
 }

--- a/Tests/TTS/test_console_speak_autoplay.py
+++ b/Tests/TTS/test_console_speak_autoplay.py
@@ -35,6 +35,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from textual.app import App
 
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
@@ -44,6 +45,7 @@ from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSGlobalOverrideDecisionEvent,
     TTSMessageSpeechRequestEvent,
     TTSPlaybackEvent,
+    TTSProgressEvent,
 )
 from tldw_chatbook.Widgets.Chat_Widgets.chat_message import ChatMessage
 
@@ -73,6 +75,31 @@ class _FakeApp:
 
     async def _offer_tts_global_override(self, token: str) -> None:
         await TldwCli._offer_tts_global_override(self, token)
+
+
+class _ProgressHost(App[None]):
+    """Real Textual app exposing the DOMQuery used by the progress handler."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.loguru_logger = MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_tts_progress_handler_supports_real_textual_dom_query() -> None:
+    host = _ProgressHost()
+
+    async with host.run_test():
+        await TldwCli.handle_tts_progress_event(
+            host,
+            TTSProgressEvent(
+                message_id="console-msg-1",
+                progress=0.5,
+                status="Generating audio",
+            ),
+        )
+
+    host.loguru_logger.error.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_console_speak_autoplay.py
+++ b/Tests/TTS/test_console_speak_autoplay.py
@@ -77,7 +77,7 @@ class _FakeApp:
         await TldwCli._offer_tts_global_override(self, token)
 
 
-class _ProgressHost(App[None]):
+class ProgressHost(App[None]):
     """Real Textual app exposing the DOMQuery used by the progress handler."""
 
     def __init__(self) -> None:
@@ -87,7 +87,8 @@ class _ProgressHost(App[None]):
 
 @pytest.mark.asyncio
 async def test_tts_progress_handler_supports_real_textual_dom_query() -> None:
-    host = _ProgressHost()
+    """Verify progress handling with Textual's concrete DOMQuery type."""
+    host = ProgressHost()
 
     async with host.run_test():
         await TldwCli.handle_tts_progress_event(

--- a/Tests/UI/test_personas_generation_wiring.py
+++ b/Tests/UI/test_personas_generation_wiring.py
@@ -6,12 +6,16 @@ wiring (which field, which context mode, where the result lands, what happens
 on failure) is exercised without a provider.
 """
 
+# ``scaled_db`` is imported as a pytest fixture and then injected by name.
+# Ruff otherwise treats each fixture parameter as an ordinary redefinition.
+# ruff: noqa: F811
+
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
 import pytest
-from textual.widgets import Input
+from textual.widgets import Button, Input
 
 import tldw_chatbook.config as config_module
 from tldw_chatbook.Character_Chat.character_generation import (
@@ -25,6 +29,11 @@ from Tests.UI.test_personas_dictionaries import PersonasTestApp
 from Tests.UI.test_personas_library_scale import scaled_db  # noqa: F401  (fixture)
 
 pytestmark = pytest.mark.asyncio
+
+
+def _press(screen, selector: str) -> None:
+    """Post a button press without relying on an off-screen cached region."""
+    screen.query_one(selector, Button).press()
 
 
 class _FakeController:
@@ -109,10 +118,10 @@ async def test_generate_uses_the_editors_selected_context_mode(
         await pilot.click("#personas-char-editor-generate-context")
         await pilot.pause()
         # Scenario lives in the Advanced section; open it the way a user would.
-        await pilot.click("#personas-char-editor-advanced-toggle")
+        _press(screen, "#personas-char-editor-advanced-toggle")
         await pilot.pause()
 
-        await pilot.click("#personas-char-editor-generate-scenario")
+        _press(screen, "#personas-char-editor-generate-scenario")
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
@@ -181,14 +190,14 @@ async def test_regenerate_reruns_the_pending_field(
         screen,
         editor,
     ):
-        await pilot.click("#personas-char-editor-advanced-toggle")
+        _press(screen, "#personas-char-editor-advanced-toggle")
         await pilot.pause()
-        await pilot.click("#personas-char-editor-generate-scenario")
+        _press(screen, "#personas-char-editor-generate-scenario")
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         controller.result = "take two"
-        await pilot.click("#personas-char-editor-generate-regenerate")
+        _press(screen, "#personas-char-editor-generate-regenerate")
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 

--- a/backlog/tasks/task-710 - Make-external-audio.cpp-Console-TTS-settings-coherent.md
+++ b/backlog/tasks/task-710 - Make-external-audio.cpp-Console-TTS-settings-coherent.md
@@ -236,9 +236,25 @@ TASK-710 therefore remains **In Progress** and is not marked Done.
   after the two preceding wizard tests because the resulting `HomeScreen` lacks
   the expected shell-nav button. It is intentionally not fixed in this TTS
   closeout.
-- No process is listening on `127.0.0.1:8080`, so a fresh live external
-  audio.cpp rerun remains unavailable. Chatbook did not launch or supervise a
-  server. TASK-710 remains **In Progress**.
+- At the time of that audit, no process was listening on `127.0.0.1:8080`, so
+  a fresh live external audio.cpp rerun was unavailable. Chatbook did not launch
+  or supervise a server. TASK-710 remained **In Progress**.
+
+### Post-UAT progress-handler correction (2026-07-31)
+
+- A fresh live Console UAT exposed one caught UI error on each progress event:
+  the progress handler called unsupported `DOMQuery.union()`. The handler now
+  uses the same materialized two-query iteration as the working completion
+  handler.
+- A real-Textual regression test first reproduced the exact error and then
+  passed after the correction. The focused Console/native lifecycle set passed
+  all 35 tests; targeted Ruff lint and the new test file's format check passed.
+- The complete first-user UAT then passed against the user-owned listener at
+  `127.0.0.1:8080`: four progress events completed without handler errors, one
+  829,118-byte mono PCM16 WAV played through `afplay` (exit 0), and no streaming
+  events were emitted. The listener remained healthy under the same PID 36992
+  before and after the run. Evidence is retained under
+  `/private/tmp/tldw-task710-live-uat-v4963vrz`.
 
 ## Implementation Notes
 
@@ -261,6 +277,8 @@ TASK-710 therefore remains **In Progress** and is not marked Done.
 - No storage migration, dependency, managed-process behavior, or character
   profile behavior was added. ADR-023 is the governing amended decision; a new
   ADR was not created.
+- Corrected the shared TTS progress handler's Textual query iteration and added
+  a real-DOM regression test; no event, adapter, or runtime contract changed.
 - Added-line process-keyword review found only restart-recommendation copy and
   an in-process `asyncio.Event` close signal; it found no process launch or
   control API. The only changed profile-named file is the approved design

--- a/backlog/tasks/task-710 - Make-external-audio.cpp-Console-TTS-settings-coherent.md
+++ b/backlog/tasks/task-710 - Make-external-audio.cpp-Console-TTS-settings-coherent.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-26 04:41'
-updated_date: '2026-07-26 05:43'
+updated_date: '2026-07-31 11:20'
 labels:
   - tts
   - audio-cpp
@@ -211,6 +211,34 @@ skipped, and 2 errors. Its external rerun reduced to 37 failures; an untouched
 latest `origin/dev` control produced the identical exact 37 failures. The
 feature-only regression delta is zero, but the project-wide suite is not green.
 TASK-710 therefore remains **In Progress** and is not marked Done.
+
+### Latest-dev closeout audit (2026-07-31)
+
+- Rebased the clean closeout branch onto `origin/dev`
+  `70f08e5bad26571c7401435d508364607c05f967`.
+- A fresh repository-wide run on the immediately preceding TTS head completed
+  with 24,406 passed, 171 skipped, four failures, and two setup errors. The two
+  intervening `dev` commits only changed Settings styles/tests and did not
+  touch TASK-710 or any red node.
+- Both setup errors were sandbox-only loopback-bind denials. Each exact Console
+  provider gateway node passed alone outside the sandbox (0.80 and 0.83
+  seconds).
+- Closed two TTS-caused verification gaps: refreshed the reviewed production
+  diagnostic inventory for seven added TASK-494 diagnostic calls and one TTS
+  owner file (no persistent-sink topology change), and made Personas generation
+  wiring tests post button events directly when the TTS editor panel pushes
+  Advanced controls below the viewport.
+- Fresh relevant verification passed: 2,100 broad TTS/STTS tests with 14 skips,
+  all nine Personas generation-wiring tests, all three diagnostic-inventory
+  tests, Ruff check, Ruff format, and `git diff --check`.
+- The remaining observed full-suite failure is unrelated wizard test-state leakage:
+  `test_full_track_skip_everything_leaves_app_usable` passes alone but fails
+  after the two preceding wizard tests because the resulting `HomeScreen` lacks
+  the expected shell-nav button. It is intentionally not fixed in this TTS
+  closeout.
+- No process is listening on `127.0.0.1:8080`, so a fresh live external
+  audio.cpp rerun remains unavailable. Chatbook did not launch or supervise a
+  server. TASK-710 remains **In Progress**.
 
 ## Implementation Notes
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -6700,7 +6700,7 @@ class TldwCli(
         try:
             if event.message_id:
                 # Find the message widget and update progress
-                for message_widget in self.query(ChatMessage).union(
+                for message_widget in list(self.query(ChatMessage)) + list(
                     self.query(ChatMessageEnhanced)
                 ):
                     if (


### PR DESCRIPTION
## Summary
- Close the latest-dev TASK-710 verification gaps in the production diagnostic inventory and Personas generation-wiring coverage.
- Fix TTS progress handling for real Textual DOMQuery objects and add a red/green regression test.
- Record the successful first-user external audio.cpp Console UAT with complete-WAV playback and unchanged external-process ownership.

## Verification
- [x] Focused Console/native lifecycle suite: 35 passed
- [x] Targeted Ruff lint and Python compilation
- [x] git diff --check against dev
- [x] Live Console UAT: 4 progress events, 1 completion, 1 playback, 0 streaming events, afplay exit 0
- [x] External audio.cpp listener remained healthy under the same user-owned PID before and after UAT

## Architecture
No new ADR is required. ADR-023 remains the governing adapter/runtime boundary; this PR does not change that contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the TTS progress handler to work with real `textual` DOMQuery, closing TASK-710 external `audio.cpp` Console UAT gaps. Refreshed the production diagnostic inventory after a dev rebase and updated Personas generation wiring tests to press buttons directly; UAT confirms full WAV playback with unchanged external-process ownership.

<sup>Written for commit 571c077628b4a4ec31ddbef82a2c0f76ecd0498d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

