### PR TITLE
docs(briefings): re-verify phase 2b assumptions against current dev

### DIFF
--- a/Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md
+++ b/Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md
@@ -19,7 +19,8 @@ synthesis split out to phase 2b (task-1630) after the adapter reality below surf
 (this design's own "verified against the real adapters at plan time" caveat, see "Casting and
 audio" below):
 
-1. `synthesize()` returns a byte-stream `TTSAudioResponse` the caller must drain and `aclose()`.
+1. `synthesize()` returns a byte-stream `TTSAudioResponse` the caller must drain and `aclose()`
+   (it is also an async context manager -- prefer `async with`).
 2. Legacy adapters (kokoro/openai/elevenlabs/chatterbox/higgs/alltalk) reject a plain
    `TTSRequest` -- per-call synthesis goes through `generate_audio_stream(OpenAISpeechRequest,
    internal_model_id)`.
@@ -28,6 +29,46 @@ audio" below):
    decode-and-concat primitive must be written.
 5. `private_paths` has no binary append/stream/move helper -- storage is buffer-whole-then-
    `atomic_private_write_bytes` or a new helper.
+
+**Re-verified against dev 2026-07-31 (`8b7fa5eb6`), after ~2,000 lines of TTS character-assignment
+work merged from another workstream.** Findings 1, 3 and 4 hold verbatim. Three corrections, and
+one new constraint that bounds what phase 2b can promise:
+
+- **Finding 2, corrected.** The adapter-level rejection stands (`legacy_bridge.py:681`), but a
+  public all-provider entry point now exists: `TTSService.synthesize_default(text=...,
+  voice_override=...)` builds the legacy option pair itself (`request_admission.py:314,356`).
+  It reads provider/model/format/speed from the app's global `TTSPreferencesSnapshot` and accepts
+  only a voice override, so it is a **one-voice-for-everyone** path -- it cannot express a roster.
+  The new `character_request_resolver.py` does not close this either: it is hard-fenced to
+  `audio_cpp` at two levels (`character_request_resolver.py:85`, `TTS_Generation.py:562`).
+- **Finding 5, corrected.** `open_private_binary` **does** exist (`private_paths.py:864`) but is
+  **read-only** (`O_RDONLY`, `:28`) -- useful for playback-side reads, not for writing. A text
+  append stream exists (`:767`); the binary equivalent does not, and there is no public move
+  helper. The write decision stands: buffer-whole-then-`atomic_private_write_bytes`, or add
+  `open_private_binary_append` modelled on the text one.
+- **The id-builder is now duplicated and the two copies disagree.**
+  `stts_events.py:737` derives kokoro's engine suffix from `options["use_onnx"]` and alltalk's id
+  from `snapshot.model_id`; `request_admission.py:356` hardcodes `local_kokoro_default_onnx` and
+  `alltalk_default`. Phase 2b must promote one to a public builder rather than writing a third.
+- **New constraint: per-speaker exact voices work only on `audio_cpp` today.** `synthesize_exact`
+  (the only path that guarantees the voice you asked for is the voice you got) refuses every other
+  provider. A legacy-provider roster is reachable only through raw
+  `generate_audio_stream(OpenAISpeechRequest, internal_model_id)`, which returns a bare
+  `AsyncIterator[bytes]` with no response contract to validate against. Phase 2b must either scope
+  multi-voice rosters to `audio_cpp` and say so in the UI, or own that validation itself.
+- **Audio snapshots need more than 2a records.** `briefing_scripts.roster_snapshot_json` stores
+  `voice_profile_id` (a stringified profile UUID) and is deliberately immutable. For audio to stay
+  self-interpreting the `briefing_audio` row must snapshot the profile's **`revision`** plus the
+  denormalized selection -- `CharacterTTSRequestResolution` already carries `profile_revision` for
+  exactly this purpose. `profile_portability.py` is the right shape precedent but not a reusable
+  mechanism (it is `audio_cpp`-only and drops `revision`).
+- **Reference implementation to transcribe, not reinvent:** `TTSEventHandler._generate_tts`
+  (`Event_Handlers/TTS_Events/tts_events.py:731`) already solves response-contract validation,
+  batched artifact appends, `aclose()`-in-`finally` that preserves the primary exception,
+  cancellation cleanup, bounded error copy, and metrics. Playback, rate limiting and cooldown
+  admission all exist too. The genuinely new surfaces are: a general decode-and-concat stitcher,
+  a `TTSProfileService.get_profile(UUID)` passthrough (the repository has one, the service does
+  not expose it), the `briefing_audio` table, and the binary-append decision above.
 6. `briefing_presets` ships a single free-text `style_notes` field, not the separate "style and
    target-length notes" the entity table below promises: target-length guidance ships folded into
    that same free-text field for 2a, with no dedicated field of its own; a dedicated field is 2b's

--- a/backlog/tasks/task-1630 - Briefings-phase-2b-audio-synthesis-stitching-playback.md
+++ b/backlog/tasks/task-1630 - Briefings-phase-2b-audio-synthesis-stitching-playback.md
@@ -29,12 +29,47 @@ script casting, not a same-shape extension of it:
    internal_model_id)`.
 3. `text_processing`'s chunking has zero live callers -- callers must chunk AND stitch themselves;
    there is no free ride from an existing pipeline.
-4. The only existing stitcher (`_generate_legacy`,
-   `tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py`) is naive byte-concat, which is wrong
-   for WAV headers -- a real pydub decode-and-concat primitive must be written.
+4. The only multi-segment stitcher (`AudioBookGenerator._combine_segments`,
+   `tldw_chatbook/TTS/audiobook_generator.py:638`) is naive byte-concat, which is wrong for WAV
+   headers -- a real pydub decode-and-concat primitive must be written. (The real decode-and-concat
+   that exists is M4B-specific, buried in `AudioService.create_m4b_with_chapters`,
+   `audio_service.py:340`.)
 5. `Utils/private_paths` has no binary append/stream/move helper -- storage is either
    buffer-whole-then-`atomic_private_write_bytes`, or a new helper, and that choice has not been
    made.
+
+**Re-verified against dev `8b7fa5eb6` (2026-07-31)** after ~2,000 lines of TTS character-assignment
+work merged. Findings 1, 3, 4 hold (4's file attribution above is the corrected one -- an earlier
+draft wrongly named `_generate_legacy`, which merely joins the chunks of ONE response). Corrections
+and additions, all detailed in the spec's re-verification block:
+
+- **Finding 2:** a public all-provider path now exists (`TTSService.synthesize_default`,
+  `TTS_Generation.py:895`) that builds the legacy options itself -- but it is global-preferences
+  only (one voice for everyone), so it cannot serve a roster. `character_request_resolver.py` is
+  hard-fenced to `audio_cpp` and does not help legacy providers.
+- **Finding 5:** `open_private_binary` exists but is READ-ONLY (`private_paths.py:864`); the write
+  decision is unchanged.
+- **New constraint:** per-speaker *exact* voices work only on `audio_cpp` (`synthesize_exact`
+  refuses all other providers). Scope multi-voice rosters accordingly, or own the response
+  validation for the raw `generate_audio_stream` path.
+- **New surfaces this task must add:** a general decode-and-concat stitcher; a
+  `TTSProfileService.get_profile(UUID)` passthrough (the repository has one at
+  `profile_repository.py:1314`, the service does not expose it, so today a stored
+  `voice_profile_id` can only be resolved by paging `list_profiles`); the `briefing_audio` table;
+  and a public legacy internal-model-id builder (two private copies exist and they DISAGREE on
+  kokoro/alltalk ids -- `stts_events.py:737` vs `request_admission.py:356`).
+- **Transcribe, don't reinvent:** `TTSEventHandler._generate_tts` (`tts_events.py:731`) is a
+  hardened per-message synthesize→drain→append→publish loop (response-contract validation, batched
+  writes, `aclose()` in a `finally` that preserves the primary exception, cancellation cleanup,
+  bounded error copy, metrics). Playback (`TTS/audio_player.py` + `tts_events.py:1568-1600` -- read
+  the stop-guard docstring first) and cooldown/admission already exist.
+- **Snapshot more than 2a records:** `briefing_scripts.roster_snapshot_json` is immutable and holds
+  only `voice_profile_id`; the `briefing_audio` row must also snapshot the profile's `revision` and
+  denormalized selection to stay self-interpreting. `profile_portability.py` is a shape precedent,
+  not a reusable mechanism.
+- **UI note:** `ArtifactsPane.selected_script` is `recompose=True`, so audio widgets hung off
+  `#artifacts-script-detail` are rebuilt on every script selection -- playback state must live in
+  the app-level player singleton, not the widget.
 
 This task is the audio half of spec #2 phase 2: turning a cast script (`briefing_scripts`, already
 shipped) into stored, playable audio (`briefing_audio`, not yet built). The roster's


