### PR TITLE
Character probe evals — phase 1: engine and storage (task-1691)

### DIFF
--- a/Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md
+++ b/Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md
@@ -1,0 +1,1770 @@
+# Character Probe Evals — Phase 1 (Engine + Storage) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the engine and storage for character-probe evals — probe parsing, bench config, card snapshots, prompt assembly, the conversation runner, and annotation storage — with no UI.
+
+**Architecture:** A second bench type in the existing Evals slice, discriminated by `config_data.bench_type = "character_probe"` exactly as word_bench discriminates today. It reuses `eval_models` targets (and task-1611 steering), `eval_runs`/`run_group_id`, and the dataset inline-samples convention; it reuses **none** of word_bench's measurement stack. Everything here lives under `tldw_chatbook/Evals/character_probe/`, a sibling package to `word_bench/`.
+
+**Tech Stack:** Python ≥3.11, `dataclasses`, `asyncio` (with `asyncio.to_thread` for the blocking chat gateway), SQLite via `EvalsDB`/`CharactersRAGDB`, pytest.
+
+## Global Constraints
+
+Copied verbatim from `Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md`. Every task's requirements implicitly include this section.
+
+- **No logprobs, no top-K, no normalizer, no truncated mass, and no canary/degenerate vocabulary.** Only generated text matters. A character-probe target's readiness means only: can we reach this model and get text back.
+- **`chat_api_call` is synchronous and must never be called from the event loop.** Every call dispatches through `asyncio.to_thread`. The bench's own `concurrency` setting bounds the thread fan-out.
+- **Cancel stops scheduling; it cannot abort a turn already in flight.** In-flight turns run to completion and are recorded.
+- **Steering composes ahead of the card's system prompt.** Both preserved, neither discarded; the composed result is recorded in the snapshot.
+- **A card with no `first_message` starts with the user's first scripted turn.** No synthetic greeting is invented.
+- **Per-sample seed is `seed + sample_index`** so a seeded run is reproducible *and* its samples differ.
+- **Turns are delimited explicitly:** a line of `---` separates turns within a probe; a line of `===` separates probes. Interior whitespace is preserved exactly; leading/trailing blank lines around a turn are stripped.
+- **The ordered turn list lives in the `metadata` JSON**, never in `actual_output`.
+- **`sample_id` composes `(card_id, probe_index, sample_index)`.**
+- **Tags carry a kind** (`failure`/`notable`/`positive`); creating a tag requires choosing one, with no default.
+- Tests: real in-memory `EvalsDB`, fake chat callable. Every behavioural test must fail against pre-change code. Google-style docstrings with Args/Returns/Raises on public callables. Parameterized SQL only.
+- Run tests foreground: `/private/tmp/tldw-venv/bin/python -m pytest <paths> -p no:randomly` from the clone root. Never `-q`.
+
+## File Structure
+
+- `tldw_chatbook/Evals/character_probe/__init__.py` — package marker.
+- `tldw_chatbook/Evals/character_probe/models.py` — `Probe`, `ProbeSet`, `CharacterProbeConfig`, `CardSnapshot`, `ConversationTurn`, `Conversation`, `TagKind`. Pure data, no I/O.
+- `tldw_chatbook/Evals/character_probe/probe_format.py` — the `---`/`===` text format parser and serializer. Pure string handling.
+- `tldw_chatbook/Evals/character_probe/storage.py` — probe-set persistence, bench save/load, conversation persistence, annotation and review-state tables.
+- `tldw_chatbook/Evals/character_probe/cards.py` — read-only card snapshotting across the `ChaChaNotes_DB` boundary.
+- `tldw_chatbook/Evals/character_probe/prompt.py` — system-prompt composition and message-list assembly.
+- `tldw_chatbook/Evals/character_probe/runner.py` — the conversation runner, `to_thread` bridge, concurrency, cancel.
+- Tests mirror each module under `Tests/Evals/character_probe/`.
+
+---
+
+### Task 1: Probe models and the text format
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/__init__.py`
+- Create: `tldw_chatbook/Evals/character_probe/models.py`
+- Create: `tldw_chatbook/Evals/character_probe/probe_format.py`
+- Test: `Tests/Evals/character_probe/test_probe_format.py`
+
+**Interfaces:**
+- Produces: `Probe(turns: tuple[str, ...])`; `ProbeSet(probes: tuple[Probe, ...])`; `parse_probe_text(text: str) -> ProbeSet`; `format_probe_text(probe_set: ProbeSet) -> str`; constants `TURN_DELIMITER = "---"`, `PROBE_DELIMITER = "==="`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.models import Probe, ProbeSet
+from tldw_chatbook.Evals.character_probe.probe_format import (
+    format_probe_text,
+    parse_probe_text,
+)
+
+
+def test_single_probe_single_turn():
+    assert parse_probe_text("What do you think about lying?") == ProbeSet(
+        probes=(Probe(turns=("What do you think about lying?",)),)
+    )
+
+
+def test_turns_split_on_the_turn_delimiter():
+    text = "What do you think about lying?\n---\nAnd if it protected someone?"
+    assert parse_probe_text(text) == ProbeSet(
+        probes=(
+            Probe(
+                turns=(
+                    "What do you think about lying?",
+                    "And if it protected someone?",
+                )
+            ),
+        )
+    )
+
+
+def test_probes_split_on_the_probe_delimiter():
+    text = "First probe\n===\nSecond probe"
+    parsed = parse_probe_text(text)
+    assert len(parsed.probes) == 2
+    assert parsed.probes[0].turns == ("First probe",)
+    assert parsed.probes[1].turns == ("Second probe",)
+
+
+def test_a_turn_may_span_multiple_paragraphs():
+    """The whole point of the delimiter format: complex prompts are the subject."""
+    text = "Describe your earliest memory.\n\nTake your time, and include what you could smell."
+    parsed = parse_probe_text(text)
+    assert parsed.probes[0].turns == (
+        "Describe your earliest memory.\n\nTake your time, and include what you could smell.",
+    )
+
+
+def test_interior_whitespace_is_preserved_exactly():
+    text = "Line one\n    indented line\nLine three"
+    assert parsed_turn(text) == "Line one\n    indented line\nLine three"
+
+
+def parsed_turn(text: str) -> str:
+    return parse_probe_text(text).probes[0].turns[0]
+
+
+def test_blank_lines_around_a_turn_are_stripped():
+    text = "\n\nWhat is your name?\n\n\n---\n\nAnd your age?\n"
+    parsed = parse_probe_text(text)
+    assert parsed.probes[0].turns == ("What is your name?", "And your age?")
+
+
+def test_empty_text_is_rejected():
+    with pytest.raises(ValueError, match="no probes"):
+        parse_probe_text("   \n\n  ")
+
+
+def test_a_probe_with_no_turns_is_rejected():
+    with pytest.raises(ValueError, match="probe 2"):
+        parse_probe_text("Real probe\n===\n   \n===\nAnother")
+
+
+def test_round_trip_through_format_and_parse():
+    original = ProbeSet(
+        probes=(
+            Probe(turns=("One\n\nwith a paragraph", "Two")),
+            Probe(turns=("Three",)),
+        )
+    )
+    assert parse_probe_text(format_probe_text(original)) == original
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_probe_format.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Evals.character_probe'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`tldw_chatbook/Evals/character_probe/__init__.py`:
+
+```python
+"""Character probe evals: scripted question sets run against character cards,
+collected as conversations for human review.
+
+Sibling package to ``word_bench``. Shares its targets, run groups, and rail,
+but none of its measurement stack -- see
+``Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md``.
+"""
+```
+
+`tldw_chatbook/Evals/character_probe/models.py`:
+
+```python
+"""Pure data for character probe evals. No I/O, no Textual, no provider calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Probe:
+    """One scripted exchange: an ordered list of user turns.
+
+    A "one-off" question is simply a probe with a single turn -- there is no
+    separate type for it. Turn text is verbatim, including interior newlines,
+    because prompt formatting changes model behaviour.
+    """
+
+    turns: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.turns:
+            raise ValueError("A probe needs at least one turn.")
+
+
+@dataclass(frozen=True)
+class ProbeSet:
+    """An ordered collection of probes, the unit a bench runs."""
+
+    probes: tuple[Probe, ...]
+```
+
+`tldw_chatbook/Evals/character_probe/probe_format.py`:
+
+```python
+"""The plain-text probe format: `---` between turns, `===` between probes.
+
+Turns are delimited explicitly rather than by line breaks so a single turn can
+be a multi-paragraph prompt -- complex prompts are exactly what this eval
+exists to study, and a newline-delimited format could not express one.
+"""
+
+from __future__ import annotations
+
+from .models import Probe, ProbeSet
+
+#: A line containing only this separates turns within a probe.
+TURN_DELIMITER = "---"
+#: A line containing only this separates probes within a set.
+PROBE_DELIMITER = "==="
+
+
+def _split_on_delimiter(text: str, delimiter: str) -> list[str]:
+    chunks: list[str] = []
+    current: list[str] = []
+    for line in text.split("\n"):
+        if line.strip() == delimiter:
+            chunks.append("\n".join(current))
+            current = []
+        else:
+            current.append(line)
+    chunks.append("\n".join(current))
+    return chunks
+
+
+def _clean_turn(raw: str) -> str:
+    """Strip only leading/trailing blank lines; interior whitespace is data."""
+    return raw.strip("\n").strip() if not raw.strip() else raw.strip("\n")
+
+
+def parse_probe_text(text: str) -> ProbeSet:
+    """Parse the plain-text probe format into a ``ProbeSet``.
+
+    Args:
+        text: The file's contents.
+
+    Returns:
+        ProbeSet: The parsed probes, in file order.
+
+    Raises:
+        ValueError: If the text contains no probes, or if any probe has no
+            turns (naming the 1-based probe number so the author can find it).
+    """
+    probe_chunks = _split_on_delimiter(text, PROBE_DELIMITER)
+    probes: list[Probe] = []
+    for index, chunk in enumerate(probe_chunks, start=1):
+        if not chunk.strip():
+            if len(probe_chunks) == 1 or index in (1, len(probe_chunks)):
+                # A wholly empty document, or trailing/leading delimiter noise.
+                continue
+            raise ValueError(f"probe {index} has no turns")
+        turns = [
+            _clean_turn(raw)
+            for raw in _split_on_delimiter(chunk, TURN_DELIMITER)
+            if raw.strip()
+        ]
+        if not turns:
+            raise ValueError(f"probe {index} has no turns")
+        probes.append(Probe(turns=tuple(turns)))
+    if not probes:
+        raise ValueError("The probe file contains no probes.")
+    return ProbeSet(probes=tuple(probes))
+
+
+def format_probe_text(probe_set: ProbeSet) -> str:
+    """Render a ``ProbeSet`` back to the plain-text format.
+
+    Args:
+        probe_set: The set to render.
+
+    Returns:
+        str: Text that ``parse_probe_text`` round-trips to an equal ProbeSet.
+    """
+    return f"\n{PROBE_DELIMITER}\n".join(
+        f"\n{TURN_DELIMITER}\n".join(probe.turns) for probe in probe_set.probes
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_probe_format.py -p no:randomly`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/ Tests/Evals/character_probe/
+git commit -m "feat(evals): probe models and the delimited probe text format (task-1691 phase 1)"
+```
+
+---
+
+### Task 2: Probe-set storage on the dataset convention
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/storage.py`
+- Test: `Tests/Evals/character_probe/test_probe_storage.py`
+
+**Interfaces:**
+- Consumes: `ProbeSet`, `Probe`, `parse_probe_text` (Task 1).
+- Produces: `PROBE_DATASET_TYPE = "character_probe"`; `save_probe_set(db: EvalsDB, name: str, probe_set: ProbeSet, dataset_id: str | None = None) -> str`; `load_probe_set(db: EvalsDB, dataset_id: str) -> ProbeSet`; `is_probe_set(dataset_row: Mapping[str, Any]) -> bool`.
+
+Probe sets reuse the existing inline-samples convention that snippets use (`metadata[RESERVED_LOCAL_DATASET_SAMPLES_KEY]`), with `metadata["dataset_type"] = "character_probe"` discriminating them — the same shape `bench_type` gives `eval_tasks`. `EvalsDB.create_dataset` restricts `format` to `huggingface|json|csv|custom`; probe sets use `"custom"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.Evals.character_probe.models import Probe, ProbeSet
+from tldw_chatbook.Evals.character_probe.storage import (
+    PROBE_DATASET_TYPE,
+    is_probe_set,
+    load_probe_set,
+    save_probe_set,
+)
+
+
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
+
+
+@pytest.fixture
+def probe_set():
+    return ProbeSet(
+        probes=(
+            Probe(turns=("What do you think about lying?", "And to protect someone?")),
+            Probe(turns=("Describe your earliest memory.\n\nInclude the smell.",)),
+        )
+    )
+
+
+def test_save_then_load_round_trips(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    assert load_probe_set(db, dataset_id) == probe_set
+
+
+def test_saved_set_is_marked_as_a_probe_set(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    row = db.get_dataset(dataset_id)
+    assert (row.get("metadata") or {}).get("dataset_type") == PROBE_DATASET_TYPE
+    assert is_probe_set(row) is True
+
+
+def test_a_snippet_dataset_is_not_a_probe_set(db):
+    dataset_id = db.create_dataset(
+        name="snippets", format="custom", source_path="inline:snippets"
+    )
+    assert is_probe_set(db.get_dataset(dataset_id)) is False
+
+
+def test_saving_with_an_existing_id_replaces_its_probes(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    replacement = ProbeSet(probes=(Probe(turns=("Only one now",)),))
+    assert save_probe_set(db, "starter", replacement, dataset_id=dataset_id) == dataset_id
+    assert load_probe_set(db, dataset_id) == replacement
+
+
+def test_loading_a_non_probe_dataset_raises(db):
+    dataset_id = db.create_dataset(
+        name="snippets", format="custom", source_path="inline:snippets"
+    )
+    with pytest.raises(ValueError, match="not a probe set"):
+        load_probe_set(db, dataset_id)
+
+
+def test_loading_a_missing_dataset_raises(db):
+    with pytest.raises(ValueError, match="could not be found"):
+        load_probe_set(db, "nope")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_probe_storage.py -p no:randomly`
+Expected: FAIL — `ImportError: cannot import name 'save_probe_set'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `tldw_chatbook/Evals/character_probe/storage.py`:
+
+```python
+"""Persistence for character probe evals.
+
+Probe sets reuse the dataset inline-samples convention that snippets already
+use, discriminated by ``metadata["dataset_type"]`` -- the same shape
+``config_data.bench_type`` gives ``eval_tasks``. Nothing here writes SQL
+directly; every call goes through ``EvalsDB``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from ...DB.Evals_DB import EvalsDB
+from ...UI.Evals.snippet_editor import RESERVED_LOCAL_DATASET_SAMPLES_KEY
+from .models import Probe, ProbeSet
+
+#: Marks a dataset row as holding probes rather than snippets.
+PROBE_DATASET_TYPE = "character_probe"
+
+
+def is_probe_set(dataset_row: Mapping[str, Any]) -> bool:
+    """Whether a dataset row holds probes rather than snippets.
+
+    Args:
+        dataset_row: A row as returned by ``EvalsDB.get_dataset``/``list_datasets``.
+
+    Returns:
+        bool: True when the row is marked as a probe set.
+    """
+    metadata = dataset_row.get("metadata") or {}
+    return metadata.get("dataset_type") == PROBE_DATASET_TYPE
+
+
+def _probe_set_to_samples(probe_set: ProbeSet) -> list[dict[str, Any]]:
+    return [
+        {"index": index, "turns": list(probe.turns)}
+        for index, probe in enumerate(probe_set.probes)
+    ]
+
+
+def _samples_to_probe_set(samples: Any) -> ProbeSet:
+    if not isinstance(samples, list):
+        return ProbeSet(probes=())
+    probes = [
+        Probe(turns=tuple(str(turn) for turn in sample.get("turns") or ()))
+        for sample in samples
+        if isinstance(sample, Mapping) and sample.get("turns")
+    ]
+    return ProbeSet(probes=tuple(probes))
+
+
+def save_probe_set(
+    db: EvalsDB,
+    name: str,
+    probe_set: ProbeSet,
+    dataset_id: Optional[str] = None,
+) -> str:
+    """Persist a probe set, creating or replacing a dataset row.
+
+    Args:
+        db: The evals database handle.
+        name: Display name for the dataset row.
+        probe_set: The probes to store.
+        dataset_id: An existing probe-set dataset to overwrite; when omitted a
+            new dataset row is created.
+
+    Returns:
+        str: The dataset id holding the probes.
+    """
+    metadata = {
+        "dataset_type": PROBE_DATASET_TYPE,
+        RESERVED_LOCAL_DATASET_SAMPLES_KEY: _probe_set_to_samples(probe_set),
+    }
+    if dataset_id is None:
+        return db.create_dataset(
+            name=name,
+            format="custom",
+            source_path=f"inline:{name}",
+            metadata=metadata,
+        )
+    db.update_dataset(dataset_id, metadata=metadata)
+    return dataset_id
+
+
+def load_probe_set(db: EvalsDB, dataset_id: str) -> ProbeSet:
+    """Read a probe set back.
+
+    Args:
+        db: The evals database handle.
+        dataset_id: The dataset row to read.
+
+    Returns:
+        ProbeSet: The stored probes, in order.
+
+    Raises:
+        ValueError: If the dataset does not exist, or is not a probe set --
+            loading a snippet dataset as probes would otherwise silently yield
+            an empty set and look like an authoring mistake.
+    """
+    row = db.get_dataset(dataset_id)
+    if row is None:
+        raise ValueError(f"Probe set {dataset_id!r} could not be found.")
+    if not is_probe_set(row):
+        raise ValueError(f"Dataset {dataset_id!r} is not a probe set.")
+    metadata = row.get("metadata") or {}
+    return _samples_to_probe_set(metadata.get(RESERVED_LOCAL_DATASET_SAMPLES_KEY))
+```
+
+**Note for the implementer:** verify `EvalsDB.update_dataset` exists and accepts `metadata=`; if it does not, add the smallest possible method following `update_task`'s shape (parameterized, soft-delete aware) rather than writing SQL here.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_probe_storage.py -p no:randomly`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/storage.py Tests/Evals/character_probe/test_probe_storage.py
+git commit -m "feat(evals): probe sets persist on the dataset inline-samples convention (task-1691 phase 1)"
+```
+
+---
+
+### Task 3: Bench config save and load
+
+**Files:**
+- Modify: `tldw_chatbook/Evals/character_probe/models.py`
+- Modify: `tldw_chatbook/Evals/character_probe/storage.py`
+- Test: `Tests/Evals/character_probe/test_bench_storage.py`
+
+**Interfaces:**
+- Produces: `BENCH_TYPE = "character_probe"`; `CharacterProbeConfig(name, probe_set_id, character_ids, target_ids, description="", concurrency=1, samples_per_cell=1, seed=None, temperature=0.8, max_tokens=512, extra_tags=())`; `save_character_bench(db, config, task_id=None) -> str`; `load_character_bench(db, task_id) -> CharacterProbeConfig`; `is_character_bench(task_row) -> bool`.
+
+`character_ids` are **ints** (`character_cards.id`), unlike every eval id which is `str` — do not normalise them to strings.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.Evals.character_probe.models import CharacterProbeConfig
+from tldw_chatbook.Evals.character_probe.storage import (
+    BENCH_TYPE,
+    is_character_bench,
+    load_character_bench,
+    save_character_bench,
+)
+
+
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
+
+
+@pytest.fixture
+def config():
+    return CharacterProbeConfig(
+        name="villain probes",
+        probe_set_id="ps-1",
+        character_ids=(3, 7),
+        target_ids=("t-1",),
+        samples_per_cell=2,
+        seed=1234,
+    )
+
+
+def test_save_then_load_round_trips(db, config):
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id) == config
+
+
+def test_saved_bench_is_marked_with_its_type(db, config):
+    task_id = save_character_bench(db, config)
+    row = db.get_task(task_id)
+    assert (row.get("config_data") or {}).get("bench_type") == BENCH_TYPE
+    assert is_character_bench(row) is True
+
+
+def test_character_ids_survive_as_integers(db, config):
+    """character_cards.id is an INTEGER; every eval id is TEXT. Do not merge them."""
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id).character_ids == (3, 7)
+
+
+def test_defaults_are_conservative():
+    config = CharacterProbeConfig(
+        name="n", probe_set_id="p", character_ids=(1,), target_ids=("t",)
+    )
+    assert config.samples_per_cell == 1
+    assert config.seed is None
+    assert config.concurrency == 1
+    assert config.extra_tags == ()
+
+
+def test_editing_an_existing_bench_updates_in_place(db, config):
+    task_id = save_character_bench(db, config)
+    edited = CharacterProbeConfig(**{**config.__dict__, "name": "renamed"})
+    assert save_character_bench(db, edited, task_id=task_id) == task_id
+    assert load_character_bench(db, task_id).name == "renamed"
+
+
+def test_samples_per_cell_below_one_is_rejected():
+    with pytest.raises(ValueError, match="samples_per_cell"):
+        CharacterProbeConfig(
+            name="n",
+            probe_set_id="p",
+            character_ids=(1,),
+            target_ids=("t",),
+            samples_per_cell=0,
+        )
+
+
+def test_a_bench_needs_at_least_one_character():
+    with pytest.raises(ValueError, match="at least one character"):
+        CharacterProbeConfig(
+            name="n", probe_set_id="p", character_ids=(), target_ids=("t",)
+        )
+
+
+def test_loading_a_word_bench_as_a_character_bench_raises(db):
+    task_id = db.create_task(
+        name="word bench",
+        description="",
+        task_type="logprob",
+        config_data={"bench_type": "word_bench"},
+    )
+    with pytest.raises(ValueError, match="not a character probe bench"):
+        load_character_bench(db, task_id)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_bench_storage.py -p no:randomly`
+Expected: FAIL — `ImportError: cannot import name 'CharacterProbeConfig'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `models.py`:
+
+```python
+@dataclass(frozen=True)
+class CharacterProbeConfig:
+    """A character probe bench definition.
+
+    ``character_ids`` are ``character_cards.id`` INTEGERs, unlike every eval
+    id in this slice, which is TEXT. They are deliberately not normalised to
+    strings: the cross-database lookup in ``cards.py`` binds them as integers.
+    """
+
+    name: str
+    probe_set_id: str
+    character_ids: tuple[int, ...]
+    target_ids: tuple[str, ...]
+    description: str = ""
+    concurrency: int = 1
+    samples_per_cell: int = 1
+    seed: Optional[int] = None
+    temperature: float = 0.8
+    max_tokens: int = 512
+    extra_tags: tuple[dict, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.samples_per_cell < 1:
+            raise ValueError("samples_per_cell must be 1 or more.")
+        if self.concurrency < 1:
+            raise ValueError("concurrency must be 1 or more.")
+        if not self.character_ids:
+            raise ValueError("A character probe bench needs at least one character.")
+        if not self.target_ids:
+            raise ValueError("A character probe bench needs at least one target.")
+```
+
+Add `from typing import Optional` to `models.py`'s imports.
+
+Append to `storage.py`:
+
+```python
+#: Discriminates a character probe bench from a word bench in ``eval_tasks``.
+BENCH_TYPE = "character_probe"
+
+
+def is_character_bench(task_row: Mapping[str, Any]) -> bool:
+    """Whether an ``eval_tasks`` row is a character probe bench.
+
+    Args:
+        task_row: A row as returned by ``EvalsDB.get_task``/``list_tasks``.
+
+    Returns:
+        bool: True when the row carries this bench type.
+    """
+    return (task_row.get("config_data") or {}).get("bench_type") == BENCH_TYPE
+
+
+def save_character_bench(
+    db: EvalsDB, config: CharacterProbeConfig, task_id: Optional[str] = None
+) -> str:
+    """Persist a character probe bench.
+
+    Mirrors ``word_bench.storage.save_bench``: a new bench creates an
+    ``eval_tasks`` row, an existing one updates in place. The probe set is
+    fixed at creation for the same reason a word bench's dataset is -- see
+    that function's own docstring.
+
+    Args:
+        db: The evals database handle.
+        config: The bench to persist.
+        task_id: An existing bench to update; omit to create.
+
+    Returns:
+        str: The bench's ``eval_tasks`` id.
+
+    Raises:
+        ConflictError: If the name collides with another task's (including a
+            soft-deleted one -- the UNIQUE index has no ``deleted_at``
+            exemption).
+    """
+    config_data = {
+        "bench_type": BENCH_TYPE,
+        "probe_set_id": config.probe_set_id,
+        "character_ids": list(config.character_ids),
+        "target_ids": list(config.target_ids),
+        "concurrency": config.concurrency,
+        "samples_per_cell": config.samples_per_cell,
+        "seed": config.seed,
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
+        "extra_tags": list(config.extra_tags),
+    }
+    if task_id is not None:
+        db.update_task(
+            task_id,
+            name=config.name,
+            description=config.description,
+            config_data=config_data,
+        )
+        return task_id
+    return db.create_task(
+        name=config.name,
+        description=config.description,
+        task_type="generation",
+        config_data=config_data,
+    )
+
+
+def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
+    """Read a character probe bench back.
+
+    Args:
+        db: The evals database handle.
+        task_id: The bench to read.
+
+    Returns:
+        CharacterProbeConfig: The stored bench.
+
+    Raises:
+        ValueError: If the task does not exist or is not a character probe
+            bench -- loading a word bench here would otherwise produce a
+            config with empty characters and look like data loss.
+    """
+    row = db.get_task(task_id)
+    if row is None:
+        raise ValueError(f"Bench {task_id!r} could not be found.")
+    if not is_character_bench(row):
+        raise ValueError(f"Bench {task_id!r} is not a character probe bench.")
+    data = row.get("config_data") or {}
+    return CharacterProbeConfig(
+        name=row.get("name") or "",
+        description=row.get("description") or "",
+        probe_set_id=str(data.get("probe_set_id") or ""),
+        character_ids=tuple(int(cid) for cid in data.get("character_ids") or ()),
+        target_ids=tuple(str(tid) for tid in data.get("target_ids") or ()),
+        concurrency=int(data.get("concurrency") or 1),
+        samples_per_cell=int(data.get("samples_per_cell") or 1),
+        seed=data.get("seed"),
+        temperature=float(data.get("temperature", 0.8)),
+        max_tokens=int(data.get("max_tokens") or 512),
+        extra_tags=tuple(data.get("extra_tags") or ()),
+    )
+```
+
+Add `CharacterProbeConfig` to `storage.py`'s import from `.models`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_bench_storage.py -p no:randomly`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/ Tests/Evals/character_probe/test_bench_storage.py
+git commit -m "feat(evals): character probe bench config save and load (task-1691 phase 1)"
+```
+
+---
+
+### Task 4: Card snapshots across the database boundary
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/cards.py`
+- Test: `Tests/Evals/character_probe/test_cards.py`
+
+**Interfaces:**
+- Produces: `CardSnapshot(id, name, system_prompt, personality, scenario, first_message, post_history_instructions, message_example)` (added to `models.py`); `snapshot_cards(chacha_db, character_ids: Sequence[int]) -> tuple[CardSnapshot, ...]`.
+
+Character cards live in `ChaChaNotes_DB` (`CharactersRAGDB`), a different database from `EvalsDB` with no foreign keys between them. Snapshotting copies the card's text into the run so later edits or deletions never rewrite history.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.cards import snapshot_cards
+from tldw_chatbook.Evals.character_probe.models import CardSnapshot
+
+
+class _FakeCharacterDB:
+    """Stands in for CharactersRAGDB; only get_character_card_by_id is used."""
+
+    def __init__(self, cards):
+        self._cards = cards
+
+    def get_character_card_by_id(self, character_id):
+        return self._cards.get(character_id)
+
+
+def _card(**overrides):
+    base = {
+        "id": 1,
+        "name": "Vex",
+        "system_prompt": "You are Vex.",
+        "personality": "sardonic",
+        "scenario": "a rooftop at night",
+        "first_message": "You again.",
+        "post_history_instructions": "Stay in character.",
+        "message_example": "<START>",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_snapshot_copies_every_field_used_in_prompting():
+    db = _FakeCharacterDB({1: _card()})
+    (snapshot,) = snapshot_cards(db, [1])
+    assert snapshot == CardSnapshot(
+        id=1,
+        name="Vex",
+        system_prompt="You are Vex.",
+        personality="sardonic",
+        scenario="a rooftop at night",
+        first_message="You again.",
+        post_history_instructions="Stay in character.",
+        message_example="<START>",
+    )
+
+
+def test_missing_fields_become_empty_strings_not_none():
+    db = _FakeCharacterDB({1: {"id": 1, "name": "Sparse"}})
+    (snapshot,) = snapshot_cards(db, [1])
+    assert snapshot.system_prompt == ""
+    assert snapshot.first_message == ""
+
+
+def test_order_follows_the_requested_ids():
+    db = _FakeCharacterDB({1: _card(id=1, name="A"), 2: _card(id=2, name="B")})
+    assert [c.name for c in snapshot_cards(db, [2, 1])] == ["B", "A"]
+
+
+def test_a_missing_card_raises_naming_the_id():
+    db = _FakeCharacterDB({1: _card()})
+    with pytest.raises(ValueError, match="99"):
+        snapshot_cards(db, [1, 99])
+
+
+def test_no_ids_raises():
+    with pytest.raises(ValueError, match="at least one character"):
+        snapshot_cards(_FakeCharacterDB({}), [])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_cards.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...character_probe.cards'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `models.py`:
+
+```python
+@dataclass(frozen=True)
+class CardSnapshot:
+    """A character card's text, copied at run time.
+
+    Cards live in ``ChaChaNotes_DB`` while runs live in ``Evals_DB``, with no
+    foreign keys between them. Copying the text into the run means editing or
+    deleting a card later never rewrites what a past run shows -- the same
+    provenance rule word_bench applies to snippets.
+    """
+
+    id: int
+    name: str
+    system_prompt: str = ""
+    personality: str = ""
+    scenario: str = ""
+    first_message: str = ""
+    post_history_instructions: str = ""
+    message_example: str = ""
+```
+
+`tldw_chatbook/Evals/character_probe/cards.py`:
+
+```python
+"""Read-only card access across the ChaChaNotes/Evals database boundary."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from .models import CardSnapshot
+
+#: Card fields copied into a run. Every one participates in prompt assembly;
+#: anything not listed here (images, timestamps, versions) is deliberately
+#: excluded because it cannot change what the model sees.
+_SNAPSHOT_FIELDS = (
+    "system_prompt",
+    "personality",
+    "scenario",
+    "first_message",
+    "post_history_instructions",
+    "message_example",
+)
+
+
+def snapshot_cards(chacha_db: Any, character_ids: Sequence[int]) -> tuple[CardSnapshot, ...]:
+    """Copy each requested card's prompting text, in the requested order.
+
+    Args:
+        chacha_db: A ``CharactersRAGDB``-shaped handle; only
+            ``get_character_card_by_id`` is used, so a fake needs just that.
+        character_ids: ``character_cards.id`` values, as INTEGERs.
+
+    Returns:
+        tuple[CardSnapshot, ...]: One snapshot per id, in the order given.
+
+    Raises:
+        ValueError: If no ids are supplied, or a card cannot be found -- the
+            message names the missing id so the caller can drop it from the
+            bench rather than guessing which card vanished.
+    """
+    if not character_ids:
+        raise ValueError("A character probe run needs at least one character.")
+    snapshots: list[CardSnapshot] = []
+    for character_id in character_ids:
+        row = chacha_db.get_character_card_by_id(character_id)
+        if not row:
+            raise ValueError(
+                f"Character card {character_id} could not be found; "
+                "remove it from the bench or restore the card."
+            )
+        snapshots.append(
+            CardSnapshot(
+                id=int(row.get("id", character_id)),
+                name=str(row.get("name") or ""),
+                **{field: str(row.get(field) or "") for field in _SNAPSHOT_FIELDS},
+            )
+        )
+    return tuple(snapshots)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_cards.py -p no:randomly`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/cards.py tldw_chatbook/Evals/character_probe/models.py Tests/Evals/character_probe/test_cards.py
+git commit -m "feat(evals): snapshot character cards across the DB boundary (task-1691 phase 1)"
+```
+
+---
+
+### Task 5: Prompt assembly
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/prompt.py`
+- Test: `Tests/Evals/character_probe/test_prompt.py`
+
+**Interfaces:**
+- Consumes: `CardSnapshot` (Task 4).
+- Produces: `compose_system_prompt(card: CardSnapshot, steering: str | None) -> str`; `build_messages(card: CardSnapshot, steering: str | None, scripted_turns: Sequence[str], replies_so_far: Sequence[str]) -> list[dict[str, str]]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tldw_chatbook.Evals.character_probe.models import CardSnapshot
+from tldw_chatbook.Evals.character_probe.prompt import build_messages, compose_system_prompt
+
+
+def _card(**overrides):
+    base = dict(id=1, name="Vex", system_prompt="You are Vex.", first_message="You again.")
+    base.update(overrides)
+    return CardSnapshot(**base)
+
+
+def test_steering_is_placed_ahead_of_the_card_prompt():
+    composed = compose_system_prompt(_card(), "Answer in English.")
+    assert composed.startswith("Answer in English.")
+    assert composed.endswith("You are Vex.")
+
+
+def test_no_steering_yields_the_card_prompt_unchanged():
+    assert compose_system_prompt(_card(), None) == "You are Vex."
+
+
+def test_no_card_prompt_yields_the_steering_alone():
+    assert compose_system_prompt(_card(system_prompt=""), "Be brief.") == "Be brief."
+
+
+def test_first_message_seeds_an_assistant_turn():
+    messages = build_messages(_card(), None, ["Hello?"], [])
+    assert messages[0]["role"] == "system"
+    assert messages[1] == {"role": "assistant", "content": "You again."}
+    assert messages[2] == {"role": "user", "content": "Hello?"}
+
+
+def test_a_card_without_a_first_message_starts_at_the_user_turn():
+    """No synthetic greeting is invented -- that would evaluate text the
+    character never had."""
+    messages = build_messages(_card(first_message=""), None, ["Hello?"], [])
+    assert [m["role"] for m in messages] == ["system", "user"]
+
+
+def test_prior_replies_accumulate_in_order():
+    messages = build_messages(
+        _card(), None, ["One", "Two", "Three"], ["Reply one", "Reply two"]
+    )
+    assert [m["role"] for m in messages] == [
+        "system", "assistant", "user", "assistant", "user", "assistant", "user",
+    ]
+    assert messages[-1] == {"role": "user", "content": "Three"}
+    assert messages[-2] == {"role": "assistant", "content": "Reply two"}
+
+
+def test_personality_and_scenario_reach_the_system_prompt():
+    card = _card(system_prompt="You are Vex.", personality="sardonic", scenario="a rooftop")
+    composed = compose_system_prompt(card, None)
+    assert "sardonic" in composed
+    assert "rooftop" in composed
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_prompt.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...character_probe.prompt'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Assembling the messages a character probe sends.
+
+Steering composes AHEAD of the card's own system prompt: steering is a
+model-level instruction ("answer in English") and the card is the content it
+operates on. Both are preserved -- silently dropping either would evaluate
+something other than what the bench describes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .models import CardSnapshot
+
+
+def compose_system_prompt(card: CardSnapshot, steering: Optional[str]) -> str:
+    """Build the system prompt for one card under one target's steering.
+
+    Args:
+        card: The snapshotted card.
+        steering: The target's own system prompt, or None when unsteered.
+
+    Returns:
+        str: Steering first, then the card's persona text. Empty parts are
+        omitted rather than contributing blank lines.
+    """
+    parts = [
+        steering or "",
+        card.system_prompt,
+        f"Personality: {card.personality}" if card.personality else "",
+        f"Scenario: {card.scenario}" if card.scenario else "",
+        card.post_history_instructions,
+    ]
+    return "\n\n".join(part.strip() for part in parts if part and part.strip())
+
+
+def build_messages(
+    card: CardSnapshot,
+    steering: Optional[str],
+    scripted_turns: Sequence[str],
+    replies_so_far: Sequence[str],
+) -> list[dict[str, str]]:
+    """Build the message list for the next turn of a conversation.
+
+    The card's ``first_message`` seeds an opening assistant turn as it does in
+    real roleplay. A card without one starts at the user's first scripted turn
+    -- no greeting is invented, because inventing one would evaluate text the
+    character never had.
+
+    Args:
+        card: The snapshotted card.
+        steering: The target's own system prompt, or None.
+        scripted_turns: All of the probe's user turns.
+        replies_so_far: The model's replies to the preceding turns; its length
+            determines which scripted turn comes next.
+
+    Returns:
+        list[dict[str, str]]: ``role``/``content`` messages, ending with the
+        user turn awaiting a reply.
+    """
+    messages: list[dict[str, str]] = [
+        {"role": "system", "content": compose_system_prompt(card, steering)}
+    ]
+    if card.first_message:
+        messages.append({"role": "assistant", "content": card.first_message})
+    for index, reply in enumerate(replies_so_far):
+        messages.append({"role": "user", "content": scripted_turns[index]})
+        messages.append({"role": "assistant", "content": reply})
+    messages.append({"role": "user", "content": scripted_turns[len(replies_so_far)]})
+    return messages
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_prompt.py -p no:randomly`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/prompt.py Tests/Evals/character_probe/test_prompt.py
+git commit -m "feat(evals): character probe prompt assembly with steering precedence (task-1691 phase 1)"
+```
+
+---
+
+### Task 6: The conversation runner
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/runner.py`
+- Modify: `tldw_chatbook/Evals/character_probe/models.py`
+- Test: `Tests/Evals/character_probe/test_runner.py`
+
+**Interfaces:**
+- Consumes: `CardSnapshot`, `Probe`, `CharacterProbeConfig`, `build_messages`.
+- Produces: `ConversationTurn(user, reply, error="")`; `Conversation(card_id, probe_index, sample_index, target_id, turns, error="")`; `CharacterProbeRunner(chat_fn, cancel_token=None)` with `async def run(cards, probe_set, targets, config, progress=None) -> list[Conversation]`.
+
+`chat_fn` is the injected provider callable with the shape `chat_fn(messages, model, temperature, max_tokens, seed) -> str`. In production it wraps `Chat_Functions.chat_api_call`; in tests it is a fake. **It is synchronous and MUST be dispatched through `asyncio.to_thread`.**
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import asyncio
+
+import pytest
+
+from tldw_chatbook.Evals.character_probe.models import (
+    CardSnapshot,
+    CharacterProbeConfig,
+    Probe,
+    ProbeSet,
+)
+from tldw_chatbook.Evals.character_probe.runner import CharacterProbeRunner
+
+
+class _FakeChat:
+    def __init__(self, reply="ok", fail_on=None):
+        self.calls = []
+        self._reply = reply
+        self._fail_on = fail_on
+
+    def __call__(self, messages, model, temperature, max_tokens, seed):
+        self.calls.append(
+            {"messages": messages, "model": model, "seed": seed, "temperature": temperature}
+        )
+        if self._fail_on is not None and len(self.calls) == self._fail_on:
+            raise RuntimeError("provider exploded")
+        return f"{self._reply}-{len(self.calls)}"
+
+
+def _card(card_id=1):
+    return CardSnapshot(id=card_id, name=f"card{card_id}", system_prompt="sys")
+
+
+def _config(**overrides):
+    base = dict(
+        name="b", probe_set_id="ps", character_ids=(1,), target_ids=("t-1",)
+    )
+    base.update(overrides)
+    return CharacterProbeConfig(**base)
+
+
+def _targets():
+    return [{"id": "t-1", "model_id": "m", "system_prompt": None}]
+
+
+def test_turns_run_in_order_and_each_sees_the_previous_reply():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One", "Two")),))
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    (conversation,) = conversations
+    assert [t.user for t in conversation.turns] == ["One", "Two"]
+    second_call_messages = chat.calls[1]["messages"]
+    assert second_call_messages[-2] == {"role": "assistant", "content": "ok-1"}
+
+
+def test_a_failed_turn_ends_only_its_own_conversation():
+    chat = _FakeChat(fail_on=1)
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    failed = [c for c in conversations if c.error]
+    survived = [c for c in conversations if not c.error]
+    assert len(failed) == 1 and "provider exploded" in failed[0].error
+    assert len(survived) == 1
+
+
+def test_partial_turns_are_kept_when_a_later_turn_fails():
+    chat = _FakeChat(fail_on=2)
+    probe_set = ProbeSet(probes=(Probe(turns=("One", "Two")),))
+    (conversation,) = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    assert conversation.turns[0].reply == "ok-1"
+    assert conversation.error
+
+
+def test_per_sample_seed_is_offset_so_samples_differ():
+    """A single fixed seed would return N identical answers -- see the spec."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card()], probe_set, _targets(), _config(samples_per_cell=3, seed=100)
+        )
+    )
+    assert sorted(call["seed"] for call in chat.calls) == [100, 101, 102]
+
+
+def test_no_seed_passes_none():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    assert chat.calls[0]["seed"] is None
+
+
+def test_the_grid_covers_cards_probes_targets_and_samples():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+    targets = [
+        {"id": "t-1", "model_id": "m1", "system_prompt": None},
+        {"id": "t-2", "model_id": "m2", "system_prompt": None},
+    ]
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card(1), _card(2)],
+            probe_set,
+            targets,
+            _config(character_ids=(1, 2), target_ids=("t-1", "t-2"), samples_per_cell=2),
+        )
+    )
+    assert len(conversations) == 2 * 2 * 2 * 2
+
+
+def test_target_steering_reaches_the_system_prompt():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    targets = [{"id": "t-1", "model_id": "m", "system_prompt": "Be terse."}]
+    asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
+    )
+    system = chat.calls[0]["messages"][0]["content"]
+    assert system.startswith("Be terse.")
+
+
+def test_cancelling_stops_scheduling_but_keeps_completed_turns():
+    """Cancel cannot abort an in-flight turn (to_thread survives cancellation),
+    so it means: start nothing further, keep what finished."""
+    from tldw_chatbook.Evals.character_probe.runner import CancelToken
+
+    token = CancelToken()
+
+    def chat(messages, model, temperature, max_tokens, seed):
+        token.cancel()  # cancelled while the first turn is in flight
+        return "first reply"
+
+    probe_set = ProbeSet(probes=(Probe(turns=("One", "Two", "Three")),))
+    (conversation,) = asyncio.run(
+        CharacterProbeRunner(chat, cancel_token=token).run(
+            [_card()], probe_set, _targets(), _config()
+        )
+    )
+    assert len(conversation.turns) == 1
+    assert conversation.turns[0].reply == "first reply"
+    assert "Cancelled" in conversation.error
+
+
+def test_the_blocking_chat_callable_never_runs_on_the_event_loop():
+    """chat_api_call is a plain def; calling it inline would freeze the TUI."""
+    seen = {}
+
+    def chat(messages, model, temperature, max_tokens, seed):
+        try:
+            asyncio.get_running_loop()
+            seen["on_loop"] = True
+        except RuntimeError:
+            seen["on_loop"] = False
+        return "ok"
+
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config()))
+    assert seen["on_loop"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_runner.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...character_probe.runner'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `models.py`:
+
+```python
+@dataclass(frozen=True)
+class ConversationTurn:
+    """One scripted user turn and the model's reply to it."""
+
+    user: str
+    reply: str
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class Conversation:
+    """One cell: a card, a probe, a target, and one sample of the exchange."""
+
+    card_id: int
+    probe_index: int
+    sample_index: int
+    target_id: str
+    turns: tuple[ConversationTurn, ...]
+    error: str = ""
+```
+
+`tldw_chatbook/Evals/character_probe/runner.py`:
+
+```python
+"""Runs character probe conversations.
+
+Every provider call goes through ``asyncio.to_thread``: the app's chat gateway
+(``Chat_Functions.chat_api_call``) is a plain synchronous ``def``, and calling
+it from the event loop would block the whole TUI. Conversations run
+concurrently under the bench's ``concurrency`` setting; turns WITHIN a
+conversation are strictly sequential, because turn N needs turn N-1's reply.
+
+Cancelling stops SCHEDULING further turns and conversations. It cannot abort a
+turn already in flight -- ``to_thread`` survives task cancellation -- so an
+in-flight provider call always runs to completion and is recorded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from .models import (
+    CardSnapshot,
+    CharacterProbeConfig,
+    Conversation,
+    ConversationTurn,
+    ProbeSet,
+)
+from .prompt import build_messages
+
+#: The injected provider callable. Synchronous by contract.
+ChatCallable = Callable[..., str]
+
+
+class CancelToken:
+    """Cancels a whole run; see the module docstring for what that means."""
+
+    def __init__(self) -> None:
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancelled
+
+
+class CharacterProbeRunner:
+    """Runs a bench's full grid of conversations."""
+
+    def __init__(
+        self, chat_fn: ChatCallable, cancel_token: Optional[CancelToken] = None
+    ) -> None:
+        self._chat = chat_fn
+        self._cancel = cancel_token or CancelToken()
+
+    async def _run_conversation(
+        self,
+        card: CardSnapshot,
+        probe_index: int,
+        turns: Sequence[str],
+        target: Mapping[str, Any],
+        sample_index: int,
+        config: CharacterProbeConfig,
+    ) -> Conversation:
+        steering = target.get("system_prompt")
+        seed = None if config.seed is None else config.seed + sample_index
+        collected: list[ConversationTurn] = []
+        replies: list[str] = []
+        error = ""
+        for turn_index, user_turn in enumerate(turns):
+            if self._cancel.is_cancelled:
+                error = "Cancelled before this turn ran."
+                break
+            messages = build_messages(card, steering, turns, replies)
+            try:
+                reply = await asyncio.to_thread(
+                    self._chat,
+                    messages=messages,
+                    model=target.get("model_id"),
+                    temperature=config.temperature,
+                    max_tokens=config.max_tokens,
+                    seed=seed,
+                )
+            except Exception as exc:  # noqa: BLE001 -- any provider failure ends this conversation only
+                error = f"Turn {turn_index + 1} failed: {exc}"
+                break
+            reply_text = str(reply or "")
+            replies.append(reply_text)
+            collected.append(ConversationTurn(user=user_turn, reply=reply_text))
+        return Conversation(
+            card_id=card.id,
+            probe_index=probe_index,
+            sample_index=sample_index,
+            target_id=str(target.get("id")),
+            turns=tuple(collected),
+            error=error,
+        )
+
+    async def run(
+        self,
+        cards: Sequence[CardSnapshot],
+        probe_set: ProbeSet,
+        targets: Sequence[Mapping[str, Any]],
+        config: CharacterProbeConfig,
+        progress: Optional[Callable[[int, int], None]] = None,
+    ) -> list[Conversation]:
+        """Run every (card x probe x target x sample) conversation.
+
+        Args:
+            cards: Snapshotted cards, already resolved.
+            probe_set: The scripts to run.
+            targets: ``eval_models`` rows; ``system_prompt`` supplies steering.
+            config: The bench, supplying concurrency, samples, seed, sampler.
+            progress: Optional ``(done, total)`` callback fired as each
+                conversation completes.
+
+        Returns:
+            list[Conversation]: Every conversation, including failed and
+            partial ones -- a failed cell is still evidence and stays
+            reviewable.
+        """
+        jobs = [
+            (card, probe_index, probe.turns, target, sample_index)
+            for card in cards
+            for probe_index, probe in enumerate(probe_set.probes)
+            for target in targets
+            for sample_index in range(config.samples_per_cell)
+        ]
+        semaphore = asyncio.Semaphore(config.concurrency)
+        done = 0
+        total = len(jobs)
+
+        async def _guarded(job) -> Conversation:
+            nonlocal done
+            card, probe_index, turns, target, sample_index = job
+            async with semaphore:
+                conversation = await self._run_conversation(
+                    card, probe_index, turns, target, sample_index, config
+                )
+            done += 1
+            if progress is not None:
+                progress(done, total)
+            return conversation
+
+        return list(await asyncio.gather(*(_guarded(job) for job in jobs)))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_runner.py -p no:randomly`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/runner.py tldw_chatbook/Evals/character_probe/models.py Tests/Evals/character_probe/test_runner.py
+git commit -m "feat(evals): character probe conversation runner on a thread bridge (task-1691 phase 1)"
+```
+
+---
+
+### Task 7: Conversation, annotation, and review-state persistence
+
+**Files:**
+- Modify: `tldw_chatbook/Evals/character_probe/storage.py`
+- Modify: `tldw_chatbook/DB/Evals_DB.py` (two new tables + their CRUD)
+- Test: `Tests/Evals/character_probe/test_conversation_storage.py`
+
+**Interfaces:**
+- Consumes: `Conversation`, `ConversationTurn`, `CharacterProbeConfig`.
+- Produces: `conversation_sample_id(card_id: int, probe_index: int, sample_index: int) -> str`; `save_conversations(db, run_group_id, run_ids: Mapping[str, str], conversations) -> None`; `load_conversations(db, run_group_id) -> list[Conversation]`; `annotate_turn(db, run_group_id, card_id, probe_index, sample_index, target_id, turn_index, tags: Sequence[str], note: str) -> None`; `load_turn_annotations(db, run_group_id) -> dict[tuple, dict]`; `mark_conversation_reviewed(db, run_group_id, card_id, probe_index, sample_index, target_id, note: str = "") -> None`; `load_review_state(db, run_group_id) -> dict[tuple, dict]`.
+
+The ordered turn list lives in `eval_results.metadata` JSON, never in `actual_output` — that column is shaped for a single answer and cannot represent a conversation.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.Evals.character_probe.models import Conversation, ConversationTurn
+from tldw_chatbook.Evals.character_probe.storage import (
+    annotate_turn,
+    conversation_sample_id,
+    load_conversations,
+    load_review_state,
+    load_turn_annotations,
+    mark_conversation_reviewed,
+    save_conversations,
+)
+
+
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
+
+
+def _conversation(card_id=1, probe_index=0, sample_index=0, target_id="t-1"):
+    return Conversation(
+        card_id=card_id,
+        probe_index=probe_index,
+        sample_index=sample_index,
+        target_id=target_id,
+        turns=(
+            ConversationTurn(user="One", reply="Reply one"),
+            ConversationTurn(user="Two", reply="Reply two"),
+        ),
+    )
+
+
+def _seed_run(db):
+    task_id = db.create_task(
+        name="probe bench", description="", task_type="generation",
+        config_data={"bench_type": "character_probe"},
+    )
+    model_id = db.create_model(name="m", provider="llama_cpp", model_id="m")
+    run_id = db.create_run(name="r", task_id=task_id, model_id=model_id)
+    return run_id, model_id
+
+
+def test_sample_id_composes_card_probe_and_sample():
+    assert conversation_sample_id(3, 1, 2) == "3:1:2"
+
+
+def test_conversations_round_trip(db):
+    run_id, target_id = _seed_run(db)
+    original = _conversation(target_id=target_id)
+    save_conversations(db, "rg-1", {target_id: run_id}, [original])
+    (loaded,) = load_conversations(db, "rg-1")
+    assert loaded.turns == original.turns
+    assert loaded.card_id == original.card_id
+
+
+def test_turns_are_stored_in_metadata_not_actual_output(db):
+    """actual_output is shaped for a single answer; a conversation is not one."""
+    run_id, target_id = _seed_run(db)
+    save_conversations(db, "rg-1", {target_id: run_id}, [_conversation(target_id=target_id)])
+    row = db.get_run_results(run_id)[0]
+    assert "Reply one" in str(row.get("metadata"))
+
+
+def test_a_turn_annotation_persists_with_its_tags_and_note(db):
+    run_id, target_id = _seed_run(db)
+    save_conversations(db, "rg-1", {target_id: run_id}, [_conversation(target_id=target_id)])
+    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 1, ["broke-character"], "drifted here")
+    stored = load_turn_annotations(db, "rg-1")[(1, 0, 0, target_id, 1)]
+    assert stored["tags"] == ["broke-character"]
+    assert stored["note"] == "drifted here"
+
+
+def test_re_annotating_the_same_turn_replaces_it(db):
+    run_id, target_id = _seed_run(db)
+    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 0, ["refused"], "")
+    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 0, ["in-character"], "fine actually")
+    stored = load_turn_annotations(db, "rg-1")[(1, 0, 0, target_id, 0)]
+    assert stored["tags"] == ["in-character"]
+
+
+def test_a_conversation_can_be_reviewed_with_no_annotations(db):
+    """'Nothing notable' is a real verdict and needs its own home."""
+    mark_conversation_reviewed(db, "rg-1", 1, 0, 0, "t-1")
+    state = load_review_state(db, "rg-1")[(1, 0, 0, "t-1")]
+    assert state["reviewed_at"]
+    assert load_turn_annotations(db, "rg-1") == {}
+
+
+def test_review_state_is_scoped_to_its_run_group(db):
+    mark_conversation_reviewed(db, "rg-1", 1, 0, 0, "t-1")
+    assert load_review_state(db, "rg-2") == {}
+
+
+def test_character_probe_never_imports_the_word_bench_measurement_stack():
+    """This eval reads generated text only. Importing the capture client,
+    normalizer, or canary code would let distribution vocabulary leak into a
+    surface that has no distributions -- pinned the way
+    Tests/UI/test_evals_bench_editor.py pins the same rule for the editor."""
+    import pathlib
+
+    package = pathlib.Path("tldw_chatbook/Evals/character_probe")
+    forbidden = ("capture_client", "normalize_logprobs", "CANARY", "top_k", "logprobs")
+    for module in package.glob("*.py"):
+        source = module.read_text()
+        for token in forbidden:
+            assert token not in source, f"{module.name} mentions {token}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_conversation_storage.py -p no:randomly`
+Expected: FAIL — `ImportError: cannot import name 'conversation_sample_id'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `tldw_chatbook/DB/Evals_DB.py`, add two tables to the schema alongside the existing ones (follow the surrounding `CREATE TABLE` style, including `client_id` and timestamp columns):
+
+```python
+conn.execute("""
+    CREATE TABLE IF NOT EXISTS eval_probe_turn_annotations (
+        id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+        run_group_id TEXT NOT NULL,
+        card_id INTEGER NOT NULL,
+        probe_index INTEGER NOT NULL,
+        sample_index INTEGER NOT NULL,
+        target_id TEXT NOT NULL,
+        turn_index INTEGER NOT NULL,
+        tags TEXT NOT NULL,          -- JSON list of tag slugs
+        note TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+        client_id TEXT NOT NULL,
+        UNIQUE(run_group_id, card_id, probe_index, sample_index, target_id, turn_index)
+    )
+""")
+conn.execute("""
+    CREATE TABLE IF NOT EXISTS eval_probe_review_state (
+        id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+        run_group_id TEXT NOT NULL,
+        card_id INTEGER NOT NULL,
+        probe_index INTEGER NOT NULL,
+        sample_index INTEGER NOT NULL,
+        target_id TEXT NOT NULL,
+        note TEXT NOT NULL DEFAULT '',
+        reviewed_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+        client_id TEXT NOT NULL,
+        UNIQUE(run_group_id, card_id, probe_index, sample_index, target_id)
+    )
+""")
+conn.execute(
+    "CREATE INDEX IF NOT EXISTS idx_probe_annotations_group "
+    "ON eval_probe_turn_annotations (run_group_id)"
+)
+conn.execute(
+    "CREATE INDEX IF NOT EXISTS idx_probe_review_group "
+    "ON eval_probe_review_state (run_group_id)"
+)
+```
+
+Then add matching methods on `EvalsDB` (`upsert_probe_turn_annotation`, `list_probe_turn_annotations`, `upsert_probe_review_state`, `list_probe_review_state`), each parameterized and each following the surrounding methods' transaction style. Append to `character_probe/storage.py`:
+
+```python
+def conversation_sample_id(card_id: int, probe_index: int, sample_index: int) -> str:
+    """Compose the ``eval_results.sample_id`` for one conversation.
+
+    ``run_id`` already scopes the target (one run row per target, as word
+    benches do), so the sample id only needs the remaining three axes.
+
+    Args:
+        card_id: The character card's integer id.
+        probe_index: Zero-based index of the probe within its set.
+        sample_index: Zero-based sample number for this cell.
+
+    Returns:
+        str: The composed id, stable across runs.
+    """
+    return f"{card_id}:{probe_index}:{sample_index}"
+
+
+def save_conversations(
+    db: EvalsDB,
+    run_group_id: str,
+    run_ids: Mapping[str, str],
+    conversations: Sequence[Conversation],
+) -> None:
+    """Persist every conversation into ``eval_results``.
+
+    The ordered turn list goes into the ``metadata`` JSON, never into
+    ``actual_output`` -- that column holds one answer and cannot represent a
+    conversation.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The group these conversations belong to.
+        run_ids: target id -> ``eval_runs`` id for this group.
+        conversations: What the runner produced, including failed ones.
+    """
+    for conversation in conversations:
+        db.store_run_result(
+            run_id=run_ids[conversation.target_id],
+            sample_id=conversation_sample_id(
+                conversation.card_id, conversation.probe_index, conversation.sample_index
+            ),
+            input_data={
+                "card_id": conversation.card_id,
+                "probe_index": conversation.probe_index,
+                "user_turns": [turn.user for turn in conversation.turns],
+            },
+            actual_output="",
+            metadata={
+                "run_group_id": run_group_id,
+                "turns": [
+                    {"user": turn.user, "reply": turn.reply, "error": turn.error}
+                    for turn in conversation.turns
+                ],
+                "error": conversation.error,
+            },
+        )
+```
+
+`load_conversations`, `annotate_turn`, `load_turn_annotations`, `mark_conversation_reviewed`, and `load_review_state` follow the same shape: read through the new `EvalsDB` methods, rebuild the frozen dataclasses, and key the returned dicts by the tuple `(card_id, probe_index, sample_index, target_id[, turn_index])`.
+
+**Note for the implementer:** `db.store_run_result`/`db.get_run_results` may be named differently — check `Evals_DB.py` and use the existing methods rather than adding parallel ones. If a needed reader genuinely does not exist, add the smallest one following the surrounding style.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_conversation_storage.py -p no:randomly`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Run the whole phase and commit**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe Tests/Evals/word_bench -p no:randomly`
+Expected: PASS — the word_bench suite must be untouched by this phase.
+
+```bash
+git add tldw_chatbook/Evals/character_probe/storage.py tldw_chatbook/DB/Evals_DB.py Tests/Evals/character_probe/
+git commit -m "feat(evals): persist probe conversations, turn annotations, and review state (task-1691 phase 1)"
+```
+
+---
+
+## Phase 1 exit criteria
+
+- `Tests/Evals/character_probe/` passes in full, and `Tests/Evals/word_bench/` is unchanged.
+- A bench can be saved, loaded, and run end to end against a fake chat callable, producing conversations that persist and reload.
+- No module under `character_probe/` imports word_bench's capture client, normalizer, or canary code.
+
+## Not in Phase 1 (deliberate)
+
+Phase 2 (import + card selection UI), Phase 3 (review queue), and Phase 4 (summary) follow as separate plans. The starter probe set, the tag vocabulary with kinds, ordering hints, and the Estimate all belong to those phases — Phase 1 stops at the engine.

--- a/Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md
+++ b/Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md
@@ -1763,7 +1763,43 @@ git commit -m "feat(evals): persist probe conversations, turn annotations, and r
 
 - `Tests/Evals/character_probe/` passes in full, and `Tests/Evals/word_bench/` is unchanged.
 - A bench can be saved, loaded, and run end to end against a fake chat callable, producing conversations that persist and reload.
-- No module under `character_probe/` imports word_bench's capture client, normalizer, or canary code.
+- No module under `character_probe/` references word_bench's measurement concepts — no distribution
+  vocabulary appears anywhere in this package's source or surface.
+
+  **Amended after the whole-branch review (was: "imports word_bench's capture client, normalizer,
+  or canary code").** `character_probe/targets.py` deliberately imports
+  `word_bench.storage.model_steering`, the app's single existing reader for a target's steering out
+  of an `eval_models` row's `config` JSON. Importing that module pulls word_bench's own imports
+  transitively — `storage` → `capture_client` → `normalizer` → `httpx` — so the criterion as
+  originally worded is **not** met by the import graph.
+  The reuse is correct and stays: duplicating that reader is exactly what produced Critical C1, in
+  which the runner read a key no `eval_models` row has ever carried and every real run silently
+  dropped its steering. The criterion's *intent* — that none of the measurement stack's ideas leak
+  into an eval that reads only generated text — is fully met, so the criterion is amended to say
+  what is actually true rather than left silently unmet.
+
+  **The in-repo hygiene test is weaker than the rule it names.**
+  `Tests/Evals/character_probe/test_conversation_storage.py::test_character_probe_never_imports_the_word_bench_measurement_stack`
+  greps each module's SOURCE TEXT for forbidden tokens. It cannot see an import graph at all, so it
+  passes on exactly the situation described above. TASK-1754 tracks both halves of the remedy:
+  moving `model_steering`/`_steering_field` (pure functions of a row dict, with no word_bench
+  dependencies) into a shared home neither package's stack rides on, and strengthening the test to
+  assert on the real import graph — e.g. `sys.modules` after a fresh package import — instead of on
+  tokens.
+
+### Forward-looking caveats for Phase 2
+
+Two consequences of Phase 1's fail-loudly choices that a UI author will meet:
+
+- **`_stored_int_field` is strict against JSON floats.** `load_character_bench` now rejects a
+  stored `512.0` as a non-integer `max_tokens` (previously `int()` silently truncated it). A form
+  control or JSON payload that emits whole numbers as floats will therefore make a bench fail to
+  load. Coerce at the UI boundary, not by loosening the loader.
+- **`eval_models` has `UNIQUE(name, provider, model_id)`.** The prefix-steered rejection in
+  `targets.resolve_target` tells the user to use a chat-mode target instead, and steering is
+  immutable per row (there is no `update_model`), so that means creating a NEW row. A Phase 2
+  "duplicate this target" affordance must offer a **different name** — reusing the name raises
+  `ConflictError`.
 
 ## Not in Phase 1 (deliberate)
 

--- a/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
+++ b/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
@@ -164,12 +164,21 @@ the whole TUI — a failure this codebase has already been bitten by. Every call
 and `chat_conversation_scope_service.py`). The bench's own `concurrency` setting is what bounds the
 thread fan-out; the default executor's size must not be the de-facto limit.
 
-**Prompt assembly reuses `Character_Chat_Lib`'s card→prompt path** rather than a private copy —
-otherwise the eval measures a character the app never actually presents to users. The card's
-`first_message` seeds the opening assistant turn as in real roleplay, then the probe's scripted user
-turns alternate with model replies, accumulating context. **A card with no `first_message` simply
-starts with the user's first scripted turn** — no synthetic greeting is invented, because inventing
-one would mean evaluating text the character never had.
+**Prompt assembly is the engine's own code, not reuse of an existing path.** The original intent
+here was to reuse `Character_Chat_Lib`'s card→prompt path rather than write a private copy, but no
+such function exists — the actual joiner lives in
+`UI/Screens/chat_screen.py::_character_session_prompt_seed`, which the engine cannot import
+without violating its no-`UI/`-dependencies boundary. So the engine composes the prompt itself,
+deliberately including every field that shapes voice: `system_prompt`, `personality`, `scenario`,
+`message_example`, and `post_history_instructions`. Console's own joiner currently sends only
+`system_prompt`, `personality`, `description`, and `scenario` — it omits `message_example` and
+`post_history_instructions` — so a probe run is **not** byte-identical to what Console sends
+today. Per the human's ruling, the eval's full-card fidelity is correct and Console is the one
+that should catch up; TASK-1744 tracks extracting one shared card→prompt function both paths use.
+The card's `first_message` seeds the opening assistant turn as in real roleplay, then the probe's
+scripted user turns alternate with model replies, accumulating context. **A card with no
+`first_message` simply starts with the user's first scripted turn** — no synthetic greeting is
+invented, because inventing one would mean evaluating text the character never had.
 
 **Target steering and card system prompts compose, steering first.** Task-1611 lets a target carry
 its own `system_prompt`; every card has one too. Steering is a model-level instruction and the card
@@ -262,7 +271,9 @@ a number.
 Real in-memory `EvalsDB` and a fake chat client, as elsewhere in the slice. Specific to this eval:
 
 - multi-turn ordering: turn *N* genuinely sees turn *N−1*'s reply
-- prompt assembly matches `Character_Chat_Lib`'s real output rather than a fork
+- prompt assembly includes every field that shapes voice (`message_example`,
+  `post_history_instructions` included), pending TASK-1744 bringing Console up to the same
+  fidelity via a shared function
 - annotation persistence and resumption across sessions
 - partial-conversation review after a mid-conversation failure
 - aggregation math, including that no composite score exists

--- a/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
+++ b/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
@@ -61,6 +61,11 @@ Take your time, and include what you could smell.
 Leading and trailing blank lines around a turn are stripped; interior whitespace is preserved
 exactly, since prompt formatting can change behaviour.
 
+**Limitation:** The v1 format does not escape delimiters, so a turn whose content contains a bare
+line of `---` or `===` will not round-trip correctly through parsing — the line will be treated as a
+delimiter. Escaping is out of scope for v1; a rich probe editor (v2, following task-1482's model)
+will address this.
+
 A rich probe editor is a follow-up, mirroring how bench authoring (task-1482) followed the sample
 bench.
 

--- a/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
+++ b/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
@@ -1,0 +1,279 @@
+# Character Probe Evals — Design
+
+**Date:** 2026-08-01
+**Status:** Approved (brainstorm), ready for implementation planning
+
+## Purpose
+
+Study how models handle particular characters and complex prompts. A run takes a selection of
+character cards, asks each of them a set of scripted questions — some single-turn, some multi-turn —
+against one or more models, collects the generated replies, and presents them for human review.
+
+There is no objective metric. The human is the instrument; the tool's job is to collect evidence
+faithfully, make it readable, and let judgments accumulate.
+
+## What this is NOT
+
+This shares none of the word bench's measurement stack. **No logprobs, no top-K, no normalizer, no
+truncated mass, and no canary/degenerate vocabulary** — that entire concept exists to judge token
+distributions, which this eval does not look at. Only generated text matters.
+
+Consequently a character-probe target's readiness means one thing: can we reach this model and get
+text back. It is a cheap reachability check, not a distribution probe, and the "degenerate canary"
+warning must never appear on this bench type.
+
+What it does reuse: targets (`eval_models` rows and their steering), run groups, the Catalog rail,
+cancel/progress, and the cost Estimate. What it does not reuse: the capture client, the normalizer,
+the results grid, and the lens vocabulary.
+
+## Entities
+
+### Probe and probe set
+
+**A probe is an ordered list of user turns.** A "one-off" question is a probe with one turn; a
+sequential probe has several. One structure, no separate types.
+
+**Probe sets reuse the Datasets rail section**, discriminated the way benches already are:
+`bench_type` on `eval_tasks` is the precedent for `dataset_type` on `eval_datasets`. A probe set
+inherits naming, soft-delete, import, and its rail row; only its content shape differs from a
+snippet list.
+
+**v1 authoring is import-only.** Probe sets are nested (probes containing turns) where every editor
+in this slice today handles flat text; building a nested editor is the largest single piece of UI
+work in this design and is deliberately deferred. v1 defines a plain-text format, imports it through
+the existing import path, and displays it read-only.
+
+**Turns are delimited explicitly, never by line breaks.** A turn separated by newline could not
+contain a multi-paragraph prompt, and complex prompts are exactly what this eval exists to study. A
+line of `---` separates turns within a probe; a line of `===` separates probes. Everything between
+delimiters is one turn verbatim, newlines included:
+
+```
+What do you think about lying?
+---
+And if lying protected someone you love?
+===
+Describe your earliest memory.
+
+Take your time, and include what you could smell.
+```
+
+Leading and trailing blank lines around a turn are stripped; interior whitespace is preserved
+exactly, since prompt formatting can change behaviour.
+
+A rich probe editor is a follow-up, mirroring how bench authoring (task-1482) followed the sample
+bench.
+
+**A built-in starter probe set ships with the feature.** Without one, nothing works until the user
+hand-authors a text file — the feature's first impression is a wall. The Evals design spec makes
+this argument already about the sample bench: it "gets a new user to a populated grid without
+authoring anything, which is the only way the value of the screen is legible before investing in
+it." The same reasoning applies with more force here, since a probe set is harder to write than a
+snippet list. The starter set contains a handful of probes that exercise the behaviours the built-in
+tags name (a one-off question, a multi-turn pressure sequence, an in-character boundary test), so a
+first run produces something worth reviewing.
+
+Two empty states matter and are easy to miss: **no probe sets** (offer the starter set), and **no
+character cards at all** (route to where cards are created — the eval is unusable without them and
+must say so rather than presenting an empty picker).
+
+### Bench
+
+An `eval_tasks` row with `config_data.bench_type = "character_probe"`, whose config holds:
+
+- `probe_set_id` — the dataset supplying the scripts
+- `character_ids` — selected cards, plus a name snapshot for display
+- `target_ids` — existing `eval_models` rows, so task-1611's steering applies unchanged
+- sampler settings — including an **optional seed** and **`samples_per_cell` (default 1)**
+- `extra_tags` — bench-local additions to the tag vocabulary
+
+### Characters
+
+Character cards live in `ChaChaNotes_DB`; evals live in `Evals_DB`. There are no foreign keys across
+that boundary, so:
+
+- selection stores card **ids plus a name snapshot** for display,
+- at run time the card's **actual text is copied into the run snapshot** (`system_prompt`,
+  `personality`, `scenario`, `first_message`, `post_history_instructions`, `message_example`).
+
+This is the same provenance rule word_bench uses for snippets, and it means editing or deleting a
+card later never rewrites history.
+
+The Evals view model wraps `EvalsDB` only and will need a second, read-only handle for
+`ChaChaNotes_DB`. The card picker (search + multi-select over potentially hundreds of cards) is a
+real component that does not exist in this slice today and must be scoped as its own work.
+
+### Cell
+
+**A cell is one conversation**, identified by (card × probe × target × sample index), stored under a
+shared `run_group_id`. Within a conversation, model turns are indexed.
+
+**Storage convention** (verified against the live schema, which is shaped for single-answer samples
+and must not be guessed at): `eval_results` carries `run_id` + `sample_id` (unique together),
+`input_data`/`metadata` JSON columns, and a flat `actual_output` TEXT column. `run_id` already
+scopes the target, as it does for word benches. Therefore:
+
+- `sample_id` composes `(card_id, probe_index, sample_index)`,
+- `input_data` holds the scripted user turns and the card reference,
+- **the ordered turn list lives in the `metadata` JSON**, never in `actual_output` — that column is
+  shaped for one answer and cannot represent a conversation.
+
+### Annotations and review state
+
+Two separate things, because they answer different questions:
+
+**Per-turn annotations** — keyed by (run_group, card, probe, target, sample, turn_index), holding
+tags, a free note, and timestamps. This is where "it broke character on the third turn" lives.
+
+**Per-conversation review state** — keyed by (run_group, card, probe, target, sample), holding
+`reviewed_at` and an optional overall note. This is the only home for "I read this and nothing was
+notable", which the queue's progress count depends on: without it, a clean conversation is
+indistinguishable from an unopened one. A conversation may be reviewed with zero turn annotations,
+and that is a meaningful, common outcome.
+
+Both attach to a **specific run's** answers: a re-run produces new answers to annotate rather than
+silently inheriting old judgments. Deleting a run group cascades both, since they describe those
+answers and mean nothing without them.
+
+### Tags
+
+Built-in defaults, extendable per bench. Every tag carries a **kind** — `failure`, `notable`, or
+`positive` — so the summary cannot imply "fewer tags is better". Tags are stored as canonical slugs
+and the UI offers existing tags before creating new ones, to limit the `broke-character` /
+`OOC` / `out-of-character` fragmentation that per-bench extension invites.
+
+**Creating a tag requires choosing its kind** — the extension flow asks, with no default. A kind
+guessed on the user's behalf would quietly mis-group observations in the summary, and `notable` is
+not a safe fallback: it would make genuine failures invisible in exactly the view meant to surface
+them.
+
+## Execution
+
+Calls go through the app's normal chat path (`chat_api_call`), not the word-bench capture client:
+multi-turn messages in, text out, real sampler, no logprobs.
+
+**`chat_api_call` is synchronous and must never be called from the event loop.** It is a plain
+`def` with no awaits; invoking it directly inside the async runner would block the loop and freeze
+the whole TUI — a failure this codebase has already been bitten by. Every call dispatches through
+`asyncio.to_thread`, the app's established bridge for exactly this (see `console_agent_bridge.py`
+and `chat_conversation_scope_service.py`). The bench's own `concurrency` setting is what bounds the
+thread fan-out; the default executor's size must not be the de-facto limit.
+
+**Prompt assembly reuses `Character_Chat_Lib`'s card→prompt path** rather than a private copy —
+otherwise the eval measures a character the app never actually presents to users. The card's
+`first_message` seeds the opening assistant turn as in real roleplay, then the probe's scripted user
+turns alternate with model replies, accumulating context. **A card with no `first_message` simply
+starts with the user's first scripted turn** — no synthetic greeting is invented, because inventing
+one would mean evaluating text the character never had.
+
+**Target steering and card system prompts compose, steering first.** Task-1611 lets a target carry
+its own `system_prompt`; every card has one too. Steering is a model-level instruction and the card
+is the content it operates on, so the steering text is placed ahead of the card's system prompt.
+Both are preserved and neither is silently discarded; the run snapshot records the composed result
+so what actually ran is never in doubt.
+
+**A conversation runs its turns strictly in sequence** — turn *N* needs turn *N−1*'s reply — while
+different conversations run concurrently under the existing concurrency setting. Parallelism scales
+with the grid, not within an exchange.
+
+**Cost is shown before running.** Total calls = cards × probes × targets × samples ×
+turns-per-probe. For 5 cards × 5 probes × 3 targets × 1 sample averaging 3 turns, that is 225 model
+calls; the Estimate must say so before Run is pressed (the lesson task-1710 paid for).
+
+**Sampling is non-deterministic and that is a real limitation.** With realistic sampling each cell is
+a single sample of a stochastic process: a model that breaks character 30% of the time looks
+identical to one that never does. Two mitigations, both opt-in: an optional **seed** (honoured by
+llama.cpp) makes re-runs comparable, and **samples-per-cell > 1** makes variance visible by showing
+siblings adjacent in review. Both default off because they multiply review volume. The sampler
+settings are stored in the snapshot so every run is self-describing.
+
+**The two settings must compose, not cancel.** A single fixed seed applied to every sample of a cell
+would return N identical answers — tripling review volume for zero information. The per-sample seed
+is therefore derived as `seed + sample_index`, so a seeded run is reproducible *and* its samples
+genuinely differ. Enabling both must be useful, not a trap.
+
+**Failure is per-conversation.** A failed turn ends that conversation, records what was collected
+plus the error, and leaves the rest of the grid running. Partial conversations remain reviewable —
+completed turns are still evidence and still annotatable. Long cards plus multi-turn scripts will
+exceed some models' context limits; that surfaces through this same path and is expected, not
+exceptional.
+
+**Cancel stops scheduling; it cannot abort a turn already in flight.** Because turns run through
+`asyncio.to_thread`, and this codebase already documents that `to_thread` survives Task
+cancellation, a blocking provider call cannot be interrupted — unlike word_bench, whose async client
+genuinely cancels mid-request. Cancelling therefore means: start no further turns and no further
+conversations; whatever is already in flight runs to completion and is recorded. **The UI must say
+this plainly** rather than implying an instant stop, or a user watching calls continue after
+pressing Cancel will reasonably conclude it is broken. Partial conversations are preserved, not
+discarded.
+
+## Review
+
+**Where it lives.** Selecting a character-probe bench's run group renders the review queue in the
+detail pane, in the same slot the results grid occupies for a word bench — the two bench types never
+share a detail surface. Both kinds appear in the rail's existing **Benches** section, so a
+character-probe bench needs a visible marker distinguishing it from a word bench at a glance;
+without one, selecting a bench is a guess about which detail surface will appear.
+
+**Review is a queue, not a grid.** A 3D grid of conversations has no good 2D rendering and the
+reader's task is sequential anyway. The run group presents an ordered queue, filterable by card,
+probe, target, or "not yet reviewed", so a reviewer can take a deliberate slice — *"just the villain
+card across all three models"* — in one sitting.
+
+**The conversation view** renders the full exchange as turns, with the card's opening message and
+each scripted user turn in place, and a tag affordance on every model turn.
+
+**Keyboard-first.** Reviewing dozens of conversations by mouse in a terminal app is untenable;
+moving between turns and conversations and applying tags must be a few keystrokes.
+
+**"Reviewed" is explicit, and "nothing notable" is a real verdict.** A conversation is done when the
+reviewer says it is — not when it happens to carry a tag. Without that, a clean, in-character,
+well-handled exchange is indistinguishable from one nobody has opened, and the progress count lies.
+This also makes the queue resumable across sessions, which annotation work requires.
+
+**Ordering hints, never verdicts.** Cheap heuristics reorder the queue to put likely-interesting
+material first: empty or very short replies, replies containing text from the card's own system
+prompt (a leak), refusal-shaped openings, and replies near-identical across targets. These are
+rendered as hints and are never tags and never scores — if they become the judgment, the tool has
+quietly invented the metric it claims not to have.
+
+**Hints are computed at review time, on demand, never during the run.** The near-identical check
+compares replies across cells, so computing it at write time would add a cross-cell pass to every
+run for a signal only the reviewer uses. Nothing about a run's cost or duration may depend on
+hinting.
+
+## Summary
+
+Tag counts aggregated across the run answer the original question: which model broke character most,
+which card was hardest, which probe broke things regardless of model.
+
+**The summary reports per-tag counts and never a composite score.** Ranking models by "fewest bad
+tags" would invent the objective metric this eval exists precisely because we lack — and would be
+wrong anyway, since `notable` and `positive` tags are not penalties. No view anywhere sums tags into
+a number.
+
+## Testing
+
+Real in-memory `EvalsDB` and a fake chat client, as elsewhere in the slice. Specific to this eval:
+
+- multi-turn ordering: turn *N* genuinely sees turn *N−1*'s reply
+- prompt assembly matches `Character_Chat_Lib`'s real output rather than a fork
+- annotation persistence and resumption across sessions
+- partial-conversation review after a mid-conversation failure
+- aggregation math, including that no composite score exists
+- snapshot provenance: a card edited or deleted after the run does not change what the run shows
+
+**The review UI's tests must drive real clicks and keypresses and assert the annotation persisted.**
+Programmatically setting a widget's value passes while the feature is unusable — exactly what
+happened with task-1710's opt-in checkbox, where 867 tests passed on a control no user could toggle.
+
+A live pass against a real llama.cpp instance with real character cards is required before this is
+called done.
+
+## Deliberate scope boundaries
+
+- **Rich probe editor** — v1 is import + read-only display; nested authoring is a follow-up.
+- **Cross-run comparison** — annotations are per run group; comparing two runs of the same bench is
+  out of scope, and non-determinism makes it unsound without seeds anyway.
+- **Automated scoring of any kind** — explicitly not a goal; the ordering hints are the only
+  machine-produced signal and they never render as judgments.

--- a/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
+++ b/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
@@ -61,10 +61,22 @@ Take your time, and include what you could smell.
 Leading and trailing blank lines around a turn are stripped; interior whitespace is preserved
 exactly, since prompt formatting can change behaviour.
 
-**Limitation:** The v1 format does not escape delimiters, so a turn whose content contains a bare
-line of `---` or `===` will not round-trip correctly through parsing — the line will be treated as a
-delimiter. Escaping is out of scope for v1; a rich probe editor (v2, following task-1482's model)
-will address this.
+**Limitation:** The v1 format does not escape delimiters, so a turn whose content contains a line of
+`---` or `===` will not round-trip correctly through parsing — the line will be treated as a
+delimiter. This applies to any line whose **stripped** content is a delimiter, not only a bare one:
+matching compares `line.strip()`, so `"  ---  "` and `"\t==="` delimit exactly as `---` and `===`
+do, and an indented or trailing-space delimiter line cannot appear inside a turn either.
+
+That leniency is a **deliberate ruling**, not an oversight of the "a line of `---`" wording above.
+The two failure modes are not symmetric. Under a strict match, an invisible trailing space makes a
+delimiter silently *fail* to delimit — merging two turns into one prompt that then runs and returns
+plausible-looking results. That is both likely (editors and copy-paste add trailing whitespace
+constantly) and near-impossible to spot. Under the lenient match, the cost is that an indented
+literal `---` inside a turn is consumed as a delimiter — less likely, and it fails visibly as a
+probe split in the wrong place. Both behaviours are pinned by test so neither can drift.
+
+Escaping is out of scope for v1; a rich probe editor (v2, following task-1482's model) will address
+this.
 
 A rich probe editor is a follow-up, mirroring how bench authoring (task-1482) followed the sample
 bench.

--- a/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
+++ b/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
@@ -98,11 +98,21 @@ Character cards live in `ChaChaNotes_DB`; evals live in `Evals_DB`. There are no
 that boundary, so:
 
 - selection stores card **ids plus a name snapshot** for display,
-- at run time the card's **actual text is copied into the run snapshot** (`system_prompt`,
-  `personality`, `scenario`, `first_message`, `post_history_instructions`, `message_example`).
+- at run time the card's **actual text is copied into the run snapshot** (`description`,
+  `system_prompt`, `personality`, `scenario`, `first_message`, `post_history_instructions`,
+  `message_example`).
+
+`description` was missing from that list in the original draft of this spec. That was an **error,
+not a decision**: it is a real `character_cards` column, it is the primary V2 persona field, and
+Console already sends it. The whole-branch review of task-1691 phase 1 found the engine faithfully
+implementing the omission, so every probe ran against a character stripped of its main definition,
+with no copy of it kept anywhere in the run. Corrected under the same full-card-fidelity ruling
+that governs the rest of this section.
 
 This is the same provenance rule word_bench uses for snippets, and it means editing or deleting a
-card later never rewrites history.
+card later never rewrites history. The run snapshot therefore holds the card TEXT (not just ids),
+the composed system prompt per card per target, the resolved target list with its steering, and the
+sampler settings — a run that cannot be re-derived from the mutable bench row afterwards.
 
 The Evals view model wraps `EvalsDB` only and will need a second, read-only handle for
 `ChaChaNotes_DB`. The card picker (search + multi-select over potentially hundreds of cards) is a
@@ -169,12 +179,25 @@ here was to reuse `Character_Chat_Lib`'s card→prompt path rather than write a 
 such function exists — the actual joiner lives in
 `UI/Screens/chat_screen.py::_character_session_prompt_seed`, which the engine cannot import
 without violating its no-`UI/`-dependencies boundary. So the engine composes the prompt itself,
-deliberately including every field that shapes voice: `system_prompt`, `personality`, `scenario`,
-`message_example`, and `post_history_instructions`. Console's own joiner currently sends only
-`system_prompt`, `personality`, `description`, and `scenario` — it omits `message_example` and
+deliberately including every field that shapes voice: `system_prompt`, `personality`, `description`,
+`scenario`, `message_example`, and `post_history_instructions`. Console's own joiner currently sends
+only `system_prompt`, `personality`, `description`, and `scenario` — it omits `message_example` and
 `post_history_instructions` — so a probe run is **not** byte-identical to what Console sends
 today. Per the human's ruling, the eval's full-card fidelity is correct and Console is the one
 that should catch up; TASK-1744 tracks extracting one shared card→prompt function both paths use.
+The engine composes those four shared fields **in Console's own order** so that shared function has
+one less difference to reconcile, then appends the two Console does not send.
+
+**Card macros are resolved, not passed through.** Cards are authored against SillyTavern-style
+macros, and Console resolves `{{char}}`/`{{user}}` (and their aliases) before the text reaches any
+provider payload — task-1530 exists because they otherwise leak verbatim. The engine resolves them
+the same way, through the same non-UI function (`Character_Chat_Lib.replace_placeholders`), with
+`{{user}}` → `"User"` as Console substitutes it: a probe is a script, not a real person, and a
+probe that shipped a literal `{{user}}` would be evaluating text no real chat with that card ever
+produces. Two things are deliberately **not** macro-resolved: a probe's scripted user turns (the
+eval author's text, sent verbatim per the format's own rule) and a target's steering (attached to a
+target, not a card — a run spans several cards, so there is no one right name to substitute).
+
 The card's `first_message` seeds the opening assistant turn as in real roleplay, then the probe's
 scripted user turns alternate with model replies, accumulating context. **A card with no
 `first_message` simply starts with the user's first scripted turn** — no synthetic greeting is
@@ -271,9 +294,14 @@ a number.
 Real in-memory `EvalsDB` and a fake chat client, as elsewhere in the slice. Specific to this eval:
 
 - multi-turn ordering: turn *N* genuinely sees turn *N−1*'s reply
-- prompt assembly includes every field that shapes voice (`message_example`,
+- prompt assembly includes every field that shapes voice (`description`, `message_example`,
   `post_history_instructions` included), pending TASK-1744 bringing Console up to the same
   fidelity via a shared function
+- **targets come from real `eval_models` rows, never hand-built dicts.** A target's steering lives
+  inside the row's `config` JSON, not as a top-level column; a fixture that invents the flatter
+  shape will agree with code that reads the wrong place, which is exactly how phase 1 shipped seven
+  green tasks while every real run dropped its steering. The same rule holds for anything else read
+  off a database row.
 - annotation persistence and resumption across sessions
 - partial-conversation review after a mid-conversation failure
 - aggregation math, including that no composite score exists

--- a/Tests/Evals/character_probe/test_bench_storage.py
+++ b/Tests/Evals/character_probe/test_bench_storage.py
@@ -139,6 +139,117 @@ def test_samples_per_cell_round_trips_at_minimum_legal_value(db):
     assert load_character_bench(db, task_id).samples_per_cell == 1
 
 
+def test_is_character_bench_is_false_for_string_config_data():
+    """Corrupt data must not crash a yes/no question. ``(x or {}).get(...)``
+    rescues None and every other falsy value but lets a TRUTHY non-mapping
+    through to .get and raises AttributeError -- the exact bug already fixed
+    in this function's twin, is_probe_set."""
+    assert is_character_bench({"config_data": "corrupt"}) is False
+
+
+def test_is_character_bench_is_false_for_list_config_data():
+    assert is_character_bench({"config_data": [1, 2, 3]}) is False
+
+
+def test_is_character_bench_is_false_for_absent_config_data():
+    assert is_character_bench({}) is False
+
+
+def test_loading_a_bench_with_corrupt_config_data_raises_the_named_error(db, config):
+    """A non-mapping config_data must surface as the normal 'not a character
+    probe bench' ValueError, not an unrelated AttributeError."""
+    task_id = save_character_bench(db, config)
+    conn = db.get_connection()
+    with conn:
+        conn.execute(
+            "UPDATE eval_tasks SET config_data = ? WHERE id = ?",
+            ('"corrupt"', task_id),
+        )
+    with pytest.raises(ValueError, match="not a character probe bench"):
+        load_character_bench(db, task_id)
+
+
+def _corrupt_config_field(db, task_id, key, raw_json_value):
+    """Hand-edit one config_data field, as an external writer might."""
+    import json
+
+    row = db.get_task(task_id)
+    data = dict(row["config_data"])
+    data[key] = json.loads(raw_json_value)
+    conn = db.get_connection()
+    with conn:
+        conn.execute(
+            "UPDATE eval_tasks SET config_data = ? WHERE id = ?",
+            (json.dumps(data), task_id),
+        )
+
+
+def test_a_stored_null_temperature_loads_as_the_default(db, config):
+    """float(None) raises a bare TypeError two lines below the helper whose
+    whole purpose is to name the bench and the field."""
+    task_id = save_character_bench(db, config)
+    _corrupt_config_field(db, task_id, "temperature", "null")
+    assert load_character_bench(db, task_id).temperature == 0.8
+
+
+def test_a_stored_string_temperature_raises_naming_the_bench_and_field(db, config):
+    task_id = save_character_bench(db, config)
+    _corrupt_config_field(db, task_id, "temperature", '"hot"')
+    with pytest.raises(ValueError, match="temperature") as excinfo:
+        load_character_bench(db, task_id)
+    assert task_id in str(excinfo.value)
+
+
+def test_a_negative_temperature_raises(db, config):
+    task_id = save_character_bench(db, config)
+    _corrupt_config_field(db, task_id, "temperature", "-1.0")
+    with pytest.raises(ValueError, match="temperature"):
+        load_character_bench(db, task_id)
+
+
+def test_a_stored_string_seed_raises_instead_of_detonating_mid_run(db, config):
+    """An unvalidated seed reaches the runner as ``config.seed +
+    sample_index`` on the first cell -- a bare TypeError after real provider
+    calls have already been paid for, naming neither bench nor field."""
+    task_id = save_character_bench(db, config)
+    _corrupt_config_field(db, task_id, "seed", '"1234"')
+    with pytest.raises(ValueError, match="seed") as excinfo:
+        load_character_bench(db, task_id)
+    assert task_id in str(excinfo.value)
+
+
+def test_a_negative_seed_is_accepted(db, config):
+    """Unlike every other numeric field here: llama.cpp reads -1 as 'pick a
+    random seed', so it is a real value a user may deliberately store."""
+    task_id = save_character_bench(db, config)
+    _corrupt_config_field(db, task_id, "seed", "-1")
+    assert load_character_bench(db, task_id).seed == -1
+
+
+def test_an_absent_seed_loads_as_none(db):
+    config = CharacterProbeConfig(
+        name="n", probe_set_id="p", character_ids=(1,), target_ids=("t",)
+    )
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id).seed is None
+
+
+def test_a_numeric_string_max_tokens_is_rejected_not_coerced(db, config):
+    """_stored_int_field's docstring always claimed a string is rejected, but
+    int("512") succeeds, so a stored string silently loaded as a number."""
+    task_id = save_character_bench(db, config)
+    _corrupt_config_field(db, task_id, "max_tokens", '"512"')
+    with pytest.raises(ValueError, match="max_tokens"):
+        load_character_bench(db, task_id)
+
+
+def test_a_float_max_tokens_is_rejected_not_truncated(db, config):
+    task_id = save_character_bench(db, config)
+    _corrupt_config_field(db, task_id, "max_tokens", "2.7")
+    with pytest.raises(ValueError, match="max_tokens"):
+        load_character_bench(db, task_id)
+
+
 def test_character_ids_must_be_integers():
     """Rejected at construction, not merely at the storage boundary -- a
     caller building one directly with string ids (easy to do from a form

--- a/Tests/Evals/character_probe/test_bench_storage.py
+++ b/Tests/Evals/character_probe/test_bench_storage.py
@@ -105,3 +105,47 @@ def test_editing_a_deleted_bench_raises(db, config):
     db.delete_task(task_id)
     with pytest.raises(ValueError, match="could not be updated"):
         save_character_bench(db, config, task_id=task_id)
+
+
+def test_max_tokens_zero_round_trips(db):
+    """A stored max_tokens of 0 is a real, explicitly-chosen value, not a
+    missing one -- ``data.get("max_tokens") or 512`` cannot tell "the
+    caller stored 0" from "this key is absent", since both are falsy, and
+    would silently replace a deliberate 0 with the default on every load.
+    """
+    config = CharacterProbeConfig(
+        name="n", probe_set_id="p", character_ids=(1,), target_ids=("t",),
+        max_tokens=0,
+    )
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id).max_tokens == 0
+
+
+def test_concurrency_round_trips_at_minimum_legal_value(db):
+    config = CharacterProbeConfig(
+        name="n", probe_set_id="p", character_ids=(1,), target_ids=("t",),
+        concurrency=1,
+    )
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id).concurrency == 1
+
+
+def test_samples_per_cell_round_trips_at_minimum_legal_value(db):
+    config = CharacterProbeConfig(
+        name="n", probe_set_id="p", character_ids=(1,), target_ids=("t",),
+        samples_per_cell=1,
+    )
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id).samples_per_cell == 1
+
+
+def test_character_ids_must_be_integers():
+    """Rejected at construction, not merely at the storage boundary -- a
+    caller building one directly with string ids (easy to do from a form
+    field) must not be able to end up with a config that round-trips
+    through save/load as a *different* type than it started as.
+    """
+    with pytest.raises(ValueError, match="character_ids"):
+        CharacterProbeConfig(
+            name="n", probe_set_id="p", character_ids=("3", "7"), target_ids=("t",)
+        )

--- a/Tests/Evals/character_probe/test_bench_storage.py
+++ b/Tests/Evals/character_probe/test_bench_storage.py
@@ -1,0 +1,107 @@
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.Evals.character_probe.models import CharacterProbeConfig
+from tldw_chatbook.Evals.character_probe.storage import (
+    BENCH_TYPE,
+    is_character_bench,
+    load_character_bench,
+    save_character_bench,
+)
+
+
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
+
+
+@pytest.fixture
+def config():
+    return CharacterProbeConfig(
+        name="villain probes",
+        probe_set_id="ps-1",
+        character_ids=(3, 7),
+        target_ids=("t-1",),
+        samples_per_cell=2,
+        seed=1234,
+    )
+
+
+def test_save_then_load_round_trips(db, config):
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id) == config
+
+
+def test_saved_bench_is_marked_with_its_type(db, config):
+    task_id = save_character_bench(db, config)
+    row = db.get_task(task_id)
+    assert (row.get("config_data") or {}).get("bench_type") == BENCH_TYPE
+    assert is_character_bench(row) is True
+
+
+def test_character_ids_survive_as_integers(db, config):
+    """character_cards.id is an INTEGER; every eval id is TEXT. Do not merge them."""
+    task_id = save_character_bench(db, config)
+    assert load_character_bench(db, task_id).character_ids == (3, 7)
+
+
+def test_defaults_are_conservative():
+    config = CharacterProbeConfig(
+        name="n", probe_set_id="p", character_ids=(1,), target_ids=("t",)
+    )
+    assert config.samples_per_cell == 1
+    assert config.seed is None
+    assert config.concurrency == 1
+    assert config.extra_tags == ()
+
+
+def test_editing_an_existing_bench_updates_in_place(db, config):
+    task_id = save_character_bench(db, config)
+    edited = CharacterProbeConfig(**{**config.__dict__, "name": "renamed"})
+    assert save_character_bench(db, edited, task_id=task_id) == task_id
+    assert load_character_bench(db, task_id).name == "renamed"
+
+
+def test_samples_per_cell_below_one_is_rejected():
+    with pytest.raises(ValueError, match="samples_per_cell"):
+        CharacterProbeConfig(
+            name="n",
+            probe_set_id="p",
+            character_ids=(1,),
+            target_ids=("t",),
+            samples_per_cell=0,
+        )
+
+
+def test_a_bench_needs_at_least_one_character():
+    with pytest.raises(ValueError, match="at least one character"):
+        CharacterProbeConfig(
+            name="n", probe_set_id="p", character_ids=(), target_ids=("t",)
+        )
+
+
+def test_loading_a_word_bench_as_a_character_bench_raises(db):
+    # EvalsDB.create_task's config_format has no default -- it is a required
+    # keyword here, unlike the brief this test was drafted from, which
+    # omitted it and would raise TypeError before writing a row.
+    task_id = db.create_task(
+        name="word bench",
+        description="",
+        task_type="logprob",
+        config_format="custom",
+        config_data={"bench_type": "word_bench"},
+    )
+    with pytest.raises(ValueError, match="not a character probe bench"):
+        load_character_bench(db, task_id)
+
+
+def test_editing_a_deleted_bench_raises(db, config):
+    """update_task returns False (never raises) when no live row matches;
+    silently returning task_id would tell the caller "saved" for a write
+    that persisted nothing -- the same failure mode save_probe_set already
+    guards against for update_dataset.
+    """
+    task_id = save_character_bench(db, config)
+    db.delete_task(task_id)
+    with pytest.raises(ValueError, match="could not be updated"):
+        save_character_bench(db, config, task_id=task_id)

--- a/Tests/Evals/character_probe/test_cards.py
+++ b/Tests/Evals/character_probe/test_cards.py
@@ -1,0 +1,67 @@
+import pytest
+
+from tldw_chatbook.Evals.character_probe.cards import snapshot_cards
+from tldw_chatbook.Evals.character_probe.models import CardSnapshot
+
+
+class _FakeCharacterDB:
+    """Stands in for CharactersRAGDB; only get_character_card_by_id is used."""
+
+    def __init__(self, cards):
+        self._cards = cards
+
+    def get_character_card_by_id(self, character_id):
+        return self._cards.get(character_id)
+
+
+def _card(**overrides):
+    base = {
+        "id": 1,
+        "name": "Vex",
+        "system_prompt": "You are Vex.",
+        "personality": "sardonic",
+        "scenario": "a rooftop at night",
+        "first_message": "You again.",
+        "post_history_instructions": "Stay in character.",
+        "message_example": "<START>",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_snapshot_copies_every_field_used_in_prompting():
+    db = _FakeCharacterDB({1: _card()})
+    (snapshot,) = snapshot_cards(db, [1])
+    assert snapshot == CardSnapshot(
+        id=1,
+        name="Vex",
+        system_prompt="You are Vex.",
+        personality="sardonic",
+        scenario="a rooftop at night",
+        first_message="You again.",
+        post_history_instructions="Stay in character.",
+        message_example="<START>",
+    )
+
+
+def test_missing_fields_become_empty_strings_not_none():
+    db = _FakeCharacterDB({1: {"id": 1, "name": "Sparse"}})
+    (snapshot,) = snapshot_cards(db, [1])
+    assert snapshot.system_prompt == ""
+    assert snapshot.first_message == ""
+
+
+def test_order_follows_the_requested_ids():
+    db = _FakeCharacterDB({1: _card(id=1, name="A"), 2: _card(id=2, name="B")})
+    assert [c.name for c in snapshot_cards(db, [2, 1])] == ["B", "A"]
+
+
+def test_a_missing_card_raises_naming_the_id():
+    db = _FakeCharacterDB({1: _card()})
+    with pytest.raises(ValueError, match="99"):
+        snapshot_cards(db, [1, 99])
+
+
+def test_no_ids_raises():
+    with pytest.raises(ValueError, match="at least one character"):
+        snapshot_cards(_FakeCharacterDB({}), [])

--- a/Tests/Evals/character_probe/test_cards.py
+++ b/Tests/Evals/character_probe/test_cards.py
@@ -65,3 +65,36 @@ def test_a_missing_card_raises_naming_the_id():
 def test_no_ids_raises():
     with pytest.raises(ValueError, match="at least one character"):
         snapshot_cards(_FakeCharacterDB({}), [])
+
+
+class _MismatchedIdDB:
+    """Returns a row whose own id disagrees with whatever id was requested."""
+
+    def get_character_card_by_id(self, character_id):
+        return _card(id=999999, name="Impostor")
+
+
+def test_a_row_agreeing_with_the_requested_id_is_accepted():
+    db = _FakeCharacterDB({1: _card(id=1, name="Vex")})
+    (snapshot,) = snapshot_cards(db, [1])
+    assert snapshot.id == 1
+    assert snapshot.name == "Vex"
+
+
+def test_a_row_reporting_a_different_id_raises_naming_both():
+    with pytest.raises(ValueError, match="999999") as excinfo:
+        snapshot_cards(_MismatchedIdDB(), [1])
+    assert "1" in str(excinfo.value)
+    assert "999999" in str(excinfo.value)
+
+
+def test_string_id_is_rejected():
+    db = _FakeCharacterDB({1: _card()})
+    with pytest.raises(ValueError, match="int"):
+        snapshot_cards(db, ["1"])
+
+
+def test_bool_id_is_rejected():
+    db = _FakeCharacterDB({1: _card()})
+    with pytest.raises(ValueError, match="int"):
+        snapshot_cards(db, [True])

--- a/Tests/Evals/character_probe/test_cards.py
+++ b/Tests/Evals/character_probe/test_cards.py
@@ -18,6 +18,7 @@ def _card(**overrides):
     base = {
         "id": 1,
         "name": "Vex",
+        "description": "A dock-side fixer.",
         "system_prompt": "You are Vex.",
         "personality": "sardonic",
         "scenario": "a rooftop at night",
@@ -35,6 +36,7 @@ def test_snapshot_copies_every_field_used_in_prompting():
     assert snapshot == CardSnapshot(
         id=1,
         name="Vex",
+        description="A dock-side fixer.",
         system_prompt="You are Vex.",
         personality="sardonic",
         scenario="a rooftop at night",
@@ -49,6 +51,44 @@ def test_missing_fields_become_empty_strings_not_none():
     (snapshot,) = snapshot_cards(db, [1])
     assert snapshot.system_prompt == ""
     assert snapshot.first_message == ""
+    assert snapshot.description == ""
+
+
+def test_description_is_snapshotted():
+    """``description`` is a real ``character_cards`` column and the primary
+    V2 persona field -- Console sends it. It was missing from
+    _SNAPSHOT_FIELDS until the whole-branch review of task-1691 phase 1, so
+    every probe ran against a character stripped of its main definition.
+    Pinned here as well as in test_prompt.py because a snapshot that omits
+    it is permanent: the run keeps no other copy of the card."""
+    db = _FakeCharacterDB({1: _card(description="A dock-side fixer.")})
+    (snapshot,) = snapshot_cards(db, [1])
+    assert snapshot.description == "A dock-side fixer."
+
+
+def test_every_snapshotted_field_is_composed_into_the_prompt():
+    """Adding a field to _SNAPSHOT_FIELDS is only half a change: a field the
+    snapshot carries but prompt.py never composes is text the model never
+    sees, which is exactly how ``description`` went missing. Every text
+    field's value must appear in the composed prompt (``first_message``
+    seeds the assistant turn instead, so it is checked there)."""
+    from tldw_chatbook.Evals.character_probe.prompt import build_messages
+
+    values = {
+        "description": "DESCRIPTION-TEXT",
+        "system_prompt": "SYSTEM-TEXT",
+        "personality": "PERSONALITY-TEXT",
+        "scenario": "SCENARIO-TEXT",
+        "post_history_instructions": "POST-TEXT",
+        "message_example": "EXAMPLE-TEXT",
+        "first_message": "GREETING-TEXT",
+    }
+    db = _FakeCharacterDB({1: _card(**values)})
+    (snapshot,) = snapshot_cards(db, [1])
+    messages = build_messages(snapshot, None, ["Hi?"], [])
+    rendered = "\n".join(m["content"] for m in messages)
+    for field, value in values.items():
+        assert value in rendered, f"{field} never reaches the model"
 
 
 def test_order_follows_the_requested_ids():

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -1,0 +1,116 @@
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.Evals.character_probe.models import Conversation, ConversationTurn
+from tldw_chatbook.Evals.character_probe.storage import (
+    annotate_turn,
+    conversation_sample_id,
+    load_conversations,
+    load_review_state,
+    load_turn_annotations,
+    mark_conversation_reviewed,
+    save_conversations,
+)
+
+
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
+
+
+def _conversation(card_id=1, probe_index=0, sample_index=0, target_id="t-1"):
+    return Conversation(
+        card_id=card_id,
+        probe_index=probe_index,
+        sample_index=sample_index,
+        target_id=target_id,
+        turns=(
+            ConversationTurn(user="One", reply="Reply one"),
+            ConversationTurn(user="Two", reply="Reply two"),
+        ),
+    )
+
+
+def _seed_run(db):
+    task_id = db.create_task(
+        name="probe bench", description="", task_type="generation",
+        config_format="custom", config_data={"bench_type": "character_probe"},
+    )
+    model_id = db.create_model(name="m", provider="llama_cpp", model_id="m")
+    run_id = db.create_run(name="r", task_id=task_id, model_id=model_id)
+    return run_id, model_id
+
+
+def test_sample_id_composes_card_probe_and_sample():
+    assert conversation_sample_id(3, 1, 2) == "3:1:2"
+
+
+def test_conversations_round_trip(db):
+    run_id, target_id = _seed_run(db)
+    original = _conversation(target_id=target_id)
+    save_conversations(db, "rg-1", {target_id: run_id}, [original])
+    (loaded,) = load_conversations(db, "rg-1")
+    assert loaded.turns == original.turns
+    assert loaded.card_id == original.card_id
+
+
+def test_save_conversations_rejects_a_stale_run_id(db):
+    """update_run silently no-ops on an unmatched id; save_conversations must
+    not let a deleted/nonexistent run look like a successful stamp."""
+    with pytest.raises(ValueError):
+        save_conversations(
+            db, "rg-1", {"t-1": "no-such-run-id"}, [_conversation(target_id="t-1")]
+        )
+
+
+def test_turns_are_stored_in_metadata_not_actual_output(db):
+    """actual_output is shaped for a single answer; a conversation is not one."""
+    run_id, target_id = _seed_run(db)
+    save_conversations(db, "rg-1", {target_id: run_id}, [_conversation(target_id=target_id)])
+    row = db.get_run_results(run_id)[0]
+    assert "Reply one" in str(row.get("metadata"))
+
+
+def test_a_turn_annotation_persists_with_its_tags_and_note(db):
+    run_id, target_id = _seed_run(db)
+    save_conversations(db, "rg-1", {target_id: run_id}, [_conversation(target_id=target_id)])
+    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 1, ["broke-character"], "drifted here")
+    stored = load_turn_annotations(db, "rg-1")[(1, 0, 0, target_id, 1)]
+    assert stored["tags"] == ["broke-character"]
+    assert stored["note"] == "drifted here"
+
+
+def test_re_annotating_the_same_turn_replaces_it(db):
+    run_id, target_id = _seed_run(db)
+    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 0, ["refused"], "")
+    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 0, ["in-character"], "fine actually")
+    stored = load_turn_annotations(db, "rg-1")[(1, 0, 0, target_id, 0)]
+    assert stored["tags"] == ["in-character"]
+
+
+def test_a_conversation_can_be_reviewed_with_no_annotations(db):
+    """'Nothing notable' is a real verdict and needs its own home."""
+    mark_conversation_reviewed(db, "rg-1", 1, 0, 0, "t-1")
+    state = load_review_state(db, "rg-1")[(1, 0, 0, "t-1")]
+    assert state["reviewed_at"]
+    assert load_turn_annotations(db, "rg-1") == {}
+
+
+def test_review_state_is_scoped_to_its_run_group(db):
+    mark_conversation_reviewed(db, "rg-1", 1, 0, 0, "t-1")
+    assert load_review_state(db, "rg-2") == {}
+
+
+def test_character_probe_never_imports_the_word_bench_measurement_stack():
+    """This eval reads generated text only. Importing the capture client,
+    normalizer, or canary code would let distribution vocabulary leak into a
+    surface that has no distributions -- pinned the way
+    Tests/UI/test_evals_bench_editor.py pins the same rule for the editor."""
+    import pathlib
+
+    package = pathlib.Path("tldw_chatbook/Evals/character_probe")
+    forbidden = ("capture_client", "normalize_logprobs", "CANARY", "top_k", "logprobs")
+    for module in package.glob("*.py"):
+        source = module.read_text()
+        for token in forbidden:
+            assert token not in source, f"{module.name} mentions {token}"

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -1,14 +1,24 @@
 import pytest
 
 from tldw_chatbook.DB.Evals_DB import EvalsDB
-from tldw_chatbook.Evals.character_probe.models import Conversation, ConversationTurn
+from tldw_chatbook.Evals.character_probe.models import (
+    CardSnapshot,
+    CharacterProbeConfig,
+    Conversation,
+    ConversationTurn,
+    Probe,
+    ProbeSet,
+)
 from tldw_chatbook.Evals.character_probe.storage import (
     annotate_turn,
     conversation_sample_id,
+    create_probe_run_group,
     load_conversations,
+    load_probe_run_snapshot,
     load_review_state,
     load_turn_annotations,
     mark_conversation_reviewed,
+    save_character_bench,
     save_conversations,
 )
 
@@ -99,6 +109,220 @@ def test_a_conversation_can_be_reviewed_with_no_annotations(db):
 def test_review_state_is_scoped_to_its_run_group(db):
     mark_conversation_reviewed(db, "rg-1", 1, 0, 0, "t-1")
     assert load_review_state(db, "rg-2") == {}
+
+
+def test_save_conversations_writes_nothing_when_a_target_is_unknown(db):
+    """The unknown-target check used to run INSIDE the write loop, so earlier
+    conversations were already committed when it raised -- a half-written
+    group that loads back as if it were complete, since nothing
+    distinguishes a missing conversation from one never meant to exist."""
+    run_id, target_id = _seed_run(db)
+    conversations = [
+        _conversation(card_id=1, target_id=target_id),
+        _conversation(card_id=2, target_id="not-a-target"),
+    ]
+    with pytest.raises(ValueError, match="not-a-target"):
+        save_conversations(db, "rg-1", {target_id: run_id}, conversations)
+    assert db.get_run_results(run_id) == []
+    assert load_conversations(db, "rg-1") == []
+
+
+def test_save_conversations_does_not_stamp_runs_when_validation_fails(db):
+    """The run_group_id stamp is a write too: it must not land either."""
+    run_id, target_id = _seed_run(db)
+    with pytest.raises(ValueError):
+        save_conversations(
+            db,
+            "rg-1",
+            {target_id: run_id},
+            [_conversation(target_id="not-a-target")],
+        )
+    assert db.get_run(run_id)["run_group_id"] is None
+
+
+# --- Run group + snapshot (whole-branch review I4) ----------------------
+
+
+def _bench_config(**overrides):
+    base = dict(
+        name="villain probes",
+        probe_set_id="ps-1",
+        character_ids=(1,),
+        target_ids=("t-1",),
+        temperature=0.3,
+        max_tokens=256,
+        seed=1234,
+        samples_per_cell=2,
+    )
+    base.update(overrides)
+    return CharacterProbeConfig(**base)
+
+
+def _cards():
+    return [
+        CardSnapshot(
+            id=1,
+            name="Vex",
+            description="A dock-side fixer.",
+            system_prompt="You are {{char}}.",
+            personality="sardonic",
+        )
+    ]
+
+
+@pytest.fixture
+def bench(db):
+    config = _bench_config()
+    return config, save_character_bench(db, config)
+
+
+def _target_row(db, name="steered", config=None):
+    row_id = db.create_model(
+        name=name, provider="llama_cpp", model_id="m", config=config or {}
+    )
+    return db.get_model(row_id)
+
+
+def test_create_probe_run_group_returns_a_run_per_target(db, bench):
+    config, task_id = bench
+    targets = [_target_row(db, "base"), _target_row(db, "steered")]
+    group_id, run_ids = create_probe_run_group(
+        db, task_id, config, _cards(), ProbeSet(probes=(Probe(turns=("One",)),)), targets
+    )
+    assert set(run_ids) == {t["id"] for t in targets}
+    assert len(db.list_runs(run_group_id=group_id)) == 2
+
+
+def test_the_run_snapshot_carries_the_card_text(db, bench):
+    """CardSnapshot's whole provenance purpose -- copying card text across a
+    boundary with no foreign keys -- was defeated the moment a run ended,
+    because nothing about the cards was persisted."""
+    config, task_id = bench
+    group_id, _ = create_probe_run_group(
+        db,
+        task_id,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [_target_row(db)],
+    )
+    snapshot = load_probe_run_snapshot(db, group_id)
+    (card,) = snapshot["cards"]
+    assert card["description"] == "A dock-side fixer."
+    assert card["system_prompt"] == "You are {{char}}."
+    assert card["name"] == "Vex"
+
+
+def test_the_run_snapshot_carries_the_sampler_settings(db, bench):
+    config, task_id = bench
+    group_id, _ = create_probe_run_group(
+        db,
+        task_id,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [_target_row(db)],
+    )
+    assert load_probe_run_snapshot(db, group_id)["sampler"] == {
+        "temperature": 0.3,
+        "max_tokens": 256,
+        "seed": 1234,
+        "samples_per_cell": 2,
+        "concurrency": 1,
+    }
+
+
+def test_the_run_snapshot_carries_the_composed_system_prompt(db, bench):
+    """What the model was actually told is not derivable from the parts
+    later: field order, labelling and macro resolution all live in prompt.py,
+    which is free to change."""
+    config, task_id = bench
+    target = _target_row(db, config={"system_prompt": "Be terse."})
+    group_id, _ = create_probe_run_group(
+        db,
+        task_id,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [target],
+    )
+    composed = load_probe_run_snapshot(db, group_id)["composed_system_prompts"]
+    text = composed["1"][target["id"]]
+    assert text.startswith("Be terse.")
+    assert "You are Vex." in text  # steering kept AND macros resolved
+    assert "A dock-side fixer." in text
+
+
+def test_the_run_snapshot_carries_the_target_list_with_its_steering(db, bench):
+    config, task_id = bench
+    target = _target_row(db, name="terse", config={"system_prompt": "Be terse."})
+    group_id, _ = create_probe_run_group(
+        db,
+        task_id,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [target],
+    )
+    (stored,) = load_probe_run_snapshot(db, group_id)["targets"]
+    assert stored == {
+        "id": target["id"],
+        "name": "terse",
+        "provider": "llama_cpp",
+        "model_id": "m",
+        "system_prompt": "Be terse.",
+    }
+
+
+def test_the_snapshot_survives_the_bench_being_edited_afterwards(db, bench):
+    """A run must be self-describing: eval_tasks is mutable, so rendering
+    from the live bench would let a later edit rewrite history."""
+    config, task_id = bench
+    group_id, _ = create_probe_run_group(
+        db,
+        task_id,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [_target_row(db)],
+    )
+    save_character_bench(
+        db, _bench_config(name="renamed", temperature=1.9), task_id=task_id
+    )
+    snapshot = load_probe_run_snapshot(db, group_id)
+    assert snapshot["bench_name"] == "villain probes"
+    assert snapshot["sampler"]["temperature"] == 0.3
+
+
+def test_each_run_reports_its_own_cell_count(db, bench):
+    """The target axis IS the run, so it is not part of one run's count."""
+    config, task_id = bench  # samples_per_cell=2
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+    group_id, run_ids = create_probe_run_group(
+        db, task_id, config, _cards(), probe_set, [_target_row(db)]
+    )
+    (run_id,) = run_ids.values()
+    assert db.get_run(run_id)["total_samples"] == 1 * 2 * 2
+
+
+def test_loading_the_snapshot_of_an_unknown_run_group_raises(db):
+    with pytest.raises(ValueError, match="No runs found"):
+        load_probe_run_snapshot(db, "rg-nope")
+
+
+def test_a_prefix_steered_target_never_opens_a_run_group(db, bench):
+    config, task_id = bench
+    prefixed = _target_row(db, config={"prefix": "Be careful. "})
+    with pytest.raises(ValueError, match="prefix"):
+        create_probe_run_group(
+            db,
+            task_id,
+            config,
+            _cards(),
+            ProbeSet(probes=(Probe(turns=("One",)),)),
+            [prefixed],
+        )
+    assert db.list_runs(task_id=task_id) == []
 
 
 def test_character_probe_never_imports_the_word_bench_measurement_stack():

--- a/Tests/Evals/character_probe/test_engine_end_to_end.py
+++ b/Tests/Evals/character_probe/test_engine_end_to_end.py
@@ -1,0 +1,316 @@
+"""The engine's deliverable: a whole probe run, end to end, with no UI.
+
+Phase 1's second exit criterion, in one place: "a bench can be saved,
+loaded, and run end to end against a fake chat callable, producing
+conversations that persist and reload."
+
+Every seam here uses REAL rows -- a real in-memory ``EvalsDB``, real
+``create_model``/``get_model`` targets, a real dataset holding the probe set,
+a real ``eval_tasks`` bench. Nothing is hand-built into a shape the database
+does not produce. That rule is the whole point of this file: the branch's
+own steering test passed for seven tasks against a target dict shaped
+``{"id": ..., "model_id": ..., "system_prompt": ...}``, a shape no
+``eval_models`` row has ever had, while every real run silently dropped its
+steering. A hand-built fixture can agree with buggy code; a round trip
+through the database cannot.
+
+Mirrors ``Tests/Evals/word_bench/test_engine_end_to_end.py``'s conventions:
+real DB, scripted fake client, assertions on what came back OUT of storage
+rather than on what went in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.Evals.character_probe.cards import snapshot_cards
+from tldw_chatbook.Evals.character_probe.models import CharacterProbeConfig
+from tldw_chatbook.Evals.character_probe.probe_format import parse_probe_text
+from tldw_chatbook.Evals.character_probe.runner import CharacterProbeRunner
+from tldw_chatbook.Evals.character_probe.storage import (
+    annotate_turn,
+    create_probe_run_group,
+    load_character_bench,
+    load_conversations,
+    load_probe_run_snapshot,
+    load_probe_set,
+    load_review_state,
+    load_turn_annotations,
+    mark_conversation_reviewed,
+    save_character_bench,
+    save_conversations,
+    save_probe_set,
+)
+
+PROBE_TEXT = """\
+What do you think about lying?
+---
+And if lying protected someone you love?
+===
+Describe your earliest memory.
+"""
+
+
+class _FakeCharacterDB:
+    """Stands in for CharactersRAGDB; only get_character_card_by_id is used.
+
+    Character cards live in ChaChaNotes_DB, a different database with no
+    foreign keys to Evals_DB, so this half of the run legitimately has no
+    real row to read -- that boundary is exactly what snapshot_cards exists
+    to cross.
+    """
+
+    def __init__(self, cards):
+        self._cards = cards
+
+    def get_character_card_by_id(self, character_id):
+        return self._cards.get(character_id)
+
+
+class _ScriptedChat:
+    """A fake chat callable that answers in character and records its calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, messages, model, temperature, max_tokens, seed):
+        self.calls.append(
+            {
+                "messages": messages,
+                "model": model,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "seed": seed,
+            }
+        )
+        return f"reply-{len(self.calls)}"
+
+
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
+
+
+@pytest.fixture
+def chacha_db():
+    return _FakeCharacterDB(
+        {
+            7: {
+                "id": 7,
+                "name": "Vex",
+                "description": "A dock-side fixer who owes everyone a favour.",
+                "personality": "sardonic",
+                "scenario": "a rooftop at night",
+                "system_prompt": "You are {{char}}. {{user}} is your rival.",
+                "first_message": "You again, {{user}}.",
+                "post_history_instructions": "Stay in character.",
+                "message_example": "{{user}}: Hi\n{{char}}: Hey.",
+            }
+        }
+    )
+
+
+@pytest.fixture
+def targets(db):
+    """Two REAL eval_models rows: one unsteered, one steered.
+
+    Steering lives in the row's ``config`` JSON -- never as a top-level
+    column -- and these rows come back from ``get_model`` exactly as the
+    application reads them.
+    """
+    base_id = db.create_model(name="base", provider="llama_cpp", model_id="qwen3-8b")
+    steered_id = db.create_model(
+        name="steered",
+        provider="llama_cpp",
+        model_id="qwen3-8b",
+        config={"system_prompt": "Answer in English."},
+    )
+    return [db.get_model(base_id), db.get_model(steered_id)]
+
+
+def test_a_bench_runs_end_to_end_and_its_conversations_reload(db, chacha_db, targets):
+    # --- author: a probe set and a bench, both persisted -----------------
+    probe_set_id = save_probe_set(db, "starter", parse_probe_text(PROBE_TEXT))
+    config = CharacterProbeConfig(
+        name="villain probes",
+        description="does Vex hold up under pressure",
+        probe_set_id=probe_set_id,
+        character_ids=(7,),
+        target_ids=tuple(t["id"] for t in targets),
+        temperature=0.3,
+        max_tokens=256,
+        seed=1234,
+        samples_per_cell=2,
+    )
+    task_id = save_character_bench(db, config)
+
+    # --- load it back: the bench and its probes both round trip ----------
+    loaded_config = load_character_bench(db, task_id)
+    assert loaded_config == config
+    probe_set = load_probe_set(db, probe_set_id)
+    assert [len(p.turns) for p in probe_set.probes] == [2, 1]
+
+    # --- resolve: cards across the DB boundary, targets from real rows ---
+    cards = snapshot_cards(chacha_db, list(loaded_config.character_ids))
+    assert cards[0].description  # the primary V2 persona field survived
+
+    # --- open the run group, snapshotting what is about to run -----------
+    group_id, run_ids = create_probe_run_group(
+        db, task_id, loaded_config, cards, probe_set, targets
+    )
+    assert set(run_ids) == {t["id"] for t in targets}
+
+    # --- run the grid against the fake chat callable ---------------------
+    chat = _ScriptedChat()
+    seen_progress = []
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run(
+            cards,
+            probe_set,
+            targets,
+            loaded_config,
+            progress=lambda done, total: seen_progress.append((done, total)),
+        )
+    )
+    # 1 card x 2 probes x 2 targets x 2 samples
+    assert len(conversations) == 8
+    assert seen_progress[-1] == (8, 8)
+    # 2 turns in probe 0, 1 in probe 1 -> 3 provider calls per target-sample
+    assert len(chat.calls) == 12
+
+    # --- C1: the steered target's steering actually reached the model ----
+    steered_id = targets[1]["id"]
+    steered_systems = {
+        call["messages"][0]["content"]
+        for call in chat.calls
+        if call["messages"][0]["content"].startswith("Answer in English.")
+    }
+    assert steered_systems, "target steering never reached the system prompt"
+    system = next(iter(steered_systems))
+    assert "You are Vex. User is your rival." in system  # macros resolved
+    assert "A dock-side fixer who owes everyone a favour." in system
+    assert "{{char}}" not in system and "{{user}}" not in system
+    # ...and the unsteered target's prompt is the same card text without it
+    unsteered = [
+        call["messages"][0]["content"]
+        for call in chat.calls
+        if not call["messages"][0]["content"].startswith("Answer in English.")
+    ]
+    assert unsteered and all(u.startswith("You are Vex.") for u in unsteered)
+
+    # --- the provider was asked for the model NAME, not the row's uuid ---
+    assert {call["model"] for call in chat.calls} == {"qwen3-8b"}
+    assert {call["temperature"] for call in chat.calls} == {0.3}
+    assert {call["max_tokens"] for call in chat.calls} == {256}
+    # seed + sample_index, so two samples of a cell are not identical
+    assert {call["seed"] for call in chat.calls} == {1234, 1235}
+
+    # --- persist, using the run ids the run group handed back ------------
+    save_conversations(db, group_id, run_ids, conversations)
+
+    # --- I4: the run is self-describing, from storage alone --------------
+    snapshot = load_probe_run_snapshot(db, group_id)
+    (snap_card,) = snapshot["cards"]
+    assert snap_card["description"] == (
+        "A dock-side fixer who owes everyone a favour."
+    )
+    assert snap_card["system_prompt"] == "You are {{char}}. {{user}} is your rival."
+    assert snapshot["sampler"] == {
+        "temperature": 0.3,
+        "max_tokens": 256,
+        "seed": 1234,
+        "samples_per_cell": 2,
+        "concurrency": 1,
+    }
+    assert {t["id"] for t in snapshot["targets"]} == {t["id"] for t in targets}
+    assert snapshot["composed_system_prompts"]["7"][steered_id].startswith(
+        "Answer in English."
+    )
+    assert snapshot["probes"] == [
+        {
+            "turns": [
+                "What do you think about lying?",
+                "And if lying protected someone you love?",
+            ]
+        },
+        {"turns": ["Describe your earliest memory."]},
+    ]
+
+    # --- load the conversations back -------------------------------------
+    reloaded = load_conversations(db, group_id)
+    assert len(reloaded) == 8
+    by_key = {
+        (c.card_id, c.probe_index, c.sample_index, c.target_id): c for c in reloaded
+    }
+    assert set(by_key) == {
+        (c.card_id, c.probe_index, c.sample_index, c.target_id) for c in conversations
+    }
+    first = by_key[(7, 0, 0, targets[0]["id"])]
+    assert [t.user for t in first.turns] == [
+        "What do you think about lying?",
+        "And if lying protected someone you love?",
+    ]
+    assert all(t.reply.startswith("reply-") for t in first.turns)
+    assert not any(c.error for c in reloaded)
+
+    # --- review: annotate a turn, mark a conversation reviewed -----------
+    annotate_turn(
+        db, group_id, 7, 0, 0, targets[0]["id"], 1, ["broke-character"], "drifted"
+    )
+    mark_conversation_reviewed(db, group_id, 7, 0, 0, targets[0]["id"], "read it")
+
+    # --- and reload it, as a resumed session would ------------------------
+    annotations = load_turn_annotations(db, group_id)
+    assert annotations[(7, 0, 0, targets[0]["id"], 1)] == {
+        "tags": ["broke-character"],
+        "note": "drifted",
+    }
+    review = load_review_state(db, group_id)[(7, 0, 0, targets[0]["id"])]
+    assert review["reviewed_at"]
+    assert review["note"] == "read it"
+    # "nothing notable" is a distinct verdict: the other seven are unreviewed
+    assert len(review_keys := load_review_state(db, group_id)) == 1
+    assert set(review_keys) == {(7, 0, 0, targets[0]["id"])}
+
+
+def test_a_run_survives_its_card_being_edited_afterwards(db, chacha_db, targets):
+    """The provenance rule, proven through storage rather than asserted: a
+    card edited after the run must not change what the run shows. Cards live
+    in another database with no foreign keys, so nothing but the snapshot
+    protects this."""
+    probe_set_id = save_probe_set(db, "starter", parse_probe_text(PROBE_TEXT))
+    config = CharacterProbeConfig(
+        name="villain probes",
+        probe_set_id=probe_set_id,
+        character_ids=(7,),
+        target_ids=(targets[0]["id"],),
+    )
+    task_id = save_character_bench(db, config)
+    cards = snapshot_cards(chacha_db, [7])
+    probe_set = load_probe_set(db, probe_set_id)
+    group_id, run_ids = create_probe_run_group(
+        db, task_id, config, cards, probe_set, [targets[0]]
+    )
+    conversations = asyncio.run(
+        CharacterProbeRunner(_ScriptedChat()).run(
+            cards, probe_set, [targets[0]], config
+        )
+    )
+    save_conversations(db, group_id, run_ids, conversations)
+
+    # The card is rewritten (and could equally have been deleted).
+    chacha_db._cards[7]["description"] = "Rewritten entirely."
+    chacha_db._cards[7]["system_prompt"] = "You are somebody else now."
+
+    snapshot = load_probe_run_snapshot(db, group_id)
+    (snap_card,) = snapshot["cards"]
+    assert snap_card["description"] == (
+        "A dock-side fixer who owes everyone a favour."
+    )
+    assert snapshot["composed_system_prompts"]["7"][targets[0]["id"]].startswith(
+        "You are Vex."
+    )
+    assert len(load_conversations(db, group_id)) == 2

--- a/Tests/Evals/character_probe/test_probe_format.py
+++ b/Tests/Evals/character_probe/test_probe_format.py
@@ -1,0 +1,79 @@
+import pytest
+
+from tldw_chatbook.Evals.character_probe.models import Probe, ProbeSet
+from tldw_chatbook.Evals.character_probe.probe_format import (
+    format_probe_text,
+    parse_probe_text,
+)
+
+
+def test_single_probe_single_turn():
+    assert parse_probe_text("What do you think about lying?") == ProbeSet(
+        probes=(Probe(turns=("What do you think about lying?",)),)
+    )
+
+
+def test_turns_split_on_the_turn_delimiter():
+    text = "What do you think about lying?\n---\nAnd if it protected someone?"
+    assert parse_probe_text(text) == ProbeSet(
+        probes=(
+            Probe(
+                turns=(
+                    "What do you think about lying?",
+                    "And if it protected someone?",
+                )
+            ),
+        )
+    )
+
+
+def test_probes_split_on_the_probe_delimiter():
+    text = "First probe\n===\nSecond probe"
+    parsed = parse_probe_text(text)
+    assert len(parsed.probes) == 2
+    assert parsed.probes[0].turns == ("First probe",)
+    assert parsed.probes[1].turns == ("Second probe",)
+
+
+def test_a_turn_may_span_multiple_paragraphs():
+    """The whole point of the delimiter format: complex prompts are the subject."""
+    text = "Describe your earliest memory.\n\nTake your time, and include what you could smell."
+    parsed = parse_probe_text(text)
+    assert parsed.probes[0].turns == (
+        "Describe your earliest memory.\n\nTake your time, and include what you could smell.",
+    )
+
+
+def test_interior_whitespace_is_preserved_exactly():
+    text = "Line one\n    indented line\nLine three"
+    assert parsed_turn(text) == "Line one\n    indented line\nLine three"
+
+
+def parsed_turn(text: str) -> str:
+    return parse_probe_text(text).probes[0].turns[0]
+
+
+def test_blank_lines_around_a_turn_are_stripped():
+    text = "\n\nWhat is your name?\n\n\n---\n\nAnd your age?\n"
+    parsed = parse_probe_text(text)
+    assert parsed.probes[0].turns == ("What is your name?", "And your age?")
+
+
+def test_empty_text_is_rejected():
+    with pytest.raises(ValueError, match="no probes"):
+        parse_probe_text("   \n\n  ")
+
+
+def test_a_probe_with_no_turns_is_rejected():
+    with pytest.raises(ValueError, match="probe 2"):
+        parse_probe_text("Real probe\n===\n   \n===\nAnother")
+
+
+def test_round_trip_through_format_and_parse():
+    original = ProbeSet(
+        probes=(
+            Probe(turns=("One\n\nwith a paragraph", "Two")),
+            Probe(turns=("Three",)),
+        )
+    )
+    assert parse_probe_text(format_probe_text(original)) == original

--- a/Tests/Evals/character_probe/test_probe_format.py
+++ b/Tests/Evals/character_probe/test_probe_format.py
@@ -115,3 +115,30 @@ def test_turn_containing_bare_delimiter_does_not_round_trip():
     # The turn is split into two at the --- delimiter
     assert len(parsed.probes[0].turns) == 2
     assert parsed.probes[0].turns == ("before", "after")
+
+
+def test_a_whitespace_padded_delimiter_still_delimits():
+    """Deliberate leniency, pinned so it cannot drift either way.
+
+    A strict match would make an INVISIBLE trailing space silently fail to
+    delimit, merging two turns into one prompt that then runs and produces
+    plausible-looking results -- likely (editors add trailing whitespace
+    constantly) and very hard to see. The lenient match's cost is that an
+    indented literal --- inside a turn is eaten, which is less likely and
+    fails visibly. See the module docstring for the full ruling.
+    """
+    parsed = parse_probe_text("First turn\n  ---  \nSecond turn")
+    assert parsed.probes[0].turns == ("First turn", "Second turn")
+
+
+def test_a_whitespace_padded_probe_delimiter_still_delimits():
+    parsed = parse_probe_text("Probe one\n\t===\nProbe two")
+    assert [p.turns for p in parsed.probes] == [("Probe one",), ("Probe two",)]
+
+
+def test_an_indented_delimiter_inside_a_turn_is_eaten():
+    """The documented cost of the leniency above -- pinned so the limitation
+    is deliberate rather than a surprise, matching how the bare-delimiter
+    round-trip loss is already pinned."""
+    parsed = parse_probe_text("before\n    ---\nafter")
+    assert parsed.probes[0].turns == ("before", "after")

--- a/Tests/Evals/character_probe/test_probe_format.py
+++ b/Tests/Evals/character_probe/test_probe_format.py
@@ -77,3 +77,41 @@ def test_round_trip_through_format_and_parse():
         )
     )
     assert parse_probe_text(format_probe_text(original)) == original
+
+
+def test_whitespace_only_lines_are_stripped():
+    """Trailing spaces on an empty line should not corrupt the turn."""
+    text = "  \nHello\n---\nSecond"
+    parsed = parse_probe_text(text)
+    assert parsed.probes[0].turns == ("Hello", "Second")
+
+
+def test_stray_turn_delimiter_raises_error():
+    """A duplicated or stray turn delimiter in the middle should raise."""
+    text = "First\n---\n---\nSecond"
+    with pytest.raises(ValueError, match="stray or duplicated"):
+        parse_probe_text(text)
+
+
+def test_probe_rejects_empty_turn():
+    """Attempting to create a probe with an empty turn should raise."""
+    with pytest.raises(ValueError, match="empty or whitespace-only"):
+        Probe(turns=("",))
+
+
+def test_probe_rejects_whitespace_only_turn():
+    """Attempting to create a probe with a whitespace-only turn should raise."""
+    with pytest.raises(ValueError, match="empty or whitespace-only"):
+        Probe(turns=("   ",))
+
+
+def test_turn_containing_bare_delimiter_does_not_round_trip():
+    """Document the lossy behavior: delimiters within turn text are not escaped."""
+    # This turn contains a bare --- line
+    original_turn = "before\n---\nafter"
+    probe = Probe(turns=(original_turn,))
+    formatted = format_probe_text(ProbeSet(probes=(probe,)))
+    parsed = parse_probe_text(formatted)
+    # The turn is split into two at the --- delimiter
+    assert len(parsed.probes[0].turns) == 2
+    assert parsed.probes[0].turns == ("before", "after")

--- a/Tests/Evals/character_probe/test_probe_storage.py
+++ b/Tests/Evals/character_probe/test_probe_storage.py
@@ -100,6 +100,93 @@ def test_saving_with_a_stale_dataset_id_raises_rather_than_silently_succeeding(
         save_probe_set(db, "starter", probe_set, dataset_id="does-not-exist")
 
 
+def _store_samples(db, dataset_id, samples):
+    """Replace a probe-set dataset's stored samples with an arbitrary value,
+    as an external writer or a hand-edited row might."""
+    import json
+
+    metadata = {
+        "dataset_type": PROBE_DATASET_TYPE,
+        RESERVED_LOCAL_DATASET_SAMPLES_KEY: samples,
+    }
+    conn = db.get_connection()
+    with conn:
+        conn.execute(
+            "UPDATE eval_datasets SET metadata = ? WHERE id = ?",
+            (json.dumps(metadata), dataset_id),
+        )
+
+
+def test_a_missing_samples_key_raises_naming_the_dataset(db, probe_set):
+    """load_probe_set's docstring promises it prevents a silent empty set;
+    returning ProbeSet(probes=()) here delivered exactly what it promised to
+    prevent, and a bench would then run and produce nothing."""
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    conn = db.get_connection()
+    with conn:
+        conn.execute(
+            "UPDATE eval_datasets SET metadata = ? WHERE id = ?",
+            ('{"dataset_type": "character_probe"}', dataset_id),
+        )
+    with pytest.raises(ValueError, match="no stored samples list") as excinfo:
+        load_probe_set(db, dataset_id)
+    assert dataset_id in str(excinfo.value)
+
+
+def test_a_non_list_samples_value_raises(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    _store_samples(db, dataset_id, {"turns": ["One"]})
+    with pytest.raises(ValueError, match="no stored samples list"):
+        load_probe_set(db, dataset_id)
+
+
+def test_turns_stored_as_a_bare_string_are_rejected(db, probe_set):
+    """A string is iterable, so this silently produced a probe of
+    one-character turns rather than one turn."""
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    _store_samples(db, dataset_id, [{"turns": "Hello"}])
+    with pytest.raises(ValueError, match="as a string") as excinfo:
+        load_probe_set(db, dataset_id)
+    assert dataset_id in str(excinfo.value)
+
+
+def test_a_sample_with_no_turns_is_rejected_rather_than_skipped(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    _store_samples(db, dataset_id, [{"turns": ["One"]}, {"turns": []}])
+    with pytest.raises(ValueError, match="has no turns"):
+        load_probe_set(db, dataset_id)
+
+
+def test_a_non_mapping_sample_is_rejected(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    _store_samples(db, dataset_id, ["One"])
+    with pytest.raises(ValueError, match="not a mapping"):
+        load_probe_set(db, dataset_id)
+
+
+def test_a_non_string_turn_is_rejected(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    _store_samples(db, dataset_id, [{"turns": [5]}])
+    with pytest.raises(ValueError, match="non-string turn"):
+        load_probe_set(db, dataset_id)
+
+
+def test_a_whitespace_only_turn_is_rejected_with_the_dataset_named(db, probe_set):
+    """Probe's own rule, re-raised with the dataset and sample named so the
+    author can find the offending row."""
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    _store_samples(db, dataset_id, [{"turns": ["   "]}])
+    with pytest.raises(ValueError, match="sample 0 is invalid") as excinfo:
+        load_probe_set(db, dataset_id)
+    assert dataset_id in str(excinfo.value)
+
+
+def test_an_explicitly_empty_probe_list_is_not_an_error(db):
+    """A deliberately empty probe set is not a missing one."""
+    dataset_id = save_probe_set(db, "empty", ProbeSet(probes=()))
+    assert load_probe_set(db, dataset_id) == ProbeSet(probes=())
+
+
 def test_samples_do_not_carry_a_redundant_index_field(db, probe_set):
     dataset_id = save_probe_set(db, "starter", probe_set)
     row = db.get_dataset(dataset_id)

--- a/Tests/Evals/character_probe/test_probe_storage.py
+++ b/Tests/Evals/character_probe/test_probe_storage.py
@@ -1,0 +1,64 @@
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.Evals.character_probe.models import Probe, ProbeSet
+from tldw_chatbook.Evals.character_probe.storage import (
+    PROBE_DATASET_TYPE,
+    is_probe_set,
+    load_probe_set,
+    save_probe_set,
+)
+
+
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
+
+
+@pytest.fixture
+def probe_set():
+    return ProbeSet(
+        probes=(
+            Probe(turns=("What do you think about lying?", "And to protect someone?")),
+            Probe(turns=("Describe your earliest memory.\n\nInclude the smell.",)),
+        )
+    )
+
+
+def test_save_then_load_round_trips(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    assert load_probe_set(db, dataset_id) == probe_set
+
+
+def test_saved_set_is_marked_as_a_probe_set(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    row = db.get_dataset(dataset_id)
+    assert (row.get("metadata") or {}).get("dataset_type") == PROBE_DATASET_TYPE
+    assert is_probe_set(row) is True
+
+
+def test_a_snippet_dataset_is_not_a_probe_set(db):
+    dataset_id = db.create_dataset(
+        name="snippets", format="custom", source_path="inline:snippets"
+    )
+    assert is_probe_set(db.get_dataset(dataset_id)) is False
+
+
+def test_saving_with_an_existing_id_replaces_its_probes(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    replacement = ProbeSet(probes=(Probe(turns=("Only one now",)),))
+    assert save_probe_set(db, "starter", replacement, dataset_id=dataset_id) == dataset_id
+    assert load_probe_set(db, dataset_id) == replacement
+
+
+def test_loading_a_non_probe_dataset_raises(db):
+    dataset_id = db.create_dataset(
+        name="snippets", format="custom", source_path="inline:snippets"
+    )
+    with pytest.raises(ValueError, match="not a probe set"):
+        load_probe_set(db, dataset_id)
+
+
+def test_loading_a_missing_dataset_raises(db):
+    with pytest.raises(ValueError, match="could not be found"):
+        load_probe_set(db, "nope")

--- a/Tests/Evals/character_probe/test_probe_storage.py
+++ b/Tests/Evals/character_probe/test_probe_storage.py
@@ -8,6 +8,9 @@ from tldw_chatbook.Evals.character_probe.storage import (
     load_probe_set,
     save_probe_set,
 )
+from tldw_chatbook.Evaluations_Interop.evaluation_normalizers import (
+    RESERVED_LOCAL_DATASET_SAMPLES_KEY,
+)
 
 
 @pytest.fixture
@@ -62,3 +65,43 @@ def test_loading_a_non_probe_dataset_raises(db):
 def test_loading_a_missing_dataset_raises(db):
     with pytest.raises(ValueError, match="could not be found"):
         load_probe_set(db, "nope")
+
+
+def test_is_probe_set_false_for_string_metadata():
+    """Corrupt data (metadata that isn't a mapping) must not crash."""
+    assert is_probe_set({"metadata": "corrupt"}) is False
+
+
+def test_is_probe_set_false_for_list_metadata():
+    assert is_probe_set({"metadata": [1, 2, 3]}) is False
+
+
+def test_loading_a_dataset_with_corrupt_metadata_raises_the_named_error(db):
+    """A non-mapping ``metadata`` should surface as the normal 'not a probe
+    set' ValueError, not an unrelated AttributeError from ``is_probe_set``.
+    """
+    dataset_id = db.create_dataset(
+        name="snippets", format="custom", source_path="inline:snippets"
+    )
+    conn = db.get_connection()
+    with conn:
+        conn.execute(
+            "UPDATE eval_datasets SET metadata = ? WHERE id = ?",
+            ('"corrupt"', dataset_id),
+        )
+    with pytest.raises(ValueError, match="not a probe set"):
+        load_probe_set(db, dataset_id)
+
+
+def test_saving_with_a_stale_dataset_id_raises_rather_than_silently_succeeding(
+    db, probe_set
+):
+    with pytest.raises(ValueError, match="could not be updated"):
+        save_probe_set(db, "starter", probe_set, dataset_id="does-not-exist")
+
+
+def test_samples_do_not_carry_a_redundant_index_field(db, probe_set):
+    dataset_id = save_probe_set(db, "starter", probe_set)
+    row = db.get_dataset(dataset_id)
+    samples = row["metadata"][RESERVED_LOCAL_DATASET_SAMPLES_KEY]
+    assert all("index" not in sample for sample in samples)

--- a/Tests/Evals/character_probe/test_prompt.py
+++ b/Tests/Evals/character_probe/test_prompt.py
@@ -1,0 +1,95 @@
+import pytest
+
+from tldw_chatbook.Evals.character_probe.models import CardSnapshot
+from tldw_chatbook.Evals.character_probe.prompt import build_messages, compose_system_prompt
+
+
+def _card(**overrides):
+    base = dict(id=1, name="Vex", system_prompt="You are Vex.", first_message="You again.")
+    base.update(overrides)
+    return CardSnapshot(**base)
+
+
+def test_steering_is_placed_ahead_of_the_card_prompt():
+    composed = compose_system_prompt(_card(), "Answer in English.")
+    assert composed.startswith("Answer in English.")
+    assert composed.endswith("You are Vex.")
+
+
+def test_no_steering_yields_the_card_prompt_unchanged():
+    assert compose_system_prompt(_card(), None) == "You are Vex."
+
+
+def test_no_card_prompt_yields_the_steering_alone():
+    assert compose_system_prompt(_card(system_prompt=""), "Be brief.") == "Be brief."
+
+
+def test_first_message_seeds_an_assistant_turn():
+    messages = build_messages(_card(), None, ["Hello?"], [])
+    assert messages[0]["role"] == "system"
+    assert messages[1] == {"role": "assistant", "content": "You again."}
+    assert messages[2] == {"role": "user", "content": "Hello?"}
+
+
+def test_a_card_without_a_first_message_starts_at_the_user_turn():
+    """No synthetic greeting is invented -- that would evaluate text the
+    character never had."""
+    messages = build_messages(_card(first_message=""), None, ["Hello?"], [])
+    assert [m["role"] for m in messages] == ["system", "user"]
+
+
+def test_prior_replies_accumulate_in_order():
+    messages = build_messages(
+        _card(), None, ["One", "Two", "Three"], ["Reply one", "Reply two"]
+    )
+    assert [m["role"] for m in messages] == [
+        "system", "assistant", "user", "assistant", "user", "assistant", "user",
+    ]
+    assert messages[-1] == {"role": "user", "content": "Three"}
+    assert messages[-2] == {"role": "assistant", "content": "Reply two"}
+
+
+def test_personality_and_scenario_reach_the_system_prompt():
+    card = _card(system_prompt="You are Vex.", personality="sardonic", scenario="a rooftop")
+    composed = compose_system_prompt(card, None)
+    assert "sardonic" in composed
+    assert "rooftop" in composed
+
+
+def test_message_example_reaches_the_system_prompt():
+    """cards.py snapshots message_example specifically because ``every one
+    participates in prompt assembly`` -- dropping it here would silently
+    narrow what the probe evaluates versus what was promised at the
+    snapshot boundary."""
+    card = _card(message_example="<START>\n{{user}}: Hi\n{{char}}: Hey.")
+    composed = compose_system_prompt(card, None)
+    assert "{{user}}: Hi" in composed
+
+
+def test_message_example_absent_contributes_nothing():
+    composed = compose_system_prompt(_card(message_example=""), None)
+    assert composed == "You are Vex."
+
+
+def test_post_history_instructions_come_after_message_example():
+    card = _card(message_example="EXAMPLE-TEXT", post_history_instructions="POST-TEXT")
+    composed = compose_system_prompt(card, None)
+    assert composed.index("EXAMPLE-TEXT") < composed.index("POST-TEXT")
+
+
+def test_exhausted_script_raises_instead_of_indexerror():
+    """One reply per turn already recorded -- there is no next scripted turn.
+    This must fail loudly and namedly, matching the rest of the package's
+    convention, rather than raising a bare IndexError deep inside assembly."""
+    with pytest.raises(ValueError, match="already complete"):
+        build_messages(_card(), None, ["One"], ["Reply one"])
+
+
+def test_more_replies_than_turns_also_raises():
+    with pytest.raises(ValueError, match="already complete"):
+        build_messages(_card(), None, ["One"], ["Reply one", "Reply two"])
+
+
+def test_no_scripted_turns_at_all_raises():
+    with pytest.raises(ValueError, match="already complete"):
+        build_messages(_card(), None, [], [])

--- a/Tests/Evals/character_probe/test_prompt.py
+++ b/Tests/Evals/character_probe/test_prompt.py
@@ -71,6 +71,18 @@ def test_message_example_absent_contributes_nothing():
     assert composed == "You are Vex."
 
 
+def test_empty_card_and_no_steering_pins_a_blank_system_message():
+    """A card with no system prompt, no persona fields, and no steering still
+    emits a leading `{"role": "system", "content": ""}`, not a missing or
+    skipped system message. This is deliberate -- see compose_system_prompt's
+    docstring -- so a later refactor cannot silently drop the system message
+    (or its stable position as messages[0]) for a content-free card."""
+    empty_card = CardSnapshot(id=1, name="Blank")
+    assert compose_system_prompt(empty_card, None) == ""
+    messages = build_messages(empty_card, None, ["Hi?"], [])
+    assert messages[0] == {"role": "system", "content": ""}
+
+
 def test_post_history_instructions_come_after_message_example():
     card = _card(message_example="EXAMPLE-TEXT", post_history_instructions="POST-TEXT")
     composed = compose_system_prompt(card, None)

--- a/Tests/Evals/character_probe/test_prompt.py
+++ b/Tests/Evals/character_probe/test_prompt.py
@@ -63,7 +63,88 @@ def test_message_example_reaches_the_system_prompt():
     snapshot boundary."""
     card = _card(message_example="<START>\n{{user}}: Hi\n{{char}}: Hey.")
     composed = compose_system_prompt(card, None)
-    assert "{{user}}: Hi" in composed
+    assert "User: Hi" in composed
+
+
+def test_card_macros_are_resolved_not_leaked():
+    """Cards are authored against SillyTavern-style macros. Console resolves
+    them before sending (task-1530) precisely because they otherwise reach
+    the provider verbatim; a probe that shipped a literal ``{{char}}`` would
+    be evaluating text no real chat with this card ever produces."""
+    card = _card(
+        system_prompt="You are {{char}}. {{user}} is your rival.",
+        message_example="{{user}}: Hi\n{{char}}: Hey.",
+        personality="{{char}} is sardonic",
+        description="{{char}} runs the docks",
+        scenario="{{user}} finds {{char}} on a rooftop",
+        post_history_instructions="Stay as {{char}}.",
+    )
+    composed = compose_system_prompt(card, None)
+    assert "{{char}}" not in composed
+    assert "{{user}}" not in composed
+    assert "You are Vex. User is your rival." in composed
+    assert "Vex is sardonic" in composed
+    assert "Vex runs the docks" in composed
+    assert "User finds Vex on a rooftop" in composed
+    assert "Stay as Vex." in composed
+
+
+def test_the_first_message_resolves_its_macros_too():
+    card = _card(first_message="Well, {{user}}. {{char}} was expecting you.")
+    messages = build_messages(card, None, ["Hello?"], [])
+    assert messages[1] == {
+        "role": "assistant",
+        "content": "Well, User. Vex was expecting you.",
+    }
+
+
+def test_scripted_turns_are_sent_verbatim():
+    """A probe's turns are the eval author's text, not the card's, and the
+    probe format's rule is that turn text is reproduced exactly -- prompt
+    formatting changes model behaviour."""
+    messages = build_messages(_card(), None, ["Who is {{char}}?"], [])
+    assert messages[-1] == {"role": "user", "content": "Who is {{char}}?"}
+
+
+def test_steering_is_not_macro_resolved():
+    """Steering is a model-level instruction attached to a TARGET, not card
+    text. A run spans several cards, so resolving it would give one card's
+    name to a string that belongs to none of them."""
+    composed = compose_system_prompt(_card(), "Never mention {{char}}.")
+    assert composed.startswith("Never mention {{char}}.")
+
+
+def test_a_nameless_card_falls_back_rather_than_substituting_nothing():
+    card = _card(name="  ", system_prompt="You are {{char}}.")
+    assert compose_system_prompt(card, None) == "You are Character."
+
+
+def test_description_reaches_the_system_prompt():
+    """``description`` is the primary V2 persona field and the one Console
+    already sends. It was absent from CardSnapshot, from _SNAPSHOT_FIELDS and
+    from the spec's field list until the whole-branch review of task-1691
+    phase 1, so every probe ran against a character stripped of its main
+    definition."""
+    card = _card(description="A dock-side fixer who owes everyone a favour.")
+    composed = compose_system_prompt(card, None)
+    assert "A dock-side fixer who owes everyone a favour." in composed
+
+
+def test_description_absent_contributes_nothing():
+    assert compose_system_prompt(_card(description=""), None) == "You are Vex."
+
+
+def test_description_follows_personality_as_console_orders_them():
+    """Console's joiner is system_prompt, personality, description, scenario;
+    matching it leaves TASK-1744's shared function one less difference to
+    reconcile."""
+    card = _card(
+        system_prompt="SYS", personality="PERS", description="DESC", scenario="SCEN"
+    )
+    composed = compose_system_prompt(card, None)
+    assert composed.index("SYS") < composed.index("PERS")
+    assert composed.index("PERS") < composed.index("DESC")
+    assert composed.index("DESC") < composed.index("SCEN")
 
 
 def test_message_example_absent_contributes_nothing():

--- a/Tests/Evals/character_probe/test_runner.py
+++ b/Tests/Evals/character_probe/test_runner.py
@@ -121,6 +121,37 @@ def test_per_sample_seed_is_offset_so_samples_differ(targets):
     assert sorted(call["seed"] for call in chat.calls) == [100, 101, 102]
 
 
+def test_a_negative_seed_stays_random_for_every_sample(targets):
+    """llama.cpp reads a negative seed as "pick a random seed", and
+    load_character_bench explicitly accepts one. Offsetting it turns
+    -1, 0, 1 ... -- so sample 0 is randomly seeded and every LATER sample
+    gets a deterministic seed the user never asked for. That defeats the
+    only reason to take several samples (seeing variance) while looking
+    like it worked."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card()], probe_set, targets, _config(samples_per_cell=3, seed=-1)
+        )
+    )
+    assert [call["seed"] for call in chat.calls] == [-1, -1, -1]
+
+
+def test_a_seed_of_zero_is_still_offset(targets):
+    """0 is a real, explicitly-chosen seed, not a sentinel -- the same
+    falsy-but-real case Task 3 fixed for max_tokens. Only NEGATIVE seeds
+    are the random sentinel, so 0 must keep offsetting."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card()], probe_set, targets, _config(samples_per_cell=3, seed=0)
+        )
+    )
+    assert sorted(call["seed"] for call in chat.calls) == [0, 1, 2]
+
+
 def test_no_seed_passes_none(targets):
     chat = _FakeChat()
     probe_set = ProbeSet(probes=(Probe(turns=("One",)),))

--- a/Tests/Evals/character_probe/test_runner.py
+++ b/Tests/Evals/character_probe/test_runner.py
@@ -9,6 +9,9 @@ samples of a cell are not identical.
 
 import asyncio
 
+import pytest
+
+from tldw_chatbook.DB.Evals_DB import EvalsDB
 from tldw_chatbook.Evals.character_probe.models import (
     CardSnapshot,
     CharacterProbeConfig,
@@ -45,15 +48,38 @@ def _config(**overrides):
     return CharacterProbeConfig(**base)
 
 
-def _targets():
-    return [{"id": "t-1", "model_id": "m", "system_prompt": None}]
+@pytest.fixture
+def db():
+    return EvalsDB(db_path=":memory:", client_id="test")
 
 
-def test_turns_run_in_order_and_each_sees_the_previous_reply():
+def _real_target(db, name, provider="llama_cpp", model_id="m", config=None):
+    """One REAL eval_models row, read back exactly as the app reads it.
+
+    Never hand-build a target dict here. The whole-branch review of this
+    branch found the runner reading ``target["system_prompt"]`` -- a key no
+    ``eval_models`` row has ever carried, since steering lives in the row's
+    ``config`` JSON -- and the runner's own steering test passed anyway,
+    because the fixture invented a shape the database does not produce. A
+    fixture that goes through ``create_model`` + ``get_model`` cannot lie
+    about the shape of a row.
+    """
+    row_id = db.create_model(
+        name=name, provider=provider, model_id=model_id, config=config or {}
+    )
+    return db.get_model(row_id)
+
+
+@pytest.fixture
+def targets(db):
+    return [_real_target(db, "t-1")]
+
+
+def test_turns_run_in_order_and_each_sees_the_previous_reply(targets):
     chat = _FakeChat()
     probe_set = ProbeSet(probes=(Probe(turns=("One", "Two")),))
     conversations = asyncio.run(
-        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
     )
     (conversation,) = conversations
     assert [t.user for t in conversation.turns] == ["One", "Two"]
@@ -61,11 +87,11 @@ def test_turns_run_in_order_and_each_sees_the_previous_reply():
     assert second_call_messages[-2] == {"role": "assistant", "content": "ok-1"}
 
 
-def test_a_failed_turn_ends_only_its_own_conversation():
+def test_a_failed_turn_ends_only_its_own_conversation(targets):
     chat = _FakeChat(fail_on=1)
     probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
     conversations = asyncio.run(
-        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
     )
     failed = [c for c in conversations if c.error]
     survived = [c for c in conversations if not c.error]
@@ -73,67 +99,145 @@ def test_a_failed_turn_ends_only_its_own_conversation():
     assert len(survived) == 1
 
 
-def test_partial_turns_are_kept_when_a_later_turn_fails():
+def test_partial_turns_are_kept_when_a_later_turn_fails(targets):
     chat = _FakeChat(fail_on=2)
     probe_set = ProbeSet(probes=(Probe(turns=("One", "Two")),))
     (conversation,) = asyncio.run(
-        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
     )
     assert conversation.turns[0].reply == "ok-1"
     assert conversation.error
 
 
-def test_per_sample_seed_is_offset_so_samples_differ():
+def test_per_sample_seed_is_offset_so_samples_differ(targets):
     """A single fixed seed would return N identical answers -- see the spec."""
     chat = _FakeChat()
     probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
     asyncio.run(
         CharacterProbeRunner(chat).run(
-            [_card()], probe_set, _targets(), _config(samples_per_cell=3, seed=100)
+            [_card()], probe_set, targets, _config(samples_per_cell=3, seed=100)
         )
     )
     assert sorted(call["seed"] for call in chat.calls) == [100, 101, 102]
 
 
-def test_no_seed_passes_none():
+def test_no_seed_passes_none(targets):
     chat = _FakeChat()
     probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
     asyncio.run(
-        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
     )
     assert chat.calls[0]["seed"] is None
 
 
-def test_the_grid_covers_cards_probes_targets_and_samples():
+def test_the_grid_covers_cards_probes_targets_and_samples(db):
     chat = _FakeChat()
     probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
-    targets = [
-        {"id": "t-1", "model_id": "m1", "system_prompt": None},
-        {"id": "t-2", "model_id": "m2", "system_prompt": None},
+    two_targets = [
+        _real_target(db, "t-1", model_id="m1"),
+        _real_target(db, "t-2", model_id="m2"),
     ]
     conversations = asyncio.run(
         CharacterProbeRunner(chat).run(
             [_card(1), _card(2)],
             probe_set,
-            targets,
+            two_targets,
             _config(character_ids=(1, 2), target_ids=("t-1", "t-2"), samples_per_cell=2),
         )
     )
     assert len(conversations) == 2 * 2 * 2 * 2
 
 
-def test_target_steering_reaches_the_system_prompt():
+def test_target_steering_reaches_the_system_prompt(db):
+    """The whole-branch review's C1: steering lives in the row's ``config``
+    JSON, never as a top-level ``system_prompt`` column, so a runner reading
+    the top level drops it for EVERY real row. Built from a real
+    ``create_model``/``get_model`` round trip so this can never pass against
+    a shape the database does not produce."""
     chat = _FakeChat()
     probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
-    targets = [{"id": "t-1", "model_id": "m", "system_prompt": "Be terse."}]
+    steered = [_real_target(db, "steered", config={"system_prompt": "Be terse."})]
+    assert "system_prompt" not in steered[0]  # it is inside config, nowhere else
     asyncio.run(
-        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
+        CharacterProbeRunner(chat).run([_card()], probe_set, steered, _config())
     )
     system = chat.calls[0]["messages"][0]["content"]
     assert system.startswith("Be terse.")
 
 
-def test_cancelling_stops_scheduling_but_keeps_completed_turns():
+def test_the_model_name_on_the_wire_is_the_rows_model_id_not_its_uuid(db):
+    """``eval_models.id`` identifies the target; ``model_id`` is what the
+    provider is asked for. Sending the row id would name a model no provider
+    has."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    row = _real_target(db, "t-1", model_id="qwen3-8b")
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, [row], _config())
+    )
+    assert chat.calls[0]["model"] == "qwen3-8b"
+    assert conversations[0].target_id == row["id"]
+
+
+def test_a_target_without_a_model_id_fails_loudly(db):
+    """Unfixed, ``None`` reaches the provider as the model name and the
+    conversation records the literal string 'None' as its target."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    broken = dict(_real_target(db, "t-1"))
+    broken["model_id"] = None
+    with pytest.raises(ValueError, match="model_id"):
+        asyncio.run(
+            CharacterProbeRunner(chat).run([_card()], probe_set, [broken], _config())
+        )
+    assert chat.calls == []  # rejected before a single provider call
+
+
+def test_a_target_without_an_id_fails_loudly(db):
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    broken = dict(_real_target(db, "t-1"))
+    del broken["id"]
+    with pytest.raises(ValueError, match="'id'"):
+        asyncio.run(
+            CharacterProbeRunner(chat).run([_card()], probe_set, [broken], _config())
+        )
+
+
+def test_a_prefix_steered_target_is_rejected_rather_than_run_unsteered(db):
+    """A raw-completion prefix has no slot in a chat-shaped probe. Running it
+    anyway would evaluate an unsteered model while the run claims otherwise --
+    the exact silent-drop this package now refuses."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    prefixed = [_real_target(db, "raw", config={"prefix": "Be careful. "})]
+    with pytest.raises(ValueError, match="prefix"):
+        asyncio.run(
+            CharacterProbeRunner(chat).run([_card()], probe_set, prefixed, _config())
+        )
+    assert chat.calls == []
+
+
+def test_duplicate_targets_are_rejected(db):
+    """Everything downstream is keyed by target id, so a duplicate would
+    collapse two columns into one run's worth of results."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    row = _real_target(db, "t-1")
+    with pytest.raises(ValueError, match="duplicate"):
+        asyncio.run(
+            CharacterProbeRunner(chat).run([_card()], probe_set, [row, row], _config())
+        )
+
+
+def test_no_targets_at_all_is_rejected(db):
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    with pytest.raises(ValueError, match="at least one target"):
+        asyncio.run(CharacterProbeRunner(chat).run([_card()], probe_set, [], _config()))
+
+
+def test_cancelling_stops_scheduling_but_keeps_completed_turns(targets):
     """Cancel cannot abort an in-flight turn (to_thread survives cancellation),
     so it means: start nothing further, keep what finished."""
     from tldw_chatbook.Evals.character_probe.runner import CancelToken
@@ -147,7 +251,7 @@ def test_cancelling_stops_scheduling_but_keeps_completed_turns():
     probe_set = ProbeSet(probes=(Probe(turns=("One", "Two", "Three")),))
     (conversation,) = asyncio.run(
         CharacterProbeRunner(chat, cancel_token=token).run(
-            [_card()], probe_set, _targets(), _config()
+            [_card()], probe_set, targets, _config()
         )
     )
     assert len(conversation.turns) == 1
@@ -155,7 +259,7 @@ def test_cancelling_stops_scheduling_but_keeps_completed_turns():
     assert "Cancelled" in conversation.error
 
 
-def test_cancelling_starts_no_further_conversations():
+def test_cancelling_starts_no_further_conversations(targets):
     """Rule 2 is about the whole run, not just one conversation's remaining
     turns: once cancelled, conversations that have not yet run their first
     turn must come back as immediately-cancelled, not skipped or executed."""
@@ -175,7 +279,7 @@ def test_cancelling_starts_no_further_conversations():
     probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
     conversations = asyncio.run(
         CharacterProbeRunner(chat, cancel_token=token).run(
-            [_card()], probe_set, _targets(), _config()
+            [_card()], probe_set, targets, _config()
         )
     )
     assert len(calls) == 1  # the second conversation never reached the provider
@@ -185,7 +289,7 @@ def test_cancelling_starts_no_further_conversations():
     assert "Cancelled" in untouched[0].error
 
 
-def test_the_blocking_chat_callable_never_runs_on_the_event_loop():
+def test_the_blocking_chat_callable_never_runs_on_the_event_loop(targets):
     """chat_api_call is a plain def; calling it inline would freeze the TUI."""
     seen = {}
 
@@ -198,11 +302,11 @@ def test_the_blocking_chat_callable_never_runs_on_the_event_loop():
         return "ok"
 
     probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
-    asyncio.run(CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config()))
+    asyncio.run(CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config()))
     assert seen["on_loop"] is False
 
 
-def test_progress_callback_reports_running_totals():
+def test_progress_callback_reports_running_totals(targets):
     """`progress(done, total)` is the only feedback a caller gets while a
     grid runs; done must climb to exactly total, once per conversation."""
     chat = _FakeChat()
@@ -211,18 +315,39 @@ def test_progress_callback_reports_running_totals():
 
     asyncio.run(
         CharacterProbeRunner(chat).run(
-            [_card()], probe_set, _targets(), _config(), progress=lambda done, total: calls.append((done, total))
+            [_card()], probe_set, targets, _config(), progress=lambda done, total: calls.append((done, total))
         )
     )
     # concurrency=1 (config default) makes this deterministic.
     assert calls == [(1, 2), (2, 2)]
 
 
-def test_no_progress_callback_is_optional():
+def test_no_progress_callback_is_optional(targets):
     """progress=None (the default) must not be called and must not raise."""
     chat = _FakeChat()
     probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
     conversations = asyncio.run(
-        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
     )
     assert len(conversations) == 1
+
+
+def test_a_raising_progress_callback_cannot_destroy_the_run(targets):
+    """The callback runs inside an asyncio.gather child, so unguarded it
+    propagates out of gather and discards every conversation the run already
+    completed -- real provider calls thrown away because an observer failed.
+    A run's output must survive its observer."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+
+    def exploding_progress(done, total):
+        raise RuntimeError("the progress bar was unmounted")
+
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card()], probe_set, targets, _config(), progress=exploding_progress
+        )
+    )
+    assert len(conversations) == 2
+    assert [c.turns[0].reply for c in conversations] == ["ok-1", "ok-2"]
+    assert not any(c.error for c in conversations)

--- a/Tests/Evals/character_probe/test_runner.py
+++ b/Tests/Evals/character_probe/test_runner.py
@@ -1,0 +1,228 @@
+"""Tests for the character probe conversation runner.
+
+Covers the three rules the design spec calls out as load-bearing: the chat
+callable is dispatched through ``asyncio.to_thread`` and must never see a
+running loop; cancellation stops scheduling but cannot abort a turn already
+in flight; and each sample's seed is offset from the bench seed so repeated
+samples of a cell are not identical.
+"""
+
+import asyncio
+
+from tldw_chatbook.Evals.character_probe.models import (
+    CardSnapshot,
+    CharacterProbeConfig,
+    Probe,
+    ProbeSet,
+)
+from tldw_chatbook.Evals.character_probe.runner import CharacterProbeRunner
+
+
+class _FakeChat:
+    def __init__(self, reply="ok", fail_on=None):
+        self.calls = []
+        self._reply = reply
+        self._fail_on = fail_on
+
+    def __call__(self, messages, model, temperature, max_tokens, seed):
+        self.calls.append(
+            {"messages": messages, "model": model, "seed": seed, "temperature": temperature}
+        )
+        if self._fail_on is not None and len(self.calls) == self._fail_on:
+            raise RuntimeError("provider exploded")
+        return f"{self._reply}-{len(self.calls)}"
+
+
+def _card(card_id=1):
+    return CardSnapshot(id=card_id, name=f"card{card_id}", system_prompt="sys")
+
+
+def _config(**overrides):
+    base = dict(
+        name="b", probe_set_id="ps", character_ids=(1,), target_ids=("t-1",)
+    )
+    base.update(overrides)
+    return CharacterProbeConfig(**base)
+
+
+def _targets():
+    return [{"id": "t-1", "model_id": "m", "system_prompt": None}]
+
+
+def test_turns_run_in_order_and_each_sees_the_previous_reply():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One", "Two")),))
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    (conversation,) = conversations
+    assert [t.user for t in conversation.turns] == ["One", "Two"]
+    second_call_messages = chat.calls[1]["messages"]
+    assert second_call_messages[-2] == {"role": "assistant", "content": "ok-1"}
+
+
+def test_a_failed_turn_ends_only_its_own_conversation():
+    chat = _FakeChat(fail_on=1)
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    failed = [c for c in conversations if c.error]
+    survived = [c for c in conversations if not c.error]
+    assert len(failed) == 1 and "provider exploded" in failed[0].error
+    assert len(survived) == 1
+
+
+def test_partial_turns_are_kept_when_a_later_turn_fails():
+    chat = _FakeChat(fail_on=2)
+    probe_set = ProbeSet(probes=(Probe(turns=("One", "Two")),))
+    (conversation,) = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    assert conversation.turns[0].reply == "ok-1"
+    assert conversation.error
+
+
+def test_per_sample_seed_is_offset_so_samples_differ():
+    """A single fixed seed would return N identical answers -- see the spec."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card()], probe_set, _targets(), _config(samples_per_cell=3, seed=100)
+        )
+    )
+    assert sorted(call["seed"] for call in chat.calls) == [100, 101, 102]
+
+
+def test_no_seed_passes_none():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    assert chat.calls[0]["seed"] is None
+
+
+def test_the_grid_covers_cards_probes_targets_and_samples():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+    targets = [
+        {"id": "t-1", "model_id": "m1", "system_prompt": None},
+        {"id": "t-2", "model_id": "m2", "system_prompt": None},
+    ]
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card(1), _card(2)],
+            probe_set,
+            targets,
+            _config(character_ids=(1, 2), target_ids=("t-1", "t-2"), samples_per_cell=2),
+        )
+    )
+    assert len(conversations) == 2 * 2 * 2 * 2
+
+
+def test_target_steering_reaches_the_system_prompt():
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    targets = [{"id": "t-1", "model_id": "m", "system_prompt": "Be terse."}]
+    asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, targets, _config())
+    )
+    system = chat.calls[0]["messages"][0]["content"]
+    assert system.startswith("Be terse.")
+
+
+def test_cancelling_stops_scheduling_but_keeps_completed_turns():
+    """Cancel cannot abort an in-flight turn (to_thread survives cancellation),
+    so it means: start nothing further, keep what finished."""
+    from tldw_chatbook.Evals.character_probe.runner import CancelToken
+
+    token = CancelToken()
+
+    def chat(messages, model, temperature, max_tokens, seed):
+        token.cancel()  # cancelled while the first turn is in flight
+        return "first reply"
+
+    probe_set = ProbeSet(probes=(Probe(turns=("One", "Two", "Three")),))
+    (conversation,) = asyncio.run(
+        CharacterProbeRunner(chat, cancel_token=token).run(
+            [_card()], probe_set, _targets(), _config()
+        )
+    )
+    assert len(conversation.turns) == 1
+    assert conversation.turns[0].reply == "first reply"
+    assert "Cancelled" in conversation.error
+
+
+def test_cancelling_starts_no_further_conversations():
+    """Rule 2 is about the whole run, not just one conversation's remaining
+    turns: once cancelled, conversations that have not yet run their first
+    turn must come back as immediately-cancelled, not skipped or executed."""
+    from tldw_chatbook.Evals.character_probe.runner import CancelToken
+
+    token = CancelToken()
+    calls = []
+
+    def chat(messages, model, temperature, max_tokens, seed):
+        calls.append(1)
+        token.cancel()  # cancel during the very first provider call in the run
+        return "reply"
+
+    # concurrency=1 (the config default) makes ordering deterministic: probe 0
+    # must fully resolve (and trip the cancellation) before probe 1 is even
+    # attempted.
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat, cancel_token=token).run(
+            [_card()], probe_set, _targets(), _config()
+        )
+    )
+    assert len(calls) == 1  # the second conversation never reached the provider
+    assert len(conversations) == 2  # but it is still present, marked cancelled
+    untouched = [c for c in conversations if not c.turns]
+    assert len(untouched) == 1
+    assert "Cancelled" in untouched[0].error
+
+
+def test_the_blocking_chat_callable_never_runs_on_the_event_loop():
+    """chat_api_call is a plain def; calling it inline would freeze the TUI."""
+    seen = {}
+
+    def chat(messages, model, temperature, max_tokens, seed):
+        try:
+            asyncio.get_running_loop()
+            seen["on_loop"] = True
+        except RuntimeError:
+            seen["on_loop"] = False
+        return "ok"
+
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    asyncio.run(CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config()))
+    assert seen["on_loop"] is False
+
+
+def test_progress_callback_reports_running_totals():
+    """`progress(done, total)` is the only feedback a caller gets while a
+    grid runs; done must climb to exactly total, once per conversation."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)), Probe(turns=("Two",))))
+    calls = []
+
+    asyncio.run(
+        CharacterProbeRunner(chat).run(
+            [_card()], probe_set, _targets(), _config(), progress=lambda done, total: calls.append((done, total))
+        )
+    )
+    # concurrency=1 (config default) makes this deterministic.
+    assert calls == [(1, 2), (2, 2)]
+
+
+def test_no_progress_callback_is_optional():
+    """progress=None (the default) must not be called and must not raise."""
+    chat = _FakeChat()
+    probe_set = ProbeSet(probes=(Probe(turns=("One",)),))
+    conversations = asyncio.run(
+        CharacterProbeRunner(chat).run([_card()], probe_set, _targets(), _config())
+    )
+    assert len(conversations) == 1

--- a/Tests/Evals/test_evals_db_v3_to_v4_migration.py
+++ b/Tests/Evals/test_evals_db_v3_to_v4_migration.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import sqlite3
 
-from tldw_chatbook.DB.Evals_DB import EvalsDB
+from tldw_chatbook.DB.Evals_DB import SCHEMA_VERSION, EvalsDB
 from tldw_chatbook.DB.sql_validation import validate_identifier
 
 #: The exact v3 shape of Evals_DB._create_schema, minus `run_group_id` and
@@ -284,15 +284,20 @@ def test_v3_database_really_lacks_run_group_id_before_it_is_opened(tmp_path):
 
 def test_opening_a_v3_database_migrates_to_v4_and_adds_run_group_id(tmp_path):
     """The ALTER TABLE path: EvalsDB opening a real, hand-built v3 file must
-    reach SCHEMA_VERSION 4, add `eval_runs.run_group_id`, and create its
-    index -- the exact upgrade every existing user's database takes."""
+    pass through the v4 step, add `eval_runs.run_group_id`, and create its
+    index -- the exact upgrade every existing user's database takes. The
+    final PRAGMA user_version is compared against the live SCHEMA_VERSION
+    rather than a literal 4: opening a v3 database runs every migration up
+    to the current version in one pass (task-1691 added a v5 step after
+    this test was written), and this test's own concern is the v3->v4
+    ALTER specifically, not freezing the module's overall version."""
     path = str(tmp_path / "v3.db")
     ids = _build_v3_database(path)
 
     db = EvalsDB(db_path=path, client_id="test")
     conn = db.get_connection()
 
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
 
     columns = {row[1] for row in conn.execute("PRAGMA table_info(eval_runs)")}
     assert "run_group_id" in columns
@@ -341,7 +346,7 @@ def test_reopening_a_migrated_v3_database_is_idempotent(tmp_path):
 
     first = EvalsDB(db_path=path, client_id="test")
     first_conn = first.get_connection()
-    assert first_conn.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert first_conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
 
     # A second, independent EvalsDB instance opening the same file must not
     # raise (the guarded `if "run_group_id" not in existing` check in
@@ -351,7 +356,7 @@ def test_reopening_a_migrated_v3_database_is_idempotent(tmp_path):
     second = EvalsDB(db_path=path, client_id="test")
     second_conn = second.get_connection()
 
-    assert second_conn.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert second_conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
     columns = {row[1] for row in second_conn.execute("PRAGMA table_info(eval_runs)")}
     assert "run_group_id" in columns
     indexes = [

--- a/Tests/Evals/word_bench/test_storage.py
+++ b/Tests/Evals/word_bench/test_storage.py
@@ -38,8 +38,12 @@ def _capture(token=" a"):
     )
 
 
-def test_schema_version_is_four():
-    assert SCHEMA_VERSION == 4
+def test_schema_version_is_five():
+    # task-1691 phase 1: bumped for the character probe annotation and
+    # review-state tables (eval_probe_turn_annotations/eval_probe_review_state)
+    # added to this same shared Evals_DB schema -- word_bench's own tables
+    # and behavior are unchanged.
+    assert SCHEMA_VERSION == 5
 
 
 def test_run_group_id_column_exists(db):

--- a/backlog/tasks/task-1744 - Shared card-to-prompt assembly with full-card fidelity in Console.md
+++ b/backlog/tasks/task-1744 - Shared card-to-prompt assembly with full-card fidelity in Console.md
@@ -1,0 +1,45 @@
+---
+id: TASK-1744
+title: Shared card-to-prompt assembly with full-card fidelity in Console
+status: To Do
+assignee: []
+created_date: '2026-08-01 11:16'
+labels:
+  - evals
+  - roleplay
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The character-probe eval engine (`tldw_chatbook/Evals/character_probe/prompt.py`) composes a
+card's system prompt from every field that shapes voice, including `message_example` and
+`post_history_instructions`. Console's own card->prompt joiner
+(`UI/Screens/chat_screen.py::_character_session_prompt_seed`) sends only `system_prompt`,
+`personality`, `description`, and `scenario` -- it omits both fields today, so a character in
+Console does not behave exactly as its author wrote it, and a probe run is not byte-identical to
+what Console actually sends.
+
+This was originally meant to be a non-issue: the phase 1 design spec called for the eval to reuse
+Console's existing card->prompt path rather than duplicate it. That reuse turned out to be
+impossible as scoped -- the only implementation lived in `UI/Screens/chat_screen.py`, and the
+eval engine may not import from `UI/` (the eval must stay a pure, UI-independent package). The
+engine ended up with its own, more complete assembly instead, which is the behavior the human
+has ruled correct: full-card fidelity stays, and Console should be brought up to match it, not
+the other way around.
+
+The goal is to extract one card->prompt function that both the character-probe engine and Console
+use, with Console gaining `message_example` and `post_history_instructions` so characters behave
+as authored in real chat, not just in probe runs. This also finally removes the duplicate prompt
+logic the original spec wanted to avoid but could not deliver, since the shared function can now
+live somewhere both the engine and the UI layer are permitted to import from.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 One shared card->prompt function is used by both the character-probe engine and Console's chat path -- no second, independently-maintained copy of the assembly logic remains in either place
+- [ ] #2 Console's assembled system prompt includes `message_example` and `post_history_instructions` content for cards that carry it, matching what the character-probe engine already sends
+- [ ] #3 A test proves both callers produce identical prompt assembly output for the same card and steering input
+<!-- AC:END -->

--- a/backlog/tasks/task-1754 - Move model_steering to a shared home and pin the import graph.md
+++ b/backlog/tasks/task-1754 - Move model_steering to a shared home and pin the import graph.md
@@ -1,0 +1,70 @@
+---
+id: TASK-1754
+title: Move model_steering to a shared home and pin the import graph
+status: To Do
+assignee: []
+created_date: '2026-08-01 12:45'
+labels:
+  - evals
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A target's steering lives inside its `eval_models` row's `config` JSON, and the app has exactly one
+reader for it: `word_bench.storage.model_steering` (with its helper `_steering_field`). Both are
+pure functions of a row dict — they touch nothing else in `word_bench` — but they live inside a
+module whose own imports reach `capture_client`, `normalizer`, and `httpx`.
+
+The character-probe engine reuses that reader deliberately (`character_probe/targets.py`), and that
+reuse is correct: the alternative was tried and produced Critical C1 of the phase 1 whole-branch
+review, in which a second, private steering reader looked for `row["system_prompt"]` — a key no
+`eval_models` row has ever carried — so every real run silently dropped its target's steering while
+a hand-built test fixture agreed with the bug. Duplicating a row reader is the failure mode, not the
+fix.
+
+The cost is that importing the character-probe package now drags word_bench's measurement stack in
+transitively, which contradicts the letter of that package's own separation rule (phase 1 exit
+criterion 3, since amended to say what is actually true). The intent of the rule holds — no
+distribution vocabulary or concepts appear anywhere in the character-probe source or surface — but
+the import graph does not.
+
+The rule's in-repo guard is also weaker than the rule itself:
+`Tests/Evals/character_probe/test_conversation_storage.py::test_character_probe_never_imports_the_word_bench_measurement_stack`
+greps each module's SOURCE TEXT for forbidden tokens, so it cannot detect an import-graph violation
+at all and passes on exactly this situation. A hygiene test that cannot fail on the thing it is
+named after is a false assurance, and this repo has paid for false assurances before.
+
+Moving the reader to a shared home that neither package's stack rides on lets both bench types keep
+one definition of what a stored row means without either dragging the other's dependencies. It
+complements TASK-1744's de-duplication theme: one function, one meaning, imported by everyone who
+needs it, rather than a copy per caller.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `model_steering` and its `_steering_field` helper live in a shared module that imports neither `word_bench`'s nor `character_probe`'s own modules, and both packages read a target's steering through it
+- [ ] #2 No copy of the steering-reading logic remains in `word_bench.storage` or anywhere else — callers of the old name continue to work or are updated, with no second implementation
+- [ ] #3 Importing `tldw_chatbook.Evals.character_probe` (any module of it) does not load `word_bench`'s capture client, normalizer, or `httpx`
+- [ ] #4 The character-probe hygiene test asserts on the real import graph (e.g. inspecting `sys.modules` after a fresh package import in a subprocess) rather than on source tokens, and is proven to FAIL when a forbidden import is reintroduced
+- [ ] #5 The word bench's own behaviour is unchanged: `Tests/Evals/word_bench/` passes untouched
+- [ ] #6 Phase 1 exit criterion 3 in `Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md` is restored to its original absolute wording once the import graph actually satisfies it
+<!-- AC:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two Phase 2 caveats recorded here so they are not rediscovered the expensive way. Neither is this
+task's work; both are consequences of phase 1's fail-loudly choices that a UI author will meet.
+
+- **`_stored_int_field` is strict against JSON floats.** `load_character_bench` rejects a stored
+  `512.0` as a non-integer `max_tokens`; the previous `int()` coercion silently truncated it (and
+  accepted the string `"512"`). A form control or JSON payload that emits whole numbers as floats
+  will make a bench fail to load. Coerce at the UI boundary — do not loosen the loader back.
+- **`eval_models` has `UNIQUE(name, provider, model_id)`.** `targets.resolve_target` rejects a
+  prefix-steered target and tells the user to use a chat-mode one instead; steering is immutable per
+  row (there is no `update_model`), so that means creating a NEW row. A Phase 2 "duplicate this
+  target" affordance must offer a **different name**, or `create_model` raises `ConflictError`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -37,7 +37,7 @@ from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
 
 # Database Schema Version
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 
 class EvalsDBError(Exception):
@@ -308,6 +308,42 @@ class EvalsDB:
             )
         """)
 
+        # Character probe review tables (task-1691 phase 1): per-turn
+        # annotations and per-conversation review state are two separate
+        # homes -- see EvalsDB.upsert_probe_turn_annotation/
+        # upsert_probe_review_state for why they must not be merged.
+        conn.execute("""
+            CREATE TABLE eval_probe_turn_annotations (
+                id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+                run_group_id TEXT NOT NULL,
+                card_id INTEGER NOT NULL,
+                probe_index INTEGER NOT NULL,
+                sample_index INTEGER NOT NULL,
+                target_id TEXT NOT NULL,
+                turn_index INTEGER NOT NULL,
+                tags TEXT NOT NULL,          -- JSON list of tag slugs
+                note TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+                client_id TEXT NOT NULL,
+                UNIQUE(run_group_id, card_id, probe_index, sample_index, target_id, turn_index)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE eval_probe_review_state (
+                id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+                run_group_id TEXT NOT NULL,
+                card_id INTEGER NOT NULL,
+                probe_index INTEGER NOT NULL,
+                sample_index INTEGER NOT NULL,
+                target_id TEXT NOT NULL,
+                note TEXT NOT NULL DEFAULT '',
+                reviewed_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+                client_id TEXT NOT NULL,
+                UNIQUE(run_group_id, card_id, probe_index, sample_index, target_id)
+            )
+        """)
+
         # Create indexes for performance
         conn.execute("CREATE INDEX idx_eval_tasks_type ON eval_tasks (task_type)")
         conn.execute("CREATE INDEX idx_eval_tasks_deleted ON eval_tasks (deleted_at)")
@@ -318,6 +354,14 @@ class EvalsDB:
         conn.execute("CREATE INDEX idx_eval_results_run ON eval_results (run_id)")
         conn.execute(
             "CREATE INDEX idx_eval_run_metrics_run ON eval_run_metrics (run_id)"
+        )
+        conn.execute(
+            "CREATE INDEX idx_probe_annotations_group "
+            "ON eval_probe_turn_annotations (run_group_id)"
+        )
+        conn.execute(
+            "CREATE INDEX idx_probe_review_group "
+            "ON eval_probe_review_state (run_group_id)"
         )
 
         # Create FTS5 tables for search
@@ -581,6 +625,52 @@ class EvalsDB:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_eval_runs_group "
                 "ON eval_runs (run_group_id)"
+            )
+
+        if current_version < 5 and SCHEMA_VERSION >= 5:
+            logger.info(
+                "Migrating to version 5: Adding character probe annotation "
+                "and review-state tables"
+            )
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS eval_probe_turn_annotations (
+                    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+                    run_group_id TEXT NOT NULL,
+                    card_id INTEGER NOT NULL,
+                    probe_index INTEGER NOT NULL,
+                    sample_index INTEGER NOT NULL,
+                    target_id TEXT NOT NULL,
+                    turn_index INTEGER NOT NULL,
+                    tags TEXT NOT NULL,
+                    note TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+                    client_id TEXT NOT NULL,
+                    UNIQUE(run_group_id, card_id, probe_index, sample_index, target_id, turn_index)
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS eval_probe_review_state (
+                    id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+                    run_group_id TEXT NOT NULL,
+                    card_id INTEGER NOT NULL,
+                    probe_index INTEGER NOT NULL,
+                    sample_index INTEGER NOT NULL,
+                    target_id TEXT NOT NULL,
+                    note TEXT NOT NULL DEFAULT '',
+                    reviewed_at TEXT NOT NULL DEFAULT (datetime('now', 'utc')),
+                    client_id TEXT NOT NULL,
+                    UNIQUE(run_group_id, card_id, probe_index, sample_index, target_id)
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_probe_annotations_group "
+                "ON eval_probe_turn_annotations (run_group_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_probe_review_group "
+                "ON eval_probe_review_state (run_group_id)"
             )
 
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
@@ -1707,6 +1797,145 @@ class EvalsDB:
             }
 
         return metrics
+
+    # --- Character Probe Review Management (task-1691 phase 1) ---
+    #
+    # Two separate homes, deliberately not merged:
+    #   eval_probe_turn_annotations -- keyed down to turn_index, holds tags
+    #     + a note about ONE turn ("it broke character on the third turn").
+    #   eval_probe_review_state -- keyed one level up (no turn_index), holds
+    #     reviewed_at + an optional note about a WHOLE conversation. This is
+    #     the only home for "I read this and nothing was notable", which
+    #     must be recordable with zero turn annotations.
+    # Both use INSERT OR REPLACE against their UNIQUE key, the same
+    # replace-on-conflict convention store_run_metrics already uses above:
+    # re-annotating a turn, or re-marking a conversation reviewed, replaces
+    # the prior row (a fresh id, created_at, and updated_at/reviewed_at)
+    # rather than erroring or accumulating duplicates.
+
+    def upsert_probe_turn_annotation(
+        self,
+        run_group_id: str,
+        card_id: int,
+        probe_index: int,
+        sample_index: int,
+        target_id: str,
+        turn_index: int,
+        tags: List[str],
+        note: str = "",
+    ) -> None:
+        """Create or replace one conversation turn's annotation.
+
+        Args:
+            run_group_id: The run group the conversation belongs to.
+            card_id: The character card's ``character_cards.id``.
+            probe_index: The probe's zero-based index within its probe set.
+            sample_index: The zero-based sample number for this cell.
+            target_id: The target's ``eval_models.id``.
+            turn_index: The zero-based turn within the conversation.
+            tags: Tag slugs describing this turn. Stored as a JSON list.
+            note: Free-text reviewer note for this turn.
+        """
+        conn = self._get_connection()
+        with conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO eval_probe_turn_annotations
+                (run_group_id, card_id, probe_index, sample_index, target_id,
+                 turn_index, tags, note, client_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_group_id,
+                    card_id,
+                    probe_index,
+                    sample_index,
+                    target_id,
+                    turn_index,
+                    json.dumps(list(tags)),
+                    note,
+                    self.client_id,
+                ),
+            )
+
+    def list_probe_turn_annotations(self, run_group_id: str) -> List[Dict[str, Any]]:
+        """Every turn annotation recorded for one run group.
+
+        Args:
+            run_group_id: The run group to read.
+
+        Returns:
+            Matching ``eval_probe_turn_annotations`` rows, each with ``tags``
+            parsed from JSON into a list.
+        """
+        conn = self._get_connection()
+        cursor = conn.execute(
+            "SELECT * FROM eval_probe_turn_annotations WHERE run_group_id = ?",
+            (run_group_id,),
+        )
+        rows = []
+        for row in cursor.fetchall():
+            data = dict(row)
+            data["tags"] = json.loads(data["tags"])
+            rows.append(data)
+        return rows
+
+    def upsert_probe_review_state(
+        self,
+        run_group_id: str,
+        card_id: int,
+        probe_index: int,
+        sample_index: int,
+        target_id: str,
+        note: str = "",
+    ) -> None:
+        """Mark one conversation reviewed, creating or replacing its state.
+
+        Args:
+            run_group_id: The run group the conversation belongs to.
+            card_id: The character card's ``character_cards.id``.
+            probe_index: The probe's zero-based index within its probe set.
+            sample_index: The zero-based sample number for this cell.
+            target_id: The target's ``eval_models.id``.
+            note: Free-text reviewer note for the whole conversation. Empty
+                is a normal value -- "reviewed, nothing notable" carries no
+                note at all.
+        """
+        conn = self._get_connection()
+        with conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO eval_probe_review_state
+                (run_group_id, card_id, probe_index, sample_index, target_id,
+                 note, client_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_group_id,
+                    card_id,
+                    probe_index,
+                    sample_index,
+                    target_id,
+                    note,
+                    self.client_id,
+                ),
+            )
+
+    def list_probe_review_state(self, run_group_id: str) -> List[Dict[str, Any]]:
+        """Every conversation's review state for one run group.
+
+        Args:
+            run_group_id: The run group to read.
+
+        Returns:
+            Matching ``eval_probe_review_state`` rows.
+        """
+        conn = self._get_connection()
+        cursor = conn.execute(
+            "SELECT * FROM eval_probe_review_state WHERE run_group_id = ?",
+            (run_group_id,),
+        )
+        return [dict(row) for row in cursor.fetchall()]
 
     # --- Analysis Methods ---
 

--- a/tldw_chatbook/Evals/character_probe/__init__.py
+++ b/tldw_chatbook/Evals/character_probe/__init__.py
@@ -1,0 +1,7 @@
+"""Character probe evals: scripted question sets run against character cards,
+collected as conversations for human review.
+
+Sibling package to ``word_bench``. Shares its targets, run groups, and rail,
+but none of its measurement stack -- see
+``Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md``.
+"""

--- a/tldw_chatbook/Evals/character_probe/cards.py
+++ b/tldw_chatbook/Evals/character_probe/cards.py
@@ -25,29 +25,58 @@ def snapshot_cards(chacha_db: Any, character_ids: Sequence[int]) -> tuple[CardSn
     Args:
         chacha_db: A ``CharactersRAGDB``-shaped handle; only
             ``get_character_card_by_id`` is used, so a fake needs just that.
-        character_ids: ``character_cards.id`` values, as INTEGERs.
+        character_ids: ``character_cards.id`` values, as genuine ``int``.
+            Not merely documented: a handle that accepts a non-int id (e.g.
+            a string that a driver happens to coerce) is exactly the kind
+            of load-bearing accident this package refuses to tolerate, so
+            each id's type is checked here rather than trusted from the
+            caller.
 
     Returns:
         tuple[CardSnapshot, ...]: One snapshot per id, in the order given.
+        Each snapshot's ``id`` is always the *requested* id, never merely
+        echoed back from the row, so a caller can trust the snapshot is
+        labelled with what it asked for.
 
     Raises:
-        ValueError: If no ids are supplied, or a card cannot be found -- the
-            message names the missing id so the caller can drop it from the
-            bench rather than guessing which card vanished.
+        ValueError: If no ids are supplied.
+        ValueError: If any id is not a genuine ``int`` (``bool`` included,
+            since it is an ``int`` subclass but never a real card id) --
+            mirrors ``CharacterProbeConfig``'s own id validation.
+        ValueError: If a card cannot be found -- the message names the
+            missing id so the caller can drop it from the bench rather than
+            guessing which card vanished.
+        ValueError: If the row returned for an id carries its own ``id``
+            field and it disagrees with the requested id -- accepting the
+            row's id here would let a misbehaving handle mislabel a
+            snapshot, and a mislabelled snapshot is permanent once a run
+            records it.
     """
     if not character_ids:
         raise ValueError("A character probe run needs at least one character.")
     snapshots: list[CardSnapshot] = []
     for character_id in character_ids:
+        if not isinstance(character_id, int) or isinstance(character_id, bool):
+            raise ValueError(
+                f"character_ids must be int (character_cards.id), got "
+                f"{character_id!r} of type {type(character_id).__name__}."
+            )
         row = chacha_db.get_character_card_by_id(character_id)
         if not row:
             raise ValueError(
                 f"Character card {character_id} could not be found; "
                 "remove it from the bench or restore the card."
             )
+        row_id = row.get("id", character_id)
+        if row_id != character_id:
+            raise ValueError(
+                f"Character card handle returned id {row_id!r} for "
+                f"requested id {character_id!r}; refusing to snapshot a "
+                "mismatched row."
+            )
         snapshots.append(
             CardSnapshot(
-                id=int(row.get("id", character_id)),
+                id=character_id,
                 name=str(row.get("name") or ""),
                 **{field: str(row.get(field) or "") for field in _SNAPSHOT_FIELDS},
             )

--- a/tldw_chatbook/Evals/character_probe/cards.py
+++ b/tldw_chatbook/Evals/character_probe/cards.py
@@ -6,10 +6,24 @@ from typing import Any, Sequence
 
 from .models import CardSnapshot
 
-#: Card fields copied into a run. Every one participates in prompt assembly;
-#: anything not listed here (images, timestamps, versions) is deliberately
-#: excluded because it cannot change what the model sees.
+#: Card fields copied into a run. Every one participates in prompt assembly,
+#: and adding a field here is only HALF the change --
+#: ``prompt.compose_system_prompt`` must compose it too, or the snapshot
+#: grows text the model never sees.
+#:
+#: What is excluded is the card's non-prompting columns (``image``, the
+#: ``created_at``/``last_modified`` timestamps, ``version``/``client_id``/
+#: ``deleted``) plus the metadata columns no probe path reads today
+#: (``creator_notes``, ``alternate_greetings``, ``tags``, ``creator``,
+#: ``character_version``, ``extensions``). Omitting a field from this list
+#: is NOT automatically harmless: ``description`` -- the primary V2 persona
+#: field, which Console itself sends -- was missing here until the
+#: whole-branch review of task-1691 phase 1, and every probe until then ran
+#: against a character stripped of its main definition. Anything omitted in
+#: future must be omitted because it is not prompting text, not because a
+#: list happened not to mention it.
 _SNAPSHOT_FIELDS = (
+    "description",
     "system_prompt",
     "personality",
     "scenario",

--- a/tldw_chatbook/Evals/character_probe/cards.py
+++ b/tldw_chatbook/Evals/character_probe/cards.py
@@ -1,0 +1,55 @@
+"""Read-only card access across the ChaChaNotes/Evals database boundary."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from .models import CardSnapshot
+
+#: Card fields copied into a run. Every one participates in prompt assembly;
+#: anything not listed here (images, timestamps, versions) is deliberately
+#: excluded because it cannot change what the model sees.
+_SNAPSHOT_FIELDS = (
+    "system_prompt",
+    "personality",
+    "scenario",
+    "first_message",
+    "post_history_instructions",
+    "message_example",
+)
+
+
+def snapshot_cards(chacha_db: Any, character_ids: Sequence[int]) -> tuple[CardSnapshot, ...]:
+    """Copy each requested card's prompting text, in the requested order.
+
+    Args:
+        chacha_db: A ``CharactersRAGDB``-shaped handle; only
+            ``get_character_card_by_id`` is used, so a fake needs just that.
+        character_ids: ``character_cards.id`` values, as INTEGERs.
+
+    Returns:
+        tuple[CardSnapshot, ...]: One snapshot per id, in the order given.
+
+    Raises:
+        ValueError: If no ids are supplied, or a card cannot be found -- the
+            message names the missing id so the caller can drop it from the
+            bench rather than guessing which card vanished.
+    """
+    if not character_ids:
+        raise ValueError("A character probe run needs at least one character.")
+    snapshots: list[CardSnapshot] = []
+    for character_id in character_ids:
+        row = chacha_db.get_character_card_by_id(character_id)
+        if not row:
+            raise ValueError(
+                f"Character card {character_id} could not be found; "
+                "remove it from the bench or restore the card."
+            )
+        snapshots.append(
+            CardSnapshot(
+                id=int(row.get("id", character_id)),
+                name=str(row.get("name") or ""),
+                **{field: str(row.get(field) or "") for field in _SNAPSHOT_FIELDS},
+            )
+        )
+    return tuple(snapshots)

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -102,10 +102,20 @@ class CardSnapshot:
     foreign keys between them. Copying the text into the run means editing or
     deleting a card later never rewrites what a past run shows -- the same
     provenance rule word_bench applies to snippets.
+
+    Every field here is prompting text and every one is composed by
+    ``prompt.compose_system_prompt`` (``name`` additionally supplies the
+    ``{{char}}`` macro's value). ``description`` is the primary V2 persona
+    field: it was absent from this dataclass, from ``cards._SNAPSHOT_FIELDS``,
+    and from the design spec's field list until the whole-branch review of
+    task-1691 phase 1, so every probe ran against a character stripped of its
+    main definition. Adding a field here is only half a change -- compose it
+    in ``prompt.py`` too, or the snapshot grows text the model never sees.
     """
 
     id: int
     name: str
+    description: str = ""
     system_prompt: str = ""
     personality: str = ""
     scenario: str = ""
@@ -118,10 +128,22 @@ class CardSnapshot:
 class ConversationTurn:
     """One scripted user turn and the model's reply to it.
 
-    ``reply`` and ``error`` are both ``""`` by default: a turn that never
-    ran (the conversation was cancelled or failed before reaching it) is
-    simply absent from a ``Conversation.turns`` tuple, so a turn that *is*
-    present but carries no reply text is not a state this runner produces.
+    A turn is recorded only once its provider call has returned, so a turn
+    that never ran (the conversation was cancelled or failed before reaching
+    it) is simply absent from its ``Conversation.turns`` tuple. A turn that
+    *is* present may still carry ``reply == ""``, and that IS a state this
+    runner produces: the provider callable is allowed to return empty text
+    (the app's own response extraction yields ``""`` rather than raising for
+    a response with no content) and the runner records it verbatim. "The
+    model said nothing" is a real observation this eval exists to surface,
+    not a malformed row.
+
+    ``error`` is RESERVED and is never populated by the runner today: a
+    failed turn ends its whole conversation, and ``Conversation.error`` is
+    that failure's only home. The field exists -- and round-trips through
+    storage -- so that a future per-turn record (a retried turn, say) has
+    somewhere to live without a storage migration. Do not read ``""`` here
+    as "this turn succeeded"; read ``Conversation.error`` for that.
     """
 
     user: str

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -1,0 +1,28 @@
+"""Pure data for character probe evals. No I/O, no Textual, no provider calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Probe:
+    """One scripted exchange: an ordered list of user turns.
+
+    A "one-off" question is simply a probe with a single turn -- there is no
+    separate type for it. Turn text is verbatim, including interior newlines,
+    because prompt formatting changes model behaviour.
+    """
+
+    turns: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.turns:
+            raise ValueError("A probe needs at least one turn.")
+
+
+@dataclass(frozen=True)
+class ProbeSet:
+    """An ordered collection of probes, the unit a bench runs."""
+
+    probes: tuple[Probe, ...]

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -33,3 +34,46 @@ class ProbeSet:
     """An ordered collection of probes, the unit a bench runs."""
 
     probes: tuple[Probe, ...]
+
+
+@dataclass(frozen=True)
+class CharacterProbeConfig:
+    """A character probe bench definition.
+
+    ``character_ids`` are ``character_cards.id`` INTEGERs, unlike every eval
+    id in this slice, which is TEXT. They are deliberately not normalised to
+    strings: the cross-database lookup against ``ChaChaNotes_DB`` binds them
+    as integers.
+
+    Defaults are conservative on purpose: ``samples_per_cell=1`` (no
+    surprise fan-out cost), ``seed=None`` (no false sense of determinism
+    unless explicitly requested), and ``concurrency=1`` (no surprise
+    parallel-request load against a target).
+
+    Raises:
+        ValueError: If ``samples_per_cell`` or ``concurrency`` is less than
+            1, or if ``character_ids``/``target_ids`` is empty -- a bench
+            with no characters or no targets can never produce a cell.
+    """
+
+    name: str
+    probe_set_id: str
+    character_ids: tuple[int, ...]
+    target_ids: tuple[str, ...]
+    description: str = ""
+    concurrency: int = 1
+    samples_per_cell: int = 1
+    seed: Optional[int] = None
+    temperature: float = 0.8
+    max_tokens: int = 512
+    extra_tags: tuple[dict, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.samples_per_cell < 1:
+            raise ValueError("samples_per_cell must be 1 or more.")
+        if self.concurrency < 1:
+            raise ValueError("concurrency must be 1 or more.")
+        if not self.character_ids:
+            raise ValueError("A character probe bench needs at least one character.")
+        if not self.target_ids:
+            raise ValueError("A character probe bench needs at least one target.")

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -92,3 +92,23 @@ class CharacterProbeConfig:
                     f"character_ids must be int (character_cards.id), got "
                     f"{cid!r} of type {type(cid).__name__}."
                 )
+
+
+@dataclass(frozen=True)
+class CardSnapshot:
+    """A character card's text, copied at run time.
+
+    Cards live in ``ChaChaNotes_DB`` while runs live in ``Evals_DB``, with no
+    foreign keys between them. Copying the text into the run means editing or
+    deleting a card later never rewrites what a past run shows -- the same
+    provenance rule word_bench applies to snippets.
+    """
+
+    id: int
+    name: str
+    system_prompt: str = ""
+    personality: str = ""
+    scenario: str = ""
+    first_message: str = ""
+    post_history_instructions: str = ""
+    message_example: str = ""

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -12,6 +12,10 @@ class Probe:
     A "one-off" question is simply a probe with a single turn -- there is no
     separate type for it. Turn text is verbatim, including interior newlines,
     because prompt formatting changes model behaviour.
+
+    Raises:
+        ValueError: If the probe has no turns, or if any turn is empty or
+            contains only whitespace.
     """
 
     turns: tuple[str, ...]
@@ -19,6 +23,9 @@ class Probe:
     def __post_init__(self) -> None:
         if not self.turns:
             raise ValueError("A probe needs at least one turn.")
+        for turn in self.turns:
+            if not turn.strip():
+                raise ValueError("A turn cannot be empty or whitespace-only.")
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -56,6 +56,23 @@ class CharacterProbeConfig:
     unless explicitly requested), and ``concurrency=1`` (no surprise
     parallel-request load against a target).
 
+    ``seed`` has THREE meanings, and the distinction is load-bearing rather
+    than cosmetic -- ``runner._sample_seed`` branches on it:
+
+    * ``None`` -- unseeded. No seed is sent at all.
+    * a NEGATIVE value -- the "pick a random seed" sentinel llama.cpp
+      defines (``-1`` conventionally). It is a sentinel, not a number to do
+      arithmetic on, so it is sent UNCHANGED for every sample of a cell.
+      Offsetting it would make ``-1`` run as ``-1, 0, 1, ...``: sample 0
+      randomly seeded, every later sample deterministic and never asked
+      for, which destroys exactly the variance multi-sampling exists to
+      show.
+    * ZERO or POSITIVE -- a real seed. The per-sample seed is
+      ``seed + sample_index``, so a seeded run is reproducible *and* its
+      samples genuinely differ. ``0`` is a real seed here, not a falsy
+      stand-in for "unset" (the same distinction ``storage``'s stored-field
+      readers enforce).
+
     Raises:
         ValueError: If ``samples_per_cell`` or ``concurrency`` is less than
             1, or if ``character_ids``/``target_ids`` is empty -- a bench

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -112,3 +112,37 @@ class CardSnapshot:
     first_message: str = ""
     post_history_instructions: str = ""
     message_example: str = ""
+
+
+@dataclass(frozen=True)
+class ConversationTurn:
+    """One scripted user turn and the model's reply to it.
+
+    ``reply`` and ``error`` are both ``""`` by default: a turn that never
+    ran (the conversation was cancelled or failed before reaching it) is
+    simply absent from a ``Conversation.turns`` tuple, so a turn that *is*
+    present but carries no reply text is not a state this runner produces.
+    """
+
+    user: str
+    reply: str
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class Conversation:
+    """One cell: a card, a probe, a target, and one sample of the exchange.
+
+    ``turns`` holds only the turns that actually ran -- a conversation that
+    failed or was cancelled partway through keeps its completed turns and
+    records why it stopped in ``error``, rather than discarding the partial
+    transcript. A failed or partial conversation is still evidence and stays
+    reviewable.
+    """
+
+    card_id: int
+    probe_index: int
+    sample_index: int
+    target_id: str
+    turns: tuple[ConversationTurn, ...]
+    error: str = ""

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -43,7 +43,13 @@ class CharacterProbeConfig:
     ``character_ids`` are ``character_cards.id`` INTEGERs, unlike every eval
     id in this slice, which is TEXT. They are deliberately not normalised to
     strings: the cross-database lookup against ``ChaChaNotes_DB`` binds them
-    as integers.
+    as integers. This is enforced here, not merely documented: a caller
+    constructing one directly with string ids (e.g. ``("3", "7")``, easy to
+    do by accident from a form field) is rejected at construction rather
+    than being accepted here only to come back out as ``int`` after a
+    ``storage.save_character_bench``/``load_character_bench`` round trip --
+    an asymmetry a future UI caller would otherwise have to discover the
+    expensive way.
 
     Defaults are conservative on purpose: ``samples_per_cell=1`` (no
     surprise fan-out cost), ``seed=None`` (no false sense of determinism
@@ -54,6 +60,9 @@ class CharacterProbeConfig:
         ValueError: If ``samples_per_cell`` or ``concurrency`` is less than
             1, or if ``character_ids``/``target_ids`` is empty -- a bench
             with no characters or no targets can never produce a cell.
+        ValueError: If any element of ``character_ids`` is not an ``int``
+            (``bool`` included, since it is an ``int`` subclass but never a
+            real card id) -- see the type-fidelity note above.
     """
 
     name: str
@@ -77,3 +86,9 @@ class CharacterProbeConfig:
             raise ValueError("A character probe bench needs at least one character.")
         if not self.target_ids:
             raise ValueError("A character probe bench needs at least one target.")
+        for cid in self.character_ids:
+            if not isinstance(cid, int) or isinstance(cid, bool):
+                raise ValueError(
+                    f"character_ids must be int (character_cards.id), got "
+                    f"{cid!r} of type {type(cid).__name__}."
+                )

--- a/tldw_chatbook/Evals/character_probe/probe_format.py
+++ b/tldw_chatbook/Evals/character_probe/probe_format.py
@@ -3,6 +3,20 @@
 Turns are delimited explicitly rather than by line breaks so a single turn can
 be a multi-paragraph prompt -- complex prompts are exactly what this eval
 exists to study, and a newline-delimited format could not express one.
+
+**Delimiter matching is lenient about surrounding whitespace**: a line
+delimits when ``line.strip()`` equals the delimiter, so ``"  ---  "`` is a
+delimiter just as ``"---"`` is. The spec's wording ("a line of ``---``")
+reads stricter than that, and the leniency is a deliberate ruling rather
+than an oversight. The two failure modes are not symmetric: with a strict
+match, an INVISIBLE trailing space makes a delimiter silently fail to
+delimit, merging two turns into one prompt that then runs and produces
+plausible-looking results -- likely to happen (editors and copy-paste add
+trailing whitespace constantly) and very hard to see. With the lenient
+match, the cost is that an indented literal ``---`` inside a turn is eaten
+as a delimiter -- less likely, and it fails visibly as a probe split in the
+wrong place. The lenient reading is chosen for that reason; the cost is
+documented rather than hidden, and pinned by test.
 """
 
 from __future__ import annotations
@@ -45,6 +59,13 @@ def _clean_turn(raw: str) -> str:
 
 def parse_probe_text(text: str) -> ProbeSet:
     """Parse the plain-text probe format into a ``ProbeSet``.
+
+    A line delimits when its STRIPPED content equals the delimiter, so
+    ``"  ---  "`` and ``"\t==="`` delimit exactly as a bare ``---``/``===``
+    does. That leniency is deliberate (see the module note below), and it
+    widens the v1 escaping limitation: no line whose stripped content is
+    ``---`` or ``===`` can appear inside a turn, indented or padded or
+    otherwise.
 
     Args:
         text: The file's contents.
@@ -92,9 +113,12 @@ def format_probe_text(probe_set: ProbeSet) -> str:
 
     Returns:
         str: Text in the plain-text format. Note: if any turn contains a line
-            that strips to ``---`` or ``===``, it will not round-trip through
-            parse_probe_text, as those are treated as delimiters. Escaping is
-            not supported in this format version.
+            that STRIPS to ``---`` or ``===`` -- including an indented or
+            trailing-space form such as ``"  ---  "``, since delimiter
+            matching compares stripped content (see the module docstring for
+            why that leniency is deliberate) -- it will not round-trip
+            through parse_probe_text, as such a line is treated as a
+            delimiter. Escaping is not supported in this format version.
     """
     return f"\n{PROBE_DELIMITER}\n".join(
         f"\n{TURN_DELIMITER}\n".join(probe.turns) for probe in probe_set.probes

--- a/tldw_chatbook/Evals/character_probe/probe_format.py
+++ b/tldw_chatbook/Evals/character_probe/probe_format.py
@@ -29,8 +29,18 @@ def _split_on_delimiter(text: str, delimiter: str) -> list[str]:
 
 
 def _clean_turn(raw: str) -> str:
-    """Strip only leading/trailing blank lines; interior whitespace is data."""
-    return raw.strip("\n").strip() if not raw.strip() else raw.strip("\n")
+    """Strip leading/trailing blank lines (including whitespace-only lines).
+
+    Interior whitespace is preserved exactly.
+    """
+    lines = raw.split("\n")
+    # Strip leading blank lines (lines with only whitespace)
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    # Strip trailing blank lines (lines with only whitespace)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(lines)
 
 
 def parse_probe_text(text: str) -> ProbeSet:
@@ -54,11 +64,18 @@ def parse_probe_text(text: str) -> ProbeSet:
                 # A wholly empty document, or trailing/leading delimiter noise.
                 continue
             raise ValueError(f"probe {index} has no turns")
-        turns = [
-            _clean_turn(raw)
-            for raw in _split_on_delimiter(chunk, TURN_DELIMITER)
-            if raw.strip()
-        ]
+        raw_turns = _split_on_delimiter(chunk, TURN_DELIMITER)
+        turns: list[str] = []
+        for i, raw in enumerate(raw_turns):
+            if not raw.strip():
+                # Check if this is a stray delimiter (not at edges)
+                if i > 0 and i < len(raw_turns) - 1:
+                    raise ValueError(
+                        f"probe {index} has a stray or duplicated turn delimiter"
+                    )
+                # Skip leading/trailing empty turns from delimiter noise
+            else:
+                turns.append(_clean_turn(raw))
         if not turns:
             raise ValueError(f"probe {index} has no turns")
         probes.append(Probe(turns=tuple(turns)))
@@ -74,7 +91,10 @@ def format_probe_text(probe_set: ProbeSet) -> str:
         probe_set: The set to render.
 
     Returns:
-        str: Text that ``parse_probe_text`` round-trips to an equal ProbeSet.
+        str: Text in the plain-text format. Note: if any turn contains a line
+            that strips to ``---`` or ``===``, it will not round-trip through
+            parse_probe_text, as those are treated as delimiters. Escaping is
+            not supported in this format version.
     """
     return f"\n{PROBE_DELIMITER}\n".join(
         f"\n{TURN_DELIMITER}\n".join(probe.turns) for probe in probe_set.probes

--- a/tldw_chatbook/Evals/character_probe/probe_format.py
+++ b/tldw_chatbook/Evals/character_probe/probe_format.py
@@ -1,0 +1,81 @@
+"""The plain-text probe format: `---` between turns, `===` between probes.
+
+Turns are delimited explicitly rather than by line breaks so a single turn can
+be a multi-paragraph prompt -- complex prompts are exactly what this eval
+exists to study, and a newline-delimited format could not express one.
+"""
+
+from __future__ import annotations
+
+from .models import Probe, ProbeSet
+
+#: A line containing only this separates turns within a probe.
+TURN_DELIMITER = "---"
+#: A line containing only this separates probes within a set.
+PROBE_DELIMITER = "==="
+
+
+def _split_on_delimiter(text: str, delimiter: str) -> list[str]:
+    chunks: list[str] = []
+    current: list[str] = []
+    for line in text.split("\n"):
+        if line.strip() == delimiter:
+            chunks.append("\n".join(current))
+            current = []
+        else:
+            current.append(line)
+    chunks.append("\n".join(current))
+    return chunks
+
+
+def _clean_turn(raw: str) -> str:
+    """Strip only leading/trailing blank lines; interior whitespace is data."""
+    return raw.strip("\n").strip() if not raw.strip() else raw.strip("\n")
+
+
+def parse_probe_text(text: str) -> ProbeSet:
+    """Parse the plain-text probe format into a ``ProbeSet``.
+
+    Args:
+        text: The file's contents.
+
+    Returns:
+        ProbeSet: The parsed probes, in file order.
+
+    Raises:
+        ValueError: If the text contains no probes, or if any probe has no
+            turns (naming the 1-based probe number so the author can find it).
+    """
+    probe_chunks = _split_on_delimiter(text, PROBE_DELIMITER)
+    probes: list[Probe] = []
+    for index, chunk in enumerate(probe_chunks, start=1):
+        if not chunk.strip():
+            if len(probe_chunks) == 1 or index in (1, len(probe_chunks)):
+                # A wholly empty document, or trailing/leading delimiter noise.
+                continue
+            raise ValueError(f"probe {index} has no turns")
+        turns = [
+            _clean_turn(raw)
+            for raw in _split_on_delimiter(chunk, TURN_DELIMITER)
+            if raw.strip()
+        ]
+        if not turns:
+            raise ValueError(f"probe {index} has no turns")
+        probes.append(Probe(turns=tuple(turns)))
+    if not probes:
+        raise ValueError("The probe file contains no probes.")
+    return ProbeSet(probes=tuple(probes))
+
+
+def format_probe_text(probe_set: ProbeSet) -> str:
+    """Render a ``ProbeSet`` back to the plain-text format.
+
+    Args:
+        probe_set: The set to render.
+
+    Returns:
+        str: Text that ``parse_probe_text`` round-trips to an equal ProbeSet.
+    """
+    return f"\n{PROBE_DELIMITER}\n".join(
+        f"\n{TURN_DELIMITER}\n".join(probe.turns) for probe in probe_set.probes
+    )

--- a/tldw_chatbook/Evals/character_probe/prompt.py
+++ b/tldw_chatbook/Evals/character_probe/prompt.py
@@ -1,0 +1,91 @@
+"""Assembling the messages a character probe sends.
+
+Steering composes AHEAD of the card's own system prompt: steering is a
+model-level instruction ("answer in English") and the card is the content it
+operates on. Both are preserved -- silently dropping either would evaluate
+something other than what the bench describes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .models import CardSnapshot
+
+
+def compose_system_prompt(card: CardSnapshot, steering: Optional[str]) -> str:
+    """Build the system prompt for one card under one target's steering.
+
+    ``message_example`` is included deliberately, not merely because it is
+    present on ``CardSnapshot``: ``cards.py`` snapshots it precisely because
+    "every one participates in prompt assembly", and example dialogue shapes
+    a character's voice as much as its personality or scenario does. Leaving
+    it out would silently narrow what the probe actually evaluates.
+
+    Args:
+        card: The snapshotted card.
+        steering: The target's own system prompt, or None when unsteered.
+
+    Returns:
+        str: Steering first, then the card's persona text. Empty parts are
+        omitted rather than contributing blank lines.
+    """
+    parts = [
+        steering or "",
+        card.system_prompt,
+        f"Personality: {card.personality}" if card.personality else "",
+        f"Scenario: {card.scenario}" if card.scenario else "",
+        f"Example dialogue:\n{card.message_example}" if card.message_example else "",
+        card.post_history_instructions,
+    ]
+    return "\n\n".join(part.strip() for part in parts if part and part.strip())
+
+
+def build_messages(
+    card: CardSnapshot,
+    steering: Optional[str],
+    scripted_turns: Sequence[str],
+    replies_so_far: Sequence[str],
+) -> list[dict[str, str]]:
+    """Build the message list for the next turn of a conversation.
+
+    The card's ``first_message`` seeds an opening assistant turn as it does in
+    real roleplay. A card without one starts at the user's first scripted turn
+    -- no greeting is invented, because inventing one would evaluate text the
+    character never had.
+
+    Args:
+        card: The snapshotted card.
+        steering: The target's own system prompt, or None.
+        scripted_turns: All of the probe's user turns.
+        replies_so_far: The model's replies to the preceding turns; its length
+            determines which scripted turn comes next.
+
+    Returns:
+        list[dict[str, str]]: ``role``/``content`` messages, ending with the
+        user turn awaiting a reply.
+
+    Raises:
+        ValueError: If ``replies_so_far`` already has as many entries as
+            ``scripted_turns`` (or more). There is no next scripted turn to
+            append in that case -- the conversation is already complete, and
+            indexing past the end would otherwise raise an ``IndexError``
+            deep inside assembly, far from the caller's actual mistake.
+    """
+    if len(replies_so_far) >= len(scripted_turns):
+        raise ValueError(
+            f"replies_so_far has {len(replies_so_far)} entries but the probe "
+            f"has only {len(scripted_turns)} scripted turn(s); there is no "
+            "next turn to build a message for -- the conversation is already "
+            "complete."
+        )
+    messages: list[dict[str, str]] = [
+        {"role": "system", "content": compose_system_prompt(card, steering)}
+    ]
+    if card.first_message:
+        messages.append({"role": "assistant", "content": card.first_message})
+    for index, reply in enumerate(replies_so_far):
+        messages.append({"role": "user", "content": scripted_turns[index]})
+        messages.append({"role": "assistant", "content": reply})
+    messages.append({"role": "user", "content": scripted_turns[len(replies_so_far)]})
+    return messages

--- a/tldw_chatbook/Evals/character_probe/prompt.py
+++ b/tldw_chatbook/Evals/character_probe/prompt.py
@@ -4,6 +4,13 @@ Steering composes AHEAD of the card's own system prompt: steering is a
 model-level instruction ("answer in English") and the card is the content it
 operates on. Both are preserved -- silently dropping either would evaluate
 something other than what the bench describes.
+
+Card text is written against SillyTavern-style macros, so ``{{char}}``,
+``{{user}}`` and their aliases are RESOLVED here before the text leaves this
+module. Console resolves them for exactly the same reason (task-1530: they
+otherwise leak verbatim into every provider payload), and a probe that
+shipped a literal ``{{user}}`` to the model would be evaluating text no real
+chat with that card ever produces.
 """
 
 from __future__ import annotations
@@ -12,36 +19,85 @@ from typing import Optional, Sequence
 
 from .models import CardSnapshot
 
+#: What ``{{user}}`` resolves to. A probe run has no human in the exchange --
+#: the "user" turns are a script -- so there is no real name to use, and
+#: "User" is what Console substitutes on the Personas surfaces too, which
+#: keeps a probe's prompt comparable with a real session's.
+USER_MACRO_NAME = "User"
+
+#: What ``{{char}}`` resolves to when a card has no usable name. Matches
+#: ``Character_Chat_Lib.replace_placeholders``'s own fallback.
+FALLBACK_CHAR_NAME = "Character"
+
+
+def resolve_card_macros(text: str, card: CardSnapshot) -> str:
+    """Resolve ``{{char}}``/``{{user}}`` (and aliases) in one card's text.
+
+    Args:
+        text: Text taken from the card.
+        card: The card the text came from; its ``name`` supplies
+            ``{{char}}``.
+
+    Returns:
+        str: The text with every macro substituted. ``""`` in, ``""`` out.
+    """
+    # Local import, matching chat_screen.py's own convention for this
+    # function: Character_Chat_Lib imports Pillow and CharactersRAGDB at
+    # module scope, and this engine package stays importable without paying
+    # for either until a prompt is actually composed.
+    from ...Character_Chat.Character_Chat_Lib import replace_placeholders
+
+    return replace_placeholders(
+        text, card.name.strip() or FALLBACK_CHAR_NAME, USER_MACRO_NAME
+    )
+
 
 def compose_system_prompt(card: CardSnapshot, steering: Optional[str]) -> str:
     """Build the system prompt for one card under one target's steering.
 
-    ``message_example`` is included deliberately, not merely because it is
-    present on ``CardSnapshot``: ``cards.py`` snapshots it precisely because
-    "every one participates in prompt assembly", and example dialogue shapes
-    a character's voice as much as its personality or scenario does. Leaving
-    it out would silently narrow what the probe actually evaluates.
+    Every field on :class:`~tldw_chatbook.Evals.character_probe.models.CardSnapshot`
+    is composed here, because ``cards.py`` snapshots a field precisely when
+    it "participates in prompt assembly". That includes ``description`` (the
+    primary V2 persona field) and ``message_example`` -- example dialogue
+    shapes a character's voice as much as its personality does, and leaving
+    either out would silently narrow what the probe evaluates.
+
+    Field order follows Console's own joiner (``system_prompt``,
+    ``personality``, ``description``, ``scenario``) so that TASK-1744, which
+    extracts one shared card-to-prompt function for both paths, has one less
+    difference to reconcile; the eval then adds ``message_example`` and
+    ``post_history_instructions``, which Console does not send yet.
+
+    Macros are resolved in the CARD's text only. ``steering`` is the eval
+    author's own model-level instruction rather than card text, so it is
+    passed through verbatim -- a ``{{char}}`` written there is not a card
+    macro and must not silently acquire one card's name in a run that spans
+    several.
 
     Args:
         card: The snapshotted card.
         steering: The target's own system prompt, or None when unsteered.
 
     Returns:
-        str: Steering first, then the card's persona text. Empty parts are
-        omitted rather than contributing blank lines. If every part is empty
-        (no steering, no card text at all), this deliberately returns ``""``
-        rather than raising: ``build_messages`` always emits exactly one
-        leading system message, so the message shape stays stable even for a
-        content-free card.
+        str: Steering first, then the card's persona text with macros
+        resolved. Empty parts are omitted rather than contributing blank
+        lines. If every part is empty (no steering, no card text at all),
+        this deliberately returns ``""`` rather than raising:
+        ``build_messages`` always emits exactly one leading system message,
+        so the message shape stays stable even for a content-free card.
     """
-    parts = [
-        steering or "",
+    card_parts = [
         card.system_prompt,
         f"Personality: {card.personality}" if card.personality else "",
+        f"Description: {card.description}" if card.description else "",
         f"Scenario: {card.scenario}" if card.scenario else "",
         f"Example dialogue:\n{card.message_example}" if card.message_example else "",
         card.post_history_instructions,
     ]
+    card_text = "\n\n".join(
+        part.strip() for part in card_parts if part and part.strip()
+    )
+    parts = [steering or "", resolve_card_macros(card_text, card)]
     return "\n\n".join(part.strip() for part in parts if part and part.strip())
 
 
@@ -54,9 +110,15 @@ def build_messages(
     """Build the message list for the next turn of a conversation.
 
     The card's ``first_message`` seeds an opening assistant turn as it does in
-    real roleplay. A card without one starts at the user's first scripted turn
-    -- no greeting is invented, because inventing one would evaluate text the
-    character never had.
+    real roleplay, with its macros resolved like the rest of the card's text.
+    A card without one starts at the user's first scripted turn -- no greeting
+    is invented, because inventing one would evaluate text the character never
+    had.
+
+    Scripted user turns are sent VERBATIM, macros included: a probe's turns
+    are the eval author's text, not the card's, and the probe format's own
+    rule is that turn text is reproduced exactly because prompt formatting
+    changes model behaviour.
 
     Args:
         card: The snapshotted card.
@@ -87,7 +149,12 @@ def build_messages(
         {"role": "system", "content": compose_system_prompt(card, steering)}
     ]
     if card.first_message:
-        messages.append({"role": "assistant", "content": card.first_message})
+        messages.append(
+            {
+                "role": "assistant",
+                "content": resolve_card_macros(card.first_message, card),
+            }
+        )
     for index, reply in enumerate(replies_so_far):
         messages.append({"role": "user", "content": scripted_turns[index]})
         messages.append({"role": "assistant", "content": reply})

--- a/tldw_chatbook/Evals/character_probe/prompt.py
+++ b/tldw_chatbook/Evals/character_probe/prompt.py
@@ -28,7 +28,11 @@ def compose_system_prompt(card: CardSnapshot, steering: Optional[str]) -> str:
 
     Returns:
         str: Steering first, then the card's persona text. Empty parts are
-        omitted rather than contributing blank lines.
+        omitted rather than contributing blank lines. If every part is empty
+        (no steering, no card text at all), this deliberately returns ``""``
+        rather than raising: ``build_messages`` always emits exactly one
+        leading system message, so the message shape stays stable even for a
+        content-free card.
     """
     parts = [
         steering or "",

--- a/tldw_chatbook/Evals/character_probe/runner.py
+++ b/tldw_chatbook/Evals/character_probe/runner.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Callable, Mapping, Optional, Sequence
 
+from loguru import logger
+
 from .models import (
     CardSnapshot,
     CharacterProbeConfig,
@@ -29,6 +31,7 @@ from .models import (
     ProbeSet,
 )
 from .prompt import build_messages
+from .targets import ResolvedTarget, resolve_targets
 
 #: The injected provider callable. Synchronous by contract -- see the module
 #: docstring for why it must never be awaited directly.
@@ -86,12 +89,17 @@ class CharacterProbeRunner:
         card: CardSnapshot,
         probe_index: int,
         turns: Sequence[str],
-        target: Mapping[str, Any],
+        target: ResolvedTarget,
         sample_index: int,
         config: CharacterProbeConfig,
     ) -> Conversation:
-        """Run one card/probe/target/sample cell's turns, in order."""
-        steering = target.get("system_prompt")
+        """Run one card/probe/target/sample cell's turns, in order.
+
+        ``target`` arrives already resolved (see :mod:`.targets`): its
+        steering has been read out of the row's ``config`` JSON, which is
+        the only place an ``eval_models`` row ever keeps it.
+        """
+        steering = target.steering
         seed = None if config.seed is None else config.seed + sample_index
         collected: list[ConversationTurn] = []
         replies: list[str] = []
@@ -105,7 +113,7 @@ class CharacterProbeRunner:
                 reply = await asyncio.to_thread(
                     self._chat,
                     messages=messages,
-                    model=target.get("model_id"),
+                    model=target.model_id,
                     temperature=config.temperature,
                     max_tokens=config.max_tokens,
                     seed=seed,
@@ -120,7 +128,7 @@ class CharacterProbeRunner:
             card_id=card.id,
             probe_index=probe_index,
             sample_index=sample_index,
-            target_id=str(target.get("id")),
+            target_id=target.id,
             turns=tuple(collected),
             error=error,
         )
@@ -138,13 +146,21 @@ class CharacterProbeRunner:
         Args:
             cards: Snapshotted cards, already resolved.
             probe_set: The scripts to run.
-            targets: ``eval_models``-shaped rows; each needs ``id`` and
-                ``model_id``, and its ``system_prompt`` (if any) supplies the
-                steering ahead of the card's own system prompt.
+            targets: ``eval_models`` rows, as ``EvalsDB.get_model``/
+                ``list_models`` return them. Each is validated and its
+                steering read out of its ``config`` JSON by
+                :func:`~tldw_chatbook.Evals.character_probe.targets.resolve_targets`
+                BEFORE the first provider call, so a malformed or
+                prefix-steered row costs nothing rather than surfacing
+                mid-grid. That steering composes ahead of the card's own
+                system prompt.
             config: The bench, supplying concurrency, samples, seed, and
                 sampling parameters.
             progress: Optional ``(done, total)`` callback fired once per
-                conversation as it finishes, regardless of outcome.
+                conversation as it finishes, regardless of outcome. A
+                callback that RAISES is logged and swallowed: an observer
+                must never be able to destroy the run it is watching (see
+                ``_guarded`` below).
 
         Returns:
             list[Conversation]: Every conversation, including failed,
@@ -152,12 +168,18 @@ class CharacterProbeRunner:
             still evidence and stays reviewable. Length is always
             ``len(cards) * len(probe_set.probes) * len(targets) *
             config.samples_per_cell``.
+
+        Raises:
+            ValueError: Propagated from ``resolve_targets`` for an empty
+                target list, duplicate target ids, or any row that is
+                malformed or prefix-steered.
         """
+        resolved_targets = resolve_targets(targets)
         jobs = [
             (card, probe_index, probe.turns, target, sample_index)
             for card in cards
             for probe_index, probe in enumerate(probe_set.probes)
-            for target in targets
+            for target in resolved_targets
             for sample_index in range(config.samples_per_cell)
         ]
         semaphore = asyncio.Semaphore(config.concurrency)
@@ -173,7 +195,20 @@ class CharacterProbeRunner:
                 )
             done += 1
             if progress is not None:
-                progress(done, total)
+                try:
+                    progress(done, total)
+                except Exception:  # noqa: BLE001 -- see below
+                    # A progress callback is an OBSERVER. Left unguarded it
+                    # runs inside an asyncio.gather child, so one raising
+                    # callback propagates out of gather and discards every
+                    # conversation the run already completed -- hours of
+                    # real provider calls thrown away because a progress
+                    # bar's widget was unmounted. A run's output must
+                    # survive its observer.
+                    logger.exception(
+                        "character probe progress callback failed at "
+                        f"{done}/{total}; continuing the run"
+                    )
             return conversation
 
         return list(await asyncio.gather(*(_guarded(job) for job in jobs)))

--- a/tldw_chatbook/Evals/character_probe/runner.py
+++ b/tldw_chatbook/Evals/character_probe/runner.py
@@ -1,0 +1,179 @@
+"""Runs character probe conversations.
+
+Every provider call goes through ``asyncio.to_thread``: the app's chat gateway
+(``Chat_Functions.chat_api_call``) is a plain synchronous ``def``, and calling
+it from the event loop would block the whole TUI. Conversations run
+concurrently under the bench's ``concurrency`` setting; turns WITHIN a
+conversation are strictly sequential, because turn N needs turn N-1's reply.
+
+Cancelling stops SCHEDULING further turns and conversations. It cannot abort a
+turn already in flight -- ``to_thread`` survives task cancellation -- so an
+in-flight provider call always runs to completion and is recorded. A
+conversation whose first turn has not yet started when cancellation lands
+still appears in the result list, marked with an empty ``turns`` tuple and a
+"Cancelled" ``error``, rather than being silently dropped: the grid's shape
+(one entry per card x probe x target x sample) stays predictable regardless
+of when a run was stopped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from .models import (
+    CardSnapshot,
+    CharacterProbeConfig,
+    Conversation,
+    ConversationTurn,
+    ProbeSet,
+)
+from .prompt import build_messages
+
+#: The injected provider callable. Synchronous by contract -- see the module
+#: docstring for why it must never be awaited directly.
+#: Shape: ``chat_fn(messages, model, temperature, max_tokens, seed) -> str``.
+ChatCallable = Callable[..., str]
+
+#: Optional progress callback, fired as ``progress(done, total)`` once per
+#: conversation that finishes (successfully, with an error, or cancelled).
+ProgressCallback = Callable[[int, int], None]
+
+
+class CancelToken:
+    """Cancels a whole run; see the module docstring for what that means."""
+
+    def __init__(self) -> None:
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        """Request that no further turns or conversations be scheduled."""
+        self._cancelled = True
+
+    @property
+    def is_cancelled(self) -> bool:
+        """Whether :meth:`cancel` has been called."""
+        return self._cancelled
+
+
+class CharacterProbeRunner:
+    """Runs a bench's full grid of conversations.
+
+    The grid is every combination of the resolved ``cards``, the probes in
+    ``probe_set``, the requested ``targets``, and ``config.samples_per_cell``
+    -- one :class:`~tldw_chatbook.Evals.character_probe.models.Conversation`
+    per combination.
+    """
+
+    def __init__(
+        self, chat_fn: ChatCallable, cancel_token: Optional[CancelToken] = None
+    ) -> None:
+        """Create a runner bound to one provider callable.
+
+        Args:
+            chat_fn: The synchronous provider callable; see :data:`ChatCallable`.
+                Always dispatched through ``asyncio.to_thread``, never awaited
+                or called directly on the event loop.
+            cancel_token: Shared cancellation flag. A fresh, never-cancelled
+                :class:`CancelToken` is created when omitted, so a caller who
+                does not need cancellation can ignore this entirely.
+        """
+        self._chat = chat_fn
+        self._cancel = cancel_token or CancelToken()
+
+    async def _run_conversation(
+        self,
+        card: CardSnapshot,
+        probe_index: int,
+        turns: Sequence[str],
+        target: Mapping[str, Any],
+        sample_index: int,
+        config: CharacterProbeConfig,
+    ) -> Conversation:
+        """Run one card/probe/target/sample cell's turns, in order."""
+        steering = target.get("system_prompt")
+        seed = None if config.seed is None else config.seed + sample_index
+        collected: list[ConversationTurn] = []
+        replies: list[str] = []
+        error = ""
+        for turn_index, user_turn in enumerate(turns):
+            if self._cancel.is_cancelled:
+                error = "Cancelled before this turn ran."
+                break
+            messages = build_messages(card, steering, turns, replies)
+            try:
+                reply = await asyncio.to_thread(
+                    self._chat,
+                    messages=messages,
+                    model=target.get("model_id"),
+                    temperature=config.temperature,
+                    max_tokens=config.max_tokens,
+                    seed=seed,
+                )
+            except Exception as exc:  # noqa: BLE001 -- a provider failure ends only this conversation
+                error = f"Turn {turn_index + 1} failed: {exc}"
+                break
+            reply_text = str(reply or "")
+            replies.append(reply_text)
+            collected.append(ConversationTurn(user=user_turn, reply=reply_text))
+        return Conversation(
+            card_id=card.id,
+            probe_index=probe_index,
+            sample_index=sample_index,
+            target_id=str(target.get("id")),
+            turns=tuple(collected),
+            error=error,
+        )
+
+    async def run(
+        self,
+        cards: Sequence[CardSnapshot],
+        probe_set: ProbeSet,
+        targets: Sequence[Mapping[str, Any]],
+        config: CharacterProbeConfig,
+        progress: Optional[ProgressCallback] = None,
+    ) -> list[Conversation]:
+        """Run every (card x probe x target x sample) conversation.
+
+        Args:
+            cards: Snapshotted cards, already resolved.
+            probe_set: The scripts to run.
+            targets: ``eval_models``-shaped rows; each needs ``id`` and
+                ``model_id``, and its ``system_prompt`` (if any) supplies the
+                steering ahead of the card's own system prompt.
+            config: The bench, supplying concurrency, samples, seed, and
+                sampling parameters.
+            progress: Optional ``(done, total)`` callback fired once per
+                conversation as it finishes, regardless of outcome.
+
+        Returns:
+            list[Conversation]: Every conversation, including failed,
+            partial, and cancelled ones -- a failed or cancelled cell is
+            still evidence and stays reviewable. Length is always
+            ``len(cards) * len(probe_set.probes) * len(targets) *
+            config.samples_per_cell``.
+        """
+        jobs = [
+            (card, probe_index, probe.turns, target, sample_index)
+            for card in cards
+            for probe_index, probe in enumerate(probe_set.probes)
+            for target in targets
+            for sample_index in range(config.samples_per_cell)
+        ]
+        semaphore = asyncio.Semaphore(config.concurrency)
+        done = 0
+        total = len(jobs)
+
+        async def _guarded(job) -> Conversation:
+            nonlocal done
+            card, probe_index, turns, target, sample_index = job
+            async with semaphore:
+                conversation = await self._run_conversation(
+                    card, probe_index, turns, target, sample_index, config
+                )
+            done += 1
+            if progress is not None:
+                progress(done, total)
+            return conversation
+
+        return list(await asyncio.gather(*(_guarded(job) for job in jobs)))

--- a/tldw_chatbook/Evals/character_probe/runner.py
+++ b/tldw_chatbook/Evals/character_probe/runner.py
@@ -43,6 +43,45 @@ ChatCallable = Callable[..., str]
 ProgressCallback = Callable[[int, int], None]
 
 
+def _sample_seed(bench_seed: Optional[int], sample_index: int) -> Optional[int]:
+    """The seed for one sample of a cell.
+
+    A non-negative bench seed is offset by the sample index, which is the
+    whole point of seeding a multi-sample run: one fixed seed would return
+    N identical answers, tripling review volume for zero information, so a
+    seeded run must be reproducible AND have samples that genuinely differ.
+
+    A NEGATIVE seed is a sentinel, not an arithmetic value: llama.cpp reads
+    it as "pick a random seed", and ``storage.load_character_bench``
+    deliberately accepts one for that reason. Offsetting it is worse than
+    useless -- ``-1`` becomes ``-1, 0, 1, ...``, so sample 0 is randomly
+    seeded while every later sample gets a *deterministic* seed the user
+    never chose. The offset exists precisely so samples differ; applied to
+    the random sentinel it does the exact opposite, quietly collapsing the
+    variance the samples were taken to reveal, and the run still looks like
+    it worked. A negative seed is therefore passed through unchanged for
+    every sample.
+
+    ``0`` is NOT a sentinel: it is a real, explicitly-chosen seed (the same
+    falsy-but-real case ``storage._stored_int_field`` exists for), so it
+    offsets normally.
+
+    Args:
+        bench_seed: ``CharacterProbeConfig.seed``.
+        sample_index: Zero-based sample number within its cell.
+
+    Returns:
+        Optional[int]: ``None`` when unseeded, the seed unchanged when it is
+        the negative random sentinel, otherwise ``bench_seed +
+        sample_index``.
+    """
+    if bench_seed is None:
+        return None
+    if bench_seed < 0:
+        return bench_seed
+    return bench_seed + sample_index
+
+
 class CancelToken:
     """Cancels a whole run; see the module docstring for what that means."""
 
@@ -100,7 +139,7 @@ class CharacterProbeRunner:
         the only place an ``eval_models`` row ever keeps it.
         """
         steering = target.steering
-        seed = None if config.seed is None else config.seed + sample_index
+        seed = _sample_seed(config.seed, sample_index)
         collected: list[ConversationTurn] = []
         replies: list[str] = []
         error = ""

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -8,14 +8,14 @@ directly; every call goes through ``EvalsDB``.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 
 from ...DB.Evals_DB import EvalsDB
 from ...Evaluations_Interop.evaluation_normalizers import (
     RESERVED_LOCAL_DATASET_SAMPLES_KEY,
 )
-from .models import CharacterProbeConfig, Probe, ProbeSet
+from .models import CharacterProbeConfig, Conversation, ConversationTurn, Probe, ProbeSet
 
 #: Marks a dataset row as holding probes rather than snippets.
 PROBE_DATASET_TYPE = "character_probe"
@@ -311,3 +311,380 @@ def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
         max_tokens=_stored_int_field(data, "max_tokens", 512, task_id),
         extra_tags=tuple(data.get("extra_tags") or ()),
     )
+
+
+#: get_run_results is a paginated API (default limit=1000), same reason
+#: word_bench.storage._RESULTS_PAGE_SIZE pages it: a run with more cells
+#: than one page would otherwise silently load only part of the group.
+_RESULTS_PAGE_SIZE = 1000
+
+
+def conversation_sample_id(card_id: int, probe_index: int, sample_index: int) -> str:
+    """Compose the ``eval_results.sample_id`` for one conversation.
+
+    ``run_id`` already scopes the target (one run row per target, as word
+    benches do), so the sample id only needs the remaining three axes.
+
+    Args:
+        card_id: The character card's integer id.
+        probe_index: Zero-based index of the probe within its set.
+        sample_index: Zero-based sample number for this cell.
+
+    Returns:
+        str: The composed id, stable across runs.
+    """
+    return f"{card_id}:{probe_index}:{sample_index}"
+
+
+def save_conversations(
+    db: EvalsDB,
+    run_group_id: str,
+    run_ids: Mapping[str, str],
+    conversations: Sequence[Conversation],
+) -> None:
+    """Persist every conversation into ``eval_results``.
+
+    The ordered turn list goes into the ``metadata`` JSON, never into
+    ``actual_output`` -- that column holds one answer and cannot represent a
+    conversation.
+
+    Every run named in ``run_ids`` is stamped with ``run_group_id`` (via
+    ``EvalsDB.update_run``), mirroring ``word_bench.storage.
+    create_run_group``'s own convention of tagging every run in a group so
+    later reads can find them all with one ``list_runs(run_group_id=...)``
+    call. This runs unconditionally, even for a target whose conversations
+    all failed before producing a turn -- ``load_conversations`` below has
+    no other way to discover which runs belong to this group.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The group these conversations belong to.
+        run_ids: target id -> ``eval_runs`` id for this group.
+        conversations: What the runner produced, including failed ones.
+
+    Raises:
+        ValueError: If a conversation's ``target_id`` has no entry in
+            ``run_ids`` -- storing it would otherwise raise an opaque
+            ``KeyError`` naming neither the conversation nor the run group.
+        ValueError: If a run id in ``run_ids`` does not name a live run.
+            ``EvalsDB.update_run`` returns nothing and silently no-ops on an
+            unmatched id, so a stale run id would otherwise look like a
+            successful stamp that in fact wrote nothing -- the same failure
+            mode ``save_probe_set``/``save_character_bench`` above already
+            guard against for ``update_dataset``/``update_task``.
+    """
+    for run_id in set(run_ids.values()):
+        if db.get_run(run_id) is None:
+            raise ValueError(
+                f"Run {run_id!r} (in run_ids for run group {run_group_id!r}) "
+                "does not exist; it may have been deleted."
+            )
+        db.update_run(run_id, {"run_group_id": run_group_id})
+
+    for conversation in conversations:
+        if conversation.target_id not in run_ids:
+            raise ValueError(
+                f"No run id supplied for target {conversation.target_id!r} "
+                f"in run group {run_group_id!r}; run_ids covers "
+                f"{sorted(run_ids)!r}."
+            )
+        db.store_result(
+            run_id=run_ids[conversation.target_id],
+            sample_id=conversation_sample_id(
+                conversation.card_id, conversation.probe_index, conversation.sample_index
+            ),
+            input_data={
+                "card_id": conversation.card_id,
+                "probe_index": conversation.probe_index,
+                "user_turns": [turn.user for turn in conversation.turns],
+            },
+            actual_output="",
+            metadata={
+                "run_group_id": run_group_id,
+                "turns": [
+                    {"user": turn.user, "reply": turn.reply, "error": turn.error}
+                    for turn in conversation.turns
+                ],
+                "error": conversation.error,
+            },
+        )
+
+
+def _turn_field(payload: Mapping[str, Any], field: str, row_id: Any) -> str:
+    """One string field out of a stored turn payload, missing-vs-corrupt aware.
+
+    Args:
+        payload: One entry of a stored ``metadata["turns"]`` list.
+        field: ``"user"``, ``"reply"``, or ``"error"``.
+        row_id: The owning ``eval_results`` row's id, only for the error
+            message below.
+
+    Returns:
+        str: The field's value, or ``""`` if the key is genuinely absent.
+
+    Raises:
+        ValueError: If the key is present with a non-``str`` value -- naming
+            both the row and the offending field, rather than handing a
+            malformed value on to ``ConversationTurn``.
+    """
+    value = payload.get(field, "")
+    if not isinstance(value, str):
+        raise ValueError(
+            f"eval_results row {row_id!r} has a non-string {field!r} in a "
+            f"stored turn: {value!r}"
+        )
+    return value
+
+
+def _conversation_from_row(row: Mapping[str, Any], target_id: str) -> Conversation:
+    """Rebuild one ``Conversation`` from its ``eval_results`` row.
+
+    Args:
+        row: A row as returned by ``EvalsDB.get_run_results``, already
+            JSON-decoded.
+        target_id: The owning run's target, supplied by the caller
+            (``load_conversations``) rather than read from the row itself --
+            a target is implicit in which run a row belongs to, per
+            ``save_conversations``'s own docstring.
+
+    Returns:
+        Conversation: The reconstructed conversation.
+
+    Raises:
+        ValueError: If ``sample_id`` is not shaped like
+            ``conversation_sample_id`` produces, or if ``metadata`` is
+            missing its turn list or carries a non-string field -- naming
+            the offending row rather than raising an opaque ``KeyError``/
+            ``TypeError`` out of the reconstruction below.
+    """
+    row_id = row.get("id")
+    sample_id = row.get("sample_id") or ""
+    parts = sample_id.split(":")
+    if len(parts) != 3:
+        raise ValueError(
+            f"eval_results row {row_id!r} has a malformed sample_id "
+            f"{sample_id!r}; expected 'card:probe:sample'."
+        )
+    try:
+        card_id, probe_index, sample_index = (int(part) for part in parts)
+    except ValueError:
+        raise ValueError(
+            f"eval_results row {row_id!r} has a non-integer sample_id "
+            f"{sample_id!r}."
+        ) from None
+
+    metadata = row.get("metadata")
+    if not isinstance(metadata, Mapping):
+        raise ValueError(
+            f"eval_results row {row_id!r} has a non-mapping metadata; "
+            "expected a conversation payload."
+        )
+    turns_payload = metadata.get("turns")
+    if not isinstance(turns_payload, list):
+        raise ValueError(
+            f"eval_results row {row_id!r} is missing its turns list in "
+            "metadata."
+        )
+    turns = []
+    for turn in turns_payload:
+        if not isinstance(turn, Mapping):
+            raise ValueError(
+                f"eval_results row {row_id!r} has a non-mapping turn entry: "
+                f"{turn!r}"
+            )
+        turns.append(
+            ConversationTurn(
+                user=_turn_field(turn, "user", row_id),
+                reply=_turn_field(turn, "reply", row_id),
+                error=_turn_field(turn, "error", row_id),
+            )
+        )
+
+    error = metadata.get("error", "")
+    if not isinstance(error, str):
+        raise ValueError(
+            f"eval_results row {row_id!r} has a non-string metadata error: "
+            f"{error!r}"
+        )
+
+    return Conversation(
+        card_id=card_id,
+        probe_index=probe_index,
+        sample_index=sample_index,
+        target_id=target_id,
+        turns=tuple(turns),
+        error=error,
+    )
+
+
+def load_conversations(db: EvalsDB, run_group_id: str) -> list[Conversation]:
+    """Rebuild every conversation stored under one run group.
+
+    Mirrors ``word_bench.storage.load_grid``'s own approach: find every run
+    sharing ``run_group_id`` (via ``EvalsDB.list_runs``), then drain each
+    run's ``eval_results`` a page at a time so a group with more cells than
+    one page is never silently truncated.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The run group to read, as passed to
+            ``save_conversations``.
+
+    Returns:
+        list[Conversation]: Every conversation stored under this group,
+        across every target. A run group with no runs at all (nothing has
+        been saved for it yet) returns an empty list rather than raising --
+        the review queue may probe a group speculatively.
+
+    Raises:
+        ValueError: Propagated from ``_conversation_from_row`` for a row
+            whose ``sample_id`` or ``metadata`` is corrupt.
+    """
+    conversations: list[Conversation] = []
+    for run in db.list_runs(run_group_id=run_group_id, limit=10_000):
+        target_id = run["model_id"]
+        offset = 0
+        while True:
+            page = db.get_run_results(
+                run["id"], limit=_RESULTS_PAGE_SIZE, offset=offset
+            )
+            if not page:
+                break
+            for row in page:
+                conversations.append(_conversation_from_row(row, target_id))
+            if len(page) < _RESULTS_PAGE_SIZE:
+                break
+            offset += _RESULTS_PAGE_SIZE
+    return conversations
+
+
+def annotate_turn(
+    db: EvalsDB,
+    run_group_id: str,
+    card_id: int,
+    probe_index: int,
+    sample_index: int,
+    target_id: str,
+    turn_index: int,
+    tags: Sequence[str],
+    note: str,
+) -> None:
+    """Record or replace one conversation turn's reviewer annotation.
+
+    This is the "it broke character on the third turn" home -- keyed all the
+    way down to ``turn_index``, distinct from ``mark_conversation_reviewed``
+    below, which has no turn axis at all. Re-annotating the same turn
+    replaces its tags and note rather than accumulating a second row (see
+    ``EvalsDB.upsert_probe_turn_annotation``).
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The run group the conversation belongs to.
+        card_id: The character card's id.
+        probe_index: The probe's zero-based index within its probe set.
+        sample_index: The zero-based sample number for this cell.
+        target_id: The target's id, as used in ``save_conversations``'s
+            ``run_ids``.
+        turn_index: The zero-based turn within the conversation.
+        tags: Tag slugs describing this turn.
+        note: Free-text reviewer note for this turn.
+    """
+    db.upsert_probe_turn_annotation(
+        run_group_id=run_group_id,
+        card_id=card_id,
+        probe_index=probe_index,
+        sample_index=sample_index,
+        target_id=target_id,
+        turn_index=turn_index,
+        tags=list(tags),
+        note=note,
+    )
+
+
+def load_turn_annotations(
+    db: EvalsDB, run_group_id: str
+) -> dict[tuple[int, int, int, str, int], dict[str, Any]]:
+    """Every turn annotation recorded for one run group.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The run group to read.
+
+    Returns:
+        A dict keyed by ``(card_id, probe_index, sample_index, target_id,
+        turn_index)``, each value ``{"tags": [...], "note": str}``. Empty
+        for a run group with no annotations, never raising.
+    """
+    return {
+        (
+            row["card_id"],
+            row["probe_index"],
+            row["sample_index"],
+            row["target_id"],
+            row["turn_index"],
+        ): {"tags": row["tags"], "note": row["note"]}
+        for row in db.list_probe_turn_annotations(run_group_id)
+    }
+
+
+def mark_conversation_reviewed(
+    db: EvalsDB,
+    run_group_id: str,
+    card_id: int,
+    probe_index: int,
+    sample_index: int,
+    target_id: str,
+    note: str = "",
+) -> None:
+    """Mark one whole conversation reviewed.
+
+    This is the ONLY home for "I read this and nothing was notable" -- a
+    conversation is markable reviewed with zero turn annotations, which is a
+    common, meaningful outcome the review queue's progress count depends on,
+    not an edge case. Re-marking a reviewed conversation replaces its note
+    and refreshes ``reviewed_at`` (see
+    ``EvalsDB.upsert_probe_review_state``).
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The run group the conversation belongs to.
+        card_id: The character card's id.
+        probe_index: The probe's zero-based index within its probe set.
+        sample_index: The zero-based sample number for this cell.
+        target_id: The target's id, as used in ``save_conversations``'s
+            ``run_ids``.
+        note: Free-text reviewer note for the whole conversation.
+    """
+    db.upsert_probe_review_state(
+        run_group_id=run_group_id,
+        card_id=card_id,
+        probe_index=probe_index,
+        sample_index=sample_index,
+        target_id=target_id,
+        note=note,
+    )
+
+
+def load_review_state(
+    db: EvalsDB, run_group_id: str
+) -> dict[tuple[int, int, int, str], dict[str, Any]]:
+    """Every conversation's review state for one run group.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The run group to read.
+
+    Returns:
+        A dict keyed by ``(card_id, probe_index, sample_index, target_id)``,
+        each value ``{"reviewed_at": str, "note": str}``. Empty for a run
+        group with nothing marked reviewed, never raising.
+    """
+    return {
+        (
+            row["card_id"],
+            row["probe_index"],
+            row["sample_index"],
+            row["target_id"],
+        ): {"reviewed_at": row["reviewed_at"], "note": row["note"]}
+        for row in db.list_probe_review_state(run_group_id)
+    }

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -8,14 +8,25 @@ directly; every call goes through ``EvalsDB``.
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Mapping, Sequence
+from dataclasses import asdict
 from typing import Any, Optional
 
 from ...DB.Evals_DB import EvalsDB
 from ...Evaluations_Interop.evaluation_normalizers import (
     RESERVED_LOCAL_DATASET_SAMPLES_KEY,
 )
-from .models import CharacterProbeConfig, Conversation, ConversationTurn, Probe, ProbeSet
+from .models import (
+    CardSnapshot,
+    CharacterProbeConfig,
+    Conversation,
+    ConversationTurn,
+    Probe,
+    ProbeSet,
+)
+from .prompt import compose_system_prompt
+from .targets import ResolvedTarget, resolve_targets
 
 #: Marks a dataset row as holding probes rather than snippets.
 PROBE_DATASET_TYPE = "character_probe"
@@ -44,14 +55,71 @@ def _probe_set_to_samples(probe_set: ProbeSet) -> list[dict[str, Any]]:
     return [{"turns": list(probe.turns)} for probe in probe_set.probes]
 
 
-def _samples_to_probe_set(samples: Any) -> ProbeSet:
+def _samples_to_probe_set(samples: Any, dataset_id: str) -> ProbeSet:
+    """Rebuild a ``ProbeSet`` from a dataset row's stored samples list.
+
+    Every corrupt shape raises here, naming the dataset (and the offending
+    sample's index). Returning an empty or partial set instead would produce
+    exactly the outcome ``load_probe_set``'s docstring promises it prevents:
+    a bench that runs, produces nothing, and looks like an authoring mistake
+    rather than the damaged row it is.
+
+    Args:
+        samples: The value stored under the dataset's samples key.
+        dataset_id: The owning dataset, only for the error messages below.
+
+    Returns:
+        ProbeSet: The stored probes, in order. An explicitly-stored empty
+        list yields an empty ``ProbeSet`` and does NOT raise -- that is a
+        deliberately empty probe set, not a missing one.
+
+    Raises:
+        ValueError: If the samples key is absent or does not hold a list;
+            if any entry is not a mapping; if an entry's ``turns`` is
+            missing, empty, or a bare string (a string would otherwise
+            iterate character by character into a probe of one-character
+            turns); if any turn is not a string; or if the turns violate
+            ``Probe``'s own rules (no turns, or an empty/whitespace-only
+            turn) -- re-raised with the dataset named.
+    """
     if not isinstance(samples, list):
-        return ProbeSet(probes=())
-    probes = [
-        Probe(turns=tuple(str(turn) for turn in sample.get("turns") or ()))
-        for sample in samples
-        if isinstance(sample, Mapping) and sample.get("turns")
-    ]
+        raise ValueError(
+            f"Probe set {dataset_id!r} has no stored samples list "
+            f"(found {type(samples).__name__}); the dataset is marked as a "
+            "probe set but its probes are missing or corrupt."
+        )
+    probes: list[Probe] = []
+    for index, sample in enumerate(samples):
+        if not isinstance(sample, Mapping):
+            raise ValueError(
+                f"Probe set {dataset_id!r} sample {index} is not a mapping: "
+                f"{sample!r}"
+            )
+        turns = sample.get("turns")
+        if isinstance(turns, str):
+            raise ValueError(
+                f"Probe set {dataset_id!r} sample {index} stores its turns as "
+                f"a string ({turns!r}); a probe's turns are a list, and "
+                "iterating a string here would silently produce a probe of "
+                "one-character turns."
+            )
+        if not turns or not isinstance(turns, Sequence):
+            raise ValueError(
+                f"Probe set {dataset_id!r} sample {index} has no turns: "
+                f"{turns!r}"
+            )
+        for turn in turns:
+            if not isinstance(turn, str):
+                raise ValueError(
+                    f"Probe set {dataset_id!r} sample {index} has a "
+                    f"non-string turn: {turn!r}"
+                )
+        try:
+            probes.append(Probe(turns=tuple(turns)))
+        except ValueError as exc:
+            raise ValueError(
+                f"Probe set {dataset_id!r} sample {index} is invalid: {exc}"
+            ) from None
     return ProbeSet(probes=tuple(probes))
 
 
@@ -112,6 +180,9 @@ def load_probe_set(db: EvalsDB, dataset_id: str) -> ProbeSet:
         ValueError: If the dataset does not exist, or is not a probe set --
             loading a snippet dataset as probes would otherwise silently yield
             an empty set and look like an authoring mistake.
+        ValueError: Propagated from ``_samples_to_probe_set`` if the row IS
+            marked as a probe set but its samples are missing or corrupt --
+            same reason, one layer in.
     """
     row = db.get_dataset(dataset_id)
     if row is None:
@@ -119,7 +190,9 @@ def load_probe_set(db: EvalsDB, dataset_id: str) -> ProbeSet:
     if not is_probe_set(row):
         raise ValueError(f"Dataset {dataset_id!r} is not a probe set.")
     metadata = row.get("metadata") or {}
-    return _samples_to_probe_set(metadata.get(RESERVED_LOCAL_DATASET_SAMPLES_KEY))
+    return _samples_to_probe_set(
+        metadata.get(RESERVED_LOCAL_DATASET_SAMPLES_KEY), dataset_id
+    )
 
 
 #: Discriminates a character probe bench from a word bench in ``eval_tasks``.
@@ -133,9 +206,20 @@ def is_character_bench(task_row: Mapping[str, Any]) -> bool:
         task_row: A row as returned by ``EvalsDB.get_task``/``list_tasks``.
 
     Returns:
-        bool: True when the row carries this bench type.
+        bool: True when the row carries this bench type. A row whose
+        ``config_data`` is missing or is not itself a mapping (corrupt
+        data) is treated as "not a character bench" rather than raising --
+        byte-for-byte the guard ``is_probe_set`` above already carries, and
+        for the same reason: a caller that only wants a yes/no answer must
+        never have to catch an unrelated ``AttributeError``. ``(x or {})``
+        alone does NOT provide this: it rescues ``None`` and every other
+        falsy value, but a TRUTHY non-mapping -- a string, a list -- sails
+        straight through to ``.get`` and raises.
     """
-    return (task_row.get("config_data") or {}).get("bench_type") == BENCH_TYPE
+    config_data = task_row.get("config_data")
+    if not isinstance(config_data, Mapping):
+        return False
+    return config_data.get("bench_type") == BENCH_TYPE
 
 
 def save_character_bench(
@@ -255,21 +339,94 @@ def _stored_int_field(
 
     Raises:
         ValueError: If the key is present with a value that is not
-            integer-shaped (e.g. a string) or is negative -- naming both
-            the bench id and the field.
+            integer-shaped, or is negative -- naming both the bench id and
+            the field. "Integer-shaped" means a genuine ``int``, checked by
+            type rather than by attempting ``int(value)``: the coercion
+            this function used to perform accepted the numeric STRING
+            ``"512"`` (``int("512")`` succeeds) and silently truncated the
+            float ``2.7`` to ``2``, neither of which this docstring ever
+            claimed. ``bool`` is rejected too -- it is an ``int`` subclass,
+            but ``True`` is never a stored setting.
     """
     value = data.get(key)
     if value is None:
         return default
-    try:
-        result = int(value)
-    except (TypeError, ValueError):
+    if not isinstance(value, int) or isinstance(value, bool):
         raise ValueError(
             f"Bench {task_id!r} has a non-integer {key!r}: {value!r}"
-        ) from None
-    if result < 0:
-        raise ValueError(f"Bench {task_id!r} has a negative {key!r}: {result!r}")
-    return result
+        )
+    if value < 0:
+        raise ValueError(f"Bench {task_id!r} has a negative {key!r}: {value!r}")
+    return value
+
+
+def _stored_seed(data: Mapping[str, Any], task_id: str) -> Optional[int]:
+    """The bench's optional ``seed``, validated rather than passed through.
+
+    ``seed`` is the one genuinely optional numeric setting -- ``None`` means
+    "no seed", which is the default and is NOT an error. Everything else
+    must be a real ``int``: an unvalidated stored value reaches the runner
+    as ``config.seed + sample_index`` on the first cell of a grid, so a
+    stored string detonates with a bare ``TypeError`` mid-run, after real
+    provider calls have already been paid for and with nothing in the
+    message naming the bench or the field.
+
+    A NEGATIVE seed is accepted, unlike every other numeric field here:
+    llama.cpp uses ``-1`` for "pick a random seed", so it is a real value a
+    user may deliberately store.
+
+    Args:
+        data: The bench's ``config_data``, already parsed into a dict.
+        task_id: The owning bench's id, only for the error message below.
+
+    Returns:
+        Optional[int]: The stored seed, or ``None`` when unseeded.
+
+    Raises:
+        ValueError: If the stored seed is present and is not an ``int``
+            (``bool`` included), naming both the bench and the field.
+    """
+    value = data.get("seed")
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"Bench {task_id!r} has a non-integer 'seed': {value!r}")
+    return value
+
+
+def _stored_temperature(data: Mapping[str, Any], task_id: str, default: float) -> float:
+    """The bench's ``temperature``, with the same named-error contract.
+
+    ``float(data.get("temperature", 0.8))`` -- what this replaced -- raises
+    a bare ``TypeError`` on a stored ``null`` and a bare ``ValueError`` on a
+    stored string, two lines below ``_stored_int_field``, whose entire
+    purpose is to name the bench and the field when that happens.
+
+    Args:
+        data: The bench's ``config_data``, already parsed into a dict.
+        task_id: The owning bench's id, only for the error message below.
+        default: Value to use when the key is absent or explicitly ``None``.
+
+    Returns:
+        float: The stored temperature, or ``default``.
+
+    Raises:
+        ValueError: If the stored value is not a real number (``bool``
+            excluded, being an ``int`` subclass that is never a sampler
+            setting) or is negative -- naming the bench and the field.
+    """
+    value = data.get("temperature")
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(
+            f"Bench {task_id!r} has a non-numeric 'temperature': {value!r}"
+        )
+    if value < 0:
+        raise ValueError(
+            f"Bench {task_id!r} has a negative 'temperature': {value!r}"
+        )
+    return float(value)
 
 
 def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
@@ -288,9 +445,10 @@ def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
             config with empty characters and look like data loss. Also
             propagated from ``_stored_int_field`` (see its own docstring)
             for a corrupt ``concurrency``/``samples_per_cell``/
-            ``max_tokens``, and from ``CharacterProbeConfig.__post_init__``
-            for a stored ``concurrency``/``samples_per_cell`` below its
-            ``>= 1`` floor.
+            ``max_tokens``, from ``_stored_seed``/``_stored_temperature``
+            for a corrupt ``seed``/``temperature``, and from
+            ``CharacterProbeConfig.__post_init__`` for a stored
+            ``concurrency``/``samples_per_cell`` below its ``>= 1`` floor.
     """
     row = db.get_task(task_id)
     if row is None:
@@ -306,8 +464,8 @@ def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
         target_ids=tuple(str(tid) for tid in data.get("target_ids") or ()),
         concurrency=_stored_int_field(data, "concurrency", 1, task_id),
         samples_per_cell=_stored_int_field(data, "samples_per_cell", 1, task_id),
-        seed=data.get("seed"),
-        temperature=float(data.get("temperature", 0.8)),
+        seed=_stored_seed(data, task_id),
+        temperature=_stored_temperature(data, task_id, 0.8),
         max_tokens=_stored_int_field(data, "max_tokens", 512, task_id),
         extra_tags=tuple(data.get("extra_tags") or ()),
     )
@@ -336,6 +494,173 @@ def conversation_sample_id(card_id: int, probe_index: int, sample_index: int) ->
     return f"{card_id}:{probe_index}:{sample_index}"
 
 
+def _probe_run_snapshot(
+    config: CharacterProbeConfig,
+    cards: Sequence[CardSnapshot],
+    probe_set: ProbeSet,
+    targets: Sequence[ResolvedTarget],
+) -> dict[str, Any]:
+    """The fully-resolved configuration one run group ran with.
+
+    This is what makes a run self-describing, which the design spec requires
+    twice over: "at run time the card's actual text is copied into the run
+    snapshot", and "the sampler settings are stored in the snapshot so every
+    run is self-describing". Without it, ``CardSnapshot``'s whole provenance
+    purpose is defeated the moment the run ends -- the cards were copied
+    across the database boundary and then thrown away, so a card edited
+    afterwards silently rewrites what a past run appears to have asked.
+
+    Card TEXT is stored, not just ids, for the same reason word_bench stores
+    snippet text rather than only hashes: a run must still render after its
+    cards are edited or deleted, and there are no foreign keys across the
+    ``ChaChaNotes_DB``/``Evals_DB`` boundary to prevent either.
+
+    ``composed_system_prompts`` records the ACTUAL composed text per card
+    per target -- what the model was really told, steering included, after
+    macro resolution. The spec asks for exactly this ("the run snapshot
+    records the composed result so what actually ran is never in doubt"),
+    and it is not derivable from the parts later: field order, labelling,
+    and macro resolution all live in ``prompt.py``, which is free to change.
+
+    Args:
+        config: The bench being run.
+        cards: The snapshotted cards, in run order.
+        probe_set: The scripts being run.
+        targets: The resolved targets, in run order.
+
+    Returns:
+        dict[str, Any]: A JSON-serialisable snapshot.
+    """
+    return {
+        "bench_name": config.name,
+        "bench_description": config.description,
+        "probe_set_id": config.probe_set_id,
+        "sampler": {
+            "temperature": config.temperature,
+            "max_tokens": config.max_tokens,
+            "seed": config.seed,
+            "samples_per_cell": config.samples_per_cell,
+            "concurrency": config.concurrency,
+        },
+        "extra_tags": list(config.extra_tags),
+        "targets": [
+            {
+                "id": target.id,
+                "name": target.name,
+                "provider": target.provider,
+                "model_id": target.model_id,
+                "system_prompt": target.steering,
+            }
+            for target in targets
+        ],
+        "cards": [asdict(card) for card in cards],
+        "probes": [{"turns": list(probe.turns)} for probe in probe_set.probes],
+        "composed_system_prompts": {
+            # Card ids are INTEGERs and JSON object keys are strings, so
+            # these come back out of storage as strings; a reader keying by
+            # card id must str() it, exactly as this writer does.
+            str(card.id): {
+                target.id: compose_system_prompt(card, target.steering)
+                for target in targets
+            }
+            for card in cards
+        },
+    }
+
+
+def create_probe_run_group(
+    db: EvalsDB,
+    task_id: str,
+    config: CharacterProbeConfig,
+    cards: Sequence[CardSnapshot],
+    probe_set: ProbeSet,
+    targets: Sequence[Mapping[str, Any]],
+) -> tuple[str, dict[str, str]]:
+    """Open a run group for one probe run: one ``eval_runs`` row per target.
+
+    Mirrors ``word_bench.storage.create_run_group`` seam for seam -- a run
+    per target sharing a ``run_group_id``, with the run's own snapshot in
+    ``config_overrides["snapshot"]`` -- so the two bench types stay legible
+    against each other and a later reader can find a whole group with one
+    ``list_runs(run_group_id=...)`` call.
+
+    Call this BEFORE running, then pass the returned ``run_ids`` to
+    ``save_conversations``. The snapshot is written at launch, from the
+    resolved cards and targets the run is about to use, so it records what
+    actually ran rather than what the (mutable) bench row says afterwards.
+
+    Args:
+        db: The evals database handle.
+        task_id: The bench's ``eval_tasks`` id.
+        config: The bench being run.
+        cards: The snapshotted cards, in run order.
+        probe_set: The scripts being run.
+        targets: ``eval_models`` rows for the run's targets.
+
+    Returns:
+        tuple[str, dict[str, str]]: The new ``run_group_id``, and
+        target id -> ``eval_runs`` id for every target.
+
+    Raises:
+        ValueError: Propagated from ``resolve_targets`` for an empty target
+            list, duplicate target ids, or a malformed/prefix-steered row.
+        InputError: From ``EvalsDB.create_run`` if ``task_id`` or a target
+            id does not name a live row -- a target id IS an ``eval_models``
+            id, which ``create_run`` validates.
+    """
+    resolved = resolve_targets(targets)
+    group_id = uuid.uuid4().hex
+    snapshot = _probe_run_snapshot(config, cards, probe_set, resolved)
+    # One conversation per card x probe x sample, per target -- the target
+    # axis is the run itself, so it is NOT part of a single run's count.
+    per_target_cells = len(cards) * len(probe_set.probes) * config.samples_per_cell
+    run_ids: dict[str, str] = {}
+    for target in resolved:
+        run_id = db.create_run(
+            name=f"{config.name or 'Character probe'} · "
+            f"{target.name or target.model_id}",
+            task_id=task_id,
+            model_id=target.id,
+            config_overrides={"snapshot": snapshot, "target_id": target.id},
+        )
+        db.update_run(
+            run_id, {"run_group_id": group_id, "total_samples": per_target_cells}
+        )
+        run_ids[target.id] = run_id
+    return group_id, run_ids
+
+
+def load_probe_run_snapshot(db: EvalsDB, run_group_id: str) -> dict[str, Any]:
+    """Read back the snapshot ``create_probe_run_group`` wrote.
+
+    Every run in a group carries the same snapshot (written once, at
+    launch), so the first run found answers for the group -- the same
+    approach ``word_bench.storage._load_run_group_snapshot`` takes, and for
+    the same reason: the snapshot, never the live ``eval_tasks`` row, is
+    what a past run must render from.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The group to read.
+
+    Returns:
+        dict[str, Any]: The stored snapshot. ``{}`` for a group whose runs
+        were created some other way and carry no snapshot, rather than
+        raising -- absent provenance is not a corrupt group.
+
+    Raises:
+        ValueError: If no runs share this ``run_group_id`` -- naming the
+            group, rather than returning ``{}`` and letting a caller mistake
+            "this group does not exist" for "this group has no snapshot".
+    """
+    runs = db.list_runs(run_group_id=run_group_id, limit=10_000)
+    if not runs:
+        raise ValueError(f"No runs found for run group {run_group_id!r}.")
+    overrides = runs[0].get("config_overrides") or {}
+    snapshot = overrides.get("snapshot")
+    return snapshot if isinstance(snapshot, Mapping) else {}
+
+
 def save_conversations(
     db: EvalsDB,
     run_group_id: str,
@@ -356,6 +681,13 @@ def save_conversations(
     all failed before producing a turn -- ``load_conversations`` below has
     no other way to discover which runs belong to this group.
 
+    EVERY check runs before the FIRST write. An unknown target used to be
+    detected inside the write loop, so a group could be left half-committed
+    -- earlier conversations stored, the rest not, and the run group loading
+    back as if it were complete, since nothing distinguishes a missing
+    conversation from one that was never meant to exist. Validating in one
+    pass first means the group is either fully written or not started.
+
     Args:
         db: The evals database handle.
         run_group_id: The group these conversations belong to.
@@ -373,21 +705,25 @@ def save_conversations(
             mode ``save_probe_set``/``save_character_bench`` above already
             guard against for ``update_dataset``/``update_task``.
     """
+    unknown = sorted(
+        {c.target_id for c in conversations if c.target_id not in run_ids}
+    )
+    if unknown:
+        raise ValueError(
+            f"No run id supplied for target(s) {unknown!r} in run group "
+            f"{run_group_id!r}; run_ids covers {sorted(run_ids)!r}."
+        )
     for run_id in set(run_ids.values()):
         if db.get_run(run_id) is None:
             raise ValueError(
                 f"Run {run_id!r} (in run_ids for run group {run_group_id!r}) "
                 "does not exist; it may have been deleted."
             )
+
+    for run_id in set(run_ids.values()):
         db.update_run(run_id, {"run_group_id": run_group_id})
 
     for conversation in conversations:
-        if conversation.target_id not in run_ids:
-            raise ValueError(
-                f"No run id supplied for target {conversation.target_id!r} "
-                f"in run group {run_group_id!r}; run_ids covers "
-                f"{sorted(run_ids)!r}."
-            )
         db.store_result(
             run_id=run_ids[conversation.target_id],
             sample_id=conversation_sample_id(

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -9,13 +9,13 @@ directly; every call goes through ``EvalsDB``.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Optional
 
 from ...DB.Evals_DB import EvalsDB
 from ...Evaluations_Interop.evaluation_normalizers import (
     RESERVED_LOCAL_DATASET_SAMPLES_KEY,
 )
-from .models import Probe, ProbeSet
+from .models import CharacterProbeConfig, Probe, ProbeSet
 
 #: Marks a dataset row as holding probes rather than snippets.
 PROBE_DATASET_TYPE = "character_probe"
@@ -120,3 +120,133 @@ def load_probe_set(db: EvalsDB, dataset_id: str) -> ProbeSet:
         raise ValueError(f"Dataset {dataset_id!r} is not a probe set.")
     metadata = row.get("metadata") or {}
     return _samples_to_probe_set(metadata.get(RESERVED_LOCAL_DATASET_SAMPLES_KEY))
+
+
+#: Discriminates a character probe bench from a word bench in ``eval_tasks``.
+BENCH_TYPE = "character_probe"
+
+
+def is_character_bench(task_row: Mapping[str, Any]) -> bool:
+    """Whether an ``eval_tasks`` row is a character probe bench.
+
+    Args:
+        task_row: A row as returned by ``EvalsDB.get_task``/``list_tasks``.
+
+    Returns:
+        bool: True when the row carries this bench type.
+    """
+    return (task_row.get("config_data") or {}).get("bench_type") == BENCH_TYPE
+
+
+def save_character_bench(
+    db: EvalsDB, config: CharacterProbeConfig, task_id: Optional[str] = None
+) -> str:
+    """Persist a character probe bench.
+
+    Mirrors ``word_bench.storage.save_bench``: a new bench creates an
+    ``eval_tasks`` row, an existing one updates in place. ``task_type`` is
+    ``"generation"`` because ``EvalsDB.create_task``'s ``CHECK`` constraint
+    permits only a small fixed set of DB-level literals, none of which name
+    this eval type; ``config_data.bench_type`` is the real discriminator,
+    the same convention word_bench uses for its own ``task_type`` literal.
+    ``config_format`` is ``"custom"`` for the same reason word_bench passes
+    it explicitly -- ``create_task`` has no default for that parameter, and
+    omitting it (as an earlier draft of this function did) raises a
+    ``TypeError`` before a single row is written.
+
+    ``probe_set_id`` lives only in ``config_data``, never passed through as
+    ``create_task``'s ``dataset_id``: that column carries a real ``FOREIGN
+    KEY`` to ``eval_datasets(id)``, and a probe set is only sometimes an
+    ``eval_datasets`` row (see ``save_probe_set`` above) -- forcing every
+    bench to reference one there would reject a bench referencing a probe
+    set by a not-yet-persisted or external id.
+
+    Args:
+        db: The evals database handle.
+        config: The bench to persist.
+        task_id: An existing bench to update; omit to create.
+
+    Returns:
+        str: The bench's ``eval_tasks`` id.
+
+    Raises:
+        ConflictError: If the name collides with another task's (including a
+            soft-deleted one -- the UNIQUE index has no ``deleted_at``
+            exemption).
+        ValueError: If ``task_id`` is given (the edit path) and
+            ``update_task`` matched no row -- the bench was deleted (by this
+            process or another) between whenever the caller loaded it and
+            this call. ``update_task`` itself only returns ``False`` here,
+            never raises; silently returning ``task_id`` anyway would tell
+            the caller "saved" for a write that persisted nothing, the same
+            failure mode ``save_probe_set`` above already guards against for
+            ``update_dataset``.
+    """
+    config_data = {
+        "bench_type": BENCH_TYPE,
+        "probe_set_id": config.probe_set_id,
+        "character_ids": list(config.character_ids),
+        "target_ids": list(config.target_ids),
+        "concurrency": config.concurrency,
+        "samples_per_cell": config.samples_per_cell,
+        "seed": config.seed,
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
+        "extra_tags": list(config.extra_tags),
+    }
+    if task_id is not None:
+        updated = db.update_task(
+            task_id,
+            name=config.name,
+            description=config.description,
+            config_data=config_data,
+        )
+        if not updated:
+            raise ValueError(
+                f"Bench {task_id!r} could not be updated; it may have been "
+                "deleted."
+            )
+        return task_id
+    return db.create_task(
+        name=config.name,
+        description=config.description,
+        task_type="generation",
+        config_format="custom",
+        config_data=config_data,
+    )
+
+
+def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
+    """Read a character probe bench back.
+
+    Args:
+        db: The evals database handle.
+        task_id: The bench to read.
+
+    Returns:
+        CharacterProbeConfig: The stored bench.
+
+    Raises:
+        ValueError: If the task does not exist or is not a character probe
+            bench -- loading a word bench here would otherwise produce a
+            config with empty characters and look like data loss.
+    """
+    row = db.get_task(task_id)
+    if row is None:
+        raise ValueError(f"Bench {task_id!r} could not be found.")
+    if not is_character_bench(row):
+        raise ValueError(f"Bench {task_id!r} is not a character probe bench.")
+    data = row.get("config_data") or {}
+    return CharacterProbeConfig(
+        name=row.get("name") or "",
+        description=row.get("description") or "",
+        probe_set_id=str(data.get("probe_set_id") or ""),
+        character_ids=tuple(int(cid) for cid in data.get("character_ids") or ()),
+        target_ids=tuple(str(tid) for tid in data.get("target_ids") or ()),
+        concurrency=int(data.get("concurrency") or 1),
+        samples_per_cell=int(data.get("samples_per_cell") or 1),
+        seed=data.get("seed"),
+        temperature=float(data.get("temperature", 0.8)),
+        max_tokens=int(data.get("max_tokens") or 512),
+        extra_tags=tuple(data.get("extra_tags") or ()),
+    )

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -1,0 +1,109 @@
+"""Persistence for character probe evals.
+
+Probe sets reuse the dataset inline-samples convention that snippets already
+use, discriminated by ``metadata["dataset_type"]`` -- the same shape
+``config_data.bench_type`` gives ``eval_tasks``. Nothing here writes SQL
+directly; every call goes through ``EvalsDB``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ...DB.Evals_DB import EvalsDB
+from ...Evaluations_Interop.evaluation_normalizers import (
+    RESERVED_LOCAL_DATASET_SAMPLES_KEY,
+)
+from .models import Probe, ProbeSet
+
+#: Marks a dataset row as holding probes rather than snippets.
+PROBE_DATASET_TYPE = "character_probe"
+
+
+def is_probe_set(dataset_row: Mapping[str, Any]) -> bool:
+    """Whether a dataset row holds probes rather than snippets.
+
+    Args:
+        dataset_row: A row as returned by ``EvalsDB.get_dataset``/``list_datasets``.
+
+    Returns:
+        bool: True when the row is marked as a probe set.
+    """
+    metadata = dataset_row.get("metadata") or {}
+    return metadata.get("dataset_type") == PROBE_DATASET_TYPE
+
+
+def _probe_set_to_samples(probe_set: ProbeSet) -> list[dict[str, Any]]:
+    return [
+        {"index": index, "turns": list(probe.turns)}
+        for index, probe in enumerate(probe_set.probes)
+    ]
+
+
+def _samples_to_probe_set(samples: Any) -> ProbeSet:
+    if not isinstance(samples, list):
+        return ProbeSet(probes=())
+    probes = [
+        Probe(turns=tuple(str(turn) for turn in sample.get("turns") or ()))
+        for sample in samples
+        if isinstance(sample, Mapping) and sample.get("turns")
+    ]
+    return ProbeSet(probes=tuple(probes))
+
+
+def save_probe_set(
+    db: EvalsDB,
+    name: str,
+    probe_set: ProbeSet,
+    dataset_id: str | None = None,
+) -> str:
+    """Persist a probe set, creating or replacing a dataset row.
+
+    Args:
+        db: The evals database handle.
+        name: Display name for the dataset row.
+        probe_set: The probes to store.
+        dataset_id: An existing probe-set dataset to overwrite; when omitted a
+            new dataset row is created.
+
+    Returns:
+        str: The dataset id holding the probes.
+    """
+    metadata = {
+        "dataset_type": PROBE_DATASET_TYPE,
+        RESERVED_LOCAL_DATASET_SAMPLES_KEY: _probe_set_to_samples(probe_set),
+    }
+    if dataset_id is None:
+        return db.create_dataset(
+            name=name,
+            format="custom",
+            source_path=f"inline:{name}",
+            metadata=metadata,
+        )
+    db.update_dataset(dataset_id, metadata=metadata)
+    return dataset_id
+
+
+def load_probe_set(db: EvalsDB, dataset_id: str) -> ProbeSet:
+    """Read a probe set back.
+
+    Args:
+        db: The evals database handle.
+        dataset_id: The dataset row to read.
+
+    Returns:
+        ProbeSet: The stored probes, in order.
+
+    Raises:
+        ValueError: If the dataset does not exist, or is not a probe set --
+            loading a snippet dataset as probes would otherwise silently yield
+            an empty set and look like an authoring mistake.
+    """
+    row = db.get_dataset(dataset_id)
+    if row is None:
+        raise ValueError(f"Probe set {dataset_id!r} could not be found.")
+    if not is_probe_set(row):
+        raise ValueError(f"Dataset {dataset_id!r} is not a probe set.")
+    metadata = row.get("metadata") or {}
+    return _samples_to_probe_set(metadata.get(RESERVED_LOCAL_DATASET_SAMPLES_KEY))

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -216,6 +216,62 @@ def save_character_bench(
     )
 
 
+def _stored_int_field(
+    data: Mapping[str, Any], key: str, default: int, task_id: str
+) -> int:
+    """One integer field out of a stored ``config_data``, missing-vs-falsy aware.
+
+    A present-but-falsy stored value (``0``, most notably a zero
+    ``max_tokens``) is a real value the caller explicitly chose, not an
+    absent one -- ``data.get(key) or default`` cannot tell those apart,
+    since ``0`` and a missing key are both falsy, and would silently
+    replace a deliberately-stored ``0`` with ``default`` on every load.
+    Only a genuinely missing key, or an explicit stored ``None``, reads as
+    ``default`` here.
+
+    A present value that is negative or not integer-shaped is instead
+    treated as corrupt data and rejected outright, matching the
+    "fail loudly on a corrupt row" contract this module already applies to
+    ``bench_type`` (``is_character_bench``/``load_character_bench`` below)
+    and, for the probe-set half of this file, ``is_probe_set``/
+    ``load_probe_set`` -- silently coercing a negative or garbage stored
+    value into ``default`` would look like a normal, freshly-created bench
+    rather than the sign of a hand-edited or otherwise damaged row that it
+    actually is. ``0`` itself is not rejected here: whether it is a
+    sensible value for a *particular* field (e.g. ``max_tokens``) is that
+    field's own concern -- ``CharacterProbeConfig.__post_init__`` already
+    enforces a ``>= 1`` floor for ``concurrency``/``samples_per_cell``, so
+    a stored ``0`` for either of those still fails loudly, just one layer
+    up, the moment this function's caller constructs the config below.
+
+    Args:
+        data: The bench's ``config_data``, already parsed into a dict.
+        key: The field to read.
+        default: Value to use when the key is absent or explicitly ``None``.
+        task_id: The owning bench's id, only for the error message below.
+
+    Returns:
+        int: The stored value, or ``default``.
+
+    Raises:
+        ValueError: If the key is present with a value that is not
+            integer-shaped (e.g. a string) or is negative -- naming both
+            the bench id and the field.
+    """
+    value = data.get(key)
+    if value is None:
+        return default
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Bench {task_id!r} has a non-integer {key!r}: {value!r}"
+        ) from None
+    if result < 0:
+        raise ValueError(f"Bench {task_id!r} has a negative {key!r}: {result!r}")
+    return result
+
+
 def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
     """Read a character probe bench back.
 
@@ -229,7 +285,12 @@ def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
     Raises:
         ValueError: If the task does not exist or is not a character probe
             bench -- loading a word bench here would otherwise produce a
-            config with empty characters and look like data loss.
+            config with empty characters and look like data loss. Also
+            propagated from ``_stored_int_field`` (see its own docstring)
+            for a corrupt ``concurrency``/``samples_per_cell``/
+            ``max_tokens``, and from ``CharacterProbeConfig.__post_init__``
+            for a stored ``concurrency``/``samples_per_cell`` below its
+            ``>= 1`` floor.
     """
     row = db.get_task(task_id)
     if row is None:
@@ -243,10 +304,10 @@ def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
         probe_set_id=str(data.get("probe_set_id") or ""),
         character_ids=tuple(int(cid) for cid in data.get("character_ids") or ()),
         target_ids=tuple(str(tid) for tid in data.get("target_ids") or ()),
-        concurrency=int(data.get("concurrency") or 1),
-        samples_per_cell=int(data.get("samples_per_cell") or 1),
+        concurrency=_stored_int_field(data, "concurrency", 1, task_id),
+        samples_per_cell=_stored_int_field(data, "samples_per_cell", 1, task_id),
         seed=data.get("seed"),
         temperature=float(data.get("temperature", 0.8)),
-        max_tokens=int(data.get("max_tokens") or 512),
+        max_tokens=_stored_int_field(data, "max_tokens", 512, task_id),
         extra_tags=tuple(data.get("extra_tags") or ()),
     )

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -681,12 +681,25 @@ def save_conversations(
     all failed before producing a turn -- ``load_conversations`` below has
     no other way to discover which runs belong to this group.
 
-    EVERY check runs before the FIRST write. An unknown target used to be
-    detected inside the write loop, so a group could be left half-committed
-    -- earlier conversations stored, the rest not, and the run group loading
-    back as if it were complete, since nothing distinguishes a missing
-    conversation from one that was never meant to exist. Validating in one
-    pass first means the group is either fully written or not started.
+    EVERY check this function makes runs before the FIRST write. An unknown
+    target used to be detected inside the write loop, so a group could be
+    left half-committed -- earlier conversations stored, the rest not, and
+    the run group loading back as if it were complete, since nothing
+    distinguishes a missing conversation from one that was never meant to
+    exist.
+
+    That is a claim about VALIDATION ordering only, not about atomicity: the
+    write loop itself is NOT transactional. ``EvalsDB.store_result`` commits
+    each row in its own ``with conn`` block, so an error raised by the
+    database mid-loop still leaves the preceding rows committed. The one
+    reachable way to provoke that is two conversations sharing a
+    ``sample_id`` -- the same ``(card_id, probe_index, sample_index)`` under
+    one target -- which trips ``eval_results``'s UNIQUE
+    ``(run_id, sample_id)`` on the second write. A runner-produced grid
+    cannot contain such a pair (every cell is one point of a product of
+    distinct axes), so this is a hand-assembled-input hazard rather than a
+    live one; making the loop genuinely atomic needs a batch write on
+    ``EvalsDB``, which is not this function's to add.
 
     Args:
         db: The evals database handle.

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -28,17 +28,20 @@ def is_probe_set(dataset_row: Mapping[str, Any]) -> bool:
         dataset_row: A row as returned by ``EvalsDB.get_dataset``/``list_datasets``.
 
     Returns:
-        bool: True when the row is marked as a probe set.
+        bool: True when the row is marked as a probe set. A row whose
+        ``metadata`` is missing or is not itself a mapping (corrupt data)
+        is treated as "not a probe set" rather than raising, so a caller
+        that only wants a yes/no answer never has to catch an unrelated
+        ``AttributeError`` for that case.
     """
-    metadata = dataset_row.get("metadata") or {}
+    metadata = dataset_row.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return False
     return metadata.get("dataset_type") == PROBE_DATASET_TYPE
 
 
 def _probe_set_to_samples(probe_set: ProbeSet) -> list[dict[str, Any]]:
-    return [
-        {"index": index, "turns": list(probe.turns)}
-        for index, probe in enumerate(probe_set.probes)
-    ]
+    return [{"turns": list(probe.turns)} for probe in probe_set.probes]
 
 
 def _samples_to_probe_set(samples: Any) -> ProbeSet:
@@ -69,6 +72,14 @@ def save_probe_set(
 
     Returns:
         str: The dataset id holding the probes.
+
+    Raises:
+        ValueError: If ``dataset_id`` is given but does not identify a live
+            dataset row -- ``EvalsDB.update_dataset`` reports this by
+            returning ``False`` rather than raising, and silently ignoring
+            that would look like a successful save that in fact wrote
+            nothing (see ``LocalEvaluationsService.update_dataset`` for the
+            same convention).
     """
     metadata = {
         "dataset_type": PROBE_DATASET_TYPE,
@@ -81,7 +92,9 @@ def save_probe_set(
             source_path=f"inline:{name}",
             metadata=metadata,
         )
-    db.update_dataset(dataset_id, metadata=metadata)
+    updated = db.update_dataset(dataset_id, name=name, metadata=metadata)
+    if not updated:
+        raise ValueError(f"Probe set {dataset_id!r} could not be updated.")
     return dataset_id
 
 

--- a/tldw_chatbook/Evals/character_probe/targets.py
+++ b/tldw_chatbook/Evals/character_probe/targets.py
@@ -16,8 +16,12 @@ run needs from it are NOT top-level columns:
 The steering read itself is ``word_bench.storage.model_steering`` -- the one
 existing home for that convention (task-1611), reused rather than
 reimplemented so the two bench types can never drift into disagreeing about
-what a row means. Only that reader is used; none of word_bench's measurement
-code is touched.
+what a row means. The design spec lists targets "and their steering" among
+the things this eval explicitly DOES reuse, so this import is the sanctioned
+kind; only that one reader is called, and none of word_bench's measurement
+code is referenced here or anywhere else in this package. (Importing that
+module does pull word_bench's own imports in transitively -- unavoidable
+without duplicating the reader, which is the thing worth avoiding.)
 """
 
 from __future__ import annotations

--- a/tldw_chatbook/Evals/character_probe/targets.py
+++ b/tldw_chatbook/Evals/character_probe/targets.py
@@ -1,0 +1,148 @@
+"""Resolving an ``eval_models`` row into what a probe run actually needs.
+
+A "target" reaches this package as a raw ``eval_models`` row, exactly as
+``EvalsDB.get_model``/``list_models`` hand it back. Two of the three things a
+run needs from it are NOT top-level columns:
+
+* the provider-side model name is the row's ``model_id`` column, while the
+  row's ``id`` is the target's own identity (what a run and a conversation
+  are keyed by) -- confusing the two sends a UUID to the provider;
+* the target's steering lives inside the free-form ``config`` JSON column,
+  never at the top level. Reading ``row["system_prompt"]`` finds nothing on
+  any row the database has ever produced, which is precisely how a whole
+  branch of this package came to drop every target's steering silently while
+  a test built its own row shape and passed.
+
+The steering read itself is ``word_bench.storage.model_steering`` -- the one
+existing home for that convention (task-1611), reused rather than
+reimplemented so the two bench types can never drift into disagreeing about
+what a row means. Only that reader is used; none of word_bench's measurement
+code is touched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence
+
+from ..word_bench.storage import model_steering
+
+
+@dataclass(frozen=True)
+class ResolvedTarget:
+    """One validated target: who it is, what to call, and how it is steered.
+
+    ``id`` is the ``eval_models`` row id -- the value a ``Conversation``'s
+    ``target_id`` carries and the value ``EvalsDB.create_run`` stores as its
+    ``model_id`` column. ``model_id`` is the provider-side model name that
+    goes out on the wire. They are deliberately separate fields with the
+    confusable names kept, so a reader comparing this against a raw row can
+    see which column each came from.
+    """
+
+    id: str
+    model_id: str
+    name: str = ""
+    provider: str = ""
+    steering: Optional[str] = None
+
+
+def _required_text(target: Mapping[str, Any], key: str) -> str:
+    value = target.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"Target row {target.get('id')!r} (name {target.get('name')!r}) "
+            f"has no usable {key!r}: {value!r}. A character probe cannot run "
+            "it -- an absent model_id reaches the provider as None, and an "
+            "absent id becomes the literal string 'None' on every "
+            "conversation it produces."
+        )
+    return value.strip()
+
+
+def resolve_target(target: Mapping[str, Any]) -> ResolvedTarget:
+    """Validate one ``eval_models`` row and read its steering.
+
+    Args:
+        target: A row as returned by ``EvalsDB.get_model``/``list_models``,
+            with ``config`` already parsed into a mapping by those methods.
+
+    Returns:
+        ResolvedTarget: The row's identity, provider-side model name, and
+        chat-mode steering (``None`` when the row is unsteered).
+
+    Raises:
+        ValueError: If ``id`` or ``model_id`` is missing, not a string, or
+            blank -- naming the offending row, per this package's
+            fail-loudly convention, rather than letting ``None`` reach the
+            provider and ``"None"`` become a conversation's target.
+        ValueError: If the row is steered with a raw-completion ``prefix``.
+            A probe is chat-shaped -- a system message followed by
+            alternating turns -- and has no slot a literal prefix could be
+            prepended to, so honouring such a target is impossible. This
+            REJECTS rather than ignoring on purpose: quietly running it
+            would evaluate an unsteered model while the bench's own record
+            claims a steered one, which is the exact failure this whole
+            module exists to prevent. Steering is immutable per
+            ``eval_models`` row (there is no ``update_model``), so the
+            remedy is a new row carrying ``system_prompt`` instead.
+        ValueError: Propagated from ``model_steering`` for a row whose
+            ``config`` is corrupt or carries both steering kinds at once.
+    """
+    target_id = _required_text(target, "id")
+    model_name = _required_text(target, "model_id")
+    prefix, system_prompt = model_steering(target)
+    if prefix:
+        raise ValueError(
+            f"Target {target_id!r} (name {target.get('name')!r}) is steered "
+            f"with a raw-completion prefix ({prefix!r}), which a character "
+            "probe cannot honour: a probe sends a system message and "
+            "alternating chat turns, with no place to prepend a literal "
+            "prefix. Refusing rather than dropping it -- running this "
+            "target would evaluate an UNSTEERED model while the run claims "
+            "otherwise. Steering cannot be edited on an eval_models row, so "
+            "use (or create) a target that carries system_prompt instead."
+        )
+    return ResolvedTarget(
+        id=target_id,
+        model_id=model_name,
+        name=str(target.get("name") or ""),
+        provider=str(target.get("provider") or ""),
+        steering=system_prompt,
+    )
+
+
+def resolve_targets(targets: Sequence[Mapping[str, Any]]) -> list[ResolvedTarget]:
+    """Validate a whole target list in ONE pass, before anything runs.
+
+    Resolving up front rather than per cell means a malformed or
+    prefix-steered target is reported before the first provider call, not
+    after part of a grid has already been paid for.
+
+    Args:
+        targets: ``eval_models`` rows.
+
+    Returns:
+        list[ResolvedTarget]: One per row, in the order given.
+
+    Raises:
+        ValueError: If ``targets`` is empty -- a run with no targets can
+            never produce a cell.
+        ValueError: If two rows share an ``id``. Everything downstream is
+            keyed by target id (``run_ids`` in storage, ``target_id`` on
+            every conversation), so a duplicate would silently collapse two
+            columns into one -- the same guard, for the same reason, that
+            ``word_bench.storage.create_run_group`` applies.
+        ValueError: Propagated from :func:`resolve_target` for any single
+            malformed row.
+    """
+    if not targets:
+        raise ValueError("A character probe run needs at least one target.")
+    resolved = [resolve_target(target) for target in targets]
+    ids = [item.id for item in resolved]
+    if len(set(ids)) != len(ids):
+        duplicates = sorted({tid for tid in ids if ids.count(tid) > 1})
+        raise ValueError(
+            f"targets must have unique ids, got duplicates: {duplicates!r}"
+        )
+    return resolved


### PR DESCRIPTION
## Summary

Engine and storage for a new eval type: run scripted question sets ("probes") against character cards and collect the conversations for human review. **No UI in this phase** — that's phase 2. Design spec and plan are in the branch.

Why this eval exists: word benches measure a next-token distribution objectively. This one asks how a model handles a *character* under pressure, where there is no objective metric and the human is the instrument. So the engine's job is to collect evidence faithfully and record exactly what produced it.

**What's here**
- **Probe format** — turns delimited by `---`, probes by `===`, so a single turn can be a multi-paragraph prompt (complex prompts are the subject of the eval). Interior whitespace is byte-exact; a bare delimiter line inside a turn is a documented v1 limitation.
- **Probe sets** reuse the existing dataset inline-samples convention, discriminated by `dataset_type` just as benches use `bench_type`.
- **Bench config** with conservative defaults (`samples_per_cell=1`, `seed=None`) and a per-sample seed of `seed + sample_index`, so seeding and multi-sampling compose instead of returning N identical answers.
- **Card snapshots** across the `ChaChaNotes` ↔ `Evals` DB boundary, copying the card's text into the run so later edits or deletions never rewrite history.
- **Prompt assembly** — steering composes *ahead* of the card's system prompt; `{{char}}`/`{{user}}` macros resolved; a card with no `first_message` starts at the user's first turn rather than inventing a greeting.
- **Conversation runner** — turns sequential within a conversation, conversations concurrent under the bench's `concurrency`, every provider call dispatched via `asyncio.to_thread` because the app's chat gateway is synchronous and calling it on the event loop would freeze the TUI. Cancel stops *scheduling*; it cannot abort an in-flight turn, and says so.
- **Persistence** — conversations (turns in `metadata`, never `actual_output`), a run snapshot carrying card text, composed prompts, targets and sampler settings, plus **two** annotation homes: per-turn tags and per-conversation review state, because "I read this and nothing was notable" is a real verdict the progress count depends on.

## Verification

722 tests in `Tests/Evals` (862 including the Evals UI suites). Seven tasks, each independently reviewed; six needed a fix round.

**The whole-branch review is what makes this PR trustworthy.** All seven per-task reviews passed, several verifying findings by executing code — and the final review still found two Criticals that were invisible from inside any single task:

- **Target steering never reached the model.** The runner read `system_prompt` off the row; real `eval_models` rows keep it in `config`. The test passed only because its fixture hand-built a shape the database never produces. Now read via the sibling package's `model_steering`, with fixtures that round-trip through real `create_model`/`get_model` rows and assert the raw key is *absent*.
- **The card's `description` — the primary persona field, which Console sends — was never snapshotted**, so probes measured a gutted character.
- Plus: nothing about a run was persisted at all, defeating the snapshot's entire purpose two tasks after it was built.

The durable fix is `test_engine_end_to_end.py`, which chains bench → probe set → real card snapshots → run → persist → annotate → reload using **real database rows and zero hand-built dicts**. It would have caught both Criticals on day one.

## Follow-ups filed

- **task-1744** — one shared card→prompt function for both the engine and Console, with Console gaining `message_example`/`post_history_instructions` so characters behave as authored.
- **task-1754** — move `model_steering` to a shared home so neither package drags the other's stack, and pin the *import graph* rather than source-text tokens (the current hygiene test greps text and cannot see a transitive violation — recorded honestly in the plan rather than left implied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements phase 1 of task-1691 by adding the engine and storage for character-probe evals that run scripted question sets against character cards and persist conversations for human review. No UI in this phase.

- **New Features**
  - Probe format with `---` between turns and `===` between probes; stored as datasets with `metadata.dataset_type="character_probe"`.
  - Character-probe bench (`bench_type="character_probe"`) with conservative defaults and per-sample seed offset; negative seeds now pass through unoffset so they stay random across samples.
  - Card snapshots copy all prompting fields (including `description`, `first_message`, `post_history_instructions`, `message_example`) to keep runs stable over time.
  - Prompt assembly composes target steering ahead of the card system prompt and resolves `{{char}}`/`{{user}}` macros.
  - Target resolution reads steering from `eval_models.config` via the shared reader; rejects prefix steering.
  - Async runner executes turns sequentially and conversations concurrently via `asyncio.to_thread`; cancellation stops scheduling but not in-flight turns.
  - Persistence: run snapshots saved on each `eval_runs` row; conversations stored in `eval_results.metadata`; per-turn tags and per-conversation review state supported.

- **Migration**
  - Database schema bumps to 5; opening with `EvalsDB` migrates automatically and adds probe annotation/review tables.
  - Save probe sets as datasets with `format="custom"` and `metadata.dataset_type="character_probe"`.
  - Ensure model steering lives in `eval_models.config`; prefix-based steering is not supported for probes.

<sup>Written for commit 60ad3ae79aa010d2260a75df3eb013cc51d4d20c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

