### PR TITLE
fix(security): redact credentials from egress logs

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2400,7 +2400,7 @@
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "ca82a96931afabf055ca",
+      "diagnostic_digest": "77e51ea48869deb02e1c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/egress.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/superpowers/plans/2026-08-01-egress-log-url-redaction.md
+++ b/Docs/superpowers/plans/2026-08-01-egress-log-url-redaction.md
@@ -1,0 +1,83 @@
+# Egress Log URL Redaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent request credentials and URL details from reaching every egress-policy log line.
+
+**Architecture:** Keep redaction local to the two logging boundaries in `egress.py`. A private parser renders only a safe HTTP(S) origin and falls back to a constant for malformed input; policy decisions and caller-visible errors do not change.
+
+**Tech Stack:** Python 3.11, `urllib.parse`, Loguru, pytest
+
+---
+
+### Task 1: Redact URLs at both egress log sites
+
+**Files:**
+- Modify: `tldw_chatbook/Utils/egress.py`
+- Test: `Tests/Utils/test_egress.py`
+- Modify: `Docs/security/production-diagnostic-inventory.json`
+- Modify: `backlog/tasks/task-1722 - Redact-credentials-from-egress-block-logs.md`
+
+- [x] **Step 1: Write failing warning- and debug-path tests**
+
+Add `test_egress_block_log_redacts_url_credentials`, patch `_resolve` to return `10.0.0.1`, capture `egress.logger.warning`, and evaluate a URL containing userinfo, a path, a token query, and a fragment.
+
+Add `test_disabled_egress_log_redacts_url_credentials`, patch `get_cli_setting` to return `False` for the `enabled` key, capture `egress.logger.debug`, and evaluate the same credential-bearing URL.
+
+For both messages, assert that `https://example.test:8443` remains present while the userinfo, path, query, fragment, and their secret values are absent.
+
+- [x] **Step 2: Run the focused tests and verify the current leak**
+
+Run: `pytest -q Tests/Utils/test_egress.py -k "test_egress_block_log_redacts_url_credentials or test_disabled_egress_log_redacts_url_credentials"`
+
+Expected: FAIL because the current messages contain the full URL.
+
+- [x] **Step 3: Implement the minimal log-label helper**
+
+Add this private helper and call it from `_blocked` and the disabled branch of `_pre_resolution`:
+
+```python
+def _log_origin(url: str) -> str:
+    """Return a credential- and query-free URL label for transport logs."""
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return "<invalid-url>"
+    if not host or parsed.scheme not in ("http", "https"):
+        return "<invalid-url>"
+    rendered_host = f"[{host}]" if ":" in host else host
+    rendered_port = f":{port}" if port is not None else ""
+    return f"{parsed.scheme}://{rendered_host}{rendered_port}"
+```
+
+- [x] **Step 4: Run the focused tests and full egress module**
+
+Run: `pytest -q Tests/Utils/test_egress.py -k "test_egress_block_log_redacts_url_credentials or test_disabled_egress_log_redacts_url_credentials"`
+
+Expected: PASS.
+
+Run: `pytest -q Tests/Utils/test_egress.py`
+
+Expected: PASS.
+
+- [x] **Step 5: Run static checks and inspect the diff**
+
+Regenerate the reviewed persistent-diagnostic inventory, verify that only the existing `egress.py` owner digest changes, and run its architecture gate:
+
+Run: `python scripts/check_persistent_diagnostic_inventory.py --write`
+
+Run: `pytest -q Tests/Architecture/test_persistent_diagnostic_inventory.py`
+
+Run: `ruff check tldw_chatbook/Utils/egress.py Tests/Utils/test_egress.py`
+
+Run: `ruff format --check tldw_chatbook/Utils/egress.py Tests/Utils/test_egress.py`
+
+Run: `git diff --check`
+
+Expected: all commands succeed.
+
+- [x] **Step 6: Complete TASK-1722 bookkeeping and commit**
+
+Check every acceptance criterion, add concise implementation notes, set the task to Done only after verification, then commit the task, design, plan, implementation, and tests together.