### PR DESCRIPTION
## Summary

Phase 2b (audio) was scoped against a TTS-layer survey taken before phase 2a started. Since then roughly 2,000 lines of TTS character-assignment work merged from another workstream (a new `character_request_resolver.py`, a much larger profile service, a portability codec). This re-verifies every recorded assumption against dev's tip and corrects what drifted, so the 2b plan is written against facts rather than a stale snapshot.

**Three of the five recorded findings were wrong or misleading:**

1. **Legacy adapters / synthesis path** — half-obsolete. A public all-provider entry point now exists (`TTSService.synthesize_default`) that builds the legacy request options itself, so part of the façade 2b planned to write already exists. But it reads the app's *global* preferences and accepts only a single voice override, so it cannot express a roster; and the new character resolver is hard-fenced to `audio_cpp` at two levels, so it does not close the gap for legacy providers.
2. **Private storage** — `open_private_binary` does exist, but it is read-only (useful for playback reads, not writes). The write decision is unchanged rather than absent.
3. **Stitcher attribution** — task-1630 named `_generate_legacy`, which joins the chunks of a *single* response (correct behaviour). The real naive multi-segment stitcher is `AudioBookGenerator._combine_segments`; the only true decode-and-concat is M4B-specific.

Findings 1, 3 and 4 (streaming response contract, dead chunking helper, no general stitcher) hold verbatim.

