### PR TITLE
Evals follow-up batch: copy truth, a missing pin, description hygiene (tasks 1612-1614)

### DIFF
--- a/Tests/Evals/test_evals_db.py
+++ b/Tests/Evals/test_evals_db.py
@@ -177,6 +177,46 @@ class TestTaskOperations:
         assert task["description"] == "Updated description"
         assert task["config_data"]["version"] == 2
 
+    def test_create_task_strips_control_characters_from_description(self, in_memory_db):
+        """create_task has always filtered control characters out of
+        ``description`` -- see its own inline comment ("Clean control
+        characters from name and description"). Pins the exact round-trip
+        so a future refactor (e.g. task-1614's shared ``_clean_task_
+        description`` helper) cannot silently change this behavior."""
+        task_id = in_memory_db.create_task(
+            name="hazard_task",
+            description="Hazard\x00\x01\x07 description\x1b[31m",
+            task_type="question_answer",
+            config_format="custom",
+            config_data={"test": "data"},
+        )
+
+        task = in_memory_db.get_task(task_id)
+        assert task["description"] == "Hazard description[31m"
+
+    def test_update_task_strips_control_characters_from_description(self, in_memory_db):
+        """task-1614: parity fix -- update_task used to pass ``description``
+        straight through with NO control-character filtering at all,
+        unlike create_task (see the sibling test above for that path's
+        identical, pre-existing behavior). Both now share
+        ``_clean_task_description``, so this pins the same exact
+        round-trip on the update path."""
+        task_id = in_memory_db.create_task(
+            name="hazard_update_task",
+            description="Original",
+            task_type="question_answer",
+            config_format="custom",
+            config_data={"test": "data"},
+        )
+
+        success = in_memory_db.update_task(
+            task_id, description="Hazard\x00\x01\x07 description\x1b[31m"
+        )
+        assert success
+
+        task = in_memory_db.get_task(task_id)
+        assert task["description"] == "Hazard description[31m"
+
     def test_delete_task(self, in_memory_db):
         """Test task deletion (soft delete)."""
         task_id = in_memory_db.create_task(

--- a/Tests/UI/test_evals_bench_editor.py
+++ b/Tests/UI/test_evals_bench_editor.py
@@ -341,6 +341,29 @@ def _target_status_text(screen, index: int) -> str:
     return text.plain if hasattr(text, "plain") else str(text)
 
 
+def test_llama_targets_uses_the_documented_list_limit_not_list_models_default(
+    evals_db: EvalsDB,
+):
+    """task-1612: ``EvalsViewModel.llama_targets()`` used to call
+    ``db.list_models(provider="llama_cpp")`` with no ``limit=`` at all,
+    silently falling back to ``EvalsDB.list_models``'s own default of 100
+    -- unlike every other read on ``EvalsViewModel``
+    (``_all_tasks``/``datasets``/``run_groups``/``runs_for_task``), which
+    all pass the module's documented ``_LIST_LIMIT`` (500) so a busy
+    install's older rows do not silently fall off. This creates more than
+    100 ``llama_cpp`` models and asserts none are dropped -- before the
+    fix, only the newest 100 came back."""
+    for i in range(120):
+        evals_db.create_model(
+            name=f"llama-target-{i}", provider="llama_cpp", model_id=f"model-{i}"
+        )
+
+    view_model = EvalsViewModel(evals_db)
+    targets = view_model.llama_targets()
+
+    assert len(targets) == 120
+
+
 # ---------------------------------------------------------------------------
 # Detail pane: bench metadata + target table
 # ---------------------------------------------------------------------------
@@ -1172,13 +1195,19 @@ async def test_blank_name_save_failure_renders_the_db_rejection_callout(
 async def test_renaming_to_a_taken_name_renders_the_conflict_callout(
     evals_app, evals_db, bench_with_mixed_readiness
 ):
-    """Mutation check (Step 4 of the task-5 brief): dropping the
-    `ConflictError` half of `_on_save_pressed`'s `except (ValueError,
-    ConflictError)` clause makes this test fail -- `Evals_DB.update_task`
-    raises `ConflictError` (an `EvalsDBError`, NOT a `ValueError`) for a
-    `eval_tasks.name` UNIQUE collision, so a bare `except ValueError` would
-    let it propagate uncaught out of this handler instead of rendering the
-    callout asserted below."""
+    """Mutation check (task-1612): dropping `_on_save_pressed`'s
+    `except ConflictError` clause makes this test fail -- `Evals_DB.
+    update_task` raises `ConflictError` (an `EvalsDBError`, NOT a
+    `ValueError`), so it would no longer be caught by the sibling
+    `except (ValueError, RuntimeError)` clause and would propagate
+    uncaught out of this handler instead of rendering the callout below.
+
+    task-1612: pins the bench-vocabulary copy exactly -- the DB's own
+    raw message ("Task name already exists") says "Task", not "bench",
+    and never mentions that `eval_tasks.name`'s UNIQUE index has no
+    `deleted_at` exemption (a deleted bench's name stays reserved), so a
+    prior substring-only assertion here would have tolerated either the
+    raw DB copy or this replacement."""
     task_id, _ = bench_with_mixed_readiness
     other_dataset_id = evals_db.create_dataset(
         name="other-dataset", format="custom", source_path="inline:other-dataset"
@@ -1206,7 +1235,11 @@ async def test_renaming_to_a_taken_name_renders_the_conflict_callout(
 
         callout = screen.query_one("#evals-bench-form-error")
         assert callout.display
-        assert "already exists" in str(callout.renderable)
+        assert str(callout.renderable) == (
+            'A bench named "taken-name" already exists -- choose a '
+            "different name. (Deleting a bench does not free its name: "
+            "a deleted bench may still be holding it.)"
+        )
 
         # No recompose on failure: the Input still shows what was typed.
         assert screen.query_one("#evals-bench-name", Input).value == "taken-name"

--- a/Tests/UI/test_evals_bench_editor.py
+++ b/Tests/UI/test_evals_bench_editor.py
@@ -1579,6 +1579,48 @@ async def test_zero_models_state_offers_create_target_and_stages_it(
 
 
 @pytest.mark.asyncio
+async def test_create_target_with_no_llama_cpp_server_configured_notifies_and_creates_nothing(
+    evals_app, evals_db, bench_with_zero_llama_models
+):
+    """task-1613: pins the zero-config error path for the "+ New target"
+    mini-form's button (``#evals-bench-create-target`` -- task-1611 T2
+    renamed its LABEL from "Create target from configured llama.cpp
+    server" to "+ New target", but kept the id and the gate this test
+    drives). Unlike every other create-target test in this module, this
+    one uses the bare ``evals_app`` fixture (an empty ``app_config``, no
+    llama_cpp URL set) rather than ``evals_app_configured`` -- exercising
+    ``evals_screen.py``'s ``_on_bench_create_target_requested`` early
+    return on ``sample_bench.configured_llama_cpp_url(app_config) is
+    None``, BEFORE it ever reaches ``db.create_model``."""
+    task_id = bench_with_zero_llama_models
+    assert evals_db.list_models(provider="llama_cpp") == []
+
+    async with evals_app.run_test(size=_REALISTIC_SIZE) as pilot:
+        await pilot.pause()
+        evals_app.screen.select(kind="bench", id=task_id)
+        await pilot.pause()
+        screen = evals_app.screen
+
+        create_button = screen.query_one("#evals-bench-create-target", Button)
+        assert create_button.region.width > 0
+
+        await pilot.click("#evals-bench-create-target")
+        await pilot.pause()
+
+        assert evals_app.app_instance.notifications
+        message, severity = evals_app.app_instance.notifications[-1]
+        assert severity == "error"
+        assert message == (
+            "No llama.cpp server is configured; set one in Settings first."
+        )
+
+        assert evals_db.list_models(provider="llama_cpp") == [], (
+            "the zero-config click must not create an eval_models row"
+        )
+        assert not screen.query("#evals-bench-target-0"), "nothing was staged"
+
+
+@pytest.mark.asyncio
 async def test_add_target_picker_option_labels_escape_markup_hazard_names(
     evals_app, bench_with_markup_hazard_llama_model
 ):

--- a/Tests/UI/test_evals_screen.py
+++ b/Tests/UI/test_evals_screen.py
@@ -773,11 +773,14 @@ async def test_primary_action_state_stays_disabled_for_a_target_less_bench(
         label, disabled, tooltip = screen._primary_action_state()
         assert label == "Run draft bench"
         assert disabled is True
-        # Exact-match: same wording as the readiness panel's own "No
-        # targets configured yet." for the identical state
-        # (inspector.py/bench_editor.py), per the coordinator's fix.
+        # Exact-match. task-1612: appends "and Save" -- staging a target
+        # in the bench editor's Add picker does not touch this row's
+        # persisted `target_ids` (only Save does), so a user who has just
+        # staged one but not yet saved would otherwise read this tooltip
+        # as stale/wrong while it still claims "no targets yet".
         assert tooltip == (
-            "This bench has no targets yet; add one in the bench editor."
+            "This bench has no targets yet; add one in the bench editor "
+            "and Save."
         )
 
 

--- a/backlog/tasks/task-1612 - Bench-authoring-copy-polish-batch.md
+++ b/backlog/tasks/task-1612 - Bench-authoring-copy-polish-batch.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-1612
-title: >-
-  Bench authoring copy polish batch
-status: In Progress
+title: Bench authoring copy polish batch
+status: Done
 assignee: []
 created_date: '2026-07-31 15:10'
+updated_date: '2026-08-01 02:26'
 labels:
   - evals
 dependencies: []
@@ -18,9 +18,26 @@ Copy findings from the task-1482 whole-branch review, none blocking: (1) a renam
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] Rename-collision copy speaks bench vocabulary and explains the deleted-name reservation
-- [ ] The zero-target blocked reason names Save as the arming step
-- [ ] llama_targets() uses the documented list limit
+- [x] #1 Rename-collision copy speaks bench vocabulary and explains the deleted-name reservation
+- [x] #2 The zero-target blocked reason names Save as the arming step
+- [x] #3 llama_targets() uses the documented list limit
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. (a) In bench_editor.py's _on_save_pressed except clause, special-case ConflictError separately from ValueError/RuntimeError and render bench-vocabulary copy explaining the deleted-name-reservation trap; update/relax the existing substring test if needed and confirm it still passes, keep it as substring "already exists" per task note (copy can change freely) unless a more precise pin is warranted.
+2. (b) Append the Save-is-the-arming-step clause to evals_screen.py's zero-target tooltip; update test_evals_screen.py's exact-match assertion.
+3. (c) Pass limit=_LIST_LIMIT into EvalsViewModel.llama_targets()'s list_models() call and note in its docstring why (matches other read methods in the module).
+4. Run the targeted test files, add/adjust assertions, commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+(a) bench_editor.py's _on_save_pressed now catches ConflictError in its own except clause (split out of the former except (ValueError, ConflictError, RuntimeError) tuple) and renders bench-vocabulary copy naming the trap: 'A bench named "<name>" already exists -- choose a different name. (Deleting a bench does not free its name: a deleted bench may still be holding it.)' The DB's raw "Task name already exists" is never surfaced to the UI now. Pinned the existing rename-collision test (test_renaming_to_a_taken_name_renders_the_conflict_callout) to the exact new copy instead of the prior substring check.
+(b) evals_screen.py's zero-target primary-action tooltip now reads "...add one in the bench editor and Save." naming Save as the arming step. Updated test_primary_action_state_stays_disabled_for_a_target_less_bench's exact-match assertion.
+(c) EvalsViewModel.llama_targets() (evals_state.py) now passes limit=_LIST_LIMIT into list_models(), matching every other read method on the class; docstring/inline comment explain why. Added a new red-before-green unit test (test_llama_targets_uses_the_documented_list_limit_not_list_models_default) that creates 120 llama_cpp models and asserts none are dropped -- verified it fails against the pre-fix call (only 100 returned) and passes after.
+Ran Tests/UI/test_evals_bench_editor.py + Tests/UI/test_evals_screen.py together: 119 passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1612 - Bench-authoring-copy-polish-batch.md
+++ b/backlog/tasks/task-1612 - Bench-authoring-copy-polish-batch.md
@@ -2,7 +2,7 @@
 id: TASK-1612
 title: >-
   Bench authoring copy polish batch
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-31 15:10'
 labels:

--- a/backlog/tasks/task-1613 - Pin-the-zero-config-create-target-error-path.md
+++ b/backlog/tasks/task-1613 - Pin-the-zero-config-create-target-error-path.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-1613
-title: >-
-  Pin the zero-config create-target error path
-status: In Progress
+title: Pin the zero-config create-target error path
+status: Done
 assignee: []
 created_date: '2026-07-31 15:10'
+updated_date: '2026-08-01 02:29'
 labels:
   - evals
 dependencies: []
@@ -14,11 +14,27 @@ priority: low
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Task-1482 review coverage gap. Clicking "Create target from configured llama.cpp server" with no llama_cpp URL configured notifies "No llama.cpp server is configured; set one in Settings first." — verified correct by a reviewer's live probe, but no test pins the copy or the no-row-created outcome.
+Task-1482 review coverage gap. Clicking the "+ New target" mini-form's button (id #evals-bench-create-target -- task-1611 T2 renamed its rendered label from the older "Create target from configured llama.cpp server" and made it always-rendered, not only in the zero-llama_cpp-models state; the button's id and its zero-config gate are unchanged from task-1482) with no llama_cpp URL configured notifies "No llama.cpp server is configured; set one in Settings first." -- verified correct by a reviewer's live probe, but no test pins the copy or the no-row-created outcome.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] A test drives the zero-config click and asserts the exact toast and that no eval_models row is created
+- [x] #1 A test drives the zero-config click and asserts the exact toast and that no eval_models row is created
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify the current exact toast string and control id for the zero-config create-target path (evals_screen.py's _on_bench_create_target_requested, gated on sample_bench.configured_llama_cpp_url(app_config) is None) against the task's claimed copy/button label.
+2. Fix the task description: the button id is #evals-bench-create-target, unchanged since task-1482, but task-1611 T2 renamed its rendered LABEL from "Create target from configured llama.cpp server" to "+ New target" (and made it always-rendered, not zero-models-gated) -- the task file's copy is stale.
+3. Add a new test using the (unconfigured) evals_app fixture + bench_with_zero_llama_models: click #evals-bench-create-target, assert the exact toast text and severity, and assert no eval_models row was created.
+4. Red-before-green: temporarily neutralize the gate to confirm the test fails, then restore and confirm it passes; run the full bench editor test file.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified the current toast copy ("No llama.cpp server is configured; set one in Settings first.", severity="error") is unchanged since the reviewer's original probe -- evals_screen.py's _on_bench_create_target_requested, gated on sample_bench.configured_llama_cpp_url(app_config) is None, before ever reaching db.create_model. Confirmed the control is #evals-bench-create-target and, per the task's own instruction, fixed the task description: task-1611 T2 renamed the button's rendered LABEL from "Create target from configured llama.cpp server" to "+ New target" (and made it always-rendered rather than zero-models-gated); the id and zero-config gate are unchanged from task-1482.
+Added test_create_target_with_no_llama_cpp_server_configured_notifies_and_creates_nothing in Tests/UI/test_evals_bench_editor.py, using the (unconfigured) evals_app fixture + bench_with_zero_llama_models: clicks #evals-bench-create-target and asserts the exact toast text/severity plus evals_db.list_models(provider="llama_cpp") == [] (no row created) and no target row staged. Red-before-green: temporarily neutralized the gate (if False and ...) -- test failed on the empty-notifications assert AND the log showed a model row being created, confirming both assertions bite; restored and re-ran green.
+Full Tests/UI/test_evals_bench_editor.py: 60 passed (59 + this new test).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1613 - Pin-the-zero-config-create-target-error-path.md
+++ b/backlog/tasks/task-1613 - Pin-the-zero-config-create-target-error-path.md
@@ -2,7 +2,7 @@
 id: TASK-1613
 title: >-
   Pin the zero-config create-target error path
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-31 15:10'
 labels:

--- a/backlog/tasks/task-1614 - update_task-description-hygiene-parity.md
+++ b/backlog/tasks/task-1614 - update_task-description-hygiene-parity.md
@@ -2,7 +2,7 @@
 id: TASK-1614
 title: >-
   update_task description hygiene parity
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-31 15:10'
 labels:

--- a/backlog/tasks/task-1614 - update_task-description-hygiene-parity.md
+++ b/backlog/tasks/task-1614 - update_task-description-hygiene-parity.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-1614
-title: >-
-  update_task description hygiene parity
-status: In Progress
+title: update_task description hygiene parity
+status: Done
 assignee: []
 created_date: '2026-07-31 15:10'
+updated_date: '2026-08-01 02:33'
 labels:
   - evals
 dependencies: []
@@ -18,8 +18,28 @@ Task-1482 (Task 3) fixed the name-hygiene asymmetry between create_task and upda
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] update_task applies the same description cleaning as create_task, via a shared helper
-- [ ] A test pins a control-character description round-trip on both paths
+- [x] #1 update_task applies the same description cleaning as create_task, via a shared helper
+- [x] #2 A test pins a control-character description round-trip on both paths
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Grep all callers of EvalsDB.update_task that pass description= to check whether newly stripping control characters would break any caller's expectations (storage.py save_bench: UI-form-driven, fine; local_evaluations_service.py/evaluation_scope_service.py: pass-through, but their own tests use FakeEvalsDB/fakes, not the real EvalsDB, so no risk).
+2. Add a `_clean_task_description` helper next to the existing `_clean_task_name` helper (same file-level location, same "shared by create_task and update_task" framing), matching create_task's existing inline control-char-only filter behavior exactly (no strip, no blank rejection -- description has no NOT NULL constraint).
+3. Replace create_task's inline filter block with a call to the new helper (no behavior change -- pin with a create_task-path test first if none exists).
+4. Apply the same helper inside update_task's `if description is not None` branch (this is the actual parity fix).
+5. Add a control-character description round-trip test for both create_task and update_task in Tests/Evals/test_evals_db.py; red-before-green the update_task one (temporarily revert to raw passthrough, confirm it fails, restore).
+6. One mutation check on the shared helper: neutralize its filter body, confirm BOTH new tests catch it, restore.
+7. Run Tests/Evals/test_evals_db.py + Tests/Evals/test_eval_properties.py + Tests/Evals/word_bench/test_storage_authoring.py + the Evaluations_Interop suites, commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added _clean_task_description (Evals_DB.py, next to _clean_task_name) filtering control characters only -- no strip, no blank rejection, since eval_tasks.description carries no NOT NULL constraint and a falsy value must round-trip unchanged (including an explicit "clear the description" update). create_task's pre-existing inline filter block was replaced with a call to the helper (behavior-preserving, covered by the existing hypothesis roundtrip property test plus a new pinned unit test). update_task's `if description is not None` branch now calls the same helper -- this is the actual parity fix, since it previously passed description straight through with zero cleaning.
+Grepped every update_task(description=...) caller: storage.py's save_bench (UI-form-driven, fine to newly filter) and the Evaluations_Interop pass-through path (local_evaluations_service.py / evaluation_scope_service.py) -- the latter's own tests use FakeEvalsDB/FakeLocalEvaluationService fakes, never the real EvalsDB, so stripping control characters there carries no test-breakage risk; ran both interop suites to confirm (34 passed).
+Added test_create_task_strips_control_characters_from_description and test_update_task_strips_control_characters_from_description (Tests/Evals/test_evals_db.py), both asserting the identical control-character round-trip. Red-before-green: temporarily reverted update_task's call to a raw passthrough -- the update test failed as expected (create_task's own pre-existing behavior stayed covered by the existing property test). Mutation check on the shared helper (the batch's most substantive change): neutralized its filter body to a no-op -- BOTH new tests failed, confirming each pins real behavior rather than tautology. Restored after each check.
+Ran Tests/Evals/test_evals_db.py + test_eval_properties.py + word_bench/test_storage_authoring.py (73 passed) and both Evaluations_Interop suites (34 passed).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -108,6 +108,14 @@ def _clean_task_description(description: Optional[str]) -> Optional[str]:
     and no surrounding-whitespace strip is applied either, matching
     ``create_task``'s own pre-existing behavior exactly (control-character
     filter only).
+
+    Args:
+        description: The raw description as supplied by a caller, or
+            ``None``/``""`` when the task carries no description.
+
+    Returns:
+        Optional[str]: The description with non-printable characters and
+        NULs removed; a falsy input is returned unchanged.
     """
     if not description:
         return description

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -92,6 +92,28 @@ def _clean_task_name(name: str) -> str:
     return cleaned
 
 
+def _clean_task_description(description: Optional[str]) -> Optional[str]:
+    """Strip control characters from a task description.
+
+    Shared by ``create_task`` and ``update_task`` (task-1614 hygiene
+    parity, mirroring ``_clean_task_name``'s own task-1482 history) --
+    before this helper, ``update_task``'s ``description`` parameter
+    passed straight through completely unfiltered while ``create_task``
+    already stripped control characters from it.
+
+    Unlike ``_clean_task_name``, a falsy (``None``/``""``) description is
+    returned unchanged rather than rejected -- ``eval_tasks.description``
+    carries no ``NOT NULL`` constraint, an empty description is a normal,
+    valid value (including an explicit "clear the description" update),
+    and no surrounding-whitespace strip is applied either, matching
+    ``create_task``'s own pre-existing behavior exactly (control-character
+    filter only).
+    """
+    if not description:
+        return description
+    return "".join(c for c in description if c.isprintable() and ord(c) != 0)
+
+
 class EvalsDB:
     """Database manager for LLM evaluation data and results."""
 
@@ -571,10 +593,7 @@ class EvalsDB:
 
         # Clean control characters from name and description
         name = _clean_task_name(name)
-        if description:
-            description = "".join(
-                c for c in description if c.isprintable() and ord(c) != 0
-            )
+        description = _clean_task_description(description)
 
         if task_type not in [
             "question_answer",
@@ -679,6 +698,11 @@ class EvalsDB:
         ``create_task`` uses (control-char filter + strip + blank rejection)
         so the two paths cannot drift again -- this used to only ``.strip()``
         and never rejected a blank name (task-1482 hygiene parity).
+        ``description`` is likewise cleaned through the same
+        ``_clean_task_description`` helper ``create_task`` uses
+        (control-char filter, no strip, no blank rejection) -- this used
+        to pass ``description`` straight through with no cleaning at all
+        (task-1614 hygiene parity).
 
         Raises:
             InputError: If ``name`` is given and, once cleaned, is empty.
@@ -696,7 +720,7 @@ class EvalsDB:
 
         if description is not None:
             updates.append("description = ?")
-            params.append(description)
+            params.append(_clean_task_description(description))
 
         if config_data is not None:
             updates.append("config_data = ?")

--- a/tldw_chatbook/UI/Evals/bench_editor.py
+++ b/tldw_chatbook/UI/Evals/bench_editor.py
@@ -1269,15 +1269,35 @@ class BenchEditor(Vertical):
 
         try:
             save_bench(db, config, self._bench_id)
-        except (ValueError, ConflictError, RuntimeError) as exc:
+        except ConflictError:
+            # `eval_tasks.name` collided with another task's name -- LIVE
+            # OR soft-deleted (see `save_bench`'s own docstring): the
+            # UNIQUE index on `eval_tasks.name` carries no `deleted_at`
+            # exemption, so a deleted bench's name stays reserved forever.
+            # `Evals_DB`'s raw message ("Task name already exists") uses
+            # the DB's own vocabulary ("Task", not "bench") and says
+            # nothing about the reservation trap -- a user who just
+            # deleted a bench and reused its name would see this collision
+            # with NO bench of that name visible anywhere in the library,
+            # which reads as a lie without the explanation below (task-1612
+            # copy polish; the earlier commit's own comment on this branch
+            # already named this exact trap without fixing the copy).
+            # Task-1612 pins this new copy exactly (see
+            # test_renaming_to_a_taken_name_renders_the_conflict_callout);
+            # the DB's raw message is deliberately never surfaced now.
+            self._show_form_error(
+                f'A bench named "{config.name}" already exists -- choose a '
+                "different name. (Deleting a bench does not free its name: "
+                "a deleted bench may still be holding it.)"
+            )
+            return
+        except (ValueError, RuntimeError) as exc:
             # ValueError: BenchConfig re-validation inside save_bench (a
             # duplicate target_id -- unreachable here since the Add
             # picker's own inline rejection, `_on_add_target_pressed`,
             # already keeps `self._staged_target_ids` duplicate-free), or
             # `Evals_DB.InputError` (a ValueError subclass) from
             # `_clean_task_name` rejecting a blank/control-char-only name.
-            # ConflictError: `eval_tasks.name` collided with another task's
-            # name, live OR soft-deleted (see `save_bench`'s docstring).
             # RuntimeError: `save_bench`'s update branch found no matching
             # row -- the bench was deleted (this process or another)
             # between this form loading it and this Save (PR #1138
@@ -1286,10 +1306,13 @@ class BenchEditor(Vertical):
             # user would otherwise have seen nothing at all -- not even a
             # crash, if some caller ever swallowed it -- instead of the
             # honest "this bench is gone" this callout states.
-            # Mutation check: dropping either the `ConflictError` or the
-            # `RuntimeError` half of this tuple makes the matching Save
-            # failure raise straight out of this handler instead of
-            # rendering the callout.
+            # Mutation check: dropping the `RuntimeError` half of this
+            # tuple makes that Save failure raise straight out of this
+            # handler instead of rendering the callout. `ConflictError` has
+            # its own mutation check above -- dropping that `except`
+            # clause entirely makes the matching Save failure raise
+            # straight out of this handler too (it no longer widens
+            # `except ValueError`, so it is no longer implicitly caught).
             self._show_form_error(str(exc))
             return
 

--- a/tldw_chatbook/UI/Evals/evals_state.py
+++ b/tldw_chatbook/UI/Evals/evals_state.py
@@ -115,7 +115,13 @@ class EvalsViewModel:
         """
         if self._db is None:
             return []
-        return self._db.list_models(provider="llama_cpp")
+        # task-1612: `limit=_LIST_LIMIT` (500), not `list_models`'s own
+        # default of 100 -- every other read on this class already passes
+        # `_LIST_LIMIT` for the reason its own module-level docstring
+        # gives (no pagination UI yet). Silently capping at 100 here would
+        # let a busy install's older llama_cpp targets fall off the Add
+        # picker with no visible sign anything was truncated.
+        return self._db.list_models(provider="llama_cpp", limit=_LIST_LIMIT)
 
     def run_groups(self) -> list[dict[str, Any]]:
         """One row per distinct ``run_group_id``, newest run first.

--- a/tldw_chatbook/UI/Screens/evals_screen.py
+++ b/tldw_chatbook/UI/Screens/evals_screen.py
@@ -1399,11 +1399,19 @@ class EvalsScreen(LabScreen):
             # the two surfaces.
             target_ids = (bench.get("config_data") or {}).get("target_ids") or []
             if not target_ids:
+                # task-1612: staging a target in the bench editor's Add
+                # picker does NOT touch this row's persisted `target_ids`
+                # -- only Save does (see `bench_editor.py`'s own module
+                # docstring: staged targets are form state until Save
+                # writes them via `save_bench`). Without naming Save here,
+                # a user who has just staged one reads this tooltip as
+                # stale or wrong, since it still says "no targets yet"
+                # while one is visibly staged in the editor.
                 return (
                     f"Run {name}",
                     True,
                     "This bench has no targets yet; add one in the bench "
-                    "editor.",
+                    "editor and Save.",
                 )
             return (
                 f"Run {name}",


### PR DESCRIPTION
## Summary

Closes the last three follow-ups from the bench-authoring (#1138) and target-steering (#1155) programmes. Small, disjoint, one commit each.

- **1612 — copy that tells the truth.** A rename collision used to render the DB's raw `"Task name already exists"`: wrong vocabulary, and actively confusing because `eval_tasks.name` is UNIQUE with **no `deleted_at` exemption** — a deleted bench keeps its name reserved forever, so users could hit this with no bench of that name visible anywhere. The new copy speaks bench, explains the trap, and doesn't promise a reclaim that isn't possible. Also: the zero-target blocked reason now names **Save** as the arming step (staging alone doesn't arm Run, and the reason reads from saved state), and `llama_targets()` uses the module's documented `_LIST_LIMIT` instead of silently inheriting `list_models`' default of 100.
- **1613 — the missing pin.** The zero-config create-target path (no llama.cpp URL configured) was verified correct by hand during review but never tested; now it asserts the exact toast and that **no `eval_models` row is written**. The task's own description was corrected — it named a button label that target steering replaced.
- **1614 — description hygiene parity.** `update_task` now applies the same control-character cleaning `create_task` always had, through a shared helper, with a round-trip pinned on both paths.

## Verification

- 245 + 46 + 550 tests green across the Evals, bench-editor/screen/empty-state, and Evaluations_Interop scopes.
- Independent review: **Approve, zero findings** — the deleted-name claim was verified against the schema, the "…and Save" copy checked accurate in both the never-staged and staged-but-unsaved readings, and every `update_task(description=...)` caller grepped to confirm none newly rejects input.
- One judgment call, deliberate and documented: description cleaning strips control characters only (matching `create_task`'s long-standing behavior) rather than adopting the stricter name contract.

Tasks 1612, 1613, 1614 Done. **This closes every open follow-up from the Evals authoring and steering programmes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes follow-ups 1612–1614 for Evals authoring/steering: clearer bench rename-collision messaging, accurate run tooltip, full llama.cpp target listing, and consistent description cleaning, with docs clarifying `_clean_task_description`. Adds tests that pin the zero‑config create‑target path and the description-cleaning round trip.

- **Bug Fixes**
  - 1612: Bench rename collision shows bench‑vocabulary copy and explains that deleted benches keep the name reserved; no raw DB message is surfaced.
  - 1612: Primary action tooltip now says “add one in the bench editor and Save.”
  - 1612: `llama_targets()` passes `_LIST_LIMIT` so >100 llama.cpp targets don’t disappear from the picker.
  - 1613: Test asserts the zero‑config “+ New target” click shows the error toast and creates no `eval_models` row.
  - 1614: `update_task` cleans descriptions like `create_task` via `_clean_task_description` (control chars only); added Google‑style Args/Returns docstring.

<sup>Written for commit 0a9282aa55f2868e5e25821b162881d7db72a87c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

