### PR TITLE
Evals: semantic-similarity path tests prove structurally, not by float accident (task-1615)

### DIFF
--- a/Tests/Evals/test_evaluation_metrics.py
+++ b/Tests/Evals/test_evaluation_metrics.py
@@ -48,8 +48,17 @@ class _ConstantEmbeddingModel:
 
     def __init__(self, vector):
         self._vector = vector
+        #: Number of encode() calls — the STRUCTURAL proof of which path
+        #: ran. The original detection relied on this vector's cosine
+        #: self-similarity landing a few ULPs short of 1.0, but that is
+        #: platform-dependent (on some BLAS/numpy builds the rounding
+        #: cancels and it computes exactly 1.0, making score-based
+        #: assertions vacuous or false — TASK-1615). Whether the model was
+        #: consulted at all is deterministic everywhere.
+        self.encode_calls = 0
 
     def encode(self, texts):
+        self.encode_calls += 1
         return [self._vector for _ in texts]
 
 
@@ -529,16 +538,23 @@ class TestSemanticSimilarityExactMatchShortCircuit:
         )
 
         assert score == 1.0
+        # Structural proof the short-circuit fired: the model was never
+        # consulted. Without this, the test is vacuous on platforms where
+        # the vector's self-similarity happens to compute exactly 1.0
+        # (TASK-1615) - the score alone cannot distinguish the two paths
+        # there.
+        assert model.encode_calls == 0
 
     def test_non_identical_strings_still_use_the_embedding_path(self):
         """Only LITERAL equality short-circuits; near-misses must not.
 
         "4" and "4 " are different strings (trailing space), so they must
         still go through the embedding model rather than short-circuiting.
-        Both map to the same precision-losing vector here, so the result
-        should be extremely close to 1.0 but demonstrably NOT the exact
-        1.0 the short-circuit would produce - proving this pair took the
-        embedding path, not the short-circuit.
+        The proof is structural - the model's encode() was consulted - not
+        score-based: both strings map to the same constant vector, whose
+        cosine self-similarity is exactly 1.0 on some BLAS/numpy builds
+        (TASK-1615), so ``score != 1.0`` was platform-dependent and false
+        here.
         """
         model = _ConstantEmbeddingModel(_PRECISION_LOSING_VECTOR)
 
@@ -546,7 +562,7 @@ class TestSemanticSimilarityExactMatchShortCircuit:
             "4", "4 ", embedding_model=model
         )
 
-        assert score != 1.0
+        assert model.encode_calls > 0
         assert score == pytest.approx(1.0)
 
 

--- a/backlog/tasks/task-1615 - Semantic-similarity-float-precision-test-fails-on-dev.md
+++ b/backlog/tasks/task-1615 - Semantic-similarity-float-precision-test-fails-on-dev.md
@@ -2,7 +2,7 @@
 id: TASK-1615
 title: >-
   Semantic-similarity float-precision test fails on dev
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-31 15:40'
 labels:
@@ -21,5 +21,11 @@ priority: low
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] The test passes deterministically, with the fix in either the fixture or the short-circuit sentinel
+- [x] The test passes deterministically, with the fix in either the fixture or the short-circuit sentinel
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: both tests in TestSemanticSimilarityExactMatchShortCircuit proved their path by floating-point accident — the fixture vector's cosine self-similarity lands a few ULPs short of 1.0 on some BLAS/numpy builds but EXACTLY 1.0 on this machine's, making `score != 1.0` false (the reported failure) and the exact-match test's `score == 1.0` vacuous (it would pass without the short-circuit). Fix is structural: `_ConstantEmbeddingModel` counts `encode()` calls; the exact-match test asserts the model was never consulted, the near-miss test asserts it was. Score assertions retained where platform-independent (`== 1.0` by short-circuit construction; `approx(1.0)` sanity). Mutation-verified: disabling the short-circuit fails the exact-match test via encode_calls even where the score still computes 1.0.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

Fixes the pre-existing deterministic failure `test_non_identical_strings_still_use_the_embedding_path` (`assert 1.0 != 1.0`), flagged during both recent Evals programs.

Root cause: both tests in `TestSemanticSimilarityExactMatchShortCircuit` proved which code path ran by **floating-point accident** — the fixture vector's cosine self-similarity lands a few ULPs short of 1.0 on some BLAS/numpy builds, but **exactly 1.0 on this machine's**, making the near-miss test's `score != 1.0` false, and (worse) making the exact-match test **vacuous** — it would pass with the short-circuit deleted.

Fix is structural: `_ConstantEmbeddingModel` counts `encode()` calls; exact-match asserts the model was **never consulted**, near-miss asserts it **was**. Platform-independent score assertions retained.

## Verification

- 23/23 in `Tests/Evals/test_evaluation_metrics.py` (was 22 passed / 1 failed).
- Mutation check: disabling the short-circuit (`if False and predicted == expected`) fails all 4 exact-match cases **via the call counter** — the score alone stays 1.0 on this platform, proving the old test could not detect this regression here. Restored clean.

Task-1615 Done (notes in the task file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes semantic-similarity path tests by proving the code path structurally (via embedding-model call counts) instead of relying on float equality. Fixes the nondeterministic failure on some BLAS/numpy builds and satisfies TASK-1615’s requirement for deterministic tests.

- **Bug Fixes**
  - Added an `encode_calls` counter to `_ConstantEmbeddingModel` and switched tests to assert call counts (0 for exact match, >0 for near miss).
  - Kept platform-independent score checks (`== 1.0` for short-circuit, `approx(1.0)` sanity).

<sup>Written for commit 21c7b3b48903734d17d420197c2f3081196f2c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

