### PR TITLE
Managed model acquisition (TASK-595): consent-driven, resumable, verified downloads

### DIFF
--- a/.superpowers/pr1157-fix-report.md
+++ b/.superpowers/pr1157-fix-report.md
@@ -1,0 +1,364 @@
+# PR #1157 fix-wave report (TASK-595 managed model acquisition)
+
+Branch: `feat/managed-model-acquisition`. All fixes are TDD: each new/changed
+test was confirmed to fail against the pre-fix code (via `git stash` of the
+production file) before the fix was applied, then confirmed green after.
+
+Full gate: `PYTHONPATH=<worktree> <worktree>/.venv/bin/pytest
+Tests/Model_Artifacts/ Tests/STT/test_boundaries.py -q` → **379 passed**
+(baseline was 366; 13 new tests added, 0 removed). The sealed TASK-594 suite
+(`Tests/Model_Artifacts/test_service.py`, `test_operation_leases.py`,
+`test_operation_leases_process.py`, 280 tests) has **zero diff** and stays
+green. `Tests/Wizards/` (179 tests, unrelated to this PR) also re-verified
+green as a sanity check (366+179=545, matching the baseline figure given).
+
+---
+
+## P1 — SECURITY: client-level Authorization leaks across cross-origin redirect
+
+**Root cause.** `fetch.py`'s `stream_fetch` built its per-hop header dict
+(`send_headers`) and stripped `_STRIP_HEADERS` from THAT dict only, then
+passed it straight to `client.stream(...)`. httpx merges a client's own
+default headers (e.g. `httpx.AsyncClient(headers={"Authorization": ...})`)
+onto the request during `send()`, AFTER `send_headers` was already built —
+so a client-level credential was invisible to the strip and reached a
+cross-origin redirect target verbatim. The existing cross-origin test only
+ever exercised the PER-CALL `headers=` argument, which was already handled
+correctly.
+
+**Change.** `stream_fetch` now builds the request explicitly via
+`client.build_request(...)` and, on a cross-origin hop, pops
+`_STRIP_HEADERS` off the BUILT request's merged headers (mirroring
+`Utils/egress.py`'s `guarded_fetch_httpx_async`, which already does this).
+`tldw_chatbook/Model_Artifacts/fetch.py`.
+
+**Test.** `Tests/Model_Artifacts/test_credentials_and_boundaries.py::test_cross_origin_redirect_strips_client_level_default_authorization`
+— two `FixtureArtifactServer`s, client constructed with a client-level
+`Authorization` header, origin A redirects to origin B; asserts A saw the
+header and B did not, and the body still downloaded.
+Pre-fix: `AssertionError: the client-level credential must NOT have crossed
+the origin boundary`. Post-fix: passes.
+
+---
+
+## P1 — RACE: install() staging-dir creation vs. reconcile()'s orphan lease
+
+**Root cause.** `service.py`'s `install()` called `tempfile.mkdtemp(...)`
+(which creates the directory as part of name generation) and only acquired
+the per-directory `_install_staging_lease_key` lease AFTERWARD. Between
+those two steps, the directory existed on disk with no lease protecting
+it; a concurrent `reconcile()` pass could see it, acquire the (still-free)
+lease itself, and delete a staging dir `install()` was about to write into.
+
+**Change.** `install()` now generates the staging directory's NAME first
+(`uuid.uuid4().hex`, prefixed `install-`), acquires the lease keyed on that
+name, and only THEN calls `os.mkdir()`. Since `reconcile()`'s staging scan
+only ever sees names that already exist on disk, nothing is visible to GC
+until the lease is already held. `tldw_chatbook/Model_Artifacts/service.py`
+(`ModelArtifactService.install`).
+
+**Test.** `Tests/Model_Artifacts/test_reconcile_staging_gc.py::test_install_staging_directory_creation_is_atomic_with_lease_acquisition`
+— monkeypatches `os.mkdir` (which BOTH `tempfile.mkdtemp` internally and the
+new direct call go through, so the same probe works against either
+implementation) to independently attempt a non-blocking acquire of the
+directory's orphan-detection lease at the exact moment it's about to be
+created. Pre-fix: the first (real creation) call finds the lease free
+(`probe_acquired == [True, False, False]`, the later `False`s being
+redundant `Path.mkdir(exist_ok=True)` calls from the copy phase that run
+after pre-fix's own lease acquisition). Post-fix: `not any(probe_acquired)`
+holds — the lease is always already held.
+
+The sealed TASK-594 suite's own race-adjacent tests
+(`test_reconcile_reports_live_pre_lifecycle_install_staging_entry`,
+`test_install_acquires_exact_writer_leases_in_fixed_order`, etc.) all still
+pass unmodified — they probe a LATER point in `install()` (after
+`_copy_payload`) where the lease was already held either way.
+
+---
+
+## P2 — RETRYABLE LIE: install failure destroys the resumable download
+
+**Root cause.** The fetch-state sidecar lived INSIDE the payload directory
+(`staging_dir/fetch-state.json`). `core.install`'s payload-tree validation
+rejects any file it doesn't declare, so `_install_artifact` deleted the
+sidecar UNCONDITIONALLY before every `core.install` call — regardless of
+whether install then succeeded, failed retryably, or failed for a reason
+that never even touched the payload files. On the NEXT `provision()`
+attempt, `_fetch_one_file` would see no sidecar (`recorded_done=0`) while
+the actual file was fully present and correct, and
+`_reconcile_durable_bytes` would then `truncate(0)` the good file, forcing
+a full re-download — even though nothing was ever actually wrong with the
+staged bytes.
+
+**Change (the "preferred approach" from the finding).** The sidecar now
+lives as a SIBLING file, `staging/managed/<id>/<rev>/<variant>.fetch-state.json`,
+never a child of the payload directory `core.install` validates. Added
+`_fetch_sidecar_path()` in `acquisition.py` and updated every reader/writer
+to use it (`_fetch_artifact`, `_fetch_one_file`'s sidecar_path param,
+`_preverify_one_file`, `_staged_bytes_for`). `_install_artifact` no longer
+deletes the sidecar before calling `core.install`; it is now left
+completely untouched until AFTER a successful install, then cleaned up
+together with `staging_dir`. Updated the Task 2 GC classifier in
+`service.py`: `_is_valid_managed_staging_entry` now handles either the
+payload directory OR its sibling sidecar file as the scanned candidate,
+resolving the counterpart and requiring BOTH to be real for the entry to
+survive GC. Added a mirrored `_MANAGED_FETCH_SIDECAR_SUFFIX` constant in
+`service.py` plus a drift-guard test asserting the two constants match
+(mirrors the existing `fetch.py`/`egress.py` `_STRIP_HEADERS` pattern).
+
+I judged the "preferred" relocation sufficient and did NOT reorder the
+sealed core's `install()` internals (lease-acquire-then-copy vs.
+copy-then-lease-acquire) — that would be a much larger, riskier change to
+`ModelArtifactService.install()` (TASK-594, protected by the sealed-suite
+constraint) for a narrower residual: a LATE lease-contention failure inside
+`core.install`, occurring AFTER `consume_source` has already moved files
+into the core's own ephemeral staging, still destroys those specific bytes
+via that ephemeral staging's own failure-path `rmtree` — a genuine, but
+separate, core-level design property, not something `_install_artifact`'s
+own logic controls. The fix here closes the concrete, demonstrated
+own-goal: acquisition.py destroying its own crumb trail before even
+calling `core.install`, for ANY reason install might fail, including one
+that never touches the payload at all.
+
+**Tests (both required by the finding):**
+
+(a) `Tests/Model_Artifacts/test_provision_install.py::test_retryable_install_failure_leaves_staged_bytes_resumable_via_range`
+— seeds a partial file + sidecar, monkeypatches `core.install` to raise
+`ArtifactStateError` directly (a retryable failure, independent of the
+sealed core's internal mechanics), asserts the partial bytes and sidecar
+survive untouched, then calls `_fetch_artifact` again and asserts the
+request the fixture server received included a `Range` header (a resume,
+not a full re-download) and the file completes correctly.
+Pre-fix: `assert False` (no `Range` in the second request — the sidecar was
+gone, forcing a from-scratch fetch). Post-fix: passes.
+
+(b) GC classifies the new layout correctly:
+`test_managed_entry_with_valid_sidecar_survives` (sibling sidecar + payload
+dir → survives), `test_managed_entry_with_sidecar_inside_payload_dir_is_ignored_and_removed`
+(sidecar in the OLD in-tree location no longer counts → orphan, removed),
+`test_managed_entry_sidecar_without_payload_dir_is_removed` (stray sidecar
+with no matching payload dir → removed), all in
+`Tests/Model_Artifacts/test_reconcile_staging_gc.py`. Plus
+`test_fetch_sidecar_suffix_mirror_matches_acquisition` (drift guard).
+
+**Test churn (mechanical, not new coverage).** Every existing TASK-595 test
+that hand-constructed a sidecar at the old `staging_dir / "fetch-state.json"`
+path was updated to the sibling convention (`staging_dir.parent /
+f"{staging_dir.name}.fetch-state.json"`): `test_preflight.py`,
+`test_provision_fetch.py`, `test_provision_install.py`,
+`test_provision_crash_recovery.py`, `test_credentials_and_boundaries.py`.
+Two tests in `test_provision_install.py` were also renamed/re-asserted to
+reflect the new "sidecar survives a failed install" behavior
+(`test_install_failure_leaves_staging_dir_and_sidecar_intact_for_resume`,
+formerly `test_install_failure_does_not_install_and_staging_dir_survives`,
+which used to assert the OPPOSITE — that the sidecar was gone).
+
+---
+
+## P2 — ArtifactPathError escapes `_run_core_call` (closes TASK-1566)
+
+**Root cause.** `_run_core_call` caught `ArtifactIntegrityError`,
+`ArtifactConflictError`, and `ArtifactStateError` from `core.install`/
+`core.activate`, but not `ArtifactPathError` (also a documented
+`core.install` failure mode) — it escaped `provision()` raw, breaking the
+spec's never-trap rule.
+
+**Change.** Added `ArtifactPathError` to the non-retryable except tuple
+(sibling of `ArtifactIntegrityError`/`ArtifactConflictError` under
+`ArtifactError`, so exception ordering is unaffected) and imported it from
+`.service`. `tldw_chatbook/Model_Artifacts/acquisition.py`.
+
+**Test.** `Tests/Model_Artifacts/test_provision_install.py::test_install_artifact_wraps_core_path_error_as_non_retryable`
+— monkeypatches `core.install` to raise `ArtifactPathError`, asserts
+`TransferError(retryable=False)` with the cause chained. Pre-fix: the raw
+`ArtifactPathError` propagates unwrapped. Post-fix: passes.
+
+**Backlog.** TASK-1566 ("Wrap ArtifactPathError from core.install in the
+acquisition never-trap taxonomy") set to Done with implementation notes, in
+this commit. Note: this worktree's `backlog/tasks/` has a genuine TASK-1566
+ID COLLISION with an unrelated task from another branch/worktree
+("Wizard step compose() crash policy…" — filed on `wizard-loose-ends`,
+unrelated to this PR). `backlog task edit 1566` resolves ambiguously
+between the two same-numbered files, so I edited the correct file
+(`task-1566 - Wrap-ArtifactPathError-...md`) directly rather than via the
+CLI, to avoid silently corrupting the other task. The collision itself is
+out of scope for this fix-wave (a backlog-hygiene issue, not a PR #1157
+finding) and is left for whoever reconciles the two branches' task numbers.
+
+---
+
+## P2 — STALE-CHECKPOINT FAILURE: over-large checkpoint should restart, not fail
+
+**Root cause.** `_reconcile_durable_bytes` only cross-checks a sidecar's
+`bytes_done` against the file's ACTUAL on-disk size, never against the
+file's CURRENT declared `size_bytes`. If a catalog's declared size for an
+artifact/revision/variant shrank between provision() runs (a corrected or
+re-cut upstream entry) while a fully-consistent (actual bytes == recorded
+bytes) but now-oversized checkpoint survived, `resume_from` would end up
+`>= max_bytes` inside `stream_fetch`, raising `FetchTooLargeError` — wrapped
+by `_fetch_one_file` as a NON-retryable "upstream body exceeds declared
+size" `TransferError`, when a clean restart-from-zero was really called for.
+
+**Change.** After `_reconcile_durable_bytes` returns, normalize
+`recorded_done` to 0 if it exceeds `file.size_bytes`, before deriving
+`resume_from`. `stream_fetch`'s `mode="wb"` path (used when `resume_from ==
+0`) naturally truncates whatever stale bytes remain on disk.
+`tldw_chatbook/Model_Artifacts/acquisition.py` (`_fetch_one_file`).
+
+**Test.** `Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_over_large_checkpoint_restarts_cleanly`
+— seeds a 4000-byte on-disk file + matching sidecar claiming 4000 bytes,
+while the descriptor's CURRENT declared size is only 1000 bytes; asserts
+the fetch restarts cleanly (full GET, no `Range` header) and completes with
+the correct 1000-byte body. Pre-fix: raises `TransferError` ("upstream body
+exceeds declared size... resume offset already at or past the bound").
+Post-fix: passes.
+
+---
+
+## P2 — PREFLIGHT CREDIT: staged credit not capped by actual on-disk size
+
+**Root cause.** `_staged_bytes_for` summed a sidecar's `bytes_done` per
+file, capped only by the ENTRY's aggregate declared total (`entry.total_bytes`)
+— never by the file's actual on-disk size, and without checking that the
+sidecar's file-path key was even one of the descriptor's declared files. A
+stale sidecar claiming bytes for a file that doesn't exist (or is smaller
+than claimed) inflated `already_staged_bytes`, letting preflight's space
+math approve an acquisition that could then run out of space partway
+through the real download.
+
+**Change.** `_staged_bytes_for` now takes the full `descriptor` (not just
+the `ArtifactRef`) and caps each file's credit by
+`min(recorded bytes_done, actual on-disk file size, declared file size)`;
+sidecar entries naming a file the descriptor doesn't declare are ignored
+outright. `tldw_chatbook/Model_Artifacts/acquisition.py`
+(`_staged_bytes_for`, `_aggregate_closure`'s call site).
+
+**Test.** `Tests/Model_Artifacts/test_preflight.py::test_preflight_stale_sidecar_credit_capped_by_actual_file_size`
+— sidecar claims 5000 bytes for a 2048-byte declared file whose staged file
+on disk is only 100 bytes; asserts `already_staged_bytes == 100` (not 2048
+or 5000). Pre-fix: `assert 2048 == 100` (capped only by declared total).
+Post-fix: passes. Two pre-existing tests
+(`test_preflight_counts_staged_credit`,
+`test_preflight_clamps_oversized_staged_credit_to_entry_total`) were
+updated to also write a real on-disk file matching their sidecar's claim
+(previously they asserted credit for a file that was never actually
+staged, tolerated only because the old code never checked). Both also had
+a latent filename bug (sidecar key `"m.onnx"` vs. the descriptor's real
+declared file `"model.onnx"` from `make_descriptor`) that the new
+"ignore undeclared files" check surfaced and required fixing.
+
+---
+
+## P2 — MISSING ETag / P2 — UNVALIDATED Content-Range on resume (fetch.py)
+
+Both findings live in the same `stream_fetch` hop-response-handling block
+and were fixed together.
+
+**Root cause (missing ETag).** `stream_fetch` only rejected a resumed
+response as a validator mismatch when the server's replied `ETag` was
+present AND differed from the saved one (`if resume_from and validators
+and validators.etag and got.etag: if got.etag != validators.etag: raise`).
+A 206 that omitted `ETag` entirely (`got.etag` falsy) skipped the check
+silently, treating "no information" as "matches".
+
+**Root cause (Content-Range).** A 206 status code alone does not prove the
+response body starts at the requested `Range` offset — only `Content-Range`
+does. `stream_fetch` never parsed or checked it at all, so a server (or a
+buggy proxy) answering 206 with a body that doesn't actually start where
+requested would have its bytes silently appended to stale on-disk data.
+
+**Change.** In `tldw_chatbook/Model_Artifacts/fetch.py`: (1) the ETag check
+now fires whenever `validators.etag` was set and the resumed response's
+`got.etag` is EITHER missing or different (`if not got.etag or got.etag !=
+validators.etag: raise FetchRestartRequired`). (2) Added
+`_parse_content_range_start()` (a small regex-based parser for `Content-
+Range: bytes <start>-<end>/<total>`) and, whenever `resume_from` is set and
+the response is 206, require the parsed start to equal `resume_from` — a
+missing or unparseable header, or a mismatched start, raises
+`FetchRestartRequired` BEFORE the destination is ever opened for append.
+
+Both checks required updating `Tests/Model_Artifacts/fixture_http.py`'s
+`FixtureArtifactServer` to actually send `Content-Range` on 206 responses
+(it previously sent none at all — every existing resume test only ever
+passed because nothing validated it); added `omit_content_range` and
+`bad_range_start` route options to construct the adversarial cases without
+breaking any legitimate resume test (the fixture defaults to reporting the
+REAL slice offset it just served, so every pre-existing resume test's
+`Content-Range` now correctly matches `resume_from` with no test changes
+needed beyond the fixture itself).
+
+**Tests**, all in `Tests/Model_Artifacts/test_stream_fetch.py`:
+- `test_missing_etag_on_resume_raises_restart_without_append` — route
+  serves 206 with no ETag (`ignore_if_range=True` forces 206 despite the
+  If-Range mismatch this produces); asserts `FetchRestartRequired` and no
+  bytes appended. Pre-fix: `DID NOT RAISE FetchRestartRequired`.
+- `test_content_range_start_mismatch_raises_restart_without_append` — route
+  reports `bad_range_start=999` while resuming from 100; asserts
+  `FetchRestartRequired`, no append. Pre-fix: did not raise.
+- `test_missing_content_range_on_resume_raises_restart_without_append` —
+  route omits `Content-Range` entirely on a real 206; asserts
+  `FetchRestartRequired`, no append. Pre-fix: did not raise.
+
+All three pass post-fix; all three confirmed to fail against pre-fix
+`fetch.py` (via `git stash`).
+
+---
+
+## BUG — BLOCKING HASH: `_preverify_one_file` hashes synchronously
+
+**Root cause.** `_preverify_one_file` is `async def`, but called
+`self._hash_staged_file(...)` (a plain synchronous method) directly, with
+no `await` anywhere in the loop. Hashing a multi-gigabyte staged file this
+way blocks the ENTIRE event loop — every other coroutine, including any
+other artifact's fetch/pre-verify progress and the app's own UI loop if
+this service shares one — for as long as the hash takes.
+
+**Change.** `_hash_staged_file` now runs via `loop.run_in_executor(None,
+...)`, called from `_preverify_one_file`. Progress-callback invocation
+inside `_hash_staged_file` is marshalled back onto the event loop via
+`loop.call_soon_threadsafe(progress_state.callback, event)` rather than
+called directly from the executor thread — justified because
+`progress_state.callback` is caller-supplied and, per this codebase's
+"Background Work" threading convention (CLAUDE.md: workers call back via
+`call_from_thread`, never directly), may touch UI state that must only be
+touched from the event-loop thread. Byte-counter mutation
+(`progress_state.preverify_bytes_done += ...`) stays directly on the
+executor thread — safe because `_preverify_artifact` processes one file at
+a time, so only one executor call is ever hashing at once; verified this
+doesn't reorder or drop progress events because `run_in_executor`'s own
+"future done" notification is scheduled via the SAME `call_soon_threadsafe`
+mechanism, strictly AFTER every per-chunk callback scheduled while the
+executor function was still running (asyncio's ready queue is FIFO), so by
+the time the awaiting coroutine resumes, all progress events for that hash
+have already fired in order.
+`tldw_chatbook/Model_Artifacts/acquisition.py` (`_preverify_one_file`,
+`_hash_staged_file`).
+
+**Test.** `Tests/Model_Artifacts/test_provision_install.py::test_preverify_hashing_does_not_block_event_loop`
+— monkeypatches `hashlib.sha256` (as imported into `acquisition.py`) to a
+wrapper that sleeps 0.05s per `update()` call (8 chunks ≈ 0.4s total),
+races a concurrent "heartbeat" coroutine ticking every ~0.01s alongside the
+hash, and asserts the heartbeat ticks at least 3 times during the hash.
+Pre-fix: `assert 0 >= 3` (the synchronous call never yields control, so the
+heartbeat coroutine never gets scheduled at all during the ~0.4s hash).
+Post-fix: passes.
+
+---
+
+## Files changed
+
+- `tldw_chatbook/Model_Artifacts/fetch.py` — client-default header strip,
+  Content-Range validation, missing-ETag rejection.
+- `tldw_chatbook/Model_Artifacts/service.py` — atomic staging-dir creation
+  vs. lease; sidecar-sibling-aware GC classifier.
+- `tldw_chatbook/Model_Artifacts/acquisition.py` — sidecar relocation
+  (`_fetch_sidecar_path`), `ArtifactPathError` wrapping, stale-checkpoint
+  normalization, preflight staged-credit capping, off-loop hashing.
+- `Tests/Model_Artifacts/fixture_http.py` — `Content-Range` on 206
+  responses; `omit_content_range`/`bad_range_start` route options.
+- `Tests/Model_Artifacts/test_stream_fetch.py`,
+  `test_credentials_and_boundaries.py`, `test_preflight.py`,
+  `test_provision_fetch.py`, `test_provision_install.py`,
+  `test_provision_crash_recovery.py`, `test_reconcile_staging_gc.py` — new
+  regression tests + sidecar-path/layout updates for existing tests.
+- `backlog/tasks/task-1566 - Wrap-ArtifactPathError-....md` — closed.

--- a/Docs/superpowers/specs/2026-07-30-managed-model-acquisition-design.md
+++ b/Docs/superpowers/specs/2026-07-30-managed-model-acquisition-design.md
@@ -24,8 +24,14 @@ every integrity-bearing step.
    (workers never import the acquisition modules), following
    `Tests/STT/test_boundaries.py`.
 4. **Composition over the sealed core** (Approach A): a new
-   `ArtifactAcquisitionService` composes `ModelArtifactService`; only two
-   small, sync, agreed additions touch the core.
+   `ArtifactAcquisitionService` composes `ModelArtifactService`; only three
+   small, sync, agreed additions touch the core: `install(...,
+   consume_source: bool = False)`; `reconcile()`'s staging GC; and a
+   per-staging-dir `install()` lease (its `locks_path` property plus
+   `ReconcileReport.staging_removed`) added mid-implementation as an
+   approved in-flight fix for a real race between a crashed `install()`'s
+   abandoned staging tempdir and a concurrent `reconcile()` pass (see
+   Core additions below).
 
 ## Architecture
 
@@ -40,7 +46,7 @@ every integrity-bearing step.
   redirects) re-shaped to stream chunks to a staged file under a hard
   `max_bytes` bound instead of buffering bodies in memory. Supports `Range`
   resume and returns captured validators (ETag / Last-Modified).
-- **Core additions (sync, small):**
+- **Core additions (sync, small; three total, not two — see Decision 4):**
   - `ModelArtifactService.install(..., consume_source: bool = False)` —
     per-file `os.replace` when the source directory lies inside the service
     root; a source outside the root raises `ArtifactPathError` (no silent
@@ -52,6 +58,16 @@ every integrity-bearing step.
     Valid-sidecar staging is resumable state and is never GC'd (see
     Recovery). Deletions are containment-checked and counted in
     `ReconcileReport`.
+  - Per-staging-dir `install()` lease — a reserved `#install-staging`
+    lease key held for one `install()` call's whole staging tempdir
+    lifetime, exposed via the new `ModelArtifactService.locks_path`
+    property (so `ArtifactAcquisitionService`, in a different module, can
+    take its own reserved-namespace leases against the same lock root) and
+    surfaced in reports via `ReconcileReport.staging_removed`. Approved
+    mid-implementation, not part of the original two-addition plan: without
+    it, `reconcile()`'s staging GC could not tell a crashed `install()`'s
+    abandoned tempdir apart from one still legitimately in flight, a real
+    race between the two.
 
 ### Serialization: one acquisition-session lease
 
@@ -105,11 +121,17 @@ touching staging.
 
 ### Cancellation semantics (stated honestly)
 
-Task cancellation is honored at fetch chunk boundaries, at lease polls
-(bridged into the leases' `cancelled` callable), and between artifacts. An
-`install()` already running in an executor completes before cancellation
-takes effect — it is short relative to transfers, and AC #3's guarantees
-hold regardless.
+Task cancellation is honored at fetch chunk boundaries and between
+artifacts. Lease acquisition is non-blocking with a short, fixed timeout
+(0.1s for `provision()`'s acquisition-session lease; see
+`NONBLOCKING_LEASE_TIMEOUT_SECONDS`) rather than a long poll, so no
+`cancelled`-callable bridge into `leases.py` was ever implemented or is
+needed — a wait that short has nothing meaningful to interrupt mid-flight.
+`ArtifactOperationLease.cancelled` remains available as a constructor
+parameter for a future caller that does need it, but no lease in this
+acquisition path passes one. An `install()` already running in an executor
+completes before cancellation takes effect — it is short relative to
+transfers, and AC #3's guarantees hold regardless.
 
 ## API surface
 

--- a/Tests/Model_Artifacts/fixture_http.py
+++ b/Tests/Model_Artifacts/fixture_http.py
@@ -18,6 +18,8 @@ class _Route:
     require_token: str | None
     last_modified: str | None = None
     ignore_if_range: bool = False
+    pause_after: int | None = None
+    pause_event: threading.Event | None = None
 
 
 class FixtureArtifactServer:
@@ -103,6 +105,20 @@ class FixtureArtifactServer:
                     self.wfile.flush()
                     self.connection.close()  # simulate mid-body drop
                     return
+                pause_at = route.pause_after
+                if pause_at is not None and pause_at < len(body):
+                    # Write a first slice, then block this request-handler
+                    # thread on a test-supplied gate before sending the
+                    # rest -- a genuinely slow/open connection for
+                    # cancellation tests, not a sleep-based guess. Bounded
+                    # so a test that forgets to set the gate can't hang
+                    # server teardown forever.
+                    self.wfile.write(body[:pause_at])
+                    self.wfile.flush()
+                    if route.pause_event is not None:
+                        route.pause_event.wait(timeout=5.0)
+                    self.wfile.write(body[pause_at:])
+                    return
                 self.wfile.write(body)
 
         self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
@@ -120,6 +136,8 @@ class FixtureArtifactServer:
         disconnect_after: int | None = None,
         require_token: str | None = None,
         ignore_if_range: bool = False,
+        pause_after: int | None = None,
+        pause_event: threading.Event | None = None,
     ) -> None:
         """Register (or replace) a route this server responds to.
 
@@ -140,6 +158,12 @@ class FixtureArtifactServer:
                 (206) unconditionally even when ``If-Range`` doesn't match
                 the route's current validator, instead of falling back to a
                 full 200.
+            pause_after: If set, write only this many bytes, then block the
+                request-handler thread on ``pause_event`` (bounded to 5s)
+                before sending the rest -- keeps a connection genuinely
+                open/slow for cancellation tests.
+            pause_event: The gate ``pause_after`` blocks on; the test sets
+                it to release the remainder of the body.
         """
         if etag and weak_etag:
             etag = f"W/{etag}"
@@ -151,6 +175,8 @@ class FixtureArtifactServer:
             require_token=require_token,
             last_modified=last_modified,
             ignore_if_range=ignore_if_range,
+            pause_after=pause_after,
+            pause_event=pause_event,
         )
 
     def url(self, path: str) -> str:

--- a/Tests/Model_Artifacts/fixture_http.py
+++ b/Tests/Model_Artifacts/fixture_http.py
@@ -21,6 +21,8 @@ class _Route:
     pause_after: int | None = None
     pause_event: threading.Event | None = None
     redirect_to: str | None = None
+    omit_content_range: bool = False
+    bad_range_start: int | None = None
 
 
 class FixtureArtifactServer:
@@ -108,6 +110,22 @@ class FixtureArtifactServer:
                     self.send_header("Last-Modified", route.last_modified)
                 if route.support_range:
                     self.send_header("Accept-Ranges", "bytes")
+                if status == 206 and not route.omit_content_range:
+                    # RFC 9110 14.4: a compliant 206 always carries
+                    # Content-Range so the client can confirm where the
+                    # body actually starts -- reported_start defaults to
+                    # the REAL slice offset, but a route can override it
+                    # (bad_range_start) to simulate a server that lies.
+                    reported_start = (
+                        route.bad_range_start
+                        if route.bad_range_start is not None
+                        else start
+                    )
+                    total = len(route.body)
+                    end = reported_start + len(body) - 1 if body else reported_start
+                    self.send_header(
+                        "Content-Range", f"bytes {reported_start}-{end}/{total}"
+                    )
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
                 if head_only:
@@ -152,6 +170,8 @@ class FixtureArtifactServer:
         pause_after: int | None = None,
         pause_event: threading.Event | None = None,
         redirect_to: str | None = None,
+        omit_content_range: bool = False,
+        bad_range_start: int | None = None,
     ) -> None:
         """Register (or replace) a route this server responds to.
 
@@ -188,6 +208,15 @@ class FixtureArtifactServer:
                 ``.url(...)``, to model a cross-origin hand-off (e.g. an
                 authenticated repository redirecting to an unauthenticated
                 CDN URL on a different port/origin).
+            omit_content_range: If set, a 206 response omits ``Content-
+                Range`` entirely -- simulates a non-compliant server so a
+                caller can prove a missing header is rejected, not treated
+                as an implicit match.
+            bad_range_start: If set, a 206 response's ``Content-Range``
+                header reports THIS start offset instead of the real slice
+                offset the ``Range`` request produced -- simulates a
+                server whose header disagrees with where the body (as
+                received) actually starts.
         """
         if etag and weak_etag:
             etag = f"W/{etag}"
@@ -202,6 +231,8 @@ class FixtureArtifactServer:
             pause_after=pause_after,
             pause_event=pause_event,
             redirect_to=redirect_to,
+            omit_content_range=omit_content_range,
+            bad_range_start=bad_range_start,
         )
 
     def url(self, path: str) -> str:

--- a/Tests/Model_Artifacts/fixture_http.py
+++ b/Tests/Model_Artifacts/fixture_http.py
@@ -17,6 +17,7 @@ class _Route:
     disconnect_after: int | None
     require_token: str | None
     last_modified: str | None = None
+    ignore_if_range: bool = False
 
 
 class FixtureArtifactServer:
@@ -67,7 +68,7 @@ class FixtureArtifactServer:
                 range_header = self.headers.get("Range")
                 if_range = self.headers.get("If-Range")
                 honor_range = bool(range_header) and route.support_range
-                if honor_range and if_range is not None:
+                if honor_range and if_range is not None and not route.ignore_if_range:
                     # Real servers refuse a stale If-Range by falling back to
                     # a full 200 -- the behavior fetch.py's resume-mismatch
                     # detection depends on. Match against whichever validator
@@ -77,6 +78,10 @@ class FixtureArtifactServer:
                     current_validator = route.etag or route.last_modified
                     if if_range != current_validator:
                         honor_range = False
+                # ignore_if_range=True simulates a non-compliant server that
+                # honors Range unconditionally, ignoring any If-Range
+                # mismatch -- the failure mode fetch.py's post-response
+                # validator check (not the status-code check) exists for.
                 if honor_range:
                     start = int(range_header.split("=")[1].split("-")[0])
                     body = body[start:]
@@ -114,6 +119,7 @@ class FixtureArtifactServer:
         support_range: bool = True,
         disconnect_after: int | None = None,
         require_token: str | None = None,
+        ignore_if_range: bool = False,
     ) -> None:
         """Register (or replace) a route this server responds to.
 
@@ -130,6 +136,10 @@ class FixtureArtifactServer:
             disconnect_after: If set, write only this many bytes then close
                 the connection mid-body (simulates a dropped transfer).
             require_token: If set, require ``Authorization: Bearer <token>``.
+            ignore_if_range: Simulate a non-compliant server: honor ``Range``
+                (206) unconditionally even when ``If-Range`` doesn't match
+                the route's current validator, instead of falling back to a
+                full 200.
         """
         if etag and weak_etag:
             etag = f"W/{etag}"
@@ -140,6 +150,7 @@ class FixtureArtifactServer:
             disconnect_after=disconnect_after,
             require_token=require_token,
             last_modified=last_modified,
+            ignore_if_range=ignore_if_range,
         )
 
     def url(self, path: str) -> str:

--- a/Tests/Model_Artifacts/fixture_http.py
+++ b/Tests/Model_Artifacts/fixture_http.py
@@ -16,6 +16,7 @@ class _Route:
     support_range: bool
     disconnect_after: int | None
     require_token: str | None
+    last_modified: str | None = None
 
 
 class FixtureArtifactServer:
@@ -64,13 +65,27 @@ class FixtureArtifactServer:
                 start = 0
                 status = 200
                 range_header = self.headers.get("Range")
-                if range_header and route.support_range:
+                if_range = self.headers.get("If-Range")
+                honor_range = bool(range_header) and route.support_range
+                if honor_range and if_range is not None:
+                    # Real servers refuse a stale If-Range by falling back to
+                    # a full 200 -- the behavior fetch.py's resume-mismatch
+                    # detection depends on. Match against whichever validator
+                    # this route currently has (an ETag comparison and a
+                    # Last-Modified comparison are mutually exclusive in
+                    # practice since the client sends only one).
+                    current_validator = route.etag or route.last_modified
+                    if if_range != current_validator:
+                        honor_range = False
+                if honor_range:
                     start = int(range_header.split("=")[1].split("-")[0])
                     body = body[start:]
                     status = 206
                 self.send_response(status)
                 if route.etag:
                     self.send_header("ETag", route.etag)
+                if route.last_modified:
+                    self.send_header("Last-Modified", route.last_modified)
                 if route.support_range:
                     self.send_header("Accept-Ranges", "bytes")
                 self.send_header("Content-Length", str(len(body)))
@@ -95,6 +110,7 @@ class FixtureArtifactServer:
         *,
         etag: str | None = '"v1"',
         weak_etag: bool = False,
+        last_modified: str | None = None,
         support_range: bool = True,
         disconnect_after: int | None = None,
         require_token: str | None = None,
@@ -106,6 +122,9 @@ class FixtureArtifactServer:
             body: Full response body for a non-Range request.
             etag: ETag value to send (``None`` to omit the header).
             weak_etag: Wrap ``etag`` as a weak validator (``W/"..."``).
+            last_modified: ``Last-Modified`` header value to send (``None``
+                to omit). Also doubles as the conditional-range validator
+                when ``etag`` is ``None``, mirroring real servers.
             support_range: Whether ``Range`` requests are honored (206) or
                 ignored (always 200 with the full body).
             disconnect_after: If set, write only this many bytes then close
@@ -114,7 +133,14 @@ class FixtureArtifactServer:
         """
         if etag and weak_etag:
             etag = f"W/{etag}"
-        self._routes[path] = _Route(body, etag, support_range, disconnect_after, require_token)
+        self._routes[path] = _Route(
+            body=body,
+            etag=etag,
+            support_range=support_range,
+            disconnect_after=disconnect_after,
+            require_token=require_token,
+            last_modified=last_modified,
+        )
 
     def url(self, path: str) -> str:
         """Absolute ``http://127.0.0.1:<port><path>`` URL for this server."""

--- a/Tests/Model_Artifacts/fixture_http.py
+++ b/Tests/Model_Artifacts/fixture_http.py
@@ -20,6 +20,7 @@ class _Route:
     ignore_if_range: bool = False
     pause_after: int | None = None
     pause_event: threading.Event | None = None
+    redirect_to: str | None = None
 
 
 class FixtureArtifactServer:
@@ -62,6 +63,18 @@ class FixtureArtifactServer:
                     self.headers.get("Authorization") != f"Bearer {route.require_token}"
                 ):
                     self.send_response(401)
+                    self.end_headers()
+                    return
+                if route.redirect_to is not None:
+                    # A 302 to a DIFFERENT origin (e.g. a second
+                    # FixtureArtifactServer on another port) -- models an
+                    # authenticated repository handing off to an
+                    # unauthenticated CDN URL. Sent unconditionally past the
+                    # require_token gate above so a caller can prove BOTH
+                    # that the credential reached this route AND that it did
+                    # NOT reach the redirect target.
+                    self.send_response(302)
+                    self.send_header("Location", route.redirect_to)
                     self.end_headers()
                     return
                 body = route.body
@@ -138,12 +151,15 @@ class FixtureArtifactServer:
         ignore_if_range: bool = False,
         pause_after: int | None = None,
         pause_event: threading.Event | None = None,
+        redirect_to: str | None = None,
     ) -> None:
         """Register (or replace) a route this server responds to.
 
         Args:
             path: Request path, e.g. ``"/f.bin"``.
-            body: Full response body for a non-Range request.
+            body: Full response body for a non-Range request. Ignored (but
+                still required) when ``redirect_to`` is set -- a redirect
+                route never writes a body of its own.
             etag: ETag value to send (``None`` to omit the header).
             weak_etag: Wrap ``etag`` as a weak validator (``W/"..."``).
             last_modified: ``Last-Modified`` header value to send (``None``
@@ -154,6 +170,8 @@ class FixtureArtifactServer:
             disconnect_after: If set, write only this many bytes then close
                 the connection mid-body (simulates a dropped transfer).
             require_token: If set, require ``Authorization: Bearer <token>``.
+                Checked BEFORE ``redirect_to``, so a redirect route can also
+                require a credential on the request that triggers the hop.
             ignore_if_range: Simulate a non-compliant server: honor ``Range``
                 (206) unconditionally even when ``If-Range`` doesn't match
                 the route's current validator, instead of falling back to a
@@ -164,6 +182,12 @@ class FixtureArtifactServer:
                 open/slow for cancellation tests.
             pause_event: The gate ``pause_after`` blocks on; the test sets
                 it to release the remainder of the body.
+            redirect_to: If set, this route answers every request with a
+                302 to this absolute URL instead of serving ``body`` --
+                typically another ``FixtureArtifactServer`` instance's
+                ``.url(...)``, to model a cross-origin hand-off (e.g. an
+                authenticated repository redirecting to an unauthenticated
+                CDN URL on a different port/origin).
         """
         if etag and weak_etag:
             etag = f"W/{etag}"
@@ -177,6 +201,7 @@ class FixtureArtifactServer:
             ignore_if_range=ignore_if_range,
             pause_after=pause_after,
             pause_event=pause_event,
+            redirect_to=redirect_to,
         )
 
     def url(self, path: str) -> str:

--- a/Tests/Model_Artifacts/fixture_http.py
+++ b/Tests/Model_Artifacts/fixture_http.py
@@ -1,0 +1,131 @@
+"""Localhost HTTP fixture for artifact-fetch tests. stdlib only."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+@dataclass
+class _Route:
+    """One configured response for a fixture path."""
+
+    body: bytes
+    etag: str | None
+    support_range: bool
+    disconnect_after: int | None
+    require_token: str | None
+
+
+class FixtureArtifactServer:
+    """Configurable localhost server: Range, ETag, faults, auth.
+
+    Use as a context manager so the background thread and socket are always
+    torn down, even on test failure::
+
+        with FixtureArtifactServer() as srv:
+            srv.serve("/f.bin", b"...")
+            ... srv.url("/f.bin") ...
+    """
+
+    def __init__(self) -> None:
+        self._routes: dict[str, _Route] = {}
+        self.requests: dict[str, list[dict]] = {}
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args):  # quiet
+                pass
+
+            def _route(self):
+                return outer._routes.get(self.path)
+
+            def do_HEAD(self):
+                self._respond(head_only=True)
+
+            def do_GET(self):
+                self._respond(head_only=False)
+
+            def _respond(self, *, head_only: bool):
+                route = self._route()
+                outer.requests.setdefault(self.path, []).append(dict(self.headers))
+                if route is None:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                if route.require_token and (
+                    self.headers.get("Authorization") != f"Bearer {route.require_token}"
+                ):
+                    self.send_response(401)
+                    self.end_headers()
+                    return
+                body = route.body
+                start = 0
+                status = 200
+                range_header = self.headers.get("Range")
+                if range_header and route.support_range:
+                    start = int(range_header.split("=")[1].split("-")[0])
+                    body = body[start:]
+                    status = 206
+                self.send_response(status)
+                if route.etag:
+                    self.send_header("ETag", route.etag)
+                if route.support_range:
+                    self.send_header("Accept-Ranges", "bytes")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                if head_only:
+                    return
+                cut = route.disconnect_after
+                if cut is not None and cut < len(body):
+                    self.wfile.write(body[:cut])
+                    self.wfile.flush()
+                    self.connection.close()  # simulate mid-body drop
+                    return
+                self.wfile.write(body)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def serve(
+        self,
+        path: str,
+        body: bytes,
+        *,
+        etag: str | None = '"v1"',
+        weak_etag: bool = False,
+        support_range: bool = True,
+        disconnect_after: int | None = None,
+        require_token: str | None = None,
+    ) -> None:
+        """Register (or replace) a route this server responds to.
+
+        Args:
+            path: Request path, e.g. ``"/f.bin"``.
+            body: Full response body for a non-Range request.
+            etag: ETag value to send (``None`` to omit the header).
+            weak_etag: Wrap ``etag`` as a weak validator (``W/"..."``).
+            support_range: Whether ``Range`` requests are honored (206) or
+                ignored (always 200 with the full body).
+            disconnect_after: If set, write only this many bytes then close
+                the connection mid-body (simulates a dropped transfer).
+            require_token: If set, require ``Authorization: Bearer <token>``.
+        """
+        if etag and weak_etag:
+            etag = f"W/{etag}"
+        self._routes[path] = _Route(body, etag, support_range, disconnect_after, require_token)
+
+    def url(self, path: str) -> str:
+        """Absolute ``http://127.0.0.1:<port><path>`` URL for this server."""
+        host, port = self._server.server_address
+        return f"http://{host}:{port}{path}"
+
+    def __enter__(self) -> "FixtureArtifactServer":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        self._server.shutdown()
+        self._server.server_close()
+        return False

--- a/Tests/Model_Artifacts/provision_processes.py
+++ b/Tests/Model_Artifacts/provision_processes.py
@@ -1,0 +1,188 @@
+"""Spawn targets for cross-process managed-acquisition crash-recovery tests.
+
+Mirrors ``lease_processes.py``'s style: small, self-contained functions a
+``multiprocessing.Process`` (spawn context) can target directly, taking only
+picklable primitives as arguments.
+
+Each entrypoint here runs a real ``ArtifactAcquisitionService.provision()``
+call against a caller-supplied fixture URL and deterministically freezes
+itself -- via a local ``threading.Event`` that nothing ever sets -- the first
+time an ``AcquisitionProgress`` event matches a caller-chosen (phase,
+artifact_id) pair, after signalling the parent's ``ready`` event. The parent
+then sends SIGKILL. Freezing on a never-set local event (rather than timing
+a kill against a sleep or a hash/IO duration) makes the crash point exact:
+whatever durable state existed the instant the matching progress event fired
+is exactly what a real crash landing there would leave behind, with no
+timing race against how fast the interpreter can finish the current phase.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Protocol
+
+
+class EventLike(Protocol):
+    """Spawn-safe event operations used by the child targets."""
+
+    def set(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+
+def build_descriptor(
+    artifact_id: str,
+    revision: str,
+    variant: str,
+    *,
+    role: str,
+    source_url: str,
+    size_bytes: int,
+    sha256: str,
+    dependencies: tuple[tuple[str, str, str], ...],
+):
+    """Construct one single-file ``ArtifactDescriptor`` from primitives.
+
+    ``size_bytes``/``sha256`` are caller-supplied independently of whatever
+    the fixture route currently serves -- deliberately, so a caller can
+    declare a file larger than what the route serves on a first pass (see
+    ``provision_signal_on_phase``'s docstring for why that is the only way
+    to get a real, un-seeded, durably-partial sidecar entry out of one
+    genuine ``stream_fetch`` call).
+    """
+
+    from tldw_chatbook.Model_Artifacts import (
+        ArtifactDescriptor,
+        ArtifactFile,
+        ArtifactFormat,
+        ArtifactRef,
+        ArtifactRole,
+        ProvenanceClass,
+    )
+
+    ref = ArtifactRef(artifact_id, revision, variant)
+    files = (ArtifactFile("model.bin", size_bytes, sha256),)
+    return ArtifactDescriptor(
+        reference=ref,
+        model_id="test/model",
+        role=ArtifactRole(role),
+        format=ArtifactFormat.ONNX,
+        consumer="test",
+        model_family="test-family",
+        upstream_repository="test/repo",
+        upstream_revision="main",
+        source_url=source_url,
+        precision=variant,
+        license_id="test-license",
+        license_url="https://example.test/license",
+        usage_notice="Test model",
+        runtime_name="test-runtime",
+        runtime_version_constraint="==1.0.0",
+        supported_os=("linux",),
+        supported_architectures=("x86-64",),
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+        files=files,
+        expected_installed_bytes=size_bytes,
+        dependencies=tuple(ArtifactRef(*dep) for dep in dependencies),
+    )
+
+
+class DictCatalog:
+    """Minimal in-process ``ArtifactCatalog`` keyed by ``ArtifactRef``."""
+
+    def __init__(self, mapping: dict) -> None:
+        self._mapping = mapping
+
+    def descriptor(self, ref):
+        """Return the descriptor registered for ``ref``."""
+        return self._mapping[ref]
+
+
+def provision_signal_on_phase(
+    root_dir: str,
+    artifact_specs: tuple[dict, ...],
+    root_ref: tuple[str, str, str],
+    trusted_origin: str,
+    signal_phase: str,
+    signal_artifact_id: str | None,
+    ready: EventLike,
+) -> None:
+    """Run ``provision()`` for a closure, freezing at a chosen progress event.
+
+    The child never returns control past the frozen point on its own --
+    the parent is expected to send SIGKILL once ``ready`` is observed set.
+    If the parent fails to do so, the freeze times out after 30s and the
+    process exits normally (a safety net, not the intended path).
+
+    Args:
+        root_dir: Filesystem path for the ``ModelArtifactService`` root.
+        artifact_specs: One dict per artifact in the closure, each with
+            keys ``artifact_id``, ``revision``, ``variant``, ``role``
+            (``"root"``/``"dependency"``), ``source_url``, ``size_bytes``,
+            ``sha256``, and ``dependencies`` (a tuple of
+            ``(artifact_id, revision, variant)`` triples).
+        root_ref: The ``(artifact_id, revision, variant)`` triple naming
+            which spec is the closure root.
+        trusted_origin: Hostname exempted from the private-IP egress block
+            (the fixture server's loopback hostname).
+        signal_phase: The ``AcquisitionProgress.phase`` value to freeze on
+            (``"fetch"``, ``"pre-verify"``, ``"verify-install"``, or
+            ``"activate"``).
+        signal_artifact_id: Restrict the freeze to progress events about
+            this artifact_id, or ``None`` to freeze on the first matching
+            phase regardless of which artifact it names.
+        ready: Set the instant the matching event fires, immediately before
+            freezing -- the parent waits on this before sending SIGKILL.
+    """
+
+    import asyncio
+
+    from tldw_chatbook.Model_Artifacts import ArtifactRef, closure_fingerprint
+    from tldw_chatbook.Model_Artifacts.acquisition import (
+        AcquisitionConsent,
+        ArtifactAcquisitionService,
+        resolve_catalog_closure,
+    )
+    from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
+
+    descriptors = {}
+    for spec in artifact_specs:
+        descriptor = build_descriptor(
+            spec["artifact_id"],
+            spec["revision"],
+            spec["variant"],
+            role=spec["role"],
+            source_url=spec["source_url"],
+            size_bytes=spec["size_bytes"],
+            sha256=spec["sha256"],
+            dependencies=spec.get("dependencies", ()),
+        )
+        descriptors[descriptor.reference] = descriptor
+
+    catalog = DictCatalog(descriptors)
+    root = ArtifactRef(*root_ref)
+    closure = resolve_catalog_closure(root, catalog)
+    fingerprint = closure_fingerprint(root, (item.reference for item in closure))
+    consent = AcquisitionConsent(closure_fingerprint=fingerprint)
+
+    core = ModelArtifactService(Path(root_dir))
+    svc = ArtifactAcquisitionService(
+        core,
+        free_bytes_probe=lambda _p: 10**12,
+        trusted_origins=frozenset({trusted_origin}),
+    )
+
+    hold = threading.Event()  # never set -- the parent SIGKILLs us instead
+
+    def on_progress(progress) -> None:
+        if signal_phase != progress.phase:
+            return
+        if signal_artifact_id is not None and progress.ref.artifact_id != signal_artifact_id:
+            return
+        if ready.is_set():
+            return
+        ready.set()
+        hold.wait(timeout=30.0)
+
+    asyncio.run(svc.provision(root, consent, catalog, progress=on_progress))

--- a/Tests/Model_Artifacts/test_acquisition_types.py
+++ b/Tests/Model_Artifacts/test_acquisition_types.py
@@ -1,0 +1,178 @@
+"""TASK-595 Task 4: pure acquisition types and the catalog closure walk."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tldw_chatbook.Model_Artifacts import ArtifactRef, closure_fingerprint
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    ACQUISITION_SAFETY_MARGIN_BYTES,
+    MAX_FILE_REFETCHES,
+    AcquisitionConsent,
+    ArtifactPreflightEntry,
+    CatalogError,
+    PreflightNotGrantableError,
+    PreflightReport,
+    resolve_catalog_closure,
+)
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts import ArtifactDescriptor
+
+
+def make_descriptor(
+    ref: ArtifactRef | None = None,
+    dependencies: tuple[ArtifactRef, ...] = (),
+) -> ArtifactDescriptor:
+    """Build a minimal descriptor for testing."""
+    from tldw_chatbook.Model_Artifacts import (
+        ArtifactDescriptor,
+        ArtifactFile,
+        ArtifactFormat,
+        ArtifactRole,
+        ProvenanceClass,
+    )
+
+    if ref is None:
+        ref = ArtifactRef("root", "r" * 40, "int8")
+
+    content = b"x"
+    files = (ArtifactFile("model.onnx", len(content), hashlib.sha256(content).hexdigest()),)
+
+    return ArtifactDescriptor(
+        reference=ref,
+        model_id="test/model",
+        role=ArtifactRole.ROOT,
+        format=ArtifactFormat.ONNX,
+        consumer="test",
+        model_family="test-family",
+        upstream_repository="test/repo",
+        upstream_revision="main",
+        source_url="https://example.test/model",
+        precision="int8",
+        license_id="test-license",
+        license_url="https://example.test/license",
+        usage_notice="Test model",
+        runtime_name="test-runtime",
+        runtime_version_constraint="==1.0.0",
+        supported_os=("linux",),
+        supported_architectures=("x86-64",),
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+        files=files,
+        expected_installed_bytes=len(content),
+        dependencies=dependencies,
+    )
+
+
+class DictCatalog:
+    """Simple in-memory catalog for testing."""
+
+    def __init__(self, mapping: dict[ArtifactRef, ArtifactDescriptor]) -> None:
+        self._m = mapping
+
+    def descriptor(self, ref: ArtifactRef) -> ArtifactDescriptor:
+        """Retrieve a descriptor by ref."""
+        return self._m[ref]
+
+
+def _ref(a: str = "root", r: str = "r1", v: str = "int8") -> ArtifactRef:
+    """Build a test ArtifactRef."""
+    return ArtifactRef(a, r, v)
+
+
+def test_closure_walk_resolves_dependencies_in_stable_order() -> None:
+    """Verify resolve_catalog_closure returns sorted by ref."""
+    dep = _ref("aaa-dep")
+    root = _ref("root")
+    catalog = DictCatalog(
+        {
+            root: make_descriptor(ref=root, dependencies=(dep,)),
+            dep: make_descriptor(ref=dep),
+        }
+    )
+    closure = resolve_catalog_closure(root, catalog)
+    ids = [d.reference.artifact_id for d in closure]
+    assert ids == sorted(ids)
+    assert len(closure) == 2
+
+
+def test_closure_walk_detects_cycles() -> None:
+    """Verify resolve_catalog_closure raises CatalogError for cycles."""
+    a, b = _ref("a"), _ref("b")
+    catalog = DictCatalog(
+        {
+            a: make_descriptor(ref=a, dependencies=(b,)),
+            b: make_descriptor(ref=b, dependencies=(a,)),
+        }
+    )
+    with pytest.raises(CatalogError):
+        resolve_catalog_closure(a, catalog)
+
+
+def test_closure_walk_detects_revision_conflicts() -> None:
+    """Verify resolve_catalog_closure raises CatalogError for conflicting revisions."""
+    dep1, dep2 = _ref("dep", "r1"), _ref("dep", "r2")
+    a, b = _ref("a"), _ref("b")
+    root = _ref("root")
+    catalog = DictCatalog(
+        {
+            root: make_descriptor(ref=root, dependencies=(a, b)),
+            a: make_descriptor(ref=a, dependencies=(dep1,)),
+            b: make_descriptor(ref=b, dependencies=(dep2,)),
+            dep1: make_descriptor(ref=dep1),
+            dep2: make_descriptor(ref=dep2),
+        }
+    )
+    with pytest.raises(CatalogError):
+        resolve_catalog_closure(root, catalog)
+
+
+def test_unknown_ref_is_a_typed_error() -> None:
+    """Verify resolve_catalog_closure raises CatalogError for unknown refs."""
+    with pytest.raises(CatalogError):
+        resolve_catalog_closure(_ref("missing"), DictCatalog({}))
+
+
+def _report(**overrides: object) -> PreflightReport:
+    """Build a PreflightReport with default values."""
+    defaults: dict[str, object] = {
+        "root": _ref(),
+        "closure_fingerprint": "f" * 64,
+        "entries": (),
+        "download_bytes": 0,
+        "already_staged_bytes": 0,
+        "staging_overhead_bytes": 0,
+        "retained_bytes": 0,
+        "destination": Path("/tmp/x"),
+        "free_bytes": 10**12,
+        "required_bytes": 10**6,
+        "sufficient_space": True,
+        "gating_errors": (),
+    }
+    defaults.update(overrides)
+    return PreflightReport(**defaults)  # type: ignore[arg-type]
+
+
+def test_grant_returns_consent_with_fingerprint() -> None:
+    """Verify PreflightReport.grant() returns AcquisitionConsent."""
+    consent = _report().grant()
+    assert isinstance(consent, AcquisitionConsent)
+    assert consent.closure_fingerprint == "f" * 64
+
+
+def test_grant_refuses_gating_errors_and_insufficient_space() -> None:
+    """Verify PreflightReport.grant() raises PreflightNotGrantableError."""
+    with pytest.raises(PreflightNotGrantableError):
+        _report(gating_errors=("token required",)).grant()
+    with pytest.raises(PreflightNotGrantableError):
+        _report(sufficient_space=False).grant()
+
+
+def test_constants_are_defined() -> None:
+    """Verify module constants."""
+    assert ACQUISITION_SAFETY_MARGIN_BYTES == 256 * 1024 * 1024
+    assert MAX_FILE_REFETCHES == 1

--- a/Tests/Model_Artifacts/test_acquisition_types.py
+++ b/Tests/Model_Artifacts/test_acquisition_types.py
@@ -27,8 +27,21 @@ if TYPE_CHECKING:
 def make_descriptor(
     ref: ArtifactRef | None = None,
     dependencies: tuple[ArtifactRef, ...] = (),
+    files_body: bytes | None = None,
+    source_url: str | None = None,
 ) -> ArtifactDescriptor:
-    """Build a minimal descriptor for testing."""
+    """Build a minimal descriptor for testing.
+
+    Args:
+        ref: The reference to build the descriptor for (defaults to a
+            fixed "root" reference).
+        dependencies: Dependency references for closure-walk tests.
+        files_body: Payload bytes for the single declared file, used by
+            preflight/fetch tests that need a real byte count and digest
+            (defaults to the historical single-byte ``b"x"`` content).
+        source_url: Override for ``source_url``, e.g. a fixture server URL
+            (defaults to the historical placeholder URL).
+    """
     from tldw_chatbook.Model_Artifacts import (
         ArtifactDescriptor,
         ArtifactFile,
@@ -40,7 +53,7 @@ def make_descriptor(
     if ref is None:
         ref = ArtifactRef("root", "r" * 40, "int8")
 
-    content = b"x"
+    content = files_body if files_body is not None else b"x"
     files = (ArtifactFile("model.onnx", len(content), hashlib.sha256(content).hexdigest()),)
 
     return ArtifactDescriptor(
@@ -52,7 +65,7 @@ def make_descriptor(
         model_family="test-family",
         upstream_repository="test/repo",
         upstream_revision="main",
-        source_url="https://example.test/model",
+        source_url=source_url if source_url is not None else "https://example.test/model",
         precision="int8",
         license_id="test-license",
         license_url="https://example.test/license",

--- a/Tests/Model_Artifacts/test_credentials_and_boundaries.py
+++ b/Tests/Model_Artifacts/test_credentials_and_boundaries.py
@@ -171,8 +171,10 @@ async def test_gated_repo_with_resolver_provisions_and_never_leaks_token(tmp_pat
 
     # 3. The fetch-state sidecar specifically no longer exists (install()
     #    removes it), which the tree scan above already covers, but assert
-    #    it explicitly as the most direct claim the brief asks for.
-    sidecar_path = root_dir / "staging" / "managed" / "gated-model" / "r1" / "int8" / "fetch-state.json"
+    #    it explicitly as the most direct claim the brief asks for. Lives
+    #    as a SIBLING of the payload directory, never a child of it (see
+    #    acquisition.py's _fetch_sidecar_path).
+    sidecar_path = root_dir / "staging" / "managed" / "gated-model" / "r1" / "int8.fetch-state.json"
     assert not sidecar_path.exists()
 
 
@@ -224,6 +226,58 @@ async def test_cross_origin_redirect_strips_authorization_but_body_still_downloa
         assert b_requests, "the redirect target must have been reached at all"
         assert all("Authorization" not in headers for headers in b_requests), (
             "the credential must NOT have crossed the origin boundary"
+        )
+
+
+@pytest.mark.asyncio
+async def test_cross_origin_redirect_strips_client_level_default_authorization(tmp_path):
+    """Same hand-off as the per-call-header test above, but the credential
+    is attached as a CLIENT-LEVEL default header
+    (``httpx.AsyncClient(headers={"Authorization": ...})``), which a caller
+    who reuses one client across many requests (a repository's own bearer
+    token, say) may reasonably do instead of passing it per call.
+
+    ``stream_fetch``'s own ``send_headers`` stripping only ever sees the
+    per-call ``headers=`` argument it built itself -- httpx merges a
+    client's default headers onto the request during ``send()``, AFTER
+    that per-call dict was stripped, so a client-level credential was
+    previously invisible to the cross-origin strip and reached origin B
+    verbatim. Regression test for that gap.
+    """
+    body = b"cross-origin-body-bytes-" * 300  # 7200 bytes
+    with FixtureArtifactServer() as origin_a, FixtureArtifactServer() as origin_b:
+        origin_b.serve("/final.bin", body)
+        origin_a.serve(
+            "/gated.bin",
+            b"",  # never served -- redirect_to short-circuits before the body
+            require_token=TOKEN,
+            redirect_to=origin_b.url("/final.bin"),
+        )
+
+        dest = tmp_path / "f.bin"
+        async with httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {TOKEN}"}
+        ) as client:
+            result = await stream_fetch(
+                origin_a.url("/gated.bin"),
+                dest,
+                client=client,
+                max_bytes=len(body) + 10,
+                trusted_origins=_trusted(origin_a),
+            )
+
+        assert dest.read_bytes() == body
+        assert result.bytes_written == len(body)
+
+        a_requests = origin_a.requests["/gated.bin"]
+        assert any(headers.get("Authorization") == f"Bearer {TOKEN}" for headers in a_requests), (
+            "the authenticated redirect origin must have SEEN the client-level credential"
+        )
+
+        b_requests = origin_b.requests["/final.bin"]
+        assert b_requests, "the redirect target must have been reached at all"
+        assert all("Authorization" not in headers for headers in b_requests), (
+            "the client-level credential must NOT have crossed the origin boundary"
         )
 
 

--- a/Tests/Model_Artifacts/test_credentials_and_boundaries.py
+++ b/Tests/Model_Artifacts/test_credentials_and_boundaries.py
@@ -1,0 +1,385 @@
+"""TASK-595 Task 9: credential resolution, secret hygiene, worker import boundary.
+
+Four things this file pins down that no earlier task's tests cover:
+
+(a) A ``CredentialResolver`` that returns a working token doesn't just clear
+    ``preflight()``'s gating probe -- it lets ``provision()`` actually fetch,
+    verify, and install against the same gated repository (Task 5 already
+    covers "no resolver -> gating_errors" in
+    ``test_preflight.py::test_preflight_gated_repo_reports_instructions``;
+    not duplicated here).
+(b) The resolved token never leaks into a log record (loguru, bridged to
+    ``caplog``, plus httpx/httpcore's native stdlib logging), the fetch-state
+    sidecar, any file under the artifact store, or a raised error's
+    ``str()``.
+(c) Task 3 review carry-over: an authenticated origin that 302-redirects to
+    a DIFFERENT origin must not leak ``Authorization`` across the hop --
+    ``fetch.stream_fetch`` already strips it (Task 3), but nothing exercised
+    that path against two real, differently-ported fixture servers until now.
+(d) Import boundary: the STT/worker surface that actually runs local
+    transcription must never import the async, credentialed acquisition
+    modules -- following ``Tests/STT/test_boundaries.py``'s subprocess
+    import-recording mechanism and module list, extended with the concrete
+    legacy worker module.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import textwrap
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
+from Tests.Model_Artifacts.test_acquisition_types import DictCatalog, make_descriptor
+from tldw_chatbook.Model_Artifacts import ArtifactRef
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    ArtifactAcquisitionService,
+    CredentialResolver,
+    EnvConfigCredentialResolver,
+)
+from tldw_chatbook.Model_Artifacts.fetch import stream_fetch
+from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
+
+TOKEN = "tok-secret-9f3c4a"
+
+
+def _trusted(srv: FixtureArtifactServer) -> frozenset:
+    """Trusted-origins set for a fixture server, in egress's real format.
+
+    Keyed on the bare, lowercased HOSTNAME (see ``test_stream_fetch.py`` /
+    ``test_preflight.py``'s identical helpers) -- both fixture servers in
+    the cross-origin test bind the SAME loopback hostname on different
+    ports, and egress's trust check is host-only (port-blind), so this one
+    entry covers both.
+    """
+    return frozenset({urlparse(srv.url("/")).hostname})
+
+
+class _StaticResolver:
+    """Test double: always resolves to the same token (or ``None``).
+
+    Records every ``repository`` it was asked to resolve for, so a test can
+    prove the resolver was actually consulted rather than bypassed.
+    """
+
+    def __init__(self, token: str | None) -> None:
+        self._token = token
+        self.resolved_for: list[str] = []
+
+    def resolve(self, repository: str) -> str | None:
+        """Return the configured token, recording the request."""
+        self.resolved_for.append(repository)
+        return self._token
+
+
+# ---------------------------------------------------------------------------
+# (a) + (b): resolver-backed provision succeeds end-to-end against a gated
+# repository, and the token never leaks anywhere.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _loguru_to_caplog(caplog):
+    """Bridge loguru output into pytest's ``caplog`` for this module only.
+
+    loguru does not propagate to stdlib ``logging`` (and therefore not to
+    ``caplog``) without an explicit bridge -- the same pattern already used
+    in ``Tests/Internal_Prompts/conftest.py``, scoped here to this file so
+    it doesn't change log-capture behavior for the rest of the suite.
+    """
+    from loguru import logger as loguru_logger
+
+    class PropagateHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = loguru_logger.add(PropagateHandler(), format="{message}")
+    yield
+    loguru_logger.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_gated_repo_with_resolver_provisions_and_never_leaks_token(tmp_path, caplog):
+    """A working credential clears preflight gating AND completes a real
+    fetch/pre-verify/install/activate against the gated route -- proving the
+    resolver is wired into BOTH the HEAD probe and the real fetch, not just
+    one of them. Then scans everywhere a leaked secret could hide.
+    """
+    root_dir = tmp_path / "root"
+    core = ModelArtifactService(root_dir)
+    root = ArtifactRef("gated-model", "r1", "int8")
+    resolver = _StaticResolver(TOKEN)
+
+    with caplog.at_level(logging.DEBUG):
+        with FixtureArtifactServer() as srv:
+            body = b"gated-payload-bytes-" * 400  # 8400 bytes
+            srv.serve("/m.onnx", body, require_token=TOKEN, etag='"v1"', support_range=True)
+            svc = ArtifactAcquisitionService(
+                core,
+                free_bytes_probe=lambda p: 10**12,
+                trusted_origins=_trusted(srv),
+                credential_resolver=resolver,
+            )
+            catalog = DictCatalog(
+                {root: make_descriptor(ref=root, files_body=body, source_url=srv.url("/m.onnx"))}
+            )
+
+            report = await svc.preflight(root, catalog)
+            assert report.gating_errors == (), (
+                "a working credential must clear the preflight gating probe"
+            )
+            consent = report.grant()
+
+            activated = await svc.provision(root, consent, catalog)
+            assert activated == root
+
+    # The resolver was genuinely consulted (both the probe and the fetch
+    # ask for the same repository -- make_descriptor's fixed "test/repo").
+    assert resolver.resolved_for
+    assert set(resolver.resolved_for) == {"test/repo"}
+
+    installed_refs = {
+        item.descriptor.reference for item in core.list_installed() if item.descriptor is not None
+    }
+    assert root in installed_refs
+    with core.acquire(root) as handle:
+        assert handle.handle.root == root
+
+    # (b) secret hygiene, four independent surfaces:
+
+    # 1. No log record -- loguru (bridged above) or httpx/httpcore's native
+    #    stdlib DEBUG logging (connection tracing, request/response lines)
+    #    -- carries the token.
+    assert TOKEN not in caplog.text
+    for record in caplog.records:
+        assert TOKEN not in record.getMessage()
+
+    # 2. Nothing under the artifact store's root -- staging sidecars,
+    #    installed payloads, manifests, lease files -- contains the token.
+    scanned = 0
+    for path in root_dir.rglob("*"):
+        if path.is_file():
+            scanned += 1
+            assert TOKEN.encode() not in path.read_bytes(), f"token leaked into {path}"
+    assert scanned > 0, "sanity: the artifact store must contain files to scan"
+
+    # 3. The fetch-state sidecar specifically no longer exists (install()
+    #    removes it), which the tree scan above already covers, but assert
+    #    it explicitly as the most direct claim the brief asks for.
+    sidecar_path = root_dir / "staging" / "managed" / "gated-model" / "r1" / "int8" / "fetch-state.json"
+    assert not sidecar_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# (c) Task 3 review carry: cross-origin redirect strips Authorization.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_origin_redirect_strips_authorization_but_body_still_downloads(tmp_path):
+    """An authenticated origin (A) 302-redirects to a DIFFERENT origin (B)
+    -- modeled with two real ``FixtureArtifactServer`` instances on
+    different ports, which ``fetch._same_origin`` treats as different
+    origins even though both bind the same loopback hostname. The
+    ``Authorization`` header must reach A (which requires it to authorize
+    the redirect) but must NOT reach B, and the body must still download
+    correctly from B.
+    """
+    body = b"cross-origin-body-bytes-" * 300  # 7200 bytes
+    with FixtureArtifactServer() as origin_a, FixtureArtifactServer() as origin_b:
+        origin_b.serve("/final.bin", body)
+        origin_a.serve(
+            "/gated.bin",
+            b"",  # never served -- redirect_to short-circuits before the body
+            require_token=TOKEN,
+            redirect_to=origin_b.url("/final.bin"),
+        )
+
+        dest = tmp_path / "f.bin"
+        async with httpx.AsyncClient() as client:
+            result = await stream_fetch(
+                origin_a.url("/gated.bin"),
+                dest,
+                client=client,
+                max_bytes=len(body) + 10,
+                headers={"Authorization": f"Bearer {TOKEN}"},
+                trusted_origins=_trusted(origin_a),
+            )
+
+        assert dest.read_bytes() == body
+        assert result.bytes_written == len(body)
+
+        a_requests = origin_a.requests["/gated.bin"]
+        assert any(headers.get("Authorization") == f"Bearer {TOKEN}" for headers in a_requests), (
+            "the authenticated redirect origin must have SEEN the credential"
+        )
+
+        b_requests = origin_b.requests["/final.bin"]
+        assert b_requests, "the redirect target must have been reached at all"
+        assert all("Authorization" not in headers for headers in b_requests), (
+            "the credential must NOT have crossed the origin boundary"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (d) Import boundary: STT/worker surface never imports acquisition/fetch.
+# ---------------------------------------------------------------------------
+
+
+def test_stt_and_transcription_worker_modules_never_import_acquisition_or_fetch() -> None:
+    """Neither ``Model_Artifacts.acquisition`` nor ``Model_Artifacts.fetch``
+    may be imported, attempted, or newly loaded as a side effect of
+    importing the STT runtime-dispatch surface (``contracts``,
+    ``coordinator``, ``legacy_bridge``, ``registry``, ``routing`` -- the
+    exact module list ``Tests/STT/test_boundaries.py`` already guards) or
+    the concrete legacy transcription worker
+    (``Local_Ingestion.transcription_service``) that surface ultimately
+    dispatches to.
+
+    Reuses that test's subprocess + import-recording-hook mechanism
+    verbatim (a clean ``sys.modules`` baseline per run, plus a hook that
+    also catches an import attempted-and-caught, not just one that
+    actually landed in ``sys.modules``) rather than duplicating it against
+    a different, narrower forbidden-module pair.
+
+    ``Model_Artifacts.leases`` and ``.service`` ARE expected to load here
+    (``STT.persistence`` -- reached transitively -- uses
+    ``ArtifactLeaseKey``); only the async, network-capable, credentialed
+    modules are forbidden.
+    """
+    script = textwrap.dedent(
+        """
+        import builtins
+        import importlib.util
+        import json
+        import sys
+
+        import tldw_chatbook
+
+        baseline_modules = set(sys.modules)
+        attempted_imports = set()
+        original_import = builtins.__import__
+
+        def recording_import(name, globals=None, locals=None, fromlist=(), level=0):
+            absolute_name = name
+            package = globals.get("__package__") if globals is not None else None
+            if level and package:
+                absolute_name = importlib.util.resolve_name(
+                    f"{'.' * level}{name}",
+                    package,
+                )
+            attempted_imports.add(absolute_name)
+            attempted_imports.update(
+                f"{absolute_name}.{requested_name}"
+                for requested_name in fromlist or ()
+                if requested_name != "*"
+            )
+            return original_import(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = recording_import
+        try:
+            import tldw_chatbook.STT.contracts
+            import tldw_chatbook.STT.coordinator
+            import tldw_chatbook.STT.legacy_bridge
+            import tldw_chatbook.STT.registry
+            import tldw_chatbook.STT.routing
+            import tldw_chatbook.Local_Ingestion.transcription_service
+        finally:
+            builtins.__import__ = original_import
+
+        print(
+            json.dumps(
+                {
+                    "all": sorted(sys.modules),
+                    "attempted": sorted(attempted_imports),
+                    "incremental": sorted(set(sys.modules) - baseline_modules),
+                }
+            )
+        )
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    imported = json.loads(completed.stdout)
+
+    forbidden = (
+        "tldw_chatbook.Model_Artifacts.acquisition",
+        "tldw_chatbook.Model_Artifacts.fetch",
+    )
+    for observed_key in ("all", "attempted", "incremental"):
+        observed_modules = set(imported[observed_key])
+        leaked = {
+            name
+            for name in forbidden
+            if any(
+                module == name or module.startswith(f"{name}.") for module in observed_modules
+            )
+        }
+        assert leaked == set(), f"{observed_key} leaked forbidden imports: {leaked}"
+
+    # Sanity: prove this isn't vacuous by confirming the SIBLING modules
+    # (leases/service) really were loaded -- if the whole Model_Artifacts
+    # package were untouched, the assertions above would pass trivially.
+    all_modules = set(imported["all"])
+    assert "tldw_chatbook.Model_Artifacts.leases" in all_modules
+    assert "tldw_chatbook.Model_Artifacts.service" in all_modules
+
+
+# ---------------------------------------------------------------------------
+# Bonus: EnvConfigCredentialResolver's own env -> config precedence.
+# ---------------------------------------------------------------------------
+
+
+def test_env_config_resolver_prefers_huggingface_api_key_env(monkeypatch) -> None:
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "from-env-primary")
+    monkeypatch.setenv("HF_TOKEN", "from-env-fallback")
+    resolver = EnvConfigCredentialResolver()
+    assert resolver.resolve("any/repo") == "from-env-primary"
+
+
+def test_env_config_resolver_falls_back_to_hf_token_env(monkeypatch) -> None:
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.setenv("HF_TOKEN", "from-hf-token")
+    resolver = EnvConfigCredentialResolver()
+    assert resolver.resolve("any/repo") == "from-hf-token"
+
+
+def test_env_config_resolver_falls_back_to_config_when_env_unset(monkeypatch) -> None:
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.acquisition.get_cli_setting",
+        lambda section, key, default=None: "from-config" if key == "huggingface_api_key" else default,
+    )
+    resolver = EnvConfigCredentialResolver()
+    assert resolver.resolve("any/repo") == "from-config"
+
+
+def test_env_config_resolver_returns_none_when_nothing_configured(monkeypatch) -> None:
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.acquisition.get_cli_setting",
+        lambda section, key, default=None: default,
+    )
+    resolver = EnvConfigCredentialResolver()
+    assert resolver.resolve("any/repo") is None
+
+
+def test_credential_resolver_protocol_is_satisfied_by_duck_typed_object() -> None:
+    """Structural typing: anything with a matching ``resolve`` method
+    satisfies ``CredentialResolver`` without inheriting from it."""
+    assert isinstance(_StaticResolver("x"), CredentialResolver)

--- a/Tests/Model_Artifacts/test_install_consume_source.py
+++ b/Tests/Model_Artifacts/test_install_consume_source.py
@@ -18,6 +18,7 @@ from Tests.Model_Artifacts.test_service import (
     descriptor,
     source_tree,
     install_inputs,
+    symlink_or_skip,
 )
 
 
@@ -106,3 +107,53 @@ def test_default_copy_behavior_unchanged(service: ModelArtifactService, tmp_path
     service.install(desc, source)
     for file in desc.files:
         assert (source / file.path).exists()
+
+
+def test_consume_source_rejects_symlinked_file(service: ModelArtifactService, tmp_path: Path) -> None:
+    """consume_source rejects when a declared file is a symlink."""
+    desc = descriptor()
+    source = Path(service.staging_path) / "managed" / "src"
+    source.mkdir(parents=True)
+    # Write the payload files to the source
+    for file in desc.files:
+        file_path = source / file.path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"x")
+
+    # Replace the declared file with a symlink
+    for file in desc.files:
+        file_path = source / file.path
+        file_path.unlink()
+        target = tmp_path / "external_target"
+        target.write_bytes(b"x")
+        symlink_or_skip(file_path, target, target_is_directory=False)
+
+    with pytest.raises(ArtifactPathError):
+        service.install(desc, source, consume_source=True)
+    # Files must still exist in source (not consumed on refusal).
+    for file in desc.files:
+        assert (source / file.path).exists()
+
+
+def test_consume_source_rejects_symlink_in_ancestry(service: ModelArtifactService, tmp_path: Path) -> None:
+    """consume_source rejects when source path contains a symlink component."""
+    desc = descriptor()
+    # Create actual directory with files
+    actual_source = Path(service.staging_path) / "managed" / "actual_src"
+    actual_source.mkdir(parents=True)
+    for file in desc.files:
+        file_path = actual_source / file.path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"x")
+
+    # Create a symlinked path to the source
+    symlink_parent = Path(service.staging_path) / "managed" / "symlink_parent"
+    symlink_parent.mkdir(parents=True)
+    symlink_source = symlink_parent / "symlinked_src"
+    symlink_or_skip(symlink_source, actual_source, target_is_directory=True)
+
+    with pytest.raises(ArtifactPathError):
+        service.install(desc, symlink_source, consume_source=True)
+    # Files must still exist in source (not consumed on refusal).
+    for file in desc.files:
+        assert (actual_source / file.path).exists()

--- a/Tests/Model_Artifacts/test_install_consume_source.py
+++ b/Tests/Model_Artifacts/test_install_consume_source.py
@@ -1,0 +1,108 @@
+"""TASK-595 Task 1: consume_source install semantics."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Model_Artifacts.service import (
+    ArtifactPathError,
+    ModelArtifactService,
+)
+
+# Reuse the descriptor/payload builders from test_service.py
+from Tests.Model_Artifacts.test_service import (
+    artifact_file,
+    descriptor,
+    source_tree,
+    install_inputs,
+)
+
+
+@pytest.fixture()
+def service(tmp_path: Path) -> ModelArtifactService:
+    """Create a service with a managed root."""
+    return ModelArtifactService(tmp_path / "root")
+
+
+def test_consume_source_moves_files_and_installs(service: ModelArtifactService, tmp_path: Path) -> None:
+    """Files are moved (source emptied), install verifies and promotes."""
+    # Use a descriptor with a single file to keep things simple
+    desc = descriptor()
+    # Create a source directory inside the service staging path
+    source = Path(service.staging_path) / "managed" / "src"
+    source.mkdir(parents=True)
+    # Write the payload files to the source
+    for file in desc.files:
+        file_path = source / file.path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"x")  # matches artifact_file() default content
+
+    ref = service.install(desc, source, consume_source=True)
+    installed = service.artifact_path(ref)
+    assert installed.exists()
+    # Moved, not copied: the declared payload files are gone from source.
+    for file in desc.files:
+        assert not (source / file.path).exists()
+
+
+def test_consume_source_outside_root_raises(service: ModelArtifactService, tmp_path: Path) -> None:
+    """Raises ArtifactPathError when source is outside the service root."""
+    desc = descriptor()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    # Write the payload files to the outside directory
+    for file in desc.files:
+        file_path = outside / file.path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"x")
+
+    with pytest.raises(ArtifactPathError):
+        service.install(desc, outside, consume_source=True)
+    # Nothing consumed on refusal.
+    for file in desc.files:
+        assert (outside / file.path).exists()
+
+
+def test_consume_source_exdev_falls_back_to_copy(service: ModelArtifactService, monkeypatch) -> None:
+    """EXDEV inside the root degrades to copy+delete, still installing."""
+    desc = descriptor()
+    source = Path(service.staging_path) / "managed" / "src"
+    source.mkdir(parents=True)
+    # Write the payload files to the source
+    for file in desc.files:
+        file_path = source / file.path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"x")
+
+    real_replace = os.replace
+
+    def exdev_replace(src, dst, *a, **k):
+        # Only raise EXDEV for payload files from the source directory,
+        # not for manifest files from atomic_write_json.
+        if Path(src).is_relative_to(source):
+            raise OSError(18, "Invalid cross-device link")  # errno.EXDEV
+        return real_replace(src, dst, *a, **k)
+
+    monkeypatch.setattr("tldw_chatbook.Model_Artifacts.service.os.replace", exdev_replace)
+    ref = service.install(desc, source, consume_source=True)
+    monkeypatch.setattr("tldw_chatbook.Model_Artifacts.service.os.replace", real_replace)
+    assert service.artifact_path(ref).exists()
+
+
+def test_default_copy_behavior_unchanged(service: ModelArtifactService, tmp_path: Path) -> None:
+    """consume_source=False keeps today's copy semantics: source intact."""
+    desc = descriptor()
+    source = tmp_path / "root" / "staging" / "src2"
+    source.mkdir(parents=True)
+    # Write the payload files to the source
+    for file in desc.files:
+        file_path = source / file.path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"x")
+
+    service.install(desc, source)
+    for file in desc.files:
+        assert (source / file.path).exists()

--- a/Tests/Model_Artifacts/test_install_consume_source.py
+++ b/Tests/Model_Artifacts/test_install_consume_source.py
@@ -110,7 +110,12 @@ def test_default_copy_behavior_unchanged(service: ModelArtifactService, tmp_path
 
 
 def test_consume_source_rejects_symlinked_file(service: ModelArtifactService, tmp_path: Path) -> None:
-    """consume_source rejects when a declared file is a symlink."""
+    """consume_source rejects when a declared file is a symlink.
+
+    NOTE: This test exercises the _validate_payload_tree layer (defense-in-depth).
+    The primary pin for _copy_payload containment is test_consume_source_outside_root_raises,
+    which verifies that outside-root sources are caught by _assert_managed_path(source).
+    """
     desc = descriptor()
     source = Path(service.staging_path) / "managed" / "src"
     source.mkdir(parents=True)
@@ -136,7 +141,12 @@ def test_consume_source_rejects_symlinked_file(service: ModelArtifactService, tm
 
 
 def test_consume_source_rejects_symlink_in_ancestry(service: ModelArtifactService, tmp_path: Path) -> None:
-    """consume_source rejects when source path contains a symlink component."""
+    """consume_source rejects when source path contains a symlink component.
+
+    NOTE: This test exercises the _assert_managed_path layer (defense-in-depth).
+    The primary pin for _copy_payload containment is test_consume_source_outside_root_raises,
+    which verifies that outside-root sources are caught by _assert_managed_path(source).
+    """
     desc = descriptor()
     # Create actual directory with files
     actual_source = Path(service.staging_path) / "managed" / "actual_src"

--- a/Tests/Model_Artifacts/test_preflight.py
+++ b/Tests/Model_Artifacts/test_preflight.py
@@ -143,3 +143,113 @@ async def test_preflight_gated_repo_reports_instructions(tmp_path):
     assert all("tok-secret" not in message for message in report.gating_errors)
     with pytest.raises(PreflightNotGrantableError):
         report.grant()
+
+
+@pytest.mark.asyncio
+async def test_preflight_upgrade_retains_prior_active_version(tmp_path):
+    """An installed+active v1 is retained while a not-installed v2 downloads fresh.
+
+    v2 must NOT be reported as already_installed; the byte cost of v1 must
+    surface as retained_bytes (kept on disk during the upgrade), and v2's
+    full size must surface as download_bytes -- no double-counting either
+    way.
+    """
+    core = ModelArtifactService(tmp_path / "root")
+    artifact_id = "root-model"
+    v1_ref = ArtifactRef(artifact_id, "r1", "int8")
+    v2_ref = ArtifactRef(artifact_id, "r2", "int8")
+    v1_body = b"v1" * 100  # 200 bytes
+    v1_descriptor = make_descriptor(ref=v1_ref, files_body=v1_body)
+
+    # Install and activate v1 directly against the core (copy semantics,
+    # matching test_install_consume_source.py's payload construction).
+    v1_source = tmp_path / "v1-source"
+    v1_source.mkdir()
+    (v1_source / v1_descriptor.files[0].path).write_bytes(v1_body)
+    core.install(v1_descriptor, v1_source)
+    core.activate(v1_ref)
+
+    with FixtureArtifactServer() as srv:
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        v2_body = b"v2" * 2048  # 4096 bytes -- deliberately != v1's size
+        srv.serve("/v2.onnx", v2_body)
+        v2_descriptor = make_descriptor(
+            ref=v2_ref, files_body=v2_body, source_url=srv.url("/v2.onnx")
+        )
+        catalog = DictCatalog({v2_ref: v2_descriptor})
+        report = await svc.preflight(v2_ref, catalog)
+    assert report.entries[0].already_installed is False
+    assert report.retained_bytes == len(v1_body)
+    assert report.download_bytes == len(v2_body)
+
+
+@pytest.mark.asyncio
+async def test_preflight_exact_installed_version_has_no_download_or_retention(tmp_path):
+    """Preflighting the exact installed+active version costs and retains nothing.
+
+    No gating probe is expected here either (the sole entry is already
+    installed), so this test needs no fixture server at all.
+    """
+    core = ModelArtifactService(tmp_path / "root")
+    root_ref = ArtifactRef("root-model", "r1", "int8")
+    body = b"m" * 2048
+    desc = make_descriptor(ref=root_ref, files_body=body)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / desc.files[0].path).write_bytes(body)
+    core.install(desc, source)
+    core.activate(root_ref)
+
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    catalog = DictCatalog({root_ref: desc})
+    report = await svc.preflight(root_ref, catalog)
+
+    assert report.entries[0].already_installed is True
+    assert report.download_bytes == 0
+    assert report.retained_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_preflight_clamps_oversized_staged_credit_to_entry_total(tmp_path):
+    """A stale/corrupt sidecar claiming more bytes than the artifact is clamped.
+
+    Regression test for the review finding: 999_999 claimed bytes_done for a
+    2048-byte artifact must not inflate already_staged_bytes past the
+    entry's own total, and must not drive download_bytes negative.
+    """
+    core = ModelArtifactService(tmp_path / "root")
+    root = ArtifactRef("root-model", "r1", "int8")
+    staged = Path(core.staging_path) / "managed" / "root-model" / "r1" / "int8"
+    staged.mkdir(parents=True)
+    (staged / "fetch-state.json").write_text(
+        json.dumps(
+            {
+                "files": {
+                    "m.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": 999_999,
+                        "complete": False,
+                    }
+                }
+            }
+        )
+    )
+    with FixtureArtifactServer() as srv:
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        body = b"m" * 2048
+        srv.serve("/m.onnx", body)
+        catalog = DictCatalog(
+            {
+                root: make_descriptor(
+                    ref=root, files_body=body, source_url=srv.url("/m.onnx")
+                )
+            }
+        )
+        report = await svc.preflight(root, catalog)
+    assert report.already_staged_bytes == 2048
+    assert report.download_bytes == 0

--- a/Tests/Model_Artifacts/test_preflight.py
+++ b/Tests/Model_Artifacts/test_preflight.py
@@ -69,16 +69,24 @@ async def test_preflight_aggregates_and_grants(tmp_path):
 
 @pytest.mark.asyncio
 async def test_preflight_counts_staged_credit(tmp_path):
-    """A partial fetch-state sidecar credits already_staged_bytes."""
+    """A partial fetch-state sidecar credits already_staged_bytes.
+
+    The staged file itself must actually exist with AT LEAST as many
+    bytes as the sidecar claims: credit is capped by the file's real
+    on-disk size, not just the sidecar's say-so (see the review finding
+    covered by test_preflight_stale_sidecar_credit_capped_by_actual_file_size)."""
     core = ModelArtifactService(tmp_path / "root")
     root = ArtifactRef("root-model", "r1", "int8")
     staged = Path(core.staging_path) / "managed" / "root-model" / "r1" / "int8"
     staged.mkdir(parents=True)
-    (staged / "fetch-state.json").write_text(
+    (staged / "model.onnx").write_bytes(b"m" * 500)
+    # Sidecar lives as a SIBLING of the payload directory (see
+    # acquisition.py's _fetch_sidecar_path), never a child of it.
+    (staged.parent / f"{staged.name}.fetch-state.json").write_text(
         json.dumps(
             {
                 "files": {
-                    "m.onnx": {
+                    "model.onnx": {
                         "etag": '"v1"',
                         "last_modified": None,
                         "bytes_done": 500,
@@ -227,17 +235,24 @@ async def test_preflight_clamps_oversized_staged_credit_to_entry_total(tmp_path)
 
     Regression test for the review finding: 999_999 claimed bytes_done for a
     2048-byte artifact must not inflate already_staged_bytes past the
-    entry's own total, and must not drive download_bytes negative.
+    entry's own total, and must not drive download_bytes negative. The
+    staged file is written at its full declared size (2048 bytes) so this
+    test still exercises the "declared total" clamp specifically, distinct
+    from the "actual on-disk size" clamp
+    (test_preflight_stale_sidecar_credit_capped_by_actual_file_size).
     """
     core = ModelArtifactService(tmp_path / "root")
     root = ArtifactRef("root-model", "r1", "int8")
     staged = Path(core.staging_path) / "managed" / "root-model" / "r1" / "int8"
     staged.mkdir(parents=True)
-    (staged / "fetch-state.json").write_text(
+    (staged / "model.onnx").write_bytes(b"m" * 2048)
+    # Sidecar lives as a SIBLING of the payload directory (see
+    # acquisition.py's _fetch_sidecar_path), never a child of it.
+    (staged.parent / f"{staged.name}.fetch-state.json").write_text(
         json.dumps(
             {
                 "files": {
-                    "m.onnx": {
+                    "model.onnx": {
                         "etag": '"v1"',
                         "last_modified": None,
                         "bytes_done": 999_999,
@@ -263,6 +278,61 @@ async def test_preflight_clamps_oversized_staged_credit_to_entry_total(tmp_path)
         report = await svc.preflight(root, catalog)
     assert report.already_staged_bytes == 2048
     assert report.download_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_preflight_stale_sidecar_credit_capped_by_actual_file_size(tmp_path):
+    """A sidecar claiming more bytes than are ACTUALLY on disk right now
+    must not inflate already_staged_bytes past what could genuinely be
+    resumed -- the declared-size clamp alone (the previous behavior)
+    doesn't catch this: 5000 is already less than nothing here, so it
+    passed the OLD "cap by declared total" check unchanged, yet the
+    staged FILE itself holds only 100 bytes. Preflight's space math must
+    trust the smaller, real number, or it can approve an acquisition that
+    then runs out of space because the "already staged" credit was
+    phantom.
+
+    Regression test for the review finding: cap each file's credit by
+    ``min(recorded bytes_done, actual file size on disk, declared file
+    size)``.
+    """
+    core = ModelArtifactService(tmp_path / "root")
+    root = ArtifactRef("root-model", "r1", "int8")
+    staged = Path(core.staging_path) / "managed" / "root-model" / "r1" / "int8"
+    staged.mkdir(parents=True)
+    (staged / "model.onnx").write_bytes(b"m" * 100)  # only 100 bytes ACTUALLY staged
+    # Sidecar lives as a SIBLING of the payload directory (see
+    # acquisition.py's _fetch_sidecar_path), never a child of it.
+    (staged.parent / f"{staged.name}.fetch-state.json").write_text(
+        json.dumps(
+            {
+                "files": {
+                    "model.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": 5000,  # claims far more than exists
+                        "complete": False,
+                    }
+                }
+            }
+        )
+    )
+    with FixtureArtifactServer() as srv:
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        body = b"m" * 2048
+        srv.serve("/m.onnx", body)
+        catalog = DictCatalog(
+            {
+                root: make_descriptor(
+                    ref=root, files_body=body, source_url=srv.url("/m.onnx")
+                )
+            }
+        )
+        report = await svc.preflight(root, catalog)
+    assert report.already_staged_bytes == 100
+    assert report.download_bytes == 2048 - 100
 
 
 def _two_file_descriptor(ref: ArtifactRef) -> ArtifactDescriptor:

--- a/Tests/Model_Artifacts/test_preflight.py
+++ b/Tests/Model_Artifacts/test_preflight.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from urllib.parse import urlparse
 
+import httpx
 import pytest
 
 from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
 from Tests.Model_Artifacts.test_acquisition_types import DictCatalog, make_descriptor
-from tldw_chatbook.Model_Artifacts import ArtifactRef
+from tldw_chatbook.Model_Artifacts import (
+    ArtifactDescriptor,
+    ArtifactFile,
+    ArtifactFormat,
+    ArtifactRef,
+    ArtifactRole,
+    ProvenanceClass,
+)
 from tldw_chatbook.Model_Artifacts.acquisition import (
     ArtifactAcquisitionService,
+    CatalogError,
     PreflightNotGrantableError,
 )
 from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
@@ -253,3 +263,103 @@ async def test_preflight_clamps_oversized_staged_credit_to_entry_total(tmp_path)
         report = await svc.preflight(root, catalog)
     assert report.already_staged_bytes == 2048
     assert report.download_bytes == 0
+
+
+def _two_file_descriptor(ref: ArtifactRef) -> ArtifactDescriptor:
+    """A 2-file descriptor -- real per-file URLs are undefined until the
+    catalog work (TASK-596/1301) specifies them; only the file COUNT
+    matters here (mirrors test_provision_fetch.py's identical-purpose
+    ``_make_two_file_descriptor``, duplicated locally per this suite's
+    convention of not cross-importing test-private helpers)."""
+
+    files = (
+        ArtifactFile("a.bin", 4, hashlib.sha256(b"aaaa").hexdigest()),
+        ArtifactFile("b.bin", 4, hashlib.sha256(b"bbbb").hexdigest()),
+    )
+    return ArtifactDescriptor(
+        reference=ref,
+        model_id="test/model",
+        role=ArtifactRole.ROOT,
+        format=ArtifactFormat.ONNX,
+        consumer="test",
+        model_family="test-family",
+        upstream_repository="test/repo",
+        upstream_revision="main",
+        source_url="https://example.test/model",
+        precision="int8",
+        license_id="test-license",
+        license_url="https://example.test/license",
+        usage_notice="Test model",
+        runtime_name="test-runtime",
+        runtime_version_constraint="==1.0.0",
+        supported_os=("linux",),
+        supported_architectures=("x86-64",),
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+        files=files,
+        expected_installed_bytes=8,
+        dependencies=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_multi_file_descriptor_raises_catalog_error(tmp_path):
+    """A 2-file descriptor fails ``preflight()`` itself, before any report
+    or consent exists -- not just later at ``provision()``'s fetch phase.
+
+    Regression test for the review finding: previously only
+    ``_fetch_artifact`` guarded this shape, so a preflight report could be
+    built and consent granted for a closure that ``provision()`` would
+    ALWAYS reject with ``CatalogError`` -- after already taking the
+    exclusive session lease. The spec requires catalog problems to surface
+    at preflight. No network fixture is needed: ``_aggregate_closure``
+    raises before ``preflight()`` ever reaches its gating probe.
+    """
+    core = ModelArtifactService(tmp_path / "root")
+    root = ArtifactRef("multi-file-model", "r1", "int8")
+    catalog = DictCatalog({root: _two_file_descriptor(root)})
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+
+    with pytest.raises(CatalogError) as excinfo:
+        await svc.preflight(root, catalog)
+    assert "multi-file-model" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_probe_gating_head_does_not_follow_redirects(tmp_path):
+    """The preflight gating HEAD probe must not follow a redirect, even
+    when the injected ``client_factory`` seam supplies a client configured
+    to do so by default.
+
+    Regression test for the review finding: an injected redirect-following
+    client would both bypass this app's own egress SSRF check for the
+    redirect target (only ``entry.source_url`` -- origin A here -- is
+    checked before the request) AND, when a credential is configured,
+    carry the bearer token cross-origin. ``follow_redirects=False`` passed
+    explicitly on the ``.head()`` call itself is what guarantees this
+    regardless of the client's own configured default -- proven here by
+    asserting the redirect target never receives any request at all.
+    """
+    with FixtureArtifactServer() as origin_a, FixtureArtifactServer() as origin_b:
+        origin_b.serve("/final.bin", b"body-bytes")
+        origin_a.serve("/gated.bin", b"", redirect_to=origin_b.url("/final.bin"))
+
+        root = ArtifactRef("root-model", "r1", "int8")
+        catalog = DictCatalog(
+            {root: make_descriptor(ref=root, source_url=origin_a.url("/gated.bin"))}
+        )
+        core = ModelArtifactService(tmp_path / "root")
+        injected_client = httpx.AsyncClient(follow_redirects=True)
+        try:
+            svc = ArtifactAcquisitionService(
+                core,
+                free_bytes_probe=lambda p: 10**12,
+                trusted_origins=frozenset({urlparse(origin_a.url("/")).hostname}),
+                client_factory=lambda: injected_client,
+            )
+            await svc.preflight(root, catalog)
+        finally:
+            await injected_client.aclose()
+
+        assert origin_b.requests == {}, (
+            "the gating probe must not follow a redirect to a different origin"
+        )

--- a/Tests/Model_Artifacts/test_preflight.py
+++ b/Tests/Model_Artifacts/test_preflight.py
@@ -1,0 +1,145 @@
+"""TASK-595 Task 5: consent preflight -- staged credit, space math, gating probe."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
+from Tests.Model_Artifacts.test_acquisition_types import DictCatalog, make_descriptor
+from tldw_chatbook.Model_Artifacts import ArtifactRef
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    ArtifactAcquisitionService,
+    PreflightNotGrantableError,
+)
+from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
+
+
+def _trusted(srv: FixtureArtifactServer) -> frozenset:
+    """Trusted-origins set for a fixture server, in egress's real format.
+
+    ``tldw_chatbook.Utils.egress._normalize_trusted`` / ``_post_resolution``
+    key membership on the bare, lowercased HOSTNAME (e.g. ``"127.0.0.1"``),
+    not a scheme+host+port URL string -- mirrors the ``_trusted`` helper in
+    ``Tests/Model_Artifacts/test_stream_fetch.py``. The fixture server binds
+    to the loopback IP literal, which classifies as "private" under
+    ``_classify_ip`` and would otherwise be egress-blocked; listing it here
+    is what lets policy allow the preflight HEAD probe to reach it.
+    """
+    return frozenset({urlparse(srv.url("/")).hostname})
+
+
+@pytest.mark.asyncio
+async def test_preflight_aggregates_and_grants(tmp_path):
+    """download_bytes sums not-installed totals; a clean report grants."""
+    core = ModelArtifactService(tmp_path / "root")
+    with FixtureArtifactServer() as srv:
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        body = b"m" * 2048
+        srv.serve("/m.onnx", body)
+        root = ArtifactRef("root-model", "r1", "int8")
+        catalog = DictCatalog(
+            {
+                root: make_descriptor(
+                    ref=root, files_body=body, source_url=srv.url("/m.onnx")
+                )
+            }
+        )
+        report = await svc.preflight(root, catalog)
+    assert report.download_bytes == 2048
+    assert report.sufficient_space is True
+    assert report.entries[0].already_installed is False
+    report.grant()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_preflight_counts_staged_credit(tmp_path):
+    """A partial fetch-state sidecar credits already_staged_bytes."""
+    core = ModelArtifactService(tmp_path / "root")
+    root = ArtifactRef("root-model", "r1", "int8")
+    staged = Path(core.staging_path) / "managed" / "root-model" / "r1" / "int8"
+    staged.mkdir(parents=True)
+    (staged / "fetch-state.json").write_text(
+        json.dumps(
+            {
+                "files": {
+                    "m.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": 500,
+                        "complete": False,
+                    }
+                }
+            }
+        )
+    )
+    with FixtureArtifactServer() as srv:
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        body = b"m" * 2048
+        srv.serve("/m.onnx", body)
+        catalog = DictCatalog(
+            {
+                root: make_descriptor(
+                    ref=root, files_body=body, source_url=srv.url("/m.onnx")
+                )
+            }
+        )
+        report = await svc.preflight(root, catalog)
+    assert report.already_staged_bytes == 500
+    assert report.download_bytes == 2048 - 500
+
+
+@pytest.mark.asyncio
+async def test_preflight_insufficient_space_blocks_grant(tmp_path):
+    """A tiny free_bytes_probe blocks grant() even with no gating errors."""
+    core = ModelArtifactService(tmp_path / "root")
+    with FixtureArtifactServer() as srv:
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10, trusted_origins=_trusted(srv)
+        )
+        body = b"m" * 2048
+        srv.serve("/m.onnx", body)
+        root = ArtifactRef("root-model", "r1", "int8")
+        catalog = DictCatalog(
+            {
+                root: make_descriptor(
+                    ref=root, files_body=body, source_url=srv.url("/m.onnx")
+                )
+            }
+        )
+        report = await svc.preflight(root, catalog)
+    assert report.sufficient_space is False
+    with pytest.raises(PreflightNotGrantableError):
+        report.grant()
+
+
+@pytest.mark.asyncio
+async def test_preflight_gated_repo_reports_instructions(tmp_path):
+    """A 401-gated repository surfaces a gating error without leaking the token."""
+    core = ModelArtifactService(tmp_path / "root")
+    with FixtureArtifactServer() as srv:
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        body = b"m" * 2048
+        srv.serve("/m.onnx", body, require_token="tok-secret")
+        root = ArtifactRef("root-model", "r1", "int8")
+        catalog = DictCatalog(
+            {
+                root: make_descriptor(
+                    ref=root, files_body=body, source_url=srv.url("/m.onnx")
+                )
+            }
+        )
+        report = await svc.preflight(root, catalog)
+    assert report.gating_errors, "401 repo must surface a gating error"
+    assert all("tok-secret" not in message for message in report.gating_errors)
+    with pytest.raises(PreflightNotGrantableError):
+        report.grant()

--- a/Tests/Model_Artifacts/test_provision_crash_recovery.py
+++ b/Tests/Model_Artifacts/test_provision_crash_recovery.py
@@ -177,7 +177,7 @@ async def test_kill_mid_fetch_valid_sidecar_survives_and_fresh_provision_resumes
         staging_dir = (
             core.staging_path / "managed" / ref_parts[0] / ref_parts[1] / ref_parts[2]
         )
-        sidecar_path = staging_dir / "fetch-state.json"
+        sidecar_path = staging_dir.parent / f"{staging_dir.name}.fetch-state.json"
 
         # The fetch phase durably completed before the freeze: a real,
         # parseable checkpoint sits on disk.
@@ -396,7 +396,7 @@ def test_reconcile_after_crash_removes_only_orphans_leaves_everything_else(tmp_p
         / survivor_ref_parts[1]
         / survivor_ref_parts[2]
     )
-    assert (survivor_dir / "fetch-state.json").exists()
+    assert (survivor_dir.parent / f"{survivor_dir.name}.fetch-state.json").exists()
 
     # A hand-crafted orphan: no sidecar at all, unrelated to the crash above.
     orphan_dir = core.staging_path / "managed" / "orphan-model" / "rev1" / "int8"
@@ -412,7 +412,7 @@ def test_reconcile_after_crash_removes_only_orphans_leaves_everything_else(tmp_p
     # The crash-surviving valid entry is untouched.
     assert survivor_dir.exists()
     assert (survivor_dir / "model.bin").exists()
-    assert (survivor_dir / "fetch-state.json").exists()
+    assert (survivor_dir.parent / f"{survivor_dir.name}.fetch-state.json").exists()
 
     # Content entirely outside the managed store is untouched.
     assert unrelated_file.read_text() == "do not touch"

--- a/Tests/Model_Artifacts/test_provision_crash_recovery.py
+++ b/Tests/Model_Artifacts/test_provision_crash_recovery.py
@@ -1,0 +1,419 @@
+"""TASK-595 Task 10: crash recovery, containment, and public exports.
+
+Real subprocess crashes (``multiprocessing`` + SIGKILL), not asyncio
+cancellation -- Task 7's cancellation test already covers the in-process
+case (``test_provision_cancel_mid_fetch_releases_lease_and_preserves_prior_active``
+in ``test_provision_fetch.py``). These tests prove the same guarantees hold
+when the OS, not asyncio, tears the process down: the exclusive session
+lease is a real ``portalocker`` flock the kernel releases on process death;
+a durable, sidecar-recorded checkpoint on disk is what a *different* process
+picks back up.
+
+Each scenario freezes the child at an exact point via
+``provision_processes.provision_signal_on_phase`` -- a progress-callback
+hook blocking on a local, never-set ``threading.Event`` -- so the crash
+lands deterministically rather than racing a sleep against I/O speed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import multiprocessing
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
+from Tests.Model_Artifacts.provision_processes import (
+    DictCatalog,
+    build_descriptor,
+    provision_signal_on_phase,
+)
+from tldw_chatbook.Model_Artifacts import ArtifactRef, closure_fingerprint
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    AcquisitionConsent,
+    ArtifactAcquisitionService,
+)
+from tldw_chatbook.Model_Artifacts.leases import ArtifactOperationLease, LeaseMode
+from tldw_chatbook.Model_Artifacts.service import (
+    ACQUISITION_SESSION_LEASE_KEY,
+    ModelArtifactService,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _trusted_hostname(srv: FixtureArtifactServer) -> str:
+    """Bare hostname a fixture server answers on (egress trust needs this,
+    not a full URL -- see test_stream_fetch.py's identical helper)."""
+
+    return urlparse(srv.url("/")).hostname
+
+
+def _spawn_and_kill_at(
+    root_dir: Path,
+    artifact_specs: tuple[dict, ...],
+    root_ref_parts: tuple[str, str, str],
+    trusted_origin: str,
+    *,
+    signal_phase: str,
+    signal_artifact_id: str | None,
+) -> None:
+    """Run ``provision_signal_on_phase`` in a real subprocess; SIGKILL it
+    the instant it freezes at ``signal_phase``.
+
+    Raises via assertion if the child never reaches the freeze point (a
+    real bug, not a flake -- the child's own 30s safety-net timeout would
+    otherwise let it silently finish normally and this helper's caller
+    would then be asserting about the WRONG process state).
+    """
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    process = context.Process(
+        target=provision_signal_on_phase,
+        args=(
+            str(root_dir),
+            artifact_specs,
+            root_ref_parts,
+            trusted_origin,
+            signal_phase,
+            signal_artifact_id,
+            ready,
+        ),
+    )
+    process.start()
+    try:
+        assert ready.wait(10.0), (
+            f"child never reached phase={signal_phase!r}, exit={process.exitcode}"
+        )
+        process.kill()  # SIGKILL -- kill -9, not a graceful terminate()
+        process.join(10.0)
+        if process.is_alive():
+            process.terminate()
+            process.join(5.0)
+        if process.is_alive():
+            process.kill()
+            process.join(5.0)
+        assert process.is_alive() is False
+    finally:
+        if process.is_alive():
+            process.kill()
+            process.join(5.0)
+
+
+async def _assert_session_lease_is_free(core: ModelArtifactService) -> None:
+    """The exclusive acquisition-session lease must be immediately
+    acquirable -- the killed child's flock was released by the kernel,
+    not left dangling."""
+
+    loop = asyncio.get_running_loop()
+    probe = ArtifactOperationLease(
+        core.locks_path,
+        ACQUISITION_SESSION_LEASE_KEY,
+        LeaseMode.EXCLUSIVE,
+        timeout_seconds=1.0,
+    )
+    await loop.run_in_executor(None, probe.acquire)
+    await loop.run_in_executor(None, probe.release)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: kill mid-fetch (frozen at pre-verify, right after a genuine
+# partial-but-durable fetch completed) -- valid sidecar survives reconcile,
+# session lease frees, a fresh provision resumes via Range and completes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_mid_fetch_valid_sidecar_survives_and_fresh_provision_resumes(
+    tmp_path,
+):
+    # The descriptor declares the FULL body's size/hash; the fixture route
+    # initially serves only a leading slice of it with a matching (short)
+    # Content-Length -- a genuine, unforced stream_fetch success (no
+    # protocol violation) that durably records a real bytes_done < declared
+    # size in the sidecar. That is the only way a first-ever fetch attempt
+    # leaves a partial-but-valid checkpoint behind: a SIGKILL landing
+    # mid-transfer of a file's ONLY attempt leaves no sidecar at all (see
+    # this suite's docstring), so this test freezes AFTER that attempt
+    # legitimately finished (pre-verify has not yet compared the hash),
+    # which is exactly the "fetched but not yet installed" crash window
+    # Task 2's staging GC rule exists for.
+    full_body = b"AB" * 3000  # 6000 bytes
+    initial_body = full_body[:2400]
+    sha256 = hashlib.sha256(full_body).hexdigest()
+    root_dir = tmp_path / "root"
+    ref_parts = ("crash-model", "r" * 40, "int8")
+
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.bin", initial_body, etag='"v1"', support_range=True)
+        trusted = _trusted_hostname(srv)
+
+        spec = {
+            "artifact_id": ref_parts[0],
+            "revision": ref_parts[1],
+            "variant": ref_parts[2],
+            "role": "root",
+            "source_url": srv.url("/model.bin"),
+            "size_bytes": len(full_body),
+            "sha256": sha256,
+            "dependencies": (),
+        }
+
+        _spawn_and_kill_at(
+            root_dir,
+            (spec,),
+            ref_parts,
+            trusted,
+            signal_phase="pre-verify",
+            signal_artifact_id=ref_parts[0],
+        )
+
+        core = ModelArtifactService(root_dir)
+        staging_dir = (
+            core.staging_path / "managed" / ref_parts[0] / ref_parts[1] / ref_parts[2]
+        )
+        sidecar_path = staging_dir / "fetch-state.json"
+
+        # The fetch phase durably completed before the freeze: a real,
+        # parseable checkpoint sits on disk.
+        assert sidecar_path.exists()
+        sidecar_before = json.loads(sidecar_path.read_text())
+        assert sidecar_before["files"]["model.bin"] == {
+            "etag": '"v1"',
+            "last_modified": None,
+            "bytes_done": len(initial_body),
+            "complete": False,
+        }
+        assert (staging_dir / "model.bin").stat().st_size == len(initial_body)
+
+        # (a) valid-sidecar managed staging survives reconcile() (Task 2's rule).
+        report = core.reconcile()
+        assert staging_dir.exists()
+        assert (staging_dir / "model.bin").exists()
+        assert sidecar_path.exists()
+        assert report.staging_removed == ()
+
+        # (b) the session lease is free -- the OS released the killed
+        # child's flock.
+        await _assert_session_lease_is_free(core)
+
+        # (c) a fresh provision resumes via Range and completes.
+        srv.serve("/model.bin", full_body, etag='"v1"', support_range=True)
+        descriptor = build_descriptor(
+            *ref_parts,
+            role="root",
+            source_url=srv.url("/model.bin"),
+            size_bytes=len(full_body),
+            sha256=sha256,
+            dependencies=(),
+        )
+        catalog = DictCatalog({descriptor.reference: descriptor})
+        root_ref = ArtifactRef(*ref_parts)
+        consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(root_ref, ()))
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda _p: 10**12, trusted_origins=frozenset({trusted})
+        )
+
+        activated = await svc.provision(root_ref, consent, catalog)
+
+        assert activated == root_ref
+        range_headers = [headers.get("Range") for headers in srv.requests["/model.bin"]]
+        assert f"bytes={len(initial_body)}-" in range_headers
+        assert not staging_dir.exists()
+        with core.acquire(root_ref) as handle:
+            assert handle.handle.root == root_ref
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: kill between install and activate -- both artifacts already
+# installed, activation not yet run; a fresh provision activates the
+# already-installed closure with zero fixture requests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_between_install_and_activate_fresh_provision_activates_with_zero_requests(
+    tmp_path,
+):
+    dep_body = b"dependency-payload-bytes"
+    root_body = b"root-payload-bytes-here"
+    dep_sha256 = hashlib.sha256(dep_body).hexdigest()
+    root_sha256 = hashlib.sha256(root_body).hexdigest()
+    root_dir = tmp_path / "root"
+    # Deliberately sorts before the root ref: resolve_catalog_closure walks
+    # in stable ArtifactRef order, so the dependency installs first and the
+    # freeze on root's own "verify-install" event lands only once BOTH
+    # artifacts are fully installed.
+    dep_ref_parts = ("aaa-dep-model", "d" * 40, "int8")
+    root_ref_parts = ("zzz-root-model", "r" * 40, "int8")
+
+    with FixtureArtifactServer() as srv:
+        srv.serve("/dep.bin", dep_body, etag='"dep-v1"', support_range=True)
+        srv.serve("/root.bin", root_body, etag='"root-v1"', support_range=True)
+        trusted = _trusted_hostname(srv)
+
+        dep_spec = {
+            "artifact_id": dep_ref_parts[0],
+            "revision": dep_ref_parts[1],
+            "variant": dep_ref_parts[2],
+            "role": "dependency",
+            "source_url": srv.url("/dep.bin"),
+            "size_bytes": len(dep_body),
+            "sha256": dep_sha256,
+            "dependencies": (),
+        }
+        root_spec = {
+            "artifact_id": root_ref_parts[0],
+            "revision": root_ref_parts[1],
+            "variant": root_ref_parts[2],
+            "role": "root",
+            "source_url": srv.url("/root.bin"),
+            "size_bytes": len(root_body),
+            "sha256": root_sha256,
+            "dependencies": (dep_ref_parts,),
+        }
+
+        _spawn_and_kill_at(
+            root_dir,
+            (dep_spec, root_spec),
+            root_ref_parts,
+            trusted,
+            signal_phase="verify-install",
+            signal_artifact_id=root_ref_parts[0],
+        )
+
+        core = ModelArtifactService(root_dir)
+        dep_ref = ArtifactRef(*dep_ref_parts)
+        root_ref = ArtifactRef(*root_ref_parts)
+
+        # Both artifacts are genuinely installed; activation never ran.
+        installed_refs = {
+            item.descriptor.reference
+            for item in core.list_installed()
+            if item.descriptor is not None
+        }
+        assert installed_refs == {dep_ref, root_ref}
+        assert not core.active_path(root_ref.artifact_id).exists()
+
+        await _assert_session_lease_is_free(core)
+
+        requests_before = {path: len(reqs) for path, reqs in srv.requests.items()}
+
+        dep_descriptor = build_descriptor(
+            *dep_ref_parts,
+            role="dependency",
+            source_url=srv.url("/dep.bin"),
+            size_bytes=len(dep_body),
+            sha256=dep_sha256,
+            dependencies=(),
+        )
+        root_descriptor = build_descriptor(
+            *root_ref_parts,
+            role="root",
+            source_url=srv.url("/root.bin"),
+            size_bytes=len(root_body),
+            sha256=root_sha256,
+            dependencies=(dep_ref_parts,),
+        )
+        catalog = DictCatalog({dep_ref: dep_descriptor, root_ref: root_descriptor})
+        consent = AcquisitionConsent(
+            closure_fingerprint=closure_fingerprint(root_ref, (dep_ref,))
+        )
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda _p: 10**12, trusted_origins=frozenset({trusted})
+        )
+
+        events = []
+        activated = await svc.provision(root_ref, consent, catalog, progress=events.append)
+
+        assert activated == root_ref
+        assert [event.phase for event in events] == ["activate"]
+        assert {path: len(reqs) for path, reqs in srv.requests.items()} == requests_before
+
+        with core.acquire(root_ref) as handle:
+            assert handle.handle.root == root_ref
+            assert set(handle.handle.closure) == {root_ref, dep_ref}
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: containment -- reconcile()'s staging_removed names only
+# orphans; a crash-surviving valid entry and unrelated tmp_path content are
+# both left alone.
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_after_crash_removes_only_orphans_leaves_everything_else(tmp_path):
+    survivor_body = b"survivor-bytes" * 20
+    survivor_sha256 = hashlib.sha256(survivor_body).hexdigest()
+    root_dir = tmp_path / "root"
+    survivor_ref_parts = ("survivor-model", "s" * 40, "int8")
+
+    # Unrelated content sitting alongside the managed store root -- must be
+    # completely untouched by reconcile()'s staging GC.
+    unrelated_file = tmp_path / "user_notes.txt"
+    unrelated_file.write_text("do not touch")
+    unrelated_dir = tmp_path / "unrelated_project"
+    unrelated_dir.mkdir()
+    (unrelated_dir / "keep.bin").write_bytes(b"keep-me")
+
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.bin", survivor_body, etag='"v1"', support_range=True)
+        trusted = _trusted_hostname(srv)
+
+        survivor_spec = {
+            "artifact_id": survivor_ref_parts[0],
+            "revision": survivor_ref_parts[1],
+            "variant": survivor_ref_parts[2],
+            "role": "root",
+            "source_url": srv.url("/model.bin"),
+            "size_bytes": len(survivor_body),
+            "sha256": survivor_sha256,
+            "dependencies": (),
+        }
+
+        # A real crash mid-pipeline: the fetch fully (and durably) completed,
+        # but the process dies before pre-verify's hash comparison -- the
+        # entry must read as "resumable", not "orphaned".
+        _spawn_and_kill_at(
+            root_dir,
+            (survivor_spec,),
+            survivor_ref_parts,
+            trusted,
+            signal_phase="pre-verify",
+            signal_artifact_id=survivor_ref_parts[0],
+        )
+
+    core = ModelArtifactService(root_dir)
+    survivor_dir = (
+        core.staging_path
+        / "managed"
+        / survivor_ref_parts[0]
+        / survivor_ref_parts[1]
+        / survivor_ref_parts[2]
+    )
+    assert (survivor_dir / "fetch-state.json").exists()
+
+    # A hand-crafted orphan: no sidecar at all, unrelated to the crash above.
+    orphan_dir = core.staging_path / "managed" / "orphan-model" / "rev1" / "int8"
+    orphan_dir.mkdir(parents=True)
+    (orphan_dir / "model.bin").write_bytes(b"abandoned")
+
+    report = core.reconcile()
+
+    # Only the orphan is named as removed.
+    assert report.staging_removed == ("managed/orphan-model/rev1/int8",)
+    assert not orphan_dir.exists()
+
+    # The crash-surviving valid entry is untouched.
+    assert survivor_dir.exists()
+    assert (survivor_dir / "model.bin").exists()
+    assert (survivor_dir / "fetch-state.json").exists()
+
+    # Content entirely outside the managed store is untouched.
+    assert unrelated_file.read_text() == "do not touch"
+    assert (unrelated_dir / "keep.bin").read_bytes() == b"keep-me"

--- a/Tests/Model_Artifacts/test_provision_fetch.py
+++ b/Tests/Model_Artifacts/test_provision_fetch.py
@@ -1,0 +1,455 @@
+"""TASK-595 Task 7: provision() fetch phase -- durable staging, sidecar, resume.
+
+Covers ``ArtifactAcquisitionService._fetch_artifact`` (and its private
+helpers) directly for the per-file mechanics -- skip/resume/restart/ENOSPC
+-- and ``provision()`` end-to-end for the cancellation guarantee, which is
+a provision()-level property (session lease release, prior-active-artifact
+survival), not something the fetch phase alone can prove.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import errno
+import json
+import threading
+from urllib.parse import urlparse
+
+import pytest
+
+from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
+from Tests.Model_Artifacts.test_acquisition_types import DictCatalog, make_descriptor
+from tldw_chatbook.Model_Artifacts import ArtifactRef, closure_fingerprint
+from tldw_chatbook.Model_Artifacts import fetch as fetch_module
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    AcquisitionConsent,
+    AcquisitionProgress,
+    ArtifactAcquisitionService,
+    TransferError,
+    _ProvisionProgressState,
+)
+from tldw_chatbook.Model_Artifacts.leases import (
+    ArtifactOperationLease,
+    LeaseMode,
+)
+from tldw_chatbook.Model_Artifacts.service import (
+    ACQUISITION_SESSION_LEASE_KEY,
+    ModelArtifactService,
+)
+from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
+
+
+def _trusted(srv: FixtureArtifactServer) -> frozenset:
+    """Trusted-origins set for a fixture server (see test_stream_fetch.py's
+    identical helper for why this is the bare hostname, not a URL)."""
+
+    return frozenset({urlparse(srv.url("/")).hostname})
+
+
+# ---------------------------------------------------------------------------
+# Direct _reconcile_durable_bytes unit coverage (Task 3 review carry-over):
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_truncates_untrusted_excess_beyond_durable_checkpoint(tmp_path):
+    """Bytes beyond the sidecar's last durable checkpoint are unverified --
+    a crash/disconnect can leave an unfsynced tail on disk that must never
+    be trusted for a Range resume."""
+
+    destination = tmp_path / "f.bin"
+    destination.write_bytes(b"0" * 4000 + b"?" * 2000)  # 6000 on disk
+
+    result = ArtifactAcquisitionService._reconcile_durable_bytes(destination, 4000)
+
+    assert result == 4000
+    assert destination.stat().st_size == 4000
+    assert destination.read_bytes() == b"0" * 4000
+
+
+def test_reconcile_restarts_from_zero_when_sidecar_over_claims(tmp_path):
+    """A sidecar claiming MORE durable bytes than the file actually holds
+    cannot be trusted at all -- restart that file from zero."""
+
+    destination = tmp_path / "f.bin"
+    destination.write_bytes(b"0" * 100)  # far short of the claimed 4000
+
+    result = ArtifactAcquisitionService._reconcile_durable_bytes(destination, 4000)
+
+    assert result == 0
+    assert not destination.exists()
+
+
+def test_reconcile_is_a_noop_when_already_consistent(tmp_path):
+    destination = tmp_path / "f.bin"
+    destination.write_bytes(b"0" * 4000)
+
+    result = ArtifactAcquisitionService._reconcile_durable_bytes(destination, 4000)
+
+    assert result == 4000
+    assert destination.read_bytes() == b"0" * 4000
+
+
+def test_reconcile_missing_file_with_zero_recorded_is_a_noop(tmp_path):
+    destination = tmp_path / "missing.bin"
+    assert ArtifactAcquisitionService._reconcile_durable_bytes(destination, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_artifact: fresh download, skip, resume, restart, ENOSPC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_full_download_writes_sidecar_and_reports_progress(tmp_path):
+    body = b"0123456789" * 1000  # 10 KB
+    events: list[AcquisitionProgress] = []
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.onnx", body, etag='"v1"', support_range=True)
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=body, source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+
+        progress_state = _ProvisionProgressState(callback=events.append, bytes_total=len(body))
+        await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert (staging_dir / "model.onnx").read_bytes() == body
+        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        assert sidecar["files"]["model.onnx"] == {
+            "etag": '"v1"',
+            "last_modified": None,
+            "bytes_done": len(body),
+            "complete": True,
+        }
+        assert progress_state.bytes_done == len(body)
+        assert events, "on_chunk must emit at least one progress event"
+        assert all(event.phase == "fetch" for event in events)
+        assert events[-1].bytes_done == len(body)
+        assert events[-1].bytes_total == len(body)
+        assert events[-1].ref == desc.reference
+        assert events[-1].file == "model.onnx"
+
+
+@pytest.mark.asyncio
+async def test_fetch_skips_file_already_complete_in_sidecar(tmp_path):
+    body = b"x" * 500
+    with FixtureArtifactServer() as srv:
+        # Deliberately no route registered: any network attempt 404s, which
+        # would surface as a TransferError this test never expects.
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=body, source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "model.onnx").write_bytes(body)
+        atomic_write_json(
+            staging_dir / "fetch-state.json",
+            {
+                "files": {
+                    "model.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": len(body),
+                        "complete": True,
+                    }
+                }
+            },
+        )
+
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=0)
+        await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert "/model.onnx" not in srv.requests
+        assert progress_state.bytes_done == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_resumes_partial_file_with_range_request(tmp_path):
+    body = b"0123456789" * 1000  # 10 KB
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.onnx", body, etag='"v1"', support_range=True)
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=body, source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "model.onnx").write_bytes(body[:4000])
+        atomic_write_json(
+            staging_dir / "fetch-state.json",
+            {
+                "files": {
+                    "model.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": 4000,
+                        "complete": False,
+                    }
+                }
+            },
+        )
+
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=len(body) - 4000)
+        await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert (staging_dir / "model.onnx").read_bytes() == body
+        assert any("Range" in headers for headers in srv.requests["/model.onnx"])
+        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        entry = sidecar["files"]["model.onnx"]
+        assert entry["bytes_done"] == len(body)
+        assert entry["complete"] is True
+        assert entry["etag"] == '"v1"'
+        assert progress_state.bytes_done == len(body) - 4000
+
+
+@pytest.mark.asyncio
+async def test_fetch_restarts_from_zero_on_changed_etag(tmp_path):
+    old_body = b"0123456789" * 1000
+    new_body = b"9876543210" * 1200  # different content and length: new revision
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.onnx", new_body, etag='"v2"', support_range=True)
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=new_body, source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "model.onnx").write_bytes(old_body[:100])
+        atomic_write_json(
+            staging_dir / "fetch-state.json",
+            {
+                "files": {
+                    "model.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": 100,
+                        "complete": False,
+                    }
+                }
+            },
+        )
+
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=len(new_body))
+        await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert (staging_dir / "model.onnx").read_bytes() == new_body
+        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        entry = sidecar["files"]["model.onnx"]
+        assert entry["etag"] == '"v2"'
+        assert entry["bytes_done"] == len(new_body)
+        assert entry["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_mid_body_disconnect_leaves_durable_sidecar_and_reprovision_resumes(
+    tmp_path,
+):
+    # Large enough that the disconnect lands after one full fetch.py chunk
+    # (1 MB) has actually been written to disk -- proving the reconciliation
+    # truncation is genuinely exercised, not just tolerated as a no-op. A
+    # smaller body would have httpx buffer internally and raise before
+    # yielding any bytes at all, which would leave nothing to reconcile.
+    body = b"AB" * 1_500_000  # 3,000,000 bytes
+    seed = body[:1_000_000]
+    with FixtureArtifactServer() as srv:
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=body, source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "model.onnx").write_bytes(seed)
+        atomic_write_json(
+            staging_dir / "fetch-state.json",
+            {
+                "files": {
+                    "model.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": len(seed),
+                        "complete": False,
+                    }
+                }
+            },
+        )
+
+        # First attempt: server drops the resumed response mid-body, after
+        # one full chunk (1 MB) of the resume was already durably written
+        # to disk by fetch.py -- but NOT fsynced/recorded to the sidecar,
+        # since that only happens after stream_fetch returns successfully.
+        srv.serve(
+            "/model.onnx", body, etag='"v1"', support_range=True, disconnect_after=1_100_000
+        )
+        progress_state = _ProvisionProgressState(
+            callback=None, bytes_total=len(body) - len(seed)
+        )
+        with pytest.raises(TransferError) as excinfo:
+            await svc._fetch_artifact(desc, staging_dir, progress_state)
+        assert excinfo.value.retryable is True
+
+        # Durable state consistent: the sidecar still shows the last
+        # checkpoint that was actually fsynced and recorded -- this failed
+        # call never got far enough to update it.
+        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        assert sidecar["files"]["model.onnx"]["bytes_done"] == len(seed)
+        # The failed attempt genuinely left an untrusted tail beyond the
+        # durable checkpoint (the whole point of this scenario).
+        assert (staging_dir / "model.onnx").stat().st_size > len(seed)
+
+        # Second attempt ("re-provision"): server now completes normally.
+        srv.serve("/model.onnx", body, etag='"v1"', support_range=True)
+        progress_state2 = _ProvisionProgressState(
+            callback=None, bytes_total=len(body) - len(seed)
+        )
+        await svc._fetch_artifact(desc, staging_dir, progress_state2)
+
+        assert (staging_dir / "model.onnx").read_bytes() == body
+        # The reconciled resume asked for the durable checkpoint, never the
+        # untrusted post-disconnect tail -- proves reconciliation actually
+        # ran (truncating the leaked bytes), not just that a Range request
+        # happened at all.
+        assert srv.requests["/model.onnx"][-1].get("Range") == f"bytes={len(seed)}-"
+        sidecar_final = json.loads((staging_dir / "fetch-state.json").read_text())
+        assert sidecar_final["files"]["model.onnx"]["complete"] is True
+        assert sidecar_final["files"]["model.onnx"]["bytes_done"] == len(body)
+
+
+@pytest.mark.asyncio
+async def test_fetch_enospc_raises_transfer_error_retryable_and_retains_staging(
+    tmp_path, monkeypatch
+):
+    class _ENOSPCFile:
+        """Wraps a real file handle but fails every write with ENOSPC."""
+
+        def __init__(self, real):
+            self._real = real
+
+        def write(self, data):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        def flush(self):
+            pass
+
+        def fileno(self):
+            return self._real.fileno()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            self._real.close()
+            return False
+
+    def fake_open(path, mode):
+        return _ENOSPCFile(builtins.open(path, mode))
+
+    # Shadowing fetch.py's module-global `open` (its own written-as-`open`
+    # calls resolve through the module namespace before falling back to the
+    # builtin); acquisition.py's own truncate-path `open` calls are
+    # untouched since they resolve in a different module's namespace.
+    monkeypatch.setattr(fetch_module, "open", fake_open, raising=False)
+
+    body = b"y" * 2000
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.onnx", body, etag='"v1"', support_range=True)
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=body, source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=len(body))
+        with pytest.raises(TransferError) as excinfo:
+            await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert excinfo.value.retryable is True
+        # Staging retained -- no cleanup on a failed fetch.
+        assert staging_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# provision() cancellation: session lease released, sidecar durable-only,
+# prior active artifact survives untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provision_cancel_mid_fetch_releases_lease_and_preserves_prior_active(
+    tmp_path,
+):
+    core = ModelArtifactService(tmp_path / "root")
+
+    prior_ref = ArtifactRef("prior-model", "r1", "int8")
+    prior_body = b"p" * 32
+    prior_desc = make_descriptor(ref=prior_ref, files_body=prior_body)
+    prior_source = tmp_path / "prior-source"
+    prior_source.mkdir()
+    (prior_source / prior_desc.files[0].path).write_bytes(prior_body)
+    core.install(prior_desc, prior_source)
+    core.activate(prior_ref)
+
+    new_ref = ArtifactRef("new-model", "r1", "int8")
+    body = b"n" * 3_000_000  # 3 MB
+    # fetch.py's aiter_bytes(chunk_size=1 MB) only yields once a full chunk
+    # has actually arrived -- pausing at 1.2 MB guarantees one full 1 MB
+    # chunk is delivered (firing on_chunk/progress) before the connection
+    # genuinely blocks awaiting the rest of the second chunk.
+    pause_after = 1_200_000
+    gate = threading.Event()
+
+    with FixtureArtifactServer() as srv:
+        srv.serve(
+            "/model.bin",
+            body,
+            etag='"v1"',
+            support_range=True,
+            pause_after=pause_after,
+            pause_event=gate,
+        )
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        new_desc = make_descriptor(
+            ref=new_ref, files_body=body, source_url=srv.url("/model.bin")
+        )
+        catalog = DictCatalog({new_ref: new_desc})
+        consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(new_ref, ()))
+
+        progress_seen = asyncio.Event()
+
+        def on_progress(progress: AcquisitionProgress) -> None:
+            if progress.phase == "fetch":
+                progress_seen.set()
+
+        task = asyncio.create_task(
+            svc.provision(new_ref, consent, catalog, progress=on_progress)
+        )
+        try:
+            # Gated by the progress callback firing on the first received
+            # chunk, not a sleep-based guess at timing.
+            await asyncio.wait_for(progress_seen.wait(), timeout=5.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            gate.set()  # release the paused handler thread promptly
+
+    # The session lease was released in provision()'s finally, not left
+    # held by the cancelled task.
+    loop = asyncio.get_running_loop()
+    probe = ArtifactOperationLease(
+        core.locks_path,
+        ACQUISITION_SESSION_LEASE_KEY,
+        LeaseMode.EXCLUSIVE,
+        timeout_seconds=1.0,
+    )
+    await loop.run_in_executor(None, probe.acquire)
+    await loop.run_in_executor(None, probe.release)
+
+    # Sidecar reflects only durable bytes: stream_fetch never returned
+    # successfully, so nothing was ever written for the new artifact.
+    sidecar_path = (
+        core.staging_path / "managed" / "new-model" / "r1" / "int8" / "fetch-state.json"
+    )
+    assert not sidecar_path.exists()
+
+    # The prior active artifact is untouched and still acquirable.
+    with core.acquire(prior_ref) as handle:
+        assert handle.handle.root == prior_ref

--- a/Tests/Model_Artifacts/test_provision_fetch.py
+++ b/Tests/Model_Artifacts/test_provision_fetch.py
@@ -164,7 +164,7 @@ async def test_fetch_full_download_writes_sidecar_and_reports_progress(tmp_path)
         await svc._fetch_artifact(desc, staging_dir, progress_state)
 
         assert (staging_dir / "model.onnx").read_bytes() == body
-        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        sidecar = json.loads((staging_dir.parent / f"{staging_dir.name}.fetch-state.json").read_text())
         assert sidecar["files"]["model.onnx"] == {
             "etag": '"v1"',
             "last_modified": None,
@@ -181,6 +181,58 @@ async def test_fetch_full_download_writes_sidecar_and_reports_progress(tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_fetch_over_large_checkpoint_restarts_cleanly(tmp_path):
+    """A sidecar checkpoint from a PRIOR provision() run can exceed the
+    file's CURRENT declared size if the catalog's declared size for this
+    artifact/revision/variant shrank between runs (a corrected or re-cut
+    upstream entry). ``_reconcile_durable_bytes`` only cross-checks the
+    checkpoint against the file's ACTUAL on-disk bytes -- here they agree
+    (4000 claimed, 4000 present), so reconciliation leaves it untouched --
+    never against the CURRENT ``file.size_bytes``. Left unchecked this
+    becomes ``resume_from >= max_bytes`` inside ``stream_fetch``, which
+    raises ``FetchTooLargeError`` and gets wrapped as a NON-retryable
+    ``TransferError`` ("upstream body exceeds declared size") instead of
+    the clean restart-from-zero this really calls for.
+
+    Regression test for the review finding: normalize an over-large
+    checkpoint to zero before deriving resume_from.
+    """
+    body = b"0123456789" * 100  # 1000 bytes -- the file's CURRENT declared size
+    stale_bytes = b"x" * 4000  # what a now-stale prior checkpoint claimed
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.onnx", body, etag='"v1"', support_range=True)
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=body, source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "model.onnx").write_bytes(stale_bytes)
+        atomic_write_json(
+            staging_dir.parent / f"{staging_dir.name}.fetch-state.json",
+            {
+                "files": {
+                    "model.onnx": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": len(stale_bytes),
+                        "complete": False,
+                    }
+                }
+            },
+        )
+
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=len(body))
+        await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert (staging_dir / "model.onnx").read_bytes() == body
+        sidecar = json.loads((staging_dir.parent / f"{staging_dir.name}.fetch-state.json").read_text())
+        assert sidecar["files"]["model.onnx"]["complete"] is True
+        assert sidecar["files"]["model.onnx"]["bytes_done"] == len(body)
+        # A clean restart-from-zero means a FULL GET, never a Range resume.
+        assert not any("Range" in r for r in srv.requests["/model.onnx"])
+
+
+@pytest.mark.asyncio
 async def test_fetch_skips_file_already_complete_in_sidecar(tmp_path):
     body = b"x" * 500
     with FixtureArtifactServer() as srv:
@@ -193,7 +245,7 @@ async def test_fetch_skips_file_already_complete_in_sidecar(tmp_path):
         staging_dir.mkdir(parents=True)
         (staging_dir / "model.onnx").write_bytes(body)
         atomic_write_json(
-            staging_dir / "fetch-state.json",
+            staging_dir.parent / f"{staging_dir.name}.fetch-state.json",
             {
                 "files": {
                     "model.onnx": {
@@ -233,7 +285,7 @@ async def test_fetch_zero_byte_file_creates_empty_destination_and_skips_network(
         destination = staging_dir / "model.onnx"
         assert destination.exists()
         assert destination.read_bytes() == b""
-        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        sidecar = json.loads((staging_dir.parent / f"{staging_dir.name}.fetch-state.json").read_text())
         entry = sidecar["files"]["model.onnx"]
         assert entry["complete"] is True
         assert entry["bytes_done"] == 0
@@ -277,7 +329,7 @@ async def test_fetch_resumes_partial_file_with_range_request(tmp_path):
         staging_dir.mkdir(parents=True)
         (staging_dir / "model.onnx").write_bytes(body[:4000])
         atomic_write_json(
-            staging_dir / "fetch-state.json",
+            staging_dir.parent / f"{staging_dir.name}.fetch-state.json",
             {
                 "files": {
                     "model.onnx": {
@@ -295,7 +347,7 @@ async def test_fetch_resumes_partial_file_with_range_request(tmp_path):
 
         assert (staging_dir / "model.onnx").read_bytes() == body
         assert any("Range" in headers for headers in srv.requests["/model.onnx"])
-        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        sidecar = json.loads((staging_dir.parent / f"{staging_dir.name}.fetch-state.json").read_text())
         entry = sidecar["files"]["model.onnx"]
         assert entry["bytes_done"] == len(body)
         assert entry["complete"] is True
@@ -316,7 +368,7 @@ async def test_fetch_restarts_from_zero_on_changed_etag(tmp_path):
         staging_dir.mkdir(parents=True)
         (staging_dir / "model.onnx").write_bytes(old_body[:100])
         atomic_write_json(
-            staging_dir / "fetch-state.json",
+            staging_dir.parent / f"{staging_dir.name}.fetch-state.json",
             {
                 "files": {
                     "model.onnx": {
@@ -333,7 +385,7 @@ async def test_fetch_restarts_from_zero_on_changed_etag(tmp_path):
         await svc._fetch_artifact(desc, staging_dir, progress_state)
 
         assert (staging_dir / "model.onnx").read_bytes() == new_body
-        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        sidecar = json.loads((staging_dir.parent / f"{staging_dir.name}.fetch-state.json").read_text())
         entry = sidecar["files"]["model.onnx"]
         assert entry["etag"] == '"v2"'
         assert entry["bytes_done"] == len(new_body)
@@ -359,7 +411,7 @@ async def test_fetch_mid_body_disconnect_leaves_durable_sidecar_and_reprovision_
         staging_dir.mkdir(parents=True)
         (staging_dir / "model.onnx").write_bytes(seed)
         atomic_write_json(
-            staging_dir / "fetch-state.json",
+            staging_dir.parent / f"{staging_dir.name}.fetch-state.json",
             {
                 "files": {
                     "model.onnx": {
@@ -389,7 +441,7 @@ async def test_fetch_mid_body_disconnect_leaves_durable_sidecar_and_reprovision_
         # Durable state consistent: the sidecar still shows the last
         # checkpoint that was actually fsynced and recorded -- this failed
         # call never got far enough to update it.
-        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        sidecar = json.loads((staging_dir.parent / f"{staging_dir.name}.fetch-state.json").read_text())
         assert sidecar["files"]["model.onnx"]["bytes_done"] == len(seed)
         # The failed attempt genuinely left an untrusted tail beyond the
         # durable checkpoint (the whole point of this scenario).
@@ -408,7 +460,7 @@ async def test_fetch_mid_body_disconnect_leaves_durable_sidecar_and_reprovision_
         # ran (truncating the leaked bytes), not just that a Range request
         # happened at all.
         assert srv.requests["/model.onnx"][-1].get("Range") == f"bytes={len(seed)}-"
-        sidecar_final = json.loads((staging_dir / "fetch-state.json").read_text())
+        sidecar_final = json.loads((staging_dir.parent / f"{staging_dir.name}.fetch-state.json").read_text())
         assert sidecar_final["files"]["model.onnx"]["complete"] is True
         assert sidecar_final["files"]["model.onnx"]["bytes_done"] == len(body)
 
@@ -546,8 +598,10 @@ async def test_provision_cancel_mid_fetch_releases_lease_and_preserves_prior_act
 
     # Sidecar reflects only durable bytes: stream_fetch never returned
     # successfully, so nothing was ever written for the new artifact.
+    # Sibling of the payload directory, never a child of it -- see
+    # acquisition.py's _fetch_sidecar_path.
     sidecar_path = (
-        core.staging_path / "managed" / "new-model" / "r1" / "int8" / "fetch-state.json"
+        core.staging_path / "managed" / "new-model" / "r1" / "int8.fetch-state.json"
     )
     assert not sidecar_path.exists()
 

--- a/Tests/Model_Artifacts/test_provision_fetch.py
+++ b/Tests/Model_Artifacts/test_provision_fetch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 import errno
+import hashlib
 import json
 import threading
 from urllib.parse import urlparse
@@ -20,12 +21,21 @@ import pytest
 
 from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
 from Tests.Model_Artifacts.test_acquisition_types import DictCatalog, make_descriptor
-from tldw_chatbook.Model_Artifacts import ArtifactRef, closure_fingerprint
+from tldw_chatbook.Model_Artifacts import (
+    ArtifactDescriptor,
+    ArtifactFile,
+    ArtifactFormat,
+    ArtifactRef,
+    ArtifactRole,
+    ProvenanceClass,
+    closure_fingerprint,
+)
 from tldw_chatbook.Model_Artifacts import fetch as fetch_module
 from tldw_chatbook.Model_Artifacts.acquisition import (
     AcquisitionConsent,
     AcquisitionProgress,
     ArtifactAcquisitionService,
+    CatalogError,
     TransferError,
     _ProvisionProgressState,
 )
@@ -45,6 +55,45 @@ def _trusted(srv: FixtureArtifactServer) -> frozenset:
     identical helper for why this is the bare hostname, not a URL)."""
 
     return frozenset({urlparse(srv.url("/")).hostname})
+
+
+def _make_two_file_descriptor(source_url: str) -> ArtifactDescriptor:
+    """A 2-file descriptor -- ``make_descriptor`` only ever builds one file.
+
+    Only the file COUNT matters for the CatalogError coverage below: real
+    per-file URLs for a multi-file descriptor don't exist yet (that's
+    TASK-596/1301's job), so there is nothing meaningful to make these
+    URLs resolve to.
+    """
+
+    ref = ArtifactRef("multi-file-model", "r" * 40, "int8")
+    files = (
+        ArtifactFile("a.bin", 4, hashlib.sha256(b"aaaa").hexdigest()),
+        ArtifactFile("b.bin", 4, hashlib.sha256(b"bbbb").hexdigest()),
+    )
+    return ArtifactDescriptor(
+        reference=ref,
+        model_id="test/model",
+        role=ArtifactRole.ROOT,
+        format=ArtifactFormat.ONNX,
+        consumer="test",
+        model_family="test-family",
+        upstream_repository="test/repo",
+        upstream_revision="main",
+        source_url=source_url,
+        precision="int8",
+        license_id="test-license",
+        license_url="https://example.test/license",
+        usage_notice="Test model",
+        runtime_name="test-runtime",
+        runtime_version_constraint="==1.0.0",
+        supported_os=("linux",),
+        supported_architectures=("x86-64",),
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+        files=files,
+        expected_installed_bytes=8,
+        dependencies=(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +211,58 @@ async def test_fetch_skips_file_already_complete_in_sidecar(tmp_path):
 
         assert "/model.onnx" not in srv.requests
         assert progress_state.bytes_done == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_zero_byte_file_creates_empty_destination_and_skips_network(tmp_path):
+    """A zero-byte declared file must never leave the sidecar claiming
+    'complete' over a destination that doesn't exist -- Task 8's pre-verify
+    would hit FileNotFoundError trying to hash it."""
+
+    with FixtureArtifactServer() as srv:
+        # Deliberately no route registered: a zero-byte file has nothing to
+        # stream and must never attempt a network request at all.
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = make_descriptor(files_body=b"", source_url=srv.url("/model.onnx"))
+        staging_dir = tmp_path / "staging" / "m"
+
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=0)
+        await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        destination = staging_dir / "model.onnx"
+        assert destination.exists()
+        assert destination.read_bytes() == b""
+        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        entry = sidecar["files"]["model.onnx"]
+        assert entry["complete"] is True
+        assert entry["bytes_done"] == 0
+        assert "/model.onnx" not in srv.requests
+
+
+@pytest.mark.asyncio
+async def test_fetch_multi_file_descriptor_raises_catalog_error_without_touching_anything(
+    tmp_path,
+):
+    """Per-file URLs for a multi-file descriptor are undefined until the
+    catalog work (TASK-596/1301) specifies them. ``_fetch_artifact`` must
+    fail loudly with a typed CatalogError instead of silently guessing a
+    joined URL and fetching the wrong bytes -- and must do so before
+    touching staging, the sidecar, or the network at all."""
+
+    with FixtureArtifactServer() as srv:
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        desc = _make_two_file_descriptor(srv.url("/base/"))
+        staging_dir = tmp_path / "staging" / "m"
+
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=8)
+        with pytest.raises(CatalogError) as excinfo:
+            await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert "multi-file-model" in str(excinfo.value)
+        assert not staging_dir.exists()
+        assert not srv.requests
 
 
 @pytest.mark.asyncio

--- a/Tests/Model_Artifacts/test_provision_install.py
+++ b/Tests/Model_Artifacts/test_provision_install.py
@@ -12,8 +12,11 @@ closure without touching the network at all.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import hashlib
 import json
+import time
 from urllib.parse import urlparse
 
 import pytest
@@ -24,6 +27,7 @@ from tldw_chatbook.Model_Artifacts import (
     ArtifactDescriptor,
     ArtifactFile,
     ArtifactFormat,
+    ArtifactPathError,
     ArtifactRef,
     ArtifactRole,
     ArtifactIntegrityError,
@@ -127,6 +131,79 @@ async def test_preverify_matches_declared_hash_and_reports_real_progress(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_preverify_hashing_does_not_block_event_loop(tmp_path, monkeypatch):
+    """``_hash_staged_file`` must run off the event loop -- otherwise
+    hashing a large staged file blocks every other coroutine (any other
+    artifact's progress, cancellation checks, the UI event loop this
+    service shares) for the whole read, since a tight
+    ``hashlib.sha256().update()`` loop has no ``await`` to yield control.
+
+    Proven with a concurrent heartbeat coroutine: monkeypatch
+    ``hashlib.sha256`` (as imported into ``acquisition.py``) to sleep
+    briefly per chunk, simulating a slow hash/disk read, and count how many
+    times a sibling coroutine ticks WHILE that hashing is in flight. Against
+    the pre-fix code (a synchronous call with no internal ``await``), the
+    whole hash runs to completion before the event loop gets a chance to
+    schedule anything else, so the heartbeat gets zero ticks; with hashing
+    moved to an executor hop, the awaiting coroutine actually suspends and
+    the heartbeat ticks concurrently.
+    """
+    chunk_bytes = b"x" * (1024 * 1024)
+    body = chunk_bytes * 8  # 8 MiB == 8 reads at _hash_staged_file's 1 MiB chunk size
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=body)
+    staging_dir = tmp_path / "staging" / "m"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").write_bytes(body)
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+    progress_state = _ProvisionProgressState(callback=None, bytes_total=len(body))
+
+    real_sha256 = hashlib.sha256
+
+    class SlowHash:
+        """Wraps a real SHA-256 but sleeps per ``update()`` call -- makes
+        the hash operation take long enough (~0.4s over 8 chunks) for a
+        blocked-vs-not-blocked event loop to be reliably observable."""
+
+        def __init__(self) -> None:
+            self._real = real_sha256()
+
+        def update(self, data: bytes) -> None:
+            time.sleep(0.05)
+            self._real.update(data)
+
+        def hexdigest(self) -> str:
+            return self._real.hexdigest()
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.acquisition.hashlib.sha256", SlowHash
+    )
+
+    heartbeats = 0
+
+    async def heartbeat() -> None:
+        nonlocal heartbeats
+        while True:
+            heartbeats += 1
+            await asyncio.sleep(0.01)
+
+    hb_task = asyncio.ensure_future(heartbeat())
+    try:
+        await svc._preverify_artifact(desc, staging_dir, progress_state)
+    finally:
+        hb_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await hb_task
+
+    assert heartbeats >= 3, (
+        "the event loop must keep running (heartbeat ticking) WHILE "
+        "_hash_staged_file is hashing, proving the hash runs off-loop"
+    )
+    assert progress_state.preverify_bytes_done == len(body)
+
+
+@pytest.mark.asyncio
 async def test_preverify_progress_total_defaults_to_bytes_total_when_unset(tmp_path):
     """Direct construction without ``preverify_bytes_total`` (every other
     test in this file) keeps working: it defaults to ``bytes_total`` via
@@ -171,8 +248,14 @@ async def test_provision_preverify_total_ignores_fetch_phases_netted_staged_cred
 
     staged = core.staging_path / "managed" / ref.artifact_id / ref.revision / ref.variant
     staged.mkdir(parents=True)
+    # A real on-disk partial file matching the sidecar's claimed 500 bytes
+    # -- staged-credit math caps a sidecar's claim by the file's ACTUAL
+    # on-disk size (see the preflight staged-credit review finding), so
+    # this setup needs a real file to still net download_bytes down to
+    # 1548 the way this test's docstring describes.
+    (staged / "model.bin").write_bytes(b"m" * 500)
     atomic_write_json(
-        staged / "fetch-state.json",
+        staged.parent / f"{staged.name}.fetch-state.json",
         {
             "files": {
                 "model.bin": {
@@ -254,9 +337,10 @@ async def test_preverify_mismatch_refetches_once_and_recovers_on_good_content(tm
         )
         staging_dir = tmp_path / "staging" / "m"
         staging_dir.mkdir(parents=True)
+        sidecar_path = staging_dir.parent / f"{staging_dir.name}.fetch-state.json"
         (staging_dir / "model.bin").write_bytes(wrong_body)
         atomic_write_json(
-            staging_dir / "fetch-state.json",
+            sidecar_path,
             {
                 "files": {
                     "model.bin": {
@@ -277,7 +361,7 @@ async def test_preverify_mismatch_refetches_once_and_recovers_on_good_content(tm
 
         assert (staging_dir / "model.bin").read_bytes() == correct_body
         assert len(srv.requests["/model.bin"]) == 1
-        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        sidecar = json.loads(sidecar_path.read_text())
         assert sidecar["files"]["model.bin"]["complete"] is True
         assert sidecar["files"]["model.bin"]["bytes_done"] == len(correct_body)
 
@@ -302,7 +386,7 @@ async def test_preverify_mismatch_persisting_past_max_refetches_raises_transfer_
         staging_dir.mkdir(parents=True)
         (staging_dir / "model.bin").write_bytes(wrong_body)
         atomic_write_json(
-            staging_dir / "fetch-state.json",
+            staging_dir.parent / f"{staging_dir.name}.fetch-state.json",
             {
                 "files": {
                     "model.bin": {
@@ -340,9 +424,10 @@ async def test_install_promotes_payload_and_removes_staging_dir_and_sidecar(tmp_
 
     staging_dir = core.staging_path / "managed" / "m" / ("r" * 40) / "int8"
     staging_dir.mkdir(parents=True)
+    sidecar_path = staging_dir.parent / f"{staging_dir.name}.fetch-state.json"
     (staging_dir / "model.bin").write_bytes(body)
     atomic_write_json(
-        staging_dir / "fetch-state.json",
+        sidecar_path,
         {"files": {"model.bin": {"etag": None, "last_modified": None, "bytes_done": len(body), "complete": True}}},
     )
 
@@ -352,10 +437,11 @@ async def test_install_promotes_payload_and_removes_staging_dir_and_sidecar(tmp_
     assert installed.exists()
     assert (installed / "model.bin").read_bytes() == body
     assert not staging_dir.exists()
+    assert not sidecar_path.exists()
 
 
 @pytest.mark.asyncio
-async def test_install_failure_does_not_install_and_staging_dir_survives(tmp_path):
+async def test_install_failure_leaves_staging_dir_and_sidecar_intact_for_resume(tmp_path):
     """core.install's own integrity check fails (staged content doesn't
     match the declared hash -- as if pre-verify had been skipped, the
     defense-in-depth check this exercises).
@@ -366,9 +452,19 @@ async def test_install_failure_does_not_install_and_staging_dir_survives(tmp_pat
     behind for inspection -- that is Task 1's sealed core behavior, not
     something this phase controls. What Task 8 owns and this test pins:
     nothing gets installed, and ``_install_artifact`` itself does not
-    ``rmtree`` our staging directory on failure (only a successful install
-    triggers that cleanup) -- unlike the sidecar, which is removed
-    up front regardless, to satisfy install's exact-file-set check.
+    ``rmtree`` our staging directory OR touch the sidecar on failure --
+    only a successful install triggers that cleanup (see
+    ``test_install_promotes_payload_and_removes_staging_dir_and_sidecar``).
+
+    Regression test for TASK-595 final-review P2 (retryable install
+    failures must not destroy the only resumable state): the sidecar now
+    lives OUTSIDE the payload directory (a SIBLING file, never a child of
+    it -- see acquisition.py's ``_fetch_sidecar_path``) and is left
+    completely untouched by ``_install_artifact`` until AFTER a
+    successful install, unlike the earlier design which deleted it
+    UNCONDITIONALLY before every attempt (required then, since
+    ``core.install``'s payload-tree validation rejects an undeclared
+    file living inside the payload dir).
 
     ``core.install``'s raw ``ArtifactIntegrityError`` is wrapped by
     ``_run_core_call`` (review finding: core ``ArtifactError`` subclasses
@@ -382,9 +478,10 @@ async def test_install_failure_does_not_install_and_staging_dir_survives(tmp_pat
 
     staging_dir = core.staging_path / "managed" / "m" / ("r" * 40) / "int8"
     staging_dir.mkdir(parents=True)
+    sidecar_path = staging_dir.parent / f"{staging_dir.name}.fetch-state.json"
     (staging_dir / "model.bin").write_bytes(b"corrupt!")  # wrong content, right length
     atomic_write_json(
-        staging_dir / "fetch-state.json",
+        sidecar_path,
         {"files": {"model.bin": {"etag": None, "last_modified": None, "bytes_done": 8, "complete": True}}},
     )
 
@@ -395,8 +492,94 @@ async def test_install_failure_does_not_install_and_staging_dir_survives(tmp_pat
     assert isinstance(excinfo.value.__cause__, ArtifactIntegrityError)
 
     assert staging_dir.exists()
-    assert not (staging_dir / "fetch-state.json").exists()
+    assert sidecar_path.exists(), (
+        "a failed install must NOT destroy the sidecar -- it is the only "
+        "resumable state a later provision() attempt has to work with"
+    )
     assert core.list_installed() == ()
+
+
+@pytest.mark.asyncio
+async def test_retryable_install_failure_leaves_staged_bytes_resumable_via_range(
+    tmp_path, monkeypatch
+):
+    """A 'retryable' install failure must not destroy the resumable
+    download it claims can still be retried.
+
+    Regression test for TASK-595 final-review P2: the fetch-state sidecar
+    used to live INSIDE the payload directory and was deleted
+    UNCONDITIONALLY before every ``core.install`` attempt (required then,
+    since install's payload-tree validation rejects an undeclared file
+    living inside the payload dir); that pre-deletion destroyed the
+    checkpoint on ANY failure, including a merely transient, RETRYABLE
+    one -- forcing a full re-download on retry despite the ``retryable``
+    label. With the sidecar living OUTSIDE the payload tree (a sibling
+    file), a failed install leaves it -- and the partial bytes it
+    describes -- exactly where a fresh fetch phase can resume from.
+
+    ``core.install`` is monkeypatched to fail directly (simulating
+    whatever internal reason -- lease contention, I/O, or anything else
+    that surfaces as a retryable ``ArtifactStateError``) rather than
+    exercising the sealed core's real internals: this isolates the claim
+    under test (acquisition.py's OWN handling of the sidecar) from the
+    core's separate, more complex internal failure modes.
+    """
+    full_body = b"0123456789" * 1000  # 10,000 bytes
+    partial = full_body[:4000]
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.bin", full_body, etag='"v1"', support_range=True)
+        desc = _descriptor(
+            ArtifactRef("m", "r" * 40, "int8"),
+            files_body=full_body,
+            source_url=srv.url("/model.bin"),
+        )
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+
+        staging_dir = core.staging_path / "managed" / "m" / ("r" * 40) / "int8"
+        staging_dir.mkdir(parents=True)
+        sidecar_path = staging_dir.parent / f"{staging_dir.name}.fetch-state.json"
+        (staging_dir / "model.bin").write_bytes(partial)
+        atomic_write_json(
+            sidecar_path,
+            {
+                "files": {
+                    "model.bin": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": len(partial),
+                        "complete": False,
+                    }
+                }
+            },
+        )
+
+        def raise_state_error(*args, **kwargs):
+            raise ArtifactStateError("simulated transient lease contention")
+
+        monkeypatch.setattr(core, "install", raise_state_error)
+
+        with pytest.raises(TransferError) as excinfo:
+            await svc._install_artifact(desc, staging_dir)
+        assert excinfo.value.retryable is True
+
+        # The partial bytes and their sidecar checkpoint survived untouched.
+        assert (staging_dir / "model.bin").read_bytes() == partial
+        assert sidecar_path.exists()
+        sidecar = json.loads(sidecar_path.read_text())
+        assert sidecar["files"]["model.bin"]["bytes_done"] == len(partial)
+
+        # A fresh fetch phase (what the NEXT provision() attempt runs
+        # first) resumes via Range, not a full re-download from zero.
+        progress_state = _ProvisionProgressState(
+            callback=None, bytes_total=len(full_body) - len(partial)
+        )
+        await svc._fetch_artifact(desc, staging_dir, progress_state)
+
+        assert (staging_dir / "model.bin").read_bytes() == full_body
+        assert any("Range" in headers for headers in srv.requests["/model.bin"])
+        final_sidecar = json.loads(sidecar_path.read_text())
+        assert final_sidecar["files"]["model.bin"]["complete"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -612,6 +795,43 @@ async def test_install_artifact_wraps_core_integrity_error_as_non_retryable(
 
     assert excinfo.value.retryable is False
     assert isinstance(excinfo.value.__cause__, ArtifactIntegrityError)
+    assert "m" in str(excinfo.value)
+    assert "install" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_install_artifact_wraps_core_path_error_as_non_retryable(
+    tmp_path, monkeypatch
+):
+    """``core.install`` raising ``ArtifactPathError`` must surface as a
+    non-retryable ``TransferError``, never the raw core error.
+
+    Regression test for TASK-1566 (filed during TASK-595's final review):
+    ``_run_core_call`` caught ``ArtifactIntegrityError``/
+    ``ArtifactConflictError``/``ArtifactStateError`` but NOT
+    ``ArtifactPathError`` -- which ``core.install`` documents raising for
+    an unsafe or invalid source/destination path -- so it escaped
+    ``provision()`` raw, breaking the spec's never-trap rule. Not
+    retryable: the same unsafe/invalid path would fail again.
+    """
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=b"x")
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+
+    staging_dir = core.staging_path / "managed" / "m" / ("r" * 40) / "int8"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").write_bytes(b"x")
+
+    def raise_path_error(*args, **kwargs):
+        raise ArtifactPathError("simulated unsafe path")
+
+    monkeypatch.setattr(core, "install", raise_path_error)
+
+    with pytest.raises(TransferError) as excinfo:
+        await svc._install_artifact(desc, staging_dir)
+
+    assert excinfo.value.retryable is False
+    assert isinstance(excinfo.value.__cause__, ArtifactPathError)
     assert "m" in str(excinfo.value)
     assert "install" in str(excinfo.value)
 

--- a/Tests/Model_Artifacts/test_provision_install.py
+++ b/Tests/Model_Artifacts/test_provision_install.py
@@ -27,6 +27,7 @@ from tldw_chatbook.Model_Artifacts import (
     ArtifactRef,
     ArtifactRole,
     ArtifactIntegrityError,
+    ArtifactStateError,
     ProvenanceClass,
     closure_fingerprint,
 )
@@ -123,6 +124,99 @@ async def test_preverify_matches_declared_hash_and_reports_real_progress(tmp_pat
     assert progress_state.preverify_bytes_done == len(body)
     # The fetch counter is untouched by pre-verify -- separately tracked.
     assert progress_state.bytes_done == 0
+
+
+@pytest.mark.asyncio
+async def test_preverify_progress_total_defaults_to_bytes_total_when_unset(tmp_path):
+    """Direct construction without ``preverify_bytes_total`` (every other
+    test in this file) keeps working: it defaults to ``bytes_total`` via
+    ``__post_init__``, matching this class's behavior before Task 4's
+    review-finding fix introduced the separate field."""
+    body = b"y" * 100
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=body)
+    staging_dir = tmp_path / "staging" / "m"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").write_bytes(body)
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+    progress_state = _ProvisionProgressState(callback=None, bytes_total=len(body))
+
+    assert progress_state.preverify_bytes_total == len(body)
+    await svc._preverify_artifact(desc, staging_dir, progress_state)
+    assert progress_state.preverify_bytes_done == len(body)
+
+
+@pytest.mark.asyncio
+async def test_provision_preverify_total_ignores_fetch_phases_netted_staged_credit(
+    tmp_path, monkeypatch
+):
+    """Pre-verify's progress total is the full closure file size, NOT the
+    fetch phase's total (``PreflightReport.download_bytes``), which nets
+    out already-staged credit from a resumed run.
+
+    Regression test for the review finding: ``_hash_staged_file`` always
+    re-hashes a staged file's ENTIRE on-disk content, but the fetch and
+    pre-verify progress events previously shared one ``bytes_total``
+    (the fetch phase's netted-down total) -- so ANY resumed run's
+    pre-verify progress would overshoot 100%. Here, 500 of 2048 bytes are
+    already durably staged and credited before this run starts, netting
+    the fetch total (``bytes_total``) down to 1548 while the file's real,
+    full size (what pre-verify actually hashes) stays 2048.
+    """
+    body = b"m" * 2048
+    ref = ArtifactRef("root-model", "r" * 40, "int8")
+    desc = _descriptor(ref, files_body=body)
+    core = ModelArtifactService(tmp_path / "root")
+
+    staged = core.staging_path / "managed" / ref.artifact_id / ref.revision / ref.variant
+    staged.mkdir(parents=True)
+    atomic_write_json(
+        staged / "fetch-state.json",
+        {
+            "files": {
+                "model.bin": {
+                    "etag": None,
+                    "last_modified": None,
+                    "bytes_done": 500,
+                    "complete": False,
+                }
+            }
+        },
+    )
+
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    catalog = DictCatalog({ref: desc})
+    consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(ref, ()))
+
+    captured: list[_ProvisionProgressState] = []
+
+    async def fake_fetch(descriptor, staging_dir, progress_state):
+        captured.append(progress_state)
+
+    async def fake_preverify(descriptor, staging_dir, progress_state):
+        captured.append(progress_state)
+
+    async def fake_install(descriptor, staging_dir):
+        pass
+
+    monkeypatch.setattr(svc, "_fetch_artifact", fake_fetch)
+    monkeypatch.setattr(svc, "_preverify_artifact", fake_preverify)
+    monkeypatch.setattr(svc, "_install_artifact", fake_install)
+    # Nothing was actually installed (every phase above is faked as a
+    # no-op) -- fake activate() too so provision() completes instead of
+    # failing on core.activate()'s own "nothing installed" check, which is
+    # irrelevant to what this test verifies (the progress_state wiring).
+    monkeypatch.setattr(core, "activate", lambda root_reference: root_reference)
+
+    await svc.provision(ref, consent, catalog)
+
+    assert len(captured) == 2
+    state = captured[0]
+    assert state.bytes_total == 1548, "fetch total nets out the 500 staged bytes"
+    assert state.preverify_bytes_total == 2048, (
+        "pre-verify total is the full file size, unaffected by staged credit"
+    )
 
 
 @pytest.mark.asyncio
@@ -274,7 +368,13 @@ async def test_install_failure_does_not_install_and_staging_dir_survives(tmp_pat
     nothing gets installed, and ``_install_artifact`` itself does not
     ``rmtree`` our staging directory on failure (only a successful install
     triggers that cleanup) -- unlike the sidecar, which is removed
-    up front regardless, to satisfy install's exact-file-set check."""
+    up front regardless, to satisfy install's exact-file-set check.
+
+    ``core.install``'s raw ``ArtifactIntegrityError`` is wrapped by
+    ``_run_core_call`` (review finding: core ``ArtifactError`` subclasses
+    must never escape ``provision()`` raw) into a non-retryable
+    ``TransferError`` with the original preserved as ``__cause__``.
+    """
 
     desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=b"expected")
     core = ModelArtifactService(tmp_path / "root")
@@ -288,8 +388,11 @@ async def test_install_failure_does_not_install_and_staging_dir_survives(tmp_pat
         {"files": {"model.bin": {"etag": None, "last_modified": None, "bytes_done": 8, "complete": True}}},
     )
 
-    with pytest.raises(ArtifactIntegrityError):
+    with pytest.raises(TransferError) as excinfo:
         await svc._install_artifact(desc, staging_dir)
+
+    assert excinfo.value.retryable is False
+    assert isinstance(excinfo.value.__cause__, ArtifactIntegrityError)
 
     assert staging_dir.exists()
     assert not (staging_dir / "fetch-state.json").exists()
@@ -472,3 +575,79 @@ async def test_provision_activates_already_installed_closure_with_zero_fetch_req
         assert set(handle.handle.closure) == {root_ref, dep_ref}
 
     assert [event.phase for event in events] == ["activate"]
+
+
+# ---------------------------------------------------------------------------
+# _run_core_call: core.install/core.activate ArtifactError never escapes raw.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_artifact_wraps_core_integrity_error_as_non_retryable(
+    tmp_path, monkeypatch
+):
+    """``core.install`` raising ``ArtifactIntegrityError`` must surface as a
+    non-retryable ``TransferError``, never the raw core error.
+
+    Regression test for the review finding: core ``ArtifactError``
+    subclasses escaped ``provision()`` untouched, breaking the spec's
+    never-trap rule. Integrity failures are not retryable -- the same
+    staged content would fail again.
+    """
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=b"x")
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+
+    staging_dir = core.staging_path / "managed" / "m" / ("r" * 40) / "int8"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").write_bytes(b"x")
+
+    def raise_integrity_error(*args, **kwargs):
+        raise ArtifactIntegrityError("simulated integrity failure")
+
+    monkeypatch.setattr(core, "install", raise_integrity_error)
+
+    with pytest.raises(TransferError) as excinfo:
+        await svc._install_artifact(desc, staging_dir)
+
+    assert excinfo.value.retryable is False
+    assert isinstance(excinfo.value.__cause__, ArtifactIntegrityError)
+    assert "m" in str(excinfo.value)
+    assert "install" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_provision_activate_wraps_core_state_error_as_retryable(
+    tmp_path, monkeypatch
+):
+    """``core.activate`` raising ``ArtifactStateError`` (lease-timeout/
+    contention style failure) must surface as a retryable ``TransferError``.
+
+    Both artifacts are pre-installed so ``provision()`` skips straight to
+    ``core.activate`` without any network activity, isolating this to the
+    activate hop specifically.
+    """
+    ref = ArtifactRef("root-model", "r" * 40, "int8")
+    desc = _descriptor(ref, files_body=b"x")
+    core = ModelArtifactService(tmp_path / "root")
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "model.bin").write_bytes(b"x")
+    core.install(desc, source)
+
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    catalog = DictCatalog({ref: desc})
+    consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(ref, ()))
+
+    def raise_state_error(*args, **kwargs):
+        raise ArtifactStateError("simulated lease contention")
+
+    monkeypatch.setattr(core, "activate", raise_state_error)
+
+    with pytest.raises(TransferError) as excinfo:
+        await svc.provision(ref, consent, catalog)
+
+    assert excinfo.value.retryable is True
+    assert isinstance(excinfo.value.__cause__, ArtifactStateError)
+    assert "root-model" in str(excinfo.value)
+    assert "activate" in str(excinfo.value)

--- a/Tests/Model_Artifacts/test_provision_install.py
+++ b/Tests/Model_Artifacts/test_provision_install.py
@@ -1,0 +1,474 @@
+"""TASK-595 Task 8: pre-verify + install + activate phases.
+
+Covers ``ArtifactAcquisitionService._preverify_artifact`` and
+``_install_artifact`` directly for the per-file mechanics (hash success,
+zero-byte files, mismatch-then-refetch recovery, install cleanup), and
+``provision()`` end-to-end for the three scenarios the task brief calls
+out: a full closure (root + dependency) fetched/verified/installed/
+activated, a corrupt payload that exhausts its one automatic refetch, and
+the crash-after-install completion path that activates a fully-installed
+closure without touching the network at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.parse import urlparse
+
+import pytest
+
+from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
+from Tests.Model_Artifacts.test_acquisition_types import DictCatalog
+from tldw_chatbook.Model_Artifacts import (
+    ArtifactDescriptor,
+    ArtifactFile,
+    ArtifactFormat,
+    ArtifactRef,
+    ArtifactRole,
+    ArtifactIntegrityError,
+    ProvenanceClass,
+    closure_fingerprint,
+)
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    AcquisitionConsent,
+    AcquisitionProgress,
+    ArtifactAcquisitionService,
+    MAX_FILE_REFETCHES,
+    TransferError,
+    _ProvisionProgressState,
+)
+from tldw_chatbook.Model_Artifacts.service import ModelArtifactService
+from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
+
+
+def _trusted(srv: FixtureArtifactServer) -> frozenset:
+    """Trusted-origins set for a fixture server (see test_stream_fetch.py's
+    identical helper for why this is the bare hostname, not a URL)."""
+
+    return frozenset({urlparse(srv.url("/")).hostname})
+
+
+def _descriptor(
+    ref: ArtifactRef,
+    *,
+    role: ArtifactRole = ArtifactRole.ROOT,
+    dependencies: tuple[ArtifactRef, ...] = (),
+    files_body: bytes = b"x",
+    source_url: str = "https://example.test/model",
+) -> ArtifactDescriptor:
+    """Build a single-file descriptor with a caller-chosen role.
+
+    ``test_acquisition_types.make_descriptor`` always hardcodes
+    ``role=ArtifactRole.ROOT`` -- fine for the closure-walk and preflight
+    math it was written for, but ``core.activate``'s closure resolution
+    (``_load_installed_descriptor``) rejects an installed dependency whose
+    manifest role isn't ``DEPENDENCY``. This task's tests exercise real
+    activation over a root+dependency closure, so the role needs to be
+    settable per descriptor.
+    """
+
+    files = (ArtifactFile("model.bin", len(files_body), hashlib.sha256(files_body).hexdigest()),)
+    return ArtifactDescriptor(
+        reference=ref,
+        model_id="test/model",
+        role=role,
+        format=ArtifactFormat.ONNX,
+        consumer="test",
+        model_family="test-family",
+        upstream_repository="test/repo",
+        upstream_revision="main",
+        source_url=source_url,
+        precision=ref.variant,
+        license_id="test-license",
+        license_url="https://example.test/license",
+        usage_notice="Test model",
+        runtime_name="test-runtime",
+        runtime_version_constraint="==1.0.0",
+        supported_os=("linux",),
+        supported_architectures=("x86-64",),
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+        files=files,
+        expected_installed_bytes=len(files_body),
+        dependencies=dependencies,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _preverify_artifact: hash success, zero-byte files, mismatch + recovery.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preverify_matches_declared_hash_and_reports_real_progress(tmp_path):
+    body = b"0123456789" * 500  # 5 KB
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=body)
+    staging_dir = tmp_path / "staging" / "m"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").write_bytes(body)
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+    events: list[AcquisitionProgress] = []
+    progress_state = _ProvisionProgressState(callback=events.append, bytes_total=len(body))
+
+    await svc._preverify_artifact(desc, staging_dir, progress_state)
+
+    assert events, "streaming hash must emit at least one progress event"
+    assert all(event.phase == "pre-verify" for event in events)
+    assert events[-1].bytes_done == len(body)
+    assert events[-1].bytes_total == len(body)
+    assert events[-1].ref == desc.reference
+    assert events[-1].file == "model.bin"
+    assert progress_state.preverify_bytes_done == len(body)
+    # The fetch counter is untouched by pre-verify -- separately tracked.
+    assert progress_state.bytes_done == 0
+
+
+@pytest.mark.asyncio
+async def test_preverify_zero_byte_file_hashes_without_error(tmp_path):
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=b"")
+    staging_dir = tmp_path / "staging" / "m"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").touch()
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+    progress_state = _ProvisionProgressState(callback=None, bytes_total=0)
+
+    await svc._preverify_artifact(desc, staging_dir, progress_state)
+
+    assert progress_state.preverify_bytes_done == 0
+
+
+@pytest.mark.asyncio
+async def test_preverify_mismatch_refetches_once_and_recovers_on_good_content(tmp_path):
+    """A corrupt staged file is deleted, its sidecar entry reset, and the
+    whole artifact refetched exactly once -- if that refetch's content now
+    matches, pre-verify succeeds instead of raising."""
+
+    correct_body = b"correct-content-bytes-" * 50
+    wrong_body = b"wr0ng-c0ntent-byte5---" * 50
+    assert len(correct_body) == len(wrong_body)
+
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.bin", correct_body, etag='"v2"', support_range=True)
+        desc = _descriptor(
+            ArtifactRef("m", "r" * 40, "int8"),
+            files_body=correct_body,
+            source_url=srv.url("/model.bin"),
+        )
+        staging_dir = tmp_path / "staging" / "m"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "model.bin").write_bytes(wrong_body)
+        atomic_write_json(
+            staging_dir / "fetch-state.json",
+            {
+                "files": {
+                    "model.bin": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": len(wrong_body),
+                        "complete": True,
+                    }
+                }
+            },
+        )
+
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=len(correct_body))
+
+        await svc._preverify_artifact(desc, staging_dir, progress_state)
+
+        assert (staging_dir / "model.bin").read_bytes() == correct_body
+        assert len(srv.requests["/model.bin"]) == 1
+        sidecar = json.loads((staging_dir / "fetch-state.json").read_text())
+        assert sidecar["files"]["model.bin"]["complete"] is True
+        assert sidecar["files"]["model.bin"]["bytes_done"] == len(correct_body)
+
+
+@pytest.mark.asyncio
+async def test_preverify_mismatch_persisting_past_max_refetches_raises_transfer_error(tmp_path):
+    """When the refetch's content is ALSO wrong, exactly one refetch is
+    attempted (MAX_FILE_REFETCHES == 1) before a typed, retryable failure."""
+
+    correct_body = b"correct-content-bytes-" * 50
+    wrong_body = b"wr0ng-c0ntent-byte5---" * 50
+    assert len(correct_body) == len(wrong_body)
+
+    with FixtureArtifactServer() as srv:
+        srv.serve("/model.bin", wrong_body, etag='"v1"', support_range=True)
+        desc = _descriptor(
+            ArtifactRef("m", "r" * 40, "int8"),
+            files_body=correct_body,
+            source_url=srv.url("/model.bin"),
+        )
+        staging_dir = tmp_path / "staging" / "m"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "model.bin").write_bytes(wrong_body)
+        atomic_write_json(
+            staging_dir / "fetch-state.json",
+            {
+                "files": {
+                    "model.bin": {
+                        "etag": '"v1"',
+                        "last_modified": None,
+                        "bytes_done": len(wrong_body),
+                        "complete": True,
+                    }
+                }
+            },
+        )
+
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(core, trusted_origins=_trusted(srv))
+        progress_state = _ProvisionProgressState(callback=None, bytes_total=len(correct_body))
+
+        with pytest.raises(TransferError) as excinfo:
+            await svc._preverify_artifact(desc, staging_dir, progress_state)
+
+        assert excinfo.value.retryable is True
+        assert len(srv.requests["/model.bin"]) == MAX_FILE_REFETCHES
+
+
+# ---------------------------------------------------------------------------
+# _install_artifact: consume_source install, sidecar + staging cleanup.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_promotes_payload_and_removes_staging_dir_and_sidecar(tmp_path):
+    body = b"payload-bytes" * 10
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=body)
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+
+    staging_dir = core.staging_path / "managed" / "m" / ("r" * 40) / "int8"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").write_bytes(body)
+    atomic_write_json(
+        staging_dir / "fetch-state.json",
+        {"files": {"model.bin": {"etag": None, "last_modified": None, "bytes_done": len(body), "complete": True}}},
+    )
+
+    await svc._install_artifact(desc, staging_dir)
+
+    installed = core.artifact_path(desc.reference)
+    assert installed.exists()
+    assert (installed / "model.bin").read_bytes() == body
+    assert not staging_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_install_failure_does_not_install_and_staging_dir_survives(tmp_path):
+    """core.install's own integrity check fails (staged content doesn't
+    match the declared hash -- as if pre-verify had been skipped, the
+    defense-in-depth check this exercises).
+
+    ``consume_source=True`` moves the file out of our staging directory
+    (into ``core.install``'s OWN internal staging) before verifying it
+    there, so a failure at this point does not leave the corrupt bytes
+    behind for inspection -- that is Task 1's sealed core behavior, not
+    something this phase controls. What Task 8 owns and this test pins:
+    nothing gets installed, and ``_install_artifact`` itself does not
+    ``rmtree`` our staging directory on failure (only a successful install
+    triggers that cleanup) -- unlike the sidecar, which is removed
+    up front regardless, to satisfy install's exact-file-set check."""
+
+    desc = _descriptor(ArtifactRef("m", "r" * 40, "int8"), files_body=b"expected")
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core)
+
+    staging_dir = core.staging_path / "managed" / "m" / ("r" * 40) / "int8"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "model.bin").write_bytes(b"corrupt!")  # wrong content, right length
+    atomic_write_json(
+        staging_dir / "fetch-state.json",
+        {"files": {"model.bin": {"etag": None, "last_modified": None, "bytes_done": 8, "complete": True}}},
+    )
+
+    with pytest.raises(ArtifactIntegrityError):
+        await svc._install_artifact(desc, staging_dir)
+
+    assert staging_dir.exists()
+    assert not (staging_dir / "fetch-state.json").exists()
+    assert core.list_installed() == ()
+
+
+# ---------------------------------------------------------------------------
+# provision() end-to-end: happy path, corrupt payload, crash-after-install.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provision_end_to_end_installs_and_activates_root_and_dependency(tmp_path):
+    dep_ref = ArtifactRef("dep-model", "d" * 40, "int8")
+    root_ref = ArtifactRef("root-model", "r" * 40, "int8")
+    dep_body = b"dependency-payload-" * 300
+    root_body = b"root-payload-bytes-" * 300
+
+    with FixtureArtifactServer() as srv:
+        srv.serve("/dep.bin", dep_body, etag='"dep-v1"', support_range=True)
+        srv.serve("/root.bin", root_body, etag='"root-v1"', support_range=True)
+
+        dep_desc = _descriptor(
+            dep_ref,
+            role=ArtifactRole.DEPENDENCY,
+            files_body=dep_body,
+            source_url=srv.url("/dep.bin"),
+        )
+        root_desc = _descriptor(
+            root_ref,
+            role=ArtifactRole.ROOT,
+            dependencies=(dep_ref,),
+            files_body=root_body,
+            source_url=srv.url("/root.bin"),
+        )
+        catalog = DictCatalog({root_ref: root_desc, dep_ref: dep_desc})
+
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        consent = AcquisitionConsent(
+            closure_fingerprint=closure_fingerprint(root_ref, (dep_ref,))
+        )
+
+        events: list[AcquisitionProgress] = []
+        activated = await svc.provision(root_ref, consent, catalog, progress=events.append)
+
+        assert activated == root_ref
+
+        installed_refs = {
+            item.descriptor.reference for item in core.list_installed() if item.descriptor is not None
+        }
+        assert installed_refs == {root_ref, dep_ref}
+
+        with core.acquire(root_ref) as handle:
+            assert handle.handle.root == root_ref
+            assert set(handle.handle.closure) == {root_ref, dep_ref}
+
+        # ALL managed staging for both artifacts is gone -- not an empty
+        # directory with a stale sidecar, which would look resumable
+        # forever to a later GC pass.
+        for ref in (root_ref, dep_ref):
+            staging_dir = (
+                core.staging_path / "managed" / ref.artifact_id / ref.revision / ref.variant
+            )
+            assert not staging_dir.exists()
+
+        phases_seen = [event.phase for event in events]
+        for phase in ("fetch", "pre-verify", "verify-install", "activate"):
+            assert phase in phases_seen, f"missing phase {phase!r} in {phases_seen}"
+        first = {phase: phases_seen.index(phase) for phase in set(phases_seen)}
+        assert first["fetch"] < first["pre-verify"] < first["verify-install"] < first["activate"]
+        assert phases_seen.count("activate") == 1
+        assert phases_seen[-1] == "activate"
+
+        fetch_events = [event for event in events if event.phase == "fetch"]
+        assert fetch_events[-1].bytes_done == len(dep_body) + len(root_body)
+        preverify_events = [event for event in events if event.phase == "pre-verify"]
+        assert preverify_events[-1].bytes_done == len(dep_body) + len(root_body)
+
+
+@pytest.mark.asyncio
+async def test_provision_corrupt_payload_refetches_exactly_once_then_fails(tmp_path):
+    ref = ArtifactRef("bad-model", "b" * 40, "int8")
+    correct_body = b"correct-content-bytes-" * 400
+    wrong_body = b"wr0ng-c0ntent-byte5---" * 400
+    assert len(correct_body) == len(wrong_body)
+
+    with FixtureArtifactServer() as srv:
+        # The server never fixes itself -- both the initial fetch and the
+        # one automatic refetch see the same wrong bytes.
+        srv.serve("/model.bin", wrong_body, etag='"v1"', support_range=True)
+
+        core = ModelArtifactService(tmp_path / "root")
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+
+        # A prior, unrelated artifact is already installed and active --
+        # proves the failed provision leaves other closures untouched.
+        prior_ref = ArtifactRef("prior-model", "p" * 40, "int8")
+        prior_desc = _descriptor(prior_ref, files_body=b"prior-bytes")
+        prior_source = tmp_path / "prior-source"
+        prior_source.mkdir()
+        (prior_source / "model.bin").write_bytes(b"prior-bytes")
+        core.install(prior_desc, prior_source)
+        core.activate(prior_ref)
+
+        desc = _descriptor(ref, files_body=correct_body, source_url=srv.url("/model.bin"))
+        catalog = DictCatalog({ref: desc})
+        consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(ref, ()))
+
+        with pytest.raises(TransferError) as excinfo:
+            await svc.provision(ref, consent, catalog)
+        assert excinfo.value.retryable is True
+
+        # Exactly one refetch attempt: the initial fetch plus one refetch,
+        # never more.
+        assert len(srv.requests["/model.bin"]) == 1 + MAX_FILE_REFETCHES
+
+        installed_refs = {
+            item.descriptor.reference for item in core.list_installed() if item.descriptor is not None
+        }
+        assert ref not in installed_refs
+
+        # Prior state genuinely untouched.
+        assert installed_refs == {prior_ref}
+        with core.acquire(prior_ref) as handle:
+            assert handle.handle.root == prior_ref
+
+
+@pytest.mark.asyncio
+async def test_provision_activates_already_installed_closure_with_zero_fetch_requests(tmp_path):
+    """The crash-after-install recovery path: both artifacts are already
+    installed (simulating a prior run that crashed before activation) --
+    provision() must activate them without any network activity at all."""
+
+    dep_ref = ArtifactRef("dep-model", "d" * 40, "int8")
+    root_ref = ArtifactRef("root-model", "r" * 40, "int8")
+    dep_body = b"dep-bytes-already-installed"
+    root_body = b"root-bytes-already-installed"
+
+    core = ModelArtifactService(tmp_path / "root")
+
+    dep_desc = _descriptor(dep_ref, role=ArtifactRole.DEPENDENCY, files_body=dep_body)
+    root_desc = _descriptor(
+        root_ref, role=ArtifactRole.ROOT, dependencies=(dep_ref,), files_body=root_body
+    )
+
+    dep_source = tmp_path / "dep-source"
+    dep_source.mkdir()
+    (dep_source / "model.bin").write_bytes(dep_body)
+    core.install(dep_desc, dep_source)
+
+    root_source = tmp_path / "root-source"
+    root_source.mkdir()
+    (root_source / "model.bin").write_bytes(root_body)
+    core.install(root_desc, root_source)
+    # Deliberately no core.activate() here -- this IS the crash point this
+    # test recovers from.
+
+    catalog = DictCatalog({root_ref: root_desc, dep_ref: dep_desc})
+    consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(root_ref, (dep_ref,)))
+
+    with FixtureArtifactServer() as srv:
+        # Deliberately no route registered: any network attempt 404s, and
+        # this test asserts none happens at all.
+        svc = ArtifactAcquisitionService(
+            core, free_bytes_probe=lambda p: 10**12, trusted_origins=_trusted(srv)
+        )
+        events: list[AcquisitionProgress] = []
+        activated = await svc.provision(root_ref, consent, catalog, progress=events.append)
+
+        assert activated == root_ref
+        assert srv.requests == {}
+
+    with core.acquire(root_ref) as handle:
+        assert handle.handle.root == root_ref
+        assert set(handle.handle.closure) == {root_ref, dep_ref}
+
+    assert [event.phase for event in events] == ["activate"]

--- a/Tests/Model_Artifacts/test_provision_serialization.py
+++ b/Tests/Model_Artifacts/test_provision_serialization.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Model_Artifacts.acquisition import (
     AcquisitionConsent,
     ArtifactAcquisitionService,
     ConsentMismatchError,
+    TransferError,
 )
 from tldw_chatbook.Model_Artifacts.leases import (
     ArtifactLeaseTimeoutError,
@@ -336,14 +337,19 @@ async def test_provision_holds_session_lease_across_phase_stub(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
-async def test_provision_not_yet_installed_reaches_fetch_stub(tmp_path):
-    """A not-yet-installed artifact really does reach the fetch stub.
+async def test_provision_not_yet_installed_reaches_fetch_phase(tmp_path):
+    """A not-yet-installed artifact really does reach the fetch phase.
 
-    Regression guard for the stub contract itself (lessons-testing-evidence:
-    a guard/extension-point that no test ever calls is unverified plumbing).
-    Consent is constructed directly rather than via preflight().grant() to
-    stay network-free -- preflight() would otherwise gating-probe this
-    artifact's placeholder source_url.
+    Regression guard for the extension point itself (lessons-testing-
+    evidence: a guard/extension-point that no test ever calls is unverified
+    plumbing). Originally asserted the Task 6 stub's ``NotImplementedError``;
+    Task 7 replaced that stub with a real implementation, so reaching it now
+    means a genuine network attempt against the placeholder ``source_url``
+    (an RFC 2606 ``.test`` domain, guaranteed to never resolve) -- which the
+    egress policy's DNS-failure path rejects, wrapped as ``TransferError``.
+    Consent is constructed directly rather than via ``preflight().grant()``
+    to keep this test's OWN setup network-free -- ``preflight()`` would
+    otherwise gating-probe this same placeholder URL itself.
     """
 
     core = ModelArtifactService(tmp_path / "root")
@@ -353,5 +359,6 @@ async def test_provision_not_yet_installed_reaches_fetch_stub(tmp_path):
     catalog = DictCatalog({root: desc})
     consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(root, ()))
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(TransferError) as excinfo:
         await svc.provision(root, consent, catalog)
+    assert excinfo.value.retryable is False

--- a/Tests/Model_Artifacts/test_provision_serialization.py
+++ b/Tests/Model_Artifacts/test_provision_serialization.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import multiprocessing
+import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -166,9 +167,16 @@ async def test_provision_serializes_concurrent_calls_in_process(tmp_path, monkey
     assert events == ["enter", "exit", "enter", "exit"]
     # Both calls reach the real core.activate() (fetch/preverify/install were
     # faked as no-ops, so nothing was actually installed) and fail there --
-    # confirms no OTHER exception masked the ordering proof above.
-    assert isinstance(result1, ArtifactDependencyError)
-    assert isinstance(result2, ArtifactDependencyError)
+    # confirms no OTHER exception masked the ordering proof above. The raw
+    # ArtifactDependencyError core.activate() raises is wrapped by
+    # _run_core_call into a retryable TransferError (never-trap rule); the
+    # original is still reachable as __cause__.
+    assert isinstance(result1, TransferError)
+    assert result1.retryable is True
+    assert isinstance(result1.__cause__, ArtifactDependencyError)
+    assert isinstance(result2, TransferError)
+    assert result2.retryable is True
+    assert isinstance(result2.__cause__, ArtifactDependencyError)
 
 
 @pytest.mark.integration
@@ -334,6 +342,116 @@ async def test_provision_holds_session_lease_across_phase_stub(tmp_path, monkeyp
     )
     await loop.run_in_executor(None, probe2.acquire)
     probe2.release()
+
+
+@pytest.mark.asyncio
+async def test_provision_releases_session_lease_when_cancelled_during_acquire(
+    tmp_path, monkeypatch
+):
+    """Cancelling provision() while the session lease is still being
+    acquired in its worker thread must not leak the OS-backed flock.
+
+    Regression test for a review finding: ``await run_in_executor(None,
+    lease.acquire)`` sat OUTSIDE the try/finally that released the lease,
+    so a ``CancelledError`` delivered while that call was still running in
+    its worker thread (not yet returned) left the lease's file handle open
+    for the rest of the process's life -- every later ``provision()`` call
+    would then raise ``AcquisitionBusyError`` forever, and
+    ``reconcile()``'s managed-staging GC (which also requires the session
+    lease to be free) would be permanently disabled.
+
+    ``lease.acquire`` cannot be interrupted once its worker thread has
+    started, so the fix must WAIT for it to actually finish before
+    deciding whether to release -- a naive ``if lease.acquired`` check
+    performed immediately after catching the cancellation (without first
+    waiting for the in-flight acquire to settle) would still read False
+    here, since ``gated_acquire`` below deliberately keeps the acquire in
+    flight, blocked on ``gate``, at the moment ``task.cancel()`` is called.
+
+    ``captured["lease"]`` deliberately keeps its own reference to the
+    abandoned lease object, independent of ``provision()``'s own (now-dead)
+    frame: confirmed by trial that without a held reference, CPython's
+    reference counting can close the abandoned handle as an incidental side
+    effect of collecting the ``CancelledError``'s traceback shortly after
+    ``pytest.raises`` releases it -- closing a file descriptor releases its
+    flock too, which would silently "self-heal" this exact leak in-process
+    and produce a false pass. A real caller that catches and logs/reports
+    the ``CancelledError`` (holding its traceback, and therefore this
+    frame, alive far longer) would not get that same accidental rescue, so
+    the test must not rely on it either.
+    """
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    root = ArtifactRef("root-model", "r1", "int8")
+    desc = make_descriptor(ref=root)
+    catalog = DictCatalog({root: desc})
+    consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(root, ()))
+
+    started = threading.Event()
+    gate = threading.Event()
+    # Set once the gated acquire attempt has fully settled (succeeded OR
+    # itself failed) -- awaited below before probing. Without this, the
+    # probe's own acquire could race ahead of the background attempt and
+    # spuriously "win" the flock first, which would make the background
+    # attempt fail out on ITS OWN contention timeout (never setting
+    # ``lease._handle``) and mask a real leak as a false pass.
+    settled = threading.Event()
+    original_acquire = ArtifactOperationLease.acquire
+    captured = {}
+
+    def gated_acquire(self):
+        is_session_lease = self.key == ACQUISITION_SESSION_LEASE_KEY
+        if is_session_lease:
+            captured["lease"] = self
+            started.set()
+            assert gate.wait(timeout=5.0), "test gate was never released"
+        try:
+            return original_acquire(self)
+        finally:
+            if is_session_lease:
+                settled.set()
+
+    monkeypatch.setattr(ArtifactOperationLease, "acquire", gated_acquire)
+
+    loop = asyncio.get_running_loop()
+    task = asyncio.create_task(svc.provision(root, consent, catalog))
+    assert await loop.run_in_executor(None, started.wait, 5.0), "acquire never started"
+
+    task.cancel()
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert await loop.run_in_executor(None, settled.wait, 5.0), (
+        "the in-flight acquire attempt never settled"
+    )
+    # ``captured["lease"]`` is not asserted on directly here: a correct fix
+    # releases it as part of its own cancellation handling (before
+    # ``await task`` above even returns), while the buggy version leaves it
+    # acquired forever -- ".acquired" legitimately differs between the two,
+    # so the probe below (not this snapshot) is the single source of truth.
+
+    # Restore the real acquire before probing -- the gate above only
+    # applies to the cancelled attempt.
+    monkeypatch.setattr(ArtifactOperationLease, "acquire", original_acquire)
+
+    # Direct, authoritative evidence the OS-backed flock was released: a
+    # fresh non-blocking probe must succeed instead of timing out busy.
+    probe = ArtifactOperationLease(
+        core.locks_path,
+        ACQUISITION_SESSION_LEASE_KEY,
+        LeaseMode.EXCLUSIVE,
+        timeout_seconds=1.0,
+    )
+    await loop.run_in_executor(None, probe.acquire)
+    probe.release()
+
+    # And per the review's own framing: a subsequent provision() call must
+    # not raise AcquisitionBusyError (it still fails, but for the unrelated
+    # reason that the placeholder source_url never resolves).
+    with pytest.raises(TransferError):
+        await svc.provision(root, consent, catalog)
 
 
 @pytest.mark.asyncio

--- a/Tests/Model_Artifacts/test_provision_serialization.py
+++ b/Tests/Model_Artifacts/test_provision_serialization.py
@@ -1,0 +1,357 @@
+"""TASK-595 Task 6: provision() skeleton.
+
+Session lease + in-process lock serialization, consent drift detection, and
+the idempotent already-installed completion path. The fetch/pre-verify/
+install phases are method stubs filled in by Tasks 7-8; none of these tests
+need them to succeed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from Tests.Model_Artifacts.lease_processes import hold_one
+from Tests.Model_Artifacts.test_acquisition_types import DictCatalog, make_descriptor
+from tldw_chatbook.Model_Artifacts import ArtifactDependencyError, ArtifactRef, closure_fingerprint
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    AcquisitionBusyError,
+    AcquisitionConsent,
+    ArtifactAcquisitionService,
+    ConsentMismatchError,
+)
+from tldw_chatbook.Model_Artifacts.leases import (
+    ArtifactLeaseTimeoutError,
+    ArtifactOperationLease,
+    LeaseMode,
+)
+from tldw_chatbook.Model_Artifacts.service import (
+    ACQUISITION_SESSION_LEASE_KEY,
+    ModelArtifactService,
+)
+
+
+@contextmanager
+def holding_process(
+    target: Callable[..., None],
+    args: tuple[object, ...],
+) -> Iterator[multiprocessing.Process]:
+    """Spawn a subprocess holding a lease, mirroring test_operation_leases_process.py.
+
+    Duplicated locally rather than imported: that module's helper is a
+    test-private detail, not a shared utility, and the two are small enough
+    that duplicating is cheaper than coupling two unrelated test modules.
+    """
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    process = context.Process(target=target, args=(*args, ready, release))
+    process.start()
+    try:
+        assert ready.wait(10.0), f"child failed to acquire lease, exit={process.exitcode}"
+        yield process
+    finally:
+        release.set()
+        process.join(10.0)
+        if process.is_alive():
+            process.terminate()
+            process.join(5.0)
+        if process.is_alive():
+            process.kill()
+            process.join(5.0)
+        assert process.is_alive() is False
+        assert process.exitcode == 0
+
+
+def _installed_root(tmp_path: Path) -> tuple[ModelArtifactService, ArtifactRef, object]:
+    """Build a core with one artifact installed and activated."""
+
+    core = ModelArtifactService(tmp_path / "root")
+    root = ArtifactRef("root-model", "r1", "int8")
+    desc = make_descriptor(ref=root)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / desc.files[0].path).write_bytes(b"x")
+    core.install(desc, source)
+    core.activate(root)
+    return core, root, desc
+
+
+@pytest.mark.asyncio
+async def test_provision_serializes_concurrent_calls_in_process(tmp_path, monkeypatch):
+    """A second in-process provision() call blocks on the asyncio.Lock.
+
+    A naive version of this test (assert the fetch stub was not re-entered
+    right after starting task2) passed even with the ``asyncio.Lock``
+    entirely removed -- confirmed by mutation. The reason: the non-blocking
+    session lease ALSO serializes (with ``AcquisitionBusyError`` instead of
+    a wait), and if task2 raced straight to that lease attempt, its 0.1s
+    timeout could still resolve (fail) before the test's short
+    ``asyncio.sleep(0)`` assertion, or -- worse -- could coincidentally
+    succeed if task1 happened to release within that same 0.1s poll window,
+    making the mutation's absence of a lock invisible. The fix: hold task1
+    paused (via ``gate``, entirely test-controlled) for LONGER than the
+    session lease's own timeout, then assert task2 is not even **done**
+    yet. An ``asyncio.Lock`` wait has no timeout and blocks indefinitely;
+    a raced, un-queued session-lease attempt would have already resolved
+    (successfully or as ``AcquisitionBusyError``) well within that window.
+    """
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    root = ArtifactRef("root-model", "r1", "int8")
+    desc = make_descriptor(ref=root)
+    catalog = DictCatalog({root: desc})
+    consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(root, ()))
+
+    events: list[str] = []
+    entered = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def fake_fetch(descriptor, staging_dir, progress_state):
+        events.append("enter")
+        entered.set()
+        await gate.wait()
+        events.append("exit")
+
+    async def fake_preverify(descriptor, staging_dir, progress_state):
+        pass
+
+    async def fake_install(descriptor, staging_dir):
+        pass
+
+    monkeypatch.setattr(svc, "_fetch_artifact", fake_fetch)
+    monkeypatch.setattr(svc, "_preverify_artifact", fake_preverify)
+    monkeypatch.setattr(svc, "_install_artifact", fake_install)
+
+    async def run_and_capture() -> BaseException | ArtifactRef:
+        try:
+            return await svc.provision(root, consent, catalog)
+        except BaseException as error:  # noqa: BLE001 -- asserted by caller, not swallowed
+            return error
+
+    task1 = asyncio.create_task(run_and_capture())
+    await asyncio.wait_for(entered.wait(), timeout=5.0)
+    assert events == ["enter"]
+
+    entered.clear()
+    task2 = asyncio.create_task(run_and_capture())
+    # Comfortably longer than _SESSION_LEASE_TIMEOUT_SECONDS (0.1s): if
+    # task2 reached the session-lease acquire attempt at all (i.e. the
+    # in-process Lock did not queue it first), it would have resolved --
+    # successfully or as AcquisitionBusyError -- well within this window,
+    # since task1 (still paused on `gate`) has not released anything yet.
+    await asyncio.sleep(0.4)
+    assert task2.done() is False, (
+        "second provision() call must block on the asyncio.Lock, "
+        "not race the session lease"
+    )
+    assert events == ["enter"]
+    assert entered.is_set() is False
+
+    gate.set()
+    result1 = await task1
+    assert events[:2] == ["enter", "exit"]
+
+    await asyncio.wait_for(entered.wait(), timeout=5.0)
+    result2 = await task2
+
+    assert events == ["enter", "exit", "enter", "exit"]
+    # Both calls reach the real core.activate() (fetch/preverify/install were
+    # faked as no-ops, so nothing was actually installed) and fail there --
+    # confirms no OTHER exception masked the ordering proof above.
+    assert isinstance(result1, ArtifactDependencyError)
+    assert isinstance(result2, ArtifactDependencyError)
+
+
+@pytest.mark.integration
+def test_provision_cross_process_busy_raises(tmp_path):
+    """An externally held session lease makes provision() fail fast, busy.
+
+    Mirrors Tests/Model_Artifacts/test_operation_leases_process.py's own
+    style (plain sync test, real subprocess) rather than nesting blocking
+    subprocess start/join calls inside an async test function.
+    """
+
+    core, root, desc = _installed_root(tmp_path)
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    catalog = DictCatalog({root: desc})
+    consent = asyncio.run(svc.preflight(root, catalog)).grant()
+
+    raw_key = (
+        ACQUISITION_SESSION_LEASE_KEY.artifact_id,
+        ACQUISITION_SESSION_LEASE_KEY.revision,
+        ACQUISITION_SESSION_LEASE_KEY.variant,
+    )
+    with holding_process(
+        hold_one,
+        (str(core.locks_path), raw_key, LeaseMode.EXCLUSIVE.value),
+    ):
+        with pytest.raises(AcquisitionBusyError):
+            asyncio.run(svc.provision(root, consent, catalog))
+
+    # Once released, the identical call succeeds (busy was transient).
+    result = asyncio.run(svc.provision(root, consent, catalog))
+    assert result == root
+
+
+@pytest.mark.asyncio
+async def test_provision_fingerprint_drift_raises_consent_mismatch(tmp_path):
+    """Consent minted from one catalog does not carry over a mutated one.
+
+    Both entries are pre-installed so preflight() never needs the network
+    gating probe; the drift is purely in the CLOSURE SHAPE (root+dependency
+    vs. root alone), which is what closure_fingerprint actually hashes (it
+    does not hash descriptor content -- only the set of ArtifactRefs in the
+    closure).
+    """
+
+    core = ModelArtifactService(tmp_path / "root")
+    root = ArtifactRef("root-model", "r1", "int8")
+    dep = ArtifactRef("dep-model", "r1", "int8")
+    body = b"m" * 16
+
+    root_desc_with_dep = make_descriptor(ref=root, dependencies=(dep,), files_body=body)
+    dep_desc = make_descriptor(ref=dep, files_body=body)
+
+    root_source = tmp_path / "root-source"
+    root_source.mkdir()
+    (root_source / root_desc_with_dep.files[0].path).write_bytes(body)
+    core.install(root_desc_with_dep, root_source)
+
+    dep_source = tmp_path / "dep-source"
+    dep_source.mkdir()
+    (dep_source / dep_desc.files[0].path).write_bytes(body)
+    core.install(dep_desc, dep_source)
+
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    catalog_v1 = DictCatalog({root: root_desc_with_dep, dep: dep_desc})
+    report = await svc.preflight(root, catalog_v1)
+    consent = report.grant()
+
+    root_desc_without_dep = make_descriptor(ref=root, files_body=body)
+    catalog_v2 = DictCatalog({root: root_desc_without_dep})
+
+    with pytest.raises(ConsentMismatchError):
+        await svc.provision(root, consent, catalog_v2)
+
+
+@pytest.mark.asyncio
+async def test_provision_fully_installed_closure_skips_stubs(tmp_path, monkeypatch):
+    """A fully-installed closure activates without touching any phase stub."""
+
+    core, root, desc = _installed_root(tmp_path)
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    catalog = DictCatalog({root: desc})
+    report = await svc.preflight(root, catalog)
+    consent = report.grant()
+
+    calls = {"fetch": 0, "preverify": 0, "install": 0}
+
+    async def counting_fetch(descriptor, staging_dir, progress_state):
+        calls["fetch"] += 1
+
+    async def counting_preverify(descriptor, staging_dir, progress_state):
+        calls["preverify"] += 1
+
+    async def counting_install(descriptor, staging_dir):
+        calls["install"] += 1
+
+    monkeypatch.setattr(svc, "_fetch_artifact", counting_fetch)
+    monkeypatch.setattr(svc, "_preverify_artifact", counting_preverify)
+    monkeypatch.setattr(svc, "_install_artifact", counting_install)
+
+    result = await svc.provision(root, consent, catalog)
+
+    assert result == root
+    assert calls == {"fetch": 0, "preverify": 0, "install": 0}
+
+
+@pytest.mark.asyncio
+async def test_provision_holds_session_lease_across_phase_stub(tmp_path, monkeypatch):
+    """The session lease stays held while paused inside a phase stub.
+
+    Regression guard for the Task 2 carry-over: the lease must be held for
+    provision()'s ENTIRE run, not released between the pre-checks and the
+    per-artifact phase loop -- releasing early would let reconcile()'s
+    managed-staging GC (``_gc_managed_staging``) race a live download the
+    same way an earlier draft let it race a live ``install()``.
+
+    In-process exclusive locks on this lock file DO conflict across
+    different ``ArtifactOperationLease`` handles (confirmed: portalocker's
+    flock-based exclusive lock is scoped to the open file description, not
+    the process), so a same-process non-blocking probe is a faithful test
+    of "is the lease currently held" without needing a subprocess.
+    """
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    root = ArtifactRef("root-model", "r1", "int8")
+    desc = make_descriptor(ref=root)
+    catalog = DictCatalog({root: desc})
+    consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(root, ()))
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def paused_fetch(descriptor, staging_dir, progress_state):
+        entered.set()
+        await release.wait()
+        raise NotImplementedError("stop here; only the pause matters")
+
+    monkeypatch.setattr(svc, "_fetch_artifact", paused_fetch)
+
+    task = asyncio.create_task(svc.provision(root, consent, catalog))
+    await asyncio.wait_for(entered.wait(), timeout=5.0)
+
+    loop = asyncio.get_running_loop()
+    probe = ArtifactOperationLease(
+        core.locks_path,
+        ACQUISITION_SESSION_LEASE_KEY,
+        LeaseMode.EXCLUSIVE,
+        timeout_seconds=0.1,
+    )
+    with pytest.raises(ArtifactLeaseTimeoutError):
+        await loop.run_in_executor(None, probe.acquire)
+
+    release.set()
+    with pytest.raises(NotImplementedError):
+        await task
+
+    # Released in provision()'s finally: a fresh probe now succeeds.
+    probe2 = ArtifactOperationLease(
+        core.locks_path,
+        ACQUISITION_SESSION_LEASE_KEY,
+        LeaseMode.EXCLUSIVE,
+        timeout_seconds=1.0,
+    )
+    await loop.run_in_executor(None, probe2.acquire)
+    probe2.release()
+
+
+@pytest.mark.asyncio
+async def test_provision_not_yet_installed_reaches_fetch_stub(tmp_path):
+    """A not-yet-installed artifact really does reach the fetch stub.
+
+    Regression guard for the stub contract itself (lessons-testing-evidence:
+    a guard/extension-point that no test ever calls is unverified plumbing).
+    Consent is constructed directly rather than via preflight().grant() to
+    stay network-free -- preflight() would otherwise gating-probe this
+    artifact's placeholder source_url.
+    """
+
+    core = ModelArtifactService(tmp_path / "root")
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    root = ArtifactRef("root-model", "r1", "int8")
+    desc = make_descriptor(ref=root)
+    catalog = DictCatalog({root: desc})
+    consent = AcquisitionConsent(closure_fingerprint=closure_fingerprint(root, ()))
+
+    with pytest.raises(NotImplementedError):
+        await svc.provision(root, consent, catalog)

--- a/Tests/Model_Artifacts/test_reconcile_staging_gc.py
+++ b/Tests/Model_Artifacts/test_reconcile_staging_gc.py
@@ -1,12 +1,23 @@
 """TASK-595 Task 2: reconcile deletes staging orphans, preserves resumable state."""
 
+import hashlib
 import json
+import os
 from pathlib import Path
 
 import pytest
 
+from tldw_chatbook.Model_Artifacts import (
+    ArtifactDescriptor,
+    ArtifactFile,
+    ArtifactFormat,
+    ArtifactRef,
+    ArtifactRole,
+    ProvenanceClass,
+)
 from tldw_chatbook.Model_Artifacts.service import (
     ArtifactLeaseKey,
+    ArtifactLeaseTimeoutError,
     ArtifactOperationLease,
     LeaseMode,
     ModelArtifactService,
@@ -22,6 +33,133 @@ def _managed_dir(service, artifact="m1", rev="r1", variant="int8") -> Path:
     d = Path(service.staging_path) / "managed" / artifact / rev / variant
     d.mkdir(parents=True)
     return d
+
+
+def _sidecar_path(managed_dir: Path) -> Path:
+    """The fetch-state sidecar's path for ``managed_dir`` -- a SIBLING
+    file (``<variant>.fetch-state.json``), never a child of the payload
+    directory it describes (see acquisition.py's ``_fetch_sidecar_path``
+    and this file's drift-guard test)."""
+    return managed_dir.parent / f"{managed_dir.name}.fetch-state.json"
+
+
+def _install_inputs(tmp_path: Path) -> tuple[ArtifactDescriptor, Path]:
+    """Build a minimal valid descriptor + matching source directory.
+
+    A small local stand-in for test_service.py's ``install_inputs`` --
+    that helper (and every other in that file) is private to the sealed
+    TASK-594 suite and must not be imported from here (see this repo's
+    "not cross-importing test-private helpers" convention, e.g.
+    test_preflight.py's ``_two_file_descriptor`` docstring).
+    """
+    content = b"model-bytes"
+    source = tmp_path / "install-source"
+    source.mkdir()
+    (source / "model.onnx").write_bytes(content)
+    file = ArtifactFile("model.onnx", len(content), hashlib.sha256(content).hexdigest())
+    item = ArtifactDescriptor(
+        reference=ArtifactRef("race-model", "r" * 40, "int8"),
+        model_id="test/model",
+        role=ArtifactRole.ROOT,
+        format=ArtifactFormat.ONNX,
+        consumer="test",
+        model_family="test-family",
+        upstream_repository="test/repo",
+        upstream_revision="main",
+        source_url="https://example.test/model",
+        precision="int8",
+        license_id="test-license",
+        license_url="https://example.test/license",
+        usage_notice="Test model",
+        runtime_name="test-runtime",
+        runtime_version_constraint="==1.0.0",
+        supported_os=("linux",),
+        supported_architectures=("x86-64",),
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+        files=(file,),
+        expected_installed_bytes=len(content),
+        dependencies=(),
+    )
+    return item, source
+
+
+def test_install_staging_directory_creation_is_atomic_with_lease_acquisition(
+    service, tmp_path, monkeypatch
+):
+    """install()'s ``install-*`` staging directory must never become
+    visible on disk BEFORE its per-directory orphan-detection lease is
+    held.
+
+    P1 RACE (TASK-595 final review): reconcile()'s staging GC
+    (``_gc_install_staging_orphan``) treats an ``install-*`` directory as
+    abandoned -- safe to delete -- whenever ``_install_staging_lease_key``
+    for its name is free. If install() creates the directory FIRST and
+    only acquires that lease AFTERWARD, a concurrent reconcile() pass can
+    observe the directory in that window, acquire the (still-free) lease
+    itself, and delete a staging dir install() is about to copy files
+    into.
+
+    Proven by intercepting the actual ``os.mkdir`` call install() uses to
+    create the staging directory -- this covers BOTH implementations:
+    pre-fix, ``tempfile.mkdtemp`` creates the directory via its own
+    internal ``os.mkdir`` call (the ``tempfile`` module binds ``_os`` to
+    the SAME ``os`` module object, so patching ``os.mkdir`` intercepts it
+    too); post-fix, the directory is created via a direct ``os.mkdir``
+    call. At the exact moment either version is about to create the
+    directory, this test independently attempts a NON-BLOCKING acquire of
+    that same directory's orphan-detection lease from a separate lease
+    handle -- modeling reconcile()'s own non-blocking probe. If install()
+    already holds the lease (the fix), the probe's acquire must fail
+    (busy). If it does not yet hold it (the bug), the probe's acquire
+    succeeds -- proving the directory would be visible on disk with
+    nothing yet protecting it from GC.
+    """
+    item, source = _install_inputs(tmp_path)
+    real_mkdir = os.mkdir
+    probe_acquired: list[bool] = []
+
+    def probing_mkdir(path, mode=0o777, *args, **kwargs):
+        path_obj = Path(path)
+        if (
+            path_obj.parent == Path(service.staging_path)
+            and path_obj.name.startswith("install-")
+        ):
+            probe_lease = ArtifactOperationLease(
+                service.locks_path,
+                ArtifactLeaseKey("#install-staging", path_obj.name, "lock"),
+                LeaseMode.EXCLUSIVE,
+                timeout_seconds=0.01,
+            )
+            try:
+                probe_lease.acquire()
+            except ArtifactLeaseTimeoutError:
+                # Busy: install() already holds this directory's lease
+                # before the directory itself exists -- the fix.
+                probe_acquired.append(False)
+            else:
+                # Free: the directory is about to become visible on disk
+                # with NOTHING yet protecting it from a concurrent
+                # reconcile() pass -- the race.
+                probe_acquired.append(True)
+                probe_lease.release()
+        return real_mkdir(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "mkdir", probing_mkdir)
+    service.install(item, source)
+
+    # os.mkdir on the staging directory's own path fires more than once in
+    # practice -- the real creation, plus later redundant
+    # Path.mkdir(parents=True, exist_ok=True) calls from the copy phase
+    # that no-op once the directory exists. Every one of them must find
+    # the lease already held: the FIRST entry is the directory's actual
+    # creation moment (the one this test targets), and any True anywhere
+    # in this list still proves an unprotected instant existed.
+    assert probe_acquired, "the install-* staging mkdir must have been observed"
+    assert not any(probe_acquired), (
+        "install()'s per-staging lease must already be held BEFORE its "
+        "staging directory becomes visible on disk, or a concurrent "
+        "reconcile() pass can delete a live staging directory"
+    )
 
 
 def test_orphan_install_staging_is_removed(service):
@@ -44,18 +182,39 @@ def test_managed_entry_without_sidecar_is_removed(service):
 def test_managed_entry_with_valid_sidecar_survives(service):
     d = _managed_dir(service)
     (d / "model.onnx").write_bytes(b"partial")
-    (d / "fetch-state.json").write_text(json.dumps({
+    _sidecar_path(d).write_text(json.dumps({
         "files": {"model.onnx": {"etag": "\"abc\"", "last_modified": None,
                                    "bytes_done": 7, "complete": False}}
     }))
     report = service.reconcile()
     assert d.exists()
     assert (d / "model.onnx").exists()
+    assert _sidecar_path(d).exists()
+
+
+def test_managed_entry_with_sidecar_inside_payload_dir_is_ignored_and_removed(service):
+    """A sidecar written in the OLD in-tree location (``<variant>/
+    fetch-state.json``, a child of the payload directory) no longer
+    counts -- the classifier only ever looks at the SIBLING path. This
+    also means the payload directory itself is invalid (no sidecar at its
+    new location), so it is removed like any other unprotected entry;
+    the misplaced sidecar file is just an ordinary file inside it that
+    goes with it.
+    """
+    d = _managed_dir(service)
+    (d / "model.onnx").write_bytes(b"partial")
+    (d / "fetch-state.json").write_text(json.dumps({
+        "files": {"model.onnx": {"etag": "\"abc\"", "last_modified": None,
+                                   "bytes_done": 7, "complete": False}}
+    }))
+    report = service.reconcile()
+    assert not d.exists()
+    assert report.staging_removed
 
 
 def test_managed_entry_with_corrupt_sidecar_is_removed(service):
     d = _managed_dir(service)
-    (d / "fetch-state.json").write_text("{not json")
+    _sidecar_path(d).write_text("{not json")
     service.reconcile()
     assert not d.exists()
 
@@ -71,10 +230,10 @@ def test_managed_entry_with_non_mapping_sidecar_is_removed(service):
     dead staging alive indefinitely.
     """
     list_dir = _managed_dir(service, artifact="m-list")
-    (list_dir / "fetch-state.json").write_text(json.dumps([]))
+    _sidecar_path(list_dir).write_text(json.dumps([]))
 
     string_dir = _managed_dir(service, artifact="m-string")
-    (string_dir / "fetch-state.json").write_text(json.dumps("x"))
+    _sidecar_path(string_dir).write_text(json.dumps("x"))
 
     report = service.reconcile()
 
@@ -82,6 +241,32 @@ def test_managed_entry_with_non_mapping_sidecar_is_removed(service):
     assert not string_dir.exists()
     assert any("m-list" in item for item in report.staging_removed)
     assert any("m-string" in item for item in report.staging_removed)
+
+
+def test_managed_entry_sidecar_without_payload_dir_is_removed(service):
+    """A sidecar file surviving with no matching payload directory (e.g. a
+    crash between _install_artifact deleting the payload but before the
+    sidecar unlink, or simply a hand-placed stray file) is not resumable
+    state either -- both members of the pair must be real."""
+    managed_root = Path(service.staging_path) / "managed" / "m1" / "r1"
+    managed_root.mkdir(parents=True)
+    orphan_sidecar = managed_root / "int8.fetch-state.json"
+    orphan_sidecar.write_text(json.dumps({
+        "files": {"model.onnx": {"etag": None, "last_modified": None,
+                                   "bytes_done": 7, "complete": False}}
+    }))
+    report = service.reconcile()
+    assert not orphan_sidecar.exists()
+    assert any("int8.fetch-state.json" in item for item in report.staging_removed)
+
+
+def test_fetch_sidecar_suffix_mirror_matches_acquisition():
+    """Drift guard: service.py's sibling-sidecar suffix must equal
+    acquisition.py's -- see both modules' constants for the rationale."""
+    from tldw_chatbook.Model_Artifacts import acquisition
+    from tldw_chatbook.Model_Artifacts import service as service_module
+
+    assert acquisition._FETCH_SIDECAR_SUFFIX == service_module._MANAGED_FETCH_SIDECAR_SUFFIX
 
 
 def test_gc_never_escapes_staging(service, tmp_path):

--- a/Tests/Model_Artifacts/test_reconcile_staging_gc.py
+++ b/Tests/Model_Artifacts/test_reconcile_staging_gc.py
@@ -1,0 +1,99 @@
+"""TASK-595 Task 2: reconcile deletes staging orphans, preserves resumable state."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Model_Artifacts.service import (
+    ArtifactLeaseKey,
+    ArtifactOperationLease,
+    LeaseMode,
+    ModelArtifactService,
+)
+
+
+@pytest.fixture()
+def service(tmp_path):
+    return ModelArtifactService(tmp_path / "root")
+
+
+def _managed_dir(service, artifact="m1", rev="r1", variant="int8") -> Path:
+    d = Path(service.staging_path) / "managed" / artifact / rev / variant
+    d.mkdir(parents=True)
+    return d
+
+
+def test_orphan_install_staging_is_removed(service):
+    orphan = Path(service.staging_path) / "install-deadbeef"
+    orphan.mkdir()
+    (orphan / "partial.bin").write_bytes(b"x" * 10)
+    report = service.reconcile()
+    assert not orphan.exists()
+    assert any("install-deadbeef" in item for item in report.staging_removed)
+
+
+def test_managed_entry_without_sidecar_is_removed(service):
+    d = _managed_dir(service)
+    (d / "model.onnx").write_bytes(b"partial")
+    report = service.reconcile()
+    assert not d.exists()
+    assert report.staging_removed
+
+
+def test_managed_entry_with_valid_sidecar_survives(service):
+    d = _managed_dir(service)
+    (d / "model.onnx").write_bytes(b"partial")
+    (d / "fetch-state.json").write_text(json.dumps({
+        "files": {"model.onnx": {"etag": "\"abc\"", "last_modified": None,
+                                   "bytes_done": 7, "complete": False}}
+    }))
+    report = service.reconcile()
+    assert d.exists()
+    assert (d / "model.onnx").exists()
+
+
+def test_managed_entry_with_corrupt_sidecar_is_removed(service):
+    d = _managed_dir(service)
+    (d / "fetch-state.json").write_text("{not json")
+    service.reconcile()
+    assert not d.exists()
+
+
+def test_gc_never_escapes_staging(service, tmp_path):
+    """Containment: a symlink inside staging pointing outside must not
+    cause deletion outside the root (extends the 594 containment tests)."""
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "keep.txt").write_text("keep")
+    link = Path(service.staging_path) / "managed" / "evil"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(victim)
+    service.reconcile()
+    assert (victim / "keep.txt").exists()
+
+
+def test_gc_skips_install_staging_dir_held_by_a_live_installer(service, tmp_path):
+    """A held per-directory staging lease simulates a live install() call in
+    another process/thread. GC must not touch its staging directory while
+    the lease is held, and must remove it once the lease is released --
+    this is the race reconcile() vs. a pre-lifecycle-lock install() must
+    not lose (see test_reconcile_reports_live_pre_lifecycle_install_staging_entry
+    in test_service.py, which reconcile() must keep passing)."""
+    live = Path(service.staging_path) / "install-livecase"
+    live.mkdir()
+    (live / "model.onnx").write_bytes(b"copied-but-not-yet-promoted")
+    key = ArtifactLeaseKey("#install-staging", live.name, "lock")
+    lock_root = tmp_path / "root" / "locks"
+
+    with ArtifactOperationLease(lock_root, key, LeaseMode.EXCLUSIVE):
+        held_report = service.reconcile()
+
+    assert live.exists()
+    assert (live / "model.onnx").exists()
+    assert held_report.staging_removed == ()
+
+    freed_report = service.reconcile()
+
+    assert not live.exists()
+    assert any("install-livecase" in item for item in freed_report.staging_removed)

--- a/Tests/Model_Artifacts/test_reconcile_staging_gc.py
+++ b/Tests/Model_Artifacts/test_reconcile_staging_gc.py
@@ -60,6 +60,30 @@ def test_managed_entry_with_corrupt_sidecar_is_removed(service):
     assert not d.exists()
 
 
+def test_managed_entry_with_non_mapping_sidecar_is_removed(service):
+    """A sidecar that parses as valid JSON but isn't a ``{"files": {...}}``
+    mapping (the exact shape Task 7's fetch phase always writes) is still
+    garbage, not resumable state.
+
+    Regression test for the review finding: the old check only required
+    ``json.loads`` to succeed, so a bare JSON list or string -- neither a
+    usable fetch-state record -- would survive as "valid" forever, keeping
+    dead staging alive indefinitely.
+    """
+    list_dir = _managed_dir(service, artifact="m-list")
+    (list_dir / "fetch-state.json").write_text(json.dumps([]))
+
+    string_dir = _managed_dir(service, artifact="m-string")
+    (string_dir / "fetch-state.json").write_text(json.dumps("x"))
+
+    report = service.reconcile()
+
+    assert not list_dir.exists()
+    assert not string_dir.exists()
+    assert any("m-list" in item for item in report.staging_removed)
+    assert any("m-string" in item for item in report.staging_removed)
+
+
 def test_gc_never_escapes_staging(service, tmp_path):
     """Containment: a symlink inside staging pointing outside must not
     cause deletion outside the root (extends the 594 containment tests)."""

--- a/Tests/Model_Artifacts/test_service.py
+++ b/Tests/Model_Artifacts/test_service.py
@@ -37,7 +37,23 @@ from tldw_chatbook.Model_Artifacts import (
 
 
 def test_package_exports_the_complete_public_artifact_api() -> None:
+    """TASK-595 Task 10 expanded ``__all__`` with the async acquisition
+    surface (``ArtifactAcquisitionService`` et al. and ``stream_fetch``),
+    resolved lazily via ``__getattr__`` so plain ``import
+    tldw_chatbook.Model_Artifacts`` still never touches ``.acquisition``/
+    ``.fetch`` -- see ``test_package_import_does_not_load_inference_or_http_runtimes``
+    below and ``test_credentials_and_boundaries.py``'s
+    ``test_stt_and_transcription_worker_modules_never_import_acquisition_or_fetch``,
+    both of which this expansion must keep passing."""
+
     expected = {
+        "ACQUISITION_SESSION_LEASE_KEY",
+        "AcquisitionBusyError",
+        "AcquisitionConsent",
+        "AcquisitionError",
+        "AcquisitionProgress",
+        "ArtifactAcquisitionService",
+        "ArtifactCatalog",
         "ArtifactConflictError",
         "ArtifactDependencyError",
         "ArtifactDescriptor",
@@ -59,16 +75,29 @@ def test_package_exports_the_complete_public_artifact_api() -> None:
         "ArtifactOperationLease",
         "ArtifactOperationLeaseSet",
         "ArtifactPathError",
+        "ArtifactPreflightEntry",
         "ArtifactRef",
         "ArtifactRole",
         "ArtifactStateError",
+        "CatalogError",
+        "ConsentMismatchError",
+        "CredentialResolver",
+        "EnvConfigCredentialResolver",
+        "FetchResult",
+        "FetchValidators",
+        "GatedRepositoryError",
+        "InsufficientSpaceError",
         "InstalledArtifact",
         "LeasedArtifactHandle",
         "LeaseMode",
         "ModelArtifactService",
+        "PreflightNotGrantableError",
+        "PreflightReport",
         "ProvenanceClass",
         "ReconcileReport",
+        "TransferError",
         "closure_fingerprint",
+        "stream_fetch",
     }
 
     assert set(artifacts_module.__all__) == expected

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -196,6 +196,75 @@ async def test_changed_last_modified_non_compliant_server_raises_restart(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_missing_etag_on_resume_raises_restart_without_append(tmp_path):
+    """A 206 that OMITS ETag entirely must not be accepted as matching a
+    saved strong ETag -- a missing validator is treated as a mismatch, not
+    as "no information, assume it's fine". ``ignore_if_range=True`` models
+    a non-compliant server that honors ``Range`` unconditionally (206)
+    even though its route serves no ``ETag`` header at all (this is the
+    only way to force the fixture to answer 206 while the response itself
+    carries no ETag -- see FixtureArtifactServer.serve's ``ignore_if_range``
+    docstring)."""
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY, etag=None, ignore_if_range=True)
+        dest = tmp_path / "f.bin"
+        seed = BODY[:100]
+        dest.write_bytes(seed)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(etag='"v1"', last_modified=None),
+                    trusted_origins=_trusted(srv),
+                )
+    assert dest.read_bytes() == seed
+
+
+@pytest.mark.asyncio
+async def test_content_range_start_mismatch_raises_restart_without_append(tmp_path):
+    """A 206 alone does not prove the body starts at ``resume_from`` --
+    only ``Content-Range`` does. A server whose ``Content-Range`` header
+    reports a DIFFERENT start than the ``Range`` request asked for must be
+    rejected before the destination is ever opened for append."""
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY, bad_range_start=999)
+        dest = tmp_path / "f.bin"
+        seed = BODY[:100]
+        dest.write_bytes(seed)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(etag='"v1"', last_modified=None),
+                    trusted_origins=_trusted(srv),
+                )
+    assert dest.read_bytes() == seed
+
+
+@pytest.mark.asyncio
+async def test_missing_content_range_on_resume_raises_restart_without_append(tmp_path):
+    """A non-compliant server that answers 206 without ANY Content-Range
+    header at all must be rejected the same way as a mismatched one --
+    there is no header to trust, so resuming must not be assumed safe."""
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY, omit_content_range=True)
+        dest = tmp_path / "f.bin"
+        seed = BODY[:100]
+        dest.write_bytes(seed)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(etag='"v1"', last_modified=None),
+                    trusted_origins=_trusted(srv),
+                )
+    assert dest.read_bytes() == seed
+
+
+@pytest.mark.asyncio
 async def test_max_bytes_bounds_final_size(tmp_path):
     with FixtureArtifactServer() as srv:
         srv.serve("/f.bin", BODY)

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -166,6 +166,36 @@ async def test_changed_last_modified_raises_restart_without_append(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_changed_last_modified_non_compliant_server_raises_restart(tmp_path):
+    """A server that IGNORES If-Range entirely (still answers 206 even on a
+    stale conditional) is a real, and for date-based conditionals especially
+    under-implemented, failure mode -- distinct from the compliant-200 path
+    covered by ``test_changed_last_modified_raises_restart_without_append``.
+    The post-response Last-Modified comparison (not the status-code check)
+    is what must catch this one."""
+    with FixtureArtifactServer() as srv:
+        srv.serve(
+            "/f.bin", BODY, etag=None,
+            last_modified="Thu, 22 Oct 2015 07:28:00 GMT",
+            ignore_if_range=True,
+        )
+        dest = tmp_path / "f.bin"
+        seed = BODY[:100]
+        dest.write_bytes(seed)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(
+                        etag=None, last_modified="Wed, 21 Oct 2015 07:28:00 GMT"
+                    ),
+                    trusted_origins=_trusted(srv),
+                )
+    assert dest.read_bytes() == seed
+
+
+@pytest.mark.asyncio
 async def test_max_bytes_bounds_final_size(tmp_path):
     with FixtureArtifactServer() as srv:
         srv.serve("/f.bin", BODY)

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -1,0 +1,137 @@
+"""TASK-595 Task 3: streaming guarded fetch."""
+
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
+from tldw_chatbook.Model_Artifacts.fetch import (
+    FetchRestartRequired,
+    FetchTooLargeError,
+    FetchValidators,
+    stream_fetch,
+)
+
+BODY = b"0123456789" * 1000  # 10 KB
+
+
+def _trusted(srv: FixtureArtifactServer) -> frozenset:
+    """Trusted-origins set for a fixture server, in egress's real format.
+
+    ``tldw_chatbook.Utils.egress._normalize_trusted`` / ``_post_resolution``
+    key membership on the bare, lowercased HOSTNAME (e.g. ``"127.0.0.1"``),
+    not a scheme+host+port URL string -- confirmed by reading
+    ``egress._pre_resolution``/``_post_resolution`` and by the convention
+    already used across ``Tests/Image_Generation/test_http_client.py`` and
+    ``Tests/Utils/test_egress.py`` (``frozenset({"127.0.0.1"})``). The
+    fixture server binds to the loopback IP literal, which classifies as
+    "private" under ``_classify_ip`` and would otherwise be egress-blocked;
+    listing it here is what lets policy allow it.
+    """
+    return frozenset({urlparse(srv.url("/")).hostname})
+
+
+@pytest.mark.asyncio
+async def test_full_fetch_writes_and_reports(tmp_path):
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY)
+        dest = tmp_path / "f.bin"
+        async with httpx.AsyncClient() as client:
+            result = await stream_fetch(
+                srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY) + 10,
+                trusted_origins=_trusted(srv),
+            )
+    assert dest.read_bytes() == BODY
+    assert result.bytes_written == len(BODY)
+    assert result.resumed is False
+    assert result.validators.etag == '"v1"'
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_range_and_appends(tmp_path):
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY)
+        dest = tmp_path / "f.bin"
+        dest.write_bytes(BODY[:4000])
+        async with httpx.AsyncClient() as client:
+            result = await stream_fetch(
+                srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                resume_from=4000,
+                validators=FetchValidators(etag='"v1"', last_modified=None),
+                trusted_origins=_trusted(srv),
+            )
+    assert dest.read_bytes() == BODY
+    assert result.resumed is True
+    assert result.bytes_written == len(BODY) - 4000
+    # The server actually saw a Range request.
+    assert any("Range" in r for r in srv.requests["/f.bin"])
+
+
+@pytest.mark.asyncio
+async def test_changed_validator_raises_restart(tmp_path):
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY, etag='"v2"')
+        dest = tmp_path / "f.bin"
+        dest.write_bytes(BODY[:100])
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(etag='"v1"', last_modified=None),
+                    trusted_origins=_trusted(srv),
+                )
+
+
+@pytest.mark.asyncio
+async def test_weak_etag_never_resumes(tmp_path):
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY, weak_etag=True)
+        dest = tmp_path / "f.bin"
+        dest.write_bytes(BODY[:100])
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(etag='W/"v1"', last_modified=None),
+                    trusted_origins=_trusted(srv),
+                )
+
+
+@pytest.mark.asyncio
+async def test_no_range_support_raises_restart(tmp_path):
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY, support_range=False)
+        dest = tmp_path / "f.bin"
+        dest.write_bytes(BODY[:100])
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(etag='"v1"', last_modified=None),
+                    trusted_origins=_trusted(srv),
+                )
+
+
+@pytest.mark.asyncio
+async def test_max_bytes_bounds_final_size(tmp_path):
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY)
+        dest = tmp_path / "f.bin"
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchTooLargeError):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=100,
+                    trusted_origins=_trusted(srv),
+                )
+
+
+def test_strip_headers_mirror_matches_egress():
+    """Drift guard: our local strip tuple must equal egress's."""
+    from tldw_chatbook.Utils import egress
+    from tldw_chatbook.Model_Artifacts import fetch
+
+    assert set(fetch._STRIP_HEADERS) == set(egress._STRIP_HEADERS)

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -117,6 +117,55 @@ async def test_no_range_support_raises_restart(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_last_modified_only_resume_succeeds(tmp_path):
+    """FetchValidators.strong allows etag=None + last_modified set; resume
+    must actually use THAT validator in If-Range, not silently skip it."""
+    lm = 'Wed, 21 Oct 2015 07:28:00 GMT'
+    with FixtureArtifactServer() as srv:
+        srv.serve("/f.bin", BODY, etag=None, last_modified=lm)
+        dest = tmp_path / "f.bin"
+        dest.write_bytes(BODY[:4000])
+        async with httpx.AsyncClient() as client:
+            result = await stream_fetch(
+                srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                resume_from=4000,
+                validators=FetchValidators(etag=None, last_modified=lm),
+                trusted_origins=_trusted(srv),
+            )
+    assert dest.read_bytes() == BODY
+    assert result.resumed is True
+    assert result.bytes_written == len(BODY) - 4000
+    assert any("If-Range" in r for r in srv.requests["/f.bin"])
+
+
+@pytest.mark.asyncio
+async def test_changed_last_modified_raises_restart_without_append(tmp_path):
+    """Upstream changed (new Last-Modified) while resuming Last-Modified-only:
+    a spec-compliant server answers the mismatched If-Range with a full 200,
+    which must raise FetchRestartRequired -- and the destination must NOT
+    have had any (mismatched) bytes appended."""
+    with FixtureArtifactServer() as srv:
+        srv.serve(
+            "/f.bin", BODY, etag=None,
+            last_modified="Thu, 22 Oct 2015 07:28:00 GMT",
+        )
+        dest = tmp_path / "f.bin"
+        seed = BODY[:100]
+        dest.write_bytes(seed)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(FetchRestartRequired):
+                await stream_fetch(
+                    srv.url("/f.bin"), dest, client=client, max_bytes=len(BODY),
+                    resume_from=100,
+                    validators=FetchValidators(
+                        etag=None, last_modified="Wed, 21 Oct 2015 07:28:00 GMT"
+                    ),
+                    trusted_origins=_trusted(srv),
+                )
+    assert dest.read_bytes() == seed
+
+
+@pytest.mark.asyncio
 async def test_max_bytes_bounds_final_size(tmp_path):
     with FixtureArtifactServer() as srv:
         srv.serve("/f.bin", BODY)

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -78,6 +78,18 @@ block directly in the file. Also note the CLI strips some free-form sections, an
 backticks in `--notes` are interpreted by the shell — a phrase in backticks vanished
 from a task note this way.
 
+**A related trap (TASK-595 Task 10, 2026-07-31).** `backlog task edit <id> --notes "..."`
+does not append to an existing `## Implementation Notes` section — it REPLACES the
+entire content between `<!-- SECTION:NOTES:BEGIN -->` and `<!-- SECTION:NOTES:END -->`.
+A detailed Implementation Notes section written by hand-editing the task file *before*
+running the close-out `-s Done --notes "..."` command was silently discarded, confirmed
+by diffing the file before and after. Recovered by re-adding the detailed text inside
+the same markers, after the CLI's short summary.
+
+**What to do.** Run the CLI `--notes` command first (or use only the CLI's text), then
+hand-edit to elaborate — never the other order. Diff the task file after any `--notes`
+call to confirm what survived.
+
 ---
 
 ## Never `git add -A` while resolving a rebase conflict

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -501,6 +501,47 @@ asymmetrically toward failure.
 
 ---
 
+## A crash mid-transfer proves nothing durable if the checkpoint is never written mid-transfer
+
+**TASK-595 Task 10, 2026-07-31.** Asked to write a real-subprocess, SIGKILL-based test
+proving "a valid sidecar survives a mid-fetch crash and a fresh provision resumes it via
+a Range request," the obvious design was: pause a fixture connection mid-download, kill
+the child while the socket is blocked, then assert the durable checkpoint resumed. That
+design cannot pass — not because of a bug, but because of how the code under test is
+*supposed* to work: `_fetch_one_file` only calls `atomic_write_json` on the sidecar AFTER
+`stream_fetch` returns successfully for that call; a SIGKILL during the first-ever
+transfer of a file leaves no sidecar at all (confirmed directly by an existing test,
+`test_provision_cancel_mid_fetch_releases_lease_and_preserves_prior_active`, which
+asserts `not sidecar_path.exists()` after an asyncio-cancelled mid-fetch). A kill timed
+mid-socket-read can only ever produce an *orphan* (Task 2's GC correctly deletes it), not
+a resumable checkpoint — the two are mutually exclusive outcomes of the same kill point.
+
+A durable-but-partial checkpoint (`bytes_done < size, complete: false`) only exists when
+one `stream_fetch` call already returned successfully with fewer bytes than the
+descriptor declares — which requires either a pre-seeded sidecar (what the existing
+in-process tests do, legitimately, to isolate the resume *logic*) or, for a test that
+must produce this state via a genuine, un-seeded crash: declare a file's size larger than
+what the fixture route currently serves, let that first GET complete normally (a valid,
+un-truncated HTTP response, so `stream_fetch` returns without error), and freeze the
+*next* phase (pre-verify, via a local `threading.Event` a progress-callback hook blocks
+on) before its hash comparison can clear the sidecar entry on mismatch. The kill then
+lands after a real checkpoint is durable, not during the socket read that would prevent
+one existing at all.
+
+**What to do.** Before designing a crash-recovery test for any resumable-transfer
+system, read the exact write-ordering of its checkpoint (grep for where the persisted
+state is actually written, not just where progress callbacks fire) and check for an
+existing test that already documents the "no sidecar" case — it will save you from
+building a scenario the implementation cannot produce. Then time the kill off a
+deterministic signal (a callback blocking on a never-set local event) rather than a
+sleep or a byte-count race, so the exact crash point is provable, not probabilistic.
+Mutation-test the resulting guard afterward: a one-line break in the resume path
+(`resume_from = 0` unconditionally) and in the orphan classifier (`return False`
+unconditionally) each turned the corresponding assertion red, confirming neither guard
+was decorative.
+
+---
+
 ## Related
 
 - `lessons-live-verification.md` — why the suite could not see seven of these defects

--- a/backlog/tasks/task-1566 - Wrap-ArtifactPathError-from-core.install-in-the-acquisition-never-trap-taxonomy.md
+++ b/backlog/tasks/task-1566 - Wrap-ArtifactPathError-from-core.install-in-the-acquisition-never-trap-taxonomy.md
@@ -3,9 +3,10 @@ id: TASK-1566
 title: >-
   Wrap ArtifactPathError from core.install in the acquisition never-trap
   taxonomy
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-01 01:57'
+updated_date: '2026-08-01 03:00'
 labels: []
 dependencies: []
 ---
@@ -18,6 +19,14 @@ Final-review residual on TASK-595 (branch feat/managed-model-acquisition): _run_
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ArtifactPathError from core.install surfaces as TransferError(retryable=False) with the cause chained
-- [ ] #2 Regression test monkeypatches core.install to raise ArtifactPathError and asserts the wrapper
+- [x] #1 ArtifactPathError from core.install surfaces as TransferError(retryable=False) with the cause chained
+- [x] #2 Regression test monkeypatches core.install to raise ArtifactPathError and asserts the wrapper
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `ArtifactPathError` to `_run_core_call`'s except tuple alongside `ArtifactIntegrityError`/`ArtifactConflictError` (all three are non-retryable siblings under `ArtifactError`, not subclasses of each other, so ordering doesn't matter) in `tldw_chatbook/Model_Artifacts/acquisition.py`; imported `ArtifactPathError` from `.service`. Test: `test_install_artifact_wraps_core_path_error_as_non_retryable` in `Tests/Model_Artifacts/test_provision_install.py` monkeypatches `core.install` to raise `ArtifactPathError` and asserts `TransferError(retryable=False)` with the cause chained — confirmed it fails against pre-fix code (raw `ArtifactPathError` escapes `_install_artifact`).
+
+Landed as part of a broader PR #1157 review fix-wave alongside seven other findings (P1 security/race fixes in fetch.py and service.py, several P2s in acquisition.py). See that PR/commit for the full set.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1566 - Wrap-ArtifactPathError-from-core.install-in-the-acquisition-never-trap-taxonomy.md
+++ b/backlog/tasks/task-1566 - Wrap-ArtifactPathError-from-core.install-in-the-acquisition-never-trap-taxonomy.md
@@ -1,0 +1,23 @@
+---
+id: TASK-1566
+title: >-
+  Wrap ArtifactPathError from core.install in the acquisition never-trap
+  taxonomy
+status: To Do
+assignee: []
+created_date: '2026-08-01 01:57'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Final-review residual on TASK-595 (branch feat/managed-model-acquisition): _run_core_call in tldw_chatbook/Model_Artifacts/acquisition.py catches ArtifactIntegrityError/ArtifactConflictError/ArtifactStateError but not ArtifactPathError, which core.install documents raising — it escapes provision() raw, breaking the spec's rule that every failure surfaces typed with a retryable flag. Reproduced live by the re-reviewer.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ArtifactPathError from core.install surfaces as TransferError(retryable=False) with the cause chained
+- [ ] #2 Regression test monkeypatches core.install to raise ArtifactPathError and asserts the wrapper
+<!-- AC:END -->

--- a/backlog/tasks/task-1567 - Stale-install-staging-lock-files-accumulate-in-the-artifact-locks-directory.md
+++ b/backlog/tasks/task-1567 - Stale-install-staging-lock-files-accumulate-in-the-artifact-locks-directory.md
@@ -1,0 +1,21 @@
+---
+id: TASK-1567
+title: Stale install-staging lock files accumulate in the artifact locks directory
+status: To Do
+assignee: []
+created_date: '2026-08-01 01:57'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in TASK-595's final review: service.py's _install_staging_lease_key uses a fresh mkdtemp name per install and lease files are never unlinked, so one <sha256>.lock accumulates in locks/ per install, permanently. Needs cleanup on release (or a sweep in reconcile) without reintroducing the GC-vs-live-install race the lease exists to prevent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Repeated installs do not grow the locks directory without bound
+- [ ] #2 Cleanup cannot delete a lock a live installer still holds
+<!-- AC:END -->

--- a/backlog/tasks/task-1692 - Wrap-ArtifactPathError-from-core.install-in-the-acquisition-never-trap-taxonomy.md
+++ b/backlog/tasks/task-1692 - Wrap-ArtifactPathError-from-core.install-in-the-acquisition-never-trap-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-1566
+id: TASK-1692
 title: >-
   Wrap ArtifactPathError from core.install in the acquisition never-trap
   taxonomy

--- a/backlog/tasks/task-595 - Add-verified-managed-model-downloads-and-recovery.md
+++ b/backlog/tasks/task-595 - Add-verified-managed-model-downloads-and-recovery.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-595
 title: Add verified managed model downloads and recovery
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-24 01:02'
+updated_date: '2026-08-01 00:59'
 labels:
   - stt
   - artifacts
@@ -25,10 +26,71 @@ Add consent-driven managed acquisition over the shared artifact lifecycle so cur
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Preflight resolves the complete dependency closure and reports source, license, precision, total bytes, destination, staging overhead, retained versions, and required free space before any transfer.
-- [ ] #2 Downloads use per-artifact staging, bounded HTTP behavior, resume validation, stable-order installation locks, and final per-file size and SHA-256 verification.
-- [ ] #3 The root readiness record is written last; cancellation, hash failure, network failure, and process interruption leave the prior active version usable and incomplete staging non-loadable.
-- [ ] #4 Provider workers cannot initiate downloads, and every first-use acquisition requires explicit caller confirmation before enqueue.
-- [ ] #5 Authenticated repositories use supported credential boundaries without persisting or logging secrets.
-- [ ] #6 Local fixture integration tests cover resume, changed validators, corrupt payloads, concurrent installers, insufficient space, crash recovery, and staging cleanup containment.
+- [x] #1 Preflight resolves the complete dependency closure and reports source, license, precision, total bytes, destination, staging overhead, retained versions, and required free space before any transfer.
+- [x] #2 Downloads use per-artifact staging, bounded HTTP behavior, resume validation, stable-order installation locks, and final per-file size and SHA-256 verification.
+- [x] #3 The root readiness record is written last; cancellation, hash failure, network failure, and process interruption leave the prior active version usable and incomplete staging non-loadable.
+- [x] #4 Provider workers cannot initiate downloads, and every first-use acquisition requires explicit caller confirmation before enqueue.
+- [x] #5 Authenticated repositories use supported credential boundaries without persisting or logging secrets.
+- [x] #6 Local fixture integration tests cover resume, changed validators, corrupt payloads, concurrent installers, insufficient space, crash recovery, and staging cleanup containment.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+ArtifactAcquisitionService (async preflight/consent/provision) + stream_fetch over the sealed 594 core; consume_source install + orphans-only staging GC as the only core changes; session-lease serialization with busy semantics; resume/pre-verify/crash-recovery/credential fixtures per AC #6. Spec: Docs/superpowers/specs/2026-07-30-managed-model-acquisition-design.md.
+
+Delivered across 10 sequential tasks (commits tagged `TASK-595` on
+`feat/managed-model-acquisition`), composed entirely over the sealed 594
+core (`ModelArtifactService`) via a new `ArtifactAcquisitionService`:
+
+- **Core additions (exactly two, by design):** `install(..., consume_source=True)`
+  (in-root move with EXDEV copy fallback) and `reconcile()`'s
+  orphans-only managed-staging GC (a directory survives iff its
+  `fetch-state.json` sidecar parses as JSON; anything else -- missing,
+  corrupt, wrong depth -- is swept). Both are exercised directly by this
+  task's real-subprocess crash tests.
+- **`acquisition.py`:** async `preflight()` (closure walk + staged-byte
+  credit + space math + gating probe) → `PreflightReport.grant()` →
+  `provision(root, consent, catalog)` (note: explicit `root` param is a
+  reviewed deviation from an earlier consent-only signature) → durable
+  per-file fetch with Range/validator resume (`fetch.py`'s `stream_fetch`)
+  → pre-verify with one automatic refetch on hash mismatch →
+  `consume_source` install → activate-last. A typed, never-a-raw-trap
+  error family (`AcquisitionError` and subclasses) covers every failure
+  mode from catalog cycles to insufficient space to gated repositories.
+- **Concurrency:** an exclusive, non-blocking `ACQUISITION_SESSION_LEASE_KEY`
+  OS lease (busy → `AcquisitionBusyError`, not a hang) plus an in-process
+  `asyncio.Lock` so same-process concurrent callers queue instead of
+  racing that lease.
+- **Credentials (Task 9):** `CredentialResolver` protocol +
+  `EnvConfigCredentialResolver` (env, then `[API] huggingface_api_key`
+  config; keyring deliberately deferred). A dedicated subprocess
+  import-boundary test proves the synchronous STT/transcription worker
+  surface never imports `.acquisition`/`.fetch` -- provider workers
+  structurally cannot initiate a download.
+- **Crash recovery (Task 10, this close-out):** three real-subprocess,
+  SIGKILL-based tests in `Tests/Model_Artifacts/test_provision_crash_recovery.py`
+  (harness: `Tests/Model_Artifacts/provision_processes.py`, mirroring
+  `lease_processes.py`'s style) prove, under an actual OS-level kill
+  rather than asyncio cancellation: (1) a genuinely partial-but-durable
+  fetch checkpoint survives `reconcile()`, the session lease is released
+  by the kernel, and a fresh `provision()` resumes via an observed
+  `Range` request and completes; (2) killing after both artifacts in a
+  closure are installed but before `activate()` lets a fresh `provision()`
+  activate with zero fixture requests; (3) `reconcile()` after a real
+  crash removes only the orphan it names, leaving a crash-surviving valid
+  entry and unrelated sibling files completely untouched. Both guards
+  were mutation-tested (a targeted one-line break in the resume path and
+  in the orphan classifier each turned the corresponding assertion red).
+- **Public exports:** `Model_Artifacts/__init__.py.__all__` now includes
+  the full async acquisition surface. `.acquisition`/`.fetch` (both
+  `import httpx`) are resolved lazily via a module-level `__getattr__`
+  (PEP 562), not eagerly at package-import time -- Task 9's boundary
+  invariant ("plain `import tldw_chatbook.Model_Artifacts` never loads
+  httpx") stays intact; `from tldw_chatbook.Model_Artifacts import
+  ArtifactAcquisitionService` (and every other new name) still resolves
+  correctly on first access.
+
+Full gate: `Tests/Model_Artifacts/ Tests/STT/test_boundaries.py` --
+358 passed (355 pre-existing + 3 new), stable across repeated runs.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Model_Artifacts/__init__.py
+++ b/tldw_chatbook/Model_Artifacts/__init__.py
@@ -1,4 +1,20 @@
-"""Shared managed model-artifact contracts."""
+"""Shared managed model-artifact contracts.
+
+``.acquisition`` and ``.fetch`` (both ``import httpx`` at module scope) are
+deliberately NOT imported eagerly here -- ``Tests/Model_Artifacts/test_service.py``'s
+``test_package_import_does_not_load_inference_or_http_runtimes`` and
+``test_credentials_and_boundaries.py``'s
+``test_stt_and_transcription_worker_modules_never_import_acquisition_or_fetch``
+(TASK-595 Task 9) pin the invariant that plain ``import tldw_chatbook.Model_Artifacts``
+-- reached transitively by the synchronous STT/transcription worker surface,
+which only needs ``ArtifactLeaseKey``/``ModelArtifactService`` -- never pulls
+httpx or the async acquisition runtime into that process. Their names are
+still in ``__all__`` and resolve correctly on ``from ... import Name`` via
+the ``__getattr__`` below (PEP 562): the submodule import happens only the
+first time one of those specific names is actually looked up.
+"""
+
+from __future__ import annotations
 
 from .leases import (
     ArtifactLeaseCancelledError,
@@ -10,6 +26,7 @@ from .leases import (
     LeaseMode,
 )
 from .service import (
+    ACQUISITION_SESSION_LEASE_KEY,
     ArtifactConflictError,
     ArtifactDependencyError,
     ArtifactDescriptor,
@@ -36,7 +53,62 @@ from .service import (
     closure_fingerprint,
 )
 
+# Names resolved lazily from .acquisition / .fetch -- see module docstring.
+_ACQUISITION_NAMES = frozenset(
+    {
+        "AcquisitionBusyError",
+        "AcquisitionConsent",
+        "AcquisitionError",
+        "AcquisitionProgress",
+        "ArtifactAcquisitionService",
+        "ArtifactCatalog",
+        "ArtifactPreflightEntry",
+        "CatalogError",
+        "ConsentMismatchError",
+        "CredentialResolver",
+        "EnvConfigCredentialResolver",
+        "GatedRepositoryError",
+        "InsufficientSpaceError",
+        "PreflightNotGrantableError",
+        "PreflightReport",
+        "TransferError",
+    }
+)
+_FETCH_NAMES = frozenset({"FetchResult", "FetchValidators", "stream_fetch"})
+
+
+def __getattr__(name: str):
+    """Resolve acquisition/fetch names on first access (PEP 562).
+
+    Args:
+        name: The attribute being looked up on this package.
+
+    Returns:
+        The resolved object from ``.acquisition`` or ``.fetch``.
+
+    Raises:
+        AttributeError: ``name`` is not one of this package's public names.
+    """
+
+    if name in _ACQUISITION_NAMES:
+        from . import acquisition
+
+        return getattr(acquisition, name)
+    if name in _FETCH_NAMES:
+        from . import fetch
+
+        return getattr(fetch, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
+    "ACQUISITION_SESSION_LEASE_KEY",
+    "AcquisitionBusyError",
+    "AcquisitionConsent",
+    "AcquisitionError",
+    "AcquisitionProgress",
+    "ArtifactAcquisitionService",
+    "ArtifactCatalog",
     "ArtifactConflictError",
     "ArtifactDependencyError",
     "ArtifactDescriptor",
@@ -58,14 +130,27 @@ __all__ = [
     "ArtifactOperationLease",
     "ArtifactOperationLeaseSet",
     "ArtifactPathError",
+    "ArtifactPreflightEntry",
     "ArtifactRef",
     "ArtifactRole",
     "ArtifactStateError",
+    "CatalogError",
+    "ConsentMismatchError",
+    "CredentialResolver",
+    "EnvConfigCredentialResolver",
+    "FetchResult",
+    "FetchValidators",
+    "GatedRepositoryError",
+    "InsufficientSpaceError",
     "InstalledArtifact",
     "LeasedArtifactHandle",
     "LeaseMode",
     "ModelArtifactService",
+    "PreflightNotGrantableError",
+    "PreflightReport",
     "ProvenanceClass",
     "ReconcileReport",
+    "TransferError",
     "closure_fingerprint",
+    "stream_fetch",
 ]

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+import hashlib
 import json
+import shutil
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Protocol
@@ -170,25 +173,42 @@ class _ProvisionProgressState:
 
     Task 6 only constructs one instance per ``provision()`` call and threads
     it, unchanged, into ``_fetch_artifact`` and ``_preverify_artifact`` for
-    every artifact in the closure. Tasks 7-8 read and update ``bytes_done``
-    as each declared file streams or is pre-verified, and call ``callback``
-    with an ``AcquisitionProgress`` event carrying these CLOSURE-WIDE totals
-    -- per the design spec, fetch/pre-verify progress is reported summed
-    across the whole closure, not reset per artifact or per file.
+    every artifact in the closure. Task 7 reads and updates ``bytes_done``
+    as each declared file streams; Task 8 reads and updates
+    ``preverify_bytes_done`` as each staged file is hashed. Both counters
+    are reported against the SAME ``bytes_total`` (the closure's declared
+    download bytes -- the exact same files are streamed in the fetch phase
+    and hashed in the pre-verify phase) but are tracked SEPARATELY: fetch
+    finishes one full closure-wide pass through ``bytes_total`` before
+    pre-verify begins its own, so a single shared counter would either
+    stall at 100% through the whole pre-verify phase or run past 100% --
+    neither is "closure-wide, not reset per artifact or per file", the
+    property this class exists to provide. ``callback`` is called with an
+    ``AcquisitionProgress`` event carrying whichever counter belongs to the
+    active phase.
 
     Args:
         callback: The caller's optional progress sink, forwarded unchanged
             from ``provision()``'s own ``progress`` keyword argument.
-        bytes_total: Total bytes still to download across the whole
-            closure (``PreflightReport.download_bytes``), computed once
-            before the per-artifact loop starts.
+        bytes_total: Total bytes still to download (and, in the pre-verify
+            phase, to re-hash) across the whole closure
+            (``PreflightReport.download_bytes``), computed once before the
+            per-artifact loop starts.
         bytes_done: Running total of bytes fetched so far across every
             artifact already processed in this run; starts at zero.
+        preverify_bytes_done: Running total of bytes hashed so far during
+            the pre-verify phase, across every artifact already processed
+            in this run; starts at zero. A pre-verify hash mismatch and
+            refetch (Task 8) re-streams and re-hashes the same file, so
+            this counter can advance past ``bytes_total`` in that recovery
+            path -- an acceptable cosmetic wrinkle in an uncommon retry,
+            not a steady-state property.
     """
 
     callback: Callable[[AcquisitionProgress], None] | None
     bytes_total: int
     bytes_done: int = 0
+    preverify_bytes_done: int = 0
 
 
 @dataclass(frozen=True)
@@ -537,8 +557,14 @@ class ArtifactAcquisitionService:
         Artifacts already present in ``core.list_installed()`` are skipped
         entirely, bypassing the fetch/pre-verify/install phases -- this is
         both the idempotent-completion path for a fully provisioned closure
-        and the crash-after-install recovery path (Tasks 7-8 exercise the
-        latter with a mid-closure crash).
+        and the crash-after-install recovery path.
+
+        Every not-yet-installed artifact in the closure runs its three
+        phases strictly in order -- fetch (Task 7), pre-verify (Task 8),
+        install (Task 8) -- before the loop moves to the next artifact; a
+        ``verify-install`` progress event follows each artifact's install.
+        Once every artifact is installed, the whole closure is activated
+        (``core.activate``) and a final ``activate`` progress event fires.
 
         Args:
             root: The root artifact reference to provision.
@@ -550,7 +576,9 @@ class ArtifactAcquisitionService:
                 freshly resolved descriptors supply the file URLs the
                 fetch phase needs.
             progress: Optional sink for ``AcquisitionProgress`` events
-                emitted by the fetch and pre-verify phases (Tasks 7-8).
+                emitted by every phase: real byte detail for ``fetch`` and
+                ``pre-verify``, indeterminate per-artifact events for
+                ``verify-install`` and ``activate``.
 
         Returns:
             The activated root artifact reference.
@@ -566,9 +594,9 @@ class ArtifactAcquisitionService:
             CatalogError: Propagated from an unknown ref, a dependency
                 cycle, or a conflicting-revision closure during the
                 re-walk.
-            NotImplementedError: A not-yet-installed artifact reached the
-                fetch, pre-verify, or install phase stub (Tasks 7-8 fill
-                these in).
+            TransferError: A file failed to fetch, or a staged file failed
+                pre-verify a second time after one automatic refetch --
+                nothing is installed for that artifact.
         """
         async with self._lock:
             loop = asyncio.get_running_loop()
@@ -622,8 +650,18 @@ class ArtifactAcquisitionService:
                     await self._fetch_artifact(descriptor, staging_dir, progress_state)
                     await self._preverify_artifact(descriptor, staging_dir, progress_state)
                     await self._install_artifact(descriptor, staging_dir)
+                    # _install_artifact's signature is frozen at
+                    # (descriptor, staging_dir) -- no progress_state -- so
+                    # the per-artifact "verify-install" event is emitted
+                    # here, by the caller that already has it, immediately
+                    # after the phase it describes actually completes.
+                    self._emit_indeterminate_progress(
+                        progress_state, "verify-install", descriptor.reference
+                    )
 
-                return await loop.run_in_executor(None, self._core.activate, root)
+                activated = await loop.run_in_executor(None, self._core.activate, root)
+                self._emit_indeterminate_progress(progress_state, "activate", root)
+                return activated
             finally:
                 await loop.run_in_executor(None, lease.release)
 
@@ -1016,8 +1054,15 @@ class ArtifactAcquisitionService:
     ) -> None:
         """Streaming-verify every staged file's SHA-256 before install.
 
-        Stub (Task 6); Task 8 implements this phase. The signature is final
-        -- ``provision()``'s call site will not change when it does.
+        A mismatch does not fail outright: the offending file is deleted,
+        its sidecar entry is reset (so ``_fetch_artifact`` treats it as
+        never fetched), and the whole artifact is refetched once via the
+        existing ``_fetch_artifact`` path before hashing is retried. Only a
+        SECOND mismatch for the same file raises -- this bounds automatic
+        recovery to ``MAX_FILE_REFETCHES`` (1) per spec, distinct from
+        ``_fetch_artifact``'s own restart-on-``FetchRestartRequired``
+        handling (that guards a download that never completed cleanly;
+        this guards a download that completed but is wrong).
 
         Args:
             descriptor: The artifact whose staged files to verify.
@@ -1027,10 +1072,101 @@ class ArtifactAcquisitionService:
                 update as bytes are verified.
 
         Raises:
-            NotImplementedError: Always, until Task 8 implements this phase.
+            TransferError: A staged file still fails its declared SHA-256
+                after ``MAX_FILE_REFETCHES`` refetch attempts. ``retryable``
+                is True -- a subsequent ``provision()`` call may still
+                succeed (e.g. once the corrupt content upstream is fixed).
         """
 
-        raise NotImplementedError("pre-verify phase is implemented in a later task")
+        for file in descriptor.files:
+            await self._preverify_one_file(descriptor, file, staging_dir, progress_state)
+
+    async def _preverify_one_file(
+        self,
+        descriptor: ArtifactDescriptor,
+        file: ArtifactFile,
+        staging_dir: Path,
+        progress_state: _ProvisionProgressState,
+    ) -> None:
+        """Hash one staged file, refetching once via ``_fetch_artifact`` on mismatch.
+
+        Args:
+            descriptor: The artifact this file belongs to.
+            file: The declared file to verify.
+            staging_dir: The durable staging directory holding the fetched
+                files.
+            progress_state: Closure-wide progress accounting.
+
+        Raises:
+            TransferError: See ``_preverify_artifact``.
+        """
+
+        destination = staging_dir / file.path
+        sidecar_path = staging_dir / "fetch-state.json"
+        attempts_used = 0
+        while True:
+            digest = self._hash_staged_file(destination, descriptor, file, progress_state)
+            if digest == file.sha256:
+                return
+            if attempts_used >= MAX_FILE_REFETCHES:
+                raise TransferError(
+                    f"staged file '{file.path}' still fails SHA-256 verification "
+                    f"after {MAX_FILE_REFETCHES} refetch(es)",
+                    retryable=True,
+                )
+            attempts_used += 1
+            try:
+                destination.unlink()
+            except FileNotFoundError:
+                pass
+            sidecar = self._load_fetch_sidecar(sidecar_path)
+            if sidecar["files"].pop(file.path, None) is not None:
+                atomic_write_json(sidecar_path, sidecar)
+            await self._fetch_artifact(descriptor, staging_dir, progress_state)
+
+    @staticmethod
+    def _hash_staged_file(
+        destination: Path,
+        descriptor: ArtifactDescriptor,
+        file: ArtifactFile,
+        progress_state: _ProvisionProgressState,
+    ) -> str:
+        """Stream one staged file's SHA-256, reporting real byte progress.
+
+        A zero-byte declared file (Task 7 guarantees the destination exists
+        even then) reads zero chunks and hashes to the empty digest --
+        never a special case, matching how ``_fetch_one_file`` already
+        treats a zero-byte file as "real, just empty" rather than absent.
+
+        Args:
+            destination: The staged file's path (must exist).
+            descriptor: The artifact this file belongs to, for the
+                progress event's ``ref``.
+            file: The declared file being hashed, for the progress event's
+                ``file`` and to size chunk reads.
+            progress_state: Closure-wide progress accounting to read and
+                update as bytes are hashed.
+
+        Returns:
+            The lowercase hex SHA-256 digest of the file's current content.
+        """
+
+        digest = hashlib.sha256()
+        with destination.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+                progress_state.preverify_bytes_done += len(chunk)
+                if progress_state.callback is not None:
+                    progress_state.callback(
+                        AcquisitionProgress(
+                            phase="pre-verify",
+                            ref=descriptor.reference,
+                            file=file.path,
+                            bytes_done=progress_state.preverify_bytes_done,
+                            bytes_total=progress_state.bytes_total,
+                        )
+                    )
+        return digest.hexdigest()
 
     async def _install_artifact(
         self,
@@ -1039,8 +1175,25 @@ class ArtifactAcquisitionService:
     ) -> None:
         """Promote one pre-verified staged directory into the immutable store.
 
-        Stub (Task 6); Task 8 implements this phase. The signature is final
-        -- ``provision()``'s call site will not change when it does.
+        The fetch-state sidecar is removed BEFORE calling ``core.install``,
+        not after: ``install``'s payload-tree validation requires the
+        source directory to contain EXACTLY the descriptor's declared
+        files, and ``fetch-state.json`` is an acquisition-owned file the
+        core knows nothing about -- leaving it in place would make every
+        install fail with "source contains an undeclared file". Once
+        pre-verify has confirmed every staged file's content, the sidecar's
+        resume checkpoints have already served their purpose.
+
+        ``core.install(..., consume_source=True)`` is synchronous core
+        surface (file moves, lease acquisition, manifest writes), so it
+        runs in the default executor like every other core call this
+        service makes. On success, ``consume_source`` has moved every
+        declared file out of ``staging_dir`` into the immutable store; the
+        now-empty (files and sidecar both gone) directory tree is removed
+        so a later ``reconcile()`` staging GC sees nothing left to
+        classify for this artifact -- an empty leftover directory with no
+        sidecar would otherwise look identical to an abandoned partial
+        download.
 
         Args:
             descriptor: The artifact to install.
@@ -1048,10 +1201,57 @@ class ArtifactAcquisitionService:
                 files.
 
         Raises:
-            NotImplementedError: Always, until Task 8 implements this phase.
+            ArtifactError: Propagated from ``core.install`` (e.g. an
+                integrity or conflict failure). Only a SUCCESSFUL install
+                triggers the ``staging_dir`` cleanup above -- on failure it
+                is left in place (though ``consume_source`` may already
+                have moved its declared files into the core's own,
+                separately-cleaned-up staging by the time the failure
+                surfaces, so an empty leftover directory is not itself
+                proof anything is wrong).
         """
 
-        raise NotImplementedError("install phase is implemented in a later task")
+        sidecar_path = staging_dir / "fetch-state.json"
+        try:
+            sidecar_path.unlink()
+        except FileNotFoundError:
+            pass
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            functools.partial(
+                self._core.install, descriptor, staging_dir, consume_source=True
+            ),
+        )
+
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+    @staticmethod
+    def _emit_indeterminate_progress(
+        progress_state: _ProvisionProgressState,
+        phase: Literal["verify-install", "activate"],
+        ref: ArtifactRef,
+    ) -> None:
+        """Emit one per-artifact progress event with no byte detail.
+
+        Per spec, ``verify-install`` and ``activate`` events carry no real
+        byte accounting (unlike ``fetch``/``pre-verify``) -- they mark a
+        phase transition, not a position within a stream.
+
+        Args:
+            progress_state: Closure-wide progress accounting, for its
+                caller-supplied ``callback`` (may be None).
+            phase: Which indeterminate phase this event marks.
+            ref: The artifact reference this event is about.
+        """
+
+        if progress_state.callback is not None:
+            progress_state.callback(
+                AcquisitionProgress(
+                    phase=phase, ref=ref, file=None, bytes_done=0, bytes_total=0
+                )
+            )
 
     def _staged_bytes_for(self, ref: ArtifactRef) -> int:
         """Best-effort resumable-byte credit from a fetch-state sidecar.

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Protocol
 
@@ -11,7 +12,13 @@ import httpx
 
 from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise_async
 
-from .service import ArtifactError, ArtifactRef, closure_fingerprint
+from .leases import ArtifactLeaseTimeoutError, ArtifactOperationLease, LeaseMode
+from .service import (
+    ACQUISITION_SESSION_LEASE_KEY,
+    ArtifactError,
+    ArtifactRef,
+    closure_fingerprint,
+)
 
 if TYPE_CHECKING:
     from .service import ArtifactDescriptor, ModelArtifactService
@@ -23,6 +30,12 @@ MAX_FILE_REFETCHES = 1
 
 # Bounded timeout for the preflight repository-gating HEAD probe (Task 5).
 _PREFLIGHT_PROBE_TIMEOUT_SECONDS = 10.0
+
+# Non-blocking acquisition-session-lease timeout (Task 6): an immediate,
+# typed AcquisitionBusyError beats a hang -- another process or in-process
+# caller already holding the session lease means "busy right now", not
+# "worth waiting for".
+_SESSION_LEASE_TIMEOUT_SECONDS = 0.1
 
 # Credential hint named in gating_errors -- never a token value. Matches the
 # existing env precedence this codebase already documents (config.py's
@@ -140,6 +153,33 @@ class AcquisitionProgress:
     file: str | None
     bytes_done: int
     bytes_total: int
+
+
+@dataclass
+class _ProvisionProgressState:
+    """Mutable closure-wide byte accounting threaded through provision's phases.
+
+    Task 6 only constructs one instance per ``provision()`` call and threads
+    it, unchanged, into ``_fetch_artifact`` and ``_preverify_artifact`` for
+    every artifact in the closure. Tasks 7-8 read and update ``bytes_done``
+    as each declared file streams or is pre-verified, and call ``callback``
+    with an ``AcquisitionProgress`` event carrying these CLOSURE-WIDE totals
+    -- per the design spec, fetch/pre-verify progress is reported summed
+    across the whole closure, not reset per artifact or per file.
+
+    Args:
+        callback: The caller's optional progress sink, forwarded unchanged
+            from ``provision()``'s own ``progress`` keyword argument.
+        bytes_total: Total bytes still to download across the whole
+            closure (``PreflightReport.download_bytes``), computed once
+            before the per-artifact loop starts.
+        bytes_done: Running total of bytes fetched so far across every
+            artifact already processed in this run; starts at zero.
+    """
+
+    callback: Callable[[AcquisitionProgress], None] | None
+    bytes_total: int
+    bytes_done: int = 0
 
 
 @dataclass(frozen=True)
@@ -279,6 +319,15 @@ class ArtifactAcquisitionService:
         self._credential_resolver = credential_resolver
         self._free_bytes_probe = free_bytes_probe
         self._trusted_origins = trusted_origins
+        # In-process serialization for provision() (Task 6): queues same-
+        # process concurrent callers so only one at a time ever attempts the
+        # OS-backed acquisition-session lease below -- without this, two
+        # concurrent in-process calls would race each other for that
+        # exclusive lease and one would see AcquisitionBusyError even though
+        # no OTHER process is involved, which is the wrong signal in-process
+        # (queue and proceed, not "busy"). Safe to construct without a
+        # running loop on Python >= 3.10.
+        self._lock = asyncio.Lock()
 
     async def preflight(self, root: ArtifactRef, catalog: ArtifactCatalog) -> PreflightReport:
         """Aggregate space, staged-credit, and repository-gating checks.
@@ -298,6 +347,44 @@ class ArtifactAcquisitionService:
         Returns:
             A frozen ``PreflightReport``; call ``.grant()`` on it to obtain
             an ``AcquisitionConsent``.
+
+        Raises:
+            CatalogError: Propagated from an unknown ref, a dependency
+                cycle, or a conflicting-revision closure.
+        """
+        _closure, report, gating_targets = self._aggregate_closure(root, catalog)
+        gating_errors = await self._probe_gating(gating_targets.values())
+        return replace(report, gating_errors=tuple(gating_errors))
+
+    def _aggregate_closure(
+        self,
+        root: ArtifactRef,
+        catalog: ArtifactCatalog,
+    ) -> tuple[tuple[ArtifactDescriptor, ...], PreflightReport, dict[str, ArtifactPreflightEntry]]:
+        """Resolve the catalog closure and aggregate space/staged-credit math.
+
+        Pure and network-free: the only I/O is ``core.list_installed()`` and
+        ``core.disk_usage()`` (or the injected ``free_bytes_probe``), the
+        same fast synchronous calls ``preflight()`` already made directly
+        (Task 5) without an executor hop. Extracted (Task 6) so
+        ``preflight()`` and ``provision()`` share one aggregation instead of
+        two copies that could silently drift apart: ``preflight()`` layers
+        its own network gating probe on top of the returned report;
+        ``provision()`` re-runs this exact aggregation, still network-free,
+        to recheck the closure fingerprint and free space against a
+        possibly-drifted catalog without repeating the gating probe a
+        second time per run (gating already passed at grant time).
+
+        Args:
+            root: The root artifact reference to resolve and aggregate.
+            catalog: Catalog supplying descriptors for the closure walk.
+
+        Returns:
+            A tuple of: the closure descriptors in stable sorted order; a
+            ``PreflightReport`` with ``gating_errors`` deliberately left
+            empty (the caller decides whether and how to probe); and the
+            per-repository gating-probe targets, for a caller that wants to
+            hand them to ``_probe_gating``.
 
         Raises:
             CatalogError: Propagated from an unknown ref, a dependency
@@ -387,9 +474,7 @@ class ArtifactAcquisitionService:
             else self._core.disk_usage().free_bytes
         )
 
-        gating_errors = await self._probe_gating(gating_targets.values())
-
-        return PreflightReport(
+        report = PreflightReport(
             root=root,
             closure_fingerprint=fingerprint,
             entries=tuple(entries),
@@ -401,8 +486,206 @@ class ArtifactAcquisitionService:
             free_bytes=free_bytes,
             required_bytes=required_bytes,
             sufficient_space=free_bytes >= required_bytes,
-            gating_errors=tuple(gating_errors),
+            gating_errors=(),
         )
+        return closure, report, gating_targets
+
+    async def provision(
+        self,
+        root: ArtifactRef,
+        consent: AcquisitionConsent,
+        catalog: ArtifactCatalog,
+        *,
+        progress: Callable[[AcquisitionProgress], None] | None = None,
+    ) -> ArtifactRef:
+        """Acquire and activate one consented closure, resuming idempotently.
+
+        Serializes against every other ``provision()`` call twice over: an
+        in-process ``asyncio.Lock`` queues same-process callers first (so
+        two concurrent calls in this process never race the OS-backed lease
+        against each other and see a spurious busy error), then a single
+        exclusive, non-blocking ``ACQUISITION_SESSION_LEASE_KEY`` lease
+        serializes against every other OS process. The session lease is
+        held for this call's ENTIRE run -- acquired before any phase runs,
+        released only in a ``finally`` after activation succeeds or any step
+        raises -- because ``reconcile()``'s managed-staging GC
+        (``service.py``'s ``_gc_managed_staging``) treats a free session
+        lease as permission to delete orphaned download staging; releasing
+        early would let a reconcile pass race a live download the same way
+        an early Task 2 draft let it race a live ``install()``.
+
+        Re-walks ``catalog`` from ``root`` independently of ``consent``: the
+        closure fingerprint is recomputed via the same network-free
+        aggregation ``preflight()`` uses and compared against
+        ``consent.closure_fingerprint`` -- a changed dependency set since
+        ``preflight()`` raises ``ConsentMismatchError``, since consent to
+        the old content no longer applies to the new one. Free space is
+        rechecked from that same aggregation; this recheck deliberately
+        skips the network gating probe (gating already passed at grant
+        time, and repeating it here would add a per-provision network round
+        trip for no benefit at this phase).
+
+        Artifacts already present in ``core.list_installed()`` are skipped
+        entirely, bypassing the fetch/pre-verify/install phases -- this is
+        both the idempotent-completion path for a fully provisioned closure
+        and the crash-after-install recovery path (Tasks 7-8 exercise the
+        latter with a mid-closure crash).
+
+        Args:
+            root: The root artifact reference to provision.
+            consent: Consent obtained from a prior ``preflight().grant()``
+                call.
+            catalog: Catalog supplying descriptors for the closure re-walk.
+                Not carried by ``consent`` itself -- re-walking is what
+                makes the fingerprint drift check meaningful, and the
+                freshly resolved descriptors supply the file URLs the
+                fetch phase needs.
+            progress: Optional sink for ``AcquisitionProgress`` events
+                emitted by the fetch and pre-verify phases (Tasks 7-8).
+
+        Returns:
+            The activated root artifact reference.
+
+        Raises:
+            AcquisitionBusyError: Another acquisition session -- in this
+                process or another -- already holds the session lease.
+            ConsentMismatchError: The re-walked closure fingerprint no
+                longer matches ``consent`` (the catalog changed since
+                ``preflight()``).
+            InsufficientSpaceError: Free space no longer covers the
+                required bytes for this closure.
+            CatalogError: Propagated from an unknown ref, a dependency
+                cycle, or a conflicting-revision closure during the
+                re-walk.
+            NotImplementedError: A not-yet-installed artifact reached the
+                fetch, pre-verify, or install phase stub (Tasks 7-8 fill
+                these in).
+        """
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            lease = ArtifactOperationLease(
+                self._core.locks_path,
+                ACQUISITION_SESSION_LEASE_KEY,
+                LeaseMode.EXCLUSIVE,
+                timeout_seconds=_SESSION_LEASE_TIMEOUT_SECONDS,
+            )
+            try:
+                await loop.run_in_executor(None, lease.acquire)
+            except ArtifactLeaseTimeoutError as error:
+                raise AcquisitionBusyError(
+                    "another managed acquisition session is already active"
+                ) from error
+            try:
+                closure, report, _gating_targets = self._aggregate_closure(root, catalog)
+                if report.closure_fingerprint != consent.closure_fingerprint:
+                    raise ConsentMismatchError(
+                        "closure fingerprint changed since consent was granted; "
+                        "re-run preflight and obtain new consent"
+                    )
+                if not report.sufficient_space:
+                    raise InsufficientSpaceError(
+                        f"required {report.required_bytes} bytes but only "
+                        f"{report.free_bytes} free"
+                    )
+
+                installed = self._core.list_installed()
+                installed_refs = {
+                    item.descriptor.reference
+                    for item in installed
+                    if item.descriptor is not None
+                }
+
+                progress_state = _ProvisionProgressState(
+                    callback=progress,
+                    bytes_total=report.download_bytes,
+                )
+
+                for descriptor in closure:
+                    if descriptor.reference in installed_refs:
+                        continue
+                    staging_dir = (
+                        self._core.staging_path
+                        / "managed"
+                        / descriptor.reference.artifact_id
+                        / descriptor.reference.revision
+                        / descriptor.reference.variant
+                    )
+                    await self._fetch_artifact(descriptor, staging_dir, progress_state)
+                    await self._preverify_artifact(descriptor, staging_dir, progress_state)
+                    await self._install_artifact(descriptor, staging_dir)
+
+                return await loop.run_in_executor(None, self._core.activate, root)
+            finally:
+                await loop.run_in_executor(None, lease.release)
+
+    async def _fetch_artifact(
+        self,
+        descriptor: ArtifactDescriptor,
+        staging_dir: Path,
+        progress_state: _ProvisionProgressState,
+    ) -> None:
+        """Stream every declared file into durable staging with resume support.
+
+        Stub (Task 6); Task 7 implements this phase. The signature is final
+        -- ``provision()``'s call site will not change when it does.
+
+        Args:
+            descriptor: The artifact whose declared files to fetch.
+            staging_dir: The durable ``staging/managed/<id>/<rev>/<variant>``
+                directory for this artifact.
+            progress_state: Closure-wide progress accounting to read and
+                update as bytes stream in.
+
+        Raises:
+            NotImplementedError: Always, until Task 7 implements this phase.
+        """
+
+        raise NotImplementedError("fetch phase is implemented in a later task")
+
+    async def _preverify_artifact(
+        self,
+        descriptor: ArtifactDescriptor,
+        staging_dir: Path,
+        progress_state: _ProvisionProgressState,
+    ) -> None:
+        """Streaming-verify every staged file's SHA-256 before install.
+
+        Stub (Task 6); Task 8 implements this phase. The signature is final
+        -- ``provision()``'s call site will not change when it does.
+
+        Args:
+            descriptor: The artifact whose staged files to verify.
+            staging_dir: The durable staging directory holding the fetched
+                files.
+            progress_state: Closure-wide progress accounting to read and
+                update as bytes are verified.
+
+        Raises:
+            NotImplementedError: Always, until Task 8 implements this phase.
+        """
+
+        raise NotImplementedError("pre-verify phase is implemented in a later task")
+
+    async def _install_artifact(
+        self,
+        descriptor: ArtifactDescriptor,
+        staging_dir: Path,
+    ) -> None:
+        """Promote one pre-verified staged directory into the immutable store.
+
+        Stub (Task 6); Task 8 implements this phase. The signature is final
+        -- ``provision()``'s call site will not change when it does.
+
+        Args:
+            descriptor: The artifact to install.
+            staging_dir: The durable staging directory holding the verified
+                files.
+
+        Raises:
+            NotImplementedError: Always, until Task 8 implements this phase.
+        """
+
+        raise NotImplementedError("install phase is implemented in a later task")
 
     def _staged_bytes_for(self, ref: ArtifactRef) -> int:
         """Best-effort resumable-byte credit from a fetch-state sidecar.

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -43,6 +43,7 @@ from .service import (
     ArtifactConflictError,
     ArtifactError,
     ArtifactIntegrityError,
+    ArtifactPathError,
     ArtifactRef,
     ArtifactStateError,
     closure_fingerprint,
@@ -74,6 +75,41 @@ _CoreCallResult = TypeVar("_CoreCallResult")
 # precedence EnvConfigCredentialResolver (below) actually implements against
 # these same names: HUGGINGFACE_API_KEY, then HF_TOKEN, then config.
 _CREDENTIAL_ENV_HINT = "HUGGINGFACE_API_KEY (or HF_TOKEN)"
+
+# The fetch-state sidecar's filename SUFFIX when addressed as a sibling of
+# its staging directory (see _fetch_sidecar_path). Mirrors
+# service.py's _MANAGED_FETCH_SIDECAR_SUFFIX (private there, used by the
+# staging GC classifier) -- a drift-guard test in
+# test_reconcile_staging_gc.py fails if the two ever diverge, the same
+# pattern fetch.py's _STRIP_HEADERS uses against egress.py's.
+_FETCH_SIDECAR_SUFFIX = ".fetch-state.json"
+
+
+def _fetch_sidecar_path(staging_dir: Path) -> Path:
+    """Sibling fetch-state sidecar path for a managed staging directory.
+
+    TASK-595 final-review P2: the sidecar used to live INSIDE the payload
+    directory it describes (``staging_dir / "fetch-state.json"``) --
+    ``core.install``'s payload-tree validation rejects any file it
+    doesn't declare, so ``_install_artifact`` had to delete the sidecar
+    before every install attempt, destroying the only resumable state on
+    ANY install failure (including a merely transient, retryable one).
+    Living OUTSIDE the payload tree instead -- a sibling FILE named after
+    the staging directory, not a child of it -- means ``core.install``
+    never sees it at all, so nothing needs deleting before the call, and
+    a failed install leaves the sidecar (and the staged bytes it
+    describes) exactly where a later ``provision()`` attempt can resume
+    from.
+
+    Args:
+        staging_dir: The ``staging/managed/<id>/<rev>/<variant>`` payload
+            directory for one artifact.
+
+    Returns:
+        The sidecar path, a sibling of ``staging_dir`` (same parent
+        directory, name ``<variant>.fetch-state.json``).
+    """
+    return staging_dir.parent / f"{staging_dir.name}{_FETCH_SIDECAR_SUFFIX}"
 
 
 # Error hierarchy: all subclass ArtifactError
@@ -661,7 +697,11 @@ class ArtifactAcquisitionService:
                 # Clamp per entry: a stale/corrupt sidecar claiming more
                 # bytes than this artifact's own declared total must not
                 # inflate the credit shown on the consent screen.
-                staged = min(self._staged_bytes_for(ref), entry.total_bytes)
+                # ``_staged_bytes_for`` already caps each FILE's own credit
+                # by its actual on-disk size (not just the declared size),
+                # but this outer clamp against the entry's aggregate total
+                # stays as defense-in-depth.
+                staged = min(self._staged_bytes_for(descriptor), entry.total_bytes)
                 already_staged_bytes += staged
                 # Floored PER ENTRY (max(total-staged,0) here, not summed
                 # totals minus summed staged then floored once at the end)
@@ -952,7 +992,7 @@ class ArtifactAcquisitionService:
         _require_single_file(descriptor)
 
         staging_dir.mkdir(parents=True, exist_ok=True)
-        sidecar_path = staging_dir / "fetch-state.json"
+        sidecar_path = _fetch_sidecar_path(staging_dir)
         sidecar = self._load_fetch_sidecar(sidecar_path)
 
         client = self._client_factory() if self._client_factory is not None else None
@@ -1109,6 +1149,21 @@ class ArtifactAcquisitionService:
         )
 
         recorded_done = self._reconcile_durable_bytes(destination, recorded_done)
+
+        # A checkpoint from a PRIOR provision() run can exceed the file's
+        # CURRENT declared size if the catalog's declared size for this
+        # artifact/revision/variant shrank between runs (a corrected or
+        # re-cut upstream entry) -- reconciliation above only cross-checks
+        # recorded_done against the file's ACTUAL on-disk bytes, never
+        # against file.size_bytes. Left unchecked, this becomes
+        # resume_from >= max_bytes inside stream_fetch, which raises
+        # FetchTooLargeError -- wrongly surfaced as a non-retryable
+        # "upstream body exceeds declared size" failure for what is really
+        # just a stale, over-large checkpoint. Normalizing to zero here
+        # restarts the file cleanly instead: stream_fetch's mode="wb" path
+        # (resume_from == 0) truncates whatever stale bytes are on disk.
+        if recorded_done > file.size_bytes:
+            recorded_done = 0
 
         if recorded_done == file.size_bytes:
             # Reconciliation already confirms the on-disk file is exactly
@@ -1330,10 +1385,16 @@ class ArtifactAcquisitionService:
         """
 
         destination = staging_dir / file.path
-        sidecar_path = staging_dir / "fetch-state.json"
+        sidecar_path = _fetch_sidecar_path(staging_dir)
         attempts_used = 0
+        loop = asyncio.get_running_loop()
         while True:
-            digest = self._hash_staged_file(destination, descriptor, file, progress_state)
+            digest = await loop.run_in_executor(
+                None,
+                functools.partial(
+                    self._hash_staged_file, destination, descriptor, file, progress_state, loop
+                ),
+            )
             if digest == file.sha256:
                 return
             if attempts_used >= MAX_FILE_REFETCHES:
@@ -1358,8 +1419,33 @@ class ArtifactAcquisitionService:
         descriptor: ArtifactDescriptor,
         file: ArtifactFile,
         progress_state: _ProvisionProgressState,
+        loop: asyncio.AbstractEventLoop,
     ) -> str:
         """Stream one staged file's SHA-256, reporting real byte progress.
+
+        Runs entirely off the event loop: ``_preverify_one_file`` invokes
+        this via ``loop.run_in_executor``, never directly from an async
+        context. Hashing a staged file synchronously inside a coroutine
+        would block every other coroutine (including any other artifact's
+        fetch/pre-verify progress, and any UI event loop this service
+        shares) for as long as a multi-gigabyte file takes to read and
+        digest -- there is no ``await`` anywhere in a tight
+        ``hashlib.sha256().update()`` loop to yield control back.
+
+        Progress-callback invocation is marshalled back onto ``loop`` via
+        ``call_soon_threadsafe`` rather than called directly from this
+        (executor) thread: ``progress_state.callback`` is caller-supplied
+        and may update UI state that, per this codebase's threading
+        convention (``CLAUDE.md``'s "Background Work" pattern -- workers
+        call back via ``call_from_thread``, never directly), must only
+        ever be touched from the event-loop thread. ``call_soon_threadsafe``
+        is the non-Textual-specific equivalent: it schedules the callback
+        to run on ``loop`` without blocking this thread's chunk-read loop
+        waiting for it. Byte counters on ``progress_state`` are still
+        updated directly from this thread -- safe because
+        ``_preverify_artifact`` processes one file at a time, so only one
+        executor call is ever hashing at once; no concurrent writer exists
+        to race against.
 
         A zero-byte declared file (Task 7 guarantees the destination exists
         even then) reads zero chunks and hashes to the empty digest --
@@ -1374,6 +1460,8 @@ class ArtifactAcquisitionService:
                 ``file`` and to size chunk reads.
             progress_state: Closure-wide progress accounting to read and
                 update as bytes are hashed.
+            loop: The event loop ``progress_state.callback`` must be
+                invoked on.
 
         Returns:
             The lowercase hex SHA-256 digest of the file's current content.
@@ -1385,15 +1473,14 @@ class ArtifactAcquisitionService:
                 digest.update(chunk)
                 progress_state.preverify_bytes_done += len(chunk)
                 if progress_state.callback is not None:
-                    progress_state.callback(
-                        AcquisitionProgress(
-                            phase="pre-verify",
-                            ref=descriptor.reference,
-                            file=file.path,
-                            bytes_done=progress_state.preverify_bytes_done,
-                            bytes_total=progress_state.preverify_bytes_total,
-                        )
+                    event = AcquisitionProgress(
+                        phase="pre-verify",
+                        ref=descriptor.reference,
+                        file=file.path,
+                        bytes_done=progress_state.preverify_bytes_done,
+                        bytes_total=progress_state.preverify_bytes_total,
                     )
+                    loop.call_soon_threadsafe(progress_state.callback, event)
         return digest.hexdigest()
 
     async def _install_artifact(
@@ -1403,25 +1490,31 @@ class ArtifactAcquisitionService:
     ) -> None:
         """Promote one pre-verified staged directory into the immutable store.
 
-        The fetch-state sidecar is removed BEFORE calling ``core.install``,
-        not after: ``install``'s payload-tree validation requires the
-        source directory to contain EXACTLY the descriptor's declared
-        files, and ``fetch-state.json`` is an acquisition-owned file the
-        core knows nothing about -- leaving it in place would make every
-        install fail with "source contains an undeclared file". Once
-        pre-verify has confirmed every staged file's content, the sidecar's
-        resume checkpoints have already served their purpose.
+        The fetch-state sidecar lives OUTSIDE ``staging_dir`` (see
+        ``_fetch_sidecar_path``) -- a SIBLING file, never a child of the
+        payload directory ``core.install`` validates -- so it is left
+        completely untouched here until AFTER a successful install. This
+        is deliberately NOT the same as the earlier design, which deleted
+        an in-tree sidecar before every attempt (required then, since
+        ``install``'s payload-tree validation rejects any file it doesn't
+        declare): that pre-deletion destroyed the only resumable state on
+        ANY install failure, including a merely transient, retryable one
+        -- a "retryable" error that also destroys what it would resume
+        from is not actually retryable. With the sidecar out of the
+        payload tree, ``core.install`` never even sees it, so a failed
+        attempt leaves both the sidecar and the staged bytes it describes
+        exactly where a later ``provision()`` call can resume from.
 
         ``core.install(..., consume_source=True)`` is synchronous core
         surface (file moves, lease acquisition, manifest writes), so it
         runs in the default executor like every other core call this
         service makes. On success, ``consume_source`` has moved every
-        declared file out of ``staging_dir`` into the immutable store; the
-        now-empty (files and sidecar both gone) directory tree is removed
-        so a later ``reconcile()`` staging GC sees nothing left to
-        classify for this artifact -- an empty leftover directory with no
-        sidecar would otherwise look identical to an abandoned partial
-        download.
+        declared file out of ``staging_dir`` into the immutable store;
+        the now-empty directory tree AND its sibling sidecar are both
+        removed so a later ``reconcile()`` staging GC sees nothing left
+        to classify for this artifact -- an empty leftover directory (or
+        a stale sidecar with no matching payload) would otherwise look
+        identical to an abandoned partial download.
 
         Args:
             descriptor: The artifact to install.
@@ -1430,21 +1523,20 @@ class ArtifactAcquisitionService:
 
         Raises:
             TransferError: ``core.install`` raised ``ArtifactIntegrityError``,
-                ``ArtifactConflictError``, or ``ArtifactStateError`` --
-                wrapped by ``_run_core_call`` with ``retryable`` set
-                accordingly (see there). Only a SUCCESSFUL install triggers
-                the ``staging_dir`` cleanup above -- on failure it is left
-                in place (though ``consume_source`` may already have moved
-                its declared files into the core's own, separately-cleaned-
-                up staging by the time the failure surfaces, so an empty
-                leftover directory is not itself proof anything is wrong).
+                ``ArtifactConflictError``, ``ArtifactPathError``, or
+                ``ArtifactStateError`` -- wrapped by ``_run_core_call``
+                with ``retryable`` set accordingly (see there). Only a
+                SUCCESSFUL install triggers the ``staging_dir``/sidecar
+                cleanup above -- on failure both are left in place (though
+                ``consume_source`` may already have moved the payload's
+                declared files into the core's own, separately-cleaned-up
+                staging by the time the failure surfaces, so an empty
+                leftover payload directory is not itself proof anything
+                is wrong; the sidecar's checkpoint is what a resumed
+                fetch actually trusts).
         """
 
-        sidecar_path = staging_dir / "fetch-state.json"
-        try:
-            sidecar_path.unlink()
-        except FileNotFoundError:
-            pass
+        sidecar_path = _fetch_sidecar_path(staging_dir)
 
         await self._run_core_call(
             "install",
@@ -1454,6 +1546,14 @@ class ArtifactAcquisitionService:
             ),
         )
 
+        # Only reached on a SUCCESSFUL install -- both the (now-consumed)
+        # payload directory and its sibling sidecar are cleaned up
+        # together; a failure raised above skips this entirely, leaving
+        # both in place for a resumed provision() attempt.
+        try:
+            sidecar_path.unlink()
+        except FileNotFoundError:
+            pass
         shutil.rmtree(staging_dir, ignore_errors=True)
 
     async def _run_core_call(
@@ -1467,12 +1567,13 @@ class ArtifactAcquisitionService:
         ``core.install`` and ``core.activate`` are the two core entry
         points this service reaches via a bare executor hop; both can raise
         the core's own ``ArtifactError`` subclasses (integrity, conflict,
-        or lease/state contention), which would otherwise escape
-        ``provision()`` untouched -- breaking the spec's never-trap rule
-        that every acquisition-surfaced failure is a typed, retryable-
-        flagged ``AcquisitionError``. ``ArtifactIntegrityError`` and
-        ``ArtifactConflictError`` are not retryable: the same staged
-        content, or the same conflicting destination, would fail again.
+        path safety, or lease/state contention), which would otherwise
+        escape ``provision()`` untouched -- breaking the spec's never-trap
+        rule that every acquisition-surfaced failure is a typed, retryable-
+        flagged ``AcquisitionError``. ``ArtifactIntegrityError``,
+        ``ArtifactConflictError``, and ``ArtifactPathError`` are not
+        retryable: the same staged content, the same conflicting
+        destination, or the same unsafe/invalid path would fail again.
         ``ArtifactStateError`` (and its subclasses, e.g.
         ``ArtifactInUseError`` -- lease-timeout/contention style failures)
         is retryable: a later attempt may find the contended resource free.
@@ -1491,14 +1592,14 @@ class ArtifactAcquisitionService:
 
         Raises:
             TransferError: ``func`` raised ``ArtifactIntegrityError``,
-                ``ArtifactConflictError``, or ``ArtifactStateError`` (or a
-                subclass of any of these).
+                ``ArtifactConflictError``, ``ArtifactPathError``, or
+                ``ArtifactStateError`` (or a subclass of any of these).
         """
 
         loop = asyncio.get_running_loop()
         try:
             return await loop.run_in_executor(None, func)
-        except (ArtifactIntegrityError, ArtifactConflictError) as exc:
+        except (ArtifactIntegrityError, ArtifactConflictError, ArtifactPathError) as exc:
             raise TransferError(
                 f"{operation} failed for {ref.artifact_id}@{ref.revision}: {exc}",
                 retryable=False,
@@ -1535,7 +1636,7 @@ class ArtifactAcquisitionService:
                 )
             )
 
-    def _staged_bytes_for(self, ref: ArtifactRef) -> int:
+    def _staged_bytes_for(self, descriptor: ArtifactDescriptor) -> int:
         """Best-effort resumable-byte credit from a fetch-state sidecar.
 
         A missing or unparseable sidecar reads as zero credit: staged bytes
@@ -1543,20 +1644,33 @@ class ArtifactAcquisitionService:
         already fetched") -- ``provision()`` independently re-validates
         against the server's current validators before trusting any of it.
 
+        Each declared file's credit is capped by THREE independent limits:
+        the sidecar's own recorded ``bytes_done``, the file's declared
+        size, and -- the gap this closes -- the file's ACTUAL size on disk
+        right now. Capping by the declared size alone (the previous
+        behavior) still let a stale or hand-corrupted sidecar claim bytes
+        for a file that was truncated, never written, or removed out from
+        under it, inflating the credit preflight uses to decide whether
+        there's enough free space for the REMAINING download -- a report
+        computed against phantom credit can approve an acquisition that
+        then runs out of space partway through. A sidecar entry naming a
+        file this descriptor doesn't actually declare is ignored outright,
+        not just uncapped: crediting it at all would credit bytes for
+        something ``provision()`` will never look at.
+
         Args:
-            ref: The artifact reference whose staging directory to inspect.
+            descriptor: The artifact descriptor whose staging directory and
+                declared files to inspect.
 
         Returns:
-            The sum of ``bytes_done`` across every file in the sidecar, or 0.
+            The sum of capped per-file credit, or 0 for a missing or
+            unparseable sidecar.
         """
-        sidecar = (
-            self._core.staging_path
-            / "managed"
-            / ref.artifact_id
-            / ref.revision
-            / ref.variant
-            / "fetch-state.json"
+        ref = descriptor.reference
+        staging_dir = (
+            self._core.staging_path / "managed" / ref.artifact_id / ref.revision / ref.variant
         )
+        sidecar = _fetch_sidecar_path(staging_dir)
         try:
             payload = json.loads(sidecar.read_text(encoding="utf-8"))
         except (OSError, ValueError):
@@ -1564,13 +1678,25 @@ class ArtifactAcquisitionService:
         files = payload.get("files") if isinstance(payload, dict) else None
         if not isinstance(files, dict):
             return 0
+        declared_sizes = {file.path: file.size_bytes for file in descriptor.files}
         total = 0
-        for info in files.values():
+        for file_path, info in files.items():
+            if file_path not in declared_sizes:
+                continue
             if not isinstance(info, dict):
                 continue
             bytes_done = info.get("bytes_done")
-            if isinstance(bytes_done, int) and not isinstance(bytes_done, bool) and bytes_done >= 0:
-                total += bytes_done
+            if not (
+                isinstance(bytes_done, int)
+                and not isinstance(bytes_done, bool)
+                and bytes_done >= 0
+            ):
+                continue
+            try:
+                actual_size = (staging_dir / file_path).stat().st_size
+            except OSError:
+                actual_size = 0
+            total += min(bytes_done, actual_size, declared_sizes[file_path])
         return total
 
     async def _probe_gating(self, targets: Iterable[ArtifactPreflightEntry]) -> list[str]:

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -1,0 +1,220 @@
+"""TASK-595: managed model acquisition types and catalog resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Protocol
+
+from .service import ArtifactError, ArtifactRef
+
+if TYPE_CHECKING:
+    from .service import ArtifactDescriptor
+
+
+# Constants per spec (Docs/superpowers/specs/2026-07-30-managed-model-acquisition-design.md)
+ACQUISITION_SAFETY_MARGIN_BYTES = 256 * 1024 * 1024
+MAX_FILE_REFETCHES = 1
+
+
+# Error hierarchy: all subclass ArtifactError
+class AcquisitionError(ArtifactError):
+    """Base error for acquisition operations."""
+
+    pass
+
+
+class CatalogError(AcquisitionError):
+    """Catalog lookup, cycle, or revision-conflict error."""
+
+    pass
+
+
+class ConsentMismatchError(AcquisitionError):
+    """Closure fingerprint changed between preflight and provision."""
+
+    pass
+
+
+class PreflightNotGrantableError(AcquisitionError):
+    """Preflight report cannot be granted due to gating or space errors."""
+
+    pass
+
+
+class AcquisitionBusyError(AcquisitionError):
+    """Another acquisition session is already active."""
+
+    pass
+
+
+class InsufficientSpaceError(AcquisitionError):
+    """Insufficient free space for acquisition."""
+
+    pass
+
+
+class GatedRepositoryError(AcquisitionError):
+    """Authenticated repository requires credentials or fails access."""
+
+    pass
+
+
+class TransferError(AcquisitionError):
+    """Network or transfer error with optional retry flag."""
+
+    def __init__(self, message: str, retryable: bool = False) -> None:
+        """Initialize TransferError with retryable flag.
+
+        Args:
+            message: The error message.
+            retryable: Whether this error is retryable.
+        """
+        super().__init__(message)
+        self.retryable = retryable
+
+
+# Protocol for catalog descriptors
+class ArtifactCatalog(Protocol):
+    """Protocol for artifact descriptor catalogs."""
+
+    def descriptor(self, ref: ArtifactRef) -> ArtifactDescriptor:
+        """Retrieve a descriptor by reference.
+
+        Args:
+            ref: The artifact reference.
+
+        Returns:
+            The artifact descriptor.
+
+        Raises:
+            KeyError: If the reference is not found.
+        """
+        ...
+
+
+# Frozen dataclasses per spec
+@dataclass(frozen=True)
+class ArtifactPreflightEntry:
+    """One artifact entry in a preflight report."""
+
+    ref: ArtifactRef
+    source_url: str
+    repository: str
+    revision: str
+    license_id: str
+    license_url: str
+    precision: str
+    total_bytes: int
+    file_count: int
+    already_installed: bool
+
+
+@dataclass(frozen=True)
+class AcquisitionConsent:
+    """Consent to acquire a resolved closure."""
+
+    closure_fingerprint: str
+
+
+@dataclass(frozen=True)
+class AcquisitionProgress:
+    """Progress during an active acquisition operation."""
+
+    phase: Literal["fetch", "pre-verify", "verify-install", "activate"]
+    ref: ArtifactRef
+    file: str | None
+    bytes_done: int
+    bytes_total: int
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """Preflight report for a closure before acquisition.
+
+    Fields marked as space/bytes are in bytes. The report aggregates
+    requirements and fails early on gating or space constraints before
+    any actual downloads.
+    """
+
+    root: ArtifactRef
+    closure_fingerprint: str
+    entries: tuple[ArtifactPreflightEntry, ...]
+    download_bytes: int
+    already_staged_bytes: int
+    staging_overhead_bytes: int
+    retained_bytes: int
+    destination: Path
+    free_bytes: int
+    required_bytes: int
+    sufficient_space: bool
+    gating_errors: tuple[str, ...]
+
+    def grant(self) -> AcquisitionConsent:
+        """Grant acquisition consent from this preflight report.
+
+        Raises PreflightNotGrantableError if gating_errors is non-empty
+        or sufficient_space is False.
+
+        Returns:
+            AcquisitionConsent carrying the closure fingerprint.
+
+        Raises:
+            PreflightNotGrantableError: If gating errors exist or space is insufficient.
+        """
+        if self.gating_errors or not self.sufficient_space:
+            raise PreflightNotGrantableError(
+                f"preflight not grantable: gating_errors={self.gating_errors}, "
+                f"sufficient_space={self.sufficient_space}"
+            )
+        return AcquisitionConsent(closure_fingerprint=self.closure_fingerprint)
+
+
+def resolve_catalog_closure(
+    root: ArtifactRef, catalog: ArtifactCatalog
+) -> tuple[ArtifactDescriptor, ...]:
+    """Resolve the full dependency closure from catalog descriptors.
+
+    Deliberately not the core's _resolve_closure (which reads installed
+    manifests): at preflight, dependencies may not be installed at all.
+    Same rules: cycle and revision-conflict detection; stable sorted order.
+
+    Args:
+        root: The root artifact reference to resolve from.
+        catalog: The catalog providing descriptors for references.
+
+    Returns:
+        A tuple of artifact descriptors in stable sorted order (by ref).
+
+    Raises:
+        CatalogError: If an unknown ref is encountered, a dependency cycle
+            is detected, or two different revisions of the same artifact_id
+            appear in the closure.
+    """
+    resolved: dict[ArtifactRef, ArtifactDescriptor] = {}
+    revisions: dict[str, ArtifactRef] = {}
+    visiting: set[ArtifactRef] = set()
+
+    def visit(ref: ArtifactRef) -> None:
+        if ref in resolved:
+            return
+        if ref in visiting:
+            raise CatalogError(f"dependency cycle at {ref.artifact_id}")
+        seen = revisions.get(ref.artifact_id)
+        if seen is not None and seen != ref:
+            raise CatalogError(
+                f"conflicting revisions for {ref.artifact_id}: {seen.revision} vs {ref.revision}"
+            )
+        visiting.add(ref)
+        try:
+            descriptor = catalog.descriptor(ref)
+        except Exception as exc:
+            raise CatalogError(f"unknown artifact {ref.artifact_id}@{ref.revision}") from exc
+        revisions[ref.artifact_id] = ref
+        for dep in descriptor.dependencies:
+            visit(dep)
+        visiting.discard(ref)
+        resolved[ref] = descriptor
+
+    visit(root)
+    return tuple(resolved[ref] for ref in sorted(resolved))

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -7,11 +7,21 @@ import json
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Protocol
+from urllib.parse import urljoin
 
 import httpx
 
+from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
 from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise_async
 
+from .fetch import (
+    FetchRestartRequired,
+    FetchResult,
+    FetchTooLargeError,
+    FetchTransportError,
+    FetchValidators,
+    stream_fetch,
+)
 from .leases import ArtifactLeaseTimeoutError, ArtifactOperationLease, LeaseMode
 from .service import (
     ACQUISITION_SESSION_LEASE_KEY,
@@ -21,7 +31,7 @@ from .service import (
 )
 
 if TYPE_CHECKING:
-    from .service import ArtifactDescriptor, ModelArtifactService
+    from .service import ArtifactDescriptor, ArtifactFile, ModelArtifactService
 
 
 # Constants per spec (Docs/superpowers/specs/2026-07-30-managed-model-acquisition-design.md)
@@ -626,8 +636,27 @@ class ArtifactAcquisitionService:
     ) -> None:
         """Stream every declared file into durable staging with resume support.
 
-        Stub (Task 6); Task 7 implements this phase. The signature is final
-        -- ``provision()``'s call site will not change when it does.
+        For each file declared on ``descriptor``: a sidecar entry already
+        marked complete (and whose on-disk size matches) is skipped outright;
+        otherwise the durable sidecar's ``bytes_done`` is reconciled against
+        the file's ACTUAL on-disk size before any resume is attempted (see
+        ``_reconcile_durable_bytes``), then the file is streamed via
+        ``fetch.stream_fetch`` -- resumed with a ``Range`` request when
+        strong validators survive reconciliation, restarted from zero
+        otherwise. ``fetch.FetchRestartRequired`` (validators changed, or
+        the server ignored ``Range``) truncates and restarts that one file
+        from zero exactly once inline; this is unrelated to Task 8's
+        pre-verify refetch-once counter, which guards against a corrupt
+        payload that DOWNLOADED cleanly but fails its SHA-256.
+
+        Durability order (spec-mandated): ``stream_fetch`` fsyncs the file's
+        data before returning; only after a successful return is the sidecar
+        rewritten (atomically, via the same ``atomic_write_json`` the core
+        uses) to record the new checkpoint. A file that fails to fetch at
+        all -- network drop, ENOSPC, oversized body -- leaves the sidecar
+        untouched at its last durable checkpoint; the staging directory and
+        any unfsynced on-disk bytes past that checkpoint are left in place
+        (never cleaned up here) for a later resume attempt to reconcile.
 
         Args:
             descriptor: The artifact whose declared files to fetch.
@@ -637,10 +666,310 @@ class ArtifactAcquisitionService:
                 update as bytes stream in.
 
         Raises:
-            NotImplementedError: Always, until Task 7 implements this phase.
+            TransferError: A file failed to fetch -- network/transport
+                failure, disk I/O failure (e.g. ENOSPC), an egress-policy
+                block, or a response body exceeding the file's declared
+                size. ``retryable`` is True for transport/I/O failures,
+                False for an egress block or an oversized body (the same
+                URL would presumably answer the same way again).
+            asyncio.CancelledError: Propagated untouched if this call is
+                cancelled while awaiting network I/O; honored between
+                stream_fetch's internal chunks (asyncio-native, no manual
+                polling).
         """
 
-        raise NotImplementedError("fetch phase is implemented in a later task")
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        sidecar_path = staging_dir / "fetch-state.json"
+        sidecar = self._load_fetch_sidecar(sidecar_path)
+
+        client = self._client_factory() if self._client_factory is not None else None
+        owns_client = client is None
+        if owns_client:
+            client = httpx.AsyncClient()
+        assert client is not None
+        try:
+            for file in descriptor.files:
+                await self._fetch_one_file(
+                    descriptor, file, staging_dir, sidecar, sidecar_path, progress_state, client
+                )
+        finally:
+            if owns_client:
+                await client.aclose()
+
+    def _file_url(self, descriptor: ArtifactDescriptor, file: ArtifactFile) -> str:
+        """Resolve one declared file's download URL.
+
+        ``ArtifactDescriptor.source_url`` is the only fetchable location
+        this schema carries today (Task 596/1301's catalog work owns
+        richer per-file source metadata); when a descriptor declares
+        exactly one file -- the only shape exercised end-to-end so far --
+        ``source_url`` IS that file's URL directly, matching how
+        ``_probe_gating`` already treats it (a bare GET/HEAD target, never
+        joined with anything). For a descriptor declaring more than one
+        file, ``source_url`` is treated as the artifact's base location and
+        each file's relative ``path`` is joined onto it (trailing slash
+        ensured) -- the conventional repo-resolve-URL shape.
+
+        Args:
+            descriptor: The artifact descriptor supplying ``source_url``.
+            file: The declared file whose URL to resolve.
+
+        Returns:
+            The absolute URL to GET this file's bytes from.
+        """
+
+        if len(descriptor.files) == 1:
+            return descriptor.source_url
+        base = descriptor.source_url
+        if not base.endswith("/"):
+            base += "/"
+        return urljoin(base, file.path)
+
+    @staticmethod
+    def _load_fetch_sidecar(sidecar_path: Path) -> dict:
+        """Best-effort load of a fetch-state sidecar; a missing/corrupt one reads empty.
+
+        Args:
+            sidecar_path: The ``fetch-state.json`` path for one artifact.
+
+        Returns:
+            ``{"files": {...}}`` -- the parsed sidecar, or an empty shell.
+        """
+
+        try:
+            payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {"files": {}}
+        files = payload.get("files") if isinstance(payload, dict) else None
+        return {"files": files if isinstance(files, dict) else {}}
+
+    @staticmethod
+    def _reconcile_durable_bytes(destination: Path, recorded_done: int) -> int:
+        """Trust on-disk bytes only up to the sidecar's durable checkpoint.
+
+        ``fetch.stream_fetch`` resumes by opening its destination in append
+        mode at whatever the file's CURRENT length happens to be -- it does
+        not seek to ``resume_from`` itself. A file that grew past the last
+        durable sidecar checkpoint (a crash or dropped connection after
+        partial, un-fsynced writes) must be truncated back down to that
+        checkpoint before any resume is attempted, or unverified bytes would
+        be silently trusted. Symmetrically, a file SHORTER than the sidecar
+        claims means the sidecar itself over-claims -- nothing about it can
+        be trusted, so this restarts the file from zero.
+
+        Args:
+            destination: The staged file's path (may not exist yet).
+            recorded_done: The sidecar's last durably recorded byte count
+                for this file (0 if there is no usable entry).
+
+        Returns:
+            The byte count now safe to resume from -- always either
+            ``recorded_done`` (file truncated down to it, or already
+            consistent) or ``0`` (sidecar over-claimed; file removed).
+        """
+
+        actual_bytes = destination.stat().st_size if destination.exists() else 0
+        if actual_bytes > recorded_done:
+            with open(destination, "r+b") as fh:
+                fh.truncate(recorded_done)
+            return recorded_done
+        if actual_bytes < recorded_done:
+            if destination.exists():
+                destination.unlink()
+            return 0
+        return recorded_done
+
+    async def _fetch_one_file(
+        self,
+        descriptor: ArtifactDescriptor,
+        file: ArtifactFile,
+        staging_dir: Path,
+        sidecar: dict,
+        sidecar_path: Path,
+        progress_state: _ProvisionProgressState,
+        client: httpx.AsyncClient,
+    ) -> None:
+        """Fetch (or skip, or resume, or restart) one declared file.
+
+        Args:
+            descriptor: The artifact this file belongs to.
+            file: The declared file to fetch.
+            staging_dir: The durable staging directory for this artifact.
+            sidecar: The mutable in-memory sidecar payload (``{"files": {}}``);
+                updated and persisted in place on a successful fetch.
+            sidecar_path: Where to atomically persist ``sidecar`` after a
+                successful fetch.
+            progress_state: Closure-wide progress accounting.
+            client: The shared ``httpx.AsyncClient`` for this artifact's
+                fetch phase.
+
+        Raises:
+            TransferError: See ``_fetch_artifact``.
+        """
+
+        destination = staging_dir / file.path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        entry = sidecar["files"].get(file.path)
+        entry = dict(entry) if isinstance(entry, dict) else {}
+        recorded_raw = entry.get("bytes_done")
+        recorded_done = (
+            recorded_raw
+            if isinstance(recorded_raw, int)
+            and not isinstance(recorded_raw, bool)
+            and recorded_raw >= 0
+            else 0
+        )
+
+        recorded_done = self._reconcile_durable_bytes(destination, recorded_done)
+
+        if recorded_done == file.size_bytes:
+            # Reconciliation already confirms the on-disk file is exactly
+            # the declared size -- nothing left to fetch. SHA-256 content
+            # correctness is Task 8's pre-verify job, not this phase's.
+            if not entry.get("complete") or entry.get("bytes_done") != recorded_done:
+                sidecar["files"][file.path] = {
+                    "etag": entry.get("etag"),
+                    "last_modified": entry.get("last_modified"),
+                    "bytes_done": recorded_done,
+                    "complete": True,
+                }
+                atomic_write_json(sidecar_path, sidecar)
+            return
+
+        validators: FetchValidators | None = None
+        if entry.get("etag") is not None or entry.get("last_modified") is not None:
+            validators = FetchValidators(
+                etag=entry.get("etag"), last_modified=entry.get("last_modified")
+            )
+        resume_from = (
+            recorded_done if recorded_done and validators is not None and validators.strong else 0
+        )
+
+        url = self._file_url(descriptor, file)
+
+        def on_chunk(count: int) -> None:
+            progress_state.bytes_done += count
+            if progress_state.callback is not None:
+                progress_state.callback(
+                    AcquisitionProgress(
+                        phase="fetch",
+                        ref=descriptor.reference,
+                        file=file.path,
+                        bytes_done=progress_state.bytes_done,
+                        bytes_total=progress_state.bytes_total,
+                    )
+                )
+
+        try:
+            result, used_resume_from = await self._stream_with_restart(
+                url,
+                destination,
+                client=client,
+                max_bytes=file.size_bytes,
+                resume_from=resume_from,
+                validators=validators,
+                on_chunk=on_chunk,
+            )
+        except OSError as exc:
+            raise TransferError(
+                f"I/O error fetching '{file.path}': {exc}", retryable=True
+            ) from exc
+        except FetchTooLargeError as exc:
+            raise TransferError(
+                f"upstream body exceeds declared size for '{file.path}': {exc}",
+                retryable=False,
+            ) from exc
+        except FetchTransportError as exc:
+            raise TransferError(
+                f"transport error fetching '{file.path}': {exc}", retryable=True
+            ) from exc
+        except EgressBlockedError as exc:
+            # Never a raw exception mid-provision (spec's never-trap rule):
+            # unlike _probe_gating's own best-effort HEAD probe (which
+            # silently skips a blocked URL -- consent doesn't hinge on it),
+            # an egress block during the real fetch means these bytes
+            # genuinely cannot be retrieved. Not retryable: it's a policy
+            # decision on this URL, not a transient network condition.
+            raise TransferError(
+                f"egress policy blocked fetching '{file.path}': {exc}", retryable=False
+            ) from exc
+
+        total_done = used_resume_from + result.bytes_written
+        sidecar["files"][file.path] = {
+            "etag": result.validators.etag,
+            "last_modified": result.validators.last_modified,
+            "bytes_done": total_done,
+            "complete": total_done == file.size_bytes,
+        }
+        atomic_write_json(sidecar_path, sidecar)
+
+    async def _stream_with_restart(
+        self,
+        url: str,
+        destination: Path,
+        *,
+        client: httpx.AsyncClient,
+        max_bytes: int,
+        resume_from: int,
+        validators: FetchValidators | None,
+        on_chunk: Callable[[int], None],
+    ) -> tuple[FetchResult, int]:
+        """Call ``stream_fetch``, restarting once from zero on FetchRestartRequired.
+
+        Args:
+            url: The file's download URL.
+            destination: Where to stream the file's bytes.
+            client: The shared ``httpx.AsyncClient``.
+            max_bytes: The hard bound on the final file size (the
+                descriptor's declared ``size_bytes`` for this file).
+            resume_from: Durable bytes already on disk (post-reconciliation).
+            validators: Validators the existing bytes were fetched under.
+            on_chunk: Progress callback forwarded to ``stream_fetch``.
+
+        Returns:
+            The successful ``FetchResult`` together with the ``resume_from``
+            value actually used to obtain it (``0`` if a restart occurred).
+
+        Raises:
+            FetchRestartRequired: Raised again if even a from-zero attempt
+                is rejected (not expected in practice -- ``stream_fetch``
+                only raises this for a nonzero ``resume_from``).
+            FetchTooLargeError: Propagated from ``stream_fetch``.
+            FetchTransportError: Propagated from ``stream_fetch``.
+            OSError: Propagated from a local disk failure (e.g. ENOSPC).
+        """
+
+        try:
+            result = await stream_fetch(
+                url,
+                destination,
+                client=client,
+                max_bytes=max_bytes,
+                resume_from=resume_from,
+                validators=validators,
+                headers=None,
+                trusted_origins=self._trusted_origins,
+                on_chunk=on_chunk,
+            )
+            return result, resume_from
+        except FetchRestartRequired:
+            if resume_from == 0:
+                raise
+            if destination.exists():
+                destination.unlink()
+            result = await stream_fetch(
+                url,
+                destination,
+                client=client,
+                max_bytes=max_bytes,
+                resume_from=0,
+                validators=None,
+                headers=None,
+                trusted_origins=self._trusted_origins,
+                on_chunk=on_chunk,
+            )
+            return result, 0
 
     async def _preverify_artifact(
         self,

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -6,13 +6,15 @@ import asyncio
 import functools
 import hashlib
 import json
+import os
 import shutil
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterable, Literal, Protocol
+from typing import TYPE_CHECKING, Callable, Iterable, Literal, Mapping, Protocol, runtime_checkable
 
 import httpx
 
+from tldw_chatbook.config import get_cli_setting
 from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
 from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise_async
 
@@ -50,9 +52,8 @@ _PREFLIGHT_PROBE_TIMEOUT_SECONDS = 10.0
 _SESSION_LEASE_TIMEOUT_SECONDS = 0.1
 
 # Credential hint named in gating_errors -- never a token value. Matches the
-# existing env precedence this codebase already documents (config.py's
-# HUGGINGFACE_API_KEY, Constants.py's HF_TOKEN); Task 9 wires an actual
-# CredentialResolver against these same names.
+# precedence EnvConfigCredentialResolver (below) actually implements against
+# these same names: HUGGINGFACE_API_KEY, then HF_TOKEN, then config.
 _CREDENTIAL_ENV_HINT = "HUGGINGFACE_API_KEY (or HF_TOKEN)"
 
 
@@ -130,6 +131,85 @@ class ArtifactCatalog(Protocol):
             KeyError: If the reference is not found.
         """
         ...
+
+
+@runtime_checkable
+class CredentialResolver(Protocol):
+    """Resolves a per-request bearer token for a repository, without persistence.
+
+    An implementation returns ``None`` when no credential is configured --
+    a gated repository with no working credential then fails visibly at
+    ``preflight()`` (surfaced via ``PreflightReport.gating_errors``) rather
+    than silently proceeding anonymously and failing later, mid-transfer.
+
+    A token this protocol resolves is attached ONLY to the request for the
+    entry's OWN origin (see ``ArtifactAcquisitionService._auth_headers``,
+    consulted by both the preflight gating probe and the real fetch);
+    ``fetch.stream_fetch`` independently strips any ``Authorization`` header
+    on a cross-origin redirect hop regardless -- defense in depth, not the
+    only guard against a token reaching the wrong host.
+    """
+
+    def resolve(self, repository: str) -> str | None:
+        """Resolve a bearer token for ``repository``.
+
+        Args:
+            repository: The upstream repository identifier, e.g.
+                ``ArtifactDescriptor.upstream_repository``.
+
+        Returns:
+            A bearer token string, or ``None`` if no credential is
+            configured for this repository.
+        """
+        ...
+
+
+class EnvConfigCredentialResolver:
+    """Default ``CredentialResolver``: env vars, then config -- no keyring yet.
+
+    Precedence mirrors this codebase's existing HuggingFace credential
+    lookup exactly: ``config.py``'s ``huggingface_api_key`` resolves
+    ``HUGGINGFACE_API_KEY`` from the environment ahead of the ``[API]``
+    config section, and ``Constants.py`` separately documents ``HF_TOKEN``
+    as the equivalent env name other tooling in this ecosystem (llama.cpp's
+    server) already uses. This resolver checks, in order: ``HUGGINGFACE_API_KEY``
+    env, then ``HF_TOKEN`` env, then the ``[API] huggingface_api_key``
+    config setting via ``config.get_cli_setting``.
+
+    Keyring lookup ("where available", per the design spec's Credentials
+    section) is DELIBERATELY not implemented here: this class wires only
+    the env/config precedence this repository's other HuggingFace-key
+    consumers already use. A keyring backend is a follow-up, not required
+    by this task's acceptance criteria.
+
+    Read-only, every call -- a resolved token is never written back to the
+    environment, config, or anywhere else.
+    """
+
+    def resolve(self, repository: str) -> str | None:
+        """Resolve a HuggingFace-style bearer token.
+
+        ``repository`` is accepted to satisfy ``CredentialResolver`` but
+        otherwise unused: the token this resolver returns is global to the
+        process's configured identity (env or config), not scoped per
+        repository -- matching how every other HuggingFace-key consumer in
+        this codebase already resolves credentials.
+
+        Args:
+            repository: Unused; see class docstring.
+
+        Returns:
+            The resolved token, or ``None`` if none is configured anywhere
+            in the env/config precedence chain.
+        """
+        for env_var in ("HUGGINGFACE_API_KEY", "HF_TOKEN"):
+            token = os.environ.get(env_var)
+            if token:
+                return token
+        config_token = get_cli_setting("API", "huggingface_api_key", None)
+        if isinstance(config_token, str) and config_token:
+            return config_token
+        return None
 
 
 # Frozen dataclasses per spec
@@ -318,7 +398,7 @@ class ArtifactAcquisitionService:
         core: ModelArtifactService,
         *,
         client_factory: Callable[[], httpx.AsyncClient] | None = None,
-        credential_resolver: Callable[[str], str | None] | None = None,
+        credential_resolver: CredentialResolver | None = None,
         free_bytes_probe: Callable[[Path], int] | None = None,
         trusted_origins: frozenset[str] = frozenset(),
     ) -> None:
@@ -330,11 +410,17 @@ class ArtifactAcquisitionService:
             client_factory: Optional zero-arg factory returning a caller-owned
                 ``httpx.AsyncClient`` (reused across probes/fetches). When
                 absent, a short-lived client is created and closed per call.
-            credential_resolver: Optional repository -> token resolver. Not
-                yet consulted by ``preflight()`` (the HEAD probe is always
-                anonymous here); accepted now so the constructor shape is
-                stable across the whole feature -- a later task wires actual
-                credential attachment for gated repositories.
+            credential_resolver: Optional ``CredentialResolver`` (see
+                ``EnvConfigCredentialResolver`` for the default env/config
+                implementation). ``None`` means every request goes out
+                anonymous; a gated repository then fails at ``preflight()``
+                with a ``gating_errors`` entry naming the credential env var
+                to set, never a token value. When present, a resolved
+                token is attached as ``Authorization: Bearer`` to BOTH the
+                preflight gating HEAD probe and the real per-file fetch
+                (``_auth_headers``), so a working credential clears gating
+                and lets the transfer itself succeed against the same
+                gated repository.
             free_bytes_probe: Optional override returning available free
                 bytes at a given path, injected by tests instead of
                 ``core.disk_usage().free_bytes`` / ``shutil.disk_usage``.
@@ -357,6 +443,34 @@ class ArtifactAcquisitionService:
         # (queue and proceed, not "busy"). Safe to construct without a
         # running loop on Python >= 3.10.
         self._lock = asyncio.Lock()
+
+    def _auth_headers(self, repository: str) -> dict[str, str] | None:
+        """Resolve an ``Authorization`` header for ``repository``, or ``None``.
+
+        The single seam every credentialed request in this service goes
+        through -- the preflight gating HEAD probe (``_probe_gating``) and
+        the real per-file fetch (``_fetch_one_file``) both call this rather
+        than touching ``self._credential_resolver`` directly, so there is
+        exactly one place that ever holds a resolved token in memory here.
+        Never logged and never embedded in an error message -- callers that
+        need to describe what's being fetched use ``repository`` or the
+        file path, never this return value's contents.
+
+        Args:
+            repository: The upstream repository identifier to resolve a
+                credential for.
+
+        Returns:
+            ``{"Authorization": "Bearer <token>"}`` when a resolver is
+            configured and returns a truthy token for ``repository``, else
+            ``None`` (no header attached -- the request goes out anonymous).
+        """
+        if self._credential_resolver is None:
+            return None
+        token = self._credential_resolver.resolve(repository)
+        if not token:
+            return None
+        return {"Authorization": f"Bearer {token}"}
 
     async def preflight(self, root: ArtifactRef, catalog: ArtifactCatalog) -> PreflightReport:
         """Aggregate space, staged-credit, and repository-gating checks.
@@ -922,6 +1036,7 @@ class ArtifactAcquisitionService:
         )
 
         url = self._file_url(descriptor, file)
+        headers = self._auth_headers(descriptor.upstream_repository)
 
         def on_chunk(count: int) -> None:
             progress_state.bytes_done += count
@@ -944,6 +1059,7 @@ class ArtifactAcquisitionService:
                 max_bytes=file.size_bytes,
                 resume_from=resume_from,
                 validators=validators,
+                headers=headers,
                 on_chunk=on_chunk,
             )
         except OSError as exc:
@@ -988,6 +1104,7 @@ class ArtifactAcquisitionService:
         max_bytes: int,
         resume_from: int,
         validators: FetchValidators | None,
+        headers: Mapping[str, str] | None = None,
         on_chunk: Callable[[int], None],
     ) -> tuple[FetchResult, int]:
         """Call ``stream_fetch``, restarting once from zero on FetchRestartRequired.
@@ -1000,6 +1117,11 @@ class ArtifactAcquisitionService:
                 descriptor's declared ``size_bytes`` for this file).
             resume_from: Durable bytes already on disk (post-reconciliation).
             validators: Validators the existing bytes were fetched under.
+            headers: Extra headers (``_auth_headers``'s ``Authorization``,
+                if any) for the request to ``url``'s own origin -- carried
+                through to BOTH the initial attempt and a from-zero restart;
+                ``stream_fetch`` itself strips them on any cross-origin
+                redirect hop regardless of what's passed here.
             on_chunk: Progress callback forwarded to ``stream_fetch``.
 
         Returns:
@@ -1023,7 +1145,7 @@ class ArtifactAcquisitionService:
                 max_bytes=max_bytes,
                 resume_from=resume_from,
                 validators=validators,
-                headers=None,
+                headers=headers,
                 trusted_origins=self._trusted_origins,
                 on_chunk=on_chunk,
             )
@@ -1040,7 +1162,7 @@ class ArtifactAcquisitionService:
                 max_bytes=max_bytes,
                 resume_from=0,
                 validators=None,
-                headers=None,
+                headers=headers,
                 trusted_origins=self._trusted_origins,
                 on_chunk=on_chunk,
             )
@@ -1292,7 +1414,15 @@ class ArtifactAcquisitionService:
         return total
 
     async def _probe_gating(self, targets: Iterable[ArtifactPreflightEntry]) -> list[str]:
-        """Bounded, anonymous HEAD probe per repository; collect 401/403s.
+        """Bounded HEAD probe per repository; collect 401/403s.
+
+        Anonymous unless a ``credential_resolver`` is configured AND
+        resolves a token for the entry's repository, in which case the
+        probe carries the same ``Authorization`` header the real fetch
+        would use (``_auth_headers``) -- a working credential clears
+        gating here exactly as it would clear the real transfer, instead
+        of preflight reporting a repository gated that provision() would
+        actually be able to reach.
 
         Any other outcome -- 2xx/3xx/other 4xx/5xx, timeout, connection
         failure, or an egress-policy block -- is silently non-fatal here:
@@ -1322,7 +1452,9 @@ class ArtifactAcquisitionService:
                         entry.source_url, trusted_origins=self._trusted_origins
                     )
                     response = await client.head(
-                        entry.source_url, timeout=_PREFLIGHT_PROBE_TIMEOUT_SECONDS
+                        entry.source_url,
+                        timeout=_PREFLIGHT_PROBE_TIMEOUT_SECONDS,
+                        headers=self._auth_headers(entry.repository),
                     )
                 except (httpx.HTTPError, EgressBlockedError):
                     continue

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import hashlib
 import json
@@ -10,7 +11,16 @@ import os
 import shutil
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterable, Literal, Mapping, Protocol, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterable,
+    Literal,
+    Mapping,
+    Protocol,
+    TypeVar,
+    runtime_checkable,
+)
 
 import httpx
 
@@ -29,8 +39,12 @@ from .fetch import (
 from .leases import ArtifactLeaseTimeoutError, ArtifactOperationLease, LeaseMode
 from .service import (
     ACQUISITION_SESSION_LEASE_KEY,
+    NONBLOCKING_LEASE_TIMEOUT_SECONDS,
+    ArtifactConflictError,
     ArtifactError,
+    ArtifactIntegrityError,
     ArtifactRef,
+    ArtifactStateError,
     closure_fingerprint,
 )
 
@@ -45,11 +59,16 @@ MAX_FILE_REFETCHES = 1
 # Bounded timeout for the preflight repository-gating HEAD probe (Task 5).
 _PREFLIGHT_PROBE_TIMEOUT_SECONDS = 10.0
 
-# Non-blocking acquisition-session-lease timeout (Task 6): an immediate,
-# typed AcquisitionBusyError beats a hang -- another process or in-process
-# caller already holding the session lease means "busy right now", not
-# "worth waiting for".
-_SESSION_LEASE_TIMEOUT_SECONDS = 0.1
+# Non-blocking acquisition-session-lease timeout: an immediate, typed
+# AcquisitionBusyError beats a hang -- another process or in-process caller
+# already holding the session lease means "busy right now", not "worth
+# waiting for". Imported from service.py (not redefined here) -- this same
+# 0.1s value also gates reconcile()'s two staging-GC lease probes, and a
+# single shared constant keeps the three call sites from silently drifting
+# apart.
+_SESSION_LEASE_TIMEOUT_SECONDS = NONBLOCKING_LEASE_TIMEOUT_SECONDS
+
+_CoreCallResult = TypeVar("_CoreCallResult")
 
 # Credential hint named in gating_errors -- never a token value. Matches the
 # precedence EnvConfigCredentialResolver (below) actually implements against
@@ -255,40 +274,59 @@ class _ProvisionProgressState:
     it, unchanged, into ``_fetch_artifact`` and ``_preverify_artifact`` for
     every artifact in the closure. Task 7 reads and updates ``bytes_done``
     as each declared file streams; Task 8 reads and updates
-    ``preverify_bytes_done`` as each staged file is hashed. Both counters
-    are reported against the SAME ``bytes_total`` (the closure's declared
-    download bytes -- the exact same files are streamed in the fetch phase
-    and hashed in the pre-verify phase) but are tracked SEPARATELY: fetch
-    finishes one full closure-wide pass through ``bytes_total`` before
-    pre-verify begins its own, so a single shared counter would either
-    stall at 100% through the whole pre-verify phase or run past 100% --
-    neither is "closure-wide, not reset per artifact or per file", the
-    property this class exists to provide. ``callback`` is called with an
-    ``AcquisitionProgress`` event carrying whichever counter belongs to the
-    active phase.
+    ``preverify_bytes_done`` as each staged file is hashed. The two phases
+    are tracked against SEPARATE totals, not just separate running counts:
+    ``bytes_total`` is the closure's declared DOWNLOAD bytes
+    (``PreflightReport.download_bytes``), which nets out any already-staged
+    credit from a resumed run, while ``preverify_bytes_total`` is the
+    closure's full declared file size, unaffected by staged credit --
+    ``_hash_staged_file`` always re-hashes a staged file's ENTIRE on-disk
+    content regardless of how much of it was freshly downloaded versus
+    already present when this run started, so reusing the (possibly
+    netted-down) fetch total for pre-verify's progress would make ANY
+    resumed run's pre-verify events overshoot 100%. ``callback`` is called
+    with an ``AcquisitionProgress`` event carrying whichever counter (and
+    total) belongs to the active phase.
 
     Args:
         callback: The caller's optional progress sink, forwarded unchanged
             from ``provision()``'s own ``progress`` keyword argument.
-        bytes_total: Total bytes still to download (and, in the pre-verify
-            phase, to re-hash) across the whole closure
+        bytes_total: Total bytes still to download across the whole closure
             (``PreflightReport.download_bytes``), computed once before the
-            per-artifact loop starts.
+            per-artifact loop starts. Nets out already-staged credit --
+            NOT the total bytes pre-verify will hash; see
+            ``preverify_bytes_total``.
+        preverify_bytes_total: Total bytes pre-verify will hash across the
+            whole closure -- the full declared size of every not-yet-
+            installed artifact's files (``ArtifactDescriptor.
+            expected_installed_bytes``), regardless of how much of that was
+            already staged before this run started. Defaults to
+            ``bytes_total`` (see ``__post_init__``) so existing direct-
+            construction call sites that only exercise the fetch phase are
+            unaffected; ``provision()`` itself always passes both totals
+            explicitly, independently computed.
         bytes_done: Running total of bytes fetched so far across every
             artifact already processed in this run; starts at zero.
         preverify_bytes_done: Running total of bytes hashed so far during
             the pre-verify phase, across every artifact already processed
             in this run; starts at zero. A pre-verify hash mismatch and
             refetch (Task 8) re-streams and re-hashes the same file, so
-            this counter can advance past ``bytes_total`` in that recovery
-            path -- an acceptable cosmetic wrinkle in an uncommon retry,
-            not a steady-state property.
+            this counter can advance past ``preverify_bytes_total`` in that
+            recovery path -- an acceptable cosmetic wrinkle in an uncommon
+            retry, not a steady-state property.
     """
 
     callback: Callable[[AcquisitionProgress], None] | None
     bytes_total: int
+    preverify_bytes_total: int | None = None
     bytes_done: int = 0
     preverify_bytes_done: int = 0
+
+    def __post_init__(self) -> None:
+        """Default ``preverify_bytes_total`` to ``bytes_total`` when unset."""
+
+        if self.preverify_bytes_total is None:
+            self.preverify_bytes_total = self.bytes_total
 
 
 @dataclass(frozen=True)
@@ -381,6 +419,34 @@ def resolve_catalog_closure(
 
     visit(root)
     return tuple(resolved[ref] for ref in sorted(resolved))
+
+
+def _require_single_file(descriptor: ArtifactDescriptor) -> None:
+    """Raise ``CatalogError`` unless ``descriptor`` declares exactly one file.
+
+    Per-file source URLs are undefined until the catalog work
+    (TASK-596/1301) specifies them (see ``_file_url``). Shared by
+    ``_aggregate_closure`` -- so a not-yet-installed multi-file descriptor
+    fails ``preflight()`` itself, before any report or consent exists --
+    and ``_fetch_artifact`` (defense-in-depth: a descriptor's shape could in
+    principle change between ``preflight()`` and ``provision()``'s
+    independent catalog re-walk).
+
+    Args:
+        descriptor: The descriptor to check.
+
+    Raises:
+        CatalogError: ``descriptor`` declares more than one file.
+    """
+
+    if len(descriptor.files) != 1:
+        ref = descriptor.reference
+        raise CatalogError(
+            f"{ref.artifact_id}@{ref.revision} declares "
+            f"{len(descriptor.files)} files, but per-file source URLs "
+            "are undefined until the catalog work (TASK-596/1301) "
+            "specifies them"
+        )
 
 
 class ArtifactAcquisitionService:
@@ -493,7 +559,9 @@ class ArtifactAcquisitionService:
 
         Raises:
             CatalogError: Propagated from an unknown ref, a dependency
-                cycle, or a conflicting-revision closure.
+                cycle, a conflicting-revision closure, or a not-yet-
+                installed entry declaring more than one file (see
+                ``_require_single_file``).
         """
         _closure, report, gating_targets = self._aggregate_closure(root, catalog)
         gating_errors = await self._probe_gating(gating_targets.values())
@@ -531,7 +599,9 @@ class ArtifactAcquisitionService:
 
         Raises:
             CatalogError: Propagated from an unknown ref, a dependency
-                cycle, or a conflicting-revision closure.
+                cycle, a conflicting-revision closure, or a not-yet-
+                installed entry declaring more than one file (see
+                ``_require_single_file``).
         """
         closure = resolve_catalog_closure(root, catalog)
         fingerprint = closure_fingerprint(root, (descriptor.reference for descriptor in closure))
@@ -578,6 +648,16 @@ class ArtifactAcquisitionService:
             )
             entries.append(entry)
             if not already_installed:
+                # Fail loudly here, not just later in _fetch_artifact: a
+                # multi-file descriptor that still needs fetching is a
+                # catalog-contract problem (per-file URLs are undefined --
+                # see _require_single_file), and the spec requires catalog
+                # problems to surface at preflight, before any report or
+                # consent exists. An ALREADY-installed multi-file
+                # descriptor never reaches provision()'s fetch phase (the
+                # per-artifact loop skips installed entries outright), so
+                # it is deliberately not checked here.
+                _require_single_file(descriptor)
                 # Clamp per entry: a stale/corrupt sidecar claiming more
                 # bytes than this artifact's own declared total must not
                 # inflate the credit shown on the consent screen.
@@ -708,9 +788,13 @@ class ArtifactAcquisitionService:
             CatalogError: Propagated from an unknown ref, a dependency
                 cycle, or a conflicting-revision closure during the
                 re-walk.
-            TransferError: A file failed to fetch, or a staged file failed
-                pre-verify a second time after one automatic refetch --
-                nothing is installed for that artifact.
+            TransferError: A file failed to fetch, a staged file failed
+                pre-verify a second time after one automatic refetch, or
+                ``core.install``/``core.activate`` raised a core
+                ``ArtifactError`` (integrity, conflict, or state/lease
+                contention -- see ``_run_core_call``). Nothing further is
+                installed or activated for that artifact once this is
+                raised.
         """
         async with self._lock:
             loop = asyncio.get_running_loop()
@@ -720,13 +804,31 @@ class ArtifactAcquisitionService:
                 LeaseMode.EXCLUSIVE,
                 timeout_seconds=_SESSION_LEASE_TIMEOUT_SECONDS,
             )
+            # The acquire itself must live INSIDE this try/finally, not
+            # before it (a prior review found the release leaked): once
+            # lease.acquire() has started running in its worker thread, it
+            # cannot be interrupted, so a CancelledError delivered while it
+            # is still in flight must not skip past the finally below
+            # without first learning whether the acquire actually
+            # succeeded. asyncio.shield keeps the executor future running
+            # even if THIS await is cancelled; the except-CancelledError
+            # branch then waits for that same future to actually settle
+            # (ignoring whatever it raises) before re-raising, so
+            # `lease.acquired` below always reflects the true outcome
+            # instead of a stale "not yet" snapshot.
+            acquire_future = loop.run_in_executor(None, lease.acquire)
             try:
-                await loop.run_in_executor(None, lease.acquire)
-            except ArtifactLeaseTimeoutError as error:
-                raise AcquisitionBusyError(
-                    "another managed acquisition session is already active"
-                ) from error
-            try:
+                try:
+                    await asyncio.shield(acquire_future)
+                except ArtifactLeaseTimeoutError as error:
+                    raise AcquisitionBusyError(
+                        "another managed acquisition session is already active"
+                    ) from error
+                except asyncio.CancelledError:
+                    with contextlib.suppress(BaseException):
+                        await acquire_future
+                    raise
+
                 closure, report, _gating_targets = self._aggregate_closure(root, catalog)
                 if report.closure_fingerprint != consent.closure_fingerprint:
                     raise ConsentMismatchError(
@@ -749,6 +851,11 @@ class ArtifactAcquisitionService:
                 progress_state = _ProvisionProgressState(
                     callback=progress,
                     bytes_total=report.download_bytes,
+                    preverify_bytes_total=sum(
+                        descriptor.expected_installed_bytes
+                        for descriptor in closure
+                        if descriptor.reference not in installed_refs
+                    ),
                 )
 
                 for descriptor in closure:
@@ -773,11 +880,14 @@ class ArtifactAcquisitionService:
                         progress_state, "verify-install", descriptor.reference
                     )
 
-                activated = await loop.run_in_executor(None, self._core.activate, root)
+                activated = await self._run_core_call(
+                    "activate", root, functools.partial(self._core.activate, root)
+                )
                 self._emit_indeterminate_progress(progress_state, "activate", root)
                 return activated
             finally:
-                await loop.run_in_executor(None, lease.release)
+                if lease.acquired:
+                    await loop.run_in_executor(None, lease.release)
 
     async def _fetch_artifact(
         self,
@@ -822,6 +932,11 @@ class ArtifactAcquisitionService:
                 (TASK-596/1301) specifies them (see ``_file_url``). Raised
                 before touching staging, the sidecar, or the network: a
                 catalog-contract problem, not a transfer failure.
+                ``_aggregate_closure`` already rejects this same shape for
+                a not-yet-installed entry at ``preflight()`` time; this is
+                defense-in-depth for a descriptor that changed shape
+                between ``preflight()`` and ``provision()``'s independent
+                catalog re-walk.
             TransferError: A file failed to fetch -- network/transport
                 failure, disk I/O failure (e.g. ENOSPC), an egress-policy
                 block, or a response body exceeding the file's declared
@@ -834,16 +949,7 @@ class ArtifactAcquisitionService:
                 polling).
         """
 
-        if len(descriptor.files) != 1:
-            # Fail loudly before any I/O: see _file_url for why guessing a
-            # per-file URL for a multi-file descriptor is unsafe.
-            ref = descriptor.reference
-            raise CatalogError(
-                f"{ref.artifact_id}@{ref.revision} declares "
-                f"{len(descriptor.files)} files, but per-file source URLs "
-                "are undefined until the catalog work (TASK-596/1301) "
-                "specifies them"
-            )
+        _require_single_file(descriptor)
 
         staging_dir.mkdir(parents=True, exist_ok=True)
         sidecar_path = staging_dir / "fetch-state.json"
@@ -1285,7 +1391,7 @@ class ArtifactAcquisitionService:
                             ref=descriptor.reference,
                             file=file.path,
                             bytes_done=progress_state.preverify_bytes_done,
-                            bytes_total=progress_state.bytes_total,
+                            bytes_total=progress_state.preverify_bytes_total,
                         )
                     )
         return digest.hexdigest()
@@ -1323,14 +1429,15 @@ class ArtifactAcquisitionService:
                 files.
 
         Raises:
-            ArtifactError: Propagated from ``core.install`` (e.g. an
-                integrity or conflict failure). Only a SUCCESSFUL install
-                triggers the ``staging_dir`` cleanup above -- on failure it
-                is left in place (though ``consume_source`` may already
-                have moved its declared files into the core's own,
-                separately-cleaned-up staging by the time the failure
-                surfaces, so an empty leftover directory is not itself
-                proof anything is wrong).
+            TransferError: ``core.install`` raised ``ArtifactIntegrityError``,
+                ``ArtifactConflictError``, or ``ArtifactStateError`` --
+                wrapped by ``_run_core_call`` with ``retryable`` set
+                accordingly (see there). Only a SUCCESSFUL install triggers
+                the ``staging_dir`` cleanup above -- on failure it is left
+                in place (though ``consume_source`` may already have moved
+                its declared files into the core's own, separately-cleaned-
+                up staging by the time the failure surfaces, so an empty
+                leftover directory is not itself proof anything is wrong).
         """
 
         sidecar_path = staging_dir / "fetch-state.json"
@@ -1339,15 +1446,68 @@ class ArtifactAcquisitionService:
         except FileNotFoundError:
             pass
 
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
+        await self._run_core_call(
+            "install",
+            descriptor.reference,
             functools.partial(
                 self._core.install, descriptor, staging_dir, consume_source=True
             ),
         )
 
         shutil.rmtree(staging_dir, ignore_errors=True)
+
+    async def _run_core_call(
+        self,
+        operation: Literal["install", "activate"],
+        ref: ArtifactRef,
+        func: Callable[[], _CoreCallResult],
+    ) -> _CoreCallResult:
+        """Run one synchronous core call in the executor, never trapping raw.
+
+        ``core.install`` and ``core.activate`` are the two core entry
+        points this service reaches via a bare executor hop; both can raise
+        the core's own ``ArtifactError`` subclasses (integrity, conflict,
+        or lease/state contention), which would otherwise escape
+        ``provision()`` untouched -- breaking the spec's never-trap rule
+        that every acquisition-surfaced failure is a typed, retryable-
+        flagged ``AcquisitionError``. ``ArtifactIntegrityError`` and
+        ``ArtifactConflictError`` are not retryable: the same staged
+        content, or the same conflicting destination, would fail again.
+        ``ArtifactStateError`` (and its subclasses, e.g.
+        ``ArtifactInUseError`` -- lease-timeout/contention style failures)
+        is retryable: a later attempt may find the contended resource free.
+        The original error is preserved as ``__cause__`` (``raise ... from
+        exc``); the wrapped message names only the operation, artifact id,
+        and revision -- never a path.
+
+        Args:
+            operation: Which core call this is, for the error message only.
+            ref: The artifact reference the call concerns.
+            func: A zero-argument callable wrapping the real core call (see
+                ``functools.partial`` at both call sites).
+
+        Returns:
+            The core call's own return value, unchanged.
+
+        Raises:
+            TransferError: ``func`` raised ``ArtifactIntegrityError``,
+                ``ArtifactConflictError``, or ``ArtifactStateError`` (or a
+                subclass of any of these).
+        """
+
+        loop = asyncio.get_running_loop()
+        try:
+            return await loop.run_in_executor(None, func)
+        except (ArtifactIntegrityError, ArtifactConflictError) as exc:
+            raise TransferError(
+                f"{operation} failed for {ref.artifact_id}@{ref.revision}: {exc}",
+                retryable=False,
+            ) from exc
+        except ArtifactStateError as exc:
+            raise TransferError(
+                f"{operation} failed for {ref.artifact_id}@{ref.revision}: {exc}",
+                retryable=True,
+            ) from exc
 
     @staticmethod
     def _emit_indeterminate_progress(
@@ -1455,6 +1615,14 @@ class ArtifactAcquisitionService:
                         entry.source_url,
                         timeout=_PREFLIGHT_PROBE_TIMEOUT_SECONDS,
                         headers=self._auth_headers(entry.repository),
+                        # Explicit regardless of the client's own default:
+                        # client_factory is a public seam, and an injected
+                        # client configured to follow redirects would
+                        # otherwise both bypass this app's own egress check
+                        # for the redirect target (only entry.source_url is
+                        # checked above) and carry the bearer token
+                        # cross-origin.
+                        follow_redirects=False,
                     )
                 except (httpx.HTTPError, EgressBlockedError):
                     continue

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -2,19 +2,33 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Callable, Iterable, Literal, Protocol
 
-from .service import ArtifactError, ArtifactRef
+import httpx
+
+from tldw_chatbook.Utils.egress import EgressBlockedError, check_url_or_raise_async
+
+from .service import ArtifactError, ArtifactRef, closure_fingerprint
 
 if TYPE_CHECKING:
-    from .service import ArtifactDescriptor
+    from .service import ArtifactDescriptor, ModelArtifactService
 
 
 # Constants per spec (Docs/superpowers/specs/2026-07-30-managed-model-acquisition-design.md)
 ACQUISITION_SAFETY_MARGIN_BYTES = 256 * 1024 * 1024
 MAX_FILE_REFETCHES = 1
+
+# Bounded timeout for the preflight repository-gating HEAD probe (Task 5).
+_PREFLIGHT_PROBE_TIMEOUT_SECONDS = 10.0
+
+# Credential hint named in gating_errors -- never a token value. Matches the
+# existing env precedence this codebase already documents (config.py's
+# HUGGINGFACE_API_KEY, Constants.py's HF_TOKEN); Task 9 wires an actual
+# CredentialResolver against these same names.
+_CREDENTIAL_ENV_HINT = "HUGGINGFACE_API_KEY (or HF_TOKEN)"
 
 
 # Error hierarchy: all subclass ArtifactError
@@ -218,3 +232,249 @@ def resolve_catalog_closure(
 
     visit(root)
     return tuple(resolved[ref] for ref in sorted(resolved))
+
+
+class ArtifactAcquisitionService:
+    """Consent-driven managed acquisition composed over the sealed 594 core.
+
+    This service never bypasses ``ModelArtifactService``'s integrity
+    guarantees; it only calls its public sync surface (``list_installed()``,
+    ``disk_usage()``, ``artifact_path()``, and later ``install()``/lease
+    methods via an executor hop) and adds the async, consent-gated flow on
+    top: ``preflight()`` here, ``provision()`` in a later task.
+    """
+
+    def __init__(
+        self,
+        core: ModelArtifactService,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        credential_resolver: Callable[[str], str | None] | None = None,
+        free_bytes_probe: Callable[[Path], int] | None = None,
+        trusted_origins: frozenset[str] = frozenset(),
+    ) -> None:
+        """Compose an acquisition service over an existing artifact core.
+
+        Args:
+            core: The sealed ``ModelArtifactService`` this service reuses for
+                every integrity-bearing operation (verify, promote, leases).
+            client_factory: Optional zero-arg factory returning a caller-owned
+                ``httpx.AsyncClient`` (reused across probes/fetches). When
+                absent, a short-lived client is created and closed per call.
+            credential_resolver: Optional repository -> token resolver. Not
+                yet consulted by ``preflight()`` (the HEAD probe is always
+                anonymous here); accepted now so the constructor shape is
+                stable across the whole feature -- a later task wires actual
+                credential attachment for gated repositories.
+            free_bytes_probe: Optional override returning available free
+                bytes at a given path, injected by tests instead of
+                ``core.disk_usage().free_bytes`` / ``shutil.disk_usage``.
+            trusted_origins: Hostnames exempt from the private-IP egress
+                block, threaded into the preflight HEAD probe. Empty in
+                production, where repository hosts are public; tests pass
+                a fixture server's loopback hostname here.
+        """
+        self._core = core
+        self._client_factory = client_factory
+        self._credential_resolver = credential_resolver
+        self._free_bytes_probe = free_bytes_probe
+        self._trusted_origins = trusted_origins
+
+    async def preflight(self, root: ArtifactRef, catalog: ArtifactCatalog) -> PreflightReport:
+        """Aggregate space, staged-credit, and repository-gating checks.
+
+        Walks the full dependency closure from catalog descriptors (not the
+        core's installed-manifest walk -- dependencies may not exist on disk
+        yet), then aggregates a frozen report covering how many bytes remain
+        to download, how much of that is already durably staged, how much
+        disk a same-artifact upgrade would retain, and whether any
+        repository in the closure answers as gated (401/403) before any
+        consent screen is shown.
+
+        Args:
+            root: The root artifact reference to resolve and preflight.
+            catalog: Catalog supplying descriptors for the closure walk.
+
+        Returns:
+            A frozen ``PreflightReport``; call ``.grant()`` on it to obtain
+            an ``AcquisitionConsent``.
+
+        Raises:
+            CatalogError: Propagated from an unknown ref, a dependency
+                cycle, or a conflicting-revision closure.
+        """
+        closure = resolve_catalog_closure(root, catalog)
+        fingerprint = closure_fingerprint(root, (descriptor.reference for descriptor in closure))
+
+        installed = self._core.list_installed()
+        installed_refs = {
+            item.descriptor.reference for item in installed if item.descriptor is not None
+        }
+        # The prior active version of THIS artifact_id, only when an upgrade
+        # would leave it behind under a different reference than root (the
+        # same-ref case is just "already installed", not a retained extra).
+        retained_descriptor = next(
+            (
+                item.descriptor
+                for item in installed
+                if item.descriptor is not None
+                and item.active
+                and item.descriptor.reference.artifact_id == root.artifact_id
+                and item.descriptor.reference != root
+            ),
+            None,
+        )
+
+        entries: list[ArtifactPreflightEntry] = []
+        download_bytes = 0
+        already_staged_bytes = 0
+        # First not-installed entry per repository, in stable closure order --
+        # the representative whose URL gets the one bounded gating probe.
+        gating_targets: dict[str, ArtifactPreflightEntry] = {}
+        for descriptor in closure:
+            ref = descriptor.reference
+            already_installed = ref in installed_refs
+            entry = ArtifactPreflightEntry(
+                ref=ref,
+                source_url=descriptor.source_url,
+                repository=descriptor.upstream_repository,
+                revision=descriptor.upstream_revision,
+                license_id=descriptor.license_id,
+                license_url=descriptor.license_url,
+                precision=descriptor.precision,
+                total_bytes=descriptor.expected_installed_bytes,
+                file_count=len(descriptor.files),
+                already_installed=already_installed,
+            )
+            entries.append(entry)
+            if not already_installed:
+                staged = self._staged_bytes_for(ref)
+                already_staged_bytes += staged
+                download_bytes += max(entry.total_bytes - staged, 0)
+                gating_targets.setdefault(entry.repository, entry)
+
+        # consume_source install() moves staged bytes into the immutable
+        # store (os.replace, or copy+delete of the SAME bytes on EXDEV) --
+        # there is no second on-disk copy of the payload to budget for. The
+        # field survives at 0 so a future copy-based install path (or a
+        # policy change back to consume_source=False) has somewhere honest
+        # to report real overhead without an API/signature break.
+        staging_overhead_bytes = 0
+
+        retained_bytes = (
+            retained_descriptor.expected_installed_bytes if retained_descriptor is not None else 0
+        )
+
+        required_bytes = (
+            download_bytes
+            + staging_overhead_bytes
+            + retained_bytes
+            + ACQUISITION_SAFETY_MARGIN_BYTES
+        )
+
+        destination = self._core.artifact_path(root)
+        free_bytes = (
+            self._free_bytes_probe(destination)
+            if self._free_bytes_probe is not None
+            else self._core.disk_usage().free_bytes
+        )
+
+        gating_errors = await self._probe_gating(gating_targets.values())
+
+        return PreflightReport(
+            root=root,
+            closure_fingerprint=fingerprint,
+            entries=tuple(entries),
+            download_bytes=download_bytes,
+            already_staged_bytes=already_staged_bytes,
+            staging_overhead_bytes=staging_overhead_bytes,
+            retained_bytes=retained_bytes,
+            destination=destination,
+            free_bytes=free_bytes,
+            required_bytes=required_bytes,
+            sufficient_space=free_bytes >= required_bytes,
+            gating_errors=tuple(gating_errors),
+        )
+
+    def _staged_bytes_for(self, ref: ArtifactRef) -> int:
+        """Best-effort resumable-byte credit from a fetch-state sidecar.
+
+        A missing or unparseable sidecar reads as zero credit: staged bytes
+        are only ever a hint surfaced on the consent screen ("up to N bytes
+        already fetched") -- ``provision()`` independently re-validates
+        against the server's current validators before trusting any of it.
+
+        Args:
+            ref: The artifact reference whose staging directory to inspect.
+
+        Returns:
+            The sum of ``bytes_done`` across every file in the sidecar, or 0.
+        """
+        sidecar = (
+            self._core.staging_path
+            / "managed"
+            / ref.artifact_id
+            / ref.revision
+            / ref.variant
+            / "fetch-state.json"
+        )
+        try:
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return 0
+        files = payload.get("files") if isinstance(payload, dict) else None
+        if not isinstance(files, dict):
+            return 0
+        total = 0
+        for info in files.values():
+            if not isinstance(info, dict):
+                continue
+            bytes_done = info.get("bytes_done")
+            if isinstance(bytes_done, int) and not isinstance(bytes_done, bool) and bytes_done >= 0:
+                total += bytes_done
+        return total
+
+    async def _probe_gating(self, targets: Iterable[ArtifactPreflightEntry]) -> list[str]:
+        """Bounded, anonymous HEAD probe per repository; collect 401/403s.
+
+        Any other outcome -- 2xx/3xx/other 4xx/5xx, timeout, connection
+        failure, or an egress-policy block -- is silently non-fatal here:
+        those belong to the real transfer's error handling, not consent.
+        Only an explicit auth-required status is a gating signal.
+
+        Args:
+            targets: One representative entry per unique repository.
+
+        Returns:
+            Gating-error messages naming the repository and the credential
+            env var to set (never a token value); empty if none are gated.
+        """
+        targets = list(targets)
+        if not targets:
+            return []
+        client = self._client_factory() if self._client_factory is not None else None
+        owns_client = client is None
+        if owns_client:
+            client = httpx.AsyncClient()
+        assert client is not None
+        errors: list[str] = []
+        try:
+            for entry in targets:
+                try:
+                    await check_url_or_raise_async(
+                        entry.source_url, trusted_origins=self._trusted_origins
+                    )
+                    response = await client.head(
+                        entry.source_url, timeout=_PREFLIGHT_PROBE_TIMEOUT_SECONDS
+                    )
+                except (httpx.HTTPError, EgressBlockedError):
+                    continue
+                if response.status_code in (401, 403):
+                    errors.append(
+                        f"repository '{entry.repository}' requires credentials "
+                        f"(HTTP {response.status_code}); set {_CREDENTIAL_ENV_HINT} and retry"
+                    )
+        finally:
+            if owns_client:
+                await client.aclose()
+        return errors

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -348,8 +348,16 @@ class ArtifactAcquisitionService:
             )
             entries.append(entry)
             if not already_installed:
-                staged = self._staged_bytes_for(ref)
+                # Clamp per entry: a stale/corrupt sidecar claiming more
+                # bytes than this artifact's own declared total must not
+                # inflate the credit shown on the consent screen.
+                staged = min(self._staged_bytes_for(ref), entry.total_bytes)
                 already_staged_bytes += staged
+                # Floored PER ENTRY (max(total-staged,0) here, not summed
+                # totals minus summed staged then floored once at the end)
+                # -- an aggregate subtraction would let one entry's
+                # over-claimed credit silently offset another entry's real
+                # download cost instead of just clamping its own.
                 download_bytes += max(entry.total_bytes - staged, 0)
                 gating_targets.setdefault(entry.repository, entry)
 

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -7,7 +7,6 @@ import json
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Protocol
-from urllib.parse import urljoin
 
 import httpx
 
@@ -666,6 +665,11 @@ class ArtifactAcquisitionService:
                 update as bytes stream in.
 
         Raises:
+            CatalogError: ``descriptor`` declares more than one file --
+                per-file source URLs are undefined until the catalog work
+                (TASK-596/1301) specifies them (see ``_file_url``). Raised
+                before touching staging, the sidecar, or the network: a
+                catalog-contract problem, not a transfer failure.
             TransferError: A file failed to fetch -- network/transport
                 failure, disk I/O failure (e.g. ENOSPC), an egress-policy
                 block, or a response body exceeding the file's declared
@@ -677,6 +681,17 @@ class ArtifactAcquisitionService:
                 stream_fetch's internal chunks (asyncio-native, no manual
                 polling).
         """
+
+        if len(descriptor.files) != 1:
+            # Fail loudly before any I/O: see _file_url for why guessing a
+            # per-file URL for a multi-file descriptor is unsafe.
+            ref = descriptor.reference
+            raise CatalogError(
+                f"{ref.artifact_id}@{ref.revision} declares "
+                f"{len(descriptor.files)} files, but per-file source URLs "
+                "are undefined until the catalog work (TASK-596/1301) "
+                "specifies them"
+            )
 
         staging_dir.mkdir(parents=True, exist_ok=True)
         sidecar_path = staging_dir / "fetch-state.json"
@@ -705,10 +720,15 @@ class ArtifactAcquisitionService:
         exactly one file -- the only shape exercised end-to-end so far --
         ``source_url`` IS that file's URL directly, matching how
         ``_probe_gating`` already treats it (a bare GET/HEAD target, never
-        joined with anything). For a descriptor declaring more than one
-        file, ``source_url`` is treated as the artifact's base location and
-        each file's relative ``path`` is joined onto it (trailing slash
-        ensured) -- the conventional repo-resolve-URL shape.
+        joined with anything).
+
+        ``ArtifactDescriptor`` permits more than one declared file, but
+        nothing upstream of this task defines what a multi-file
+        descriptor's per-file URLs actually are -- guessing a joined
+        ``source_url`` + ``file.path`` URL here would silently fetch the
+        WRONG bytes for every file whenever that guess doesn't match
+        reality, with no signal to the caller that anything went wrong.
+        Failing loudly is safer than guessing quietly: see ``Raises``.
 
         Args:
             descriptor: The artifact descriptor supplying ``source_url``.
@@ -716,14 +736,23 @@ class ArtifactAcquisitionService:
 
         Returns:
             The absolute URL to GET this file's bytes from.
+
+        Raises:
+            CatalogError: ``descriptor`` declares more than one file --
+                per-file source URLs are undefined until the catalog work
+                (TASK-596/1301) specifies them.
         """
 
-        if len(descriptor.files) == 1:
-            return descriptor.source_url
-        base = descriptor.source_url
-        if not base.endswith("/"):
-            base += "/"
-        return urljoin(base, file.path)
+        if len(descriptor.files) != 1:
+            ref = descriptor.reference
+            raise CatalogError(
+                f"{ref.artifact_id}@{ref.revision} declares "
+                f"{len(descriptor.files)} files, but per-file source URLs "
+                "are undefined until the catalog work (TASK-596/1301) "
+                "specifies them -- refusing to guess a URL for "
+                f"'{file.path}'"
+            )
+        return descriptor.source_url
 
     @staticmethod
     def _load_fetch_sidecar(sidecar_path: Path) -> dict:
@@ -827,6 +856,14 @@ class ArtifactAcquisitionService:
             # Reconciliation already confirms the on-disk file is exactly
             # the declared size -- nothing left to fetch. SHA-256 content
             # correctness is Task 8's pre-verify job, not this phase's.
+            # A zero-byte declared file reconciles to recorded_done == 0
+            # == size_bytes WITHOUT ever creating the destination (nothing
+            # to stream, nothing to reconcile against) -- create it empty
+            # so Task 8's pre-verify hashes a real empty file instead of
+            # raising FileNotFoundError on a "complete" file that was
+            # never actually written.
+            if not destination.exists():
+                destination.touch()
             if not entry.get("complete") or entry.get("bytes_done") != recorded_done:
                 sidecar["files"][file.path] = {
                     "etag": entry.get("etag"),

--- a/tldw_chatbook/Model_Artifacts/fetch.py
+++ b/tldw_chatbook/Model_Artifacts/fetch.py
@@ -118,8 +118,18 @@ async def stream_fetch(
     request_headers: dict[str, str] = dict(headers or {})
     if resume_from:
         request_headers["Range"] = f"bytes={resume_from}-"
+        # If-Range must carry WHICHEVER validator makes resuming safe: a
+        # strong ETag if we have one, else the Last-Modified date (RFC 9110
+        # 13.1.5 -- If-Range also accepts an HTTP-date). Sending only the
+        # etag branch would silently drop the Last-Modified-only case that
+        # FetchValidators.strong explicitly allows (etag=None, last_modified
+        # set): the server would then see a bare Range with no If-Range,
+        # honor it unconditionally, and a changed resource's bytes would be
+        # appended to stale on-disk data with no mismatch ever detected.
         if validators and validators.etag:
             request_headers["If-Range"] = validators.etag
+        elif validators and validators.last_modified:
+            request_headers["If-Range"] = validators.last_modified
 
     written = 0
     for _hop in range(MAX_REDIRECT_HOPS + 1):

--- a/tldw_chatbook/Model_Artifacts/fetch.py
+++ b/tldw_chatbook/Model_Artifacts/fetch.py
@@ -8,6 +8,7 @@ by acquisition, NOT this module.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping
@@ -72,6 +73,37 @@ def _same_origin(a: httpx.URL, b: httpx.URL) -> bool:
     return (a.scheme, a.host, a.port) == (b.scheme, b.host, b.port)
 
 
+# ``Content-Range: bytes <start>-<end>/<total>`` (RFC 9110 14.4) or a
+# ``*``-total variant (``bytes <start>-<end>/*``); ``total`` is optional to
+# capture for callers that don't need it.
+_CONTENT_RANGE_RE = re.compile(r"^bytes (\d+)-(\d+)/(\d+|\*)$")
+
+
+def _parse_content_range_start(header_value: str | None) -> int | None:
+    """Extract the START byte offset from a ``Content-Range`` header.
+
+    A 206 response alone does not prove the body actually starts at the
+    ``Range`` request's offset -- only ``Content-Range`` does, and only when
+    it parses. Anything else (missing header, unparseable value) must be
+    treated by the caller as "cannot be trusted", never as "assume it's
+    fine".
+
+    Args:
+        header_value: The raw ``Content-Range`` header value, or ``None``
+            when the header was absent.
+
+    Returns:
+        The parsed start offset, or ``None`` when the header is missing or
+        does not match the expected ``bytes <start>-<end>/<total>`` shape.
+    """
+    if not header_value:
+        return None
+    match = _CONTENT_RANGE_RE.match(header_value.strip())
+    if not match:
+        return None
+    return int(match.group(1))
+
+
 async def stream_fetch(
     url: str,
     destination: Path,
@@ -134,65 +166,101 @@ async def stream_fetch(
     written = 0
     for _hop in range(MAX_REDIRECT_HOPS + 1):
         await check_url_or_raise_async(str(current), trusted_origins=trusted_origins)
+        is_same_origin = _same_origin(origin, current)
         send_headers = dict(request_headers)
-        if not _same_origin(origin, current):
+        if not is_same_origin:
             for name in list(send_headers):
                 if name.lower() in _STRIP_HEADERS:
                     del send_headers[name]
+        # Built explicitly (not passed straight to client.stream/client.get)
+        # so cross-origin credential stripping can also reach headers the
+        # CALLER attached at the client-construction level (e.g.
+        # httpx.AsyncClient(headers={"Authorization": ...})) -- httpx merges
+        # those client-default headers onto the request during send, AFTER
+        # send_headers above was already stripped, so send_headers alone
+        # never sees them. Mirrors egress.py's guarded_fetch_httpx_async.
+        request = client.build_request("GET", current, headers=send_headers)
+        if not is_same_origin:
+            for _h in _STRIP_HEADERS:
+                request.headers.pop(_h, None)
         try:
-            async with client.stream(
-                "GET", current, headers=send_headers, follow_redirects=False
-            ) as response:
-                if response.status_code in (301, 302, 303, 307, 308):
-                    location = response.headers.get("location")
-                    if not location:
-                        raise FetchTransportError("redirect without location")
-                    current = current.join(location)
-                    continue
-                if resume_from and response.status_code != 206:
-                    # Server ignored Range (200 full body / no support).
-                    raise FetchRestartRequired("server did not honor Range")
-                if response.status_code == 401 or response.status_code == 403:
-                    raise FetchTransportError(f"HTTP {response.status_code}")
-                if response.status_code >= 400:
-                    raise FetchTransportError(f"HTTP {response.status_code}")
-                got = FetchValidators(
-                    etag=response.headers.get("etag"),
-                    last_modified=response.headers.get("last-modified"),
-                )
-                if resume_from and validators and validators.etag and got.etag:
-                    if got.etag != validators.etag:
-                        raise FetchRestartRequired("validators changed upstream")
-                if (
-                    resume_from
-                    and validators
-                    and not validators.etag
-                    and validators.last_modified
-                    and got.last_modified
-                    and got.last_modified != validators.last_modified
-                ):
-                    # Symmetric to the ETag check above, and NOT redundant
-                    # with the earlier status-code check: that check only
-                    # catches a server that answers a stale If-Range with a
-                    # full 200. A server that IGNORES If-Range entirely (a
-                    # real and, for date-based conditionals specifically,
-                    # under-implemented failure mode -- If-Range is far more
-                    # commonly wired up for ETags than for Last-Modified)
-                    # still answers 206, and would otherwise have its
-                    # mismatched bytes appended with no detection at all.
-                    raise FetchRestartRequired("validators changed upstream")
-                mode = "ab" if resume_from else "wb"
-                with open(destination, mode) as fh:
-                    async for chunk in response.aiter_bytes(_CHUNK_BYTES):
-                        if resume_from + written + len(chunk) > max_bytes:
-                            raise FetchTooLargeError("byte bound exceeded")
-                        fh.write(chunk)
-                        written += len(chunk)
-                        if on_chunk:
-                            on_chunk(len(chunk))
-                    fh.flush()
-                    os.fsync(fh.fileno())
-                return FetchResult(written, got, resumed=bool(resume_from))
+            response = await client.send(request, stream=True, follow_redirects=False)
         except httpx.HTTPError as exc:
             raise FetchTransportError(type(exc).__name__) from exc
+        try:
+            if response.status_code in (301, 302, 303, 307, 308):
+                location = response.headers.get("location")
+                if not location:
+                    raise FetchTransportError("redirect without location")
+                current = current.join(location)
+                continue
+            if resume_from and response.status_code != 206:
+                # Server ignored Range (200 full body / no support).
+                raise FetchRestartRequired("server did not honor Range")
+            if response.status_code == 401 or response.status_code == 403:
+                raise FetchTransportError(f"HTTP {response.status_code}")
+            if response.status_code >= 400:
+                raise FetchTransportError(f"HTTP {response.status_code}")
+            got = FetchValidators(
+                etag=response.headers.get("etag"),
+                last_modified=response.headers.get("last-modified"),
+            )
+            if resume_from and validators and validators.etag:
+                # A missing ETag on the resumed response is NOT "no
+                # information" -- it is treated as a mismatch. Accepting it
+                # as a match would let a 206 that simply omits the header
+                # (a real, under-implemented server behavior, not just a
+                # theoretical one) get silently appended to stale on-disk
+                # bytes fetched under a DIFFERENT resource version.
+                if not got.etag or got.etag != validators.etag:
+                    raise FetchRestartRequired("validators changed upstream")
+            if (
+                resume_from
+                and validators
+                and not validators.etag
+                and validators.last_modified
+                and got.last_modified
+                and got.last_modified != validators.last_modified
+            ):
+                # Symmetric to the ETag check above, and NOT redundant
+                # with the earlier status-code check: that check only
+                # catches a server that answers a stale If-Range with a
+                # full 200. A server that IGNORES If-Range entirely (a
+                # real and, for date-based conditionals specifically,
+                # under-implemented failure mode -- If-Range is far more
+                # commonly wired up for ETags than for Last-Modified)
+                # still answers 206, and would otherwise have its
+                # mismatched bytes appended with no detection at all.
+                raise FetchRestartRequired("validators changed upstream")
+            if resume_from and response.status_code == 206:
+                # A 206 alone does not prove the body starts at
+                # resume_from -- only Content-Range does, and only when it
+                # parses AND its start matches. A missing/unparseable
+                # header or a start that disagrees with the Range we asked
+                # for must be rejected BEFORE the destination is ever
+                # opened for append, or a server's mismatched bytes would
+                # be silently appended to stale on-disk data.
+                range_start = _parse_content_range_start(
+                    response.headers.get("content-range")
+                )
+                if range_start != resume_from:
+                    raise FetchRestartRequired(
+                        "Content-Range start does not match the requested resume offset"
+                    )
+            mode = "ab" if resume_from else "wb"
+            with open(destination, mode) as fh:
+                async for chunk in response.aiter_bytes(_CHUNK_BYTES):
+                    if resume_from + written + len(chunk) > max_bytes:
+                        raise FetchTooLargeError("byte bound exceeded")
+                    fh.write(chunk)
+                    written += len(chunk)
+                    if on_chunk:
+                        on_chunk(len(chunk))
+                fh.flush()
+                os.fsync(fh.fileno())
+            return FetchResult(written, got, resumed=bool(resume_from))
+        except httpx.HTTPError as exc:
+            raise FetchTransportError(type(exc).__name__) from exc
+        finally:
+            await response.aclose()
     raise FetchTransportError("redirect hop limit exceeded")

--- a/tldw_chatbook/Model_Artifacts/fetch.py
+++ b/tldw_chatbook/Model_Artifacts/fetch.py
@@ -163,6 +163,24 @@ async def stream_fetch(
                 if resume_from and validators and validators.etag and got.etag:
                     if got.etag != validators.etag:
                         raise FetchRestartRequired("validators changed upstream")
+                if (
+                    resume_from
+                    and validators
+                    and not validators.etag
+                    and validators.last_modified
+                    and got.last_modified
+                    and got.last_modified != validators.last_modified
+                ):
+                    # Symmetric to the ETag check above, and NOT redundant
+                    # with the earlier status-code check: that check only
+                    # catches a server that answers a stale If-Range with a
+                    # full 200. A server that IGNORES If-Range entirely (a
+                    # real and, for date-based conditionals specifically,
+                    # under-implemented failure mode -- If-Range is far more
+                    # commonly wired up for ETags than for Last-Modified)
+                    # still answers 206, and would otherwise have its
+                    # mismatched bytes appended with no detection at all.
+                    raise FetchRestartRequired("validators changed upstream")
                 mode = "ab" if resume_from else "wb"
                 with open(destination, mode) as fh:
                     async for chunk in response.aiter_bytes(_CHUNK_BYTES):

--- a/tldw_chatbook/Model_Artifacts/fetch.py
+++ b/tldw_chatbook/Model_Artifacts/fetch.py
@@ -1,0 +1,170 @@
+"""Streaming guarded fetch for managed artifact acquisition (TASK-595).
+
+The egress hop loop (SSRF policy, hop cap, credential stripping) re-shaped
+to stream to disk under a hard byte bound. The fetch-state sidecar is owned
+by acquisition, NOT this module.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+import httpx
+from loguru import logger
+
+from tldw_chatbook.Utils.egress import (
+    MAX_REDIRECT_HOPS,
+    check_url_or_raise_async,
+)
+
+# Mirrors egress._STRIP_HEADERS (private there); the drift-guard test in
+# test_stream_fetch.py fails if the two sets ever diverge.
+_STRIP_HEADERS = ("authorization", "cookie", "proxy-authorization", "x-goog-api-key")
+
+_CHUNK_BYTES = 1024 * 1024
+
+
+class FetchError(Exception):
+    """Base for streaming-fetch failures. Messages never carry headers."""
+
+
+class FetchRestartRequired(FetchError):
+    """Resume impossible (validators changed/weak, or no Range support)."""
+
+
+class FetchTooLargeError(FetchError):
+    """The transfer would exceed the declared byte bound."""
+
+
+class FetchTransportError(FetchError):
+    """Network-level failure, wrapping httpx errors without header data."""
+
+
+@dataclass(frozen=True)
+class FetchValidators:
+    """HTTP validators captured from a response, used for Range resume."""
+
+    etag: str | None
+    last_modified: str | None
+
+    @property
+    def strong(self) -> bool:
+        """True when resuming on these validators is safe (strong ETag or
+        a Last-Modified date; weak `W/` ETags never qualify)."""
+        if self.etag and not self.etag.startswith("W/"):
+            return True
+        return self.etag is None and self.last_modified is not None
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    """Outcome of one stream_fetch call."""
+
+    bytes_written: int
+    validators: FetchValidators
+    resumed: bool
+
+
+def _same_origin(a: httpx.URL, b: httpx.URL) -> bool:
+    return (a.scheme, a.host, a.port) == (b.scheme, b.host, b.port)
+
+
+async def stream_fetch(
+    url: str,
+    destination: Path,
+    *,
+    client: httpx.AsyncClient,
+    max_bytes: int,
+    resume_from: int = 0,
+    validators: FetchValidators | None = None,
+    headers: Mapping[str, str] | None = None,
+    trusted_origins: frozenset[str] = frozenset(),
+    on_chunk: Callable[[int], None] | None = None,
+) -> FetchResult:
+    """Stream a URL to disk with egress guards, byte bounds, and resume.
+
+    Args:
+        url: Source URL (http/https; egress policy enforced per hop).
+        destination: File appended to (created if absent).
+        client: Caller-owned AsyncClient (connection reuse, test injection).
+        max_bytes: Hard bound on the FINAL file size (resume_from + written).
+        resume_from: Durable bytes already on disk; sends a Range request.
+        validators: Validators the existing bytes were fetched under; resume
+            requires them strong and matching the server's current ones.
+        headers: Extra headers (credentials); stripped on cross-origin hops.
+        trusted_origins: Egress-policy trust additions (fixture servers).
+        on_chunk: Called with each chunk's byte count (progress).
+
+    Returns:
+        FetchResult with bytes written THIS call, captured validators, and
+        whether a Range continuation was used.
+
+    Raises:
+        FetchRestartRequired: Resume requested but unsafe/unsupported.
+        FetchTooLargeError: Bound exceeded (pre-declared or mid-stream).
+        FetchTransportError: Connection/protocol failures.
+        EgressBlockedError: Policy rejection (from egress helpers).
+    """
+    if resume_from and not (validators and validators.strong):
+        raise FetchRestartRequired("resume requires strong validators")
+    if resume_from >= max_bytes:
+        raise FetchTooLargeError("resume offset already at or past the bound")
+
+    current = httpx.URL(url)
+    origin = current
+    request_headers: dict[str, str] = dict(headers or {})
+    if resume_from:
+        request_headers["Range"] = f"bytes={resume_from}-"
+        if validators and validators.etag:
+            request_headers["If-Range"] = validators.etag
+
+    written = 0
+    for _hop in range(MAX_REDIRECT_HOPS + 1):
+        await check_url_or_raise_async(str(current), trusted_origins=trusted_origins)
+        send_headers = dict(request_headers)
+        if not _same_origin(origin, current):
+            for name in list(send_headers):
+                if name.lower() in _STRIP_HEADERS:
+                    del send_headers[name]
+        try:
+            async with client.stream(
+                "GET", current, headers=send_headers, follow_redirects=False
+            ) as response:
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("location")
+                    if not location:
+                        raise FetchTransportError("redirect without location")
+                    current = current.join(location)
+                    continue
+                if resume_from and response.status_code != 206:
+                    # Server ignored Range (200 full body / no support).
+                    raise FetchRestartRequired("server did not honor Range")
+                if response.status_code == 401 or response.status_code == 403:
+                    raise FetchTransportError(f"HTTP {response.status_code}")
+                if response.status_code >= 400:
+                    raise FetchTransportError(f"HTTP {response.status_code}")
+                got = FetchValidators(
+                    etag=response.headers.get("etag"),
+                    last_modified=response.headers.get("last-modified"),
+                )
+                if resume_from and validators and validators.etag and got.etag:
+                    if got.etag != validators.etag:
+                        raise FetchRestartRequired("validators changed upstream")
+                mode = "ab" if resume_from else "wb"
+                with open(destination, mode) as fh:
+                    async for chunk in response.aiter_bytes(_CHUNK_BYTES):
+                        if resume_from + written + len(chunk) > max_bytes:
+                            raise FetchTooLargeError("byte bound exceeded")
+                        fh.write(chunk)
+                        written += len(chunk)
+                        if on_chunk:
+                            on_chunk(len(chunk))
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                return FetchResult(written, got, resumed=bool(resume_from))
+        except httpx.HTTPError as exc:
+            raise FetchTransportError(type(exc).__name__) from exc
+    raise FetchTransportError("redirect hop limit exceeded")

--- a/tldw_chatbook/Model_Artifacts/service.py
+++ b/tldw_chatbook/Model_Artifacts/service.py
@@ -22,6 +22,7 @@ from urllib.parse import urlsplit
 
 from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
 from tldw_chatbook.Utils.path_validation import validate_path_simple
+from . import leases as _leases
 from .leases import (
     ArtifactLeaseError,
     ArtifactLeaseKey,
@@ -110,8 +111,51 @@ _READINESS_KEYS = frozenset(
 _ACTIVE_SCHEMA_VERSION = 1
 _ACTIVE_KEYS = frozenset({"schema_version", "root"})
 _LIFECYCLE_LEASE_KEY = ArtifactLeaseKey("!lifecycle", "1", "writer")
+
+# TASK-595: reserved lease identity for the single global managed-acquisition
+# session. Defined once here (not in the not-yet-written acquisition module,
+# to avoid a circular import) so both reconcile()'s staging GC and the future
+# acquisition runtime (Task 6+) key off the exact same ArtifactLeaseKey.
+# "#managed-acquisition" can never collide with a real ArtifactRef.artifact_id
+# because canonical artifact identifiers are validated against
+# _CANONICAL_COMPONENT, which forbids a leading "#".
+ACQUISITION_SESSION_LEASE_KEY = ArtifactLeaseKey(
+    "#managed-acquisition", "session", "global"
+)
+
+# Naming convention for install()'s ephemeral staging tempdirs (see install()
+# and tempfile.mkdtemp below). reconcile() uses this same prefix to recognize
+# candidate orphans among staging's top-level entries.
+_INSTALL_STAGING_PREFIX = "install-"
 _PathSnapshot = tuple[int, int, int, int, int, int]
 _NodeIdentity = tuple[int, int, int]
+
+
+def _install_staging_lease_key(staging_name: str) -> ArtifactLeaseKey:
+    """Return the lease key one in-flight ``install()`` call holds.
+
+    ``install()`` acquires this key, non-reentrantly, for the full lifetime
+    of one staging tempdir -- from directory creation until its final
+    cleanup (success or failure). ``reconcile()`` tries the same key
+    non-blocking before deleting a candidate ``install-*`` orphan: if it is
+    still held, a live install owns that directory and it must survive;
+    if it is free, the directory was abandoned (e.g. by a crashed process,
+    whose OS-level lock is released automatically) and is safe to remove.
+
+    Reserved under the "#install-staging" namespace, which -- like
+    ``ACQUISITION_SESSION_LEASE_KEY``'s "#managed-acquisition" -- can never
+    collide with a real ``ArtifactRef.lease_key()``, since canonical
+    artifact identifiers never start with "#".
+
+    Args:
+        staging_name: Basename of the ``install-*`` staging tempdir (unique
+            per call, from ``tempfile.mkdtemp``).
+
+    Returns:
+        The reserved lease key scoped to that one staging directory.
+    """
+
+    return ArtifactLeaseKey("#install-staging", staging_name, "lock")
 
 
 def _path_snapshot(info: os.stat_result) -> _PathSnapshot:
@@ -791,6 +835,7 @@ class ReconcileReport:
     state_removed: int
     corrupt_artifacts: tuple[Path, ...]
     staging_entries: tuple[Path, ...]
+    staging_removed: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1218,6 +1263,8 @@ class ModelArtifactService:
                 )
                 state_removed += 1
 
+        staging_removed = self._gc_staging(staging_entries)
+
         return ReconcileReport(
             readiness_created=readiness_created,
             state_removed=state_removed,
@@ -1225,6 +1272,7 @@ class ModelArtifactService:
                 sorted(corrupt_paths, key=lambda path: path.as_posix())
             ),
             staging_entries=staging_entries,
+            staging_removed=staging_removed,
         )
 
     def _delete_under_leases(self, reference: ArtifactRef) -> None:
@@ -1353,6 +1401,177 @@ class ModelArtifactService:
         if _path_snapshot(self._staging_path.stat(follow_symlinks=False)) != before:
             raise ArtifactPathError("staging changed during reconciliation scan")
         return entries
+
+    def _gc_staging(self, staging_entries: tuple[Path, ...]) -> tuple[str, ...]:
+        """Garbage-collect staging orphans, preserving resumable managed state.
+
+        Two independent categories of staging content are reclaimed here;
+        everything else (unrecognized top-level names) is left alone,
+        matching reconcile()'s historical report-only behavior for
+        arbitrary staging content:
+
+        * ``install-*`` tempdirs abandoned by a crashed :meth:`install`
+          call. A live in-flight call on any process still holds
+          ``_install_staging_lease_key(name)``, so this is safe to attempt
+          under the exclusive lifecycle lease this method's caller already
+          holds -- no additional lease is required for this category.
+        * ``managed/<id>/<rev>/<variant>`` download-staging directories
+          that lack a parseable ``fetch-state.json`` sidecar. Only removed
+          when ``ACQUISITION_SESSION_LEASE_KEY`` is free (non-blocking);
+          when busy, the entire ``managed`` subtree is left untouched for
+          this reconcile pass so an in-progress acquisition's resumable
+          state is never disturbed.
+
+        Args:
+            staging_entries: Immediate children of the staging root, as
+                returned by :meth:`_staging_entries`.
+
+        Returns:
+            Staging-relative POSIX paths of every entry removed.
+        """
+
+        removed: list[str] = []
+        managed_root: Path | None = None
+        for entry in staging_entries:
+            if entry.name == "managed":
+                try:
+                    mode = entry.stat(follow_symlinks=False).st_mode
+                except FileNotFoundError:
+                    continue
+                except OSError as error:
+                    raise ArtifactPathError(
+                        "failed to inspect staging entry"
+                    ) from error
+                if stat.S_ISDIR(mode) and not stat.S_ISLNK(mode):
+                    managed_root = entry
+                continue
+            if not entry.name.startswith(_INSTALL_STAGING_PREFIX):
+                continue
+            name = self._gc_install_staging_orphan(entry)
+            if name is not None:
+                removed.append(name)
+
+        if managed_root is not None:
+            removed.extend(self._gc_managed_staging(managed_root))
+
+        return tuple(sorted(removed))
+
+    def _gc_install_staging_orphan(self, entry: Path) -> str | None:
+        """Remove one ``install-*`` staging directory if it is abandoned.
+
+        Tries ``_install_staging_lease_key(entry.name)`` non-blocking: a
+        live :meth:`install` call already holds this key for its whole
+        staging lifetime, so a busy lease means the directory is still in
+        use and must survive; a free lease means the directory was
+        abandoned (its owner is gone, and the OS released the lease when
+        that process or handle closed) and is safe to remove.
+
+        Args:
+            entry: Top-level staging directory matching the ``install-*``
+                tempdir prefix used by :meth:`install`.
+
+        Returns:
+            The removed entry's staging-relative POSIX path, or None when
+            an in-flight install still owns it.
+        """
+
+        self._assert_managed_path(self._locks_path)
+        try:
+            lease = ArtifactOperationLease(
+                self._locks_path,
+                _install_staging_lease_key(entry.name),
+                LeaseMode.EXCLUSIVE,
+                timeout_seconds=0.1,
+            )
+            lease.acquire()
+        except ArtifactLeaseTimeoutError:
+            return None
+        try:
+            self._remove_state_path(entry, "failed to remove staging orphan")
+        finally:
+            lease.release()
+        return entry.relative_to(self._staging_path).as_posix()
+
+    def _gc_managed_staging(self, managed_root: Path) -> tuple[str, ...]:
+        """GC orphaned managed-download staging entries.
+
+        Requires ``ACQUISITION_SESSION_LEASE_KEY`` non-blocking; when busy
+        (a managed acquisition may still be writing into this subtree),
+        the whole managed staging tree is left untouched for this
+        reconcile pass.
+
+        Args:
+            managed_root: The ``staging/managed`` directory (already
+                confirmed to be a real, non-symlink directory).
+
+        Returns:
+            Staging-relative POSIX paths of every orphan entry removed.
+        """
+
+        self._assert_managed_path(self._locks_path)
+        try:
+            lease = ArtifactOperationLease(
+                self._locks_path,
+                ACQUISITION_SESSION_LEASE_KEY,
+                LeaseMode.EXCLUSIVE,
+                timeout_seconds=0.1,
+            )
+            lease.acquire()
+        except ArtifactLeaseTimeoutError:
+            return ()
+        try:
+            removed: list[str] = []
+            for candidate in self._state_files(managed_root, 3):
+                if self._is_valid_managed_staging_entry(managed_root, candidate):
+                    continue
+                self._remove_state_path(
+                    candidate, "failed to remove staging orphan"
+                )
+                removed.append(candidate.relative_to(self._staging_path).as_posix())
+            return tuple(removed)
+        finally:
+            lease.release()
+
+    def _is_valid_managed_staging_entry(
+        self,
+        managed_root: Path,
+        candidate: Path,
+    ) -> bool:
+        """Return whether ``candidate`` is a live managed download directory.
+
+        A live entry is a ``managed/<id>/<rev>/<variant>`` directory --
+        exactly three path components below ``managed_root`` -- containing
+        a ``fetch-state.json`` sidecar that parses as JSON. Anything
+        shallower, deeper, symlinked, or with a missing or corrupt sidecar
+        is an orphan. ``_assert_managed_path`` on the sidecar rejects a
+        symlink anywhere in the chain up to and including ``candidate``
+        itself, so a symlinked ``candidate`` is correctly treated as an
+        orphan without ever being followed.
+
+        Args:
+            managed_root: The ``staging/managed`` directory.
+            candidate: One entry surfaced by scanning ``managed_root`` to a
+                fixed depth of three (see :meth:`_state_files`).
+
+        Returns:
+            True when the entry's resumable download state should survive
+            garbage collection.
+        """
+
+        if len(candidate.relative_to(managed_root).parts) != 3:
+            return False
+        sidecar = candidate / "fetch-state.json"
+        try:
+            self._assert_managed_path(
+                sidecar,
+                allow_missing=True,
+                target_must_be_directory=False,
+            )
+            payload = sidecar.read_text(encoding="utf-8")
+            json.loads(payload)
+        except (ArtifactPathError, OSError, ValueError):
+            return False
+        return True
 
     def _readiness_ref_from_path(self, path: Path) -> ArtifactRef | None:
         try:
@@ -1725,15 +1944,32 @@ class ModelArtifactService:
         )
 
         staging: Path | None = None
+        staging_lease: ArtifactOperationLease | None = None
         try:
             self._assert_managed_path(self._staging_path)
             staging = Path(
                 tempfile.mkdtemp(
-                    prefix="install-",
+                    prefix=_INSTALL_STAGING_PREFIX,
                     dir=self._staging_path,
                 )
             )
             self._assert_managed_path(staging)
+            self._assert_managed_path(self._locks_path)
+            # Held for this call's whole staging lifetime so reconcile()'s
+            # staging GC can tell this directory apart from one abandoned by
+            # a crashed install (see _install_staging_lease_key). Built via
+            # the leases submodule rather than the plain ArtifactOperationLease
+            # import: this is an orphan-detection lock, not one of the writer
+            # leases tests intentionally intercept via that name (see
+            # test_install_acquires_exact_writer_leases_in_fixed_order), and
+            # must keep working even when those tests replace that symbol.
+            staging_lease = _leases.ArtifactOperationLease(
+                self._locks_path,
+                _install_staging_lease_key(staging.name),
+                LeaseMode.EXCLUSIVE,
+                timeout_seconds=self._lease_timeout_seconds,
+            )
+            staging_lease.acquire()
             # Only pass consume_source if True to maintain backward compatibility
             # with tests that monkeypatch _copy_payload
             if consume_source:
@@ -1802,20 +2038,33 @@ class ModelArtifactService:
         except OSError as error:
             raise ArtifactStateError("artifact installation I/O failed") from error
         finally:
-            if staging is not None:
-                primary_error = sys.exception()
-                try:
-                    shutil.rmtree(staging)
-                except FileNotFoundError:
-                    pass
-                except OSError as cleanup_error:
-                    if primary_error is None:
-                        raise ArtifactStateError(
-                            "failed to clean operation-owned artifact staging"
-                        ) from cleanup_error
-                    primary_error.add_note(
-                        f"operation staging cleanup failed: {cleanup_error!r}"
-                    )
+            primary_error = sys.exception()
+            try:
+                if staging is not None:
+                    try:
+                        shutil.rmtree(staging)
+                    except FileNotFoundError:
+                        pass
+                    except OSError as cleanup_error:
+                        if primary_error is None:
+                            raise ArtifactStateError(
+                                "failed to clean operation-owned artifact staging"
+                            ) from cleanup_error
+                        primary_error.add_note(
+                            f"operation staging cleanup failed: {cleanup_error!r}"
+                        )
+            finally:
+                if staging_lease is not None:
+                    try:
+                        staging_lease.release()
+                    except BaseException as release_error:
+                        if primary_error is None:
+                            raise ArtifactStateError(
+                                "failed to release staging operation lease"
+                            ) from release_error
+                        primary_error.add_note(
+                            f"staging operation lease release failed: {release_error!r}"
+                        )
 
     def _resolve_closure(
         self,

--- a/tldw_chatbook/Model_Artifacts/service.py
+++ b/tldw_chatbook/Model_Artifacts/service.py
@@ -2290,15 +2290,18 @@ class ModelArtifactService:
                 file — correctness over the disk optimization.
 
         Raises:
-            ArtifactPathError: consume_source with a source outside the root.
+            ArtifactPathError: consume_source with a source outside the root,
+                or when source path contains symlinks or redirects.
         """
         if consume_source:
-            resolved = source.resolve(strict=True)
+            # Validate source is inside root and contains no symlinks or
+            # redirects anywhere in its path hierarchy.
             try:
-                resolved.relative_to(self._root)
-            except ValueError as error:
+                self._assert_managed_path(source)
+            except ArtifactPathError as error:
                 raise ArtifactPathError(
-                    "consume_source requires a source inside the service root"
+                    "consume_source requires a source inside the service root "
+                    "with no symlink or redirect path components"
                 ) from error
 
         for item in descriptor.files:

--- a/tldw_chatbook/Model_Artifacts/service.py
+++ b/tldw_chatbook/Model_Artifacts/service.py
@@ -12,7 +12,7 @@ import re
 import shutil
 import stat
 import sys
-import tempfile
+import uuid
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -134,9 +134,23 @@ ACQUISITION_SESSION_LEASE_KEY = ArtifactLeaseKey(
 NONBLOCKING_LEASE_TIMEOUT_SECONDS = 0.1
 
 # Naming convention for install()'s ephemeral staging tempdirs (see install()
-# and tempfile.mkdtemp below). reconcile() uses this same prefix to recognize
-# candidate orphans among staging's top-level entries.
+# below, which names then leases then creates each one -- never a bare
+# tempfile.mkdtemp, whose combined name+create step would leave the
+# directory visible on disk before its orphan-detection lease is held).
+# reconcile() uses this same prefix to recognize candidate orphans among
+# staging's top-level entries.
 _INSTALL_STAGING_PREFIX = "install-"
+
+# Filename SUFFIX of a managed-download fetch-state sidecar, addressed as
+# a SIBLING of the ``managed/<id>/<rev>/<variant>`` payload directory it
+# describes (``.../<variant>.fetch-state.json``), never a child of it --
+# see acquisition.py's ``_fetch_sidecar_path`` for why (core.install's
+# payload-tree validation would otherwise reject it as an undeclared
+# file, which used to force the sidecar to be deleted before every
+# install attempt, destroying resumable state on any failure). Mirrors
+# acquisition.py's private ``_FETCH_SIDECAR_SUFFIX``; a drift-guard test
+# in test_reconcile_staging_gc.py fails if the two ever diverge.
+_MANAGED_FETCH_SIDECAR_SUFFIX = ".fetch-state.json"
 _PathSnapshot = tuple[int, int, int, int, int, int]
 _NodeIdentity = tuple[int, int, int]
 
@@ -159,7 +173,8 @@ def _install_staging_lease_key(staging_name: str) -> ArtifactLeaseKey:
 
     Args:
         staging_name: Basename of the ``install-*`` staging tempdir (unique
-            per call, from ``tempfile.mkdtemp``).
+            per call, generated before the directory itself is created --
+            see ``install()``).
 
     Returns:
         The reserved lease key scoped to that one staging directory.
@@ -1562,35 +1577,49 @@ class ModelArtifactService:
         managed_root: Path,
         candidate: Path,
     ) -> bool:
-        """Return whether ``candidate`` is a live managed download directory.
+        """Return whether ``candidate`` is part of a live managed download.
 
-        A live entry is a ``managed/<id>/<rev>/<variant>`` directory --
-        exactly three path components below ``managed_root`` -- containing
-        a ``fetch-state.json`` sidecar that parses to a JSON OBJECT with a
-        ``"files"`` mapping: the exact shape ``ArtifactAcquisitionService``'s
-        fetch phase always writes (see ``acquisition.py``'s
-        ``_load_fetch_sidecar`` / ``_fetch_one_file``). Anything shallower,
-        deeper, symlinked, or whose sidecar is missing, unparseable, or
-        parses to something else entirely (e.g. a bare JSON list or string --
+        The fetch-state sidecar for ``managed/<id>/<rev>/<variant>/`` lives
+        as a SIBLING file -- ``managed/<id>/<rev>/<variant>.fetch-state.json``
+        -- never inside the payload directory it describes (see
+        acquisition.py's ``_fetch_sidecar_path`` for why). Both the payload
+        directory AND its sidecar therefore surface as SEPARATE depth-three
+        candidates from :meth:`_state_files`, and either one is classified
+        by resolving its counterpart: a candidate is live only when BOTH
+        the payload directory exists as a real (non-symlink) directory AND
+        its sidecar parses to a JSON OBJECT with a ``"files"`` mapping --
+        the exact shape ``ArtifactAcquisitionService``'s fetch phase always
+        writes (see ``acquisition.py``'s ``_load_fetch_sidecar`` /
+        ``_fetch_one_file``). Anything shallower, deeper, symlinked,
+        missing its counterpart, or whose sidecar is unparseable or parses
+        to something else entirely (e.g. a bare JSON list or string --
         valid JSON, but not a usable fetch-state record) is an orphan.
-        ``_assert_managed_path`` on the sidecar rejects a symlink anywhere in
-        the chain up to and including ``candidate`` itself, so a symlinked
-        ``candidate`` is correctly treated as an orphan without ever being
+        ``_assert_managed_path`` rejects a symlink anywhere in the chain up
+        to and including either path, so a symlinked payload directory or
+        sidecar is correctly treated as an orphan without ever being
         followed.
 
         Args:
             managed_root: The ``staging/managed`` directory.
             candidate: One entry surfaced by scanning ``managed_root`` to a
-                fixed depth of three (see :meth:`_state_files`).
+                fixed depth of three (see :meth:`_state_files`) -- either
+                the payload directory or its sibling sidecar file.
 
         Returns:
             True when the entry's resumable download state should survive
             garbage collection.
         """
 
-        if len(candidate.relative_to(managed_root).parts) != 3:
+        parts = candidate.relative_to(managed_root).parts
+        if len(parts) != 3:
             return False
-        sidecar = candidate / "fetch-state.json"
+        name = parts[-1]
+        if name.endswith(_MANAGED_FETCH_SIDECAR_SUFFIX):
+            sidecar = candidate
+            payload_dir = candidate.parent / name[: -len(_MANAGED_FETCH_SIDECAR_SUFFIX)]
+        else:
+            payload_dir = candidate
+            sidecar = candidate.parent / f"{name}{_MANAGED_FETCH_SIDECAR_SUFFIX}"
         try:
             self._assert_managed_path(
                 sidecar,
@@ -1601,7 +1630,13 @@ class ModelArtifactService:
             parsed = json.loads(payload)
         except (ArtifactPathError, OSError, ValueError):
             return False
-        return isinstance(parsed, dict) and isinstance(parsed.get("files"), dict)
+        if not (isinstance(parsed, dict) and isinstance(parsed.get("files"), dict)):
+            return False
+        try:
+            self._assert_managed_path(payload_dir)
+        except (ArtifactPathError, OSError):
+            return False
+        return True
 
     def _readiness_ref_from_path(self, path: Path) -> ArtifactRef | None:
         try:
@@ -1977,13 +2012,24 @@ class ModelArtifactService:
         staging_lease: ArtifactOperationLease | None = None
         try:
             self._assert_managed_path(self._staging_path)
-            staging = Path(
-                tempfile.mkdtemp(
-                    prefix=_INSTALL_STAGING_PREFIX,
-                    dir=self._staging_path,
-                )
-            )
-            self._assert_managed_path(staging)
+            # The staging directory's NAME is generated and its
+            # per-directory orphan-detection lease acquired BEFORE the
+            # directory itself is created on disk -- deliberately NOT a
+            # bare ``tempfile.mkdtemp``, whose combined name-and-create
+            # step makes the directory visible to a directory listing
+            # before anything protects it. reconcile()'s staging GC
+            # (``_gc_install_staging_orphan``) only ever considers names
+            # that already exist as real directories, and only treats one
+            # as abandoned -- safe to delete -- when its lease is free.
+            # Creating the directory first and leasing it second leaves a
+            # window where a concurrent reconcile() pass can observe the
+            # (leaseless) directory, acquire the lease itself, and delete
+            # a staging dir this call is about to copy files into. Naming
+            # then leasing then creating closes that window: nothing
+            # exists for reconcile() to find until the lease already
+            # belongs to this call.
+            staging_name = f"{_INSTALL_STAGING_PREFIX}{uuid.uuid4().hex}"
+            staging = self._staging_path / staging_name
             self._assert_managed_path(self._locks_path)
             # Held for this call's whole staging lifetime so reconcile()'s
             # staging GC can tell this directory apart from one abandoned by
@@ -1995,11 +2041,21 @@ class ModelArtifactService:
             # must keep working even when those tests replace that symbol.
             staging_lease = _leases.ArtifactOperationLease(
                 self._locks_path,
-                _install_staging_lease_key(staging.name),
+                _install_staging_lease_key(staging_name),
                 LeaseMode.EXCLUSIVE,
                 timeout_seconds=self._lease_timeout_seconds,
             )
             staging_lease.acquire()
+            try:
+                # Matches tempfile.mkdtemp's own directory permission bits
+                # (owner-only rwx) -- this is still a temporary, operation-
+                # owned staging directory, not a final managed-store path.
+                os.mkdir(staging, 0o700)
+            except OSError as error:
+                raise ArtifactStateError(
+                    "failed to create artifact install staging directory"
+                ) from error
+            self._assert_managed_path(staging)
             # Only pass consume_source if True to maintain backward compatibility
             # with tests that monkeypatch _copy_payload
             if consume_source:

--- a/tldw_chatbook/Model_Artifacts/service.py
+++ b/tldw_chatbook/Model_Artifacts/service.py
@@ -123,6 +123,16 @@ ACQUISITION_SESSION_LEASE_KEY = ArtifactLeaseKey(
     "#managed-acquisition", "session", "global"
 )
 
+# Non-blocking probe timeout (seconds) shared by every lease this service
+# (or its ArtifactAcquisitionService caller) only ever tries opportunistically
+# rather than waiting on: reconcile()'s two staging-GC lease probes below
+# (_gc_install_staging_orphan, _gc_managed_staging), and acquisition.py's own
+# acquisition-session lease attempt in provision() (imported from there, not
+# redefined -- this 0.1s value was previously triplicated across all three
+# call sites). An immediate, typed failure beats a hang: whoever else holds
+# the lease is busy RIGHT NOW, not "worth waiting for" at any of these sites.
+NONBLOCKING_LEASE_TIMEOUT_SECONDS = 0.1
+
 # Naming convention for install()'s ephemeral staging tempdirs (see install()
 # and tempfile.mkdtemp below). reconcile() uses this same prefix to recognize
 # candidate orphans among staging's top-level entries.
@@ -1429,11 +1439,13 @@ class ModelArtifactService:
           under the exclusive lifecycle lease this method's caller already
           holds -- no additional lease is required for this category.
         * ``managed/<id>/<rev>/<variant>`` download-staging directories
-          that lack a parseable ``fetch-state.json`` sidecar. Only removed
-          when ``ACQUISITION_SESSION_LEASE_KEY`` is free (non-blocking);
-          when busy, the entire ``managed`` subtree is left untouched for
-          this reconcile pass so an in-progress acquisition's resumable
-          state is never disturbed.
+          whose ``fetch-state.json`` sidecar is missing, unparseable, or
+          does not parse to the ``{"files": {...}}`` shape the fetch phase
+          actually writes (see :meth:`_is_valid_managed_staging_entry`).
+          Only removed when ``ACQUISITION_SESSION_LEASE_KEY`` is free
+          (non-blocking); when busy, the entire ``managed`` subtree is left
+          untouched for this reconcile pass so an in-progress acquisition's
+          resumable state is never disturbed.
 
         Args:
             staging_entries: Immediate children of the staging root, as
@@ -1494,7 +1506,7 @@ class ModelArtifactService:
                 self._locks_path,
                 _install_staging_lease_key(entry.name),
                 LeaseMode.EXCLUSIVE,
-                timeout_seconds=0.1,
+                timeout_seconds=NONBLOCKING_LEASE_TIMEOUT_SECONDS,
             )
             lease.acquire()
         except ArtifactLeaseTimeoutError:
@@ -1527,7 +1539,7 @@ class ModelArtifactService:
                 self._locks_path,
                 ACQUISITION_SESSION_LEASE_KEY,
                 LeaseMode.EXCLUSIVE,
-                timeout_seconds=0.1,
+                timeout_seconds=NONBLOCKING_LEASE_TIMEOUT_SECONDS,
             )
             lease.acquire()
         except ArtifactLeaseTimeoutError:
@@ -1554,12 +1566,17 @@ class ModelArtifactService:
 
         A live entry is a ``managed/<id>/<rev>/<variant>`` directory --
         exactly three path components below ``managed_root`` -- containing
-        a ``fetch-state.json`` sidecar that parses as JSON. Anything
-        shallower, deeper, symlinked, or with a missing or corrupt sidecar
-        is an orphan. ``_assert_managed_path`` on the sidecar rejects a
-        symlink anywhere in the chain up to and including ``candidate``
-        itself, so a symlinked ``candidate`` is correctly treated as an
-        orphan without ever being followed.
+        a ``fetch-state.json`` sidecar that parses to a JSON OBJECT with a
+        ``"files"`` mapping: the exact shape ``ArtifactAcquisitionService``'s
+        fetch phase always writes (see ``acquisition.py``'s
+        ``_load_fetch_sidecar`` / ``_fetch_one_file``). Anything shallower,
+        deeper, symlinked, or whose sidecar is missing, unparseable, or
+        parses to something else entirely (e.g. a bare JSON list or string --
+        valid JSON, but not a usable fetch-state record) is an orphan.
+        ``_assert_managed_path`` on the sidecar rejects a symlink anywhere in
+        the chain up to and including ``candidate`` itself, so a symlinked
+        ``candidate`` is correctly treated as an orphan without ever being
+        followed.
 
         Args:
             managed_root: The ``staging/managed`` directory.
@@ -1581,10 +1598,10 @@ class ModelArtifactService:
                 target_must_be_directory=False,
             )
             payload = sidecar.read_text(encoding="utf-8")
-            json.loads(payload)
+            parsed = json.loads(payload)
         except (ArtifactPathError, OSError, ValueError):
             return False
-        return True
+        return isinstance(parsed, dict) and isinstance(parsed.get("files"), dict)
 
     def _readiness_ref_from_path(self, path: Path) -> ArtifactRef | None:
         try:

--- a/tldw_chatbook/Model_Artifacts/service.py
+++ b/tldw_chatbook/Model_Artifacts/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import ipaddress
 import json
@@ -1681,19 +1682,26 @@ class ModelArtifactService:
         self,
         descriptor: ArtifactDescriptor,
         source_directory: Path,
+        *,
+        consume_source: bool = False,
     ) -> ArtifactRef:
         """Verify and promote one local source directory immutably.
 
         Args:
             descriptor: Strict descriptor for the artifact being installed.
             source_directory: Existing local directory containing its payload.
+            consume_source: Move files instead of copying when source lies inside
+                the service root. Requires source inside the root; raises
+                ArtifactPathError otherwise. On EXDEV (cross-device link), falls
+                back to copy+delete. Defaults to False (today's copy semantics).
 
         Returns:
             The installed artifact's immutable reference.
 
         Raises:
             TypeError: An argument has the wrong public API type.
-            ArtifactPathError: The source or managed destination is unsafe.
+            ArtifactPathError: The source or managed destination is unsafe, or
+                consume_source with a source outside the service root.
             ArtifactIntegrityError: A declared file fails size or digest checks.
             ArtifactConflictError: The immutable destination conflicts.
             ArtifactStateError: Artifact storage or lease operations fail.
@@ -1726,15 +1734,23 @@ class ModelArtifactService:
                 )
             )
             self._assert_managed_path(staging)
-            self._copy_payload(descriptor, source_directory, staging)
-            if (
-                self._validate_payload_tree(
-                    source_directory,
-                    descriptor.files,
-                )
-                != source_snapshot
-            ):
-                raise ArtifactPathError("source tree changed during artifact copy")
+            # Only pass consume_source if True to maintain backward compatibility
+            # with tests that monkeypatch _copy_payload
+            if consume_source:
+                self._copy_payload(descriptor, source_directory, staging, consume_source=True)
+            else:
+                self._copy_payload(descriptor, source_directory, staging)
+            # When consume_source=True, files are intentionally moved from source.
+            # Skip the unchanged-tree check in that case; it's expected to change.
+            if not consume_source:
+                if (
+                    self._validate_payload_tree(
+                        source_directory,
+                        descriptor.files,
+                    )
+                    != source_snapshot
+                ):
+                    raise ArtifactPathError("source tree changed during artifact copy")
             destination = self.artifact_path(descriptor.reference)
             self._assert_managed_path(self._locks_path)
 
@@ -2259,11 +2275,46 @@ class ModelArtifactService:
         descriptor: ArtifactDescriptor,
         source: Path,
         staging: Path,
+        *,
+        consume_source: bool = False,
     ) -> None:
+        """Copy or move declared payload into install staging.
+
+        Args:
+            descriptor: Artifact descriptor with file metadata.
+            source: Source directory containing payload files.
+            staging: Destination staging directory.
+            consume_source: Move files with os.replace when the source lies
+                inside this service's root (both stagings share it). EXDEV
+                (bind-mount inside the root) degrades to copy+delete for that
+                file — correctness over the disk optimization.
+
+        Raises:
+            ArtifactPathError: consume_source with a source outside the root.
+        """
+        if consume_source:
+            resolved = source.resolve(strict=True)
+            try:
+                resolved.relative_to(self._root)
+            except ValueError as error:
+                raise ArtifactPathError(
+                    "consume_source requires a source inside the service root"
+                ) from error
+
         for item in descriptor.files:
-            destination = staging / item.path
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(source / item.path, destination, follow_symlinks=False)
+            src = source / item.path
+            dst = staging / item.path
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if consume_source:
+                try:
+                    os.replace(src, dst)
+                    continue
+                except OSError as exc:
+                    if exc.errno != errno.EXDEV:
+                        raise
+            shutil.copyfile(src, dst, follow_symlinks=False)
+            if consume_source:
+                src.unlink()
 
     def _verify_payload(
         self,

--- a/tldw_chatbook/Model_Artifacts/service.py
+++ b/tldw_chatbook/Model_Artifacts/service.py
@@ -997,6 +997,19 @@ class ModelArtifactService:
 
         return self._staging_path
 
+    @property
+    def locks_path(self) -> Path:
+        """Return the managed lock-file root used by artifact operation leases.
+
+        Exposed (TASK-595 Task 6) so ``ArtifactAcquisitionService`` -- a
+        composed caller in a different module -- can acquire its own
+        reserved-namespace leases (e.g. ``ACQUISITION_SESSION_LEASE_KEY``)
+        against the exact same lock root this service uses internally,
+        without reaching into a private attribute.
+        """
+
+        return self._locks_path
+
     def artifact_path(self, reference: ArtifactRef) -> Path:
         """Return the contained final path for one validated reference."""
 


### PR DESCRIPTION
## Summary

Implements TASK-595 in full — consent-driven managed acquisition over the sealed TASK-594 artifact core, unblocking the chain to TASK-596 (setup controls) and TASK-1301 (the wizard's Speech step).

- **Spec:** `Docs/superpowers/specs/2026-07-30-managed-model-acquisition-design.md`
- **Plan:** `Docs/superpowers/plans/2026-07-31-managed-model-acquisition.md`
- Also carries two wizard loose ends finished earlier: **TASK-1374** (reachable re-run model prefill) and **TASK-1266** (compose-crash auto-skip policy).

## What it does

`preflight(root, catalog)` walks the closure over catalog descriptors and reports source, license, precision, per-file and total bytes, destination, staged-byte credit, retained-version accounting, and a free-space verdict, plus a bounded HEAD probe so gated repos fail *before* the consent screen. `PreflightReport.grant()` mints an `AcquisitionConsent` carrying the closure fingerprint; `provision()` re-walks the catalog and refuses on drift.

Provisioning holds one exclusive **acquisition-session lease** for its whole run (non-blocking → immediate `AcquisitionBusyError` rather than a silent multi-gigabyte wait), streams each file into durable staging with sidecar-tracked `Range` resume, **pre-verifies SHA-256 before** handing bytes to the core, installs with `consume_source=True` (move, not copy), and activates last. Already-installed closures provision with zero fetch work — which is also the crash-after-install recovery path.

**Core changes are three, all small and sync:** `install(consume_source=)`, orphans-only staging GC in `reconcile()`, and a per-staging-dir install lease (an in-flight fix for a race the implementation discovered: `reconcile()` could delete a *live* install's staging).

## Testing

545 passing across `Tests/Model_Artifacts/`, `Tests/STT/test_boundaries.py`, and `Tests/Wizards/`; the sealed 594 suite passes unmodified at every commit. Coverage per AC #6 uses a localhost fixture server (Range on/off, strong/weak/changing validators, mid-body disconnect, 401-until-token, wrong bytes, cross-origin redirect) and real `kill -9` subprocesses for crash recovery. Secret hygiene is asserted against logs, sidecars, manifests, and error strings — and the reviewer mutation-proved that test catches a deliberately leaked token.

## Known follow-ups (filed, not blocking)

- **TASK-1566** — `ArtifactPathError` from `core.install` still escapes the never-trap taxonomy without a `retryable` flag (final-review residual, parked with a ruling: real, not load-bearing, one-line fix).
- **TASK-1567** — stale install-staging lock files accumulate in `locks/`.
- AC #4's caller-confirmation UI is correctly out of scope here (the spec names UI as a non-goal); the backend obligation — `grant()` → consent → fingerprint recheck, plus a worker import boundary test — is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds managed model acquisition with consent-driven preflight, resumable and verified downloads, an exclusive session lease, and crash-safe recovery. Completes TASK-595 and also delivers the wizard re-run prefill (TASK-1374) and compose-crash auto-skip (TASK-1266).

- **New Features**
  - Preflight reports closure, space math, retained bytes, and gated repo status; `AcquisitionConsent` locks the fingerprint.
  - Resumable, verified downloads: durable sidecars, Range resume, SHA-256 pre-verify, `consume_source` install, activate, and idempotent re-runs.
  - Single global acquisition session lease serializes across processes; `reconcile()` respects it for safe GC.
  - Credential resolver enables gated repos, strips `Authorization` on cross-origin redirects (including client defaults), and keeps secrets out of logs and state.
  - Crash recovery: resumes mid-fetch from durable checkpoints; post-install crashes re-activate without network.
  - Public API expands via lazy exports: `ArtifactAcquisitionService`, `PreflightReport`, and `stream_fetch`.

- **Bug Fixes**
  - Staging GC removes only orphans and avoids live-install races via per-staging install leases; sidecar lives beside payload so retryable install errors don’t wipe resume state.
  - Clamps staged-byte credit, validates multi-file descriptors as `CatalogError`, and handles zero-byte files correctly.
  - Strengthens If-Range and validator mismatch checks, including non-compliant servers.
  - Wraps core install/activate failures as typed `TransferError` with retryable flags; shields session-lease acquire/release on cancellation.
  - Security: strips `Authorization` on cross-origin redirects even when supplied via client defaults.
  - Follow-ups: TASK-1692 (wrap `ArtifactPathError`) is implemented; TASK-1567 tracks cleaning up stale install-staging lock files.

<sup>Written for commit 9a08cd1b4796392fe0fa3113f876607ee0706623. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

