### PR TITLE
feat(console): toggle selected message on repeated activation

### DIFF
--- a/Docs/superpowers/plans/2026-07-31-console-message-selection-toggle.md
+++ b/Docs/superpowers/plans/2026-07-31-console-message-selection-toggle.md
@@ -1,0 +1,364 @@
+# Console Message Selection Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Console users deselect the active transcript message by activating that same message again with either the mouse or keyboard.
+
+**Architecture:** Add one explicit toggle operation to `ConsoleTranscript` and route direct mouse/keyboard message activation through it. Keep `select_message()` as the idempotent absolute-selection API used by navigation and internal action-focus paths, while reusing the existing clear/select refresh and notification behavior.
+
+**Tech Stack:** Python 3.11+, Textual, pytest, pytest-asyncio, Textual `App.run_test()` and Pilot.
+
+**Backlog task:** `TASK-1334`
+
+**Design spec:** `Docs/superpowers/specs/2026-07-31-console-message-selection-toggle-design.md`
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This is a routine interaction correction inside the established Console transcript selection boundary. It changes no storage, ownership, service contract, security policy, dependency, or long-lived application structure.
+
+## Global Constraints
+
+- Clicking the selected message and pressing Enter on the selected transcript message must both clear selection and hide the contextual action row.
+- Enter with no selection must still select the first transcript message.
+- Enter on a focused contextual action button must continue to activate the button without clearing selection.
+- Up/Down and J/K navigation must remain absolute selection; boundary navigation must not toggle a message off.
+- `select_message(message_id: str) -> None` remains idempotent for internal callers.
+- Unknown or stale message IDs remain no-ops.
+- Do not change CSS, persistence, message models, screen-level state, or message-action behavior.
+- Follow strict red-green-refactor: observe each new behavior test fail for the expected missing branch before editing production code.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `tldw_chatbook/Widgets/Console/console_transcript.py` | Own the selection toggle and route message-row clicks and transcript Enter activation through it. |
+| `Tests/UI/test_console_native_transcript.py` | Exercise real mounted Textual mouse and keyboard behavior with `TranscriptHarness`. |
+| `backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md` | Track acceptance criteria, ADR determination, verification, and implementation notes. |
+
+No new production modules or dependencies are required.
+
+---
+
+### Task 1: Toggle Selection from a Repeated Message-Row Click
+
+**Files:**
+- Modify: `Tests/UI/test_console_native_transcript.py:458-489`
+- Modify: `tldw_chatbook/Widgets/Console/console_transcript.py:237-243,549-556`
+
+**Interfaces:**
+- Consumes: `ConsoleTranscript.selected_message_id: str | None`, `ConsoleTranscript.select_message(message_id: str) -> None`, and `ConsoleTranscript.action_clear_selection() -> None`.
+- Produces: `ConsoleTranscript.toggle_message_selection(message_id: str) -> None`, used by the message-row click handler and Task 2's keyboard handler.
+
+- [ ] **Step 1: Add the failing mounted mouse regression**
+
+Add this test after `test_console_transcript_click_selects_message_and_shows_actions`. The production mutation it catches is `ConsoleTranscriptMessage.on_click()` using absolute selection for an already selected row.
+
+```python
+@pytest.mark.asyncio
+async def test_console_transcript_click_selected_message_clears_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+
+        await pilot.click("#console-message-m2")
+        await pilot.pause()
+        assert transcript.selected_message_id == "m2"
+        assert "Save as..." in _visible_text(app)
+
+        await pilot.click("#console-message-m2")
+        await pilot.pause()
+
+        assert transcript.selected_message_id is None
+        assert "Save as..." not in _visible_text(app)
+```
+
+- [ ] **Step 2: Run the mouse regression and verify RED**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py::test_console_transcript_click_selected_message_clears_selection -v
+```
+
+Expected: FAIL on `assert transcript.selected_message_id is None` because the second click leaves it equal to `"m2"`.
+
+- [ ] **Step 3: Add the minimal toggle operation and route row clicks through it**
+
+Add the method directly after `select_message()`:
+
+```python
+def toggle_message_selection(self, message_id: str) -> None:
+    """Toggle one message's contextual selection state."""
+    if self._message_by_id(message_id) is None:
+        return
+    if self.selected_message_id == message_id:
+        self.action_clear_selection()
+        return
+    self.select_message(message_id)
+```
+
+Change the final line of `ConsoleTranscriptMessage.on_click()`:
+
+```python
+if isinstance(transcript, ConsoleTranscript):
+    transcript.toggle_message_selection(self.message_id)
+```
+
+Do not alter `select_message()`; navigation and internal callers require absolute selection.
+
+- [ ] **Step 4: Run the mouse regression and verify GREEN**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py::test_console_transcript_click_selected_message_clears_selection -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run neighboring mouse-selection regressions**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py -k "click_selects_message or click_selected_message or click_background or click_action_button or click_rule_separator" -v
+```
+
+Expected: all selected tests PASS; action buttons, rule separators, and negative-space clicks retain their existing behavior.
+
+- [ ] **Step 6: Commit the mouse toggle**
+
+```bash
+git add Tests/UI/test_console_native_transcript.py tldw_chatbook/Widgets/Console/console_transcript.py
+git commit -m "feat(console): toggle selected message on click"
+```
+
+---
+
+### Task 2: Toggle Selection from Keyboard Enter
+
+**Files:**
+- Modify: `Tests/UI/test_console_native_transcript.py:439-455`
+- Modify: `tldw_chatbook/Widgets/Console/console_transcript.py:615-617`
+
+**Interfaces:**
+- Consumes: `ConsoleTranscript.toggle_message_selection(message_id: str) -> None` from Task 1 and the existing `ConsoleTranscriptActionButton.on_key()` event stop.
+- Produces: Enter semantics where no selection selects the first message and an existing transcript selection toggles off.
+
+- [ ] **Step 1: Replace the misleading keyboard test with explicit behavior tests**
+
+Replace `test_console_transcript_keyboard_selects_messages_and_enter_shows_actions` with these tests. The first characterizes the existing no-selection contract. The second catches the missing selected-message Enter branch.
+
+```python
+@pytest.mark.asyncio
+async def test_console_transcript_enter_selects_first_message_when_none_selected():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        transcript.focus()
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert transcript.selected_message_id == "m1"
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_enter_clears_keyboard_selected_message():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        transcript.focus()
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert transcript.selected_message_id == "m1"
+        assert "Save as..." in _visible_text(app)
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert transcript.selected_message_id is None
+        assert "Save as..." not in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_boundary_navigation_keeps_last_message_selected():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        transcript.focus()
+
+        await pilot.press("down")
+        await pilot.press("down")
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert transcript.selected_message_id == "m2"
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_enter_on_action_button_preserves_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        await pilot.click("#console-message-m2")
+        transcript.focus_action("m2", "copy")
+        await pilot.pause()
+
+        button = app.query_one("#console-message-action-copy-m2", Button)
+        assert button.has_focus
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert transcript.selected_message_id == "m2"
+        assert "Save as..." in _visible_text(app)
+```
+
+- [ ] **Step 2: Verify the new keyboard expectations before production changes**
+
+Run the failing toggle test:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py::test_console_transcript_enter_clears_keyboard_selected_message -v
+```
+
+Expected: FAIL because Enter leaves `selected_message_id == "m1"`.
+
+Run the preserved no-selection test:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py::test_console_transcript_enter_selects_first_message_when_none_selected -v
+```
+
+Expected: PASS before production changes, confirming the existing behavior that must be preserved.
+
+Run the navigation and action-button characterizations:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py -k "boundary_navigation_keeps_last_message_selected or enter_on_action_button_preserves_selection" -v
+```
+
+Expected: both tests PASS before production changes, proving the absolute-selection and focused-button event boundaries that the implementation must retain.
+
+- [ ] **Step 3: Route transcript Enter through the toggle operation**
+
+Replace `action_confirm_selection()` with:
+
+```python
+def action_confirm_selection(self) -> None:
+    if self.selected_message_id is not None:
+        self.toggle_message_selection(self.selected_message_id)
+        return
+    if self._messages:
+        self.select_message(self._messages[0].id)
+```
+
+Do not change `ConsoleTranscriptActionButton.on_key()`; it already presses the focused button and stops the Enter event before the transcript can treat it as a selection toggle.
+
+- [ ] **Step 4: Run the keyboard and preserved-boundary tests and verify GREEN**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py -k "enter_selects_first_message_when_none_selected or enter_clears_keyboard_selected_message or boundary_navigation_keeps_last_message_selected or enter_on_action_button_preserves_selection" -v
+```
+
+Expected: all four tests PASS.
+
+- [ ] **Step 5: Verify navigation and action-row input boundaries**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py -k "keyboard or boundary_navigation or action_button_preserves_selection or enter_on_action_button or escape_collapses_selected_action_row" -v
+```
+
+Expected: all selected tests PASS. Up/Down and J/K still select absolutely, Escape still clears, and contextual action-button activation preserves selection.
+
+- [ ] **Step 6: Commit the keyboard toggle**
+
+```bash
+git add Tests/UI/test_console_native_transcript.py tldw_chatbook/Widgets/Console/console_transcript.py
+git commit -m "feat(console): toggle selected message with enter"
+```
+
+---
+
+### Task 3: Verify and Close TASK-1334
+
+**Files:**
+- Modify: `backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md`
+
+**Interfaces:**
+- Consumes: the completed mouse and keyboard behavior from Tasks 1-2.
+- Produces: verified acceptance criteria, implementation notes, and a Done Backlog task.
+
+- [ ] **Step 1: Run the complete focused transcript module**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_native_transcript.py -q --tb=short
+```
+
+Expected: PASS with no errors or warnings attributable to the change.
+
+- [ ] **Step 2: Run the broader selected-message Console regressions**
+
+Run:
+
+```bash
+pytest Tests/UI/test_console_native_chat_flow.py -k "selected_message or message_action" -q --tb=short
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 3: Run static diff validation and self-review**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit status 0.
+
+Review the final diff and confirm it contains only the explicit toggle method, the two activation routes, focused tests, and task documentation. Mentally mutate each route back to `select_message()` and confirm the corresponding mouse or keyboard test would fail.
+
+- [ ] **Step 4: Complete the Backlog task**
+
+Check all five acceptance criteria, add concise implementation notes naming the toggle API, mouse/keyboard routing, tests, and verification results, preserve the recorded ADR decision (`ADR required: no`), then set the task to Done:
+
+```bash
+backlog task edit 1334 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --notes "Added an explicit Console transcript selection toggle while preserving idempotent navigation selection. Repeated message-row clicks and Enter on the selected transcript message now clear selection through the existing refresh/notification path; Enter with no selection and focused contextual action buttons retain their prior behavior. Added mounted Textual regressions for mouse and keyboard paths and verified the focused transcript and selected-message Console suites. ADR required: no; this change stays within the existing UI interaction boundary. Modified tldw_chatbook/Widgets/Console/console_transcript.py and Tests/UI/test_console_native_transcript.py." -s Done
+```
+
+- [ ] **Step 5: Commit task completion metadata**
+
+```bash
+git add "backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md"
+git commit -m "docs(backlog): complete TASK-1334"
+```

--- a/Docs/superpowers/specs/2026-07-31-console-message-selection-toggle-design.md
+++ b/Docs/superpowers/specs/2026-07-31-console-message-selection-toggle-design.md
@@ -1,7 +1,7 @@
 # Console Message Selection Toggle Design
 
 **Date:** 2026-07-31
-**Status:** Approved design; written-spec review pending
+**Status:** Approved
 
 ## Goal
 

--- a/Docs/superpowers/specs/2026-07-31-console-message-selection-toggle-design.md
+++ b/Docs/superpowers/specs/2026-07-31-console-message-selection-toggle-design.md
@@ -1,0 +1,76 @@
+# Console Message Selection Toggle Design
+
+**Date:** 2026-07-31
+**Status:** Approved design; written-spec review pending
+
+## Goal
+
+Let a Console user deselect the active transcript message by activating that
+same message again with either the mouse or keyboard, without changing how
+message navigation or contextual actions work.
+
+## Interaction Contract
+
+- Clicking an unselected message selects it and shows its contextual action
+  row.
+- Clicking the selected message again clears selection and hides the action
+  row.
+- Pressing Enter while no message is selected keeps the existing behavior of
+  selecting the first message.
+- Pressing Enter while a transcript message is selected clears that selection.
+- Pressing Enter while a contextual action button has focus continues to invoke
+  that action; it does not clear the message selection.
+- Up/Down and J/K remain absolute navigation commands. Reaching a boundary or
+  programmatically selecting the current message must not toggle it off.
+- Escape and transcript negative-space clicks retain their existing deselection
+  behavior.
+
+## Design
+
+`ConsoleTranscript` will gain a focused `toggle_message_selection(message_id)`
+operation. It will validate the message ID through the same local message list
+used by `select_message()`. When the requested ID is already selected, it will
+delegate to `action_clear_selection()`; otherwise it will delegate to
+`select_message()`.
+
+`ConsoleTranscriptMessage.on_click()` will call the toggle operation instead of
+the absolute selection operation. `ConsoleTranscript.action_confirm_selection()`
+will keep selecting the first message when no selection exists, but will call
+the toggle operation for an existing selection.
+
+The existing `select_message()` method remains idempotent and unchanged for
+arrow-key navigation, action focusing, and other internal callers. This keeps
+toggle semantics limited to explicit user activation of a message.
+
+Both toggle branches reuse the existing refresh and selection-change
+notification paths. An unknown or stale message ID remains a no-op, matching
+current selection behavior. No CSS, persistence, message model, or screen-level
+state changes are required.
+
+## Testing
+
+Focused mounted Textual regressions will verify:
+
+1. Clicking a message selects it; clicking the same row again clears
+   `selected_message_id` and removes the contextual action row.
+2. Keyboard navigation can select a message; Enter on that selected message
+   clears `selected_message_id` and removes the action row.
+3. Enter with no selection still selects the first message, and focused action
+   buttons retain their existing Enter behavior through the unchanged button
+   handler coverage.
+
+The focused Console transcript test module will run first, followed by the
+relevant broader Console UI tests and `git diff --check`.
+
+## Scope and Decision Record
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: This is a routine interaction correction within the existing Console
+transcript selection boundary. It does not change storage, ownership, service
+contracts, security policy, dependencies, or long-lived application structure.
+
+Out of scope: multi-select, persistent selection, visual restyling, changes to
+message actions, and changes to transcript navigation boundaries.

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -2612,7 +2612,6 @@ async def test_console_selected_message_copy_action_works_from_keyboard():
         transcript.focus()
         await _wait_for_focus(console.app, pilot, transcript)
         await pilot.press("down")
-        await pilot.press("enter")
         await _wait_for_selector(
             console, pilot, f"#console-message-action-copy-{message.id}"
         )

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -174,6 +174,15 @@ def save_as_modal_destinations() -> list[ConsoleSaveDestination]:
     ]
 
 
+def test_console_transcript_enter_binding_describes_selection_toggle():
+    """Keep the visible Enter hint aligned with its select-or-clear behavior."""
+    enter_binding = next(
+        binding for binding in ConsoleTranscript.BINDINGS if binding[0] == "enter"
+    )
+
+    assert enter_binding[2] == "Toggle message selection"
+
+
 def test_console_transcript_renderable_uses_full_width_rules():
     transcript = ConsoleTranscript()
     transcript.set_messages(

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -576,6 +576,27 @@ async def test_console_transcript_click_selects_message_and_shows_actions():
 
 
 @pytest.mark.asyncio
+async def test_console_transcript_click_selected_message_clears_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+
+        await pilot.click("#console-message-m2")
+        await pilot.pause()
+        assert transcript.selected_message_id == "m2"
+        assert "Save as..." in _visible_text(app)
+
+        await pilot.click("#console-message-m2")
+        await pilot.pause()
+
+        assert transcript.selected_message_id is None
+        assert "Save as..." not in _visible_text(app)
+
+
+@pytest.mark.asyncio
 async def test_console_transcript_click_background_clears_selection():
     app = TranscriptHarness()
 

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -539,22 +539,83 @@ def test_console_transcript_failed_action_row_includes_retry_without_exceeding_b
 
 
 @pytest.mark.asyncio
-async def test_console_transcript_keyboard_selects_messages_and_enter_shows_actions():
+async def test_console_transcript_enter_selects_first_message_when_none_selected():
     app = TranscriptHarness()
 
     async with app.run_test(size=(100, 32)) as pilot:
-        await pilot.press("tab")
-        await pilot.press("down")
-        await pilot.press("enter")
-        text = _visible_text(app)
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        transcript.focus()
 
-    assert "Copy" in text
-    assert "Save as..." in text
-    assert "♻" in text
-    assert "👍" in text
-    assert "👎" in text
-    assert "🗑" in text
-    assert "|" not in text
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert transcript.selected_message_id == "m1"
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_enter_clears_keyboard_selected_message():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        transcript.focus()
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert transcript.selected_message_id == "m1"
+        assert "Save as..." in _visible_text(app)
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert transcript.selected_message_id is None
+        assert "Save as..." not in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_boundary_navigation_keeps_last_message_selected():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        transcript.focus()
+
+        await pilot.press("down")
+        await pilot.press("down")
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert transcript.selected_message_id == "m2"
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_enter_on_action_button_preserves_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        await pilot.click("#console-message-m2")
+        transcript.focus_action("m2", "copy")
+        await pilot.pause()
+
+        button = app.query_one("#console-message-action-copy-m2", Button)
+        assert button.has_focus
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert transcript.selected_message_id == "m2"
+        assert "Save as..." in _visible_text(app)
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md
+++ b/backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md
@@ -1,0 +1,51 @@
+---
+id: TASK-1334
+title: Toggle selected Console message off on repeated activation
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-31 22:16'
+updated_date: '2026-07-31 22:20'
+labels:
+  - console
+  - messages
+  - ux
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-07-31-console-message-selection-toggle-design.md
+  - Docs/superpowers/plans/2026-07-31-console-message-selection-toggle.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let Console users clear the active transcript message by activating that same message again with either the mouse or keyboard, so contextual actions can be dismissed without moving to another target.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Clicking an already selected transcript message clears selection and hides its contextual action row.
+- [ ] #2 Pressing Enter while a transcript message is selected clears selection and hides its contextual action row.
+- [ ] #3 Pressing Enter with no selected message still selects the first transcript message.
+- [ ] #4 Arrow-key navigation and contextual action activation retain their existing behavior.
+- [ ] #5 Focused automated regressions cover the mouse and keyboard toggle paths.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: Routine interaction correction within the existing Console transcript selection boundary; no storage, ownership, service-contract, security, dependency, or long-lived application-structure decision changes.
+
+Design: Docs/superpowers/specs/2026-07-31-console-message-selection-toggle-design.md
+Implementation plan: Docs/superpowers/plans/2026-07-31-console-message-selection-toggle.md
+
+1. Add a failing mounted regression for clicking the selected transcript message again.
+2. Add a validated toggle_message_selection() API, route message-row clicks through it, and verify the mouse selection regressions.
+3. Replace the ambiguous keyboard test with explicit Enter-select, Enter-deselect, boundary-navigation, and focused-action-button coverage; observe the selected-message Enter test fail.
+4. Route transcript Enter through the toggle API while preserving no-selection Enter and idempotent navigation behavior.
+5. Run the focused transcript module, broader selected-message Console regressions, and git diff --check.
+6. Self-review, complete all acceptance criteria, add implementation notes, and set TASK-1334 to Done.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md
+++ b/backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-1334
 title: Toggle selected Console message off on repeated activation
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-31 22:16'
-updated_date: '2026-07-31 22:20'
+updated_date: '2026-07-31 23:18'
 labels:
   - console
   - messages
@@ -25,11 +25,11 @@ Let Console users clear the active transcript message by activating that same me
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Clicking an already selected transcript message clears selection and hides its contextual action row.
-- [ ] #2 Pressing Enter while a transcript message is selected clears selection and hides its contextual action row.
-- [ ] #3 Pressing Enter with no selected message still selects the first transcript message.
-- [ ] #4 Arrow-key navigation and contextual action activation retain their existing behavior.
-- [ ] #5 Focused automated regressions cover the mouse and keyboard toggle paths.
+- [x] #1 Clicking an already selected transcript message clears selection and hides its contextual action row.
+- [x] #2 Pressing Enter while a transcript message is selected clears selection and hides its contextual action row.
+- [x] #3 Pressing Enter with no selected message still selects the first transcript message.
+- [x] #4 Arrow-key navigation and contextual action activation retain their existing behavior.
+- [x] #5 Focused automated regressions cover the mouse and keyboard toggle paths.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,3 +49,17 @@ Implementation plan: Docs/superpowers/plans/2026-07-31-console-message-selection
 5. Run the focused transcript module, broader selected-message Console regressions, and git diff --check.
 6. Self-review, complete all acceptance criteria, add implementation notes, and set TASK-1334 to Done.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `ConsoleTranscript.toggle_message_selection()` as the explicit activation toggle while preserving idempotent `select_message()` for navigation and internal callers. Repeated message-row clicks and Enter on the selected transcript message now clear selection through the existing refresh/notification path; Enter with no selection, boundary navigation, and focused contextual action buttons retain their prior behavior.
+
+Added mounted Textual regressions for mouse, keyboard, boundary-navigation, and focused-action paths. Updated the existing keyboard-copy flow to remove its obsolete preliminary Enter, which now correctly means deselect.
+
+Verification: 57 focused transcript tests passed; 16 broader selected-message/message-action tests passed with 177 deselected. Both runs emitted the two pre-existing Requests/webrtcvad dependency warnings. `git diff --check` passed.
+
+ADR required: no. This routine UI interaction correction stays within the existing Console transcript selection boundary.
+
+Modified: `tldw_chatbook/Widgets/Console/console_transcript.py`, `Tests/UI/test_console_native_transcript.py`, and `Tests/UI/test_console_native_chat_flow.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md
+++ b/backlog/tasks/task-1334 - Toggle-selected-Console-message-off-on-repeated-activation.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-31 22:16'
-updated_date: '2026-07-31 23:18'
+updated_date: '2026-08-01 00:05'
 labels:
   - console
   - messages
