### PR TITLE
ci: supersede obsolete workflow runs instead of queueing them alongside

### DIFF
--- a/.github/workflows/backlog-guard.yml
+++ b/.github/workflows/backlog-guard.yml
@@ -9,6 +9,16 @@ on:
     paths:
       - 'backlog/tasks/**'
 
+# One run per workflow per ref: a new push supersedes the previous run instead of
+# queueing another alongside it. Without this, every push to `dev` stacked a full
+# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
+# The event name is part of the group so different trigger types (push,
+# pull_request, schedule) never cancel each other, and `main` is never cancelled
+# so its history stays complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   duplicate-task-ids:
     name: No duplicate backlog task IDs

--- a/.github/workflows/css-bundle-guard.yml
+++ b/.github/workflows/css-bundle-guard.yml
@@ -16,6 +16,16 @@ on:
     paths:
       - 'tldw_chatbook/css/**'
 
+# One run per workflow per ref: a new push supersedes the previous run instead of
+# queueing another alongside it. Without this, every push to `dev` stacked a full
+# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
+# The event name is part of the group so different trigger types (push,
+# pull_request, schedule) never cancel each other, and `main` is never cancelled
+# so its history stays complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   css-bundle-reproducible:
     name: CSS bundle reproduces from its sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,16 @@ on:
     # scheduled workflows execute from the default branch.
     - cron: '30 8 * * *'
 
+# One run per workflow per ref: a new push supersedes the previous run instead of
+# queueing another alongside it. Without this, every push to `dev` stacked a full
+# run - 50+ obsolete runs accumulated, all competing for scarce macOS runners.
+# The event name is part of the group so different trigger types (push,
+# pull_request, schedule) never cancel each other, and `main` is never cancelled
+# so its history stays complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
Adds a `concurrency` group to the three workflows on `dev`, so a new push cancels the previous run for the same workflow and ref rather than stacking another one beside it.

## Why

While investigating why an unrelated repository's CI had been queued for 40 minutes, I found this repo holding **94 queued runs with none executing** — the oldest sitting for 15 hours. **72 of them were testing superseded commits**, 54 on `dev` alone.

These workflows request `macos-latest`, a scarce and expensive runner pool, so the waste compounds fast and starves everything behind it — including other repositories on the same account, since concurrency limits are account-wide.

I cancelled the 72 superseded runs as a one-off, and jobs began executing immediately. But within minutes `dev` was back to 54 active runs, because nothing prevents the pileup from re-forming. This is the durable fix.

## Two deliberate narrowings

**The event name is part of the group.** `test.yml` has a nightly scheduled deep run; with a naive `${{ github.workflow }}-${{ github.ref }}` group, a push to the default branch would cancel it. Including `github.event_name` keeps push, pull_request, and schedule runs independent of each other.

**`cancel-in-progress` is false on `main`.** Default-branch history stays complete, which matters if anything is ever gated on CI having concluded on a specific `main` commit. The pileup is on `dev` and feature branches, which is exactly where cancelling is wanted.

## Notes

- Based on `dev` rather than `main`: `backlog-guard.yml` and `css-bundle-guard.yml` don't exist on `main`, and `dev` is where the accumulation happens.
- No job logic changed — this is three additive blocks, and all three files still parse as valid YAML.
- `python-app.yml` exists only on `main` and is untouched; worth the same treatment if it's still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub Actions concurrency to cancel superseded runs per workflow/ref, preventing piles of obsolete runs. This reduces queue time and frees scarce `macos-latest` capacity, especially on `dev`.

- **Refactors**
  - Set `concurrency.group` to `${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}` so push/pull_request/schedule runs don’t cancel each other.
  - Use `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` to keep `main` history complete; cancel on `dev` and feature branches.
  - Applied to `backlog-guard.yml`, `css-bundle-guard.yml`, and `test.yml` on `dev`. No job logic changed.

<sup>Written for commit a6caef9b52d922a853902b42031270cade4e72cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