--- a/Docs/superpowers/specs/2026-08-01-egress-log-url-redaction-design.md
+++ b/Docs/superpowers/specs/2026-08-01-egress-log-url-redaction-design.md
@@ -1,0 +1,24 @@
+# Egress Log URL Redaction Design
+
+**Status:** Approved
+**Task:** TASK-1722
+
+## Problem
+
+The egress policy currently interpolates full request URLs into its blocked-request warning and disabled-policy debug log. Presigned URLs and other credential-bearing URLs can therefore write userinfo, paths, query tokens, or fragments to persistent logs.
+
+## Decision
+
+Add a private `_log_origin(url)` helper to `tldw_chatbook/Utils/egress.py`. It parses HTTP(S) URLs and returns only `scheme://host[:port]`, preserving IPv6 brackets. Invalid or unsupported URLs return the constant `<invalid-url>`.
+
+Use the helper at both egress log sites. Request evaluation, exception messages, configuration, and public APIs remain unchanged.
+
+## Verification
+
+Focused tests will capture both warning and debug messages and prove that userinfo, path, query parameters, fragments, and their secret values are absent while the non-sensitive origin remains useful.
+
+## Architecture Decision Record
+
+- ADR required: no
+- ADR path: N/A
+- Reason: This is a localized security bug fix at an existing logging boundary and changes no storage, runtime, provider, or cross-module contract.

--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -161,6 +161,56 @@ def test_kill_switch_short_circuits_before_dns(monkeypatch):
     assert d.allowed and d.reason == "disabled"
 
 
+def test_egress_block_log_redacts_url_credentials(monkeypatch):
+    messages = []
+    monkeypatch.setattr(egress.logger, "warning", messages.append)
+    monkeypatch.setattr(egress, "_resolve", lambda host: ["10.0.0.1"])
+
+    decision = evaluate_url_policy(
+        "https://user:password@example.test:8443/models/parakeet.gguf"
+        "?token=secret#download"
+    )
+
+    assert decision.allowed is False
+    assert len(messages) == 1
+    assert "https://example.test:8443" in messages[0]
+    for sensitive_value in (
+        "user:password@",
+        "/models/parakeet.gguf",
+        "token=secret",
+        "secret",
+        "#download",
+    ):
+        assert sensitive_value not in messages[0]
+
+
+def test_disabled_egress_log_redacts_url_credentials(monkeypatch):
+    messages = []
+    monkeypatch.setattr(egress.logger, "debug", messages.append)
+    monkeypatch.setattr(
+        egress,
+        "get_cli_setting",
+        lambda section, key=None, default=None: False if key == "enabled" else default,
+    )
+
+    decision = evaluate_url_policy(
+        "https://user:password@example.test:8443/models/parakeet.gguf"
+        "?token=secret#download"
+    )
+
+    assert decision.allowed is True
+    assert len(messages) == 1
+    assert "https://example.test:8443" in messages[0]
+    for sensitive_value in (
+        "user:password@",
+        "/models/parakeet.gguf",
+        "token=secret",
+        "secret",
+        "#download",
+    ):
+        assert sensitive_value not in messages[0]
+
+
 def test_check_url_or_raise_raises_with_remedy(monkeypatch):
     _resolve_to(monkeypatch, ["127.0.0.1"])
     with pytest.raises(EgressBlockedError) as exc:

--- a/backlog/tasks/task-1722 - Redact-credentials-from-egress-block-logs.md
+++ b/backlog/tasks/task-1722 - Redact-credentials-from-egress-block-logs.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-1722
 title: Redact credentials from egress block logs
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-01 16:06'
+updated_date: '2026-08-01 18:38'
 labels:
   - security
   - logging