@@ -30,6 +30,7 @@ Let Console users clear the active transcript message by activating that same me
 - [x] #3 Pressing Enter with no selected message still selects the first transcript message.
 - [x] #4 Arrow-key navigation and contextual action activation retain their existing behavior.
 - [x] #5 Focused automated regressions cover the mouse and keyboard toggle paths.
+- [x] #6 The Enter binding help accurately describes toggling message selection.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,6 +49,7 @@ Implementation plan: Docs/superpowers/plans/2026-07-31-console-message-selection
 4. Route transcript Enter through the toggle API while preserving no-selection Enter and idempotent navigation behavior.
 5. Run the focused transcript module, broader selected-message Console regressions, and git diff --check.
 6. Self-review, complete all acceptance criteria, add implementation notes, and set TASK-1334 to Done.
+7. Address review feedback by documenting the modified public actions, correcting the Enter binding hint, and adding a focused help-contract regression.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -57,7 +59,9 @@ Added `ConsoleTranscript.toggle_message_selection()` as the explicit activation 
 
 Added mounted Textual regressions for mouse, keyboard, boundary-navigation, and focused-action paths. Updated the existing keyboard-copy flow to remove its obsolete preliminary Enter, which now correctly means deselect.
 
-Verification: 57 focused transcript tests passed; 16 broader selected-message/message-action tests passed with 177 deselected. Both runs emitted the two pre-existing Requests/webrtcvad dependency warnings. `git diff --check` passed.
+Qodo follow-up: added Google-style documentation for `toggle_message_selection()` and `action_confirm_selection()`, and changed the visible Enter binding hint from the obsolete one-way “Show actions” wording to “Toggle message selection.” Added a focused regression that failed against the stale hint before the production change. This review step was appended to the implementation plan during review remediation after the initial implementation was already complete.
+
+Verification after review remediation: 80 focused transcript tests passed; 16 broader selected-message/message-action tests passed with 257 deselected. Both runs emitted the pre-existing Requests dependency warning. `git diff --check` passed. The earlier user-approved full-suite exception remains the unrelated Audio stream recovery failure documented on PR #1148.
 
 ADR required: no. This routine UI interaction correction stays within the existing Console transcript selection boundary.
 

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -406,7 +406,7 @@ class ConsoleTranscriptMessage(Static):
         while transcript is not None and not isinstance(transcript, ConsoleTranscript):
             transcript = transcript.parent
         if isinstance(transcript, ConsoleTranscript):
