### PR TITLE
chore(backlog): file TASK-1744 — MLX test fixture sys.modules leak

### DIFF
--- a/backlog/tasks/task-1744 - Fix-sys-modules-patch-dict-leak-in-MLX-transcription-test-fixture.md
+++ b/backlog/tasks/task-1744 - Fix-sys-modules-patch-dict-leak-in-MLX-transcription-test-fixture.md
@@ -1,0 +1,31 @@
+---
+id: TASK-1744
+title: 'Fix the sys.modules patch.dict leak in the MLX transcription test fixture'
+status: To Do
+assignee: []
+created_date: '2026-08-01 11:40'
+labels: [tests, transcription, hygiene]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py`'s `service_module` fixture patches
+`sys.modules` via `patch.dict` in a way that leaks between imports: the module under test is only
+imported once per run today, so the defect is latent rather than active. The identical bug was found
+and fixed in the sibling file `test_transcription_service_parakeet_buffer_wav.py` while addressing
+PR #1171 review findings (merged as 74ddf7c6a); that fix was deliberately not extended to this file
+to keep the PR scoped. Left alone, it will bite the first time this file needs a second import in
+one process -- the failure mode is an import-order-dependent error that looks unrelated to its cause
+(numpy's "cannot load module more than once per process" was the shape it took in the sibling).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The fixture no longer leaks patched entries in `sys.modules` between tests or imports.
+- [ ] #2 A test proves the fixture is safe across two imports of the module under test in one process (fails against the current fixture).
+- [ ] #3 The file passes in isolation and when run alongside `test_transcription_service_parakeet_buffer_wav.py` in the same process.
+<!-- AC:END -->

--- a/backlog/tasks/task-1821 - Fix-sys-modules-patch-dict-leak-in-MLX-transcription-test-fixture.md
+++ b/backlog/tasks/task-1821 - Fix-sys-modules-patch-dict-leak-in-MLX-transcription-test-fixture.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-1744
+id: TASK-1821
 title: 'Fix the sys.modules patch.dict leak in the MLX transcription test fixture'
 status: To Do
 assignee: []


### PR DESCRIPTION
Files the one follow-up deliberately deferred from PR #1171's review.

`Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py`'s `service_module` fixture carries the same `patch.dict`-on-`sys.modules` leak that was fixed in its sibling (`test_transcription_service_parakeet_buffer_wav.py`) while addressing the PR #1171 findings. It is latent today — that file only imports once per run — so it was left out of #1171 to keep the diff scoped.

Backlog entry only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog task TASK-1821 (renumbered from TASK-1744) to fix a `sys.modules` leak in the MLX transcription test fixture (`Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py::service_module`). Mirrors the bug fixed in `test_transcription_service_parakeet_buffer_wav.py` in PR #1171; records acceptance criteria; no code changes.

<sup>Written for commit d7a15da39218ef37e6244ac8b9b5cf90a6d97dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

