### PR TITLE
feat(models): add curated and installed model browser views

### DIFF
--- a/Tests/Model_Artifacts/test_credentials_and_boundaries.py
+++ b/Tests/Model_Artifacts/test_credentials_and_boundaries.py
@@ -549,6 +549,8 @@ def test_stt_and_transcription_worker_modules_never_import_acquisition_or_fetch(
             import tldw_chatbook.STT.legacy_bridge
             import tldw_chatbook.STT.registry
             import tldw_chatbook.STT.routing
+            import tldw_chatbook.Model_Artifacts.curated_registry
+            import tldw_chatbook.Model_Artifacts.store
             import tldw_chatbook.Local_Ingestion.transcription_service
             import tldw_chatbook.Audio.console_dictation
         finally:

--- a/Tests/Model_Artifacts/test_curated_registry.py
+++ b/Tests/Model_Artifacts/test_curated_registry.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 
 def test_store_root_matches_the_parakeet_adapter_value() -> None:
     """Moving the root does not orphan existing managed installs."""
@@ -21,3 +23,54 @@ def test_managed_service_uses_an_explicit_root(tmp_path: Path) -> None:
 
     service = managed_service(tmp_path)
     assert service.artifacts_path == tmp_path / "artifacts"
+
+
+def test_registry_lists_registered_descriptors_in_registration_order() -> None:
+    """Curated entries are enumerable and remain catalog-compatible."""
+    from tldw_chatbook.Local_Ingestion.parakeet_v2_artifact import (
+        parakeet_v2_descriptor,
+        parakeet_v2_reference,
+        parakeet_v2_source_map,
+    )
+    from tldw_chatbook.Model_Artifacts.curated_registry import CuratedRegistry
+
+    registry = CuratedRegistry()
+    descriptor = parakeet_v2_descriptor()
+    reference = parakeet_v2_reference()
+    registry.register(descriptor, sources=parakeet_v2_source_map()[reference])
+
+    assert registry.list() == (descriptor,)
+    assert registry.descriptor(reference) is descriptor
+    assert registry.sources(reference) == parakeet_v2_source_map()[reference]
+
+
+def test_registry_descriptor_raises_keyerror_for_unknown_ref() -> None:
+    """Unknown references cannot be synthesized through the registry."""
+    from tldw_chatbook.Model_Artifacts.curated_registry import CuratedRegistry
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    with pytest.raises(KeyError):
+        CuratedRegistry().descriptor(ArtifactRef("nope", "rev", "int8"))
+
+
+def test_registry_does_not_import_the_acquisition_runtime_at_module_scope() -> None:
+    """Worker-side imports keep acquisition and fetch out of their graph."""
+    import inspect
+
+    from tldw_chatbook.Model_Artifacts import curated_registry as module
+
+    before_type_checking = inspect.getsource(module).split("if TYPE_CHECKING:")[0]
+    assert "class CuratedRegistry:" in inspect.getsource(module)
+    assert "from .acquisition import" not in before_type_checking
+
+
+def test_default_registry_contains_parakeet_v2() -> None:
+    """The existing production model is the first curated entry."""
+    from tldw_chatbook.Local_Ingestion.parakeet_v2_artifact import (
+        parakeet_v2_reference,
+    )
+    from tldw_chatbook.Model_Artifacts.curated_registry import curated_registry
+
+    assert parakeet_v2_reference() in {
+        descriptor.reference for descriptor in curated_registry().list()
+    }

--- a/Tests/Model_Artifacts/test_curated_registry.py
+++ b/Tests/Model_Artifacts/test_curated_registry.py
@@ -1,0 +1,23 @@
+"""Tests for the application-wide managed model registry and store."""
+
+from pathlib import Path
+
+
+def test_store_root_matches_the_parakeet_adapter_value() -> None:
+    """Moving the root does not orphan existing managed installs."""
+    from tldw_chatbook.Local_Ingestion import parakeet_v2_artifact
+    from tldw_chatbook.Model_Artifacts.store import managed_model_artifact_root
+
+    assert (
+        managed_model_artifact_root()
+        == parakeet_v2_artifact.managed_model_artifact_root()
+    )
+    assert isinstance(managed_model_artifact_root(), Path)
+
+
+def test_managed_service_uses_an_explicit_root(tmp_path: Path) -> None:
+    """Tests and callers can bind the service to an isolated store."""
+    from tldw_chatbook.Model_Artifacts.store import managed_service
+
+    service = managed_service(tmp_path)
+    assert service.artifacts_path == tmp_path / "artifacts"

--- a/Tests/Model_Artifacts/test_preflight.py
+++ b/Tests/Model_Artifacts/test_preflight.py
@@ -50,6 +50,9 @@ async def test_preflight_aggregates_and_grants(tmp_path):
     assert report.download_bytes == 2048
     assert report.sufficient_space is True
     assert report.entries[0].already_installed is False
+    assert report.entries[0].provenance == (
+        ProvenanceClass.CHATBOOK_CURATED,
+    )
     report.grant()  # must not raise
 
 

--- a/Tests/UI/test_lab_mode_strip.py
+++ b/Tests/UI/test_lab_mode_strip.py
@@ -270,13 +270,13 @@ async def test_lab_route_and_mode_strip_navigate_the_real_shell(
     from tldw_chatbook.UI.Screens.llm_screen import LLMScreen
 
     _prepare_clean_environment(monkeypatch, tmp_path)
-    # Isolate the navigation test from the Models screen's HuggingFace
-    # widgets: their init-fired reactives and scan/download workers schedule
+    # Isolate the navigation test from the remaining Download Models widgets:
+    # their init-fired reactives and download workers schedule
     # deferred DOM updates (call_later/thread completion) that race child
     # mounting and screen switches under run_test -- a pre-existing family of
     # races in those widgets, unrelated to shell navigation.
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
     from tldw_chatbook.Widgets.HuggingFace.download_manager import DownloadManager
-    from tldw_chatbook.Widgets.HuggingFace.local_models_widget import LocalModelsWidget
     from tldw_chatbook.Widgets.HuggingFace.model_search_widget import ModelSearchWidget
 
     async def _noop_async_update(self, *args):
@@ -284,9 +284,6 @@ async def test_lab_route_and_mode_strip_navigate_the_real_shell(
 
     monkeypatch.setattr(ModelSearchWidget, "perform_search", lambda self: None)
     monkeypatch.setattr(ModelSearchWidget, "_update_results_list", _noop_async_update)
-    monkeypatch.setattr(LocalModelsWidget, "scan_models", lambda self: None)
-    monkeypatch.setattr(LocalModelsWidget, "_refresh_model_list", _noop_async_update)
-    monkeypatch.setattr(LocalModelsWidget, "_update_summary", lambda self: None)
     monkeypatch.setattr(DownloadManager, "_refresh_downloads_list", _noop_async_update)
     monkeypatch.setattr(DownloadManager, "_update_summary", lambda self: None)
     app = _build_test_app()
@@ -309,25 +306,12 @@ async def test_lab_route_and_mode_strip_navigate_the_real_shell(
             )
             await _wait_until(
                 pilot,
-                lambda: len(app.screen.query(LocalModelsWidget)) == 1,
-                context="local models widget",
+                lambda: len(app.screen.query(InstalledView)) == 1,
+                context="installed models view",
             )
-            local_models = app.screen.query_one(LocalModelsWidget)
-            await _wait_until(
-                pilot,
-                lambda: len(local_models.query("#delete-confirm-dialog")) == 1,
-                context="delete confirmation dialog",
-            )
-            delete_confirm = local_models.query_one("#delete-confirm-dialog")
-            assert delete_confirm.display is False
-
-            local_models.show_delete_confirm = True
-            await pilot.pause()
-            assert delete_confirm.display is True
-
-            local_models.show_delete_confirm = False
-            await pilot.pause()
-            assert delete_confirm.display is False
+            installed_models = app.screen.query_one(InstalledView)
+            assert installed_models._service is None
+            assert installed_models._loaded is False
 
             assert app.screen.query_one("#lab-mode-models", Button).has_class(
                 "is-active"

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -149,6 +149,63 @@ async def test_the_status_row_reports_running_servers():
 
 
 @pytest.mark.asyncio
+async def test_model_install_progress_survives_switch_to_installed():
+    """Curated progress remains visible in Installed and in the Lab status row."""
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+    from tldw_chatbook.Widgets.ModelArtifacts import (
+        InstallProgressed,
+        InstallStatusChanged,
+    )
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        await pilot.pause()
+        await pilot.pause()
+        window = screen.query_one(LLMManagementWindow)
+        curated = window.query_one(CuratedView)
+        installed = window.query_one(InstalledView)
+        installed.ensure_loaded = MagicMock()
+        reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+        progress = AcquisitionProgress(
+            "fetch",
+            reference,
+            "encoder.onnx",
+            512,
+            1024,
+        )
+
+        curated.post_message(InstallStatusChanged(reference, active=True))
+        curated.post_message(InstallProgressed(progress))
+        await pilot.pause()
+
+        installed_row = next(
+            row for row in _rail_rows(screen) if row.lab_view_key == "installed"
+        )
+        installed_row.press()
+        await pilot.pause()
+
+        text = "\n".join(str(item.renderable) for item in installed.query(Static))
+        chip = screen.query_one("#lab-status-chip-model-install", Static)
+        assert "Downloading" in text
+        assert "Model install: downloading" in str(chip.renderable)
+
+        installed.ensure_loaded.reset_mock()
+        curated.post_message(
+            InstallStatusChanged(reference, active=False, succeeded=True)
+        )
+        await pilot.pause()
+
+        installed.ensure_loaded.assert_called_once_with(force=True)
+        assert "Model install: idle" in str(chip.renderable)
+
+
+@pytest.mark.asyncio
 async def test_the_inspector_rows_refresh_alongside_the_status_chip():
     """Regression test: `refresh_lab_status` used to update only the chip.
 

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -58,7 +58,7 @@ def _rail_rows(screen):
 
 
 @pytest.mark.asyncio
-async def test_all_nine_provider_rows_live_in_the_rail():
+async def test_all_provider_and_model_rows_live_in_the_rail():
     app = _app()
     async with app.run_test(size=(120, 40)) as pilot:
         screen = await _models_screen(app)
@@ -73,7 +73,8 @@ async def test_all_nine_provider_rows_live_in_the_rail():
             "onnx",
             "transformers",
             "mlx-lm",
-            "local-models",
+            "curated",
+            "installed",
             "download-models",
         ]
 

--- a/Tests/UI/test_model_artifact_widgets.py
+++ b/Tests/UI/test_model_artifact_widgets.py
@@ -1,0 +1,233 @@
+"""Focused Pilot tests for shared managed-model controls."""
+
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    ArtifactPreflightEntry,
+    PreflightReport,
+)
+from tldw_chatbook.Model_Artifacts.service import ArtifactRef, ProvenanceClass
+
+
+def _report(
+    destination: Path,
+    *,
+    sufficient_space: bool = True,
+    gating_errors: tuple[str, ...] = (),
+) -> PreflightReport:
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    return PreflightReport(
+        root=reference,
+        closure_fingerprint="f" * 64,
+        entries=(
+            ArtifactPreflightEntry(
+                ref=reference,
+                source_url="https://example.test/model",
+                repository="publisher/parakeet-v2",
+                revision="immutable-revision",
+                license_id="CC-BY-4.0",
+                license_url="https://example.test/license",
+                precision="int8",
+                total_bytes=1024,
+                file_count=4,
+                already_installed=False,
+                provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+            ),
+        ),
+        download_bytes=1024,
+        already_staged_bytes=64,
+        staging_overhead_bytes=128,
+        retained_bytes=0,
+        destination=destination,
+        free_bytes=4096 if sufficient_space else 1,
+        required_bytes=1152,
+        sufficient_space=sufficient_space,
+        gating_errors=gating_errors,
+    )
+
+
+class _PanelApp(App):
+    def __init__(self, report: PreflightReport) -> None:
+        self.report = report
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        from tldw_chatbook.Widgets.ModelArtifacts import ModelPlanPanel
+
+        yield ModelPlanPanel(self.report, model_label="Parakeet v2")
+
+
+class _ModalApp(App):
+    def compose(self) -> ComposeResult:
+        return []
+
+
+class _ProgressApp(App):
+    def __init__(self, initial=None) -> None:
+        self.initial = initial
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallProgress
+
+        yield ModelInstallProgress(self.initial)
+
+
+@pytest.mark.asyncio
+async def test_plan_panel_renders_every_consent_field(tmp_path: Path) -> None:
+    """Closure, source, license, bytes, staging, and disk result are visible."""
+    report = _report(tmp_path / "managed")
+    app = _PanelApp(report)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        text = "\n".join(str(item.renderable) for item in app.query(Static))
+
+    for expected in (
+        "publisher/parakeet-v2",
+        "immutable-revision",
+        "CC-BY-4.0",
+        "int8",
+        "4 files",
+        str(tmp_path / "managed"),
+        "Staging",
+        "Enough free space",
+    ):
+        assert expected in text
+
+
+@pytest.mark.asyncio
+async def test_install_is_disabled_when_report_is_not_grantable(
+    tmp_path: Path,
+) -> None:
+    """The consent plan is a hard gate, not a warning shown after failure."""
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+    report = _report(
+        tmp_path / "managed",
+        sufficient_space=False,
+        gating_errors=("Credential required",),
+    )
+    app = _ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ModelInstallModal(report, model_label="Parakeet v2"))
+        await pilot.pause()
+        confirm = app.screen.query_one("#model-install-confirm", Button)
+        text = "\n".join(str(item.renderable) for item in app.screen.query(Static))
+        assert confirm.disabled is True
+        assert "Not enough free space" in text
+        assert "Credential required" in text
+
+
+@pytest.mark.asyncio
+async def test_confirm_and_cancel_return_decisions(tmp_path: Path) -> None:
+    """The shared modal returns a decision and starts no acquisition work."""
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+    report = _report(tmp_path / "managed")
+    app = _ModalApp()
+    decisions: list[bool] = []
+    async with app.run_test() as pilot:
+        await app.push_screen(
+            ModelInstallModal(report, model_label="Parakeet v2"),
+            decisions.append,
+        )
+        await pilot.pause()
+        await pilot.click("#model-install-confirm")
+        await pilot.pause()
+        assert decisions == [True]
+
+        await app.push_screen(
+            ModelInstallModal(report, model_label="Parakeet v2"),
+            decisions.append,
+        )
+        await pilot.pause()
+        await pilot.click("#model-install-cancel")
+        await pilot.pause()
+        assert decisions == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_progress_widget_shows_each_phase_and_byte_detail() -> None:
+    """Progress names all four phases and limits byte copy to byte phases."""
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallProgress
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    events = (
+        AcquisitionProgress("fetch", reference, "encoder.onnx", 512, 1024),
+        AcquisitionProgress("pre-verify", reference, "encoder.onnx", 1024, 1024),
+        AcquisitionProgress("verify-install", reference, None, 0, 0),
+        AcquisitionProgress("activate", reference, None, 0, 0),
+    )
+    expected_labels = (
+        "Downloading",
+        "Checking",
+        "Verifying and installing",
+        "Activating",
+    )
+    app = _ProgressApp()
+    async with app.run_test() as pilot:
+        widget = app.query_one(ModelInstallProgress)
+        for index, (event, expected) in enumerate(zip(events, expected_labels)):
+            widget.update_progress(event)
+            await pilot.pause()
+            text = "\n".join(str(item.renderable) for item in widget.query(Static))
+            assert expected in text
+            if index < 2:
+                assert "encoder.onnx" in text
+                assert "/" in text
+            else:
+                assert "encoder.onnx" not in text
+                assert "/" not in text
+
+
+def test_progress_callback_posts_a_message_without_touching_widgets() -> None:
+    """The worker-thread callback only crosses the boundary with a message."""
+    from textual.message import Message
+
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Widgets.ModelArtifacts import (
+        InstallProgressed,
+        make_progress_callback,
+    )
+
+    received: list[Message] = []
+    callback = make_progress_callback(received.append)
+    event = AcquisitionProgress(
+        "fetch",
+        ArtifactRef("parakeet-v2", "immutable-revision", "int8"),
+        "encoder.onnx",
+        1,
+        2,
+    )
+
+    callback(event)
+
+    assert len(received) == 1
+    assert isinstance(received[0], InstallProgressed)
+    assert received[0].progress is event
+
+
+@pytest.mark.asyncio
+async def test_progress_widget_restores_the_latest_event_after_recompose() -> None:
+    """A host recompose does not erase an in-flight install's status."""
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+
+    event = AcquisitionProgress(
+        "fetch",
+        ArtifactRef("parakeet-v2", "immutable-revision", "int8"),
+        "encoder.onnx",
+        256,
+        1024,
+    )
+    app = _ProgressApp(event)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        text = "\n".join(str(item.renderable) for item in app.query(Static))
+
+    assert "Downloading" in text
+    assert "encoder.onnx" in text

--- a/Tests/UI/test_model_browser_state.py
+++ b/Tests/UI/test_model_browser_state.py
@@ -1,0 +1,145 @@
+"""Pure state-mapping tests for the managed model browser."""
+
+from pathlib import Path
+
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    ArtifactPreflightEntry,
+    PreflightReport,
+)
+from tldw_chatbook.Model_Artifacts.service import (
+    ArtifactDiskUsage,
+    ArtifactRef,
+    InstalledArtifact,
+    ProvenanceClass,
+)
+
+
+def _report(destination: Path) -> PreflightReport:
+    reference = ArtifactRef("parakeet-v2", "rev1", "int8")
+    return PreflightReport(
+        root=reference,
+        closure_fingerprint="f" * 64,
+        entries=(
+            ArtifactPreflightEntry(
+                ref=reference,
+                source_url="https://example.test/model",
+                repository="publisher/parakeet-v2",
+                revision="immutable-revision",
+                license_id="CC-BY-4.0",
+                license_url="https://example.test/license",
+                precision="int8",
+                total_bytes=1234,
+                file_count=4,
+                already_installed=False,
+                provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+            ),
+        ),
+        download_bytes=1234,
+        already_staged_bytes=100,
+        staging_overhead_bytes=256,
+        retained_bytes=0,
+        destination=destination,
+        free_bytes=10_000,
+        required_bytes=1490,
+        sufficient_space=True,
+        gating_errors=(),
+    )
+
+
+def test_plan_rows_and_totals_preserve_every_consent_field(tmp_path: Path) -> None:
+    """The render model contains every field required for informed consent."""
+    from tldw_chatbook.UI.Screens.model_browser_state import plan_rows, plan_totals
+
+    report = _report(tmp_path / "models")
+    row = plan_rows(report)[0]
+    totals = plan_totals(report)
+
+    assert row.repository == "publisher/parakeet-v2"
+    assert row.revision == "immutable-revision"
+    assert row.license_id == "CC-BY-4.0"
+    assert row.license_url == "https://example.test/license"
+    assert row.precision == "int8"
+    assert row.file_count == 4
+    assert row.total_bytes == 1234
+    assert row.provenance == "Curated by Chatbook"
+    assert totals.download_bytes == 1234
+    assert totals.already_staged_bytes == 100
+    assert totals.staging_overhead_bytes == 256
+    assert totals.destination == tmp_path / "models"
+    assert totals.free_bytes == 10_000
+    assert totals.required_bytes == 1490
+    assert totals.sufficient_space is True
+
+
+def test_provenance_labels_are_precise_and_never_imply_safety() -> None:
+    """Trust copy states evidence without claiming malware safety."""
+    from tldw_chatbook.UI.Screens.model_browser_state import provenance_label
+
+    labels = (
+        provenance_label((ProvenanceClass.CHATBOOK_CURATED,)),
+        provenance_label((ProvenanceClass.INTEGRITY_VERIFIED,)),
+        provenance_label((ProvenanceClass.LOCAL_INTEGRITY_RECORDED,)),
+    )
+    assert len(set(labels)) == 3
+    for label in labels:
+        assert "safe" not in label.lower()
+        assert "malware" not in label.lower()
+        assert "trusted" not in label.lower()
+
+
+def test_inventory_keeps_broken_and_unmanaged_rows_visible(tmp_path: Path) -> None:
+    """Corrupt manifests and legacy files remain visible and actionable."""
+    from tldw_chatbook.UI.Screens.model_browser_state import (
+        UnmanagedRow,
+        inventory_rows,
+    )
+
+    broken = InstalledArtifact(
+        path=tmp_path / "broken-model",
+        descriptor=None,
+        ready=False,
+        active=False,
+        error="readiness: unreadable",
+    )
+    usage = ArtifactDiskUsage(installed_bytes=100, staging_bytes=25, free_bytes=500)
+    rows = inventory_rows(
+        (broken,),
+        usage,
+        (UnmanagedRow(path=tmp_path / "legacy.gguf", size_bytes=40),),
+    )
+
+    assert rows[0].is_broken is True
+    assert "Repair" in rows[0].action_hint
+    assert rows[1].is_unmanaged is True
+    assert rows[1].provenance == "Unmanaged — integrity unknown"
+    assert rows[1].installed_store_bytes == 100
+    assert rows[1].staging_store_bytes == 25
+
+
+def test_install_failure_messages_are_typed_labeled_and_sanitized() -> None:
+    """Raw acquisition details never reach user notifications."""
+    from tldw_chatbook.Model_Artifacts.acquisition import (
+        AcquisitionBusyError,
+        CatalogError,
+        InsufficientSpaceError,
+        PreflightNotGrantableError,
+        TransferError,
+    )
+    from tldw_chatbook.UI.Screens.model_browser_state import install_failure_message
+
+    marker = "SECRET-GATING-DETAIL"
+    errors = (
+        AcquisitionBusyError(marker),
+        CatalogError(marker),
+        InsufficientSpaceError(marker),
+        PreflightNotGrantableError(marker),
+        TransferError(marker, retryable=True),
+    )
+    messages = tuple(
+        install_failure_message(error, model_label="Whisper") for error in errors
+    )
+
+    assert all(marker not in message for message in messages)
+    assert all(message for message in messages)
+    assert "Whisper" in messages[0]
+    assert "Whisper" in messages[1]

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
 from textual.widgets import Button
 
 from tldw_chatbook.Model_Artifacts.service import ArtifactRef
@@ -47,6 +48,22 @@ def test_unmanaged_scan_is_bounded_and_labels_supported_model_files(
 
     assert len(rows) == 2
     assert all(row.path.suffix == ".gguf" for row in rows)
+
+
+def test_unmanaged_scan_validates_root_before_walking(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Configured legacy roots pass the shared path-safety boundary first."""
+    from tldw_chatbook.UI.Screens import model_installed_view as module
+
+    walk = MagicMock()
+    monkeypatch.setattr(module.os, "walk", walk)
+
+    with pytest.raises(ValueError, match="dangerous pattern"):
+        module.InstalledView.scan_unmanaged(tmp_path / "../..")
+
+    walk.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -143,20 +160,22 @@ def test_repair_summary_reports_every_reconciliation_outcome(tmp_path: Path) -> 
 
 
 @pytest.mark.parametrize(
-    ("worker_name", "service_method", "worker_args"),
+    ("worker_name", "service_method", "worker_args", "log_context"),
     (
-        ("_load_inventory", "list_installed", ()),
+        ("_load_inventory", "list_installed", (), ("legacy", "configured")),
         (
             "_activate_model",
             "activate",
             (ArtifactRef("parakeet-v2", "rev", "int8"),),
+            ("parakeet-v2", "rev", "int8"),
         ),
         (
             "_delete_model",
             "delete",
             (ArtifactRef("parakeet-v2", "rev", "int8"),),
+            ("parakeet-v2", "rev", "int8"),
         ),
-        ("_repair_store", "reconcile", ()),
+        ("_repair_store", "reconcile", (), ("store", "shared")),
     ),
 )
 def test_installed_worker_failures_are_logged_and_sanitized(
@@ -165,6 +184,7 @@ def test_installed_worker_failures_are_logged_and_sanitized(
     worker_name: str,
     service_method: str,
     worker_args: tuple,
+    log_context: tuple[str, ...],
 ) -> None:
     """Every background failure retains diagnostics without exposing them in UI."""
     from tldw_chatbook.UI.Screens import model_installed_view as module
@@ -184,6 +204,8 @@ def test_installed_worker_failures_are_logged_and_sanitized(
 
     fake_logger.opt.assert_called_once_with(exception=True)
     fake_logger.error.assert_called_once()
+    logged = " ".join(str(value) for value in fake_logger.error.call_args.args).casefold()
+    assert all(value in logged for value in log_context)
     assert marker not in str(fake_app.call_from_thread.call_args)
 
 
@@ -328,6 +350,96 @@ def test_curated_preflight_result_opens_the_shared_modal(
     modal, callback = fake_app.push_screen.call_args[0]
     assert isinstance(modal, ModelInstallModal)
     assert callback == view._confirm_install
+
+
+def test_curated_progress_tolerates_recompose_gap() -> None:
+    """A progress event is retained while its widget is temporarily absent."""
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.Widgets.ModelArtifacts import InstallProgressed
+
+    progress = AcquisitionProgress(
+        "fetch",
+        ArtifactRef("parakeet-v2", "immutable-revision", "int8"),
+        "encoder.onnx",
+        1,
+        2,
+    )
+    view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
+    view.query_one = MagicMock(side_effect=NoMatches)
+    view.refresh = MagicMock()
+
+    view._install_progressed(InstallProgressed(progress))
+
+    assert view._progress is progress
+    view.refresh.assert_called_once_with(recompose=True)
+
+
+def test_curated_provision_completion_tolerates_recompose_gap() -> None:
+    """Missing progress markup cannot skip install cleanup and refresh."""
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
+    view._operation_reference = reference
+    view._pending_report = object()
+    view._progress = object()
+    view.query_one = MagicMock(side_effect=NoMatches)
+    view.notify = MagicMock()
+    view.post_message = MagicMock()
+    view.ensure_loaded = MagicMock()
+
+    view._apply_provision_result(None)
+
+    assert view._operation_reference is None
+    assert view._pending_report is None
+    assert view._progress is None
+    view.post_message.assert_called_once()
+    view.ensure_loaded.assert_called_once_with(force=True)
+
+
+@pytest.mark.parametrize("operation", ("preflight", "installation"))
+def test_curated_install_failures_log_exact_artifact_context(
+    operation: str,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Worker diagnostics identify the safe immutable artifact reference."""
+    from Tests.UI.test_model_artifact_widgets import _report
+    from tldw_chatbook.UI.Screens import model_curated_view as module
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    fake_app = MagicMock()
+    fake_logger = MagicMock()
+    fake_logger.opt.return_value = fake_logger
+    monkeypatch.setattr(module.CuratedView, "app", property(lambda self: fake_app))
+    monkeypatch.setattr(module, "logger", fake_logger)
+    view = module.CuratedView(
+        service_factory=MagicMock(),
+        registry_factory=MagicMock(),
+    )
+
+    if operation == "preflight":
+        async def fail_preflight(_reference):
+            raise RuntimeError("PRIVATE-WORKER-DETAIL")
+
+        view._preflight = fail_preflight
+        module.CuratedView._preflight_model.__wrapped__(view, reference)
+    else:
+        report = _report(tmp_path / "managed")
+        view._pending_report = report
+
+        async def fail_provision(_report):
+            raise RuntimeError("PRIVATE-WORKER-DETAIL")
+
+        view._provision = fail_provision
+        module.CuratedView._provision_model.__wrapped__(view)
+        reference = report.root
+
+    logged = " ".join(str(value) for value in fake_logger.error.call_args.args)
+    assert reference.artifact_id in logged
+    assert reference.revision in logged
+    assert reference.variant in logged
 
 
 def test_models_rail_lists_curated_and_installed_and_drops_local_models() -> None:

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -114,3 +114,57 @@ def test_lease_blocked_deletion_message_is_specific_and_sanitized() -> None:
 
     assert "in use" in message
     assert marker not in message
+
+
+@pytest.mark.asyncio
+async def test_curated_view_performs_no_io_at_compose_time(tmp_path: Path) -> None:
+    """Curated is also eagerly mounted but remains idle until selected."""
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+
+    service_factory = MagicMock()
+    registry_factory = MagicMock()
+    view = CuratedView(
+        service_factory=service_factory,
+        registry_factory=registry_factory,
+    )
+    app = _InstalledApp(view)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+    service_factory.assert_not_called()
+    registry_factory.assert_not_called()
+
+
+def test_curated_preflight_result_opens_the_shared_modal(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Selection shows the exact shared consent plan before acquisition."""
+    from Tests.UI.test_model_artifact_widgets import _report
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(CuratedView, "app", property(lambda self: fake_app))
+    view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
+    report = _report(tmp_path / "managed")
+    view._operation_reference = report.root
+
+    view._apply_preflight_result(report, None)
+
+    assert view._pending_report is report
+    modal, callback = fake_app.push_screen.call_args[0]
+    assert isinstance(modal, ModelInstallModal)
+    assert callback == view._confirm_install
+
+
+def test_models_rail_lists_curated_and_installed_and_drops_local_models() -> None:
+    """Phase 1 replaces Local Models while preserving the legacy downloader."""
+    from tldw_chatbook.UI.Screens.llm_screen import MODELS_RAIL_SECTIONS
+
+    models_section = dict(MODELS_RAIL_SECTIONS)["Models"]
+    keys = [key for key, _label in models_section]
+    assert "curated" in keys
+    assert "installed" in keys
+    assert "local-models" not in keys
+    assert "download-models" in keys

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -116,6 +116,32 @@ def test_lease_blocked_deletion_message_is_specific_and_sanitized() -> None:
     assert marker not in message
 
 
+def test_deletion_requires_confirmation_before_starting_worker(monkeypatch) -> None:
+    """The destructive service call starts only after explicit confirmation."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+    from tldw_chatbook.Widgets.ModelArtifacts.activation_controls import (
+        DeletionRequested,
+    )
+    from tldw_chatbook.Widgets.delete_confirmation_dialog import (
+        DeleteConfirmationDialog,
+    )
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    fake_app = MagicMock()
+    monkeypatch.setattr(InstalledView, "app", property(lambda self: fake_app))
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=Path("/tmp/models"))
+    view.refresh = MagicMock()
+    view._delete_model = MagicMock()
+
+    view._deletion_requested(DeletionRequested(reference))
+
+    view._delete_model.assert_not_called()
+    dialog, callback = fake_app.push_screen.call_args[0]
+    assert isinstance(dialog, DeleteConfirmationDialog)
+    callback(True)
+    view._delete_model.assert_called_once_with(reference)
+
+
 @pytest.mark.asyncio
 async def test_empty_inventory_still_reports_managed_and_staging_space(
     tmp_path: Path,

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -129,14 +129,15 @@ def test_repair_summary_reports_every_reconciliation_outcome(tmp_path: Path) -> 
         state_removed=3,
         corrupt_artifacts=(tmp_path / marker,),
         staging_entries=(tmp_path / "staged-a", tmp_path / "staged-b"),
-        staging_removed=("staged-a", "staged-b"),
+        staging_removed=(),
     )
 
     message = reconcile_result_message(report)
 
     assert "2 readiness" in message
     assert "3 stale state" in message
-    assert "2 staging" in message
+    assert "2 staging entries observed" in message
+    assert "0 staging entries removed" in message
     assert "1 corrupt model" in message
     assert marker not in message
 
@@ -233,6 +234,37 @@ async def test_empty_inventory_still_reports_managed_and_staging_space(
 
     assert "2.0 KiB staging" in text
     assert "4.0 KiB free" in text
+
+
+@pytest.mark.asyncio
+async def test_mounted_install_progress_updates_without_recomposing_inventory(
+    tmp_path: Path,
+) -> None:
+    """Frequent byte events mutate the progress widget, not every model row."""
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    progress = AcquisitionProgress(
+        "fetch",
+        reference,
+        "encoder.onnx",
+        512,
+        1024,
+    )
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    app = _InstalledApp(view)
+    async with app.run_test() as pilot:
+        view.set_install_state(None, active=True)
+        await pilot.pause()
+        view.refresh = MagicMock()
+        view.set_install_state(progress, active=True)
+        await pilot.pause()
+        text = "\n".join(str(item.renderable) for item in view.query("Static"))
+
+    view.refresh.assert_not_called()
+    assert "Downloading" in text
+    assert "encoder.onnx" in text
 
 
 def test_forced_refresh_queues_behind_an_inflight_inventory_load(tmp_path: Path) -> None:

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -117,6 +117,29 @@ def test_lease_blocked_deletion_message_is_specific_and_sanitized() -> None:
 
 
 @pytest.mark.asyncio
+async def test_empty_inventory_still_reports_managed_and_staging_space(
+    tmp_path: Path,
+) -> None:
+    """Disk totals do not disappear merely because no manifest row exists."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactDiskUsage
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    app = _InstalledApp(view)
+    async with app.run_test() as pilot:
+        view._apply_inventory(
+            (),
+            ArtifactDiskUsage(installed_bytes=0, staging_bytes=2048, free_bytes=4096),
+            None,
+        )
+        await pilot.pause()
+        text = "\n".join(str(item.renderable) for item in view.query("Static"))
+
+    assert "2.0 KiB staging" in text
+    assert "4.0 KiB free" in text
+
+
+@pytest.mark.asyncio
 async def test_curated_view_performs_no_io_at_compose_time(tmp_path: Path) -> None:
     """Curated is also eagerly mounted but remains idle until selected."""
     from tldw_chatbook.UI.Screens.model_curated_view import CuratedView

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -1,0 +1,116 @@
+"""Focused tests for the managed-model Installed view."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+
+class _InstalledApp(App):
+    def __init__(self, view) -> None:
+        self.view = view
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield self.view
+
+
+@pytest.mark.asyncio
+async def test_installed_view_performs_no_io_at_compose_time(tmp_path: Path) -> None:
+    """Eagerly mounted model views stay idle until their rail row is selected."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    service_factory = MagicMock()
+    view = InstalledView(service_factory=service_factory, legacy_dir=tmp_path)
+    app = _InstalledApp(view)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+    service_factory.assert_not_called()
+
+
+def test_unmanaged_scan_is_bounded_and_labels_supported_model_files(
+    tmp_path: Path,
+) -> None:
+    """Legacy GGUF/ONNX files stay visible without an unbounded result set."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    for index in range(3):
+        (tmp_path / f"model-{index}.gguf").write_bytes(b"x" * (1024 * 1024 + 1))
+    (tmp_path / "ignore.txt").write_text("not a model")
+
+    rows = InstalledView.scan_unmanaged(tmp_path, limit=2)
+
+    assert len(rows) == 2
+    assert all(row.path.suffix == ".gguf" for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_activation_controls_emit_intents_and_refuse_pending_reentry() -> None:
+    """Controls post exact refs and disable both mutations while pending."""
+    from tldw_chatbook.Widgets.ModelArtifacts.activation_controls import (
+        ActivationRequested,
+        DeletionRequested,
+        ModelActivationControls,
+    )
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+
+    class _ControlsApp(App):
+        def __init__(self) -> None:
+            self.messages = []
+            super().__init__()
+
+        def compose(self) -> ComposeResult:
+            yield ModelActivationControls(reference, active=False, ready=True)
+
+        def on_activation_requested(self, event: ActivationRequested) -> None:
+            self.messages.append(event)
+
+        def on_deletion_requested(self, event: DeletionRequested) -> None:
+            self.messages.append(event)
+
+    app = _ControlsApp()
+    async with app.run_test() as pilot:
+        controls = app.query_one(ModelActivationControls)
+        await pilot.click(".model-activate")
+        await pilot.pause()
+        assert isinstance(app.messages[0], ActivationRequested)
+        assert app.messages[0].reference == reference
+
+        controls.set_pending(True)
+        await pilot.pause()
+        assert app.query_one(".model-activate", Button).disabled is True
+        assert app.query_one(".model-delete", Button).disabled is True
+
+
+def test_installed_view_refuses_a_second_lifecycle_operation() -> None:
+    """Activation/deletion cannot re-enter while hashing or leasing is pending."""
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=Path("/tmp/models"))
+    view._operation_reference = ArtifactRef("parakeet-v2", "rev1", "int8")
+    view._activate_model = MagicMock()
+
+    view._request_activation(ArtifactRef("parakeet-v2", "rev2", "f32"))
+
+    view._activate_model.assert_not_called()
+
+
+def test_lease_blocked_deletion_message_is_specific_and_sanitized() -> None:
+    """An active lease is named without surfacing raw internal exception text."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactInUseError
+    from tldw_chatbook.UI.Screens.model_installed_view import lifecycle_failure_message
+
+    marker = "RAW-LEASE-DETAIL"
+    message = lifecycle_failure_message(
+        ArtifactInUseError(marker),
+        operation="delete",
+    )
+
+    assert "in use" in message
+    assert marker not in message

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -116,6 +116,76 @@ def test_lease_blocked_deletion_message_is_specific_and_sanitized() -> None:
     assert marker not in message
 
 
+def test_repair_summary_reports_every_reconciliation_outcome(tmp_path: Path) -> None:
+    """Repair copy names state/staging cleanup and corruption without paths."""
+    from tldw_chatbook.Model_Artifacts.service import ReconcileReport
+    from tldw_chatbook.UI.Screens.model_installed_view import (
+        reconcile_result_message,
+    )
+
+    marker = "PRIVATE-MODEL-PATH"
+    report = ReconcileReport(
+        readiness_created=2,
+        state_removed=3,
+        corrupt_artifacts=(tmp_path / marker,),
+        staging_entries=(tmp_path / "staged-a", tmp_path / "staged-b"),
+        staging_removed=("staged-a", "staged-b"),
+    )
+
+    message = reconcile_result_message(report)
+
+    assert "2 readiness" in message
+    assert "3 stale state" in message
+    assert "2 staging" in message
+    assert "1 corrupt model" in message
+    assert marker not in message
+
+
+@pytest.mark.parametrize(
+    ("worker_name", "service_method", "worker_args"),
+    (
+        ("_load_inventory", "list_installed", ()),
+        (
+            "_activate_model",
+            "activate",
+            (ArtifactRef("parakeet-v2", "rev", "int8"),),
+        ),
+        (
+            "_delete_model",
+            "delete",
+            (ArtifactRef("parakeet-v2", "rev", "int8"),),
+        ),
+        ("_repair_store", "reconcile", ()),
+    ),
+)
+def test_installed_worker_failures_are_logged_and_sanitized(
+    monkeypatch,
+    tmp_path: Path,
+    worker_name: str,
+    service_method: str,
+    worker_args: tuple,
+) -> None:
+    """Every background failure retains diagnostics without exposing them in UI."""
+    from tldw_chatbook.UI.Screens import model_installed_view as module
+
+    marker = "PRIVATE-WORKER-DETAIL"
+    service = MagicMock()
+    getattr(service, service_method).side_effect = RuntimeError(marker)
+    fake_app = MagicMock()
+    fake_logger = MagicMock()
+    fake_logger.opt.return_value = fake_logger
+    monkeypatch.setattr(module.InstalledView, "app", property(lambda self: fake_app))
+    monkeypatch.setattr(module, "logger", fake_logger)
+    view = module.InstalledView(service_factory=lambda: service, legacy_dir=tmp_path)
+
+    worker = getattr(module.InstalledView, worker_name).__wrapped__
+    worker(view, *worker_args)
+
+    fake_logger.opt.assert_called_once_with(exception=True)
+    fake_logger.error.assert_called_once()
+    assert marker not in str(fake_app.call_from_thread.call_args)
+
+
 def test_deletion_requires_confirmation_before_starting_worker(monkeypatch) -> None:
     """The destructive service call starts only after explicit confirmation."""
     from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
@@ -163,6 +233,27 @@ async def test_empty_inventory_still_reports_managed_and_staging_space(
 
     assert "2.0 KiB staging" in text
     assert "4.0 KiB free" in text
+
+
+def test_forced_refresh_queues_behind_an_inflight_inventory_load(tmp_path: Path) -> None:
+    """A lifecycle completion cannot lose its mandatory post-operation refresh."""
+    from tldw_chatbook.Model_Artifacts.service import ArtifactDiskUsage
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    view = InstalledView(service_factory=MagicMock(), legacy_dir=tmp_path)
+    view._loading = True
+    view._load_inventory = MagicMock()
+    view.refresh = MagicMock()
+
+    view.ensure_loaded(force=True)
+    view._apply_inventory(
+        (),
+        ArtifactDiskUsage(installed_bytes=0, staging_bytes=0, free_bytes=4096),
+        None,
+    )
+
+    view._load_inventory.assert_called_once_with()
+    assert view._loading is True
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_parakeet_v2_install_ui.py
+++ b/Tests/UI/test_parakeet_v2_install_ui.py
@@ -29,17 +29,33 @@ from tldw_chatbook.Model_Artifacts.acquisition import (
     PreflightReport,
     TransferError,
 )
+from tldw_chatbook.UI.Screens.model_browser_state import install_failure_message
 from tldw_chatbook.UI.Screens.library_screen import (
     LibraryScreen,
-    ParakeetV2InstallModal,
-    _parakeet_v2_failure_message,
     _ParakeetV2NoPendingReportError,
 )
+from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
 
 
 class _ModalApp(App):
     def compose(self):
         return []
+
+
+def _modal(report: PreflightReport) -> ModelInstallModal:
+    """Build the shared modal with Library's stable control ids."""
+    return ModelInstallModal(
+        report,
+        model_label="Parakeet v2",
+        container_id="parakeet-v2-install-modal",
+        confirm_id="parakeet-v2-install-confirm",
+        cancel_id="parakeet-v2-install-cancel",
+    )
+
+
+def _failure(exc: BaseException) -> str:
+    """Map failures through the shared, model-labeled sanitizer."""
+    return install_failure_message(exc, model_label="Parakeet v2")
 
 
 def _report(
@@ -101,7 +117,7 @@ async def test_install_modal_shows_consent_details_from_report_and_confirms(
     async with app.run_test() as pilot:
         captured: list[bool] = []
         await app.push_screen(
-            ParakeetV2InstallModal(report),
+            _modal(report),
             lambda result: captured.append(result),
         )
         await pilot.pause()
@@ -141,7 +157,7 @@ async def test_install_modal_renders_values_from_the_injected_report(
     )
     app = _ModalApp()
     async with app.run_test() as pilot:
-        await app.push_screen(ParakeetV2InstallModal(report), lambda result: None)
+        await app.push_screen(_modal(report), lambda result: None)
         await pilot.pause()
 
         text = "\n".join(
@@ -165,7 +181,7 @@ async def test_install_modal_surfaces_gating_errors_and_disables_confirm(
     )
     app = _ModalApp()
     async with app.run_test() as pilot:
-        await app.push_screen(ParakeetV2InstallModal(report), lambda result: None)
+        await app.push_screen(_modal(report), lambda result: None)
         await pilot.pause()
 
         text = "\n".join(
@@ -191,7 +207,7 @@ async def test_install_modal_shows_insufficient_space_verdict_and_disables_confi
     )
     app = _ModalApp()
     async with app.run_test() as pilot:
-        await app.push_screen(ParakeetV2InstallModal(report), lambda result: None)
+        await app.push_screen(_modal(report), lambda result: None)
         await pilot.pause()
 
         text = "\n".join(
@@ -255,7 +271,7 @@ def test_preflight_result_shows_modal_built_from_the_report(
     fake_app.push_screen.assert_called_once()
     call_args = fake_app.push_screen.call_args
     modal = call_args[0][0]
-    assert isinstance(modal, ParakeetV2InstallModal)
+    assert isinstance(modal, ModelInstallModal)
     assert modal.report is report
     assert call_args[0][1] == screen._confirm_parakeet_v2_install
 
@@ -297,6 +313,59 @@ def test_declining_confirmation_does_not_start_installer_worker() -> None:
     screen._run_parakeet_v2_install.assert_not_called()
 
 
+def test_install_worker_passes_a_progress_callback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Library forwards acquisition progress instead of installing silently."""
+    import tldw_chatbook.UI.Screens.library_screen as library_module
+
+    captured: dict[str, object] = {}
+
+    async def fake_provision(report, *, progress=None):
+        captured["report"] = report
+        captured["progress"] = progress
+        return tmp_path / "installed"
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(LibraryScreen, "app", property(lambda self: fake_app))
+    monkeypatch.setattr(library_module, "run_parakeet_v2_provision", fake_provision)
+    screen = object.__new__(LibraryScreen)
+    screen._parakeet_v2_pending_report = _report(destination=tmp_path / "d")
+
+    LibraryScreen._run_parakeet_v2_install.__wrapped__(screen)
+
+    assert captured["report"] is screen._parakeet_v2_pending_report
+    assert callable(captured["progress"])
+
+
+def test_progress_message_updates_retained_state_and_widget() -> None:
+    """Progress remains visible after the consent modal is dismissed."""
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Widgets.ModelArtifacts import (
+        InstallProgressed,
+        ModelInstallProgress,
+    )
+
+    progress = AcquisitionProgress(
+        "fetch",
+        ArtifactRef("parakeet-v2", "immutable-revision", "int8"),
+        "encoder.onnx",
+        1,
+        2,
+    )
+    widget = MagicMock(spec=ModelInstallProgress)
+    screen = object.__new__(LibraryScreen)
+    screen._parakeet_v2_install_progress = None
+    screen.query_one = MagicMock(return_value=widget)
+
+    screen.handle_model_install_progressed(InstallProgressed(progress))
+
+    assert screen._parakeet_v2_install_progress is progress
+    assert widget.display is True
+    widget.update_progress.assert_called_once_with(progress)
+
+
 # ---------------------------------------------------------------------------
 # PR-1167 review (Finding 2): failures are mapped to stable, user-safe
 # messages -- never the raw exception text, which for some of these types
@@ -309,28 +378,28 @@ _RAW_MARKER = "RAW-EXCEPTION-TEXT-MUST-NOT-REACH-NOTIFY-4f2c9a"
 
 def test_failure_message_maps_insufficient_space() -> None:
     exc = InsufficientSpaceError(f"{_RAW_MARKER}: need 900000000 but have 100")
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert message == "Not enough free disk space for this install."
     assert _RAW_MARKER not in message
 
 
 def test_failure_message_maps_gated_repository() -> None:
     exc = GatedRepositoryError(f"{_RAW_MARKER}: repo requires auth")
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert "requires a credential" in message
     assert _RAW_MARKER not in message
 
 
 def test_failure_message_maps_acquisition_busy() -> None:
     exc = AcquisitionBusyError(f"{_RAW_MARKER}: session lease held")
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert "already in progress" in message
     assert _RAW_MARKER not in message
 
 
 def test_failure_message_maps_consent_mismatch() -> None:
     exc = ConsentMismatchError(f"{_RAW_MARKER}: fingerprint changed")
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert "plan changed" in message
     assert _RAW_MARKER not in message
 
@@ -342,54 +411,52 @@ def test_failure_message_maps_preflight_not_grantable_without_leaking_gating_tup
     exc = PreflightNotGrantableError(
         f"preflight not grantable: gating_errors=('{_RAW_MARKER}',), sufficient_space=False"
     )
-    message = _parakeet_v2_failure_message(exc)
-    assert "can no longer proceed" in message
+    message = _failure(exc)
+    assert "cannot proceed" in message
     assert _RAW_MARKER not in message
 
 
 def test_failure_message_maps_catalog_error() -> None:
     exc = CatalogError(f"{_RAW_MARKER}: unknown artifact")
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert "misconfigured" in message
     assert _RAW_MARKER not in message
 
 
 def test_failure_message_maps_retryable_transfer_error() -> None:
     exc = TransferError(f"{_RAW_MARKER}: connection reset", retryable=True)
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert "interrupted" in message and "Retry" in message
     assert _RAW_MARKER not in message
 
 
 def test_failure_message_maps_non_retryable_transfer_error() -> None:
     exc = TransferError(f"{_RAW_MARKER}: oversized body", retryable=False)
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert "cannot be retried automatically" in message
     assert _RAW_MARKER not in message
 
 
-def test_failure_message_maps_no_pending_report_verbatim() -> None:
-    # The one case that's safe to show verbatim: authored entirely by this
-    # module, with no injected content.
+def test_failure_message_maps_no_pending_report_without_raw_text() -> None:
     exc = _ParakeetV2NoPendingReportError(
         "No Parakeet v2 install plan is available; retry Install."
     )
-    assert _parakeet_v2_failure_message(exc) == str(exc)
+    assert _failure(exc) == "Parakeet v2 install failed. See the application log for details."
 
 
 def test_failure_message_falls_back_for_unknown_exception_types() -> None:
     exc = RuntimeError(f"{_RAW_MARKER}: something unexpected")
-    message = _parakeet_v2_failure_message(exc)
+    message = _failure(exc)
     assert message == "Parakeet v2 install failed. See the application log for details."
     assert _RAW_MARKER not in message
 
 
 def test_preflight_result_notify_text_uses_mapped_message_not_raw_exception() -> None:
     """End-to-end through the notify composition: the same mapped message
-    ``_parakeet_v2_failure_message`` returns is what ``notify()`` actually
+    ``install_failure_message`` returns is what ``notify()`` actually
     receives, with no raw exception text anywhere in it.
     """
-    mapped = _parakeet_v2_failure_message(InsufficientSpaceError(_RAW_MARKER))
+    mapped = _failure(InsufficientSpaceError(_RAW_MARKER))
     screen = object.__new__(LibraryScreen)
     screen._parakeet_v2_install_worker = MagicMock()
     screen.app_instance = MagicMock()
@@ -402,12 +469,13 @@ def test_preflight_result_notify_text_uses_mapped_message_not_raw_exception() ->
 
 
 def test_install_result_notify_text_uses_mapped_message_not_raw_exception() -> None:
-    mapped = _parakeet_v2_failure_message(GatedRepositoryError(_RAW_MARKER))
+    mapped = _failure(GatedRepositoryError(_RAW_MARKER))
     screen = object.__new__(LibraryScreen)
     screen._library_ingest_form = LibraryIngestFormState()
     screen._parakeet_v2_install_worker = MagicMock()
     screen.app_instance = MagicMock()
     screen.refresh = MagicMock()
+    screen.query_one = MagicMock()
 
     screen._apply_parakeet_v2_install_result(None, mapped)
 
@@ -430,6 +498,7 @@ def test_successful_install_populates_current_batch_model_folder(
     screen._parakeet_v2_install_worker = MagicMock()
     screen.app_instance = MagicMock()
     screen.refresh = MagicMock()
+    screen.query_one = MagicMock()
 
     screen._apply_parakeet_v2_install_result(installed, None)
 

--- a/Tests/UI/test_parakeet_v2_install_ui.py
+++ b/Tests/UI/test_parakeet_v2_install_ui.py
@@ -17,7 +17,7 @@ from textual.app import App
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Library.library_ingest_state import LibraryIngestFormState
-from tldw_chatbook.Model_Artifacts import ArtifactRef
+from tldw_chatbook.Model_Artifacts import ArtifactRef, ProvenanceClass
 from tldw_chatbook.Model_Artifacts.acquisition import (
     AcquisitionBusyError,
     ArtifactPreflightEntry,
@@ -68,6 +68,7 @@ def _report(
         total_bytes=download_bytes,
         file_count=4,
         already_installed=already_installed,
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
     )
     return PreflightReport(
         root=ref,

--- a/Tests/Utils/test_security_enhancements.py
+++ b/Tests/Utils/test_security_enhancements.py
@@ -90,6 +90,11 @@ class TestValidatePathSimple:
         with pytest.raises(ValueError, match="dangerous pattern"):
             validate_path_simple("..\\..\\etc\\passwd")
 
+        # The second parent reference may terminate the path. Windows CI
+        # constructs this exact shape for a lock root beneath ``tmp_path``.
+        with pytest.raises(ValueError, match="dangerous pattern"):
+            validate_path_simple("C:\\Temp\\cache\\..\\..")
+
 
 class TestLogSanitizer:
     """Test the log sanitization utilities."""

--- a/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
+++ b/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:02'
-updated_date: '2026-08-01 19:05'
+updated_date: '2026-08-01 19:56'
 labels:
   - stt
   - artifacts
@@ -16,6 +16,8 @@ references:
   - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
 documentation:
   - Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md
+  - Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md
+  - Docs/superpowers/plans/2026-08-01-task-596-model-browser-phase-1.md
 priority: high
 ---
 
@@ -28,13 +30,13 @@ Replace the existing downloader-oriented GGUF browser with a provider-neutral ar
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 The browser exposes distinct Curated, Remote, and Installed views backed only by ModelArtifactService and catalog interfaces.
-- [ ] #2 Curated, Integrity verified, and Local integrity recorded provenance labels are displayed precisely and never imply malware safety.
-- [ ] #3 Install confirmation shows the full dependency closure, immutable source revision, license, precision, download bytes, staging requirement, destination, and free-space result.
+- [x] #2 Curated, Integrity verified, and Local integrity recorded provenance labels are displayed precisely and never imply malware safety.
+- [x] #3 Install confirmation shows the full dependency closure, immutable source revision, license, precision, download bytes, staging requirement, destination, and free-space result.
 - [ ] #4 Installed inventory shows active and retained revisions, dependencies, installed versus staging space, and deletion blockers including idle resident models.
 - [ ] #5 Deletion can request an idle heavy-worker recycle but cannot bypass an active lease or silently cancel an active job.
 - [ ] #6 Remote search, inventory refresh, install progress, and deletion run off the Textual event loop with bounded results and focused UI tests.
-- [ ] #7 Users can select and persist the active installed artifact revision and precision; unavailable or unverified versions cannot be selected.
-- [ ] #8 The model picker, install confirmation, progress, activation, and installed-state controls are reusable by Settings and onboarding without duplicating artifact or download logic.
+- [x] #7 Users can select and persist the active installed artifact revision and precision; unavailable or unverified versions cannot be selected.
+- [x] #8 The model picker, install confirmation, progress, activation, and installed-state controls are reusable by Settings and onboarding without duplicating artifact or download logic.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -55,4 +57,6 @@ Reason: ADR-025 already governs the shared model store, trust labels, acquisitio
 Claimed 2026-08-01 (ppqq clone). Design approved section-by-section; spec at Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md. Phased: Phase 1 = curated registry + pure view-model + shared widgets + Curated/Installed views + Library modal refactored onto the shared modal (AC 1 partial, 2, 3, 4, 6 local, 7, 8). Phase 2 = Remote search with resolve-on-select. Phase 3 = GGUF import + server path resolution + retire Widgets/HuggingFace. AC 5 idle heavy-worker recycle is deferred because no pool-owner unload mechanism exists; Phase 1 reports blockers without bypassing leases.
 
 Recovery 2026-08-01: the stale ppqq claim was exhaustively checked before resuming. No corresponding local/remote branch, worktree, GitHub PR, or visible Codex task was found. Recovery continues Phase 1 in codex/task-596-model-browser-phase-1 from origin/dev; no duplicate implementation was located.
+
+Phase 1 implementation (2026-08-01): centralized the shared managed model store, added the offline curated registry and preflight provenance, introduced pure browser state plus reusable consent/progress/activation controls, migrated Library Parakeet installation to the shared flow, and added lazy Curated and Installed Lab views. Installed includes bounded legacy-file discovery, managed/staging/free-space totals, lease-safe activation/deletion, explicit deletion confirmation, and user-triggered repair. Download Models remains available until Phase 3. Verification: focused affected suite 1184 passed, 1 expected skip; Installed/shared-widget safety follow-up 16 passed; Ruff passed on all changed Python files; mypy passed on the 10 new shared/browser modules; py_compile and git diff --check passed. The attempted repository-wide UI-inclusive run was stopped after 316 passing tests because the unrelated UI corpus projected an excessive local runtime; the scoped gate covers all changed modules plus Model_Artifacts, Local_Ingestion, STT, and console dictation. Remaining TASK-596 work: Phase 2 Remote and Phase 3 GGUF adoption/legacy browser retirement; AC #5 idle heavy-worker recycle remains deferred to a pool-owner unload mechanism.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
+++ b/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:02'
-updated_date: '2026-08-01 20:16'
+updated_date: '2026-08-01 20:17'
 labels:
   - stt
   - artifacts
@@ -61,4 +61,6 @@ Recovery 2026-08-01: the stale ppqq claim was exhaustively checked before resumi
 Phase 1 implementation (2026-08-01): centralized the shared managed model store, added the offline curated registry and preflight provenance, introduced pure browser state plus reusable consent/progress/activation controls, migrated Library Parakeet installation to the shared flow, and added lazy Curated and Installed Lab views. Installed includes bounded legacy-file discovery, managed/staging/free-space totals, lease-safe activation/deletion, explicit deletion confirmation, and user-triggered repair. Download Models remains available until Phase 3. Verification: focused affected suite 1184 passed, 1 expected skip; Installed/shared-widget safety follow-up 16 passed; Ruff passed on all changed Python files; mypy passed on the 10 new shared/browser modules; py_compile and git diff --check passed. The attempted repository-wide UI-inclusive run was stopped after 316 passing tests because the unrelated UI corpus projected an excessive local runtime; the scoped gate covers all changed modules plus Model_Artifacts, Local_Ingestion, STT, and console dictation. Remaining TASK-596 work: Phase 2 Remote and Phase 3 GGUF adoption/legacy browser retirement; AC #5 idle heavy-worker recycle remains deferred to a pool-owner unload mechanism.
 
 Final review remediation (2026-08-01): queued forced refreshes behind in-flight inventory reads; disabled lifecycle mutation during loading; persisted Curated install state into Installed and the Lab status chip; refreshed Installed on completion; added explicit deletion confirmation; expanded Repair summaries to include readiness, stale state, staging observed/removed, and corrupt-model counts; logged all Installed worker failures with sanitized UI copy; and changed byte-progress rendering to update mounted widgets in place. Final independent review found no remaining Critical or Important issues and marked the branch ready to merge. Final scoped verification on 3f160216f: 1193 passed, 1 expected skip; Ruff passed across all changed Python files; mypy passed across the 12 affected shared/browser source files; git diff --check passed.
+
+Phase 1 pull request: #1175 (https://github.com/rmusser01/tldw_chatbook/pull/1175), targeting dev.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
+++ b/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:02'
-updated_date: '2026-08-01 20:17'
+updated_date: '2026-08-01 20:36'
 labels:
   - stt
   - artifacts
@@ -63,4 +63,6 @@ Phase 1 implementation (2026-08-01): centralized the shared managed model store,
 Final review remediation (2026-08-01): queued forced refreshes behind in-flight inventory reads; disabled lifecycle mutation during loading; persisted Curated install state into Installed and the Lab status chip; refreshed Installed on completion; added explicit deletion confirmation; expanded Repair summaries to include readiness, stale state, staging observed/removed, and corrupt-model counts; logged all Installed worker failures with sanitized UI copy; and changed byte-progress rendering to update mounted widgets in place. Final independent review found no remaining Critical or Important issues and marked the branch ready to merge. Final scoped verification on 3f160216f: 1193 passed, 1 expected skip; Ruff passed across all changed Python files; mypy passed across the 12 affected shared/browser source files; git diff --check passed.
 
 Phase 1 pull request: #1175 (https://github.com/rmusser01/tldw_chatbook/pull/1175), targeting dev.
+
+PR #1175 review remediation (2026-08-01): validated legacy scan roots through the shared path-safety boundary before os.walk; added safe model/store context to background error logs; hardened Curated progress/completion handlers against Textual NoMatches during recompose; and corrected the shared Windows traversal pattern so terminal ..\.. lock roots are rejected consistently with POSIX. Verification: 1208 passed, 1 expected skip across Model_Artifacts, Local_Ingestion, STT, console dictation, affected Lab/UI modules, and path-security tests; Ruff passed on changed files; mypy passed on the three affected source modules; git diff --check passed. The 55-failure sandbox run was rerun with loopback fixture permission and passed completely.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
+++ b/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:02'
-updated_date: '2026-08-01 19:56'
+updated_date: '2026-08-01 20:16'
 labels:
   - stt
   - artifacts
@@ -59,4 +59,6 @@ Claimed 2026-08-01 (ppqq clone). Design approved section-by-section; spec at Doc
 Recovery 2026-08-01: the stale ppqq claim was exhaustively checked before resuming. No corresponding local/remote branch, worktree, GitHub PR, or visible Codex task was found. Recovery continues Phase 1 in codex/task-596-model-browser-phase-1 from origin/dev; no duplicate implementation was located.
 
 Phase 1 implementation (2026-08-01): centralized the shared managed model store, added the offline curated registry and preflight provenance, introduced pure browser state plus reusable consent/progress/activation controls, migrated Library Parakeet installation to the shared flow, and added lazy Curated and Installed Lab views. Installed includes bounded legacy-file discovery, managed/staging/free-space totals, lease-safe activation/deletion, explicit deletion confirmation, and user-triggered repair. Download Models remains available until Phase 3. Verification: focused affected suite 1184 passed, 1 expected skip; Installed/shared-widget safety follow-up 16 passed; Ruff passed on all changed Python files; mypy passed on the 10 new shared/browser modules; py_compile and git diff --check passed. The attempted repository-wide UI-inclusive run was stopped after 316 passing tests because the unrelated UI corpus projected an excessive local runtime; the scoped gate covers all changed modules plus Model_Artifacts, Local_Ingestion, STT, and console dictation. Remaining TASK-596 work: Phase 2 Remote and Phase 3 GGUF adoption/legacy browser retirement; AC #5 idle heavy-worker recycle remains deferred to a pool-owner unload mechanism.
+
+Final review remediation (2026-08-01): queued forced refreshes behind in-flight inventory reads; disabled lifecycle mutation during loading; persisted Curated install state into Installed and the Lab status chip; refreshed Installed on completion; added explicit deletion confirmation; expanded Repair summaries to include readiness, stale state, staging observed/removed, and corrupt-model counts; logged all Installed worker failures with sanitized UI copy; and changed byte-progress rendering to update mounted widgets in place. Final independent review found no remaining Critical or Important issues and marked the branch ready to merge. Final scoped verification on 3f160216f: 1193 passed, 1 expected skip; Ruff passed across all changed Python files; mypy passed across the 12 affected shared/browser source files; git diff --check passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
+++ b/backlog/tasks/task-596 - Renovate-the-local-model-artifact-browser.md
@@ -2,9 +2,10 @@
 id: TASK-596
 title: Renovate the local model artifact browser
 status: In Progress
-assignee: []
+assignee:
+  - '@codex'
 created_date: '2026-07-24 01:02'
-updated_date: '2026-08-01 16:42'
+updated_date: '2026-08-01 19:05'
 labels:
   - stt
   - artifacts
@@ -36,8 +37,22 @@ Replace the existing downloader-oriented GGUF browser with a provider-neutral ar
 - [ ] #8 The model picker, install confirmation, progress, activation, and installed-state controls are reusable by Settings and onboarding without duplicating artifact or download logic.
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. ADR required: no
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already governs the shared model store, trust labels, acquisition, activation, and deletion boundaries.
+2. Implement Phase 1 Tasks 1-4 test-first: neutral store access, curated registry, preflight provenance, and pure state mapping.
+3. Implement the minimum shared install plan/progress/modal controls and migrate the existing Library Parakeet flow.
+4. Add offline Curated and Installed Lab views, preserving lazy I/O and lease-safe activation/deletion behavior.
+5. Run focused regression tests, static checks, and code review; leave Remote, GGUF import, legacy-browser retirement, and idle-worker recycle for their approved later phases.
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Claimed 2026-08-01 (ppqq clone). Design approved section-by-section; spec at Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md. Phased: Phase 1 = curated registry + pure view-model + shared widgets + Curated/Installed views + Library modal refactored onto the shared modal (AC 1 partial, 2, 3, 4, 6 local, 7, 8). Phase 2 = Remote search with resolve-on-select. Phase 3 = GGUF import + server path resolution + retire Widgets/HuggingFace. AC 5's idle heavy-worker recycle is DEFERRED: no mechanism exists to ask a worker to unload a resident model; Phase 1 reports lease blockers honestly. Claiming per the TASK-595 duplicate-implementation guard -- check this note and the spec filename before starting parallel work.
+Claimed 2026-08-01 (ppqq clone). Design approved section-by-section; spec at Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md. Phased: Phase 1 = curated registry + pure view-model + shared widgets + Curated/Installed views + Library modal refactored onto the shared modal (AC 1 partial, 2, 3, 4, 6 local, 7, 8). Phase 2 = Remote search with resolve-on-select. Phase 3 = GGUF import + server path resolution + retire Widgets/HuggingFace. AC 5 idle heavy-worker recycle is deferred because no pool-owner unload mechanism exists; Phase 1 reports blockers without bypassing leases.
+
+Recovery 2026-08-01: the stale ppqq claim was exhaustively checked before resuming. No corresponding local/remote branch, worktree, GitHub PR, or visible Codex task was found. Recovery continues Phase 1 in codex/task-596-model-browser-phase-1 from origin/dev; no duplicate implementation was located.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Local_Ingestion/parakeet_v2_artifact.py
+++ b/tldw_chatbook/Local_Ingestion/parakeet_v2_artifact.py
@@ -61,7 +61,6 @@ from tldw_chatbook.Model_Artifacts.store import managed_model_artifact_root
 if TYPE_CHECKING:
     from tldw_chatbook.Model_Artifacts.acquisition import (
         AcquisitionProgress,
-        ArtifactCatalog,
         ArtifactSourceMap,
         CredentialResolver,
         PreflightReport,

--- a/tldw_chatbook/Local_Ingestion/parakeet_v2_artifact.py
+++ b/tldw_chatbook/Local_Ingestion/parakeet_v2_artifact.py
@@ -56,6 +56,7 @@ from tldw_chatbook.Model_Artifacts.service import (
     ModelArtifactService,
     ProvenanceClass,
 )
+from tldw_chatbook.Model_Artifacts.store import managed_model_artifact_root
 
 if TYPE_CHECKING:
     from tldw_chatbook.Model_Artifacts.acquisition import (
@@ -228,26 +229,6 @@ class ParakeetV2Catalog:
         if ref != parakeet_v2_reference():
             raise KeyError(ref)
         return parakeet_v2_descriptor()
-
-
-def managed_model_artifact_root() -> Path:
-    """Return the shared managed-artifact store root.
-
-    A sibling of the legacy installer's own ``models/stt/...`` destination
-    (``parakeet_v2_installer.parakeet_v2_install_dir()``), both beneath the
-    existing user-data directory -- so a fresh install and a legacy one
-    never collide on disk. Not Parakeet-specific: every future managed
-    artifact this application acquires shares this one
-    ``ModelArtifactService`` root, distinguished internally by artifact id,
-    revision, and variant.
-
-    Returns:
-        The absolute path to the shared managed-artifact store root.
-    """
-
-    from tldw_chatbook.Utils.paths import get_user_data_dir
-
-    return get_user_data_dir() / "models" / "managed"
 
 
 def parakeet_v2_managed_service() -> ModelArtifactService:

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -51,6 +51,7 @@ from .service import (
     ArtifactPathError,
     ArtifactRef,
     ArtifactStateError,
+    ProvenanceClass,
     _validate_url,
     closure_fingerprint,
 )
@@ -324,6 +325,7 @@ class ArtifactPreflightEntry:
     total_bytes: int
     file_count: int
     already_installed: bool
+    provenance: tuple[ProvenanceClass, ...]
 
 
 @dataclass(frozen=True)
@@ -934,6 +936,7 @@ class ArtifactAcquisitionService:
                 total_bytes=descriptor.expected_installed_bytes,
                 file_count=len(descriptor.files),
                 already_installed=already_installed,
+                provenance=descriptor.provenance,
             )
             entries.append(entry)
             if not already_installed:

--- a/tldw_chatbook/Model_Artifacts/curated_registry.py
+++ b/tldw_chatbook/Model_Artifacts/curated_registry.py
@@ -1,0 +1,101 @@
+"""Application-curated model descriptors and their download sources.
+
+The registry structurally satisfies the acquisition catalog protocol without
+loading the network-capable acquisition layer into worker processes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from .service import ArtifactDescriptor, ArtifactRef
+
+if TYPE_CHECKING:
+    from .acquisition import ArtifactCatalog  # noqa: F401
+
+
+class CuratedRegistry:
+    """Ordered catalog of model descriptors curated by the application."""
+
+    def __init__(self) -> None:
+        self._descriptors: dict[ArtifactRef, ArtifactDescriptor] = {}
+        self._sources: dict[ArtifactRef, dict[str, str]] = {}
+
+    def register(
+        self,
+        descriptor: ArtifactDescriptor,
+        *,
+        sources: Mapping[str, str],
+    ) -> None:
+        """Register one curated model and its credential-free file sources.
+
+        Args:
+            descriptor: Immutable model descriptor.
+            sources: Relative file paths mapped to download URLs.
+        """
+        self._descriptors[descriptor.reference] = descriptor
+        self._sources[descriptor.reference] = dict(sources)
+
+    def list(self) -> tuple[ArtifactDescriptor, ...]:
+        """Return registered descriptors in registration order.
+
+        Returns:
+            The registered descriptors.
+        """
+        return tuple(self._descriptors.values())
+
+    def descriptor(self, ref: ArtifactRef) -> ArtifactDescriptor:
+        """Return the descriptor for an exact reference.
+
+        Args:
+            ref: Exact model reference.
+
+        Returns:
+            The registered descriptor.
+
+        Raises:
+            KeyError: If ``ref`` is not registered.
+        """
+        return self._descriptors[ref]
+
+    def sources(self, ref: ArtifactRef) -> dict[str, str]:
+        """Return a copy of the file-source map for an exact reference.
+
+        Args:
+            ref: Exact model reference.
+
+        Returns:
+            Relative file paths mapped to download URLs.
+
+        Raises:
+            KeyError: If ``ref`` is not registered.
+        """
+        return dict(self._sources[ref])
+
+
+_REGISTRY: CuratedRegistry | None = None
+
+
+def curated_registry() -> CuratedRegistry:
+    """Return the shared registry with the built-in models registered once.
+
+    Returns:
+        The process-wide curated registry.
+    """
+    global _REGISTRY
+    if _REGISTRY is None:
+        registry = CuratedRegistry()
+        from tldw_chatbook.Local_Ingestion.parakeet_v2_artifact import (
+            parakeet_v2_descriptor,
+            parakeet_v2_reference,
+            parakeet_v2_source_map,
+        )
+
+        reference = parakeet_v2_reference()
+        registry.register(
+            parakeet_v2_descriptor(),
+            sources=parakeet_v2_source_map()[reference],
+        )
+        _REGISTRY = registry
+    return _REGISTRY

--- a/tldw_chatbook/Model_Artifacts/store.py
+++ b/tldw_chatbook/Model_Artifacts/store.py
@@ -1,0 +1,34 @@
+"""Process-wide managed model store location and service construction.
+
+Only the synchronous service layer is imported at module scope so worker-side
+imports do not pull in the acquisition or fetch runtimes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .service import ModelArtifactService
+
+
+def managed_model_artifact_root() -> Path:
+    """Return the shared managed-model store root.
+
+    Returns:
+        The absolute path to the shared managed-model store root.
+    """
+    from tldw_chatbook.Utils.paths import get_user_data_dir
+
+    return get_user_data_dir() / "models" / "managed"
+
+
+def managed_service(root: Path | None = None) -> ModelArtifactService:
+    """Return a service bound to the managed-model store.
+
+    Args:
+        root: Optional store-root override, primarily for isolated tests.
+
+    Returns:
+        A service rooted at ``root`` or the process-wide managed store.
+    """
+    return ModelArtifactService(root or managed_model_artifact_root())

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable
 
 #
 # 3rd-Party Imports
+from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, VerticalScroll, Horizontal, Vertical
 from textual.css.query import QueryError
@@ -38,6 +39,7 @@ from ..Event_Handlers.LLM_Management_Events.server_lifecycle import (
     server_is_active,
 )
 from ..Utils.log_widget_manager import LogWidgetManager
+from ..Widgets.ModelArtifacts import InstallProgressed, InstallStatusChanged
 
 if TYPE_CHECKING:
     from ..app import TldwCli
@@ -249,6 +251,8 @@ class LLMManagementWindow(Container):
         super().__init__(**kwargs)
         self.app_instance = app_instance
         self._async_presentation_generations: dict[str, int] = {}
+        self._managed_install_active = False
+        self._managed_install_progress = None
 
         # Map navigation button IDs to view IDs
         self.view_mapping = {
@@ -929,6 +933,38 @@ class LLMManagementWindow(Container):
                 yield HuggingFaceModelBrowser(
                     self.app_instance, id="huggingface-model-browser"
                 )
+
+    @on(InstallProgressed)
+    def _managed_install_progressed(self, event: InstallProgressed) -> None:
+        """Mirror Curated progress into the persistent Installed view."""
+        from .Screens.model_installed_view import InstalledView
+
+        self._managed_install_active = True
+        self._managed_install_progress = event.progress
+        try:
+            installed = self.query_one("#installed-models-view", InstalledView)
+        except QueryError:
+            return
+        installed.set_install_state(event.progress, active=True)
+
+    @on(InstallStatusChanged)
+    def _managed_install_status_changed(self, event: InstallStatusChanged) -> None:
+        """Synchronize install lifecycle state and refresh completed inventory."""
+        from .Screens.model_installed_view import InstalledView
+
+        self._managed_install_active = event.active
+        if not event.active:
+            self._managed_install_progress = None
+        try:
+            installed = self.query_one("#installed-models-view", InstalledView)
+        except QueryError:
+            return
+        installed.set_install_state(
+            self._managed_install_progress,
+            active=event.active,
+        )
+        if not event.active:
+            installed.ensure_loaded(force=True)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         """Route allowlisted actions inside this destination."""

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -259,7 +259,8 @@ class LLMManagementWindow(Container):
             "onnx": "llm-view-onnx",
             "transformers": "llm-view-transformers",
             "mlx-lm": "llm-view-mlx-lm",
-            "local-models": "llm-view-local-models",
+            "curated": "llm-view-curated",
+            "installed": "llm-view-installed",
             "download-models": "llm-view-download-models",
         }
 
@@ -897,11 +898,29 @@ class LLMManagementWindow(Container):
                     classes="log_output_large",
                 )
 
-            # Local Models View (preserved unchanged)
-            with Container(id="llm-view-local-models", classes="llm-view"):
-                from ..Widgets.HuggingFace import LocalModelsWidget
+            # Curated and Installed stay idle until their rail row is selected.
+            with Container(id="llm-view-curated", classes="llm-view"):
+                from .Screens.model_curated_view import CuratedView
 
-                yield LocalModelsWidget(self.app_instance, id="local-models-widget")
+                yield CuratedView(id="curated-models-view")
+
+            with Container(id="llm-view-installed", classes="llm-view"):
+                from .Screens.model_installed_view import InstalledView
+
+                legacy_dir = None
+                app_config = getattr(self.app_instance, "app_config", {})
+                if isinstance(app_config, dict):
+                    configured = app_config.get("llm_management", {}).get(
+                        "model_download_dir"
+                    )
+                    if configured:
+                        from pathlib import Path
+
+                        legacy_dir = Path(str(configured)).expanduser()
+                yield InstalledView(
+                    legacy_dir=legacy_dir,
+                    id="installed-models-view",
+                )
 
             # Download Models View (preserved unchanged)
             with Container(id="llm-view-download-models", classes="llm-view"):
@@ -1057,6 +1076,18 @@ class LLMManagementWindow(Container):
         that -- a live request to huggingface.co on arrival, for users who
         never open Download Models (task-887).
         """
+        if view_name in {"curated", "installed"}:
+            try:
+                managed_view = view_widget.query_one(
+                    "#curated-models-view"
+                    if view_name == "curated"
+                    else "#installed-models-view"
+                )
+            except QueryError:
+                logger.debug(f"{view_name.title()} view is unavailable; skipped.")
+                return
+            managed_view.ensure_loaded()
+            return
         if view_name != "download-models":
             return
         # Local import: this module is on the Models mount path, and the

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -232,10 +232,17 @@ from ...Widgets.Library import (
 from ...Widgets.Library.library_file_notes_workspace import (
     LibraryFileNotesWorkspace,
 )
+from ...Widgets.ModelArtifacts import (
+    InstallProgressed,
+    ModelInstallModal,
+    ModelInstallProgress,
+    make_progress_callback,
+)
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 from ..Views.RAGSearch.search_handoff import build_library_rag_console_live_work_payload
 from .destination_recovery import DestinationRecoveryState, policy_denied_recovery_state
+from .model_browser_state import install_failure_message
 from .skills_screen import SkillTrustBootstrapModal, SkillTrustPassphraseModal
 from .study_scope_models import (
     MATERIAL_SOURCE_LIBRARY,
@@ -245,11 +252,7 @@ from .study_scope_models import (
 )
 
 if TYPE_CHECKING:
-    # TASK-1696: type-only -- the Library UI is allowed to import the
-    # async acquisition layer at runtime (unlike the STT/transcription
-    # worker surface; see ``Local_Ingestion.parakeet_v2_artifact``'s module
-    # docstring), but nothing here actually needs ``PreflightReport`` as a
-    # runtime symbol, only as a type hint on ``ParakeetV2InstallModal``.
+    # Type-only: the shared modal owns the runtime acquisition-plan import.
     from ...Model_Artifacts.acquisition import PreflightReport
 
 
@@ -822,182 +825,8 @@ class IngestGuardrailModal(ModalScreen[bool]):
             self.notify("Clipboard not available", severity="warning")
 
 
-class ParakeetV2InstallModal(ModalScreen[bool]):
-    """Consent prompt for the curated Parakeet v2 INT8 download."""
-
-    DEFAULT_CSS = """
-    ParakeetV2InstallModal {
-        align: center middle;
-    }
-
-    #parakeet-v2-install-modal {
-        width: 76;
-        height: auto;
-        border: tall $accent;
-        background: $surface;
-        padding: 1 2;
-    }
-
-    #parakeet-v2-install-actions {
-        height: 3;
-        margin-top: 1;
-        align-horizontal: right;
-    }
-    """
-
-    BINDINGS = [("escape", "dismiss(false)", "Close")]
-
-    def __init__(self, report: "PreflightReport") -> None:
-        """Build the consent modal from an immutable preflight plan.
-
-        Args:
-            report: The ``PreflightReport`` a prior
-                ``run_parakeet_v2_preflight()`` call resolved. Every value
-                this modal renders -- repository, revision, license,
-                precision, per-artifact and total download bytes,
-                destination, free space, and the space verdict -- comes
-                from this report, not a hard-coded constant (TASK-1696).
-        """
-        self.report = report
-        super().__init__()
-
-    @staticmethod
-    def _mib(size_bytes: int) -> str:
-        return f"{size_bytes / (1024 * 1024):.1f}"
-
-    @property
-    def _ungrantable(self) -> bool:
-        """Whether ``self.report.grant()`` would raise.
-
-        Mirrors ``PreflightReport.grant()``'s own condition exactly (gating
-        errors or insufficient space) without calling it, so the modal can
-        disable Install before the user ever confirms a plan that would
-        immediately fail.
-        """
-        return bool(self.report.gating_errors) or not self.report.sufficient_space
-
-    def compose(self) -> ComposeResult:
-        report = self.report
-        lines = ["Install the curated Parakeet v2 INT8 speech model?", ""]
-        for entry in report.entries:
-            already = " (already installed)" if entry.already_installed else ""
-            lines.append(f"Source: {entry.repository}{already}")
-            lines.append(f"Revision: {entry.revision}")
-            lines.append(f"License: {entry.license_id}")
-            lines.append(f"Precision: {entry.precision}")
-            lines.append(f"Artifact size: {self._mib(entry.total_bytes)} MiB")
-            lines.append("")
-        lines.append(f"Download: {self._mib(report.download_bytes)} MiB")
-        lines.append(f"Destination: {report.destination}")
-        lines.append(f"Free space: {self._mib(report.free_bytes)} MiB")
-        if report.sufficient_space:
-            lines.append("Enough free space is available for this install.")
-        else:
-            lines.append(
-                f"Not enough free space: this install needs "
-                f"{self._mib(report.required_bytes)} MiB free."
-            )
-        if report.gating_errors:
-            lines.append("")
-            lines.extend(report.gating_errors)
-        lines.append("")
-        lines.append(
-            "Every declared file is checked against pinned sizes and "
-            "SHA-256 digests before the bundle becomes usable."
-        )
-        details = "\n".join(lines)
-        with Vertical(id="parakeet-v2-install-modal"):
-            yield Static(details, markup=False)
-            with Horizontal(id="parakeet-v2-install-actions"):
-                yield Button(
-                    "Cancel",
-                    id="parakeet-v2-install-cancel",
-                    variant="default",
-                )
-                yield Button(
-                    "Install",
-                    id="parakeet-v2-install-confirm",
-                    variant="primary",
-                    disabled=self._ungrantable,
-                )
-
-    @on(Button.Pressed, "#parakeet-v2-install-confirm")
-    def _confirm(self) -> None:
-        self.dismiss(True)
-
-    @on(Button.Pressed, "#parakeet-v2-install-cancel")
-    def _cancel(self) -> None:
-        self.dismiss(False)
-
-
 class _ParakeetV2NoPendingReportError(RuntimeError):
-    """Raised when confirm fires with no preflight report to grant.
-
-    Never carries anything but this module's own fixed, already-safe
-    message -- see ``_parakeet_v2_failure_message``, which is the only
-    place that re-reads it via ``str()``.
-    """
-
-
-def _parakeet_v2_failure_message(exc: BaseException) -> str:
-    """Map a Parakeet v2 preflight/provision failure to a stable, user-safe message.
-
-    PR-1167 review (Finding 2): the raw exception text is never shown to
-    the user -- ``PreflightNotGrantableError`` embeds the full
-    ``gating_errors`` tuple in its own message, and other acquisition
-    failures may carry internal state that has no business reaching a
-    notification. The full exception (type, message, traceback) is still
-    always logged at the two call sites via ``logger.opt(exception=True)``,
-    so nothing is lost for debugging -- only what reaches ``notify()``
-    changes.
-
-    Args:
-        exc: The exception raised by ``run_parakeet_v2_preflight()`` or
-            ``run_parakeet_v2_provision()`` (or, for the "confirm fired
-            with nothing pending" case, this module's own
-            ``_ParakeetV2NoPendingReportError``).
-
-    Returns:
-        A stable, sanitized message safe to pass to ``notify()``.
-    """
-    if isinstance(exc, _ParakeetV2NoPendingReportError):
-        # Authored entirely by this module, with no injected content --
-        # safe to surface verbatim, unlike every other branch below.
-        return str(exc)
-
-    from tldw_chatbook.Model_Artifacts.acquisition import (
-        AcquisitionBusyError,
-        CatalogError,
-        ConsentMismatchError,
-        GatedRepositoryError,
-        InsufficientSpaceError,
-        PreflightNotGrantableError,
-        TransferError,
-    )
-
-    if isinstance(exc, InsufficientSpaceError):
-        return "Not enough free disk space for this install."
-    if isinstance(exc, GatedRepositoryError):
-        return (
-            "This model's repository requires a credential. Configure "
-            "HUGGINGFACE_API_KEY (or HF_TOKEN) and retry."
-        )
-    if isinstance(exc, AcquisitionBusyError):
-        return "Another Parakeet v2 install is already in progress. Try again shortly."
-    if isinstance(exc, ConsentMismatchError):
-        return "The install plan changed since it was shown. Retry Install to see the current plan."
-    if isinstance(exc, PreflightNotGrantableError):
-        return (
-            "This install plan can no longer proceed (insufficient space or "
-            "a gating error). Retry Install to see the current plan."
-        )
-    if isinstance(exc, CatalogError):
-        return "The Parakeet v2 download source is misconfigured."
-    if isinstance(exc, TransferError):
-        if exc.retryable:
-            return "The download was interrupted. Retry Install to resume."
-        return "The download failed and cannot be retried automatically."
-    return "Parakeet v2 install failed. See the application log for details."
+    """Raised when confirmation has no retained preflight report."""
 
 
 def _affected_counts(preflight: PreflightResult) -> dict[str, int]:
@@ -1471,6 +1300,7 @@ class LibraryScreen(BaseAppScreen):
         # test_confirmation_starts_background_installer_worker``) once the
         # user confirms.
         self._parakeet_v2_pending_report: "PreflightReport | None" = None
+        self._parakeet_v2_install_progress = None
         # Export canvas state (F4 Task 2). ``_library_export_counts`` is
         # ``None`` until the counts worker lands a result for the current
         # scope (drives ``LibraryExportFormState.counts_loading`` --
@@ -3901,6 +3731,12 @@ class LibraryScreen(BaseAppScreen):
             id="library-header-line",
             classes="destination-status-row",
         )
+        install_progress = ModelInstallProgress(
+            self._parakeet_v2_install_progress,
+            id="library-model-install-progress",
+        )
+        install_progress.display = self._parakeet_v2_install_progress is not None
+        yield install_progress
         if shell.canvas_kind == "notes":
             with Horizontal(id="library-notes-source-strip"):
                 database_selected = self._library_notes_source == "database"
@@ -12367,6 +12203,20 @@ class LibraryScreen(BaseAppScreen):
             return
         self._parakeet_v2_install_worker = self._run_parakeet_v2_preflight()
 
+    @on(InstallProgressed)
+    def handle_model_install_progressed(self, event: InstallProgressed) -> None:
+        """Retain and render progress after the consent modal is dismissed."""
+        event.stop()
+        self._parakeet_v2_install_progress = event.progress
+        try:
+            progress = self.query_one(
+                "#library-model-install-progress", ModelInstallProgress
+            )
+        except NoMatches:
+            return
+        progress.display = True
+        progress.update_progress(event.progress)
+
     @work(thread=True, group="library_parakeet_v2_preflight", exit_on_error=False)
     def _run_parakeet_v2_preflight(self) -> None:
         """Resolve the managed-download plan off the Textual event loop."""
@@ -12379,7 +12229,7 @@ class LibraryScreen(BaseAppScreen):
             self.app.call_from_thread(
                 self._apply_parakeet_v2_preflight_result,
                 None,
-                _parakeet_v2_failure_message(exc),
+                install_failure_message(exc, model_label="Parakeet v2"),
             )
             return
         self.app.call_from_thread(
@@ -12403,7 +12253,13 @@ class LibraryScreen(BaseAppScreen):
             return
         self._parakeet_v2_pending_report = report
         self.app.push_screen(
-            ParakeetV2InstallModal(report),
+            ModelInstallModal(
+                report,
+                model_label="Parakeet v2",
+                container_id="parakeet-v2-install-modal",
+                confirm_id="parakeet-v2-install-confirm",
+                cancel_id="parakeet-v2-install-cancel",
+            ),
             self._confirm_parakeet_v2_install,
         )
 
@@ -12438,14 +12294,17 @@ class LibraryScreen(BaseAppScreen):
                     "No Parakeet v2 install plan is available; retry Install."
                 )
             installed = asyncio.run(  # policy-exception: worker-thread loop
-                run_parakeet_v2_provision(report)
+                run_parakeet_v2_provision(
+                    report,
+                    progress=make_progress_callback(self.post_message),
+                )
             )
         except Exception as exc:
             logger.opt(exception=True).error("Parakeet v2 installation failed")
             self.app.call_from_thread(
                 self._apply_parakeet_v2_install_result,
                 None,
-                _parakeet_v2_failure_message(exc),
+                install_failure_message(exc, model_label="Parakeet v2"),
             )
             return
         self.app.call_from_thread(
@@ -12462,6 +12321,13 @@ class LibraryScreen(BaseAppScreen):
         """Populate the current batch form only after verified publication."""
         self._parakeet_v2_install_worker = None
         self._parakeet_v2_pending_report = None
+        self._parakeet_v2_install_progress = None
+        try:
+            self.query_one(
+                "#library-model-install-progress", ModelInstallProgress
+            ).display = False
+        except NoMatches:
+            pass
         if error is not None or installed is None:
             self.app_instance.notify(
                 f"Parakeet v2 install failed: {error or 'unknown error'}",

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -9,6 +9,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
+from ...Widgets.ModelArtifacts import InstallProgressed, InstallStatusChanged
 from ..Lab_Modules.lab_server_status import (
     LabServerRow,
     read_server_rows,
@@ -76,6 +77,9 @@ class LLMScreen(LabScreen):
         #: body -- so it already survives the teardown; starting a second
         #: one alongside it would be a real leak.
         self._status_poll_started = False
+        self._model_install_active = False
+        self._model_install_phase: str | None = None
+        self._model_install_succeeded: bool | None = None
         #: Server rows snapshotted for the duration of one
         #: ``refresh_lab_status`` pass; None outside one. See
         #: :meth:`_current_server_rows`.
@@ -128,13 +132,47 @@ class LLMScreen(LabScreen):
         )
 
     def lab_status_chips(self) -> tuple[LabStatusChip, ...]:
-        """Return the running-server chip.
+        """Return server and managed-install status chips.
 
         Returns:
-            A single chip summarising how many local servers are alive.
+            Chips summarising local servers and managed-model installation.
         """
         rows = self._current_server_rows()
-        return (LabStatusChip(chip_id="servers", text=servers_chip_text(rows)),)
+        if self._model_install_active:
+            phase = {
+                "fetch": "downloading",
+                "pre-verify": "checking",
+                "verify-install": "installing",
+                "activate": "activating",
+            }.get(self._model_install_phase or "", "starting")
+        elif self._model_install_succeeded is False:
+            phase = "failed"
+        else:
+            phase = "idle"
+        return (
+            LabStatusChip(chip_id="servers", text=servers_chip_text(rows)),
+            LabStatusChip(
+                chip_id="model-install",
+                text=f"Model install: {phase}",
+            ),
+        )
+
+    @on(InstallProgressed)
+    def _model_install_progressed(self, event: InstallProgressed) -> None:
+        """Keep the Lab chip current while a Curated install runs."""
+        self._model_install_active = True
+        self._model_install_phase = event.progress.phase
+        self._model_install_succeeded = None
+        self.refresh_lab_status()
+
+    @on(InstallStatusChanged)
+    def _model_install_status_changed(self, event: InstallStatusChanged) -> None:
+        """Reflect managed-install start and completion in the Lab header."""
+        self._model_install_active = event.active
+        self._model_install_succeeded = event.succeeded
+        if not event.active:
+            self._model_install_phase = None
+        self.refresh_lab_status()
 
     def compose_lab_rail(self) -> ComposeResult:
         """Yield the two rail sections and their nine provider rows."""

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -42,7 +42,8 @@ MODELS_RAIL_SECTIONS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
     (
         "Models",
         (
-            ("local-models", "Local Models"),
+            ("curated", "Curated"),
+            ("installed", "Installed"),
             ("download-models", "Download Models"),
         ),
     ),

--- a/tldw_chatbook/UI/Screens/model_browser_state.py
+++ b/tldw_chatbook/UI/Screens/model_browser_state.py
@@ -1,0 +1,287 @@
+"""Pure render state for managed-model browser surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts.acquisition import PreflightReport
+    from tldw_chatbook.Model_Artifacts.service import (
+        ArtifactDiskUsage,
+        ArtifactRef,
+        InstalledArtifact,
+        ProvenanceClass,
+    )
+
+
+@dataclass(frozen=True)
+class PlanRow:
+    """One dependency in an acquisition consent plan."""
+
+    reference: ArtifactRef
+    repository: str
+    revision: str
+    license_id: str
+    license_url: str
+    precision: str
+    file_count: int
+    total_bytes: int
+    already_installed: bool
+    provenance: str
+
+
+@dataclass(frozen=True)
+class PlanTotals:
+    """Closure-wide disk requirements for an acquisition plan."""
+
+    download_bytes: int
+    already_staged_bytes: int
+    staging_overhead_bytes: int
+    retained_bytes: int
+    destination: Path
+    free_bytes: int
+    required_bytes: int
+    sufficient_space: bool
+    gating_errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UnmanagedRow:
+    """One legacy model file outside the managed store."""
+
+    path: Path
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class InventoryRow:
+    """One render-ready managed or legacy model inventory entry."""
+
+    path: Path
+    reference: ArtifactRef | None
+    model_label: str
+    revision: str | None
+    precision: str | None
+    dependencies: tuple[ArtifactRef, ...]
+    ready: bool
+    active: bool
+    is_broken: bool
+    is_unmanaged: bool
+    provenance: str
+    action_hint: str
+    error: str | None
+    size_bytes: int | None
+    installed_store_bytes: int | None
+    staging_store_bytes: int | None
+    free_bytes: int | None
+
+
+def provenance_label(provenance: tuple[ProvenanceClass, ...]) -> str:
+    """Describe the evidence recorded for a model without claiming safety.
+
+    Args:
+        provenance: Ordered provenance classes from a descriptor or report.
+
+    Returns:
+        Precise user-visible provenance text.
+    """
+    labels = {
+        "chatbook_curated": "Curated by Chatbook",
+        "integrity_verified": "Integrity verified",
+        "local_integrity_recorded": "Local integrity recorded",
+    }
+    rendered = tuple(labels[item.value] for item in provenance)
+    return " · ".join(rendered) if rendered else "Provenance unavailable"
+
+
+def plan_rows(report: PreflightReport) -> tuple[PlanRow, ...]:
+    """Map a preflight closure to render-ready dependency rows.
+
+    Args:
+        report: Immutable acquisition preflight report.
+
+    Returns:
+        One row for every model in the dependency closure.
+    """
+    return tuple(
+        PlanRow(
+            reference=entry.ref,
+            repository=entry.repository,
+            revision=entry.revision,
+            license_id=entry.license_id,
+            license_url=entry.license_url,
+            precision=entry.precision,
+            file_count=entry.file_count,
+            total_bytes=entry.total_bytes,
+            already_installed=entry.already_installed,
+            provenance=provenance_label(entry.provenance),
+        )
+        for entry in report.entries
+    )
+
+
+def plan_totals(report: PreflightReport) -> PlanTotals:
+    """Map closure-wide preflight values to render state.
+
+    Args:
+        report: Immutable acquisition preflight report.
+
+    Returns:
+        Render-ready disk, destination, and gating totals.
+    """
+    return PlanTotals(
+        download_bytes=report.download_bytes,
+        already_staged_bytes=report.already_staged_bytes,
+        staging_overhead_bytes=report.staging_overhead_bytes,
+        retained_bytes=report.retained_bytes,
+        destination=report.destination,
+        free_bytes=report.free_bytes,
+        required_bytes=report.required_bytes,
+        sufficient_space=report.sufficient_space,
+        gating_errors=report.gating_errors,
+    )
+
+
+def inventory_rows(
+    installed: Iterable[InstalledArtifact],
+    usage: ArtifactDiskUsage | None,
+    unmanaged: Iterable[UnmanagedRow],
+) -> tuple[InventoryRow, ...]:
+    """Map managed inventory and legacy files to visible rows.
+
+    Args:
+        installed: Entries returned by the managed-model service.
+        usage: Current managed-store totals, if the scan succeeded.
+        unmanaged: Legacy files discovered outside the managed store.
+
+    Returns:
+        Managed rows followed by visible unmanaged rows.
+    """
+    installed_bytes = usage.installed_bytes if usage is not None else None
+    staging_bytes = usage.staging_bytes if usage is not None else None
+    free_bytes = usage.free_bytes if usage is not None else None
+    rows: list[InventoryRow] = []
+    for item in installed:
+        descriptor = item.descriptor
+        if descriptor is None:
+            rows.append(
+                InventoryRow(
+                    path=item.path,
+                    reference=None,
+                    model_label=item.path.name,
+                    revision=None,
+                    precision=None,
+                    dependencies=(),
+                    ready=False,
+                    active=False,
+                    is_broken=True,
+                    is_unmanaged=False,
+                    provenance="Integrity state unavailable",
+                    action_hint="Unreadable manifest — Repair",
+                    error=item.error,
+                    size_bytes=None,
+                    installed_store_bytes=installed_bytes,
+                    staging_store_bytes=staging_bytes,
+                    free_bytes=free_bytes,
+                )
+            )
+            continue
+
+        is_broken = item.error is not None
+        if is_broken:
+            action_hint = "Needs repair — Repair"
+        elif item.active:
+            action_hint = "Active"
+        elif item.ready:
+            action_hint = "Ready"
+        else:
+            action_hint = "Unavailable until verified"
+        rows.append(
+            InventoryRow(
+                path=item.path,
+                reference=descriptor.reference,
+                model_label=descriptor.model_id,
+                revision=descriptor.reference.revision,
+                precision=descriptor.precision,
+                dependencies=descriptor.dependencies,
+                ready=item.ready,
+                active=item.active,
+                is_broken=is_broken,
+                is_unmanaged=False,
+                provenance=provenance_label(descriptor.provenance),
+                action_hint=action_hint,
+                error=item.error,
+                size_bytes=descriptor.expected_installed_bytes,
+                installed_store_bytes=installed_bytes,
+                staging_store_bytes=staging_bytes,
+                free_bytes=free_bytes,
+            )
+        )
+
+    rows.extend(
+        InventoryRow(
+            path=item.path,
+            reference=None,
+            model_label=item.path.name,
+            revision=None,
+            precision=None,
+            dependencies=(),
+            ready=False,
+            active=False,
+            is_broken=False,
+            is_unmanaged=True,
+            provenance="Unmanaged — integrity unknown",
+            action_hint="Import is not available yet",
+            error=None,
+            size_bytes=item.size_bytes,
+            installed_store_bytes=installed_bytes,
+            staging_store_bytes=staging_bytes,
+            free_bytes=free_bytes,
+        )
+        for item in unmanaged
+    )
+    return tuple(rows)
+
+
+def install_failure_message(exc: BaseException, *, model_label: str) -> str:
+    """Map acquisition failures to stable, sanitized user-visible text.
+
+    Args:
+        exc: Failure raised by preflight or provisioning.
+        model_label: Model name used where the message needs context.
+
+    Returns:
+        A message that does not expose raw exception details.
+    """
+    from tldw_chatbook.Model_Artifacts.acquisition import (
+        AcquisitionBusyError,
+        CatalogError,
+        ConsentMismatchError,
+        GatedRepositoryError,
+        InsufficientSpaceError,
+        PreflightNotGrantableError,
+        TransferError,
+    )
+
+    if isinstance(exc, InsufficientSpaceError):
+        return "Not enough free disk space for this install."
+    if isinstance(exc, GatedRepositoryError):
+        return (
+            "This model's repository requires a credential. Configure "
+            "HUGGINGFACE_API_KEY (or HF_TOKEN) and retry."
+        )
+    if isinstance(exc, AcquisitionBusyError):
+        return f"Another {model_label} install is already in progress. Try again shortly."
+    if isinstance(exc, ConsentMismatchError):
+        return "The install plan changed. Retry Install to review the current plan."
+    if isinstance(exc, PreflightNotGrantableError):
+        return "This install plan cannot proceed. Retry Install to review the current plan."
+    if isinstance(exc, CatalogError):
+        return f"The {model_label} download source is misconfigured."
+    if isinstance(exc, TransferError):
+        if exc.retryable:
+            return "The download was interrupted. Retry Install to resume."
+        return "The download failed and cannot be retried automatically."
+    return f"{model_label} install failed. See the application log for details."

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -1,0 +1,357 @@
+"""Lazy Curated view backed by the verified managed-model acquisition path."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from loguru import logger
+from textual import on, work
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Model_Artifacts.curated_registry import (
+    CuratedRegistry,
+    curated_registry,
+)
+from tldw_chatbook.Model_Artifacts.service import (
+    ArtifactDescriptor,
+    ArtifactRef,
+    ModelArtifactService,
+)
+from tldw_chatbook.Model_Artifacts.store import managed_service
+from tldw_chatbook.UI.Screens.model_browser_state import (
+    install_failure_message,
+    provenance_label,
+)
+from tldw_chatbook.Widgets.ModelArtifacts import (
+    InstallProgressed,
+    ModelInstallModal,
+    ModelInstallProgress,
+    make_progress_callback,
+)
+
+
+@dataclass(frozen=True)
+class CuratedRow:
+    """One curated descriptor cross-referenced with installed inventory."""
+
+    descriptor: ArtifactDescriptor
+    installed: bool
+
+
+class CuratedView(Widget):
+    """Browse and explicitly install models curated by the application."""
+
+    DEFAULT_CSS = """
+    CuratedView {
+        height: 100%;
+    }
+
+    CuratedView .curated-header {
+        height: 3;
+    }
+
+    CuratedView .curated-header Button {
+        width: auto;
+    }
+
+    CuratedView .curated-list {
+        height: 1fr;
+    }
+
+    CuratedView .curated-model-row {
+        height: auto;
+        padding: 1;
+        margin-bottom: 1;
+        border: solid $surface-lighten-1;
+    }
+
+    CuratedView .curated-model-title {
+        text-style: bold;
+    }
+
+    CuratedView .curated-model-muted {
+        color: $text-muted;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        service_factory: Callable[[], ModelArtifactService] = managed_service,
+        registry_factory: Callable[[], CuratedRegistry] = curated_registry,
+        id: str | None = None,
+    ) -> None:
+        """Create an idle curated view.
+
+        Args:
+            service_factory: Lazy managed-store service factory.
+            registry_factory: Lazy curated-registry factory.
+            id: Optional Textual widget id.
+        """
+        self._service_factory = service_factory
+        self._registry_factory = registry_factory
+        self._service: ModelArtifactService | None = None
+        self._registry: CuratedRegistry | None = None
+        self._rows: tuple[CuratedRow, ...] = ()
+        self._loaded = False
+        self._loading = False
+        self._load_error: str | None = None
+        self._operation_reference: ArtifactRef | None = None
+        self._pending_report = None
+        self._progress = None
+        super().__init__(id=id)
+
+    def compose(self) -> ComposeResult:
+        """Compose from retained state without filesystem or network I/O."""
+        with Horizontal(classes="curated-header"):
+            yield Button("Refresh", id="curated-models-refresh", variant="primary")
+        progress = ModelInstallProgress(
+            self._progress,
+            id="curated-model-install-progress",
+        )
+        progress.display = self._progress is not None
+        yield progress
+        if self._loading:
+            yield Static("Loading curated models…", markup=False)
+        elif self._load_error:
+            yield Static(self._load_error, markup=False)
+        elif not self._loaded:
+            yield Static("Open Curated to load the offline model catalog.", markup=False)
+
+        with VerticalScroll(classes="curated-list"):
+            for row in self._rows:
+                yield self._row_widget(row)
+
+    def _row_widget(self, row: CuratedRow) -> Vertical:
+        """Build one curated model row."""
+        descriptor = row.descriptor
+        install = Button(
+            "Installed" if row.installed else "Review and install…",
+            classes="curated-install",
+            variant="primary",
+            disabled=row.installed or self._operation_reference is not None,
+        )
+        install.reference = descriptor.reference
+        return Vertical(
+            Static(descriptor.model_id, classes="curated-model-title", markup=False),
+            Static(
+                f"{descriptor.model_family} · {descriptor.precision} · "
+                f"{descriptor.format.value.upper()}",
+                markup=False,
+            ),
+            Static(
+                f"Revision: {descriptor.upstream_revision}",
+                classes="curated-model-muted",
+                markup=False,
+            ),
+            Static(
+                f"License: {descriptor.license_id} · "
+                f"{provenance_label(descriptor.provenance)}",
+                classes="curated-model-muted",
+                markup=False,
+            ),
+            install,
+            classes="curated-model-row",
+        )
+
+    def _service_for_worker(self) -> ModelArtifactService:
+        """Return the lazily created managed service."""
+        if self._service is None:
+            self._service = self._service_factory()
+        return self._service
+
+    def _registry_for_worker(self) -> CuratedRegistry:
+        """Return the lazily created curated registry."""
+        if self._registry is None:
+            self._registry = self._registry_factory()
+        return self._registry
+
+    def ensure_loaded(self, *, force: bool = False) -> None:
+        """Load the offline catalog when the Curated rail row is selected.
+
+        Args:
+            force: Reload installed-state cross-references.
+        """
+        if self._loading or (self._loaded and not force):
+            return
+        self._loading = True
+        self._load_error = None
+        self.refresh(recompose=True)
+        self._load_curated()
+
+    @work(thread=True, group="curated_models_load", exclusive=True, exit_on_error=False)
+    def _load_curated(self) -> None:
+        """Cross-reference curated descriptors with installed refs off-loop."""
+        try:
+            registry = self._registry_for_worker()
+            installed = self._service_for_worker().list_installed()
+            installed_refs = {
+                item.descriptor.reference
+                for item in installed
+                if item.descriptor is not None
+            }
+            rows = tuple(
+                CuratedRow(descriptor, descriptor.reference in installed_refs)
+                for descriptor in registry.list()
+            )
+        except Exception:
+            self.app.call_from_thread(
+                self._apply_rows,
+                (),
+                "The curated model catalog could not be loaded.",
+            )
+            return
+        self.app.call_from_thread(self._apply_rows, rows, None)
+
+    def _apply_rows(
+        self,
+        rows: tuple[CuratedRow, ...],
+        error: str | None,
+    ) -> None:
+        """Apply a completed curated/inventory cross-reference."""
+        self._rows = rows
+        self._loading = False
+        self._loaded = error is None
+        self._load_error = error
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#curated-models-refresh")
+    def _refresh_pressed(self) -> None:
+        self.ensure_loaded(force=True)
+
+    @on(Button.Pressed, ".curated-install")
+    def _install_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        reference = getattr(event.button, "reference", None)
+        if not isinstance(reference, ArtifactRef) or self._operation_reference is not None:
+            return
+        self._operation_reference = reference
+        self.refresh(recompose=True)
+        self._preflight_model(reference)
+
+    def _source_map(self) -> dict[ArtifactRef, dict[str, str]]:
+        """Return sources for every descriptor in the curated registry."""
+        registry = self._registry_for_worker()
+        return {
+            descriptor.reference: registry.sources(descriptor.reference)
+            for descriptor in registry.list()
+        }
+
+    async def _preflight(self, reference: ArtifactRef):
+        """Resolve a curated acquisition plan on the worker's event loop."""
+        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
+
+        acquisition = ArtifactAcquisitionService(self._service_for_worker())
+        return await acquisition.preflight(
+            reference,
+            self._registry_for_worker(),
+            sources=self._source_map(),
+        )
+
+    @work(thread=True, group="curated_model_install", exclusive=True, exit_on_error=False)
+    def _preflight_model(self, reference: ArtifactRef) -> None:
+        """Resolve the plan off the Textual event loop."""
+        try:
+            report = asyncio.run(self._preflight(reference))
+        except Exception as exc:
+            logger.opt(exception=True).error("Curated model preflight failed")
+            self.app.call_from_thread(
+                self._apply_preflight_result,
+                None,
+                install_failure_message(exc, model_label=reference.artifact_id),
+            )
+            return
+        self.app.call_from_thread(self._apply_preflight_result, report, None)
+
+    def _apply_preflight_result(self, report, error: str | None) -> None:
+        """Show the shared plan modal or a sanitized failure."""
+        if error is not None or report is None:
+            self._operation_reference = None
+            self.notify(error or "Model preflight failed.", severity="error")
+            self.refresh(recompose=True)
+            return
+        self._pending_report = report
+        descriptor = self._registry_for_worker().descriptor(report.root)
+        self.app.push_screen(
+            ModelInstallModal(report, model_label=descriptor.model_id),
+            self._confirm_install,
+        )
+
+    def _confirm_install(self, confirmed: bool) -> None:
+        """Start provisioning only after explicit consent."""
+        if not confirmed:
+            self._pending_report = None
+            self._operation_reference = None
+            self.refresh(recompose=True)
+            return
+        self._provision_model()
+
+    async def _provision(self, report):
+        """Provision the consented report on the worker's event loop."""
+        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
+
+        acquisition = ArtifactAcquisitionService(self._service_for_worker())
+        return await acquisition.provision(
+            report.root,
+            report.grant(),
+            self._registry_for_worker(),
+            sources=self._source_map(),
+            progress=make_progress_callback(self.post_message),
+        )
+
+    @work(thread=True, group="curated_model_install", exclusive=True, exit_on_error=False)
+    def _provision_model(self) -> None:
+        """Provision the consented plan off the Textual event loop."""
+        report = self._pending_report
+        if report is None:
+            self.app.call_from_thread(
+                self._apply_provision_result,
+                "No install plan is available; review the model again.",
+            )
+            return
+        try:
+            asyncio.run(self._provision(report))
+        except Exception as exc:
+            logger.opt(exception=True).error("Curated model installation failed")
+            self.app.call_from_thread(
+                self._apply_provision_result,
+                install_failure_message(
+                    exc,
+                    model_label=report.root.artifact_id,
+                ),
+            )
+            return
+        self.app.call_from_thread(self._apply_provision_result, None)
+
+    @on(InstallProgressed)
+    def _install_progressed(self, event: InstallProgressed) -> None:
+        """Retain and render worker progress outside the modal."""
+        event.stop()
+        self._progress = event.progress
+        progress = self.query_one(
+            "#curated-model-install-progress",
+            ModelInstallProgress,
+        )
+        progress.display = True
+        progress.update_progress(event.progress)
+
+    def _apply_provision_result(self, error: str | None) -> None:
+        """Finish an installation and refresh curated installed-state."""
+        self._pending_report = None
+        self._operation_reference = None
+        self._progress = None
+        progress = self.query_one(
+            "#curated-model-install-progress",
+            ModelInstallProgress,
+        )
+        progress.display = False
+        if error is not None:
+            self.notify(error, severity="error")
+        else:
+            self.notify("Model installed and activated.", severity="information")
+        self.ensure_loaded(force=True)

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -29,6 +29,7 @@ from tldw_chatbook.UI.Screens.model_browser_state import (
 )
 from tldw_chatbook.Widgets.ModelArtifacts import (
     InstallProgressed,
+    InstallStatusChanged,
     ModelInstallModal,
     ModelInstallProgress,
     make_progress_callback,
@@ -289,6 +290,10 @@ class CuratedView(Widget):
             self._operation_reference = None
             self.refresh(recompose=True)
             return
+        if self._operation_reference is not None:
+            self.post_message(
+                InstallStatusChanged(self._operation_reference, active=True)
+            )
         self._provision_model()
 
     async def _provision(self, report):
@@ -331,7 +336,6 @@ class CuratedView(Widget):
     @on(InstallProgressed)
     def _install_progressed(self, event: InstallProgressed) -> None:
         """Retain and render worker progress outside the modal."""
-        event.stop()
         self._progress = event.progress
         progress = self.query_one(
             "#curated-model-install-progress",
@@ -342,6 +346,7 @@ class CuratedView(Widget):
 
     def _apply_provision_result(self, error: str | None) -> None:
         """Finish an installation and refresh curated installed-state."""
+        reference = self._operation_reference
         self._pending_report = None
         self._operation_reference = None
         self._progress = None
@@ -354,4 +359,12 @@ class CuratedView(Widget):
             self.notify(error, severity="error")
         else:
             self.notify("Model installed and activated.", severity="information")
+        if reference is not None:
+            self.post_message(
+                InstallStatusChanged(
+                    reference,
+                    active=False,
+                    succeeded=error is None,
+                )
+            )
         self.ensure_loaded(force=True)

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -10,6 +10,7 @@ from loguru import logger
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -260,7 +261,12 @@ class CuratedView(Widget):
         try:
             report = asyncio.run(self._preflight(reference))
         except Exception as exc:
-            logger.opt(exception=True).error("Curated model preflight failed")
+            logger.opt(exception=True).error(
+                "Curated model preflight failed for {}@{}/{}",
+                reference.artifact_id,
+                reference.revision,
+                reference.variant,
+            )
             self.app.call_from_thread(
                 self._apply_preflight_result,
                 None,
@@ -322,7 +328,12 @@ class CuratedView(Widget):
         try:
             asyncio.run(self._provision(report))
         except Exception as exc:
-            logger.opt(exception=True).error("Curated model installation failed")
+            logger.opt(exception=True).error(
+                "Curated model installation failed for {}@{}/{}",
+                report.root.artifact_id,
+                report.root.revision,
+                report.root.variant,
+            )
             self.app.call_from_thread(
                 self._apply_provision_result,
                 install_failure_message(
@@ -337,10 +348,14 @@ class CuratedView(Widget):
     def _install_progressed(self, event: InstallProgressed) -> None:
         """Retain and render worker progress outside the modal."""
         self._progress = event.progress
-        progress = self.query_one(
-            "#curated-model-install-progress",
-            ModelInstallProgress,
-        )
+        try:
+            progress = self.query_one(
+                "#curated-model-install-progress",
+                ModelInstallProgress,
+            )
+        except NoMatches:
+            self.refresh(recompose=True)
+            return
         progress.display = True
         progress.update_progress(event.progress)
 
@@ -350,11 +365,15 @@ class CuratedView(Widget):
         self._pending_report = None
         self._operation_reference = None
         self._progress = None
-        progress = self.query_one(
-            "#curated-model-install-progress",
-            ModelInstallProgress,
-        )
-        progress.display = False
+        try:
+            progress = self.query_one(
+                "#curated-model-install-progress",
+                ModelInstallProgress,
+            )
+        except NoMatches:
+            progress = None
+        if progress is not None:
+            progress.display = False
         if error is not None:
             self.notify(error, severity="error")
         else:

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from loguru import logger
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -18,6 +20,7 @@ from tldw_chatbook.Model_Artifacts.service import (
     ArtifactNotReadyError,
     ArtifactRef,
     ModelArtifactService,
+    ReconcileReport,
 )
 from tldw_chatbook.Model_Artifacts.store import managed_service
 from tldw_chatbook.UI.Screens.model_browser_state import (
@@ -30,9 +33,15 @@ from tldw_chatbook.Widgets.ModelArtifacts.activation_controls import (
     DeletionRequested,
     ModelActivationControls,
 )
+from tldw_chatbook.Widgets.ModelArtifacts.install_progress import (
+    ModelInstallProgress,
+)
 from tldw_chatbook.Widgets.delete_confirmation_dialog import (
     DeleteConfirmationDialog,
 )
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
 
 MAX_UNMANAGED_MODELS = 500
 _MODEL_EXTENSIONS = frozenset({".gguf", ".bin", ".safetensors", ".pt", ".pth", ".onnx"})
@@ -54,6 +63,24 @@ def lifecycle_failure_message(exc: BaseException, *, operation: str) -> str:
     if isinstance(exc, ArtifactNotReadyError):
         return "This model is not ready and cannot be activated."
     return f"Model {operation} failed. See the application log for details."
+
+
+def reconcile_result_message(report: ReconcileReport) -> str:
+    """Summarize every reconciliation outcome without exposing local paths.
+
+    Args:
+        report: Completed managed-store reconciliation report.
+
+    Returns:
+        Sanitized user-visible repair summary.
+    """
+    return (
+        "Repair completed: "
+        f"{report.readiness_created} readiness records restored · "
+        f"{report.state_removed} stale state records removed · "
+        f"{len(report.staging_removed)} staging entries removed · "
+        f"{len(report.corrupt_artifacts)} corrupt models found."
+    )
 
 
 class InstalledView(Widget):
@@ -114,7 +141,10 @@ class InstalledView(Widget):
         self._usage: ArtifactDiskUsage | None = None
         self._loaded = False
         self._loading = False
+        self._reload_after_load = False
         self._load_error: str | None = None
+        self._install_active = False
+        self._install_progress: AcquisitionProgress | None = None
         self._operation_reference: ArtifactRef | None = None
         self._operation_name: str | None = None
         self._pending_delete_reference: ArtifactRef | None = None
@@ -122,9 +152,31 @@ class InstalledView(Widget):
 
     def compose(self) -> ComposeResult:
         """Compose from retained in-memory state without performing I/O."""
+        lifecycle_pending = (
+            self._loading
+            or self._operation_reference is not None
+            or self._operation_name is not None
+            or self._pending_delete_reference is not None
+        )
         with Horizontal(classes="installed-header"):
-            yield Button("Refresh", id="installed-models-refresh", variant="primary")
-            yield Button("Repair", id="installed-models-repair", variant="default")
+            yield Button(
+                "Refresh",
+                id="installed-models-refresh",
+                variant="primary",
+                disabled=lifecycle_pending,
+            )
+            yield Button(
+                "Repair",
+                id="installed-models-repair",
+                variant="default",
+                disabled=lifecycle_pending,
+            )
+        progress = ModelInstallProgress(
+            self._install_progress,
+            id="installed-model-install-progress",
+        )
+        progress.display = self._install_active
+        yield progress
         if self._loading:
             yield Static("Loading installed models…", markup=False)
         elif self._load_error:
@@ -151,6 +203,25 @@ class InstalledView(Widget):
             f"{self._format_bytes(self._usage.free_bytes)} free",
             markup=False,
         )
+
+    def set_install_state(
+        self,
+        progress: AcquisitionProgress | None,
+        *,
+        active: bool,
+    ) -> None:
+        """Mirror the current managed install into this persistent view.
+
+        Args:
+            progress: Latest worker progress, when one has been emitted.
+            active: Whether provisioning is still running.
+        """
+        self._install_active = active
+        if progress is not None:
+            self._install_progress = progress
+        if not active:
+            self._install_progress = None
+        self.refresh(recompose=True)
 
     def _row_widget(self, row: InventoryRow) -> Vertical:
         """Build one inventory row from pure render state."""
@@ -186,7 +257,9 @@ class InstalledView(Widget):
                     active=row.active,
                     ready=row.ready,
                     pending=(
-                        self._operation_reference is not None
+                        self._loading
+                        or self._operation_reference is not None
+                        or self._operation_name is not None
                         or self._pending_delete_reference is not None
                     ),
                 )
@@ -245,7 +318,11 @@ class InstalledView(Widget):
         Args:
             force: Reload even when a prior inventory is retained.
         """
-        if self._loading or (self._loaded and not force):
+        if self._loading:
+            if force:
+                self._reload_after_load = True
+            return
+        if self._loaded and not force:
             return
         self._loading = True
         self._load_error = None
@@ -268,6 +345,7 @@ class InstalledView(Widget):
             unmanaged = self.scan_unmanaged(self._legacy_dir)
             rows = inventory_rows(installed, usage, unmanaged)
         except Exception:
+            logger.opt(exception=True).error("Managed model inventory load failed")
             self.app.call_from_thread(
                 self._apply_inventory,
                 (),
@@ -289,16 +367,29 @@ class InstalledView(Widget):
         self._loading = False
         self._loaded = error is None
         self._load_error = error
-        self.refresh(recompose=True)
+        reload_after_load = self._reload_after_load
+        self._reload_after_load = False
+        if reload_after_load:
+            self.ensure_loaded(force=True)
+        else:
+            self.refresh(recompose=True)
 
     @on(Button.Pressed, "#installed-models-refresh")
     def _refresh_pressed(self) -> None:
+        if (
+            self._loading
+            or self._operation_reference is not None
+            or self._operation_name is not None
+            or self._pending_delete_reference is not None
+        ):
+            return
         self.ensure_loaded(force=True)
 
     @on(Button.Pressed, "#installed-models-repair")
     def _repair_pressed(self) -> None:
         if (
-            self._operation_reference is not None
+            self._loading
+            or self._operation_reference is not None
             or self._operation_name is not None
             or self._pending_delete_reference is not None
         ):
@@ -315,7 +406,8 @@ class InstalledView(Widget):
     def _request_activation(self, reference: ArtifactRef) -> None:
         """Start activation unless another lifecycle operation is pending."""
         if (
-            self._operation_reference is not None
+            self._loading
+            or self._operation_reference is not None
             or self._operation_name is not None
             or self._pending_delete_reference is not None
         ):
@@ -329,7 +421,8 @@ class InstalledView(Widget):
     def _deletion_requested(self, event: DeletionRequested) -> None:
         event.stop()
         if (
-            self._operation_reference is not None
+            self._loading
+            or self._operation_reference is not None
             or self._operation_name is not None
             or self._pending_delete_reference is not None
         ):
@@ -372,6 +465,12 @@ class InstalledView(Widget):
         try:
             self._service_for_worker().activate(reference)
         except Exception as exc:
+            logger.opt(exception=True).error(
+                "Managed model activation failed for {}@{}/{}",
+                reference.artifact_id,
+                reference.revision,
+                reference.variant,
+            )
             self.app.call_from_thread(
                 self._apply_lifecycle_result,
                 "activate",
@@ -386,6 +485,12 @@ class InstalledView(Widget):
         try:
             self._service_for_worker().delete(reference)
         except Exception as exc:
+            logger.opt(exception=True).error(
+                "Managed model deletion failed for {}@{}/{}",
+                reference.artifact_id,
+                reference.revision,
+                reference.variant,
+            )
             self.app.call_from_thread(
                 self._apply_lifecycle_result,
                 "delete",
@@ -400,6 +505,7 @@ class InstalledView(Widget):
         try:
             report = self._service_for_worker().reconcile()
         except Exception as exc:
+            logger.opt(exception=True).error("Managed model repair failed")
             self.app.call_from_thread(
                 self._apply_lifecycle_result,
                 "repair",
@@ -410,7 +516,7 @@ class InstalledView(Widget):
             self._apply_lifecycle_result,
             "repair",
             None,
-            f"Repair completed: {report.readiness_created} readiness records restored.",
+            reconcile_result_message(report),
         )
 
     def _apply_lifecycle_result(

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -13,6 +13,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Model_Artifacts.service import (
+    ArtifactDiskUsage,
     ArtifactInUseError,
     ArtifactNotReadyError,
     ArtifactRef,
@@ -107,6 +108,7 @@ class InstalledView(Widget):
         self._legacy_dir = legacy_dir or Path("~/Downloads/tldw_models").expanduser()
         self._service: ModelArtifactService | None = None
         self._rows: tuple[InventoryRow, ...] = ()
+        self._usage: ArtifactDiskUsage | None = None
         self._loaded = False
         self._loading = False
         self._load_error: str | None = None
@@ -136,14 +138,13 @@ class InstalledView(Widget):
 
     def _summary(self) -> Static:
         """Return the managed-store disk summary."""
-        if not self._rows or self._rows[0].installed_store_bytes is None:
+        if self._usage is None:
             return Static("Disk usage unavailable.", markup=False)
-        first = self._rows[0]
         return Static(
             "Managed: "
-            f"{self._format_bytes(first.installed_store_bytes or 0)} installed, "
-            f"{self._format_bytes(first.staging_store_bytes or 0)} staging · "
-            f"{self._format_bytes(first.free_bytes or 0)} free",
+            f"{self._format_bytes(self._usage.installed_bytes)} installed, "
+            f"{self._format_bytes(self._usage.staging_bytes)} staging · "
+            f"{self._format_bytes(self._usage.free_bytes)} free",
             markup=False,
         )
 
@@ -263,18 +264,21 @@ class InstalledView(Widget):
             self.app.call_from_thread(
                 self._apply_inventory,
                 (),
+                None,
                 "The local model inventory could not be loaded.",
             )
             return
-        self.app.call_from_thread(self._apply_inventory, rows, None)
+        self.app.call_from_thread(self._apply_inventory, rows, usage, None)
 
     def _apply_inventory(
         self,
         rows: tuple[InventoryRow, ...],
+        usage: ArtifactDiskUsage | None,
         error: str | None,
     ) -> None:
         """Apply a completed inventory read on the Textual event loop."""
         self._rows = rows
+        self._usage = usage
         self._loading = False
         self._loaded = error is None
         self._load_error = error

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -30,6 +30,9 @@ from tldw_chatbook.Widgets.ModelArtifacts.activation_controls import (
     DeletionRequested,
     ModelActivationControls,
 )
+from tldw_chatbook.Widgets.delete_confirmation_dialog import (
+    DeleteConfirmationDialog,
+)
 
 MAX_UNMANAGED_MODELS = 500
 _MODEL_EXTENSIONS = frozenset({".gguf", ".bin", ".safetensors", ".pt", ".pth", ".onnx"})
@@ -114,6 +117,7 @@ class InstalledView(Widget):
         self._load_error: str | None = None
         self._operation_reference: ArtifactRef | None = None
         self._operation_name: str | None = None
+        self._pending_delete_reference: ArtifactRef | None = None
         super().__init__(id=id)
 
     def compose(self) -> ComposeResult:
@@ -181,7 +185,10 @@ class InstalledView(Widget):
                     row.reference,
                     active=row.active,
                     ready=row.ready,
-                    pending=self._operation_reference is not None,
+                    pending=(
+                        self._operation_reference is not None
+                        or self._pending_delete_reference is not None
+                    ),
                 )
             )
         return Vertical(*children, classes="installed-model-row")
@@ -290,7 +297,11 @@ class InstalledView(Widget):
 
     @on(Button.Pressed, "#installed-models-repair")
     def _repair_pressed(self) -> None:
-        if self._operation_reference is not None or self._operation_name is not None:
+        if (
+            self._operation_reference is not None
+            or self._operation_name is not None
+            or self._pending_delete_reference is not None
+        ):
             return
         self._operation_name = "repair"
         self.refresh(recompose=True)
@@ -303,7 +314,11 @@ class InstalledView(Widget):
 
     def _request_activation(self, reference: ArtifactRef) -> None:
         """Start activation unless another lifecycle operation is pending."""
-        if self._operation_reference is not None or self._operation_name is not None:
+        if (
+            self._operation_reference is not None
+            or self._operation_name is not None
+            or self._pending_delete_reference is not None
+        ):
             return
         self._operation_reference = reference
         self._operation_name = "activate"
@@ -313,12 +328,43 @@ class InstalledView(Widget):
     @on(DeletionRequested)
     def _deletion_requested(self, event: DeletionRequested) -> None:
         event.stop()
-        if self._operation_reference is not None or self._operation_name is not None:
+        if (
+            self._operation_reference is not None
+            or self._operation_name is not None
+            or self._pending_delete_reference is not None
+        ):
             return
-        self._operation_reference = event.reference
+        self._pending_delete_reference = event.reference
+        self.refresh(recompose=True)
+        self.app.push_screen(
+            DeleteConfirmationDialog(
+                item_type="Model",
+                item_name=(
+                    f"{event.reference.artifact_id} "
+                    f"({event.reference.variant})"
+                ),
+                additional_warning=(
+                    "The managed model files will be removed from this device."
+                ),
+                permanent=True,
+            ),
+            self._confirm_deletion,
+        )
+
+    def _confirm_deletion(self, confirmed: bool) -> None:
+        """Start deletion only after the confirmation dialog accepts it."""
+        reference = self._pending_delete_reference
+        self._pending_delete_reference = None
+        if not confirmed or reference is None:
+            self.refresh(recompose=True)
+            return
+        if self._operation_reference is not None or self._operation_name is not None:
+            self.refresh(recompose=True)
+            return
+        self._operation_reference = reference
         self._operation_name = "delete"
         self.refresh(recompose=True)
-        self._delete_model(event.reference)
+        self._delete_model(reference)
 
     @work(thread=True, group="installed_models_lifecycle", exclusive=True, exit_on_error=False)
     def _activate_model(self, reference: ArtifactRef) -> None:

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -1,0 +1,382 @@
+"""Lazy Installed view for managed and legacy local models."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from textual import on, work
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Model_Artifacts.service import (
+    ArtifactInUseError,
+    ArtifactNotReadyError,
+    ArtifactRef,
+    ModelArtifactService,
+)
+from tldw_chatbook.Model_Artifacts.store import managed_service
+from tldw_chatbook.UI.Screens.model_browser_state import (
+    InventoryRow,
+    UnmanagedRow,
+    inventory_rows,
+)
+from tldw_chatbook.Widgets.ModelArtifacts.activation_controls import (
+    ActivationRequested,
+    DeletionRequested,
+    ModelActivationControls,
+)
+
+MAX_UNMANAGED_MODELS = 500
+_MODEL_EXTENSIONS = frozenset({".gguf", ".bin", ".safetensors", ".pt", ".pth", ".onnx"})
+_MIN_LEGACY_MODEL_BYTES = 1024 * 1024
+
+
+def lifecycle_failure_message(exc: BaseException, *, operation: str) -> str:
+    """Map lifecycle errors to stable text without leaking raw details.
+
+    Args:
+        exc: Error raised by activate, delete, or reconcile.
+        operation: User action that failed.
+
+    Returns:
+        Sanitized user-visible failure text.
+    """
+    if isinstance(exc, ArtifactInUseError):
+        return "This model is in use. Stop active work and retry deletion."
+    if isinstance(exc, ArtifactNotReadyError):
+        return "This model is not ready and cannot be activated."
+    return f"Model {operation} failed. See the application log for details."
+
+
+class InstalledView(Widget):
+    """List and manage the shared local model inventory."""
+
+    DEFAULT_CSS = """
+    InstalledView {
+        height: 100%;
+    }
+
+    InstalledView .installed-header {
+        height: 3;
+    }
+
+    InstalledView .installed-header Button {
+        width: auto;
+        margin-right: 1;
+    }
+
+    InstalledView .installed-list {
+        height: 1fr;
+    }
+
+    InstalledView .installed-model-row {
+        height: auto;
+        margin-bottom: 1;
+        padding: 1;
+        border: solid $surface-lighten-1;
+    }
+
+    InstalledView .installed-model-title {
+        text-style: bold;
+    }
+
+    InstalledView .installed-model-muted {
+        color: $text-muted;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        service_factory: Callable[[], ModelArtifactService] = managed_service,
+        legacy_dir: Path | None = None,
+        id: str | None = None,
+    ) -> None:
+        """Create an idle view; no filesystem work occurs here.
+
+        Args:
+            service_factory: Lazy managed-store service factory.
+            legacy_dir: Legacy downloader directory to scan on activation.
+            id: Optional Textual widget id.
+        """
+        self._service_factory = service_factory
+        self._legacy_dir = legacy_dir or Path("~/Downloads/tldw_models").expanduser()
+        self._service: ModelArtifactService | None = None
+        self._rows: tuple[InventoryRow, ...] = ()
+        self._loaded = False
+        self._loading = False
+        self._load_error: str | None = None
+        self._operation_reference: ArtifactRef | None = None
+        self._operation_name: str | None = None
+        super().__init__(id=id)
+
+    def compose(self) -> ComposeResult:
+        """Compose from retained in-memory state without performing I/O."""
+        with Horizontal(classes="installed-header"):
+            yield Button("Refresh", id="installed-models-refresh", variant="primary")
+            yield Button("Repair", id="installed-models-repair", variant="default")
+        if self._loading:
+            yield Static("Loading installed models…", markup=False)
+        elif self._load_error:
+            yield Static(self._load_error, markup=False)
+        elif not self._loaded:
+            yield Static("Open Installed to load the local model inventory.", markup=False)
+        else:
+            yield self._summary()
+
+        with VerticalScroll(classes="installed-list"):
+            if self._loaded and not self._rows:
+                yield Static("No managed or legacy models found.", markup=False)
+            for row in self._rows:
+                yield self._row_widget(row)
+
+    def _summary(self) -> Static:
+        """Return the managed-store disk summary."""
+        if not self._rows or self._rows[0].installed_store_bytes is None:
+            return Static("Disk usage unavailable.", markup=False)
+        first = self._rows[0]
+        return Static(
+            "Managed: "
+            f"{self._format_bytes(first.installed_store_bytes or 0)} installed, "
+            f"{self._format_bytes(first.staging_store_bytes or 0)} staging · "
+            f"{self._format_bytes(first.free_bytes or 0)} free",
+            markup=False,
+        )
+
+    def _row_widget(self, row: InventoryRow) -> Vertical:
+        """Build one inventory row from pure render state."""
+        children: list[Widget] = [
+            Static(row.model_label, classes="installed-model-title", markup=False),
+            Static(row.provenance, classes="installed-model-muted", markup=False),
+        ]
+        if row.reference is not None:
+            children.append(
+                Static(
+                    f"Revision: {row.revision} · Precision: {row.precision}",
+                    markup=False,
+                )
+            )
+            if row.dependencies:
+                children.append(
+                    Static(
+                        "Dependencies: "
+                        + ", ".join(
+                            f"{ref.artifact_id}@{ref.revision}/{ref.variant}"
+                            for ref in row.dependencies
+                        ),
+                        markup=False,
+                    )
+                )
+        if row.size_bytes is not None:
+            children.append(Static(f"Size: {self._format_bytes(row.size_bytes)}"))
+        children.append(Static(row.action_hint, markup=False))
+        if row.reference is not None and not row.is_broken:
+            children.append(
+                ModelActivationControls(
+                    row.reference,
+                    active=row.active,
+                    ready=row.ready,
+                    pending=self._operation_reference is not None,
+                )
+            )
+        return Vertical(*children, classes="installed-model-row")
+
+    @staticmethod
+    def _format_bytes(size_bytes: int) -> str:
+        """Format bytes for compact inventory copy."""
+        size = float(size_bytes)
+        for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+            if size < 1024 or unit == "TiB":
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{size:.1f} TiB"
+
+    @staticmethod
+    def scan_unmanaged(
+        root: Path,
+        *,
+        limit: int = MAX_UNMANAGED_MODELS,
+    ) -> tuple[UnmanagedRow, ...]:
+        """Return a bounded scan of legacy model files.
+
+        Args:
+            root: Legacy downloader directory.
+            limit: Maximum rows returned.
+
+        Returns:
+            Bounded legacy model rows in deterministic path order.
+        """
+        if limit <= 0 or not root.is_dir():
+            return ()
+        rows: list[UnmanagedRow] = []
+        for directory, directories, filenames in os.walk(root):
+            directories.sort()
+            filenames.sort()
+            for filename in filenames:
+                path = Path(directory) / filename
+                if path.suffix.casefold() not in _MODEL_EXTENSIONS or path.is_symlink():
+                    continue
+                try:
+                    size_bytes = path.stat().st_size
+                except OSError:
+                    continue
+                if size_bytes <= _MIN_LEGACY_MODEL_BYTES:
+                    continue
+                rows.append(UnmanagedRow(path=path, size_bytes=size_bytes))
+                if len(rows) >= limit:
+                    return tuple(rows)
+        return tuple(rows)
+
+    def ensure_loaded(self, *, force: bool = False) -> None:
+        """Start the inventory worker on first activation or explicit refresh.
+
+        Args:
+            force: Reload even when a prior inventory is retained.
+        """
+        if self._loading or (self._loaded and not force):
+            return
+        self._loading = True
+        self._load_error = None
+        self.refresh(recompose=True)
+        self._load_inventory()
+
+    def _service_for_worker(self) -> ModelArtifactService:
+        """Create the managed service lazily on a worker thread."""
+        if self._service is None:
+            self._service = self._service_factory()
+        return self._service
+
+    @work(thread=True, group="installed_models_load", exclusive=True, exit_on_error=False)
+    def _load_inventory(self) -> None:
+        """Read managed inventory, disk totals, and legacy files off-loop."""
+        try:
+            service = self._service_for_worker()
+            installed = service.list_installed()
+            usage = service.disk_usage()
+            unmanaged = self.scan_unmanaged(self._legacy_dir)
+            rows = inventory_rows(installed, usage, unmanaged)
+        except Exception:
+            self.app.call_from_thread(
+                self._apply_inventory,
+                (),
+                "The local model inventory could not be loaded.",
+            )
+            return
+        self.app.call_from_thread(self._apply_inventory, rows, None)
+
+    def _apply_inventory(
+        self,
+        rows: tuple[InventoryRow, ...],
+        error: str | None,
+    ) -> None:
+        """Apply a completed inventory read on the Textual event loop."""
+        self._rows = rows
+        self._loading = False
+        self._loaded = error is None
+        self._load_error = error
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#installed-models-refresh")
+    def _refresh_pressed(self) -> None:
+        self.ensure_loaded(force=True)
+
+    @on(Button.Pressed, "#installed-models-repair")
+    def _repair_pressed(self) -> None:
+        if self._operation_reference is not None or self._operation_name is not None:
+            return
+        self._operation_name = "repair"
+        self.refresh(recompose=True)
+        self._repair_store()
+
+    @on(ActivationRequested)
+    def _activation_requested(self, event: ActivationRequested) -> None:
+        event.stop()
+        self._request_activation(event.reference)
+
+    def _request_activation(self, reference: ArtifactRef) -> None:
+        """Start activation unless another lifecycle operation is pending."""
+        if self._operation_reference is not None or self._operation_name is not None:
+            return
+        self._operation_reference = reference
+        self._operation_name = "activate"
+        self.refresh(recompose=True)
+        self._activate_model(reference)
+
+    @on(DeletionRequested)
+    def _deletion_requested(self, event: DeletionRequested) -> None:
+        event.stop()
+        if self._operation_reference is not None or self._operation_name is not None:
+            return
+        self._operation_reference = event.reference
+        self._operation_name = "delete"
+        self.refresh(recompose=True)
+        self._delete_model(event.reference)
+
+    @work(thread=True, group="installed_models_lifecycle", exclusive=True, exit_on_error=False)
+    def _activate_model(self, reference: ArtifactRef) -> None:
+        """Activate one exact verified model off the event loop."""
+        try:
+            self._service_for_worker().activate(reference)
+        except Exception as exc:
+            self.app.call_from_thread(
+                self._apply_lifecycle_result,
+                "activate",
+                lifecycle_failure_message(exc, operation="activation"),
+            )
+            return
+        self.app.call_from_thread(self._apply_lifecycle_result, "activate", None)
+
+    @work(thread=True, group="installed_models_lifecycle", exclusive=True, exit_on_error=False)
+    def _delete_model(self, reference: ArtifactRef) -> None:
+        """Delete one exact model without bypassing service leases."""
+        try:
+            self._service_for_worker().delete(reference)
+        except Exception as exc:
+            self.app.call_from_thread(
+                self._apply_lifecycle_result,
+                "delete",
+                lifecycle_failure_message(exc, operation="deletion"),
+            )
+            return
+        self.app.call_from_thread(self._apply_lifecycle_result, "delete", None)
+
+    @work(thread=True, group="installed_models_lifecycle", exclusive=True, exit_on_error=False)
+    def _repair_store(self) -> None:
+        """Run explicit reconciliation off the event loop."""
+        try:
+            report = self._service_for_worker().reconcile()
+        except Exception as exc:
+            self.app.call_from_thread(
+                self._apply_lifecycle_result,
+                "repair",
+                lifecycle_failure_message(exc, operation="repair"),
+            )
+            return
+        self.app.call_from_thread(
+            self._apply_lifecycle_result,
+            "repair",
+            None,
+            f"Repair completed: {report.readiness_created} readiness records restored.",
+        )
+
+    def _apply_lifecycle_result(
+        self,
+        operation: str,
+        error: str | None,
+        success_message: str | None = None,
+    ) -> None:
+        """Complete a lifecycle operation and refresh inventory."""
+        self._operation_reference = None
+        self._operation_name = None
+        if error is not None:
+            self.notify(error, severity="error")
+        else:
+            self.notify(
+                success_message or f"Model {operation} completed.",
+                severity="information",
+            )
+        self.ensure_loaded(force=True)

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -29,6 +29,7 @@ from tldw_chatbook.UI.Screens.model_browser_state import (
     UnmanagedRow,
     inventory_rows,
 )
+from tldw_chatbook.Utils.path_validation import validate_path_simple
 from tldw_chatbook.Widgets.ModelArtifacts.activation_controls import (
     ActivationRequested,
     DeletionRequested,
@@ -307,6 +308,7 @@ class InstalledView(Widget):
         Returns:
             Bounded legacy model rows in deterministic path order.
         """
+        root = validate_path_simple(root, require_exists=False).resolve()
         if limit <= 0 or not root.is_dir():
             return ()
         rows: list[UnmanagedRow] = []
@@ -361,7 +363,10 @@ class InstalledView(Widget):
             unmanaged = self.scan_unmanaged(self._legacy_dir)
             rows = inventory_rows(installed, usage, unmanaged)
         except Exception:
-            logger.opt(exception=True).error("Managed model inventory load failed")
+            logger.opt(exception=True).error(
+                "Managed model inventory load failed; legacy_scan_configured={}",
+                self._legacy_dir is not None,
+            )
             self.app.call_from_thread(
                 self._apply_inventory,
                 (),
@@ -521,7 +526,10 @@ class InstalledView(Widget):
         try:
             report = self._service_for_worker().reconcile()
         except Exception as exc:
-            logger.opt(exception=True).error("Managed model repair failed")
+            logger.opt(exception=True).error(
+                "Managed model repair failed; store={}",
+                "shared",
+            )
             self.app.call_from_thread(
                 self._apply_lifecycle_result,
                 "repair",

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -11,6 +11,7 @@ from loguru import logger
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -78,6 +79,7 @@ def reconcile_result_message(report: ReconcileReport) -> str:
         "Repair completed: "
         f"{report.readiness_created} readiness records restored · "
         f"{report.state_removed} stale state records removed · "
+        f"{len(report.staging_entries)} staging entries observed · "
         f"{len(report.staging_removed)} staging entries removed · "
         f"{len(report.corrupt_artifacts)} corrupt models found."
     )
@@ -216,12 +218,26 @@ class InstalledView(Widget):
             progress: Latest worker progress, when one has been emitted.
             active: Whether provisioning is still running.
         """
+        state_changed = active != self._install_active
         self._install_active = active
         if progress is not None:
             self._install_progress = progress
         if not active:
             self._install_progress = None
-        self.refresh(recompose=True)
+        if state_changed:
+            self.refresh(recompose=True)
+            return
+        try:
+            widget = self.query_one(
+                "#installed-model-install-progress",
+                ModelInstallProgress,
+            )
+        except NoMatches:
+            self.refresh(recompose=True)
+            return
+        widget.display = active
+        if progress is not None:
+            widget.update_progress(progress)
 
     def _row_widget(self, row: InventoryRow) -> Vertical:
         """Build one inventory row from pure render state."""

--- a/tldw_chatbook/Utils/path_validation.py
+++ b/tldw_chatbook/Utils/path_validation.py
@@ -397,7 +397,7 @@ def validate_path_simple(
         # Check for obvious traversal attempts
         dangerous_patterns = [
             "../..",  # Multiple parent refs (POSIX)
-            "..\\..\\",  # Multiple parent refs (Windows) -- kept in parity
+            "..\\..",  # Multiple parent refs (Windows) -- kept in parity
             # with the POSIX pattern above; a single "..\" segment is a
             # legitimate, unresolved component (e.g. "nested\..\locks") and
             # must not be flagged here. This function has no base directory

--- a/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
@@ -9,6 +9,7 @@ from .activation_controls import (
 from .install_modal import ModelInstallModal
 from .install_progress import (
     InstallProgressed,
+    InstallStatusChanged,
     ModelInstallProgress,
     make_progress_callback,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "ActivationRequested",
     "DeletionRequested",
     "InstallProgressed",
+    "InstallStatusChanged",
     "ModelActivationControls",
     "ModelInstallModal",
     "ModelInstallProgress",

--- a/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
@@ -1,0 +1,17 @@
+"""Reusable controls for managed-model acquisition and lifecycle UI."""
+
+from .install_modal import ModelInstallModal
+from .install_progress import (
+    InstallProgressed,
+    ModelInstallProgress,
+    make_progress_callback,
+)
+from .plan_panel import ModelPlanPanel
+
+__all__ = [
+    "InstallProgressed",
+    "ModelInstallModal",
+    "ModelInstallProgress",
+    "ModelPlanPanel",
+    "make_progress_callback",
+]

--- a/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/__init__.py
@@ -1,5 +1,11 @@
 """Reusable controls for managed-model acquisition and lifecycle UI."""
 
+from .activation_controls import (
+    ActivationRequested,
+    DeletionRequested,
+    ModelActivationControls,
+    RepairRequested,
+)
 from .install_modal import ModelInstallModal
 from .install_progress import (
     InstallProgressed,
@@ -9,9 +15,13 @@ from .install_progress import (
 from .plan_panel import ModelPlanPanel
 
 __all__ = [
+    "ActivationRequested",
+    "DeletionRequested",
     "InstallProgressed",
+    "ModelActivationControls",
     "ModelInstallModal",
     "ModelInstallProgress",
     "ModelPlanPanel",
+    "RepairRequested",
     "make_progress_callback",
 ]

--- a/tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py
@@ -77,7 +77,7 @@ class ModelActivationControls(Widget):
                 disabled=self.pending or self.active or not self.ready,
             )
             yield Button(
-                "Delete now",
+                "Delete…",
                 classes="model-delete",
                 variant="error",
                 disabled=self.pending,

--- a/tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py
@@ -1,0 +1,106 @@
+"""Intent-only activation and deletion controls for installed models."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Button
+
+from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+
+class ActivationRequested(Message):
+    """Request activation of one exact installed model reference."""
+
+    def __init__(self, reference: ArtifactRef) -> None:
+        super().__init__()
+        self.reference = reference
+
+
+class DeletionRequested(Message):
+    """Request deletion of one exact installed model reference."""
+
+    def __init__(self, reference: ArtifactRef) -> None:
+        super().__init__()
+        self.reference = reference
+
+
+class RepairRequested(Message):
+    """Request an explicit managed-store reconciliation."""
+
+
+class ModelActivationControls(Widget):
+    """Post lifecycle intents without calling the model service directly."""
+
+    DEFAULT_CSS = """
+    ModelActivationControls {
+        height: 3;
+    }
+
+    ModelActivationControls Button {
+        width: auto;
+        margin-right: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        reference: ArtifactRef,
+        *,
+        active: bool,
+        ready: bool,
+        pending: bool = False,
+    ) -> None:
+        """Create controls for one exact installed reference.
+
+        Args:
+            reference: Exact managed-model identity.
+            active: Whether this reference is already selected.
+            ready: Whether verification/readiness allows activation.
+            pending: Whether another lifecycle operation is running.
+        """
+        self.reference = reference
+        self.active = active
+        self.ready = ready
+        self.pending = pending
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        """Compose the activation and deletion buttons."""
+        with Horizontal():
+            yield Button(
+                "Active" if self.active else "Activate",
+                classes="model-activate",
+                variant="primary",
+                disabled=self.pending or self.active or not self.ready,
+            )
+            yield Button(
+                "Delete now",
+                classes="model-delete",
+                variant="error",
+                disabled=self.pending,
+            )
+
+    def set_pending(self, pending: bool) -> None:
+        """Disable or restore lifecycle controls while work is pending.
+
+        Args:
+            pending: Whether activation/deletion is pending.
+        """
+        self.pending = pending
+        activate = self.query_one(".model-activate", Button)
+        delete = self.query_one(".model-delete", Button)
+        activate.disabled = pending or self.active or not self.ready
+        delete.disabled = pending
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Post the exact lifecycle intent represented by a button."""
+        event.stop()
+        if self.pending:
+            return
+        if event.button.has_class("model-activate") and self.ready and not self.active:
+            self.post_message(ActivationRequested(self.reference))
+        elif event.button.has_class("model-delete"):
+            self.post_message(DeletionRequested(self.reference))

--- a/tldw_chatbook/Widgets/ModelArtifacts/install_modal.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/install_modal.py
@@ -1,0 +1,101 @@
+"""Consent-only modal for a managed-model acquisition plan."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button
+
+from .plan_panel import ModelPlanPanel
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts.acquisition import PreflightReport
+
+
+class ModelInstallModal(ModalScreen[bool]):
+    """Return consent for a plan while leaving all work to the host screen."""
+
+    DEFAULT_CSS = """
+    ModelInstallModal {
+        align: center middle;
+    }
+
+    ModelInstallModal .model-install-modal {
+        width: 76;
+        height: 90%;
+        max-height: 90%;
+        border: tall $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    ModelInstallModal .model-plan-panel {
+        height: 1fr;
+        overflow-y: auto;
+    }
+
+    ModelInstallModal .model-install-actions {
+        height: 3;
+        margin-top: 1;
+        align-horizontal: right;
+    }
+    """
+
+    BINDINGS = [("escape", "cancel", "Close")]
+
+    def __init__(
+        self,
+        report: PreflightReport,
+        *,
+        model_label: str,
+        container_id: str = "model-install-modal",
+        confirm_id: str = "model-install-confirm",
+        cancel_id: str = "model-install-cancel",
+    ) -> None:
+        """Build a consent prompt from an immutable preflight report.
+
+        Args:
+            report: The preflight plan to display and gate.
+            model_label: User-visible model name.
+            container_id: Container id for the consuming surface.
+            confirm_id: Confirm button id for the consuming surface.
+            cancel_id: Cancel button id for the consuming surface.
+        """
+        self.report = report
+        self.model_label = model_label
+        self.container_id = container_id
+        self.confirm_id = confirm_id
+        self.cancel_id = cancel_id
+        super().__init__()
+
+    @property
+    def ungrantable(self) -> bool:
+        """Return whether the report cannot produce valid consent."""
+        return bool(self.report.gating_errors) or not self.report.sufficient_space
+
+    def compose(self) -> ComposeResult:
+        """Compose the plan and decision controls."""
+        with Vertical(id=self.container_id, classes="model-install-modal"):
+            yield ModelPlanPanel(self.report, model_label=self.model_label)
+            with Horizontal(classes="model-install-actions"):
+                yield Button("Cancel", id=self.cancel_id, variant="default")
+                yield Button(
+                    "Install",
+                    id=self.confirm_id,
+                    variant="primary",
+                    disabled=self.ungrantable,
+                )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Dismiss with the decision represented by the pressed control."""
+        if event.button.id == self.confirm_id:
+            self.dismiss(True)
+        elif event.button.id == self.cancel_id:
+            self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        """Dismiss the modal without consent."""
+        self.dismiss(False)

--- a/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
@@ -12,6 +12,7 @@ from textual.widgets import ProgressBar, Static
 
 if TYPE_CHECKING:
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
 
 
 class InstallProgressed(Message):
@@ -25,6 +26,29 @@ class InstallProgressed(Message):
         """
         super().__init__()
         self.progress = progress
+
+
+class InstallStatusChanged(Message):
+    """Report the start or completion of one managed-model install."""
+
+    def __init__(
+        self,
+        reference: ArtifactRef,
+        *,
+        active: bool,
+        succeeded: bool | None = None,
+    ) -> None:
+        """Create a cross-view install-state message.
+
+        Args:
+            reference: Root model being installed.
+            active: Whether provisioning is still running.
+            succeeded: Completion result, or ``None`` while active.
+        """
+        super().__init__()
+        self.reference = reference
+        self.active = active
+        self.succeeded = succeeded
 
 
 def make_progress_callback(

--- a/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
@@ -1,0 +1,131 @@
+"""Persistent progress display and worker-to-UI message boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import ProgressBar, Static
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+
+
+class InstallProgressed(Message):
+    """Carry one acquisition progress event onto the Textual event loop."""
+
+    def __init__(self, progress: AcquisitionProgress) -> None:
+        """Create a progress message.
+
+        Args:
+            progress: Immutable event emitted by the acquisition worker.
+        """
+        super().__init__()
+        self.progress = progress
+
+
+def make_progress_callback(
+    post_message: Callable[[Message], object],
+) -> Callable[[AcquisitionProgress], None]:
+    """Build a worker-safe callback that posts immutable progress messages.
+
+    Args:
+        post_message: Host screen's message-posting method.
+
+    Returns:
+        A callback suitable for ``ArtifactAcquisitionService.provision``.
+    """
+
+    def callback(progress: AcquisitionProgress) -> None:
+        post_message(InstallProgressed(progress))
+
+    return callback
+
+
+def _bytes(size: int) -> str:
+    """Format a nonnegative byte count compactly."""
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KiB"
+    return f"{size / (1024 * 1024):.1f} MiB"
+
+
+class ModelInstallProgress(Widget):
+    """Show the current phase and determinate transfer/hash progress."""
+
+    DEFAULT_CSS = """
+    ModelInstallProgress {
+        height: auto;
+    }
+
+    ModelInstallProgress ProgressBar {
+        margin-top: 1;
+    }
+    """
+
+    _PHASE_LABELS = {
+        "fetch": "Downloading model",
+        "pre-verify": "Checking download",
+        "verify-install": "Verifying and installing model",
+        "activate": "Activating model",
+    }
+
+    def __init__(
+        self,
+        initial: AcquisitionProgress | None = None,
+        *,
+        id: str | None = None,
+    ) -> None:
+        """Create a progress display, optionally restoring its latest event.
+
+        Args:
+            initial: Latest event retained by the host across recomposition.
+            id: Optional Textual widget id.
+        """
+        self._initial = initial
+        super().__init__(id=id)
+
+    def compose(self) -> ComposeResult:
+        """Compose the stable progress display."""
+        yield Static("Waiting to install", id="model-install-progress-phase")
+        yield Static("", id="model-install-progress-detail", markup=False)
+        yield ProgressBar(
+            total=None,
+            show_eta=False,
+            id="model-install-progress-bar",
+        )
+
+    def on_mount(self) -> None:
+        """Restore retained progress or hide the idle determinate bar."""
+        if self._initial is not None:
+            self.update_progress(self._initial)
+            return
+        self.query_one("#model-install-progress-bar", ProgressBar).display = False
+
+    def update_progress(self, event: AcquisitionProgress) -> None:
+        """Render one acquisition progress event on the event loop.
+
+        Args:
+            event: Event delivered through ``InstallProgressed``.
+        """
+        self.query_one("#model-install-progress-phase", Static).update(
+            self._PHASE_LABELS[event.phase]
+        )
+        detail = self.query_one("#model-install-progress-detail", Static)
+        bar = self.query_one("#model-install-progress-bar", ProgressBar)
+        byte_phase = event.phase in {"fetch", "pre-verify"}
+        if byte_phase:
+            filename = event.file or "Model files"
+            detail.update(
+                f"{filename} — {_bytes(event.bytes_done)} / {_bytes(event.bytes_total)}"
+            )
+            bar.display = True
+            bar.update(total=max(event.bytes_total, 1), progress=event.bytes_done)
+            return
+
+        detail.update("")
+        bar.display = False

--- a/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
@@ -1,0 +1,83 @@
+"""Read-only acquisition plan rendering."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.widgets import Static
+
+from tldw_chatbook.UI.Screens.model_browser_state import plan_rows, plan_totals
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts.acquisition import PreflightReport
+
+
+def _mib(size_bytes: int) -> str:
+    """Format a byte count as mebibytes."""
+    return f"{size_bytes / (1024 * 1024):.1f} MiB"
+
+
+class ModelPlanPanel(Static):
+    """Render an immutable managed-model acquisition plan."""
+
+    def __init__(
+        self,
+        report: PreflightReport,
+        *,
+        model_label: str,
+        id: str | None = None,
+    ) -> None:
+        """Build the panel from preflight state only.
+
+        Args:
+            report: Immutable acquisition preflight report.
+            model_label: User-visible model name.
+            id: Optional Textual widget id.
+        """
+        rows = plan_rows(report)
+        totals = plan_totals(report)
+        lines = [f"Install {model_label}?", ""]
+        for row in rows:
+            installed = " (already installed)" if row.already_installed else ""
+            lines.extend(
+                (
+                    f"Source: {row.repository}{installed}",
+                    f"Revision: {row.revision}",
+                    f"License: {row.license_id} — {row.license_url}",
+                    f"Precision: {row.precision}",
+                    f"Contents: {row.file_count} files, {_mib(row.total_bytes)}",
+                    f"Provenance: {row.provenance}",
+                    "",
+                )
+            )
+        lines.extend(
+            (
+                f"Download: {_mib(totals.download_bytes)}",
+                f"Already staged: {_mib(totals.already_staged_bytes)}",
+                f"Staging overhead: {_mib(totals.staging_overhead_bytes)}",
+                f"Destination: {totals.destination}",
+                f"Free space: {_mib(totals.free_bytes)}",
+            )
+        )
+        if totals.sufficient_space:
+            lines.append("Enough free space is available for this install.")
+        else:
+            lines.append(
+                f"Not enough free space: this install needs "
+                f"{_mib(totals.required_bytes)} free."
+            )
+        if totals.gating_errors:
+            lines.extend(("", *totals.gating_errors))
+        lines.extend(
+            (
+                "",
+                "Every declared file is checked against pinned sizes and "
+                "SHA-256 digests before the model becomes usable.",
+            )
+        )
+        super().__init__(
+            "\n".join(lines),
+            markup=False,
+            id=id,
+            classes="model-plan-panel",
+        )


### PR DESCRIPTION
## Summary

- centralize the shared managed-model store, add the offline curated registry, and carry provenance through preflight
- add reusable install-plan, consent, progress, activation, and deletion controls; migrate Library Parakeet installation onto them
- add lazy Curated and Installed views in Lab → Models with disk inventory, bounded legacy discovery, cross-view progress, safe activation/deletion, and explicit repair

## Scope

This is TASK-596 Phase 1. Download Models remains available. Remote search, managed GGUF import/server-path migration, legacy browser retirement, and idle heavy-worker recycle remain deferred to the approved later phases. TASK-596 remains In Progress.

ADR: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
Spec: Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md
Plan: Docs/superpowers/plans/2026-08-01-task-596-model-browser-phase-1.md

## Verification

- 1193 passed, 1 expected skip across Model_Artifacts, Local_Ingestion, STT, console dictation, and changed Lab/Library UI suites
- Ruff passed across all changed Python files
- mypy passed across the 12 affected shared/browser source files
- git diff --check passed
- independent code review: no remaining Critical or Important issues; ready to merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Curated and Installed model browser views in Lab → Models using a centralized managed model store and a new curated registry. Delivers TASK-596 Phase 1; remote search, legacy browser retirement, and GGUF import remain in later phases.

- **New Features**
  - Curated and Installed views (lazy‑loaded) backed by the managed store; install status persists across views and shows in the Lab rail.
  - Curated registry with consent-based installs: preflight with provenance, plan panel, progress, safe activation/deletion, and explicit repair.
  - Installed view inventories managed models and bounded legacy folders; shows disk usage totals and supports activation/deletion.
  - Reusable widgets under `Widgets/ModelArtifacts` (plan panel, install modal/progress, activation controls) shared with Library Parakeet.

- **Bug Fixes**
  - Confirm managed model deletion, keep disk totals when inventory is empty, and tighten Windows path traversal checks.
  - Persist install and lifecycle state; update progress in place across view switches.

<sup>Written for commit df83bc395e5e9e6bc901e9c1d17edbef392e521b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