-            transcript.select_message(self.message_id)
+            transcript.toggle_message_selection(self.message_id)
 
 
 class ConsoleTranscriptActionButton(Button):
@@ -948,6 +948,15 @@ class ConsoleTranscript(VerticalScroll):
         if self.is_mounted:
             self.call_later(self.refresh_messages)
             self.call_later(self._notify_selection_changed)
+
+    def toggle_message_selection(self, message_id: str) -> None:
+        """Toggle one message's contextual selection state."""
+        if self._message_by_id(message_id) is None:
+            return
+        if self.selected_message_id == message_id:
+            self.action_clear_selection()
+            return
+        self.select_message(message_id)
 
     def focus_action(self, message_id: str, action_id: str) -> None:
         """Focus a selected-message action button by message/action ID."""

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1018,7 +1018,10 @@ class ConsoleTranscript(VerticalScroll):
         self._select_relative(-1)
 
     def action_confirm_selection(self) -> None:
-        if self.selected_message_id is None and self._messages:
+        if self.selected_message_id is not None:
+            self.toggle_message_selection(self.selected_message_id)
+            return
+        if self._messages:
             self.select_message(self._messages[0].id)
 
     def action_clear_selection(self) -> None:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -577,7 +577,7 @@ class ConsoleTranscript(VerticalScroll):
     BINDINGS = [
         ("down,j", "select_next", "Next message"),
         ("up,k", "select_previous", "Previous message"),
-        ("enter", "confirm_selection", "Show actions"),
+        ("enter", "confirm_selection", "Toggle message selection"),
         ("escape", "clear_selection", "Clear selection"),
         ("c", "invoke_selected_action('copy')", "Copy"),
         ("e", "invoke_selected_action('edit')", "Edit"),
@@ -950,7 +950,11 @@ class ConsoleTranscript(VerticalScroll):
             self.call_later(self._notify_selection_changed)
 
     def toggle_message_selection(self, message_id: str) -> None:
-        """Toggle one message's contextual selection state."""
+        """Toggle one message's contextual selection state.
+
+        Args:
+            message_id: Identifier of the transcript message to select or clear.
+        """
         if self._message_by_id(message_id) is None:
             return
         if self.selected_message_id == message_id:
@@ -1018,6 +1022,7 @@ class ConsoleTranscript(VerticalScroll):
         self._select_relative(-1)
 
     def action_confirm_selection(self) -> None:
+        """Select the first message or clear the current transcript selection."""
         if self.selected_message_id is not None:
             self.toggle_message_selection(self.selected_message_id)
             return


### PR DESCRIPTION
## Summary

- Toggle a selected Console transcript message off when it is clicked again.
- Toggle the selected transcript message off with Enter while preserving initial selection and focused action-button behavior.
- Add mounted mouse and keyboard regression coverage, including boundary navigation and the existing keyboard-copy flow.
- Complete TASK-1334. ADR required: no (localized interaction behavior with no architectural boundary changes).

## Testing

- `pytest Tests/UI/test_console_native_transcript.py -q --tb=short` — 79 passed
- `pytest Tests/UI/test_console_native_chat_flow.py -k "selected_message or message_action" -q --tb=short` — 16 passed, 257 deselected
- `git diff --check origin/dev...HEAD` — clean

## Known unrelated failure

- The full suite was attempted and stopped on `Tests/Audio/test_audio_integration.py::TestErrorRecovery::test_recording_recovery_from_stream_error`: it expected at least two chunks but received zero. The failure reproduces independently, and this branch changes no Audio files. Per request, this unrelated failure was skipped for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds selection toggle to the Console transcript. Clicking or pressing Enter on the selected message now clears selection and hides its action row, and the Enter help hint now reflects this toggle behavior. Completes TASK-1334.

- New Features
  - Added `toggle_message_selection(message_id)` and routed message-row clicks and Enter through it.
  - Enter with no selection still selects the first message; Enter on a focused action button preserves selection.
  - Up/Down and J/K remain absolute selection; boundary navigation unchanged.
  - Added focused UI regressions for mouse/keyboard and the Enter binding hint; updated keyboard copy flow to remove an obsolete Enter.

<sup>Written for commit ac1a06cac799bed6d60c29f5f17262b515386817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