**New constraint that bounds what 2b can promise:** per-speaker *exact* voices work only on `audio_cpp` today — `synthesize_exact`, the only call that guarantees the requested voice is the voice used, refuses every other provider. A legacy-provider roster is reachable only via the raw stream path, which returns no response contract to validate against.

**New surfaces 2b must add** (each verified absent): a general decode-and-concat stitcher; a `get_profile(UUID)` passthrough on the profile service (the repository has one, the service does not expose it, so a stored `voice_profile_id` can currently only be resolved by paging); the `briefing_audio` table; a public legacy internal-model-id builder — two private copies exist and they *disagree* on kokoro and alltalk ids.

**What 2b should transcribe rather than reinvent:** `TTSEventHandler._generate_tts` already solves response-contract validation, batched artifact appends, `aclose()` in a `finally` that preserves the primary exception, cancellation cleanup, bounded error copy, and metrics. Playback and cooldown admission exist too.

Also records that audio snapshots need the profile's `revision` (not just the id 2a stores) to stay self-interpreting, and that the script-detail pane recomposes on selection, so playback state must live in the app-level player singleton.

## Test plan

Documentation only — no code changes, no test impact. Every claim carries a `file:line` citation verified against dev's tip (`8b7fa5eb6`), including the absence claims, which were checked by repo-wide grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-verified the phase 2b audio plan against current dev and corrected three stale findings. Documents a new constraint, clarifies what 2b must build, and points to existing TTS code to reuse for task-1630.

- **Highlights**
  - Corrects findings: a public all-provider `synthesize_default` exists but is single-voice; `open_private_binary` is read-only; real multi-segment stitcher attribution fixed.
  - New constraint: per-speaker exact voices are `audio_cpp`-only; legacy rosters require the raw stream path with no response contract.
  - Surfaces 2b must add: decode+concat stitcher, `TTSProfileService.get_profile(UUID)` passthrough, `briefing_audio` table, and a public legacy internal-model-id builder.
  - Reuse, don’t rebuild: `TTSEventHandler._generate_tts` for validation, draining, batching, cleanup, and metrics; existing playback and cooldown/admission.

<sup>Written for commit 56e4263927eaa902f1dad91d020deeec1c9968a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