@@ -19,7 +21,36 @@ tldw_chatbook/Utils/egress.py logs the full request URL when it blocks a fetch (
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Egress log lines never contain a URL query string, fragment, or userinfo
-- [ ] #2 A blocked fetch of a URL with a token in the query string produces a log line asserted not to contain the token
-- [ ] #3 Redaction is applied at every egress log site, not only the block path
+- [x] #1 Egress log lines never contain a URL query string, fragment, or userinfo
+- [x] #2 A blocked fetch of a URL with a token in the query string produces a log line asserted not to contain the token
+- [x] #3 Redaction is applied at every egress log site, not only the block path
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing tests for blocked and disabled egress log paths using credential-bearing URLs.
+2. Add a private origin-only log label helper and apply it at both URL log sites.
+3. Regenerate and inspect the reviewed diagnostic inventory; only the existing egress.py call digest may change.
+4. Run focused tests, the full egress test module, the diagnostic inventory gate, static checks, and diff review.
+5. Check acceptance criteria, add implementation notes, and mark the task Done after verification.
+
+ADR required: no
+ADR path: N/A
+Reason: Localized security bug fix at an existing logging boundary; no architecture or cross-module contract changes.
+
+Approved design: Docs/superpowers/specs/2026-08-01-egress-log-url-redaction-design.md
+Implementation plan: Docs/superpowers/plans/2026-08-01-egress-log-url-redaction.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented origin-only sanitization for both URL-bearing egress log sites. `_log_origin()` now renders only `scheme://host[:port]` (with IPv6 brackets) and returns `<invalid-url>` for malformed or unsupported input; request evaluation and public error behavior are unchanged. Added warning- and debug-path regression tests covering userinfo, path, query-token, and fragment removal. Refreshed only the reviewed `tldw_chatbook/Utils/egress.py` diagnostic digest; owner counts and sink topology are unchanged.
+
+Verification: demonstrated both tests failing before the fix and passing afterward; post-rebase `Tests/Utils/test_egress.py` passed 72/72; the egress diagnostic owner and full sink topology match generated inventory; scoped Ruff (excluding pre-existing E402/F821 findings) and production-file format checks passed; commit/diff whitespace checks passed. The unrestricted full suite completed with 25,865 passed, 171 skipped, and four unrelated UI failures; serial reruns passed two and reproduced two deterministic latest-dev failures in unchanged Evals UI and Library worker-count sentinel paths. Latest dev also contains unrelated stale Voice V2 diagnostic inventory entries, which this task intentionally did not absorb.
+
+ADR required: no. This is a localized logging-boundary security fix. Independent review found no Critical or Important issues; its whitespace finding was fixed before the final squash.
+
+Modified: tldw_chatbook/Utils/egress.py, Tests/Utils/test_egress.py, Docs/security/production-diagnostic-inventory.json, approved design/plan documents, and this task file.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -109,8 +109,23 @@ def _classify_ip(ip_str: str) -> str:
     return "public" if ip.is_global else "private"
 
 
+def _log_origin(url: str) -> str:
+    """Return a credential- and query-free URL label for transport logs."""
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return "<invalid-url>"
+    if not host or parsed.scheme not in ("http", "https"):
+        return "<invalid-url>"
+    rendered_host = f"[{host}]" if ":" in host else host
+    rendered_port = f":{port}" if port is not None else ""
+    return f"{parsed.scheme}://{rendered_host}{rendered_port}"
+
+
 def _blocked(url: str, reason: str, host: str, detail: str = "") -> EgressDecision:
-    logger.warning(f"Egress blocked ({reason}): {url} {detail}".rstrip())
+    logger.warning(f"Egress blocked ({reason}): {_log_origin(url)} {detail}".rstrip())
     log_counter("egress_blocked", labels={"reason": reason})
     return EgressDecision(allowed=False, reason=reason, host=host)
 
@@ -118,7 +133,7 @@ def _blocked(url: str, reason: str, host: str, detail: str = "") -> EgressDecisi
 def _pre_resolution(url: str, trusted_origins: frozenset):
     """Checks that need no DNS. Returns EgressDecision, or the host to resolve."""
     if not _config_enabled():
-        logger.debug(f"Egress check disabled by [web_security] for {url}")
+        logger.debug(f"Egress check disabled by [web_security] for {_log_origin(url)}")
         log_counter("egress_check_skipped")
         return EgressDecision(allowed=True, reason="disabled", host="")
     try:


### PR DESCRIPTION
## Summary
- render only `scheme://host[:port]` at both URL-bearing egress log sites
- cover blocked-warning and disabled-policy debug paths with credential-bearing regression tests
- refresh only the reviewed `egress.py` diagnostic digest; owner counts and sink topology are unchanged
- close TASK-1722 with approved design, plan, and implementation notes

## Verification
- `Tests/Utils/test_egress.py`: 72 passed
- egress diagnostic owner entry and persistent sink topology match generated inventory
- scoped Ruff check and production-file format check pass
- commit/diff whitespace checks pass
- independent review: no Critical or Important issues

## Known latest-dev gate baseline
The unrestricted full suite completed with 25,865 passed and 171 skipped. Four unrelated UI tests failed; serial reruns passed both Watchlists parameter cases and reproduced two deterministic failures in unchanged latest-dev paths: the Evals second-target UI flow and the Library worker-count sentinel. Latest `dev` also has unrelated stale Console Voice V2 diagnostic-inventory entries; this PR intentionally changes only the `egress.py` digest.

## Task
- TASK-1722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts credentials and URL details from egress logs by logging only `scheme://host[:port]`, preventing tokens and userinfo from reaching persistent logs. Applied to blocked warnings and disabled-policy debug logs; closes TASK-1722.

- **Bug Fixes**
  - Added private `_log_origin(url)` in `tldw_chatbook/Utils/egress.py` to render only the origin (or `<invalid-url>` for malformed input).
  - Used `_log_origin` in `_blocked` and `_pre_resolution` to sanitize URL log labels.
  - Added tests asserting userinfo, path, query, and fragment are absent while the origin remains.
  - Updated the reviewed diagnostic inventory digest; no topology or owner changes.

<sup>Written for commit 96f8d796bdda8a7dda4abc4531f40a0c63a6f8df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

