### PR TITLE
Watchlists briefings phase 3: markdown export and the podcast feed directory (spec #2)

### DIFF
--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -13,3 +13,42 @@ Mixed | Local/Server". This screen was previously called "Subscriptions."
 
 - Click **Watchlists** in the nav bar, or press **Ctrl+P** → "Switch to
   Watchlists". (Or press **Ctrl+6** from anywhere.)
+
+## Exporting briefings and podcast feeds
+
+The **Artifacts** section of a watchlist holds its briefings — text digests
+of what its sources did — along with any scripts cast from them and any
+audio synthesized from those scripts. Two export actions live on that
+section's top toolbar, and both write to a location you pick:
+
+- **Export** saves the selected briefing as a Markdown file. It is enabled
+  once a briefing has finished generating.
+- **Export Feed** writes a **podcast feed directory**: a `feed.xml` plus a
+  copy of every finished audio episode in the watchlist. It is enabled once
+  at least one episode exists.
+
+If some episodes cannot be exported — a file has been moved or deleted
+since it was synthesized — the rest are still written and the app tells you
+how many of how many succeeded, and why the others were skipped.
+
+### Listening to an exported feed
+
+The exported folder is self-contained: `feed.xml` refers to the audio files
+beside it by name, never by absolute path, so you can copy, sync, or zip the
+whole directory and it keeps working on another machine.
+
+Some podcast clients accept a local folder or a `file://` URL directly. For
+clients that require HTTP, serve the folder yourself — from a terminal, in
+the exported directory:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then point the client at `http://localhost:8000/feed.xml` (or your machine's
+LAN address, if the client runs on another device). Stop the server with
+Ctrl+C when you are done.
+
+The app does not serve the folder for you. Its `[web_server]` setting is
+unrelated — that runs the whole chatbook UI in a browser instead of your
+terminal, and it is not a way to publish a feed.

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -22,7 +22,9 @@ audio synthesized from those scripts. Two export actions live on that
 section's top toolbar, and both write to a location you pick:
 
 - **Export** saves the selected briefing as a Markdown file. It is enabled
-  once a briefing has finished generating.
+  once you have selected a briefing that has finished generating — a
+  finished briefing that isn't selected, or nothing selected at all, leaves
+  the button disabled.
 - **Export Feed** writes a **podcast feed directory**: a `feed.xml` plus a
   copy of every finished audio episode in the watchlist. It is enabled once
   at least one episode exists.

--- a/Docs/superpowers/plans/2026-08-01-watchlists-briefings-phase-3.md
+++ b/Docs/superpowers/plans/2026-08-01-watchlists-briefings-phase-3.md
@@ -1,0 +1,205 @@
+# Watchlists Briefings Phase 3 — Markdown Export and the Podcast Feed Directory
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A briefing exports as markdown to a file the user picks, and a watchlist's audio episodes export as a self-contained podcast feed directory (`feed.xml` + the audio files) to a folder the user picks.
+
+**Architecture:** Two independent user-initiated exports, both leaving the private-storage boundary **by intent**. A pure RSS builder (no I/O) sits behind a directory-writing service that copies audio out of the private dir and writes `feed.xml` atomically. UI is dispatch-only workers on the existing Artifacts toolbars — no new toolbar rows, because the pane's height budget is already pinned by two geometry tests.
+
+**Tech Stack:** Python 3.11, Textual, SQLite, stdlib `xml.etree.ElementTree`, pytest (`.venv/bin/python -m pytest`, plain output).
+
+## Global Constraints
+
+- pytest is the ONLY python entry point for this repo's code. Never bare `python -c` importing `tldw_chatbook` (it loads the user's live config).
+- Never `git stash`; never `git checkout --`/`git restore` to revert (Edit-tool reverts only); never any `git worktree` command; never `-q` with pytest.
+- Never hand-edit `tldw_chatbook/css/tldw_cli_modular.tcss` — edit `css/features/_watchlists.tcss` and regenerate via `cd tldw_chatbook/css && ../../.venv/bin/python build_css.py`.
+- All screen DB calls via `asyncio.to_thread`. Workers: `group=` always set; guard flags claimed at dispatch, cleared in `finally`.
+- Toasts interpolating a value use `_notify_watchlists(..., markup=False)`. Any user-chosen path or provider text rendered in a widget is wrapped in `rich.text.Text` — never `escape_markup`.
+- Exception logging is type-only (`type(exc).__name__`); never `logger.opt(exception=True)`; never log briefing bodies or file contents.
+- No new `persist_event` event names (ADR-029 admits exactly six).
+- `--strict-markers` is on: an unregistered marker is a **collection error**. Registered: `unit`, `integration`, `slow`, `requires_cleanup`, `asyncio`, `ui`. `Tests/Watchlists/` uses `pytestmark = pytest.mark.ui`.
+- Every behavioural change gets a revert-confirm-RED-restore mutation check (Edit-tool reverts only).
+- Spec: `Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md` §"Exports and feed (phase 3)".
+
+## Decisions locked before implementation (do not relitigate; DO pin with tests)
+
+1. **No localhost serving.** Owner decision, 2026-08-01, after a seam survey found the spec's premise false: `[web_server]` is textual-serve — a *mutually exclusive process mode* that serves the TUI itself to a browser (`app.py:9231` returns instead of running the TUI), its only static route is hardcoded to textual-serve's own assets (`Web_Server/serve.py:165`), and **`web_server.enabled` is read by no code at all**. There is no server alongside the TUI to toggle. Phase 3 ships the directory; serving is documented for the user's own static server. The spec's own framing already says "the directory is the deliverable."
+2. **Never route a user-chosen destination through `private_paths`.** `secure_private_directory(..., application_owned=True)` chmods the target to `0o700` and raises `ValueError` when not application-owned; `create_private_text` opens `"xb"` and so refuses to overwrite. Applying either to the user's folder would chmod their directory and fail on re-export. User destinations use `validate_path_simple` + plain stdlib writes — the split the repo already makes (`library_screen.py:6486` and `STTS_Window.py:4040` are user-path; `Tools_Settings_Window.py:6313` is app-owned).
+3. **`audio_file_path_is_safe` runs BEFORE any filesystem access on a stored path.** Established by phase 2b's Qodo round for playback (`artifacts_pane.py:359,381` — the order is load-bearing and commented as such). Export copies files *out*, so it must honour the same order or it becomes a wider hole than playback.
+4. **RSS is written from scratch with stdlib `xml.etree.ElementTree`.** Nothing in the repo generates RSS (`rss_feed_generator.py` was deliberately deleted in `e74e37d07`, and the spec's Non-goals forbid reviving it; `feedparser` is declared but imported nowhere). The writing precedent to copy is `Web_Scraping/Article_Extractor_Lib.py:1141-1152` (`SubElement` + `tostring`). **Do not add `feedgen`** — a new dependency would inherit phase 2b's three-job CI edit for no benefit.
+
+## File Structure
+
+- `tldw_chatbook/DB/Subscriptions_DB.py` — one joined accessor for a watchlist's audio episodes (Task 2)
+- `tldw_chatbook/Subscriptions/briefing_export.py` — NEW: markdown export helper + the feed-directory writer (Tasks 1, 5)
+- `tldw_chatbook/Subscriptions/briefing_feed.py` — NEW: the pure RSS builder, no I/O (Task 3)
+- `tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py` + `UI/Screens/watchlists_collections_screen.py` — buttons, messages, workers (Tasks 1, 6)
+- Tests: `Tests/Subscriptions/test_briefing_export_markdown.py`, `test_briefing_feed.py`, `test_briefing_feed_export.py`; extensions to `Tests/Watchlists/test_watchlists_artifacts_pane.py`
+
+Where a step shows a contract instead of a full body, the full body is mandatory and the named precedent must be read first (the phase-1/2a/2b convention).
+
+---
+
+### Task 1: Markdown export of a briefing
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/briefing_export.py` (markdown half)
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py` (`#artifacts-toolbar` at `:667`; `on_button_pressed` at `:1156`; new message beside the others at `:102-225`), `UI/Screens/watchlists_collections_screen.py` (import block `:75-90`, new handler)
+- Test: `Tests/Subscriptions/test_briefing_export_markdown.py` (new), extend `Tests/Watchlists/test_watchlists_artifacts_pane.py`
+
+**Interfaces — Produces:**
+```python
+# briefing_export.py
+class BriefingExportError(RuntimeError): ...
+def safe_export_stem(text: str, *, fallback: str) -> str      # alnum/space/-/_ only, stripped
+def briefing_markdown_document(briefing: Mapping[str, Any]) -> str
+def default_briefing_filename(briefing: Mapping[str, Any], *, watchlist_name: str) -> str  # "<stem>.md"
+# artifacts_pane.py
+class ExportBriefingRequested(Message): ...        # carries nothing; screen reads selected_briefing
+```
+
+- [ ] **Step 1: Read the precedent end to end.** `UI/Screens/library_screen.py:6428` (the `FileSave` push) and `_write_library_note_export_file:6444` (validate → write → honest toasts, plus an explicit "cancelled" toast on `None`). Import the **vendored** picker: `from ...Third_Party.textual_fspicker import FileSave` — its kwarg is `default_file`, **not** `default_filename` (that is the *enhanced* picker's, a different class). Do NOT copy `UI/Voice_Cloning_Window.py:594`, which passes a `show_dirs_only` kwarg no picker class accepts and would raise `TypeError`.
+
+- [ ] **Step 2: Write the failing tests.** Service (`pytest.mark.unit`): `briefing_markdown_document` includes the body verbatim plus a front-matter header carrying watchlist name, status, coverage window and created time; a briefing whose `body_markdown` is NULL/empty raises `BriefingExportError` naming the briefing (an empty file is not an export); `safe_export_stem` strips path separators, `..`, and markup-shaped text, and falls back when nothing survives; `default_briefing_filename` ends in `.md` and never contains a separator. UI (`pytestmark = pytest.mark.ui`): the Export button renders in `#artifacts-toolbar` with `compact=True` and is **disabled when no briefing is selected or the selected briefing is not `complete`**; pressing it posts `ExportBriefingRequested`; the screen's handler pushes a `FileSave` (assert on a patched `push_screen`) seeded with the default filename; the callback writes the file and toasts success with `markup=False`; a `None` callback (user cancelled) writes nothing and toasts a cancellation; a write raising `OSError` toasts `type(exc).__name__` and writes nothing further.
+
+- [ ] **Step 3: Run, confirm RED.**
+
+- [ ] **Step 4: Implement.** Handler validates with `validate_path_simple(path, require_exists=False)` inside `try/except ValueError` → warn-and-return, then `validated.write_text(document, encoding="utf-8")` off the event loop via `asyncio.to_thread`. Button goes in the EXISTING `#artifacts-toolbar` — adding a new `Horizontal` costs a row the pane cannot spare (see Task 6's geometry note).
+
+- [ ] **Step 5: Green + mutations.** (a) Drop the `validate_path_simple` call → the traversal test REDs; restore. (b) Let an empty body export → the empty-body test REDs; restore.
+
+- [ ] **Step 6: Commit** `feat(briefings): export a briefing as markdown`.
+
+---
+
+### Task 2: One query for a watchlist's audio episodes
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py` (beside `list_briefing_audio` at `:2241`)
+- Test: `Tests/Subscriptions/test_briefing_feed_query.py` (new)
+
+**Interfaces — Produces:**
+```python
+def list_watchlist_audio_episodes(self, watchlist_id: int, *, limit: int = 500,
+                                  offset: int = 0) -> List[Dict[str, Any]]
+    # One joined SELECT across briefing_audio -> briefing_scripts -> briefings, filtered to
+    # audio.status='complete' AND audio.file_path IS NOT NULL, ordered briefings.created_at DESC,
+    # audio.id DESC. Each row carries: audio_id, script_id, briefing_id, file_path,
+    # duration_seconds, turn_count, preset_name, briefing_created_at, briefing_status,
+    # covers_from_ts, model_used.
+```
+
+- [ ] **Step 1: Read the precedent.** `list_briefing_audio:2241` for the transaction/pagination shape; every DB op — reads included — goes inside `with self.transaction() as conn:` (Qodo rule 1011851), and collection queries take `limit`/`offset` as SQL `LIMIT ?/OFFSET ?` (a Qodo finding on 2a).
+
+- [ ] **Step 2: Write the failing tests** (`pytest.mark.unit`, real `SubscriptionsDB` on `tmp_path`): a watchlist with two briefings, each with a script, each with one `complete` audio row → both returned, newest briefing first; a `failed` audio row is excluded; a `complete` row with NULL `file_path` is excluded; audio belonging to a *different* watchlist is excluded (the scoping test — assert by identity, not count); pagination walks without gaps or repeats and `limit` is honoured (spy the bound parameters, the shape used in `test_briefing_audio_db.py`); an empty watchlist returns `[]`.
+
+- [ ] **Step 3: Run, confirm RED.**
+
+- [ ] **Step 4: Implement** as a single `SELECT ... JOIN briefing_scripts ON ... JOIN briefings ON ...`. Column aliases must match the Interfaces block exactly — Tasks 3 and 5 quote those names.
+
+- [ ] **Step 5: Green + mutation.** Drop the `status='complete'` predicate → the failed-row-excluded test REDs; restore. Drop the watchlist scoping → the cross-watchlist test REDs; restore.
+
+- [ ] **Step 6: Commit** `feat(briefings): one query for a watchlist's audio episodes`.
+
+---
+
+### Task 3: The RSS feed builder (pure, no I/O)
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/briefing_feed.py`
+- Test: `Tests/Subscriptions/test_briefing_feed.py` (new)
+
+**Interfaces — Consumes:** Task 2's row shape.
+**Interfaces — Produces:**
+```python
+class FeedBuildError(RuntimeError): ...
+@dataclass(frozen=True)
+class FeedEpisode:
+    title: str; filename: str; length_bytes: int; duration_seconds: float | None
+    published: datetime; guid: str; description: str
+def build_feed_xml(*, channel_title: str, channel_description: str,
+                   episodes: Sequence[FeedEpisode], now: datetime) -> bytes
+```
+
+- [ ] **Step 1: Read the XML-writing precedent** — `Web_Scraping/Article_Extractor_Lib.py:1141-1152` (`ET.SubElement` + `ET.tostring(root, "utf-8")`). `defusedxml` is a *parsing* hardener and adds nothing here; do not import it for generation. **Do not add `feedgen`.**
+
+- [ ] **Step 2: Write the failing tests** (`pytest.mark.unit`) — parse every result with `xml.etree.ElementTree` and assert on the tree, never on a substring of the raw bytes (a substring test passes on malformed XML): the document is well-formed and has `rss[@version='2.0']` with one `channel`; channel carries title, description and `lastBuildDate`; each episode yields an `item` with `title`, `guid`, `pubDate` in RFC-822, and an `enclosure` whose `url` is the **relative filename** (the directory is self-contained — an absolute local path would leak the user's home directory into a file they may share), `length` in bytes and `type="audio/wav"`; `itunes:duration` is emitted when `duration_seconds` is present and omitted when None; a title containing `<`, `&` and `]]>` round-trips exactly through parse (escaping is ElementTree's job — assert it, do not hand-escape); an empty `episodes` sequence still produces a valid channel with zero items; a filename containing a path separator raises `FeedBuildError` naming it (a feed must never reference outside its own directory).
+
+- [ ] **Step 3: Run, confirm RED.**
+
+- [ ] **Step 4: Implement.** `now` is injected, never `datetime.now()` inside — the tests must be deterministic and the repo forbids ambient clocks in pure builders.
+
+- [ ] **Step 5: Green + mutations.** (a) Emit an absolute path in `enclosure/@url` → the relative-url test REDs; restore. (b) Drop the separator guard → that test REDs; restore.
+
+- [ ] **Step 6: Commit** `feat(briefings): build a podcast RSS feed`.
+
+---
+
+### Task 4: Writing the feed directory
+
+**Files:**
+- Modify: `tldw_chatbook/Subscriptions/briefing_export.py` (feed half)
+- Test: `Tests/Subscriptions/test_briefing_feed_export.py` (new)
+
+**Interfaces — Consumes:** Task 2's accessor; Task 3's `build_feed_xml`/`FeedEpisode`; `artifacts_pane.audio_file_path_is_safe` (`:359`) — **import it, do not re-derive the check**.
+**Interfaces — Produces:**
+```python
+@dataclass(frozen=True)
+class FeedExportResult:
+    directory: Path; episode_count: int; skipped: list[str]   # skipped names the reason per episode
+def export_feed_directory(db, watchlist_id: int, *, destination: Path,
+                          watchlist_name: str, now: datetime) -> FeedExportResult
+```
+
+- [ ] **Step 1: Read three things.** (a) The copy-out recipe — `UI/STTS_Window.py:4040-4049`: `validate_path_simple(dest, require_exists=False)` → `validate_path_simple(dest.parent, require_exists=True).resolve()` → `validate_filename(dest.name)` → `shutil.copy2`. (b) The atomic-write discipline — `Chatbooks/chatbook_creator.py:1506` `_create_zip_archive`: `os.open(partial, O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW, 0o600)` → write → `flush()` + `os.fsync()` → `os.replace(partial, final)`, with a `finally` that closes the fd and unlinks the partial on failure. (c) Decision 2 above — **never** call `secure_private_directory` on the destination.
+
+- [ ] **Step 2: Write the failing tests** (`pytest.mark.unit`, `get_user_data_dir` patched to `tmp_path` in every test that touches storage — this repo has had three live-data incidents): a happy path writes `feed.xml` plus one file per episode and returns the count; **an episode whose `file_path` fails `audio_file_path_is_safe` is skipped with a reason and its file is never opened** (patch the safety helper to False and assert no read occurred — this is the load-bearing security test); an episode whose source file has vanished is skipped with a reason, and the rest still export; `feed.xml` is written atomically (assert no `.partial` remains, and that a failure mid-write leaves the previous `feed.xml` intact); re-exporting to the same directory overwrites cleanly (no `"xb"`-style refusal — the phase-2b private-write helpers must not be used here); the destination is never chmodded to `0o700` (assert the mode survives — this pins Decision 2); a destination that fails `validate_path_simple` raises before anything is written.
+
+- [ ] **Step 3: Run, confirm RED.**
+
+- [ ] **Step 4: Implement.** Episode filenames come from `safe_export_stem` + the audio id, so two briefings with the same title cannot collide. `length_bytes` is the real file size read after the copy. Never raise for one bad episode — collect into `skipped` so a partial export is honest rather than all-or-nothing.
+
+- [ ] **Step 5: Green + mutations.** (a) Call the filesystem before the safety check → the load-bearing test REDs; restore. (b) Replace the atomic write with a plain `write_bytes` → the no-`.partial`/intact-previous test REDs; restore.
+
+- [ ] **Step 6: Commit** `feat(briefings): write a self-contained podcast feed directory`.
+
+---
+
+### Task 5: The feed export action
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py` (`#artifacts-audio-toolbar` at `:870`, `on_button_pressed` at `:1156`, new message), `UI/Screens/watchlists_collections_screen.py`
+- Test: extend `Tests/Watchlists/test_watchlists_artifacts_pane.py`
+
+**Interfaces — Consumes:** Task 4's `export_feed_directory`; `SelectDirectory` from `...Third_Party.textual_fspicker` (dismisses with `Path | None` — precedent `library_screen.py:11740`).
+**Interfaces — Produces:** `class ExportFeedRequested(Message)`.
+
+- [ ] **Step 1: Read the pane's two hard constraints.** (a) **Every reactive on this pane is `recompose=True`** (module docstring `:25-33`) — export-in-flight state must NOT live on the pane; keep the guard flag on the screen, claimed at dispatch, cleared in `finally`, `group="wl-feed-export"`, exclusive. (b) **The height budget is pinned**: `#artifacts-table` resolves to exactly `region.height == 4` (`_watchlists.tcss:1074-1088`), and Task 7 of phase 2b recorded that adding one fixed row plus a scrollable region squeezed the scripts table to its header. **Put the button in the existing `#artifacts-audio-toolbar`** (`compact=True`); do not add a `Horizontal`.
+
+- [ ] **Step 2: Write the failing tests:** the Export-feed button renders in `#artifacts-audio-toolbar` and is **disabled when the watchlist has no complete audio episodes** (a dead control is a spec violation — phase 2b shipped a disabled Play for exactly this reason); pressing it pushes `SelectDirectory` (patched `push_screen`); the callback runs the export off the event loop and toasts the episode count with `markup=False`; a cancelled picker writes nothing and toasts a cancellation; a partial export (one skipped episode) toasts honestly that N of M exported rather than claiming success; a second press while in flight is refused naming the running export; an `OSError` from the service toasts `type(exc).__name__` and leaves the app running (`host.is_running` — the phase-2b app-death lesson, where an unwrapped worker with `exit_on_error=True` killed the app).
+  Both pinned geometry tests (`test_the_list_the_button_and_the_body_are_all_on_screen`, `test_the_briefings_table_keeps_at_least_three_usable_rows`) must stay green; if the button squeezes them, stop and report rather than loosening a pinned test.
+
+- [ ] **Step 3-4: Implement + green.** All DB and filesystem work inside one `asyncio.to_thread` hop; `is_attached` before any UI mutation after an await.
+
+- [ ] **Step 5: Mutations.** (a) Claim the guard inside the worker body → the double-press test REDs; restore. (b) Report success on a partial export → the honest-count test REDs; restore.
+
+- [ ] **Step 6: Commit** `feat(briefings): export a watchlist's podcast feed directory`.
+
+---
+
+### Task 6: Close-out
+
+- [ ] Full sweep: `Tests/Subscriptions/ Tests/Watchlists/ Tests/UI/ -k watchlist`. Documented baselines (NOT ours): 2 tree-chevron failures in `test_destination_visual_parity_correction.py`; the TASK-1345 create-form mount race (rotating symptom — re-run alone before classifying).
+- [ ] `backlog/tasks/task-1540`: check AC #3 (phase 3), leaving phase 4 unchecked.
+- [ ] **Spec corrections** in `Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md` — a "Phase 3 delivery notes (2026-08-01)" block recording: (a) **localhost serving is cut**, with the reason (`[web_server]` is textual-serve, a mutually exclusive process mode; its only static route is textual's own assets; `web_server.enabled` is read by nothing) and the owner's decision to document a user-run static server instead; (b) the feed directory is self-contained and uses **relative** enclosure URLs deliberately, so sharing the folder never leaks a home path; (c) §Testing's "every new test `pytest.mark.unit` or it is invisible to CI" is **stale** — since task-1465 CI runs `pytest Tests --ignore=Tests/UI` plus `pytest Tests/UI` with no marker selection; what actually matters now is `--strict-markers` (an unregistered marker is a collection error).
+- [ ] Cross-worktree ID scan (controller supplies IDs) → file a follow-up for in-app feed serving, carrying decision 1's evidence so a future implementer does not re-discover that `[web_server]` cannot do it.
+- [ ] Add a short "Exporting a podcast feed" note to the user-facing docs directory if one covers Watchlists; if none exists, say so in the report rather than inventing a location.
+- [ ] Commit `docs(briefings): phase 3 close-out`.
+
+## Self-review
+
+**Spec coverage (phase 3 scope):** markdown export via the file picker → T1; feed directory with `feed.xml` + audio files to a user-chosen folder → T2/T3/T4/T5; "export is deliberate egress outside the private-storage boundary" → Decision 2, pinned by T4's no-chmod test; localhost serving → cut by owner decision, recorded in T6. Phase 4 (scheduling) untouched.
+
+**Placeholder scan:** none — every step names its precedent `file:line` or carries the contract inline.
+
+**Type consistency:** Task 2's column aliases are quoted verbatim by Tasks 3-5; `FeedEpisode` fields match `build_feed_xml`'s use and Task 4's construction; `Path` is the currency at every picker boundary (both pickers dismiss with `Path | None`); `safe_export_stem` is defined in T1 and reused in T4.

--- a/Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md
+++ b/Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md
@@ -1,7 +1,7 @@
 # Watchlists Briefings & Podcasts — design (spec #2)
 
 **Date:** 2026-07-30
-**Status:** phases 1-2 implemented (2026-07-31); phases 3-4 pending
+**Status:** phases 1-3 implemented (2026-08-01); phase 4 pending
 
 **Phase 1 delivery notes (2026-07-30):** two deferrals from the phase 1 plan, both confirmed by
 the project owner (2026-07-30):
@@ -112,6 +112,45 @@ continues to diverge by design (it derives kokoro's onnx/pytorch suffix from liv
 options and alltalk's from the requested model id, where the builder uses fixed constants); both
 sides carry a cross-reference comment (the TASK-1393 pact convention) so the two are never mistaken
 for interchangeable and never converged without updating both call sites' expectations.
+
+**Phase 3 delivery notes (2026-08-01):** markdown export and the podcast feed directory (Tasks
+1-5) shipped on `feat/briefings-phase-3`. Four things worth recording against this design's
+original text:
+
+- **Localhost serving is cut, by the project owner's decision — the spec's premise was false.**
+  This design's "Exports and feed" section above says "if the app's `[web_server]` is enabled it
+  can serve that directory over localhost for podcast clients; serving is a toggle." At plan time
+  that toggle turned out not to exist: `[web_server]` is **textual-serve** — a mutually exclusive
+  process mode that serves the *TUI itself* to a browser (`app.py` returns instead of running the
+  TUI when it is engaged), whose only static route is hardcoded to textual-serve's own assets, and
+  whose `enabled` key is read by no code at all anywhere in the app. There was never a server
+  running alongside the TUI for this feature to toggle. Consequently the directory is the whole
+  deliverable, exactly as this design's own wording already said ("the directory is the
+  deliverable"); a user-run static server (e.g. `python -m http.server` from the exported folder)
+  is the documented path for pointing a podcast client at it. See task-1760 for the scoped,
+  net-new follow-up (a standalone opt-in static server) this finding produced.
+- **The feed directory is self-contained by design.** `briefing_feed.build_feed_xml` writes
+  enclosure URLs as **bare relative filenames**, not absolute paths or `file://` URIs. This is
+  deliberate, not an oversight: a relative URL means the folder can be copied, zipped, synced to
+  another machine, or handed to someone else, and it still resolves correctly wherever it lands —
+  no home directory, username, or local filesystem layout ever leaks into `feed.xml`.
+- **Exported files are `0o644` by deliberate decision — recorded as Decision 4 in
+  `Subscriptions/briefing_export.py`'s module docstring.** Audio inside the app's private storage
+  (`briefing_audio_dir()`) is written `0o600` by `atomic_private_write_bytes`; naively inheriting
+  that mode into an export would make a folder the user explicitly chose *in order to share it*
+  readable only by the exporting account — silently defeating the point of exporting at all. The
+  fixed mode is applied explicitly (not derived from umask): umask expresses a default for
+  arbitrary file creation, not intent for a folder picked for sharing, and honouring a hardened
+  umask here would hand the most security-conscious users a silently unreadable feed. The real
+  access boundary is unchanged — the destination directory's own permissions (left untouched by
+  Decision 1 in the same docstring) remain what actually gates access; a `0o644` file inside a
+  `0o700` directory stays unreachable to anyone else regardless.
+- **§Testing's "every new test `pytest.mark.unit` or it is invisible to CI" is stale.** That was
+  true when this design was written; since task-1465, CI instead runs `pytest Tests
+  --ignore=Tests/UI` plus a separate `pytest Tests/UI` pass, neither with marker selection, so an
+  unmarked test is collected and run either way. What actually matters now is `--strict-markers`:
+  an unregistered `@pytest.mark.*` name is a collection **error**, not a silent no-op, so the
+  bar is "use a registered marker (or none)," not "must be `unit`."
 
 **Predecessor:** `2026-07-25-watchlists-console-rebuild-design.md` (spec #1), which deferred this
 slice: *"Spec #2 covers artifact generation (briefings, 2-speaker podcasts) and its scheduled

--- a/Tests/Subscriptions/test_briefing_export_markdown.py
+++ b/Tests/Subscriptions/test_briefing_export_markdown.py
@@ -1,0 +1,149 @@
+"""Tests for the markdown half of briefing export (spec #2 phase 3, Task 1).
+
+`briefing_export.py` turns one `briefings` row into a markdown document a
+user can save wherever they like, plus the two pure helpers around it:
+`safe_export_stem` (a filesystem-safe name from arbitrary, possibly
+adversarial text -- reused verbatim by Task 4's feed-directory writer) and
+`default_briefing_filename` (the seed the `FileSave` dialog opens with).
+
+All three functions here are pure: no DB, no filesystem, no Textual. The UI
+half (the toolbar button and the screen's dialog/write flow) is exercised
+separately in `Tests/Watchlists/test_watchlists_artifacts_pane.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Subscriptions.briefing_export import (
+    BriefingExportError,
+    briefing_markdown_document,
+    default_briefing_filename,
+    safe_export_stem,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _complete_briefing(**overrides: object) -> dict:
+    row = {
+        "id": 42,
+        "watchlist_id": 7,
+        "watchlist_name": "Morning AI Brief",
+        "status": "complete",
+        "error": None,
+        "covers_from_ts": "2026-07-25T00:00:00+00:00",
+        "covers_through_item_id": 99,
+        "model_used": "gpt-test",
+        "body_markdown": "## This week\n\nAcme shipped a thing.\n",
+        "item_count": 3,
+        "featured_count": 1,
+        "overflow_count": 0,
+        "created_at": "2026-08-01 10:00:00",
+    }
+    row.update(overrides)
+    return row
+
+
+# --- briefing_markdown_document -----------------------------------------
+
+
+def test_document_carries_the_body_verbatim():
+    document = briefing_markdown_document(_complete_briefing())
+
+    assert "## This week\n\nAcme shipped a thing.\n" in document
+
+
+def test_document_front_matter_carries_watchlist_status_window_and_created():
+    briefing = _complete_briefing()
+
+    document = briefing_markdown_document(briefing)
+
+    assert "Morning AI Brief" in document
+    assert "complete" in document
+    assert "2026-07-25T00:00:00+00:00" in document
+    assert "99" in document
+    assert "2026-08-01 10:00:00" in document
+
+
+def test_document_front_matter_precedes_the_body():
+    briefing = _complete_briefing()
+
+    document = briefing_markdown_document(briefing)
+
+    assert document.index("Morning AI Brief") < document.index(
+        "Acme shipped a thing."
+    )
+
+
+def test_null_body_raises_naming_the_briefing():
+    briefing = _complete_briefing(body_markdown=None)
+
+    with pytest.raises(BriefingExportError, match="42"):
+        briefing_markdown_document(briefing)
+
+
+def test_empty_body_raises_naming_the_briefing():
+    """Whitespace-only counts as empty too -- an empty file is not an
+    export, whatever whitespace it is made of."""
+    briefing = _complete_briefing(body_markdown="   \n  ")
+
+    with pytest.raises(BriefingExportError, match="42"):
+        briefing_markdown_document(briefing)
+
+
+# --- safe_export_stem -----------------------------------------------------
+
+
+def test_stem_keeps_ordinary_characters():
+    assert safe_export_stem("Morning Brief 2026-08-01", fallback="x") == (
+        "Morning Brief 2026-08-01"
+    )
+
+
+def test_stem_strips_path_separators():
+    stem = safe_export_stem("../../etc/passwd", fallback="fallback")
+    assert "/" not in stem
+    assert "\\" not in stem
+
+
+def test_stem_strips_dot_dot():
+    stem = safe_export_stem("..", fallback="fallback")
+    assert stem == "fallback"
+
+
+def test_stem_strips_markup_shaped_text():
+    stem = safe_export_stem("[bold red]Evening Brief[/]", fallback="x")
+    assert "[" not in stem
+    assert "]" not in stem
+
+
+def test_stem_falls_back_when_nothing_survives():
+    assert safe_export_stem("###???", fallback="fallback-name") == "fallback-name"
+
+
+def test_stem_falls_back_on_empty_input():
+    assert safe_export_stem("", fallback="fallback-name") == "fallback-name"
+
+
+# --- default_briefing_filename --------------------------------------------
+
+
+def test_default_filename_ends_in_md():
+    briefing = _complete_briefing()
+    filename = default_briefing_filename(briefing, watchlist_name="Morning AI Brief")
+    assert filename.endswith(".md")
+
+
+def test_default_filename_never_contains_a_separator():
+    briefing = _complete_briefing(watchlist_name="../../evil")
+    filename = default_briefing_filename(briefing, watchlist_name="../../evil")
+    assert "/" not in filename
+    assert "\\" not in filename
+
+
+def test_default_filename_falls_back_when_watchlist_name_is_unusable():
+    briefing = _complete_briefing()
+    filename = default_briefing_filename(briefing, watchlist_name="###???")
+    assert filename.endswith(".md")
+    assert filename != ".md"

--- a/Tests/Subscriptions/test_briefing_export_markdown.py
+++ b/Tests/Subscriptions/test_briefing_export_markdown.py
@@ -49,12 +49,19 @@ def _complete_briefing(**overrides: object) -> dict:
 
 
 def test_document_carries_the_body_verbatim():
+    """The stored `body_markdown` must appear byte-for-byte in the exported
+    document -- no reformatting, escaping, or truncation of the model- or
+    user-authored content the export exists to hand over."""
     document = briefing_markdown_document(_complete_briefing())
 
     assert "## This week\n\nAcme shipped a thing.\n" in document
 
 
 def test_document_front_matter_carries_watchlist_status_window_and_created():
+    """All four front-matter fields (watchlist name, status, coverage
+    window, created_at) must actually render, not just be accepted as
+    arguments -- a document missing one silently loses the context a
+    reader needs to place it without the app around it."""
     briefing = _complete_briefing()
 
     document = briefing_markdown_document(briefing)
@@ -67,6 +74,9 @@ def test_document_front_matter_carries_watchlist_status_window_and_created():
 
 
 def test_document_front_matter_precedes_the_body():
+    """The front matter must come BEFORE the body, not merely be present
+    somewhere in the document -- a reader (or a markdown front-matter
+    parser) reads top-down, so context has to precede content."""
     briefing = _complete_briefing()
 
     document = briefing_markdown_document(briefing)
@@ -77,6 +87,10 @@ def test_document_front_matter_precedes_the_body():
 
 
 def test_null_body_raises_naming_the_briefing():
+    """A `body_markdown` of `None` must raise, and the exception message
+    must name the specific briefing id (`42`) -- a toast built from
+    `str(exc)` is the only way the user learns WHICH row failed to
+    export."""
     briefing = _complete_briefing(body_markdown=None)
 
     with pytest.raises(BriefingExportError, match="42"):
@@ -96,33 +110,54 @@ def test_empty_body_raises_naming_the_briefing():
 
 
 def test_stem_keeps_ordinary_characters():
+    """The whitelist must not over-filter: ordinary alnum/space/hyphen text
+    (a realistic watchlist name) must survive completely unchanged,
+    including its spaces and casing -- this is the control case the
+    stripping tests below are contrasted against."""
     assert safe_export_stem("Morning Brief 2026-08-01", fallback="x") == (
         "Morning Brief 2026-08-01"
     )
 
 
 def test_stem_strips_path_separators():
+    """Both `/` and `\\` must be dropped from the output -- a watchlist or
+    briefing title containing a path separator must never be able to
+    escape the destination directory a caller builds a filename inside."""
     stem = safe_export_stem("../../etc/passwd", fallback="fallback")
     assert "/" not in stem
     assert "\\" not in stem
 
 
 def test_stem_strips_dot_dot():
+    """A bare `".."` contains no whitelisted character at all (`.` is not
+    in the whitelist), so it must fall back to the caller's `fallback`
+    rather than surviving as a literal `".."` stem -- which, unlike the
+    ordinary path-separator case above, contains no separator for a naive
+    filter to catch."""
     stem = safe_export_stem("..", fallback="fallback")
     assert stem == "fallback"
 
 
 def test_stem_strips_markup_shaped_text():
+    """Bracket/markup punctuation (`[`, `]`) must be dropped -- a crafted
+    title must not be able to produce a filename that some other surface
+    later misinterprets as markup."""
     stem = safe_export_stem("[bold red]Evening Brief[/]", fallback="x")
     assert "[" not in stem
     assert "]" not in stem
 
 
 def test_stem_falls_back_when_nothing_survives():
+    """When every character in the input is outside the whitelist, the
+    function must return the caller-supplied `fallback` verbatim rather
+    than an empty string or a stem made of leftover punctuation."""
     assert safe_export_stem("###???", fallback="fallback-name") == "fallback-name"
 
 
 def test_stem_falls_back_on_empty_input():
+    """An empty string is a degenerate case of "nothing survives" and must
+    hit the same fallback path as filtered-out text, not raise or return
+    an empty stem."""
     assert safe_export_stem("", fallback="fallback-name") == "fallback-name"
 
 
@@ -130,12 +165,18 @@ def test_stem_falls_back_on_empty_input():
 
 
 def test_default_filename_ends_in_md():
+    """The `FileSave` dialog this seeds always expects a markdown file --
+    the suggested filename must carry a `.md` extension every time, not
+    just for the input this particular briefing happens to have."""
     briefing = _complete_briefing()
     filename = default_briefing_filename(briefing, watchlist_name="Morning AI Brief")
     assert filename.endswith(".md")
 
 
 def test_default_filename_never_contains_a_separator():
+    """A hostile or path-shaped watchlist name must not survive into the
+    suggested filename as a separator -- this is the end-to-end version of
+    `safe_export_stem`'s own guarantee, through this caller specifically."""
     briefing = _complete_briefing(watchlist_name="../../evil")
     filename = default_briefing_filename(briefing, watchlist_name="../../evil")
     assert "/" not in filename
@@ -143,6 +184,11 @@ def test_default_filename_never_contains_a_separator():
 
 
 def test_default_filename_falls_back_when_watchlist_name_is_unusable():
+    """When the watchlist name has nothing left after the whitelist, the
+    result must still be a real, non-degenerate filename (via the
+    `briefing-<id>` fallback) -- not just a bare `.md` with an empty
+    stem, which would look wrong in a save dialog and could collide with
+    every other briefing that hits the same fallback."""
     briefing = _complete_briefing()
     filename = default_briefing_filename(briefing, watchlist_name="###???")
     assert filename.endswith(".md")

--- a/Tests/Subscriptions/test_briefing_feed.py
+++ b/Tests/Subscriptions/test_briefing_feed.py
@@ -65,6 +65,10 @@ def _build(episodes: list[FeedEpisode], **overrides: object) -> bytes:
 
 
 def test_document_is_well_formed_rss_2_with_exactly_one_channel():
+    """The bare well-formedness contract every other test in this file
+    relies on: `build_feed_xml` must produce a real `<rss version="2.0">`
+    root with exactly one `<channel>` -- not zero, not more than one --
+    parseable by `ElementTree` without error."""
     root = ET.fromstring(_build([]))
     assert root.tag == "rss"
     assert root.get("version") == "2.0"
@@ -73,6 +77,10 @@ def test_document_is_well_formed_rss_2_with_exactly_one_channel():
 
 
 def test_channel_carries_title_description_and_last_build_date():
+    """All three channel-level fields must actually render. `lastBuildDate`
+    specifically is round-tripped through real RFC-822 parsing back to the
+    exact injected `now` -- a string-format assertion could pass on a
+    plausible-looking but unparseable (or off-by-format) date."""
     channel = ET.fromstring(_build([])).find("channel")
     assert channel.findtext("title") == "My Watchlist"
     assert channel.findtext("description") == "Episodes from My Watchlist"
@@ -96,6 +104,10 @@ def test_channel_link_is_present_non_empty_and_a_relative_reference():
 
 
 def test_empty_episodes_still_produces_a_valid_channel_with_zero_items():
+    """The "no episodes yet" case (a fresh watchlist, or every episode
+    skipped upstream) must still yield a valid channel with a title -- not
+    an error, and not a malformed or missing channel -- with an item list
+    that is empty rather than absent."""
     channel = ET.fromstring(_build([])).find("channel")
     assert channel is not None
     assert channel.find("title") is not None
@@ -106,6 +118,11 @@ def test_empty_episodes_still_produces_a_valid_channel_with_zero_items():
 
 
 def test_each_episode_yields_an_item_with_title_guid_and_pubdate():
+    """One `FeedEpisode`'s title/guid/published must map through 1:1 into
+    its `<item>`. `pubDate` is round-tripped through real RFC-822 parsing
+    back to the exact source datetime, not merely asserted non-empty --
+    catching a wrong format that a podcast client's own parser would
+    reject even though this test's channel-shape assertions would pass."""
     episode = _episode()
     channel = ET.fromstring(_build([episode])).find("channel")
     items = channel.findall("item")
@@ -119,6 +136,9 @@ def test_each_episode_yields_an_item_with_title_guid_and_pubdate():
 
 
 def test_two_episodes_yield_two_items_in_order():
+    """Multiple episodes must preserve the ORDER they were given in --
+    `build_feed_xml` must not sort, reverse, or otherwise reorder the
+    episode list a caller already assembled."""
     first = _episode(title="First", guid="g1")
     second = _episode(title="Second", guid="g2")
     channel = ET.fromstring(_build([first, second])).find("channel")
@@ -130,6 +150,11 @@ def test_two_episodes_yield_two_items_in_order():
 
 
 def test_enclosure_url_is_the_bare_relative_filename_never_absolute():
+    """The enclosure `url` must be exactly the bare filename -- no leading
+    `/` (an absolute POSIX path) and no `:` (a URL scheme) -- so a podcast
+    client resolves it relative to wherever the self-contained folder
+    itself ends up served or opened, never against a path or host on the
+    exporting machine."""
     episode = _episode(filename="script-9-audio-3.wav")
     item = ET.fromstring(_build([episode])).find("channel").find("item")
     enclosure = item.find("enclosure")
@@ -141,6 +166,11 @@ def test_enclosure_url_is_the_bare_relative_filename_never_absolute():
 
 
 def test_enclosure_length_is_bytes_and_type_is_audio_wav():
+    """`length` must be the given byte count verbatim (not, e.g., seconds
+    or a rounded/truncated value) and `type` must be the fixed
+    `audio/wav` MIME type every enclosure declares -- both are read
+    directly by podcast clients to decide how to fetch and play the
+    file."""
     episode = _episode(length_bytes=98765)
     enclosure = ET.fromstring(_build([episode])).find("channel").find("item").find("enclosure")
     assert enclosure.get("length") == "98765"
@@ -161,6 +191,10 @@ def test_enclosure_length_is_bytes_and_type_is_audio_wav():
 
 
 def test_enclosure_url_percent_encodes_a_space_and_carries_no_raw_space():
+    """A space in the on-disk filename (`safe_export_stem` keeps spaces
+    verbatim) must be percent-encoded (`%20`) in the emitted URL, with no
+    raw space surviving -- RFC 3986 forbids a literal space in a URI
+    reference, and a client that sends it verbatim gets a 400."""
     episode = _episode(filename="Two Host Debate-42.wav")
     url = (
         ET.fromstring(_build([episode]))
@@ -174,6 +208,10 @@ def test_enclosure_url_percent_encodes_a_space_and_carries_no_raw_space():
 
 
 def test_enclosure_url_percent_encodes_non_ascii_characters():
+    """A non-ASCII letter (`é`), admitted by `safe_export_stem`'s
+    `str.isalnum()` check, must be percent-encoded as its UTF-8 bytes in
+    the emitted URL -- a raw non-ASCII byte in a URI reference is exactly
+    as invalid as a raw space, just easier to overlook in review."""
     episode = _episode(filename="Café Debate-7.wav")
     url = (
         ET.fromstring(_build([episode]))
@@ -232,6 +270,9 @@ def test_enclosure_url_percent_encoding_does_not_change_the_on_disk_filename():
 
 
 def test_itunes_duration_emitted_when_duration_seconds_present():
+    """When an episode carries a known duration, the item must include a
+    non-empty `itunes:duration` element -- podcast clients use this to show
+    a runtime before the user starts playback."""
     episode = _episode(duration_seconds=125.0)
     item = ET.fromstring(_build([episode])).find("channel").find("item")
     duration_el = item.find(f"{{{_ITUNES_NS}}}duration")
@@ -240,6 +281,10 @@ def test_itunes_duration_emitted_when_duration_seconds_present():
 
 
 def test_itunes_duration_omitted_when_duration_seconds_is_none():
+    """An unknown duration (`None`) must OMIT the element entirely rather
+    than emit a placeholder like `"0:00:00"` or an empty tag -- a bogus
+    zero duration would be actively misleading to a listening client, an
+    absent element is honestly "unknown"."""
     episode = _episode(duration_seconds=None)
     item = ET.fromstring(_build([episode])).find("channel").find("item")
     assert item.find(f"{{{_ITUNES_NS}}}duration") is None
@@ -249,6 +294,11 @@ def test_itunes_duration_omitted_when_duration_seconds_is_none():
 
 
 def test_hostile_title_round_trips_exactly_through_parse():
+    """A title containing XML-significant characters (`<`, `&`) and a
+    CDATA-closing sequence (`]]>`) must build into valid XML and parse
+    back to EXACTLY the original string -- proving `ElementTree` is
+    escaping it correctly (this module must never hand-escape itself, per
+    the module docstring)."""
     hostile_title = "Report: <Q3> Sales & Marketing ]]> Recap"
     episode = _episode(title=hostile_title)
     item = ET.fromstring(_build([episode])).find("channel").find("item")
@@ -256,6 +306,9 @@ def test_hostile_title_round_trips_exactly_through_parse():
 
 
 def test_hostile_description_round_trips_exactly_through_parse():
+    """Same property as the hostile-title test above, for `description` --
+    a second field independently exercising escaping, since a field-level
+    fix in one place would not prove the other is safe."""
     hostile_description = "A & B <together>, plus a stray ]]> marker."
     episode = _episode(description=hostile_description)
     item = ET.fromstring(_build([episode])).find("channel").find("item")
@@ -267,6 +320,11 @@ def test_hostile_description_round_trips_exactly_through_parse():
 
 @pytest.mark.parametrize("bad_filename", ["../evil.wav", "sub/evil.wav", "sub\\evil.wav"])
 def test_filename_with_a_path_separator_raises_feed_build_error_naming_it(bad_filename):
+    """A path-shaped `FeedEpisode.filename` (parent reference, POSIX or
+    Windows separator) must raise rather than be emitted into an enclosure
+    URL that could resolve outside the feed directory -- and the raised
+    message must name the exact offending filename, not a generic error,
+    so the caller can trace it back to the episode."""
     episode = _episode(filename=bad_filename)
     with pytest.raises(FeedBuildError, match=re.escape(bad_filename)):
         _build([episode])
@@ -295,12 +353,22 @@ def test_path_separator_guard_rejects_before_emitting_any_xml():
 
 
 def test_naive_now_raises_feed_build_error_naming_now():
+    """A naive (no-`tzinfo`) `now` must raise rather than being silently
+    treated as UTC -- see the module comment above on why quietly coercing
+    it would risk the "-0000 round-trips to naive, then gets
+    re-interpreted as local time" hazard downstream. The message must
+    name `now` specifically so the caller knows which argument is at
+    fault."""
     naive_now = datetime(2026, 8, 1, 12, 0, 0)  # no tzinfo
     with pytest.raises(FeedBuildError, match="now"):
         _build([], now=naive_now)
 
 
 def test_naive_episode_published_raises_feed_build_error_naming_the_episode():
+    """Same guard as the naive-`now` test above, for a single episode's
+    `published` timestamp -- and the message must name the offending
+    episode's `guid` (`briefing-audio-77`), not just say "a timestamp was
+    naive", so a multi-episode build can be traced back to which one."""
     naive_published = datetime(2026, 7, 30, 8, 0, 0)  # no tzinfo
     episode = _episode(published=naive_published, guid="briefing-audio-77")
     with pytest.raises(FeedBuildError, match="briefing-audio-77"):
@@ -337,6 +405,11 @@ def test_xmlns_itunes_is_declared_in_raw_bytes_when_a_duration_is_present():
 
 
 def test_xmlns_itunes_is_absent_from_raw_bytes_when_no_duration_is_present():
+    """The mirror of the declared-when-present test above: when nothing in
+    the build actually uses the `itunes` namespace, neither the namespace
+    declaration nor the element itself should appear in the raw bytes --
+    an unused namespace declaration is at best clutter and, in stricter
+    parsers, can itself be flagged."""
     episode = _episode(duration_seconds=None)
     text = _build([episode]).decode("utf-8")
     assert "xmlns:itunes" not in text

--- a/Tests/Subscriptions/test_briefing_feed.py
+++ b/Tests/Subscriptions/test_briefing_feed.py
@@ -186,3 +186,63 @@ def test_path_separator_guard_rejects_before_emitting_any_xml():
     bad = _episode(filename="../evil.wav", guid="g-bad")
     with pytest.raises(FeedBuildError):
         _build([good, bad])
+
+
+# --- timezone-awareness: reject naive datetimes at the boundary -------------
+#
+# `email.utils.format_datetime` does NOT treat a naive datetime as local
+# time -- it emits the correct wall-clock digits tagged "-0000" (RFC 2822's
+# "unverified offset"). The hazard is one hop downstream: "-0000" round-trips
+# through `parsedate_to_datetime` into a *naive* result, and the common
+# `.astimezone()` idiom then silently reinterprets those same digits as
+# local time -- same digits, wrong instant. `build_feed_xml` forecloses this
+# by rejecting naive input outright rather than quietly coercing it to UTC.
+
+
+def test_naive_now_raises_feed_build_error_naming_now():
+    naive_now = datetime(2026, 8, 1, 12, 0, 0)  # no tzinfo
+    with pytest.raises(FeedBuildError, match="now"):
+        _build([], now=naive_now)
+
+
+def test_naive_episode_published_raises_feed_build_error_naming_the_episode():
+    naive_published = datetime(2026, 7, 30, 8, 0, 0)  # no tzinfo
+    episode = _episode(published=naive_published, guid="briefing-audio-77")
+    with pytest.raises(FeedBuildError, match="briefing-audio-77"):
+        _build([episode])
+
+
+def test_aware_utc_datetimes_produce_a_plus_zero_offset_not_unverified():
+    """A `-0000` offset means "unverified" per RFC 2822 -- an aware UTC value
+    must emit the unambiguous `+0000` instead, proving the guard above is
+    actually necessary (not just a formality) and that the aware path is
+    unaffected by it."""
+    episode = _episode(published=_NOW)
+    xml_bytes = _build([episode], now=_NOW)
+    text = xml_bytes.decode("utf-8")
+    channel = ET.fromstring(xml_bytes).find("channel")
+    assert channel.findtext("lastBuildDate").endswith("+0000")
+    assert channel.find("item").findtext("pubDate").endswith("+0000")
+    assert "-0000" not in text
+
+
+# --- itunes namespace: pin the raw-bytes declaration, not just the URI ------
+
+
+def test_xmlns_itunes_is_declared_in_raw_bytes_when_a_duration_is_present():
+    """Finding `itunes:duration` by namespace URI (as the tests above do)
+    would still succeed even if the `xmlns:itunes` declaration were missing
+    from the serialized bytes -- an ElementTree quirk that would produce
+    invalid XML many real parsers reject. Assert the declaration itself is
+    present in the actual output, not just that the parsed tree resolves the
+    tag."""
+    episode = _episode(duration_seconds=42.0)
+    text = _build([episode]).decode("utf-8")
+    assert f'xmlns:itunes="{_ITUNES_NS}"' in text
+
+
+def test_xmlns_itunes_is_absent_from_raw_bytes_when_no_duration_is_present():
+    episode = _episode(duration_seconds=None)
+    text = _build([episode]).decode("utf-8")
+    assert "xmlns:itunes" not in text
+    assert "itunes:duration" not in text

--- a/Tests/Subscriptions/test_briefing_feed.py
+++ b/Tests/Subscriptions/test_briefing_feed.py
@@ -1,0 +1,188 @@
+"""Tests for the pure RSS feed builder (spec #2 phase 3, Task 3).
+
+`build_feed_xml` turns a watchlist's audio episodes -- already shaped as
+`FeedEpisode` -- into a self-contained RSS 2.0 podcast feed as bytes. It is
+pure: no filesystem access, no ambient clock (`now` is an injected
+parameter), so every test here is deterministic.
+
+Every assertion parses the result back with `xml.etree.ElementTree` and
+asserts on the parsed tree, never on a substring of the raw bytes -- a
+substring test would happily pass on malformed XML, which is exactly the
+failure this suite exists to exclude. The hostile-title test in particular
+is a round-trip: build with a title containing `<`, `&` and `]]>`, parse it
+back, and assert the parsed text equals the original exactly. Escaping is
+ElementTree's job; this module must never hand-escape.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+import pytest
+
+from tldw_chatbook.Subscriptions.briefing_feed import (
+    FeedBuildError,
+    FeedEpisode,
+    build_feed_xml,
+)
+
+pytestmark = pytest.mark.unit
+
+_ITUNES_NS = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+_NOW = datetime(2026, 8, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _episode(**overrides: object) -> FeedEpisode:
+    fields: dict = dict(
+        title="Episode 1",
+        filename="script-1-audio-2.wav",
+        length_bytes=12345,
+        duration_seconds=90.0,
+        published=datetime(2026, 7, 30, 8, 0, 0, tzinfo=timezone.utc),
+        guid="briefing-audio-2",
+        description="A description of episode 1.",
+    )
+    fields.update(overrides)
+    return FeedEpisode(**fields)
+
+
+def _build(episodes: list[FeedEpisode], **overrides: object) -> bytes:
+    kwargs: dict = dict(
+        channel_title="My Watchlist",
+        channel_description="Episodes from My Watchlist",
+        episodes=episodes,
+        now=_NOW,
+    )
+    kwargs.update(overrides)
+    return build_feed_xml(**kwargs)
+
+
+# --- document shape --------------------------------------------------------
+
+
+def test_document_is_well_formed_rss_2_with_exactly_one_channel():
+    root = ET.fromstring(_build([]))
+    assert root.tag == "rss"
+    assert root.get("version") == "2.0"
+    channels = root.findall("channel")
+    assert len(channels) == 1
+
+
+def test_channel_carries_title_description_and_last_build_date():
+    channel = ET.fromstring(_build([])).find("channel")
+    assert channel.findtext("title") == "My Watchlist"
+    assert channel.findtext("description") == "Episodes from My Watchlist"
+    last_build_date = channel.findtext("lastBuildDate")
+    assert last_build_date is not None
+    # Round-trip through RFC-822 parsing, not a string-format assertion.
+    assert parsedate_to_datetime(last_build_date) == _NOW
+
+
+def test_empty_episodes_still_produces_a_valid_channel_with_zero_items():
+    channel = ET.fromstring(_build([])).find("channel")
+    assert channel is not None
+    assert channel.find("title") is not None
+    assert channel.findall("item") == []
+
+
+# --- one episode -> one item -------------------------------------------------
+
+
+def test_each_episode_yields_an_item_with_title_guid_and_pubdate():
+    episode = _episode()
+    channel = ET.fromstring(_build([episode])).find("channel")
+    items = channel.findall("item")
+    assert len(items) == 1
+    item = items[0]
+    assert item.findtext("title") == episode.title
+    assert item.findtext("guid") == episode.guid
+    pub_date = item.findtext("pubDate")
+    assert pub_date is not None
+    assert parsedate_to_datetime(pub_date) == episode.published
+
+
+def test_two_episodes_yield_two_items_in_order():
+    first = _episode(title="First", guid="g1")
+    second = _episode(title="Second", guid="g2")
+    channel = ET.fromstring(_build([first, second])).find("channel")
+    items = channel.findall("item")
+    assert [item.findtext("title") for item in items] == ["First", "Second"]
+
+
+# --- enclosure ---------------------------------------------------------------
+
+
+def test_enclosure_url_is_the_bare_relative_filename_never_absolute():
+    episode = _episode(filename="script-9-audio-3.wav")
+    item = ET.fromstring(_build([episode])).find("channel").find("item")
+    enclosure = item.find("enclosure")
+    assert enclosure is not None
+    url = enclosure.get("url")
+    assert url == "script-9-audio-3.wav"
+    assert not url.startswith("/")
+    assert ":" not in url  # excludes both an absolute POSIX path and a URL scheme
+
+
+def test_enclosure_length_is_bytes_and_type_is_audio_wav():
+    episode = _episode(length_bytes=98765)
+    enclosure = ET.fromstring(_build([episode])).find("channel").find("item").find("enclosure")
+    assert enclosure.get("length") == "98765"
+    assert enclosure.get("type") == "audio/wav"
+
+
+# --- itunes:duration ----------------------------------------------------------
+
+
+def test_itunes_duration_emitted_when_duration_seconds_present():
+    episode = _episode(duration_seconds=125.0)
+    item = ET.fromstring(_build([episode])).find("channel").find("item")
+    duration_el = item.find(f"{{{_ITUNES_NS}}}duration")
+    assert duration_el is not None
+    assert duration_el.text  # non-empty
+
+
+def test_itunes_duration_omitted_when_duration_seconds_is_none():
+    episode = _episode(duration_seconds=None)
+    item = ET.fromstring(_build([episode])).find("channel").find("item")
+    assert item.find(f"{{{_ITUNES_NS}}}duration") is None
+
+
+# --- escaping: ElementTree's job, proven by round-trip -----------------------
+
+
+def test_hostile_title_round_trips_exactly_through_parse():
+    hostile_title = "Report: <Q3> Sales & Marketing ]]> Recap"
+    episode = _episode(title=hostile_title)
+    item = ET.fromstring(_build([episode])).find("channel").find("item")
+    assert item.findtext("title") == hostile_title
+
+
+def test_hostile_description_round_trips_exactly_through_parse():
+    hostile_description = "A & B <together>, plus a stray ]]> marker."
+    episode = _episode(description=hostile_description)
+    item = ET.fromstring(_build([episode])).find("channel").find("item")
+    assert item.findtext("description") == hostile_description
+
+
+# --- the path-separator guard ------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_filename", ["../evil.wav", "sub/evil.wav", "sub\\evil.wav"])
+def test_filename_with_a_path_separator_raises_feed_build_error_naming_it(bad_filename):
+    episode = _episode(filename=bad_filename)
+    with pytest.raises(FeedBuildError, match=re.escape(bad_filename)):
+        _build([episode])
+
+
+def test_path_separator_guard_rejects_before_emitting_any_xml():
+    """A single bad episode among good ones must still raise -- not silently
+    skip the bad one and emit a feed missing it (Task 4 is the layer that
+    decides skip-vs-fail for I/O-level problems; a filename this shape is a
+    programming error in the caller, not a runtime skip candidate)."""
+    good = _episode(filename="ok.wav", guid="g-ok")
+    bad = _episode(filename="../evil.wav", guid="g-bad")
+    with pytest.raises(FeedBuildError):
+        _build([good, bad])

--- a/Tests/Subscriptions/test_briefing_feed.py
+++ b/Tests/Subscriptions/test_briefing_feed.py
@@ -195,11 +195,18 @@ def test_enclosure_url_percent_encodes_non_ascii_characters():
         "already has, punctuation!.wav",
     ],
 )
-def test_enclosure_url_is_idempotently_encoded(filename):
-    """The general property: the emitted `url` is already fully encoded --
-    decoding then re-encoding it must be a no-op. A url that were only
-    partially encoded (or double-encoded) would fail this even if the
-    space/non-ASCII spot-checks above happened to pass."""
+def test_enclosure_url_decodes_back_to_exactly_the_on_disk_filename(filename):
+    """The general property, stated as the thing a client actually depends
+    on: unquoting the emitted `url` the way a static file server does must
+    yield the exact name Task 4 wrote to disk -- no more, no less.
+
+    The obvious phrasing of this property, `url == quote(unquote(url))`, is
+    a TAUTOLOGY: it holds for the output of `quote()` no matter what was
+    fed in, so a double-encoding bug (`quote(quote(name))`) satisfies it
+    and stays green. A whole-branch reviewer caught that by mutating the
+    emit to double-quote and watching all four parametrizations pass. This
+    phrasing REDs on that mutation, because a double-encoded url unquotes
+    to `Two%20Host...`, not to the filename."""
     episode = _episode(filename=filename)
     url = (
         ET.fromstring(_build([episode]))
@@ -208,7 +215,7 @@ def test_enclosure_url_is_idempotently_encoded(filename):
         .find("enclosure")
         .get("url")
     )
-    assert url == quote(unquote(url), safe="")
+    assert unquote(url) == filename
 
 
 def test_enclosure_url_percent_encoding_does_not_change_the_on_disk_filename():

--- a/Tests/Subscriptions/test_briefing_feed.py
+++ b/Tests/Subscriptions/test_briefing_feed.py
@@ -20,6 +20,7 @@ import re
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from urllib.parse import quote, unquote
 
 import pytest
 
@@ -81,6 +82,19 @@ def test_channel_carries_title_description_and_last_build_date():
     assert parsedate_to_datetime(last_build_date) == _NOW
 
 
+def test_channel_link_is_present_non_empty_and_a_relative_reference():
+    """FIX C (whole-branch review): RSS 2.0 requires `title`, `link` and
+    `description` on every channel; validators and Apple's podcast
+    requirements flag a missing `<link>`. There is no server URL to point
+    at (serving the exported folder is the user's own choice), so this is
+    the feed's own filename as a relative reference -- consistent with the
+    directory being self-contained."""
+    link = ET.fromstring(_build([])).find("channel").findtext("link")
+    assert link
+    assert "://" not in link  # a relative reference, not an invented URL
+    assert link == "feed.xml"
+
+
 def test_empty_episodes_still_produces_a_valid_channel_with_zero_items():
     channel = ET.fromstring(_build([])).find("channel")
     assert channel is not None
@@ -131,6 +145,80 @@ def test_enclosure_length_is_bytes_and_type_is_audio_wav():
     enclosure = ET.fromstring(_build([episode])).find("channel").find("item").find("enclosure")
     assert enclosure.get("length") == "98765"
     assert enclosure.get("type") == "audio/wav"
+
+
+# --- FIX A (whole-branch review): enclosure URLs are percent-encoded -------
+#
+# `FeedEpisode.filename` comes from Task 4's `safe_export_stem`, which
+# deliberately keeps spaces (pinned for its other caller by
+# `test_stem_keeps_ordinary_characters` in
+# `test_briefing_export_markdown.py`) and, via `str.isalnum()`, also admits
+# non-ASCII letters. RFC 3986 forbids a raw space in a URI reference; a
+# podcast client that sends it verbatim in the request line (rather than
+# percent-encoding on resolve) gets a 400. The fix must be applied ONLY at
+# emission -- `FeedEpisode.filename` itself, and the file Task 4 writes to
+# disk under that name, must be untouched.
+
+
+def test_enclosure_url_percent_encodes_a_space_and_carries_no_raw_space():
+    episode = _episode(filename="Two Host Debate-42.wav")
+    url = (
+        ET.fromstring(_build([episode]))
+        .find("channel")
+        .find("item")
+        .find("enclosure")
+        .get("url")
+    )
+    assert "%20" in url
+    assert " " not in url
+
+
+def test_enclosure_url_percent_encodes_non_ascii_characters():
+    episode = _episode(filename="Café Debate-7.wav")
+    url = (
+        ET.fromstring(_build([episode]))
+        .find("channel")
+        .find("item")
+        .find("enclosure")
+        .get("url")
+    )
+    assert "é" not in url
+    assert "%C3%A9" in url  # UTF-8 bytes for "é", percent-encoded
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "script-9-audio-3.wav",
+        "Two Host Debate-42.wav",
+        "Café Debate-7.wav",
+        "already has, punctuation!.wav",
+    ],
+)
+def test_enclosure_url_is_idempotently_encoded(filename):
+    """The general property: the emitted `url` is already fully encoded --
+    decoding then re-encoding it must be a no-op. A url that were only
+    partially encoded (or double-encoded) would fail this even if the
+    space/non-ASCII spot-checks above happened to pass."""
+    episode = _episode(filename=filename)
+    url = (
+        ET.fromstring(_build([episode]))
+        .find("channel")
+        .find("item")
+        .find("enclosure")
+        .get("url")
+    )
+    assert url == quote(unquote(url), safe="")
+
+
+def test_enclosure_url_percent_encoding_does_not_change_the_on_disk_filename():
+    """`FeedEpisode.filename` -- what Task 4 writes to disk and what a
+    future reader of this module should expect to find unmodified -- must
+    stay exactly as given; only the emitted `<enclosure>` URL is encoded."""
+    episode = _episode(filename="Two Host Debate-42.wav")
+    assert episode.filename == "Two Host Debate-42.wav"
+    _build([episode])  # building must not mutate the (frozen) episode
+    assert episode.filename == "Two Host Debate-42.wav"
 
 
 # --- itunes:duration ----------------------------------------------------------

--- a/Tests/Subscriptions/test_briefing_feed_export.py
+++ b/Tests/Subscriptions/test_briefing_feed_export.py
@@ -31,6 +31,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock
+from urllib.parse import unquote
 
 import pytest
 
@@ -659,3 +660,144 @@ def test_a_destination_failing_validate_path_simple_raises_before_anything_is_wr
 
     query_spy.assert_not_called()
     assert not hostile_destination.exists()
+
+
+# --- FIX B (whole-branch review): the export must page, never truncate -----
+#
+# The original implementation called `list_watchlist_audio_episodes(
+# watchlist_id)` with the accessor's default `limit=500` and never paged, so
+# episode 501+ was neither exported nor recorded in `skipped` -- the export
+# would report full success while silently dropping the tail. Real SQL
+# `LIMIT`/`OFFSET` only ever returns fewer than `limit` rows when the table
+# is actually exhausted, so shrinking `_EPISODES_PAGE_SIZE` (a module
+# attribute for exactly this reason) lets these tests exercise a real
+# multi-page walk with a handful of seeded rows rather than hundreds.
+
+
+def test_export_pages_through_more_than_one_page_of_episodes(tmp_path, monkeypatch):
+    """The literal "more episodes than one page" case: with the page size
+    shrunk to 2 and 5 real episodes seeded, every one must still be
+    exported -- no gaps, no silent truncation at the first page boundary.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(briefing_export, "_EPISODES_PAGE_SIZE", 2)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    audio_ids = [
+        _seed_episode(
+            db,
+            watchlist_id,
+            audio_dir=audio_dir,
+            created_at=f"2026-01-{n + 1:02d} 00:00:00",
+            preset_name=f"Preset {n}",
+        )[0]
+        for n in range(5)
+    ]
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 5, (
+        "a page size smaller than the episode count must not truncate the "
+        "export -- every episode must still be exported"
+    )
+    assert result.skipped == []
+
+    written_audio_files = [p for p in destination.iterdir() if p.name != "feed.xml"]
+    assert len(written_audio_files) == 5
+
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    items = tree.findall("./channel/item")
+    assert len(items) == 5
+    guids = {item.findtext("guid") for item in items}
+    assert guids == {f"briefing-audio-{audio_id}" for audio_id in audio_ids}
+
+
+def test_export_calls_the_accessor_with_explicit_paging_kwargs_until_a_page_is_empty(
+    tmp_path, monkeypatch
+):
+    """Pins the actual CALL SHAPE, not just the outcome -- a caller that
+    reverted to a single bare call (`list_watchlist_audio_episodes(
+    watchlist_id)`, the exact FIX B bug: relying on the accessor's own
+    500-row default and never paging) would still return the one episode
+    seeded here (there are far fewer than 500), so an outcome-only
+    assertion cannot tell the two apart. This asserts every call passed
+    `limit`/`offset` explicitly, offsets advanced by the page size with no
+    gaps, and the walk stopped only once a page came back empty -- which
+    requires at least two calls even for a single-episode watchlist.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    real_query = db.list_watchlist_audio_episodes
+    query_spy = Mock(wraps=real_query)
+    monkeypatch.setattr(db, "list_watchlist_audio_episodes", query_spy)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    # One page returns the single episode, a second (empty) page confirms
+    # there is nothing left -- exactly two calls, not one per episode and
+    # not an unbounded number.
+    assert query_spy.call_count == 2
+    page_size = briefing_export._EPISODES_PAGE_SIZE
+    expected_offsets = [0, page_size]
+    actual_offsets = [call.kwargs["offset"] for call in query_spy.call_args_list]
+    assert actual_offsets == expected_offsets
+    for call in query_spy.call_args_list:
+        assert call.kwargs["limit"] == page_size
+
+
+# --- FIX A (whole-branch review): percent-encoding end-to-end --------------
+
+
+def test_a_space_in_the_preset_name_stays_on_disk_but_is_encoded_in_the_feed(
+    tmp_path, monkeypatch
+):
+    """`safe_export_stem` deliberately keeps spaces in the exported filename
+    (pinned by `test_stem_keeps_ordinary_characters` for its other caller);
+    `briefing_feed.build_feed_xml` must percent-encode that same filename
+    ONLY when emitting the `<enclosure>` url, never on disk. This is the
+    end-to-end version of the property `test_briefing_feed.py` pins in
+    isolation."""
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir, preset_name="Two Host Debate")
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    episode_files = [p for p in destination.iterdir() if p.name != "feed.xml"]
+    assert len(episode_files) == 1
+    on_disk_name = episode_files[0].name
+    assert " " in on_disk_name, "the on-disk filename must keep its space"
+
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    enclosure = tree.find("./channel/item/enclosure")
+    url = enclosure.get("url")
+
+    assert " " not in url, "the enclosure URL must not carry a raw space"
+    assert "%20" in url
+    assert unquote(url) == on_disk_name, (
+        "decoding the emitted URL must recover exactly the filename actually "
+        "written to disk"
+    )

--- a/Tests/Subscriptions/test_briefing_feed_export.py
+++ b/Tests/Subscriptions/test_briefing_feed_export.py
@@ -6,8 +6,9 @@ feed: it copies a watchlist's audio episodes out of the private
 `feed.xml` RSS document (Task 3's `build_feed_xml`). Every test here
 patches `get_user_data_dir` to `tmp_path` -- this repo has had three
 separate incidents of test scaffolding touching live user files, and
-`audio_file_path_is_safe` (imported from `artifacts_pane`) resolves against
-`briefing_audio_dir()`, which reads that setting.
+`audio_file_path_is_safe` (imported from `Subscriptions.briefing_audio`,
+moved there from `artifacts_pane` in this task's review round 1) resolves
+against `briefing_audio_dir()`, which reads that setting.
 
 The load-bearing test in this file is
 `test_an_unsafe_file_path_is_skipped_without_any_filesystem_access`: it
@@ -87,6 +88,7 @@ def _seed_episode(
     preset_name: str = "Two Host Debate",
     write_real_file: bool = True,
     file_path: str | None = None,
+    covers_from_ts: str | None = None,
 ) -> tuple[int, Path]:
     """Build one full watchlist -> briefing -> script -> complete-audio chain.
 
@@ -98,6 +100,8 @@ def _seed_episode(
         `(audio_id, source_path)`.
     """
     briefing_id = _make_briefing(db, watchlist_id, created_at=created_at)
+    if covers_from_ts is not None:
+        db.update_briefing(briefing_id, covers_from_ts=covers_from_ts)
     script_id = _make_script(db, briefing_id, preset_name=preset_name)
     audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]", status="complete")
     source_path = (
@@ -156,13 +160,24 @@ def test_happy_path_writes_feed_xml_plus_one_file_per_episode_and_returns_the_co
     assert len(items) == 2
 
 
-def test_length_bytes_is_the_real_file_size_read_after_the_copy(tmp_path, monkeypatch):
+def test_length_bytes_matches_the_actual_copied_destination_files_size(
+    tmp_path, monkeypatch
+):
+    """The enclosure's `length` must reflect the file that actually landed in
+    the destination directory. Task 4 review round 1: the original version
+    of this test stated the SOURCE file before the copy ran and compared
+    against that -- since a correct copy leaves source and destination
+    byte-identical, that oracle cannot tell a (correct) dest-stat
+    implementation from a (wrong) source-stat one, and the test's own name
+    over-claimed what it checked. This stats the destination file
+    `export_feed_directory` actually produced, found via a real directory
+    listing after the call.
+    """
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db)
     audio_dir = briefing_audio.briefing_audio_dir()
-    _audio_id, source_path = _seed_episode(db, watchlist_id, audio_dir=audio_dir)
-    real_size = source_path.stat().st_size
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
 
     destination = tmp_path / "export"
     destination.mkdir()
@@ -171,9 +186,13 @@ def test_length_bytes_is_the_real_file_size_read_after_the_copy(tmp_path, monkey
         db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
     )
 
+    episode_files = [p for p in destination.iterdir() if p.name != "feed.xml"]
+    assert len(episode_files) == 1
+    actual_dest_size = episode_files[0].stat().st_size
+
     tree = ET.fromstring((destination / "feed.xml").read_bytes())
     enclosure = tree.find("./channel/item/enclosure")
-    assert int(enclosure.get("length")) == real_size
+    assert int(enclosure.get("length")) == actual_dest_size
 
 
 def test_filenames_combine_stem_and_audio_id_so_identical_titles_cannot_collide(
@@ -210,6 +229,80 @@ def test_filenames_combine_stem_and_audio_id_so_identical_titles_cannot_collide(
     written_names = sorted(p.name for p in destination.iterdir() if p.name != "feed.xml")
     assert len(written_names) == 2
     assert written_names[0] != written_names[1]
+
+
+def test_episode_titles_lead_with_the_date_so_identical_presets_are_distinguishable(
+    tmp_path, monkeypatch
+):
+    """Task 4 review round 1: `preset_name` alone made every episode
+    rendered from the same preset identical in a podcast client's episode
+    list, distinguishable only by whatever date field that client happens
+    to expose. Leading the title with the publish date fixes this
+    directly."""
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    _seed_episode(
+        db,
+        watchlist_id,
+        audio_dir=audio_dir,
+        created_at="2026-01-01 00:00:00",
+        preset_name="Same Preset",
+    )
+    _seed_episode(
+        db,
+        watchlist_id,
+        audio_dir=audio_dir,
+        created_at="2026-01-02 00:00:00",
+        preset_name="Same Preset",
+    )
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    titles = [item.findtext("title") for item in tree.findall("./channel/item")]
+
+    assert len(titles) == 2
+    assert titles[0] != titles[1], "identical-preset episodes must not share a title"
+    assert all("Same Preset" in title for title in titles)
+    assert "Jan 01, 2026" in titles[0] or "Jan 01, 2026" in titles[1]
+    assert "Jan 02, 2026" in titles[0] or "Jan 02, 2026" in titles[1]
+
+
+def test_episode_description_includes_covers_from_ts_when_present(tmp_path, monkeypatch):
+    """Task 4 review round 1: `covers_from_ts` is present on every
+    `list_watchlist_audio_episodes` row but was previously unused -- fed
+    into the description so an episode says what period it actually
+    covers, which a title/date alone cannot."""
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    _seed_episode(
+        db,
+        watchlist_id,
+        audio_dir=audio_dir,
+        covers_from_ts="2025-12-25T00:00:00+00:00",
+    )
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    description = tree.findtext("./channel/item/description")
+    assert "2025-12-25T00:00:00+00:00" in description
 
 
 # --- the load-bearing security test ------------------------------------------
@@ -291,10 +384,81 @@ def test_a_vanished_source_file_is_skipped_with_a_reason_and_others_still_export
     assert str(vanished_audio_id) in result.skipped[0]
 
 
+def test_a_malformed_briefing_created_at_is_skipped_with_a_clear_reason_others_still_export(
+    tmp_path, monkeypatch
+):
+    """Task 4 review round 1: no test previously exercised this skip path
+    (`_published_from_briefing_created_at`'s `ValueError`), and its reason
+    string used to be the bare exception type name (`"audio 3: ValueError"`)
+    -- opaque, and Task 5 surfaces `skipped` reasons verbatim in its "N of M
+    exported" message. This both covers the path and pins that the reason
+    says what actually went wrong, in plain words.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    bad_audio_id, _bad_path = _seed_episode(
+        db, watchlist_id, audio_dir=audio_dir, created_at="not-a-timestamp"
+    )
+    _good_audio_id, _good_path = _seed_episode(
+        db, watchlist_id, audio_dir=audio_dir, created_at="2026-01-02 00:00:00"
+    )
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 1
+    assert len(result.skipped) == 1
+    reason = result.skipped[0]
+    assert str(bad_audio_id) in reason
+    assert "ValueError" not in reason, "the reason must say what went wrong, not a bare exception type"
+    assert "timestamp" in reason.lower()
+
+
+def test_an_export_with_every_episode_skipped_still_writes_a_valid_empty_feed(
+    tmp_path, monkeypatch
+):
+    """Task 4 review round 1: an all-skipped export must still produce a
+    valid `feed.xml` with zero items -- the honest "0 of N exported"
+    outcome, not a missing or malformed feed."""
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir, write_real_file=False)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 0
+    assert len(result.skipped) == 1
+    assert (destination / "feed.xml").exists()
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    assert tree.tag == "rss"
+    assert tree.findall("./channel/item") == []
+
+
 # --- feed.xml atomicity -------------------------------------------------------
 
 
 def test_no_partial_file_remains_after_a_successful_export(tmp_path, monkeypatch):
+    """Task 4 review round 1: absence of a `.partial` file alone does not
+    pin atomicity -- a plain `write_bytes` also leaves none behind (the
+    reviewer confirmed this by mutation). The `os.replace` spy below is
+    what actually ties this test to the atomic-rename mechanism: it asserts
+    the real publish step ran with the expected (partial, final) pair, not
+    just that no stray file happens to remain afterward.
+    """
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db)
@@ -304,10 +468,18 @@ def test_no_partial_file_remains_after_a_successful_export(tmp_path, monkeypatch
     destination = tmp_path / "export"
     destination.mkdir()
 
+    real_replace = briefing_export.os.replace
+    replace_spy = Mock(wraps=real_replace)
+    monkeypatch.setattr(briefing_export.os, "replace", replace_spy)
+
     export_feed_directory(
         db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
     )
 
+    resolved_destination = destination.resolve()
+    replace_spy.assert_called_once_with(
+        resolved_destination / "feed.xml.partial", resolved_destination / "feed.xml"
+    )
     assert (destination / "feed.xml").exists()
     assert not (destination / "feed.xml.partial").exists()
 
@@ -390,6 +562,75 @@ def test_destination_directory_mode_is_never_forced_to_0o700(tmp_path, monkeypat
 
     mode = stat.S_IMODE(os.stat(destination).st_mode)
     assert mode == 0o755, "the user's destination directory must never be chmodded (Decision 2)"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode semantics")
+def test_exported_feed_xml_is_not_left_at_private_storage_permissions(tmp_path, monkeypatch):
+    """Task 4 review round 1 (IMPORTANT finding): `feed.xml`'s atomic-write
+    partial used to be opened at `0o600`, and `os.replace` preserves the
+    replaced-in file's mode, so every exported `feed.xml` landed `0o600` --
+    unreadable to anything but the exporting account, defeating the whole
+    point of a folder meant to be synced, zipped, or served. Fixed by
+    opening the partial at `_EXPORTED_FILE_MODE` (`0o644`) with an explicit
+    `fchmod`, deterministic regardless of the process umask.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    feed_mode = stat.S_IMODE(os.stat(destination / "feed.xml").st_mode)
+    assert feed_mode & 0o044 == 0o044, (
+        f"feed.xml must be group/other readable, got {oct(feed_mode)}"
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode semantics")
+def test_a_copied_episode_file_relaxes_the_privately_stored_sources_mode(
+    tmp_path, monkeypatch
+):
+    """Task 4 review round 1 (IMPORTANT finding): production audio is
+    written by `Utils.private_paths.atomic_private_write_bytes` at `0o600`
+    (application-owned, private-storage semantics), and `shutil.copy2`
+    preserves the SOURCE file's mode along with its data -- so every
+    exported episode silently inherited that private mode into the user's
+    own folder too. This reproduces the real scenario by explicitly
+    chmod-ing the seeded source to `0o600` (what production actually
+    writes) and asserts the COPY in the destination directory is relaxed to
+    a normal, group/other-readable mode instead of inheriting it.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _audio_id, source_path = _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+    os.chmod(source_path, 0o600)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    episode_files = [p for p in destination.iterdir() if p.name != "feed.xml"]
+    assert len(episode_files) == 1
+    episode_mode = stat.S_IMODE(os.stat(episode_files[0]).st_mode)
+    assert episode_mode & 0o044 == 0o044, (
+        f"a copied episode file must be group/other readable, not inherit the "
+        f"private source's mode, got {oct(episode_mode)}"
+    )
+    # The source itself is untouched -- only the COPY is relaxed.
+    source_mode = stat.S_IMODE(os.stat(source_path).st_mode)
+    assert source_mode == 0o600
 
 
 def test_a_destination_failing_validate_path_simple_raises_before_anything_is_written(

--- a/Tests/Subscriptions/test_briefing_feed_export.py
+++ b/Tests/Subscriptions/test_briefing_feed_export.py
@@ -801,3 +801,36 @@ def test_a_space_in_the_preset_name_stays_on_disk_but_is_encoded_in_the_feed(
         "decoding the emitted URL must recover exactly the filename actually "
         "written to disk"
     )
+
+
+class _OffsetIgnoringDB:
+    """An accessor that ignores `offset` -- the shape `task-1761` describes.
+
+    Terminating the export's pagination walk on an empty page is correct
+    only while the accessor honours `offset`; one that ignores it hands
+    back a full page forever. Without the `_EPISODES_MAX_ROWS` bound that
+    hangs a worker while growing its row list without limit, so this pins
+    the bound rather than the happy path.
+    """
+
+    def list_watchlist_audio_episodes(self, watchlist_id, *, limit, offset):
+        return [{"audio_id": 1, "file_path": None}] * limit
+
+
+def test_an_offset_ignoring_accessor_is_refused_rather_than_spun_forever(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(briefing_export, "_EPISODES_PAGE_SIZE", 10)
+    monkeypatch.setattr(briefing_export, "_EPISODES_MAX_ROWS", 50)
+    with pytest.raises(briefing_export.BriefingExportError, match="offset"):
+        briefing_export.export_feed_directory(
+            _OffsetIgnoringDB(),
+            1,
+            destination=tmp_path,
+            watchlist_name="W",
+            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+    # `tmp_path` also holds the harness's own scaffolding, so assert on the
+    # artifacts this function would have written rather than on emptiness.
+    assert not (tmp_path / "feed.xml").exists(), "a refused export must write no feed"
+    assert not list(tmp_path.glob("*.wav")), "a refused export must copy no episodes"

--- a/Tests/Subscriptions/test_briefing_feed_export.py
+++ b/Tests/Subscriptions/test_briefing_feed_export.py
@@ -128,6 +128,12 @@ def _seed_episode(
 def test_happy_path_writes_feed_xml_plus_one_file_per_episode_and_returns_the_count(
     tmp_path, monkeypatch
 ):
+    """The end-to-end deliverable: two real episodes must produce a
+    `feed.xml` naming exactly two `<item>`s, exactly two audio files
+    actually written to the destination directory, and a `FeedExportResult`
+    whose `episode_count`/`skipped`/`directory` fields agree with what
+    landed on disk -- not just that the call returns without raising.
+    """
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db, "Morning AI Brief")
@@ -199,6 +205,11 @@ def test_length_bytes_matches_the_actual_copied_destination_files_size(
 def test_filenames_combine_stem_and_audio_id_so_identical_titles_cannot_collide(
     tmp_path, monkeypatch
 ):
+    """Two episodes sharing the exact same `preset_name` must still get
+    two DISTINCT on-disk filenames -- if `_episode_filename` used the
+    preset-derived stem alone, the second episode's copy would silently
+    overwrite the first's, and the export would report success while
+    actually losing an episode."""
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db)
@@ -357,6 +368,11 @@ def test_an_unsafe_file_path_is_skipped_without_any_filesystem_access(tmp_path, 
 def test_a_vanished_source_file_is_skipped_with_a_reason_and_others_still_export(
     tmp_path, monkeypatch
 ):
+    """A DB row whose `file_path` passes the safety check but no longer
+    exists on disk (deleted out-of-band) must be recorded in `skipped`
+    naming its `audio_id`, and must not abort the export -- the other,
+    healthy episode must still make it into the feed (module docstring,
+    decision 3: one bad episode is skipped, not fatal)."""
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db)
@@ -486,6 +502,11 @@ def test_no_partial_file_remains_after_a_successful_export(tmp_path, monkeypatch
 
 
 def test_a_failure_mid_write_leaves_the_previous_feed_xml_intact(tmp_path, monkeypatch):
+    """Simulating a crash at the atomic-rename step (`os.replace` raising)
+    on a RE-export must leave the PREVIOUS `feed.xml` byte-for-byte
+    unchanged and no `.partial` left behind -- the whole point of writing
+    to a partial and renaming atomically is that a failed re-export cannot
+    corrupt or truncate the feed that was already there."""
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db)
@@ -547,6 +568,12 @@ def test_re_exporting_to_the_same_directory_overwrites_cleanly(tmp_path, monkeyp
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX file mode semantics")
 def test_destination_directory_mode_is_never_forced_to_0o700(tmp_path, monkeypatch):
+    """Pins Decision 1: the export must never chmod the user's OWN
+    destination directory, e.g. by routing it through
+    `Utils/private_paths.py`'s `secure_private_directory` (which forces
+    `0o700` and is meant for application-owned storage). A directory the
+    user deliberately made group/other-readable (`0o755`) must come out of
+    the export exactly as they left it."""
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db)
@@ -637,6 +664,11 @@ def test_a_copied_episode_file_relaxes_the_privately_stored_sources_mode(
 def test_a_destination_failing_validate_path_simple_raises_before_anything_is_written(
     tmp_path, monkeypatch
 ):
+    """A hostile destination string (a shell metacharacter sequence) must
+    be rejected BEFORE the DB is even queried, not merely before a file is
+    written -- pins the ordering, not just the outcome, via a spy on
+    `list_watchlist_audio_episodes` that must never be called, plus proof
+    the hostile path itself was never created on disk."""
     _patch_user_data_dir(monkeypatch, tmp_path)
     db = _db(tmp_path)
     watchlist_id = _make_watchlist(db)
@@ -820,6 +852,12 @@ class _OffsetIgnoringDB:
 def test_an_offset_ignoring_accessor_is_refused_rather_than_spun_forever(
     tmp_path, monkeypatch
 ):
+    """Pins `_EPISODES_MAX_ROWS` as a real upper bound, not a decorative
+    constant: an accessor that ignores `offset` (the `task-1761` shape)
+    would otherwise hand back a full page forever, growing `rows` without
+    limit inside a worker. This asserts the walk raises rather than
+    looping, and that a refused export leaves no partial artifacts behind.
+    """
     monkeypatch.setattr(briefing_export, "_EPISODES_PAGE_SIZE", 10)
     monkeypatch.setattr(briefing_export, "_EPISODES_MAX_ROWS", 50)
     with pytest.raises(briefing_export.BriefingExportError, match="offset"):
@@ -834,3 +872,224 @@ def test_an_offset_ignoring_accessor_is_refused_rather_than_spun_forever(
     # artifacts this function would have written rather than on emptiness.
     assert not (tmp_path / "feed.xml").exists(), "a refused export must write no feed"
     assert not list(tmp_path.glob("*.wav")), "a refused export must copy no episodes"
+
+
+# --- Qodo review (PR #1177): refuse to write through a symlink -------------
+#
+# `_copy_episode_audio_file` used to hand `dest_path` straight to
+# `shutil.copy2`, which follows a symlink AT `dest_path` and writes through
+# it. If the chosen export directory is shared, synced, or otherwise
+# writable by another process, a symlink planted at a predictable episode
+# filename redirects that write to an arbitrary path outside the folder,
+# with the exporting user's own permissions. `validate_path_simple` does
+# not close this: it validates the path STRING and only logs on a
+# resolution change, it never fails closed, and the destination is
+# legitimately outside our private area anyway (module docstring,
+# decision 1). Fixed by opening the destination directly with
+# `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW` and streaming the source
+# into it -- the same posture `_write_feed_xml_atomically` already held for
+# `feed.xml` itself.
+
+
+def test_a_symlink_at_the_destination_filename_is_skipped_without_being_written_through(
+    tmp_path, monkeypatch
+):
+    """A symlink planted at the EXACT filename `_copy_episode_audio_file`
+    is about to write to must never be written through: the file it points
+    to (deliberately placed OUTSIDE the export directory, the way a
+    hostile symlink actually would be) must come out of this call
+    byte-for-byte unchanged, and the episode must be recorded in
+    `skipped` by its `audio_id` -- not silently dropped, and not exported
+    by following the link. A pre-fix implementation (`shutil.copy2`) would
+    happily overwrite the pointed-to file with the episode's audio bytes,
+    which this test would catch via the unchanged-content assertion below.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    audio_id, source_path = _seed_episode(
+        db, watchlist_id, audio_dir=audio_dir, preset_name="Ep"
+    )
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    outside_target = tmp_path / "outside_target.txt"
+    outside_target.write_text("do not touch")
+
+    expected_filename = briefing_export._episode_filename(
+        {"preset_name": "Ep", "audio_id": audio_id}, source_path
+    )
+    symlink_path = destination / expected_filename
+    symlink_path.symlink_to(outside_target)
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 0
+    assert len(result.skipped) == 1
+    assert str(audio_id) in result.skipped[0]
+    assert outside_target.read_text() == "do not touch", (
+        "the symlink's target, outside the export directory, must never be "
+        "written through"
+    )
+    assert symlink_path.is_symlink(), "the planted symlink itself is left alone"
+
+
+def test_a_normal_copy_still_lands_at_exactly_0o644_after_the_symlink_fix(
+    tmp_path, monkeypatch
+):
+    """Refusing a symlinked destination must not regress the ordinary
+    (non-symlink) case: pins the copied file's mode as EXACTLY `0o644`
+    (`_EXPORTED_FILE_MODE`), not merely "some readable bits", since the
+    write path changed from `shutil.copy2` + a separate `os.chmod` call to
+    a single `os.open(..., O_NOFOLLOW)` + `fchmod` at creation time.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    episode_files = [p for p in destination.iterdir() if p.name != "feed.xml"]
+    assert len(episode_files) == 1
+    mode = stat.S_IMODE(os.stat(episode_files[0]).st_mode)
+    assert mode == 0o644
+
+
+def test_re_exporting_the_same_episode_overwrites_its_existing_destination_file(
+    tmp_path, monkeypatch
+):
+    """The `O_NOFOLLOW` guard exists to refuse a SYMLINK at the destination
+    -- it must not turn every export into a one-shot write that fails the
+    second time a REGULAR file already sits at that path. Re-exporting the
+    same episode (same `audio_id`, so the same on-disk filename) must
+    overwrite the existing destination file with the source's current
+    bytes, not raise and not silently keep the stale content.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _audio_id, source_path = _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    first = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+    assert first.episode_count == 1
+    episode_files = [p for p in destination.iterdir() if p.name != "feed.xml"]
+    assert len(episode_files) == 1
+    dest_path = episode_files[0]
+    first_content = dest_path.read_bytes()
+
+    # Change the source's bytes -- a real re-export must carry the NEW
+    # content into the already-present (regular-file) destination.
+    source_path.write_bytes(b"RIFF....WAVEfmt updated-audio-bytes")
+
+    second = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert second.episode_count == 1
+    assert second.skipped == []
+    assert dest_path.exists(), "the re-export must land at the same path"
+    assert dest_path.read_bytes() != first_content, (
+        "a re-export must overwrite the existing destination file with the "
+        "current source content"
+    )
+    mode = stat.S_IMODE(os.stat(dest_path).st_mode)
+    assert mode == 0o644
+
+
+# --- Qodo review (PR #1177): a dangling partial symlink must not wedge -----
+#
+# `_write_feed_xml_atomically`'s stale-partial cleanup used
+# `if partial_path.exists(): partial_path.unlink()` -- `Path.exists()`
+# FOLLOWS a symlink to check its target, so it returns `False` for a
+# dangling symlink at `feed.xml.partial`, silently skipping the unlink.
+# The following `O_EXCL | O_NOFOLLOW` open then fails on every subsequent
+# export to that directory: a persistent, user-visible denial of service
+# in a folder the user chose. Fixed by checking `os.path.lexists` instead,
+# which reports the directory entry itself without following it.
+
+
+def test_a_dangling_partial_symlink_does_not_permanently_block_export(
+    tmp_path, monkeypatch
+):
+    """A dangling symlink (pointing at nothing) left at `feed.xml.partial`
+    must not wedge every future export behind the `O_EXCL` open: the
+    export must still succeed, and the dangling symlink must be gone
+    afterward rather than surviving alongside (or instead of) a real
+    `feed.xml`.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    partial_path = destination / briefing_export._FEED_XML_PARTIAL_NAME
+    partial_path.symlink_to(destination / "does-not-exist.tmp")
+    assert not partial_path.exists(), "sanity: exists() must follow and see nothing"
+    assert partial_path.is_symlink()
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 1
+    assert (destination / briefing_export._FEED_XML_NAME).exists()
+    assert not partial_path.is_symlink(), "the dangling symlink must be cleared"
+
+
+def test_a_live_partial_symlink_is_cleared_rather_than_written_through(
+    tmp_path, monkeypatch
+):
+    """A LIVE symlink at `feed.xml.partial` (pointing at a real file
+    elsewhere) must be cleared the same way a dangling one is.
+    `Path.unlink()` always removes the directory entry itself, never the
+    file it points to, so this also pins that the pointed-to file is left
+    completely untouched rather than corrupted or overwritten in place.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    elsewhere = tmp_path / "elsewhere.txt"
+    elsewhere.write_text("unrelated file, must not be touched")
+
+    partial_path = destination / briefing_export._FEED_XML_PARTIAL_NAME
+    partial_path.symlink_to(elsewhere)
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 1
+    assert (destination / briefing_export._FEED_XML_NAME).exists()
+    assert not partial_path.is_symlink(), (
+        "the live symlink must be cleared, not left in place"
+    )
+    assert elsewhere.read_text() == "unrelated file, must not be touched", (
+        "the symlink's target must never be written through"
+    )

--- a/Tests/Subscriptions/test_briefing_feed_export.py
+++ b/Tests/Subscriptions/test_briefing_feed_export.py
@@ -1,0 +1,420 @@
+"""Tests for the feed-directory writer (spec #2 phase 3, Task 4).
+
+`export_feed_directory` is the deliverable of the whole spec #2 podcast
+feed: it copies a watchlist's audio episodes out of the private
+`briefing_audio_dir()` into a directory the user chose, alongside a
+`feed.xml` RSS document (Task 3's `build_feed_xml`). Every test here
+patches `get_user_data_dir` to `tmp_path` -- this repo has had three
+separate incidents of test scaffolding touching live user files, and
+`audio_file_path_is_safe` (imported from `artifacts_pane`) resolves against
+`briefing_audio_dir()`, which reads that setting.
+
+The load-bearing test in this file is
+`test_an_unsafe_file_path_is_skipped_without_any_filesystem_access`: it
+proves the safety check runs BEFORE any read of the underlying file, not
+merely that an unsafe file never ends up copied -- a real, readable file
+sits at the "unsafe" path, and the test spies on both `Path.exists` and
+`shutil.copy2` to prove neither is ever invoked for it.
+
+Same harness as `test_briefing_feed_query.py`: a real `SubscriptionsDB`,
+`WatchlistBundleService` for watchlist creation, `insert_briefing` /
+`insert_briefing_script` / `create_briefing_audio` / `update_briefing_audio`
+for the rest of the chain.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions import briefing_audio, briefing_export
+from tldw_chatbook.Subscriptions.briefing_export import (
+    FeedExportResult,
+    export_feed_directory,
+)
+from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 8, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- shared harness ---------------------------------------------------------
+
+
+def _patch_user_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Redirect `briefing_audio_dir()` into `tmp_path` -- never real storage."""
+    monkeypatch.setattr(briefing_audio, "get_user_data_dir", lambda: tmp_path)
+
+
+def _db(tmp_path: Path) -> SubscriptionsDB:
+    return SubscriptionsDB(tmp_path / "subs.db", "test")
+
+
+def _make_watchlist(db: SubscriptionsDB, name: str = "w") -> int:
+    return WatchlistBundleService(db).create(name=name)["id"]
+
+
+def _make_briefing(db: SubscriptionsDB, watchlist_id: int, *, created_at: str) -> int:
+    briefing_id = db.insert_briefing(watchlist_id)
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE briefings SET created_at = ? WHERE id = ?",
+            (created_at, briefing_id),
+        )
+    return briefing_id
+
+
+def _make_script(db: SubscriptionsDB, briefing_id: int, *, preset_name: str = "p") -> int:
+    return db.insert_briefing_script(
+        briefing_id, preset_id=None, preset_name=preset_name, roster_snapshot_json="[]"
+    )
+
+
+def _seed_episode(
+    db: SubscriptionsDB,
+    watchlist_id: int,
+    *,
+    audio_dir: Path,
+    created_at: str = "2026-01-01 00:00:00",
+    preset_name: str = "Two Host Debate",
+    write_real_file: bool = True,
+    file_path: str | None = None,
+) -> tuple[int, Path]:
+    """Build one full watchlist -> briefing -> script -> complete-audio chain.
+
+    Writes a real, readable `.wav`-shaped file under `audio_dir` unless
+    `write_real_file` is False (the "vanished file" case) or `file_path` is
+    given explicitly (the "path points outside `audio_dir`" case).
+
+    Returns:
+        `(audio_id, source_path)`.
+    """
+    briefing_id = _make_briefing(db, watchlist_id, created_at=created_at)
+    script_id = _make_script(db, briefing_id, preset_name=preset_name)
+    audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]", status="complete")
+    source_path = (
+        Path(file_path)
+        if file_path is not None
+        else audio_dir / f"script-{script_id}-audio-{audio_id}.wav"
+    )
+    if write_real_file:
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(b"RIFF....WAVEfmt fake-audio-bytes")
+    db.update_briefing_audio(
+        audio_id,
+        file_path=str(source_path),
+        duration_seconds=90.0,
+        turn_count=4,
+    )
+    return audio_id, source_path
+
+
+# --- happy path --------------------------------------------------------------
+
+
+def test_happy_path_writes_feed_xml_plus_one_file_per_episode_and_returns_the_count(
+    tmp_path, monkeypatch
+):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db, "Morning AI Brief")
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir, created_at="2026-01-01 00:00:00")
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir, created_at="2026-01-02 00:00:00")
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    result = export_feed_directory(
+        db,
+        watchlist_id,
+        destination=destination,
+        watchlist_name="Morning AI Brief",
+        now=_NOW,
+    )
+
+    assert isinstance(result, FeedExportResult)
+    assert result.episode_count == 2
+    assert result.skipped == []
+    assert result.directory == destination.resolve()
+    assert (destination / "feed.xml").exists()
+
+    written_audio_files = [p for p in destination.iterdir() if p.name != "feed.xml"]
+    assert len(written_audio_files) == 2
+
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    items = tree.findall("./channel/item")
+    assert len(items) == 2
+
+
+def test_length_bytes_is_the_real_file_size_read_after_the_copy(tmp_path, monkeypatch):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _audio_id, source_path = _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+    real_size = source_path.stat().st_size
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    enclosure = tree.find("./channel/item/enclosure")
+    assert int(enclosure.get("length")) == real_size
+
+
+def test_filenames_combine_stem_and_audio_id_so_identical_titles_cannot_collide(
+    tmp_path, monkeypatch
+):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    _seed_episode(
+        db,
+        watchlist_id,
+        audio_dir=audio_dir,
+        created_at="2026-01-01 00:00:00",
+        preset_name="Same Title",
+    )
+    _seed_episode(
+        db,
+        watchlist_id,
+        audio_dir=audio_dir,
+        created_at="2026-01-02 00:00:00",
+        preset_name="Same Title",
+    )
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 2
+    written_names = sorted(p.name for p in destination.iterdir() if p.name != "feed.xml")
+    assert len(written_names) == 2
+    assert written_names[0] != written_names[1]
+
+
+# --- the load-bearing security test ------------------------------------------
+
+
+def test_an_unsafe_file_path_is_skipped_without_any_filesystem_access(tmp_path, monkeypatch):
+    """A real, readable file sits at the "unsafe" path -- a wrong-order
+    implementation would happily read/copy it. `audio_file_path_is_safe` is
+    forced to return `False` regardless, and this asserts neither
+    `Path.exists` nor `shutil.copy2` is ever invoked against it: the safety
+    check must run before ANY filesystem probe, not just before the copy.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    audio_id, source_path = _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    monkeypatch.setattr(briefing_export, "audio_file_path_is_safe", lambda _path: False)
+
+    exists_calls: list[Path] = []
+    real_exists = Path.exists
+
+    def _spy_exists(self, *args, **kwargs):
+        exists_calls.append(self)
+        return real_exists(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", _spy_exists)
+
+    copy_mock = Mock(side_effect=AssertionError("shutil.copy2 must not run for an unsafe path"))
+    monkeypatch.setattr(briefing_export.shutil, "copy2", copy_mock)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 0
+    assert len(result.skipped) == 1
+    assert str(audio_id) in result.skipped[0]
+    copy_mock.assert_not_called()
+    assert source_path not in exists_calls, (
+        "the source file's own .exists() was probed -- the safety check "
+        "must run before any filesystem access, not just before the copy"
+    )
+
+
+def test_a_vanished_source_file_is_skipped_with_a_reason_and_others_still_export(
+    tmp_path, monkeypatch
+):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+
+    vanished_audio_id, _vanished_path = _seed_episode(
+        db,
+        watchlist_id,
+        audio_dir=audio_dir,
+        created_at="2026-01-01 00:00:00",
+        write_real_file=False,
+    )
+    _present_audio_id, _present_path = _seed_episode(
+        db, watchlist_id, audio_dir=audio_dir, created_at="2026-01-02 00:00:00"
+    )
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    result = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert result.episode_count == 1
+    assert len(result.skipped) == 1
+    assert str(vanished_audio_id) in result.skipped[0]
+
+
+# --- feed.xml atomicity -------------------------------------------------------
+
+
+def test_no_partial_file_remains_after_a_successful_export(tmp_path, monkeypatch):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert (destination / "feed.xml").exists()
+    assert not (destination / "feed.xml.partial").exists()
+
+
+def test_a_failure_mid_write_leaves_the_previous_feed_xml_intact(tmp_path, monkeypatch):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+    previous_bytes = (destination / "feed.xml").read_bytes()
+
+    # Simulate a crash between the write and the atomic rename.
+    monkeypatch.setattr(
+        briefing_export.os, "replace", Mock(side_effect=OSError("simulated crash"))
+    )
+
+    with pytest.raises(OSError):
+        export_feed_directory(
+            db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+        )
+
+    assert (destination / "feed.xml").read_bytes() == previous_bytes
+    assert not (destination / "feed.xml.partial").exists()
+
+
+def test_re_exporting_to_the_same_directory_overwrites_cleanly(tmp_path, monkeypatch):
+    """No `"xb"`-style refusal -- the phase-2b private-write helpers must
+    not be used here (Decision 2)."""
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir, created_at="2026-01-01 00:00:00")
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    first = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+    assert first.episode_count == 1
+
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir, created_at="2026-01-02 00:00:00")
+
+    second = export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    assert second.episode_count == 2
+    tree = ET.fromstring((destination / "feed.xml").read_bytes())
+    assert len(tree.findall("./channel/item")) == 2
+
+
+# --- Decision 2: never route the destination through private_paths ----------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode semantics")
+def test_destination_directory_mode_is_never_forced_to_0o700(tmp_path, monkeypatch):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    destination = tmp_path / "export"
+    destination.mkdir()
+    os.chmod(destination, 0o755)
+
+    export_feed_directory(
+        db, watchlist_id, destination=destination, watchlist_name="W", now=_NOW
+    )
+
+    mode = stat.S_IMODE(os.stat(destination).st_mode)
+    assert mode == 0o755, "the user's destination directory must never be chmodded (Decision 2)"
+
+
+def test_a_destination_failing_validate_path_simple_raises_before_anything_is_written(
+    tmp_path, monkeypatch
+):
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    watchlist_id = _make_watchlist(db)
+    audio_dir = briefing_audio.briefing_audio_dir()
+    _seed_episode(db, watchlist_id, audio_dir=audio_dir)
+
+    real_query = db.list_watchlist_audio_episodes
+    query_spy = Mock(wraps=real_query)
+    monkeypatch.setattr(db, "list_watchlist_audio_episodes", query_spy)
+
+    hostile_destination = Path(str(tmp_path / "export") + ";rm -rf ~")
+
+    with pytest.raises(ValueError):
+        export_feed_directory(
+            db,
+            watchlist_id,
+            destination=hostile_destination,
+            watchlist_name="W",
+            now=_NOW,
+        )
+
+    query_spy.assert_not_called()
+    assert not hostile_destination.exists()

--- a/Tests/Subscriptions/test_briefing_feed_query.py
+++ b/Tests/Subscriptions/test_briefing_feed_query.py
@@ -1,0 +1,339 @@
+"""Tests for `list_watchlist_audio_episodes` (spec #2 phase 3, Task 2).
+
+One joined `SELECT` across `briefing_audio -> briefing_scripts ->
+briefings`, scoped to a watchlist through the `briefings` row each script
+belongs to (`briefing_audio` has no `watchlist_id` column of its own). An
+"episode" is a `briefing_audio` row that is `status='complete'` AND has a
+non-NULL `file_path` -- two independent reasons a row could otherwise be
+excluded, seeded independently below so a single seed can't accidentally
+pass for the wrong reason.
+
+Tasks 3 (RSS feed generation) and 5 (the export button) quote this query's
+column aliases verbatim, so this file also pins the exact output shape, not
+just row counts.
+
+Same harness as `test_briefing_audio_db.py`: a real `SubscriptionsDB` on
+`:memory:`, `WatchlistBundleService` for watchlist creation,
+`insert_briefing` / `insert_briefing_script` / `create_briefing_audio` /
+`update_briefing_audio` for the rest of the chain.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
+
+pytestmark = pytest.mark.unit
+
+
+def _make_watchlist(db: SubscriptionsDB, name: str = "w") -> int:
+    return WatchlistBundleService(db).create(name=name)["id"]
+
+
+def _make_briefing(db: SubscriptionsDB, watchlist_id: int, *, created_at: str) -> int:
+    """Create a `briefings` row and pin its `created_at` explicitly.
+
+    `update_briefing`'s allowlist deliberately excludes `created_at` (it is
+    the row's own creation stamp, not something a caller revises), so this
+    reaches past it with a raw `UPDATE` -- inside `db.transaction()`,
+    matching the pattern `test_briefing_audio_db.py`'s cascade test uses for
+    the same reason (a direct statement the production allowlist won't
+    permit). SQLite's `CURRENT_TIMESTAMP` default only has one-second
+    resolution, and this suite must prove an ordering rule (newest briefing
+    first) that a same-second default would make flaky.
+    """
+    briefing_id = db.insert_briefing(watchlist_id)
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE briefings SET created_at = ? WHERE id = ?",
+            (created_at, briefing_id),
+        )
+    return briefing_id
+
+
+def _make_script(db: SubscriptionsDB, briefing_id: int, *, preset_name: str = "p") -> int:
+    return db.insert_briefing_script(
+        briefing_id, preset_id=None, preset_name=preset_name, roster_snapshot_json="[]"
+    )
+
+
+def _make_complete_audio(
+    db: SubscriptionsDB,
+    script_id: int,
+    *,
+    file_path: str = "/tmp/episode.mp3",
+    duration_seconds: float = 123.0,
+    turn_count: int = 4,
+) -> int:
+    """Create a `briefing_audio` row that qualifies as a playable episode."""
+    audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]", status="complete")
+    db.update_briefing_audio(
+        audio_id,
+        file_path=file_path,
+        duration_seconds=duration_seconds,
+        turn_count=turn_count,
+    )
+    return audio_id
+
+
+def _chain(
+    db: SubscriptionsDB,
+    watchlist_id: int,
+    *,
+    briefing_created_at: str,
+    preset_name: str = "p",
+    file_path: str = "/tmp/episode.mp3",
+) -> tuple[int, int, int]:
+    """Build one full watchlist -> briefing -> script -> complete-audio chain.
+
+    Returns:
+        `(briefing_id, script_id, audio_id)`.
+    """
+    briefing_id = _make_briefing(db, watchlist_id, created_at=briefing_created_at)
+    script_id = _make_script(db, briefing_id, preset_name=preset_name)
+    audio_id = _make_complete_audio(db, script_id, file_path=file_path)
+    return briefing_id, script_id, audio_id
+
+
+# --- happy path: newest briefing first, by identity ----------------------
+
+
+def test_returns_audio_from_both_briefings_newest_briefing_first_by_identity():
+    """Identities, not just a count -- see `list_briefing_audio`'s own
+    `test_list_briefing_audio_returns_newest_first_by_identity` precedent."""
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+
+    _older_briefing, _older_script, older_audio = _chain(
+        db, watchlist_id, briefing_created_at="2026-01-01 00:00:00"
+    )
+    _newer_briefing, _newer_script, newer_audio = _chain(
+        db, watchlist_id, briefing_created_at="2026-01-02 00:00:00"
+    )
+
+    result = db.list_watchlist_audio_episodes(watchlist_id)
+
+    assert [row["audio_id"] for row in result] == [newer_audio, older_audio]
+
+
+def test_orders_by_briefings_created_at_not_audio_created_at():
+    """The interface deliberately differs from `list_briefing_audio`'s own
+    `created_at` ordering: a podcast feed is ordered by episode (briefing)
+    recency, not by when the audio happened to be rendered. Render the
+    OLDER briefing's audio SECOND (i.e. its own row is "newer" by
+    audio.created_at/id) and confirm the briefing's recency still wins."""
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+
+    newer_briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-02 00:00:00")
+    older_briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-01 00:00:00")
+
+    newer_briefing_script = _make_script(db, newer_briefing_id)
+    newer_briefing_audio = _make_complete_audio(db, newer_briefing_script)
+
+    # Rendered AFTER the above, so it has a larger audio.id / later
+    # audio.created_at -- yet its parent briefing is the OLDER one.
+    older_briefing_script = _make_script(db, older_briefing_id)
+    older_briefing_audio = _make_complete_audio(db, older_briefing_script)
+    assert older_briefing_audio > newer_briefing_audio  # sanity: rendered later
+
+    result = db.list_watchlist_audio_episodes(watchlist_id)
+
+    assert [row["audio_id"] for row in result] == [newer_briefing_audio, older_briefing_audio]
+
+
+def test_tiebreaks_same_briefing_multiple_audio_by_audio_id_desc():
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+    briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-01 00:00:00")
+
+    script_a = _make_script(db, briefing_id)
+    audio_a = _make_complete_audio(db, script_a, file_path="/tmp/a.mp3")
+    script_b = _make_script(db, briefing_id)
+    audio_b = _make_complete_audio(db, script_b, file_path="/tmp/b.mp3")
+
+    result = db.list_watchlist_audio_episodes(watchlist_id)
+
+    assert [row["audio_id"] for row in result] == [audio_b, audio_a]
+
+
+# --- the two exclusion predicates, seeded independently -------------------
+
+
+def test_excludes_a_non_complete_audio_row_even_with_a_file_path():
+    """Isolates the `status != 'complete'` predicate: this row has a real
+    `file_path`, so only its status can be responsible for exclusion."""
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+    briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-01 00:00:00")
+    script_id = _make_script(db, briefing_id)
+
+    failed_audio = db.create_briefing_audio(script_id, voice_snapshot_json="[]", status="failed")
+    db.update_briefing_audio(failed_audio, file_path="/tmp/failed.mp3")
+
+    assert db.list_watchlist_audio_episodes(watchlist_id) == []
+
+
+def test_excludes_a_complete_audio_row_with_null_file_path():
+    """Isolates the `file_path IS NOT NULL` predicate: this row is already
+    `status='complete'`, so only the missing file can be responsible."""
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+    briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-01 00:00:00")
+    script_id = _make_script(db, briefing_id)
+
+    # status='complete' but file_path is never set (stays NULL).
+    db.create_briefing_audio(script_id, voice_snapshot_json="[]", status="complete")
+
+    assert db.list_watchlist_audio_episodes(watchlist_id) == []
+
+
+# --- scoping: identity, not count ------------------------------------------
+
+
+def test_scoped_to_watchlist_by_identity_not_count():
+    """The security-adjacent property: an export must never include another
+    watchlist's audio. Seeding a SECOND watchlist with its own complete
+    audio and asserting exact ids (not `len(...)`) catches a join bug that
+    happens to preserve row count while returning the wrong rows."""
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_a = _make_watchlist(db, "watchlist a")
+    watchlist_b = _make_watchlist(db, "watchlist b")
+
+    _, _, audio_a = _chain(db, watchlist_a, briefing_created_at="2026-01-01 00:00:00")
+    _chain(db, watchlist_b, briefing_created_at="2026-01-01 00:00:00")
+
+    result = db.list_watchlist_audio_episodes(watchlist_a)
+
+    assert [row["audio_id"] for row in result] == [audio_a]
+
+
+def test_empty_watchlist_returns_empty_list():
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+
+    assert db.list_watchlist_audio_episodes(watchlist_id) == []
+
+
+# --- pagination -------------------------------------------------------------
+
+
+def test_limit_returns_exactly_limit_rows():
+    """CLAUDE.md Performance Rules: DB listing results must be paginated.
+    Matches `list_briefing_audio`'s own
+    `test_list_briefing_audio_limit_returns_exactly_limit_rows` shape."""
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+    limit = 3
+    for n in range(limit + 5):
+        _chain(db, watchlist_id, briefing_created_at=f"2026-01-{n + 1:02d} 00:00:00")
+
+    assert len(db.list_watchlist_audio_episodes(watchlist_id, limit=limit)) == limit
+
+
+def test_offset_pages_through_every_row_without_gaps_or_repeats():
+    """Matches `list_briefing_audio`'s own
+    `test_list_briefing_audio_offset_pages_through_every_row_without_gaps_or_repeats`
+    shape: walk every page and confirm the union covers every seeded row
+    exactly once, in the same newest-first order the identity test above
+    pins."""
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+    audio_ids = [
+        _chain(db, watchlist_id, briefing_created_at=f"2026-01-{n + 1:02d} 00:00:00")[2]
+        for n in range(7)
+    ]
+    expected_newest_first = list(reversed(audio_ids))
+
+    limit = 3
+    seen: list[int] = []
+    offset = 0
+    while True:
+        page = db.list_watchlist_audio_episodes(watchlist_id, limit=limit, offset=offset)
+        if not page:
+            break
+        seen.extend(row["audio_id"] for row in page)
+        offset += limit
+
+    assert seen == expected_newest_first
+
+
+def test_limit_and_offset_are_bound_as_real_sql_parameters():
+    """Guards against a Python-side-slice reimplementation that would still
+    pass the two pagination tests above but fetch every row from SQLite on
+    every call. Spies on the real connection (`Mock(wraps=...)`, the
+    technique `test_briefing_selection.py`'s
+    `test_window_query_parameter_count_does_not_scale_with_queue_size` and
+    `test_briefing_presets_db.py`'s chunking test use) and asserts the bound
+    parameter tuple ends with the exact `(limit, offset)` values passed in.
+    """
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+    _chain(db, watchlist_id, briefing_created_at="2026-01-01 00:00:00")
+
+    real_conn = db.conn  # materialise this thread's connection first
+    spy_conn = Mock(wraps=real_conn)
+    db._local.conn = spy_conn
+    try:
+        db.list_watchlist_audio_episodes(watchlist_id, limit=17, offset=5)
+    finally:
+        db._local.conn = real_conn
+
+    bound_params = [
+        call.args[1] for call in spy_conn.execute.call_args_list if len(call.args) > 1
+    ]
+    matching = [params for params in bound_params if tuple(params)[-2:] == (17, 5)]
+    assert matching, (
+        f"expected a statement bound with (..., 17, 5) as its trailing LIMIT/OFFSET "
+        f"parameters; saw {bound_params}"
+    )
+
+
+# --- column aliases: the contract Tasks 3 and 5 quote verbatim ------------
+
+
+def test_row_shape_carries_every_documented_alias_with_correct_values():
+    db = SubscriptionsDB(":memory:", "test")
+    watchlist_id = _make_watchlist(db)
+    briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-01 00:00:00")
+    db.update_briefing(
+        briefing_id,
+        status="complete",
+        model_used="gpt-test",
+        covers_from_ts="2026-01-01T00:00:00+00:00",
+    )
+    script_id = _make_script(db, briefing_id, preset_name="Two Host Debate")
+    audio_id = _make_complete_audio(
+        db, script_id, file_path="/tmp/episode.mp3", duration_seconds=321.5, turn_count=9
+    )
+
+    result = db.list_watchlist_audio_episodes(watchlist_id)
+
+    assert len(result) == 1
+    row = result[0]
+    assert set(row.keys()) == {
+        "audio_id",
+        "script_id",
+        "briefing_id",
+        "file_path",
+        "duration_seconds",
+        "turn_count",
+        "preset_name",
+        "briefing_created_at",
+        "briefing_status",
+        "covers_from_ts",
+        "model_used",
+    }
+    assert row["audio_id"] == audio_id
+    assert row["script_id"] == script_id
+    assert row["briefing_id"] == briefing_id
+    assert row["file_path"] == "/tmp/episode.mp3"
+    assert row["duration_seconds"] == 321.5
+    assert row["turn_count"] == 9
+    assert row["preset_name"] == "Two Host Debate"
+    assert row["briefing_created_at"] == "2026-01-01 00:00:00"
+    assert row["briefing_status"] == "complete"
+    assert row["covers_from_ts"] == "2026-01-01T00:00:00+00:00"
+    assert row["model_used"] == "gpt-test"

--- a/Tests/Subscriptions/test_briefing_feed_query.py
+++ b/Tests/Subscriptions/test_briefing_feed_query.py
@@ -145,6 +145,11 @@ def test_orders_by_briefings_created_at_not_audio_created_at():
 
 
 def test_tiebreaks_same_briefing_multiple_audio_by_audio_id_desc():
+    """When two audio rows share the same briefing (so the "newer briefing
+    first" ordering above cannot distinguish them), the tiebreak must be
+    `audio_id DESC` -- the more recently created audio row first -- not an
+    arbitrary or storage-order result that would make repeated exports
+    list episodes inconsistently."""
     db = SubscriptionsDB(":memory:", "test")
     watchlist_id = _make_watchlist(db)
     briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-01 00:00:00")
@@ -211,6 +216,10 @@ def test_scoped_to_watchlist_by_identity_not_count():
 
 
 def test_empty_watchlist_returns_empty_list():
+    """A watchlist with no briefings at all -- not merely one whose audio
+    rows get filtered out -- must return an empty list rather than raise
+    or return `None`, so callers (e.g. the export directory writer) can
+    treat "nothing yet" as a normal, iterable result."""
     db = SubscriptionsDB(":memory:", "test")
     watchlist_id = _make_watchlist(db)
 
@@ -295,6 +304,13 @@ def test_limit_and_offset_are_bound_as_real_sql_parameters():
 
 
 def test_row_shape_carries_every_documented_alias_with_correct_values():
+    """Pins the full row-shape CONTRACT Tasks 3 (feed builder) and 5
+    (export UI) quote verbatim: exactly this set of column aliases, no
+    more and no fewer, each holding the value it claims to -- not merely
+    that the query returns one row. A caller that reads a value under the
+    wrong key, or a schema change that silently renamed/dropped a column,
+    would still pass a looser "row is non-empty" test but must fail this
+    one."""
     db = SubscriptionsDB(":memory:", "test")
     watchlist_id = _make_watchlist(db)
     briefing_id = _make_briefing(db, watchlist_id, created_at="2026-01-01 00:00:00")

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import sqlite3
 import threading
 import time
@@ -3998,10 +3999,16 @@ async def test_write_briefing_export_file_cancelled_error_propagates_uncaught(
 
 # --- Task 5 (phase 3): exporting a watchlist's podcast feed directory ------
 #
-# `ArtifactsPane`'s Export Feed button lives in the EXISTING `#artifacts-
-# audio-toolbar` (no new `Horizontal` -- see that compose()-site comment);
-# its disabled state, the `SelectDirectory` push it triggers, and the
-# write-path's honest toasts (including an honest partial-export count) are
+# `ArtifactsPane`'s Export Feed button lives in `#artifacts-toolbar` (no
+# new `Horizontal` -- see that compose()-site comment) -- the SAME
+# watchlist-scoped toolbar Generate/Refresh/Task 1's markdown Export
+# already live in, which renders unconditionally once a watchlist is in
+# scope. Review round 1, Important #1: an earlier draft placed it in
+# `#artifacts-audio-toolbar` instead, which only renders once a SCRIPT is
+# selected -- but the feed export is WATCHLIST-scoped, so that button was
+# unreachable without first selecting some unrelated script. Its disabled
+# state, the `SelectDirectory` push it triggers, and the write-path's
+# honest toasts (including an honest, capped partial-export count) are
 # exercised below. Mirrors the Task 1 markdown-export section immediately
 # above in almost every respect -- same guard shape, same push-then-
 # callback split, same re-arm discipline -- so most docstrings below only
@@ -4048,19 +4055,17 @@ async def test_export_feed_button_is_disabled_without_any_complete_audio_episode
     ANYWHERE in it -- a dead control offering to export nothing is a spec
     violation (phase 2b shipped a disabled Play for exactly this reason).
 
-    Deliberately watchlist-scoped, not script-scoped: the button's
-    disabled state must not depend on which script happens to be
-    currently selected, since the export itself covers the whole
-    watchlist's audio.
+    Deliberately watchlist-scoped, not script-scoped: no briefing or
+    script is ever selected in this test, proving the button's disabled
+    state depends only on the watchlist's own audio, never on a
+    selection this pane may or may not have.
     """
     _patch_audio_dir(monkeypatch, tmp_path)
     app = _build_test_app()
     watchlist_id = _seed_watchlist(app)
-    briefing_id, script_id = _seed_complete_script(app, watchlist_id)
+    _briefing_id, script_id = _seed_complete_script(app, watchlist_id)
 
-    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
-        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
-
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
         pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
         export_feed_button = pane.query_one("#artifacts-export-feed-button", Button)
         assert export_feed_button.disabled is True, "no audio anywhere -> disabled"
@@ -4085,6 +4090,42 @@ async def test_export_feed_button_is_disabled_without_any_complete_audio_episode
         pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
         assert (
             pane.query_one("#artifacts-export-feed-button", Button).disabled is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_export_feed_button_is_visible_and_enabled_with_no_script_selected(
+    monkeypatch, tmp_path
+):
+    """Review round 1, Important #1: pins the discoverability property
+    directly. The feed export is WATCHLIST-scoped -- it exports every
+    complete episode in the watchlist -- so it must be reachable with
+    NOTHING selected at all, not just once a user has happened to click
+    into some unrelated script. `#artifacts-toolbar` (where this button
+    now lives) renders unconditionally once a watchlist is in scope,
+    unlike `#artifacts-audio-toolbar` (gated on `selected_script is not
+    None`), where an earlier draft wrongly placed it -- a user could not
+    have found it there without first selecting a script that has
+    nothing to do with the export.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    _seed_exportable_audio_episode(app, watchlist_id)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        assert screen._selected_briefing is None, (
+            "the fixture must start with nothing selected"
+        )
+        assert screen._selected_script is None
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert pane.selected_briefing is None
+        assert pane.selected_script is None
+        export_feed_button = pane.query_one("#artifacts-export-feed-button", Button)
+        assert export_feed_button.disabled is False, (
+            "Export Feed must be reachable without selecting a briefing "
+            "or script first"
         )
 
 
@@ -4135,20 +4176,21 @@ async def test_pressing_export_feed_pushes_a_select_directory_dialog(
     proven here by its only observable effect (the push), the same way
     Task 1's own `test_pressing_export_pushes_a_file_save_dialog...`
     proves `ExportBriefingRequested` through ITS handler's effect.
+
+    Deliberately selects nothing (review round 1, Important #1): the
+    button lives in the watchlist-scoped `#artifacts-toolbar`, reachable
+    the moment a watchlist is in scope, not gated on any briefing/script
+    selection.
     """
     _patch_audio_dir(monkeypatch, tmp_path)
     app = _build_test_app()
     watchlist_id = _seed_watchlist(app)
-    briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
-        app, watchlist_id
-    )
+    _seed_exportable_audio_episode(app, watchlist_id)
 
     push_screen_mock = AsyncMock()
 
     async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
         monkeypatch.setattr(host, "push_screen", push_screen_mock)
-
-        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
 
         pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
         assert pane.has_audio_episodes, "the fixture needs an exportable episode"
@@ -4175,21 +4217,21 @@ async def test_a_second_export_feed_press_while_the_dialog_is_open_is_refused_th
     after the first dialog resolves (exercised both via a real path and
     via a cancel), must work again -- the re-arm assertion that catches a
     flag stuck `True` forever.
+
+    Deliberately selects nothing (review round 1, Important #1) -- see
+    `test_pressing_export_feed_pushes_a_select_directory_dialog`'s own
+    note.
     """
     _patch_audio_dir(monkeypatch, tmp_path)
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
-        app, watchlist_id
-    )
+    _seed_exportable_audio_episode(app, watchlist_id)
 
     push_screen_mock = AsyncMock()
 
     async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
         monkeypatch.setattr(host, "push_screen", push_screen_mock)
-
-        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
 
         pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
         export_feed_button = pane.query_one("#artifacts-export-feed-button", Button)
@@ -4307,6 +4349,12 @@ async def test_export_feed_directory_partial_export_toasts_the_honest_count(
     since vanished) toasts "N of M episodes exported" -- never a plain
     success -- per `FeedExportResult.skipped`'s own named invariant
     (`briefing_export.py`'s module docstring, decision 3).
+
+    Review round 1, Minor #2: the inlined reason must read as plain
+    prose, not a raw `audio {id}:` prefix that means nothing to a user --
+    `export_feed_directory` writes reasons naming an internal `audio_id`
+    for support/debugging, but the TOAST strips that id
+    (`_user_facing_skip_reasons`).
     """
     _patch_audio_dir(monkeypatch, tmp_path)
     app = _build_test_app()
@@ -4340,6 +4388,69 @@ async def test_export_feed_directory_partial_export_toasts_the_honest_count(
     args, kwargs = app.notify.call_args
     assert "Exported 1 of 2 episodes" in args[0]
     assert "successfully" not in args[0], "a partial export must never claim success"
+    assert "source file no longer exists" in args[0], (
+        "the reason itself must still read as plain prose"
+    )
+    assert re.search(r"audio \d+:", args[0]) is None, (
+        "the internal `audio {id}:` prefix must never reach the user-facing toast"
+    )
+    assert kwargs.get("severity") == "warning"
+    assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_export_feed_directory_partial_export_caps_inlined_reasons(
+    monkeypatch, tmp_path
+):
+    """Review round 1, Minor #2: five skipped episodes must not produce a
+    toast quoting all five -- `export_feed_directory` can skip
+    arbitrarily many, and a toast that inlines every one of them is
+    unreadable well before it gets there. Only the first `_MAX_INLINE_
+    SKIP_REASONS` (3) are shown, followed by an honest "…and N more"
+    trailer; the headline "N of M" count itself is never capped or
+    approximated.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    _briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+    db = app.watchlist_bundle_service.db
+    # Five more complete audio rows whose source files were never written
+    # -- each one skipped by `export_feed_directory` with its own "source
+    # file no longer exists" reason, naming a distinct `audio_id`.
+    for index in range(5):
+        missing_file = briefing_audio.briefing_audio_dir() / f"missing-{index}.wav"
+        missing_audio_id = db.create_briefing_audio(
+            script_id, voice_snapshot_json="[]"
+        )
+        db.update_briefing_audio(
+            missing_audio_id,
+            status="complete",
+            file_path=str(missing_file),
+            duration_seconds=1.0,
+            turn_count=1,
+        )
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(
+            db, watchlist_id, "Morning AI Brief", destination
+        )
+
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "Exported 1 of 6 episodes" in args[0], (
+        "the headline count is never capped, only the inlined reasons are"
+    )
+    assert args[0].count("source file no longer exists") == 3, (
+        "only the first 3 reasons are inlined"
+    )
+    assert "…and 2 more" in args[0]
+    assert re.search(r"audio \d+:", args[0]) is None
     assert kwargs.get("severity") == "warning"
     assert kwargs.get("markup") is False
 
@@ -4390,14 +4501,16 @@ async def test_export_feed_press_survives_an_os_error_from_the_service(
     Exception` is what stands between it and the whole app going down --
     exactly the phase-2b app-death lesson (an unwrapped worker with the
     default `exit_on_error=True` took the app down for real, once).
+
+    Deliberately selects nothing (review round 1, Important #1) -- see
+    `test_pressing_export_feed_pushes_a_select_directory_dialog`'s own
+    note.
     """
     _patch_audio_dir(monkeypatch, tmp_path)
     app = _build_test_app()
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app)
-    briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
-        app, watchlist_id
-    )
+    _seed_exportable_audio_episode(app, watchlist_id)
     destination = tmp_path / "export_dest"
     destination.mkdir()
 
@@ -4407,8 +4520,6 @@ async def test_export_feed_press_survives_an_os_error_from_the_service(
     monkeypatch.setattr(screen_module, "export_feed_directory", _boom)
 
     async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
-        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
-
         pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
         pane.query_one("#artifacts-export-feed-button", Button).press()
         await pilot.pause()

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -55,7 +55,7 @@ from tldw_chatbook.Subscriptions.briefing_audio import AudioGenerationError
 from tldw_chatbook.Subscriptions.briefing_cast import dump_roster
 from tldw_chatbook.Subscriptions.briefing_export import default_briefing_filename
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
-from tldw_chatbook.Third_Party.textual_fspicker import FileSave
+from tldw_chatbook.Third_Party.textual_fspicker import FileSave, SelectDirectory
 from tldw_chatbook.TTS import audio_player as audio_player_module
 from tldw_chatbook.UI.Screens import watchlists_collections_screen as screen_module
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
@@ -67,6 +67,7 @@ from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import (
     CastScriptRequested,
     CitationActivated,
     ExportBriefingRequested,
+    ExportFeedRequested,
     GenerateBriefingRequested,
     PlayAudioRequested,
     StopAudioRequested,
@@ -3992,4 +3993,482 @@ async def test_write_briefing_export_file_cancelled_error_propagates_uncaught(
                 await screen._write_briefing_export_file(destination, briefing)
 
     assert not destination.exists()
+    app.notify.assert_not_called()
+
+
+# --- Task 5 (phase 3): exporting a watchlist's podcast feed directory ------
+#
+# `ArtifactsPane`'s Export Feed button lives in the EXISTING `#artifacts-
+# audio-toolbar` (no new `Horizontal` -- see that compose()-site comment);
+# its disabled state, the `SelectDirectory` push it triggers, and the
+# write-path's honest toasts (including an honest partial-export count) are
+# exercised below. Mirrors the Task 1 markdown-export section immediately
+# above in almost every respect -- same guard shape, same push-then-
+# callback split, same re-arm discipline -- so most docstrings below only
+# name what is DIFFERENT for the feed flow rather than repeating the full
+# rationale.
+
+
+def _seed_exportable_audio_episode(
+    app, watchlist_id: int, *, filename: str = "clip.wav"
+) -> tuple[int, int, int, Path]:
+    """A `complete` briefing -> `complete` script -> `complete`, file-
+    backed `briefing_audio` row -- everything `list_watchlist_audio_
+    episodes` (and so `ArtifactsPane.has_audio_episodes`/`export_feed_
+    directory`) requires to treat this as one exportable episode.
+
+    Callers must already have redirected `briefing_audio_dir()` into a
+    temp directory (`_patch_audio_dir`, above) before calling this, so the
+    file this seeds lands somewhere `audio_file_path_is_safe` accepts.
+
+    Returns:
+        `(briefing_id, script_id, audio_id, audio_file_path)`.
+    """
+    briefing_id, script_id = _seed_complete_script(app, watchlist_id)
+    db = app.watchlist_bundle_service.db
+    audio_file = briefing_audio.briefing_audio_dir() / filename
+    audio_file.write_bytes(b"RIFF....WAVEfmt ")
+    audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+    db.update_briefing_audio(
+        audio_id,
+        status="complete",
+        file_path=str(audio_file),
+        duration_seconds=12.3,
+        turn_count=1,
+    )
+    return briefing_id, script_id, audio_id, audio_file
+
+
+@pytest.mark.asyncio
+async def test_export_feed_button_is_disabled_without_any_complete_audio_episode(
+    monkeypatch, tmp_path
+):
+    """Export Feed starts disabled with no audio anywhere in the
+    watchlist, and enables once a complete, file-backed episode exists
+    ANYWHERE in it -- a dead control offering to export nothing is a spec
+    violation (phase 2b shipped a disabled Play for exactly this reason).
+
+    Deliberately watchlist-scoped, not script-scoped: the button's
+    disabled state must not depend on which script happens to be
+    currently selected, since the export itself covers the whole
+    watchlist's audio.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id, script_id = _seed_complete_script(app, watchlist_id)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        export_feed_button = pane.query_one("#artifacts-export-feed-button", Button)
+        assert export_feed_button.disabled is True, "no audio anywhere -> disabled"
+        assert export_feed_button.compact, (
+            "a bordered button costs 3 rows in a height:1 strip"
+        )
+
+        db = app.watchlist_bundle_service.db
+        audio_file = briefing_audio.briefing_audio_dir() / "clip.wav"
+        audio_file.write_bytes(b"RIFF....WAVEfmt ")
+        audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+        db.update_briefing_audio(
+            audio_id,
+            status="complete",
+            file_path=str(audio_file),
+            duration_seconds=1.0,
+            turn_count=1,
+        )
+        await screen._load_briefings()
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert (
+            pane.query_one("#artifacts-export-feed-button", Button).disabled is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_workbench_rebuild_does_not_reset_has_audio_episodes(
+    monkeypatch, tmp_path
+):
+    """`_build_detail_pane` is a factory the workbench calls on every
+    region rebuild -- a freshly built `ArtifactsPane`'s reactives start at
+    their class defaults unless the factory explicitly reseeds them from
+    screen state, exactly like every sibling field it already seeds
+    (`briefings`, `scripts_with_audio`, ...). Missing that one line would
+    silently disable Export Feed the moment a user toggled any OTHER
+    region (e.g. the rail), even with real exportable audio still on the
+    watchlist. Mirrors `test_tree_highlight_survives_a_section_switch_
+    and_a_rail_toggle`'s own mechanism (`action_toggle_left_rail` rebuilds
+    the whole workbench) for driving a real rebuild rather than a direct,
+    unmounted factory call.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
+        assert screen._watchlist_has_audio_episodes is True
+
+        screen.action_toggle_left_rail()
+        await pilot.pause()
+        screen.action_toggle_left_rail()
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert pane.has_audio_episodes is True, (
+            "a workbench rebuild must not silently disable Export Feed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pressing_export_feed_pushes_a_select_directory_dialog(
+    monkeypatch, tmp_path
+):
+    """Pressing Export Feed posts `ExportFeedRequested`, which the
+    screen's handler answers by pushing a `SelectDirectory` dialog --
+    proven here by its only observable effect (the push), the same way
+    Task 1's own `test_pressing_export_pushes_a_file_save_dialog...`
+    proves `ExportBriefingRequested` through ITS handler's effect.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+
+    push_screen_mock = AsyncMock()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        monkeypatch.setattr(host, "push_screen", push_screen_mock)
+
+        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert pane.has_audio_episodes, "the fixture needs an exportable episode"
+        pane.query_one("#artifacts-export-feed-button", Button).press()
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert push_screen_mock.await_count == 1, "Export Feed must push exactly one dialog"
+    args, kwargs = push_screen_mock.call_args
+    dialog = args[0]
+    assert isinstance(dialog, SelectDirectory)
+    assert callable(kwargs.get("callback"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resolve_via", ["a real path", "cancel"])
+async def test_a_second_export_feed_press_while_the_dialog_is_open_is_refused_then_rearms(
+    monkeypatch, tmp_path, resolve_via,
+):
+    """Mirrors Task 1's own `test_a_second_export_press_while_the_dialog_
+    is_open_is_refused_then_rearms`: two presses in one tick must push
+    exactly ONE dialog and refuse the second with a toast; a LATER press,
+    after the first dialog resolves (exercised both via a real path and
+    via a cancel), must work again -- the re-arm assertion that catches a
+    flag stuck `True` forever.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+
+    push_screen_mock = AsyncMock()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        monkeypatch.setattr(host, "push_screen", push_screen_mock)
+
+        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        export_feed_button = pane.query_one("#artifacts-export-feed-button", Button)
+        # Two presses in the same tick, mirroring Task 1's own reasoning:
+        # `Button.press()` only POSTS `Button.Pressed`, and the first
+        # press's handler claims the guard synchronously, on the UI
+        # thread, before `run_worker` -- so by the time the second
+        # press's `ExportFeedRequested` is handled, `_feed_export_in_
+        # flight` is already `True`.
+        export_feed_button.press()
+        export_feed_button.press()
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert push_screen_mock.await_count == 1, (
+            "two rapid presses must push exactly one dialog, not stack two"
+        )
+        refusals = [
+            call
+            for call in app.notify.call_args_list
+            if "already in progress" in str(call.args[0])
+        ]
+        assert len(refusals) == 1, "the second press must be refused with a toast"
+
+        _, first_kwargs = push_screen_mock.call_args
+        callback = first_kwargs["callback"]
+        if resolve_via == "a real path":
+            destination = tmp_path / "export_dest"
+            destination.mkdir()
+            await callback(destination)
+        else:
+            await callback(None)
+
+        # The guard must have re-armed: a THIRD press now pushes ANOTHER
+        # real dialog rather than being refused.
+        push_screen_mock.reset_mock()
+        app.notify.reset_mock()
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-export-feed-button", Button).press()
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert push_screen_mock.await_count == 1, (
+            "Export Feed must be usable again once the first dialog resolved"
+        )
+
+
+@pytest.mark.asyncio
+async def test_export_feed_directory_writes_episodes_and_toasts_the_count(
+    monkeypatch, tmp_path
+):
+    """The write-path (bypassing the dialog UI, exercised separately
+    above) exports the feed via the REAL service and notifies the episode
+    count on success, with `markup=False` since the destination's own
+    directory name is interpolated into the toast.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    _briefing_id, _script_id, _audio_id, audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+    db = app.watchlist_bundle_service.db
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(
+            db, watchlist_id, "Morning AI Brief", destination
+        )
+
+    assert (destination / "feed.xml").exists()
+    assert len(list(destination.glob("*.wav"))) == 1, (
+        "the one exportable episode's audio must have been copied in"
+    )
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "Exported 1 episode" in args[0]
+    assert "of" not in args[0], "a full export must not read like a partial one"
+    assert kwargs.get("severity") == "information"
+    assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_export_feed_directory_cancelled_writes_nothing(monkeypatch, tmp_path):
+    """A `None` path (the user cancelled the dialog) writes nothing and
+    toasts a cancellation, not an error.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    _briefing_id, _script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+    db = app.watchlist_bundle_service.db
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(db, watchlist_id, "Morning AI Brief", None)
+
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "cancelled" in args[0].lower()
+    assert kwargs.get("severity") == "information"
+
+
+@pytest.mark.asyncio
+async def test_export_feed_directory_partial_export_toasts_the_honest_count(
+    monkeypatch, tmp_path
+):
+    """A partial export (one episode skipped because its source file has
+    since vanished) toasts "N of M episodes exported" -- never a plain
+    success -- per `FeedExportResult.skipped`'s own named invariant
+    (`briefing_export.py`'s module docstring, decision 3).
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    _briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+    db = app.watchlist_bundle_service.db
+    # A second, complete audio row whose source file has since vanished --
+    # `export_feed_directory` skips it (module docstring, decision 3)
+    # rather than failing the whole export.
+    missing_file = briefing_audio.briefing_audio_dir() / "missing.wav"
+    missing_audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+    db.update_briefing_audio(
+        missing_audio_id,
+        status="complete",
+        file_path=str(missing_file),
+        duration_seconds=1.0,
+        turn_count=1,
+    )
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(
+            db, watchlist_id, "Morning AI Brief", destination
+        )
+
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "Exported 1 of 2 episodes" in args[0]
+    assert "successfully" not in args[0], "a partial export must never claim success"
+    assert kwargs.get("severity") == "warning"
+    assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_export_feed_directory_rejects_an_invalid_destination(
+    monkeypatch, tmp_path
+):
+    """A destination that fails `export_feed_directory`'s own `validate_
+    path_simple(..., require_exists=True)` -- e.g. one that does not exist
+    -- is rejected with a quiet warning toast, no write, no crash.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    _briefing_id, _script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+    db = app.watchlist_bundle_service.db
+    destination = tmp_path / "does_not_exist"
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(
+            db, watchlist_id, "Morning AI Brief", destination
+        )
+
+    assert not destination.exists()
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "Rejected export destination" in args[0]
+    assert kwargs.get("severity") == "warning"
+    assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_export_feed_press_survives_an_os_error_from_the_service(
+    monkeypatch, tmp_path
+):
+    """Sibling of `test_a_database_error_during_synthesis_does_not_exit_
+    the_app`: drives the REAL press -> real `SelectDirectory` -> callback
+    path (never a patched picker, and never a direct method call) so an
+    escaping exception would actually have to survive Textual's own
+    message-pump dispatch of the dismiss callback, not merely a bare
+    coroutine call. `export_feed_directory` deliberately lets an `OSError`
+    from the atomic `feed.xml` write propagate (that function's own
+    module docstring), so `_export_feed_directory`'s broad `except
+    Exception` is what stands between it and the whole app going down --
+    exactly the phase-2b app-death lesson (an unwrapped worker with the
+    default `exit_on_error=True` took the app down for real, once).
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id, script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(screen_module, "export_feed_directory", _boom)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-export-feed-button", Button).press()
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert isinstance(host.screen_stack[-1], SelectDirectory), (
+            "the real vendored picker must be the one actually pushed"
+        )
+        host.screen_stack[-1].dismiss(destination)
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert host.is_running, "a callback failure must not exit the application"
+        assert host.screen_stack[-1] is screen, "the screen must still be standing"
+        assert screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+
+    assert not (destination / "feed.xml").exists()
+    app.notify.assert_called()
+    args, kwargs = app.notify.call_args
+    assert "OSError" in args[0]
+    assert kwargs.get("severity") == "error"
+    assert kwargs.get("markup") is False
+
+    # The guard is genuinely re-armed, not merely toasting identically
+    # while stuck -- mirrors `test_a_database_error_during_synthesis_
+    # does_not_exit_the_app`'s own follow-up assertion.
+    assert screen._feed_export_in_flight is False
+
+
+@pytest.mark.asyncio
+async def test_export_feed_directory_cancelled_error_propagates_uncaught(
+    monkeypatch, tmp_path
+):
+    """`asyncio.CancelledError` must never be reported as a failed export
+    -- mirrors Task 1's own `test_write_briefing_export_file_cancelled_
+    error_propagates_uncaught`.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    _briefing_id, _script_id, _audio_id, _audio_file = _seed_exportable_audio_episode(
+        app, watchlist_id
+    )
+    db = app.watchlist_bundle_service.db
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    def _cancel(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(screen_module, "export_feed_directory", _cancel)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        with pytest.raises(asyncio.CancelledError):
+            await screen._export_feed_directory(
+                db, watchlist_id, "Morning AI Brief", destination
+            )
+
+    assert not (destination / "feed.xml").exists()
     app.notify.assert_not_called()

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -35,7 +35,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from rich.console import Console
@@ -52,7 +52,9 @@ from tldw_chatbook.Subscriptions import briefing_cast, briefing_service
 import tldw_chatbook.Subscriptions.briefing_audio as briefing_audio
 from tldw_chatbook.Subscriptions.briefing_audio import AudioGenerationError
 from tldw_chatbook.Subscriptions.briefing_cast import dump_roster
+from tldw_chatbook.Subscriptions.briefing_export import default_briefing_filename
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
+from tldw_chatbook.Third_Party.textual_fspicker import FileSave
 from tldw_chatbook.TTS import audio_player as audio_player_module
 from tldw_chatbook.UI.Screens import watchlists_collections_screen as screen_module
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
@@ -63,6 +65,7 @@ from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import (
     BriefingSelected,
     CastScriptRequested,
     CitationActivated,
+    ExportBriefingRequested,
     GenerateBriefingRequested,
     PlayAudioRequested,
     StopAudioRequested,
@@ -3614,3 +3617,230 @@ async def test_handle_play_audio_requested_still_plays_a_normal_in_dir_path(
         await pilot.pause()
 
         assert play_calls == [audio_file]
+
+
+# --- Task 1 (phase 3): exporting a briefing as markdown --------------------
+#
+# `ArtifactsPane`'s Export button lives in the EXISTING `#artifacts-toolbar`
+# (no new `Horizontal` -- see that compose()-site comment); its disabled
+# state, the `FileSave` push it triggers, and the write-path's honest
+# toasts are exercised below. `_write_briefing_export_file` is called
+# directly for the write-path tests, the same directness `library_screen`'s
+# own `_write_library_note_export_file` tests use -- it is a plain async
+# method the `FileSave` callback resolves to, not something that needs a
+# real dialog driven through the UI to exercise.
+
+
+def _seed_complete_briefing(app, watchlist_id: int, *, body: str = "Body text") -> int:
+    """A `complete` briefing with a real body, seeded directly (no fake
+    chat needed -- these tests are about the export flow, not generation).
+    """
+    db = app.watchlist_bundle_service.db
+    briefing_id = db.insert_briefing(watchlist_id)
+    db.update_briefing(
+        briefing_id,
+        status="complete",
+        body_markdown=body,
+        covers_from_ts="2026-07-25T00:00:00+00:00",
+        covers_through_item_id=5,
+    )
+    return briefing_id
+
+
+@pytest.mark.asyncio
+async def test_export_button_is_disabled_without_a_complete_selection():
+    """Export starts disabled with nothing selected, stays disabled for a
+    `failed` row, and enables only once a `complete` briefing is selected.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    db = app.watchlist_bundle_service.db
+    failed_id = db.insert_briefing(watchlist_id)
+    db.update_briefing(failed_id, status="failed", error="boom")
+    complete_id = _seed_complete_briefing(app, watchlist_id)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        export_button = pane.query_one("#artifacts-export-button", Button)
+        assert export_button.disabled is True, "no selection -> disabled"
+        assert export_button.compact, "a bordered button costs 3 rows in a height:1 strip"
+
+        pane.select_briefing_by_id(str(failed_id))
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert (
+            pane.query_one("#artifacts-export-button", Button).disabled is True
+        ), "a failed briefing has no body worth exporting"
+
+        pane.select_briefing_by_id(str(complete_id))
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert (
+            pane.query_one("#artifacts-export-button", Button).disabled is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_pressing_export_pushes_a_file_save_dialog_seeded_with_the_default_filename(
+    monkeypatch,
+):
+    """Pressing Export posts `ExportBriefingRequested`, which the screen's
+    handler answers by pushing a `FileSave` dialog pre-filled with a
+    sanitized default filename -- proven here by its only observable
+    effect (the push), the same way `test_presets_button_opens_the_preset_
+    manager` proves `ManagePresetsRequested` through ITS handler's effect
+    rather than by intercepting the message object.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id)
+
+    push_screen_mock = AsyncMock()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        # `host` (the `DestinationHarness`) is the real Textual `App`
+        # subclass driving this pilot -- `screen.app` resolves to IT, not
+        # to the `app` (`TldwCli`) fixture, which this screen only reads
+        # as `self.app_instance` (see `_notify_watchlists`). The dialog
+        # must be patched on the object `self.app.push_screen` actually
+        # resolves through.
+        monkeypatch.setattr(host, "push_screen", push_screen_mock)
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.select_briefing_by_id(str(briefing_id))
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-export-button", Button).press()
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert push_screen_mock.await_count == 1, "Export must push exactly one dialog"
+    args, kwargs = push_screen_mock.call_args
+    dialog = args[0]
+    assert isinstance(dialog, FileSave)
+    briefing_row = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
+    expected_filename = default_briefing_filename(
+        {**briefing_row, "watchlist_name": "Morning AI Brief"},
+        watchlist_name="Morning AI Brief",
+    )
+    assert dialog._default_file == expected_filename
+    assert callable(kwargs.get("callback"))
+
+
+@pytest.mark.asyncio
+async def test_write_briefing_export_file_writes_the_document_and_toasts_success(
+    tmp_path,
+):
+    """The write-path (bypassing the dialog UI, exercised separately above)
+    writes `briefing_markdown_document`'s output and notifies on success,
+    with `markup=False` since the destination's own filename is
+    interpolated into the toast.
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id, body="Body text")
+    briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
+    briefing["watchlist_name"] = "Morning AI Brief"
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        destination = tmp_path / "export.md"
+        await screen._write_briefing_export_file(destination, briefing)
+
+    written = destination.read_text(encoding="utf-8")
+    assert "Body text" in written
+    assert "Morning AI Brief" in written
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "exported successfully" in args[0]
+    assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_write_briefing_export_file_cancelled_writes_nothing():
+    """A `None` path (the user cancelled the dialog) writes nothing and
+    toasts a cancellation, not an error. There is no destination to check
+    for a stray write against -- `None` means the dialog never returned
+    one -- so this only pins the toast.
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
+    briefing["watchlist_name"] = "Morning AI Brief"
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._write_briefing_export_file(None, briefing)
+
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "cancelled" in args[0].lower()
+    assert kwargs.get("severity") == "information"
+
+
+@pytest.mark.asyncio
+async def test_write_briefing_export_file_rejects_an_invalid_path(monkeypatch, tmp_path):
+    """A `FileSave`-returned path that fails `validate_path_simple` is
+    rejected with a quiet warning toast -- no write, no crash -- rather
+    than trusting the dialog's returned path unconditionally.
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
+    briefing["watchlist_name"] = "Morning AI Brief"
+
+    def _reject_path(*_args, **_kwargs):
+        raise ValueError("rejected for test")
+
+    monkeypatch.setattr(screen_module, "validate_path_simple", _reject_path)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        destination = tmp_path / "export.md"
+        await screen._write_briefing_export_file(destination, briefing)
+
+    assert not destination.exists()
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "Rejected export path" in args[0]
+    assert kwargs.get("severity") == "warning"
+    assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_write_briefing_export_file_write_failure_toasts_the_exception_type(
+    monkeypatch, tmp_path
+):
+    """An `OSError` from the write itself toasts `type(exc).__name__` --
+    never the briefing body, never a raw traceback -- and leaves no file
+    behind.
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
+    briefing["watchlist_name"] = "Morning AI Brief"
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        destination = tmp_path / "export.md"
+        with monkeypatch.context() as ctx:
+            ctx.setattr(Path, "write_text", _boom)
+            await screen._write_briefing_export_file(destination, briefing)
+
+    assert not destination.exists()
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "OSError" in args[0]
+    assert kwargs.get("severity") == "error"
+    assert kwargs.get("markup") is False

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -3492,12 +3492,20 @@ async def test_play_is_disabled_when_the_file_is_null_or_missing(monkeypatch, tm
 def test_audio_file_path_is_safe_rejects_a_path_outside_the_audio_dir(
     monkeypatch, tmp_path
 ) -> None:
+    """A `file_path` that is a plain, unrelated absolute path (not even
+    disguised as an in-directory path) must be rejected -- the baseline
+    "obviously outside" case the traversal and in-dir tests below
+    contrast against."""
     _patch_audio_dir(monkeypatch, tmp_path)
 
     assert audio_file_path_is_safe("/etc/passwd") is False
 
 
 def test_audio_file_path_is_safe_rejects_a_traversal_path(monkeypatch, tmp_path) -> None:
+    """A path that is textually rooted at `briefing_audio_dir()` but
+    escapes it via `..` segments must still be rejected -- a naive
+    "starts with the audio dir string" check would wrongly accept this,
+    since the check must resolve the path, not just prefix-match it."""
     _patch_audio_dir(monkeypatch, tmp_path)
     audio_dir = briefing_audio.briefing_audio_dir()
 
@@ -3509,6 +3517,10 @@ def test_audio_file_path_is_safe_rejects_a_traversal_path(monkeypatch, tmp_path)
 def test_audio_file_path_is_safe_accepts_a_normal_in_dir_path(
     monkeypatch, tmp_path
 ) -> None:
+    """The control case: a genuine, well-formed path inside
+    `briefing_audio_dir()` must be accepted -- proving the two rejection
+    tests above are pinning a real boundary and not a check so strict it
+    rejects everything."""
     _patch_audio_dir(monkeypatch, tmp_path)
     audio_dir = briefing_audio.briefing_audio_dir()
     in_dir_path = audio_dir / "script-1-audio-1.wav"

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -27,6 +27,7 @@ could plausibly have shipped:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 import threading
@@ -3733,6 +3734,88 @@ async def test_pressing_export_pushes_a_file_save_dialog_seeded_with_the_default
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("resolve_via", ["a real path", "cancel"])
+async def test_a_second_export_press_while_the_dialog_is_open_is_refused_then_rearms(
+    monkeypatch, tmp_path, resolve_via,
+):
+    """Review round 1 (Important #1): an earlier draft argued Textual
+    "refuses to stack" a second `FileSave`. A live repro of two rapid
+    presses disproved that -- the screen stack ended up
+    `['FileSave', 'FileSave']`, two live dialogs, not one refused.
+
+    Two presses in one tick (before either worker has run -- `run_worker`
+    only schedules) must push exactly ONE dialog and refuse the second
+    with a toast. Then, once the first dialog resolves -- exercised here
+    BOTH via a real path and via a cancel (`resolve_via`) -- a LATER press
+    must work again: the re-arm assertion that catches a flag stuck
+    `True` forever, which would be worse than the bug being fixed (a
+    cancelled export permanently wedging Export shut).
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id)
+
+    push_screen_mock = AsyncMock()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        monkeypatch.setattr(host, "push_screen", push_screen_mock)
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.select_briefing_by_id(str(briefing_id))
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        # Two presses in the same tick: `Button.press()` only POSTS
+        # `Button.Pressed` (Textual's message queue is FIFO and each
+        # message is handled to completion before the next is dequeued),
+        # so the first press's handler -- which claims the guard
+        # synchronously, on the UI thread, before `run_worker` -- has
+        # already set `_briefing_export_in_flight` by the time the second
+        # press's `ExportBriefingRequested` is handled.
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        export_button = pane.query_one("#artifacts-export-button", Button)
+        export_button.press()
+        export_button.press()
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert push_screen_mock.await_count == 1, (
+            "two rapid presses must push exactly one dialog, not stack two"
+        )
+        refusals = [
+            call
+            for call in app.notify.call_args_list
+            if "already in progress" in str(call.args[0])
+        ]
+        assert len(refusals) == 1, "the second press must be refused with a toast"
+
+        # Resolve the FIRST press's dialog -- the callback it was given --
+        # either via a real chosen path or via `None` (cancelled).
+        _, first_kwargs = push_screen_mock.call_args
+        callback = first_kwargs["callback"]
+        if resolve_via == "a real path":
+            await callback(tmp_path / "export.md")
+        else:
+            await callback(None)
+
+        # The guard must have re-armed: a THIRD press now pushes ANOTHER
+        # real dialog rather than being refused.
+        push_screen_mock.reset_mock()
+        app.notify.reset_mock()
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-export-button", Button).press()
+        await pilot.pause()
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert push_screen_mock.await_count == 1, (
+            "Export must be usable again once the first dialog resolved"
+        )
+
+
+@pytest.mark.asyncio
 async def test_write_briefing_export_file_writes_the_document_and_toasts_success(
     tmp_path,
 ):
@@ -3844,3 +3927,69 @@ async def test_write_briefing_export_file_write_failure_toasts_the_exception_typ
     assert "OSError" in args[0]
     assert kwargs.get("severity") == "error"
     assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_write_briefing_export_file_unicode_encode_error_toasts_the_exception_type(
+    monkeypatch, tmp_path
+):
+    """Review round 1 (Important #2): the write's `except` previously
+    caught only `OSError`, narrower than both the brief and the
+    `library_screen` precedent it claims to mirror. A live repro
+    confirmed a `UnicodeEncodeError` -- entirely plausible from model- or
+    feed-derived body text -- escaped uncaught: no toast, no
+    notification, a silent failure. Broadened to `except Exception`
+    (still logging by type only, never the body).
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
+    briefing["watchlist_name"] = "Morning AI Brief"
+
+    def _boom(*_args, **_kwargs):
+        raise UnicodeEncodeError("ascii", "x", 0, 1, "boom")
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        destination = tmp_path / "export.md"
+        with monkeypatch.context() as ctx:
+            ctx.setattr(Path, "write_text", _boom)
+            await screen._write_briefing_export_file(destination, briefing)
+
+    assert not destination.exists()
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "UnicodeEncodeError" in args[0]
+    assert kwargs.get("severity") == "error"
+    assert kwargs.get("markup") is False
+
+
+@pytest.mark.asyncio
+async def test_write_briefing_export_file_cancelled_error_propagates_uncaught(
+    monkeypatch, tmp_path
+):
+    """`asyncio.CancelledError` must never be reported as a failed export
+    -- a cancelled worker is not the same thing as a write that failed,
+    and the broadened `except Exception` above must not accidentally
+    swallow it (review round 1, Important #2's own caveat).
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id = _seed_complete_briefing(app, watchlist_id)
+    briefing = dict(app.watchlist_bundle_service.db.list_briefings(watchlist_id)[0])
+    briefing["watchlist_name"] = "Morning AI Brief"
+
+    def _cancel(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        destination = tmp_path / "export.md"
+        with monkeypatch.context() as ctx:
+            ctx.setattr(Path, "write_text", _cancel)
+            with pytest.raises(asyncio.CancelledError):
+                await screen._write_briefing_export_file(destination, briefing)
+
+    assert not destination.exists()
+    app.notify.assert_not_called()

--- a/backlog/tasks/task-1540 - Watchlists-briefings-spec-2-programme-tracking.md
+++ b/backlog/tasks/task-1540 - Watchlists-briefings-spec-2-programme-tracking.md
@@ -4,7 +4,7 @@ title: 'Watchlists briefings (spec #2) programme tracking'
 status: To Do
 assignee: []
 created_date: '2026-07-30 15:53'
-updated_date: '2026-08-01 06:56'
+updated_date: '2026-08-01 20:03'
 labels:
   - watchlists
   - briefings
@@ -37,6 +37,6 @@ land; do not fold phase implementation into it.
   - [x] Selection-mode picker: `briefing_selection_mode` shipped in phase 1 with no writer (default `auto_featured` only, `auto`/`curated` unreachable) -- add the picker. Deferred from phase 1, confirmed by the project owner 2026-07-30.
   - [x] Citations: phase 1 renders `[item N]` markers as plain text (`hyperlinks=False` by constraint) -- add links-into-reader and pruned-item degradation, incl. the named `citation-to-pruned-item-degrades` invariant test. Deferred from phase 1, confirmed by the project owner 2026-07-30.
   - Phase 2a (presets, casting, pickers, citations) shipped text-only on branch `feat/briefings-phase-2`. Phase 2b (audio synthesis, stitching, playback; task-1630) shipped 2026-07-31 on `feat/briefings-phase-2b` -- phase 2 is complete.
-- [ ] #3 Phase 3: markdown/audio exports and the podcast feed directory
+- [x] #3 Phase 3: markdown/audio exports and the podcast feed directory
 - [ ] #4 Phase 4: scheduled briefing generation via the TASK-1383 scheduler seam
 <!-- AC:END -->

--- a/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
+++ b/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
@@ -1,0 +1,75 @@
+---
+id: TASK-1760
+title: 'In-app serving for the briefings feed directory'
+status: To Do
+assignee: []
+created_date: '2026-08-01 20:05'
+labels:
+  - watchlists
+  - briefings
+  - web-server
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Spec #2's phase 3 design (`Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md`,
+"Exports and feed") promised that "if the app's `[web_server]` is enabled it can serve that
+directory over localhost for podcast clients; serving is a toggle." At phase 3 plan/implementation
+time (task-1540, phase 3 close-out) that premise turned out to be false, and the project owner
+decided to cut localhost serving from phase 3 rather than build on a mechanism that does not
+exist. This task exists so a future implementer does not have to re-discover the same evidence.
+
+**Why `[web_server]` cannot do this, in full:**
+
+- `[web_server]` is **textual-serve**, not a general-purpose HTTP static-file server. Its
+  `enabled` key is defined in the default config template (`tldw_chatbook/config.py:3665-3671`)
+  but is **read by no code anywhere in the app** -- there is no `get_cli_setting("web_server",
+  "enabled", ...)` call or equivalent gate on it at all. Toggling it currently does nothing.
+- `[web_server]` is a **mutually exclusive process mode**, not something that runs alongside the
+  TUI. `app.py`'s `main()` branches on the `--serve` CLI flag (`tldw_chatbook/app.py:9231-9254`):
+  when set, it calls `run_web_server(...)` and then `return`s -- exiting the process after the web
+  server stops -- instead of ever constructing and running `TldwCli` as a TUI. There is no code
+  path where both the TUI and a web server are live in the same process; "if `[web_server]` is
+  enabled" was never a real branch a running TUI session could take.
+- Even when engaged via `--serve`, its only static route serves **textual-serve's own browser
+  assets**, not arbitrary files from a user-chosen directory. `create_server`
+  (`tldw_chatbook/Web_Server/serve.py:258-297`) builds a `textual_serve.server.Server` whose
+  `command` re-launches `python -m tldw_chatbook.app` as a subprocess bridged to a browser
+  terminal; `ChatbookWebServerMixin.handle_textual_js`
+  (`tldw_chatbook/Web_Server/serve.py:213-220`) serves exactly one hardcoded file,
+  `self.statics_path / "js" / "textual.js"` -- textual-serve's own JS bundle, patched for viewport
+  resize. There is no route, hardcoded or configurable, that serves a directory the caller names.
+
+In short: there was never a server running alongside the TUI for a "serve this feed folder"
+toggle to flip. Phase 3 shipped the feed directory as the deliverable (the spec's own wording
+already said "the directory is the deliverable") and documents a user-run static server
+(e.g. `python -m http.server` from the exported folder) as the way to point a podcast client at
+it today.
+
+**Scope of this task: net-new work.** This is not "wire up `[web_server]`" -- it is a standalone,
+purpose-built static file server that the TUI can start and stop on demand, independent of
+textual-serve entirely:
+
+- Its own bind-address and port settings (not reusing `[web_server]`'s config section, which
+  belongs to a different, unrelated feature).
+- Started/stopped from the UI (or a command), scoped to one exported feed directory at a time.
+- A security review this scope implies, since this is new listening-socket surface: default bind
+  scope (localhost-only unless the user deliberately widens it), hardening against path traversal
+  out of the chosen directory, and an explicit posture on authentication (none by default, stated
+  plainly to the user rather than implied).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A user can serve an exported briefings feed folder over localhost and successfully point
+      a podcast client at the resulting URL
+- [ ] #2 Serving is opt-in and off by default -- no feed directory is ever served without an
+      explicit user action to start it
+- [ ] #3 The server cannot serve any file outside the one chosen directory (path traversal into
+      parent directories or elsewhere on disk is rejected)
+- [ ] #4 A security review documents the default bind scope (localhost vs. wider), and states the
+      no-auth-by-default posture explicitly rather than leaving it implicit
+<!-- AC:END -->

--- a/backlog/tasks/task-1761 - Cap-the-unbounded-offset-walk-loops-in-pagination-tests.md
+++ b/backlog/tasks/task-1761 - Cap-the-unbounded-offset-walk-loops-in-pagination-tests.md
@@ -1,0 +1,58 @@
+---
+id: TASK-1761
+title: 'Cap the unbounded offset-walk loops in pagination tests'
+status: To Do
+assignee: []
+created_date: '2026-08-01 20:05'
+labels:
+  - watchlists
+  - briefings
+  - testing
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Four briefings pagination tests walk `offset` pages with an uncapped `while True` loop, copied
+from the same precedent each time (first noted as a deferred minor at task-2 of the phase 3
+close-out, `backlog/tasks/task-1540`'s programme):
+
+- `Tests/Subscriptions/test_briefing_feed_query.py:253`
+- `Tests/Subscriptions/test_briefing_audio_db.py:213`
+- `Tests/Subscriptions/test_briefing_presets_db.py:133`
+- `Tests/Subscriptions/test_briefing_presets_db.py:311`
+
+Each follows the same shape:
+
+```python
+offset = 0
+while True:
+    page = db.list_...(..., limit=limit, offset=offset)
+    if not page:
+        break
+    seen.extend(...)
+    offset += limit
+```
+
+The loop's only exit is an empty page. If a regression made the underlying query **ignore**
+`offset` entirely (e.g. always returning the first `limit` rows), the same non-empty page would
+come back forever -- the loop never sees the empty page that is supposed to end it. Today that
+spins each test until pytest's global timeout (300s) kills the whole run, rather than failing
+fast with a message that points at the actual bug. A slow, timeout-shaped failure is a much worse
+debugging experience than an immediate, named assertion failure, and it burns the entire test
+run's time budget on one broken query.
+
+This is not a live bug today -- all four queries correctly honor `offset` right now (each test
+passes). This is purely about hardening the tests' failure mode for the day one of them
+regresses.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each of the four `while True` offset-walk loops has a local iteration cap
+- [ ] #2 Exceeding the cap fails the test immediately with a clear, specific message (naming which
+      query/test hit it) rather than spinning to pytest's global timeout
+- [ ] #3 All four tests still pass unchanged under normal (non-regressed) behavior
+<!-- AC:END -->

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -2266,6 +2266,71 @@ class SubscriptionsDB(BaseDB):
             )
             return [dict(row) for row in cursor.fetchall()]
 
+    def list_watchlist_audio_episodes(
+        self, watchlist_id: int, *, limit: int = 500, offset: int = 0
+    ) -> List[Dict[str, Any]]:
+        """List a watchlist's finished audio episodes for feed export.
+
+        One joined `SELECT` across `briefing_audio -> briefing_scripts ->
+        briefings`, scoped to `watchlist_id` through the `briefings` row
+        each script ultimately belongs to (`briefing_audio` has no
+        `watchlist_id` column of its own). Only rows a listener -- or an
+        RSS reader -- can actually play are returned: `audio.status =
+        'complete'` AND `audio.file_path IS NOT NULL` are two independent
+        predicates, since a `complete` render whose file write never
+        landed is just as unplayable as one still `generating` or
+        `failed`.
+
+        Ordered by `briefings.created_at DESC, audio.id DESC` --
+        deliberately *not* `list_briefing_audio`'s `audio.created_at`: a
+        podcast feed reads newest-briefing-first (episode recency), not
+        newest-render-first (when the audio happened to be synthesized).
+
+        Args:
+            watchlist_id: The `watchlists.id` to list episodes for. Scopes
+                the join by identity -- audio belonging to any other
+                watchlist's briefings is never returned, regardless of how
+                many rows exist elsewhere.
+            limit: Maximum number of rows to return (CLAUDE.md Performance
+                Rules: paginate DB results). Defaults to 500.
+            offset: Number of rows to skip before the page starts.
+
+        Returns:
+            Up to `limit` rows, starting at `offset`, newest-briefing-first.
+            Each row is a dict with keys `audio_id`, `script_id`,
+            `briefing_id`, `file_path`, `duration_seconds`, `turn_count`,
+            `preset_name`, `briefing_created_at`, `briefing_status`,
+            `covers_from_ts`, `model_used` -- the exact aliases Tasks 3
+            (RSS feed generation) and 5 (the export button) quote by name.
+        """
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                """
+                SELECT
+                    audio.id AS audio_id,
+                    audio.script_id AS script_id,
+                    scripts.briefing_id AS briefing_id,
+                    audio.file_path AS file_path,
+                    audio.duration_seconds AS duration_seconds,
+                    audio.turn_count AS turn_count,
+                    scripts.preset_name AS preset_name,
+                    briefings.created_at AS briefing_created_at,
+                    briefings.status AS briefing_status,
+                    briefings.covers_from_ts AS covers_from_ts,
+                    briefings.model_used AS model_used
+                FROM briefing_audio AS audio
+                JOIN briefing_scripts AS scripts ON scripts.id = audio.script_id
+                JOIN briefings ON briefings.id = scripts.briefing_id
+                WHERE briefings.watchlist_id = ?
+                  AND audio.status = 'complete'
+                  AND audio.file_path IS NOT NULL
+                ORDER BY briefings.created_at DESC, audio.id DESC
+                LIMIT ? OFFSET ?
+                """,
+                (watchlist_id, limit, offset),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
     def set_watchlist_briefing_settings(
         self,
         watchlist_id: int,

--- a/tldw_chatbook/Subscriptions/briefing_audio.py
+++ b/tldw_chatbook/Subscriptions/briefing_audio.py
@@ -195,6 +195,7 @@ from tldw_chatbook.TTS.legacy_bridge import LEGACY_PROVIDER_IDS
 from tldw_chatbook.TTS.legacy_request_builder import build_legacy_speech_request
 from tldw_chatbook.TTS.playground_types import TTSRequestedSelectionSnapshot
 from tldw_chatbook.TTS.text_processing import TextChunker
+from tldw_chatbook.Utils.path_validation import is_safe_path
 from tldw_chatbook.Utils.private_paths import (
     atomic_private_write_bytes,
     secure_private_directory,
@@ -1070,6 +1071,40 @@ def briefing_audio_dir() -> Path:
         create=True,
         application_owned=True,
     ).lexical_path
+
+
+def audio_file_path_is_safe(file_path: str | Path) -> bool:
+    """Whether `file_path` resolves to somewhere inside `briefing_audio_dir()`.
+
+    Qodo review round 1, FIX B (phase 2b): `file_path` comes from our own DB
+    row today, but nothing enforces that at the schema level, and CLAUDE.md
+    requires every file path to be checked through `Utils/path_validation.py`
+    before the filesystem ever sees it -- a tampered or corrupted row must
+    not let a caller probe (`.exists()`) or play/copy an arbitrary path.
+    Two callers share this single check rather than each carrying their own
+    copy of it: `UI.Watchlists_Modules.artifacts_pane` (disables Play;
+    `WatchlistsCollectionsScreen.handle_play_audio_requested` guards the
+    actual playback call) and `briefing_export.export_feed_directory`
+    (phase 3 Task 4 -- guards copying a file OUT of private storage for a
+    podcast feed export).
+
+    Moved here from `artifacts_pane.py` in phase 3 Task 4 review round 1:
+    this is a services-layer security check, not UI code, and living in a
+    UI module made `briefing_export.py`'s import of it the only
+    `Subscriptions -> UI` import in the whole package -- one import away
+    from a circular-import trap the day this module wants something from
+    `briefing_export` (plausible, since it names files too). `artifacts_
+    pane` re-imports the name from here, so every existing caller keeps its
+    current spelling.
+
+    Args:
+        file_path: The candidate path, as stored on a `briefing_audio` row.
+
+    Returns:
+        `True` only when `file_path` resolves (following `..`/symlinks)
+        to a location inside `briefing_audio_dir()`.
+    """
+    return is_safe_path(file_path, briefing_audio_dir())
 
 
 async def generate_script_audio(

--- a/tldw_chatbook/Subscriptions/briefing_export.py
+++ b/tldw_chatbook/Subscriptions/briefing_export.py
@@ -59,6 +59,21 @@ for this half specifically:
    (silence is never a state) applied to "one of many episodes broke",
    which is an honest partial success, not a reason to hand the user
    nothing at all.
+4. **Exported files get a fixed `0o644`, deliberately ignoring umask.**
+   Audio in `briefing_audio_dir()` is written `0o600` by
+   `atomic_private_write_bytes`, and `shutil.copy2` would carry that mode
+   into the user's folder -- which silently breaks the entire deliverable:
+   a folder meant to be synced, zipped, or served would be readable only
+   by the exporting account. (Review round 1 found exactly this; the test
+   that was supposed to catch it stopped at the directory, and its fixture
+   seeded permissive sources, so mode inheritance looked harmless.)
+   Umask is deliberately NOT consulted: it expresses a default for
+   arbitrary file creation, not intent for a folder the user explicitly
+   chose in order to share it, and honouring a hardened umask here would
+   hand precisely the most security-conscious users a silently unreadable
+   feed. The real access boundary is unchanged -- the destination
+   directory's own permissions, which Decision 1 leaves untouched, so a
+   `0o644` file inside a `0o700` directory remains unreachable to others.
 """
 
 from __future__ import annotations

--- a/tldw_chatbook/Subscriptions/briefing_export.py
+++ b/tldw_chatbook/Subscriptions/briefing_export.py
@@ -273,6 +273,17 @@ _FEED_XML_PARTIAL_NAME = "feed.xml.partial"
 #: loop itself without seeding hundreds of real rows.
 _EPISODES_PAGE_SIZE = 500
 
+#: Whole-branch review round 2: an upper bound on the pagination walk
+#: above, so a broken accessor cannot spin it forever. Terminating on an
+#: empty page is correct only while the accessor honours `offset`; one that
+#: ignored it would hand back a full page indefinitely, and the walk would
+#: hang a worker while growing its row list without limit. Set far above
+#: any plausible watchlist so it fires ONLY on that bug, and the walk
+#: raises rather than truncating when it trips -- silently exporting the
+#: first N episodes is precisely the failure decision 4 above exists to
+#: rule out.
+_EPISODES_MAX_ROWS = 100_000
+
 #: Task 4 review round 1: the mode every file this module WRITES into the
 #: user's export directory ends up at -- an ordinary, group/other-readable
 #: file, deliberately NOT the `0o600` private-storage mode `briefing_audio_
@@ -625,9 +636,18 @@ def export_feed_directory(
     # with more episodes than that, with the tail recorded nowhere. Walks
     # until the accessor returns an empty page, so the query cost for a
     # typical (well-under-one-page) watchlist is still exactly one call.
+    # The loop is bounded, not merely terminated by an empty page: an
+    # accessor that ignored `offset` would return a full page forever, and
+    # an unbounded walk would then grow `rows` without limit inside a
+    # worker -- a hang plus unbounded memory in production, not just a slow
+    # test. (That is exactly the regression `task-1761` describes for the
+    # pagination TESTS; the same failure reaches further here.) The cap is
+    # deliberately far above any plausible watchlist so it can only ever
+    # fire on a broken accessor, and it fails loudly rather than silently
+    # truncating -- the whole point of decision 4 above.
     rows: list[Mapping[str, Any]] = []
     offset = 0
-    while True:
+    while offset < _EPISODES_MAX_ROWS:
         page = db.list_watchlist_audio_episodes(
             watchlist_id, limit=_EPISODES_PAGE_SIZE, offset=offset
         )
@@ -635,6 +655,12 @@ def export_feed_directory(
             break
         rows.extend(page)
         offset += _EPISODES_PAGE_SIZE
+    else:
+        raise BriefingExportError(
+            f"Refusing to export: the episode query returned more than "
+            f"{_EPISODES_MAX_ROWS} rows, which means it is not honouring "
+            f"its offset. No files were written."
+        )
 
     episodes: list[FeedEpisode] = []
     skipped: list[str] = []

--- a/tldw_chatbook/Subscriptions/briefing_export.py
+++ b/tldw_chatbook/Subscriptions/briefing_export.py
@@ -24,10 +24,11 @@ user chose (through Task 5's `ExportFeedRequested` flow), alongside a
 markdown half above, this DOES do its own I/O -- validating the
 destination, copying files, and writing `feed.xml` atomically -- because
 the deliverable here is several files landing together, not one screen
-writing one file. Five decisions are load-bearing for this half
+writing one file. Six decisions are load-bearing for this half
 specifically: the first three from the phase 3 plan, the fourth (full
-pagination) from this whole-branch review, and the fifth (`0o644`
-permissions) from Task 4's own review round 1:
+pagination) from this whole-branch review, the fifth (`0o644`
+permissions) from Task 4's own review round 1, and the sixth
+(no-follow writes) from a later Qodo PR review round:
 
 1. **Never route the destination through `Utils/private_paths.py`.**
    `secure_private_directory(..., application_owned=True)` chmods its
@@ -76,12 +77,16 @@ permissions) from Task 4's own review round 1:
    exercise the pagination loop without seeding hundreds of real rows.
 5. **Exported files get a fixed `0o644`, deliberately ignoring umask.**
    Audio in `briefing_audio_dir()` is written `0o600` by
-   `atomic_private_write_bytes`, and `shutil.copy2` would carry that mode
-   into the user's folder -- which silently breaks the entire deliverable:
+   `atomic_private_write_bytes`. Review round 1 found that `shutil.copy2`
+   -- the original copy mechanism -- carries the SOURCE file's mode along
+   with its data, which would have silently broken the entire deliverable:
    a folder meant to be synced, zipped, or served would be readable only
-   by the exporting account. (Review round 1 found exactly this; the test
-   that was supposed to catch it stopped at the directory, and its fixture
-   seeded permissive sources, so mode inheritance looked harmless.)
+   by the exporting account. (The test that was supposed to catch it
+   stopped at the directory, and its fixture seeded permissive sources, so
+   mode inheritance looked harmless.) Decision 6 below replaced
+   `shutil.copy2` outright with a direct `os.open` write that sets
+   `0o644` at creation time, which makes the mode question moot rather
+   than merely patched after the fact.
    Umask is deliberately NOT consulted: it expresses a default for
    arbitrary file creation, not intent for a folder the user explicitly
    chose in order to share it, and honouring a hardened umask here would
@@ -89,6 +94,36 @@ permissions) from Task 4's own review round 1:
    feed. The real access boundary is unchanged -- the destination
    directory's own permissions, which Decision 1 leaves untouched, so a
    `0o644` file inside a `0o700` directory remains unreachable to others.
+6. **Neither the per-episode copy nor `feed.xml`'s write ever follows a
+   symlink planted at the destination's final path component.** A Qodo
+   review round on the PR found that `shutil.copy2(source_path,
+   dest_path)` follows a symlink AT `dest_path` and writes through it: if
+   the chosen export directory is shared, synced, or otherwise writable by
+   another process, a symlink planted at a predictable episode filename
+   redirects that write to an arbitrary path outside the folder, with the
+   exporting user's own permissions. `validate_path_simple` does not close
+   this -- it validates the path STRING and only logs when resolution
+   changes, it never fails closed, and the destination is legitimately
+   outside our private area anyway (decision 1), so no path-string check
+   can be the real boundary here. `_copy_episode_audio_file` now opens the
+   destination itself with `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW`
+   (guarded with `getattr(os, "O_NOFOLLOW", 0)`) and streams the source
+   into it -- the same posture `_write_feed_xml_atomically` already held
+   for `feed.xml`'s own write. A symlink at the final component now makes
+   the `os.open` call itself raise `OSError`, caught by the per-episode
+   loop (decision 3) exactly like any other copy failure, instead of being
+   written through. The same review round found that
+   `_write_feed_xml_atomically`'s stale-partial cleanup
+   (`if partial_path.exists(): partial_path.unlink()`) used `Path.exists()`,
+   which FOLLOWS a symlink to check its target and so returns `False` for a
+   dangling symlink left at `feed.xml.partial` -- silently skipping the
+   unlink, so the following `O_EXCL | O_NOFOLLOW` open then fails on every
+   subsequent export to that directory: a persistent, user-visible denial
+   of service in a folder the user chose. Fixed by checking
+   `os.path.lexists` instead, which reports the directory entry itself
+   (symlink or not, dangling or not) without following it; `Path.unlink()`
+   on a symlink always removes the link, never the file it points to, so a
+   LIVE symlink at that name is cleared the same safe way.
 """
 
 from __future__ import annotations
@@ -289,13 +324,16 @@ _EPISODES_MAX_ROWS = 100_000
 #: file, deliberately NOT the `0o600` private-storage mode `briefing_audio_
 #: dir()`'s own contents carry. Applied explicitly (not left to the
 #: process umask) so the result is deterministic regardless of the
-#: caller's environment: `feed.xml`'s partial is created with this mode
-#: directly, and each copied episode file is `chmod`ed to it after
-#: `shutil.copy2` (which would otherwise carry the PRIVATE source file's
-#: mode straight into the user's folder -- see `_copy_episode_audio_file`).
-#: A directory the user means to sync, zip, or serve must be readable by
-#: more than just their own account; Decision 1 already makes this promise
-#: for the directory itself, this pins the same promise for its files.
+#: caller's environment: both `feed.xml`'s partial and each copied episode
+#: file are created directly at this mode via `os.open`, with an explicit
+#: `fchmod` right after (module docstring, decision 6) -- neither one is
+#: corrected after the fact by a separate `chmod` following a
+#: `shutil.copy2` or similar copy that would otherwise carry the PRIVATE
+#: source file's mode straight into the user's folder (see
+#: `_copy_episode_audio_file`). A directory the user means to sync, zip,
+#: or serve must be readable by more than just their own account;
+#: Decision 1 already makes this promise for the directory itself, this
+#: pins the same promise for its files.
 _EXPORTED_FILE_MODE = 0o644
 
 
@@ -443,25 +481,49 @@ def _copy_episode_audio_file(
 ) -> Path:
     """Copy one episode's audio file into the feed directory.
 
-    Follows the exact validate-then-copy order `UI/STTS_Window.py:4040-4049`
+    Follows the exact validate-then-write order `UI/STTS_Window.py:4040-4049`
     uses for its own user-chosen export destination: validate the full
     destination path, validate its parent exists and resolve it (catches a
     symlink swapped in after the caller's own directory-level validation),
-    validate the bare filename, THEN copy. `source_path` is not
+    validate the bare filename, THEN write. `source_path` is not
     re-validated here -- by the time this is called, the caller has already
     confirmed it via `audio_file_path_is_safe` and `.exists()` (module
     docstring, decision 2).
 
-    Task 4 review round 1: `shutil.copy2` preserves the SOURCE file's
-    permission mode along with its data, and production audio is written
-    by `Utils.private_paths.atomic_private_write_bytes` at `0o600`
-    (application-owned, private-storage semantics). Left alone, every
-    exported episode would inherit that private mode into the user's own
-    folder -- exactly what Decision 1 forbids, just applied to a file
-    instead of the directory, and defeating the entire point of exporting
-    a folder the user means to sync, zip, or serve. The explicit `chmod`
-    below relaxes it back to an ordinary, group/other-readable file
-    regardless of what the source's mode happened to be.
+    Qodo review round: the destination used to be handed straight to
+    `shutil.copy2`, which follows a symlink planted at the final path
+    component and writes through it (module docstring, decision 6).
+    `validate_path_simple` above cannot be the boundary against that -- it
+    validates the path STRING and only logs when resolution changes, it
+    does not fail closed, and the destination is legitimately outside our
+    private area anyway (decision 1). The destination is now opened
+    directly with `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW` (guarded with
+    `getattr(os, "O_NOFOLLOW", 0)`, same idiom `_write_feed_xml_atomically`
+    already uses) and the source streamed into it: a symlink at `dest_path`
+    now makes this `os.open` call itself raise `OSError`, which the
+    caller's per-episode loop already catches and records in `skipped`
+    (decision 3) -- it never reaches this function's own control flow.
+    `O_TRUNC` (not `O_EXCL`) is deliberate: unlike `feed.xml`'s
+    fixed-name write, a re-export must still overwrite an existing
+    REGULAR file at the same path cleanly
+    (`test_re_exporting_the_same_episode_overwrites_its_existing_
+    destination_file`) -- only a symlink, never an ordinary file, is
+    refused.
+
+    Task 4 review round 1: `shutil.copy2` (the original mechanism) also
+    preserved the SOURCE file's permission mode along with its data, and
+    production audio is written by `Utils.private_paths.
+    atomic_private_write_bytes` at `0o600` (application-owned,
+    private-storage semantics). Left alone, every exported episode would
+    have inherited that private mode into the user's own folder -- exactly
+    what Decision 1 forbids, just applied to a file instead of the
+    directory. Opening the destination directly sidesteps this rather than
+    patching it after the fact: `_EXPORTED_FILE_MODE` (`0o644`) is passed
+    to `os.open` and re-asserted with `fchmod` right after (the same
+    defensive idiom `_write_feed_xml_atomically` uses for `feed.xml`'s own
+    mode), so the destination's mode never depends on the source's --
+    the separate post-copy `os.chmod` call this function used to make is
+    now redundant, and has been removed.
 
     Args:
         source_path: The episode's audio file inside `briefing_audio_dir()`.
@@ -469,11 +531,12 @@ def _copy_episode_audio_file(
         filename: The bare filename to write within `destination_dir`.
 
     Returns:
-        The validated path the file was copied to.
+        The validated path the file was written to.
 
     Raises:
         ValueError: `destination_dir / filename` fails validation.
-        OSError: The copy itself fails.
+        OSError: `dest_path` is a symlink (refused via `O_NOFOLLOW`), or
+            the write itself fails.
     """
     dest_path = destination_dir / filename
     validate_path_simple(dest_path, require_exists=False)
@@ -482,8 +545,20 @@ def _copy_episode_audio_file(
     ).resolve()
     validated_filename = validate_filename(dest_path.name)
     dest_path = validated_parent / validated_filename
-    shutil.copy2(source_path, dest_path)
-    os.chmod(dest_path, _EXPORTED_FILE_MODE)
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    dest_fd = os.open(dest_path, flags, _EXPORTED_FILE_MODE)
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(dest_fd, _EXPORTED_FILE_MODE)
+        with os.fdopen(dest_fd, "wb") as dest_stream:
+            dest_fd = -1  # ownership transferred to the stream
+            with open(source_path, "rb") as source_stream:
+                shutil.copyfileobj(source_stream, dest_stream)
+    finally:
+        if dest_fd >= 0:
+            os.close(dest_fd)
     return dest_path
 
 
@@ -501,6 +576,19 @@ def _write_feed_xml_atomically(destination_dir: Path, xml_bytes: bytes) -> None:
     `chatbook_creator`'s per-export unique output path, `feed.xml` is a
     fixed name reused on every re-export, so leaving a stale partial in
     place would permanently wedge every future export behind `O_EXCL`.
+
+    Qodo review round: that removal check used to be
+    `if partial_path.exists(): partial_path.unlink()` -- but `Path.exists()`
+    FOLLOWS a symlink to check its target, so it returns `False` for a
+    DANGLING symlink left at the partial's name, silently skipping the
+    unlink. The following `O_EXCL | O_NOFOLLOW` open would then fail on
+    every subsequent export to that directory: a persistent, user-visible
+    denial of service in a folder the user chose (module docstring,
+    decision 6). Fixed by checking `os.path.lexists` instead, which
+    reports the directory entry itself -- symlink or not, dangling or not
+    -- without following it. `Path.unlink()` on a symlink always removes
+    the link itself, never the file it points to, so a LIVE symlink at
+    that name is cleared the same safe way, never written through.
 
     Task 4 review round 1: the partial used to be opened at `0o600` (copied
     from the `chatbook_creator` precedent verbatim, without noticing that
@@ -527,7 +615,7 @@ def _write_feed_xml_atomically(destination_dir: Path, xml_bytes: bytes) -> None:
     partial_path = destination_dir / _FEED_XML_PARTIAL_NAME
 
     try:
-        if partial_path.exists():
+        if os.path.lexists(partial_path):
             partial_path.unlink()
     except OSError as exc:
         logger.warning(

--- a/tldw_chatbook/Subscriptions/briefing_export.py
+++ b/tldw_chatbook/Subscriptions/briefing_export.py
@@ -1,0 +1,168 @@
+"""Export a briefing as a self-contained markdown document (spec #2 phase 3,
+Task 1).
+
+The UI's `#artifacts-toolbar` Export button (`UI/Watchlists_Modules/
+artifacts_pane.py`) lets a user save the SELECTED briefing's body to a file
+of their own choosing, through a `FileSave` dialog (`WatchlistsCollections
+Screen.handle_export_briefing_requested`). This module is the pure half of
+that flow: turning a `briefings` row into the document text, and turning
+arbitrary (user- or model-authored) text into a filesystem-safe name. It
+does no I/O of its own -- the screen validates the chosen destination
+(`Utils.path_validation.validate_path_simple`) and writes the file, off the
+event loop, itself.
+
+`safe_export_stem` is reused verbatim by Task 4's feed-directory writer for
+episode filenames, so its contract (alnum/space/-/_ only, a caller-supplied
+fallback when nothing survives) is load-bearing for both callers, not just
+this one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class BriefingExportError(RuntimeError):
+    """Raised when a briefing has nothing worth exporting.
+
+    The only raise site today is a `complete` row whose `body_markdown` is
+    NULL or blank -- `briefing_service.generate_briefing` never records an
+    empty body as `complete` (an empty provider response is recorded
+    `failed` instead), so reaching this is a hand-edited or otherwise
+    corrupted row, not a code path the service can produce. An empty file
+    is not an export, so this refuses rather than writing nothing and
+    calling it done.
+    """
+
+
+def safe_export_stem(text: str, *, fallback: str) -> str:
+    """A filesystem-safe filename stem from arbitrary text.
+
+    Whitelists alnum, space, `-` and `_` and drops everything else --
+    including path separators, `..`, and any markup-shaped punctuation
+    (`[`, `]`, `<`, `>`, `:`, quotes) a watchlist name or briefing title
+    might contain. This is a whitelist, not a blacklist of "dangerous"
+    characters, for the same reason `content_pane.render_article` gives for
+    never hand-escaping model/source text: a blacklist fails open on
+    whatever it did not anticipate, while a whitelist cannot.
+
+    `text` may be empty, whitespace-only, or entirely made of characters
+    outside the whitelist (e.g. `"###???"`, or a lone `".."`) -- any of
+    which leaves nothing to build a name from, so `fallback` is returned
+    verbatim in that case. `fallback` is trusted, caller-supplied plain
+    text (every caller passes a short literal), so it is not itself run
+    through the whitelist.
+
+    Args:
+        text: The candidate text -- a watchlist name, a briefing title, or
+            similar user/model-authored free text.
+        fallback: Returned verbatim when nothing in `text` survives the
+            whitelist.
+
+    Returns:
+        A non-empty stem containing only alnum, space, `-` and `_`, with
+        leading/trailing whitespace stripped.
+    """
+    cleaned = "".join(
+        char for char in (text or "") if char.isalnum() or char in (" ", "-", "_")
+    ).strip()
+    return cleaned or fallback
+
+
+def _coverage_window(briefing: Mapping[str, Any]) -> str:
+    """What the briefing says it covers, in one line.
+
+    Mirrors `artifacts_pane._window_text`'s own two-part shape (the
+    `covers_from_ts` floor and the `covers_through_item_id` watermark), but
+    is not that function: this module is beneath the UI layer (Subscriptions
+    imports nothing from `UI/`), so the string is rebuilt here from the same
+    two columns rather than importing a private UI helper.
+    """
+    parts: list[str] = []
+    covers_from = briefing.get("covers_from_ts")
+    if covers_from:
+        parts.append(f"since {covers_from}")
+    covers_through = briefing.get("covers_through_item_id")
+    if covers_through not in (None, ""):
+        parts.append(f"through item {covers_through}")
+    return " · ".join(parts) if parts else "unknown"
+
+
+def briefing_markdown_document(briefing: Mapping[str, Any]) -> str:
+    """One briefing's body, as a standalone markdown document.
+
+    A short front-matter header precedes the body verbatim, naming the
+    four things a reader needs to place the document without the app
+    around it: which watchlist it is from (`briefing["watchlist_name"]` --
+    a `briefings` row itself only carries `watchlist_id`, so the caller is
+    responsible for resolving and merging in the display name before
+    calling this, exactly as `WatchlistsCollectionsScreen._watchlist_
+    display_name` already does for every other briefing-scoped toast),
+    its status, the window it covers, and when it was created.
+
+    Args:
+        briefing: A `briefings` row (as `dict(sqlite3.Row)`, or an
+            equivalent mapping in tests), with `watchlist_name` merged in.
+
+    Returns:
+        The full document text, ready to write to a `.md` file verbatim.
+
+    Raises:
+        BriefingExportError: `briefing["body_markdown"]` is NULL, missing,
+            or blank. Named error message includes the briefing's id so a
+            toast built from `str(exc)` tells the user which row failed.
+    """
+    body = str(briefing.get("body_markdown") or "").strip()
+    if not body:
+        raise BriefingExportError(
+            f"Briefing {briefing.get('id', 'unknown')} has no body to export."
+        )
+
+    watchlist_name = str(briefing.get("watchlist_name") or "").strip() or (
+        "this watchlist"
+    )
+    status = str(briefing.get("status") or "").strip() or "unknown"
+    created_at = str(briefing.get("created_at") or "").strip() or "unknown time"
+    coverage = _coverage_window(briefing)
+
+    front_matter = (
+        "---\n"
+        f"watchlist: {watchlist_name}\n"
+        f"status: {status}\n"
+        f"covers: {coverage}\n"
+        f"created: {created_at}\n"
+        "---\n\n"
+    )
+    return f"{front_matter}{body}\n"
+
+
+def default_briefing_filename(
+    briefing: Mapping[str, Any], *, watchlist_name: str
+) -> str:
+    """The filename a `FileSave` dialog opens with for this briefing.
+
+    Built from the watchlist's name and the briefing's own timestamp, run
+    through `safe_export_stem` so a watchlist named with path-shaped or
+    markup-shaped text (see that function's own docstring) cannot escape
+    the destination directory the user picks in the dialog, nor produce a
+    stem with no visible characters at all.
+
+    Args:
+        briefing: A `briefings` row -- only `id`/`created_at` are read.
+        watchlist_name: The watchlist's display name (resolved by the
+            caller; a `briefings` row itself only carries `watchlist_id`).
+
+    Returns:
+        `"<stem>.md"`. The stem never contains `/` or `\\` (excluded by
+        `safe_export_stem`'s whitelist), so this is always a bare filename,
+        never a path.
+    """
+    created_at = str(briefing.get("created_at") or "").strip()
+    stem_source = f"{watchlist_name} {created_at}".strip() if created_at else (
+        watchlist_name
+    )
+    briefing_id = briefing.get("id")
+    fallback = f"briefing-{briefing_id}" if briefing_id is not None else "briefing"
+    stem = safe_export_stem(stem_source, fallback=fallback)
+    return f"{stem}.md"

--- a/tldw_chatbook/Subscriptions/briefing_export.py
+++ b/tldw_chatbook/Subscriptions/briefing_export.py
@@ -38,15 +38,21 @@ for this half specifically:
    validate_path_simple` plus plain stdlib writes are used instead, the
    same split `UI/STTS_Window.py:4040` and `UI/library_screen.py:6486`
    already make for other user-chosen destinations.
-2. **`audio_file_path_is_safe` (imported from `UI.Watchlists_Modules.
-   artifacts_pane`, not re-derived) runs BEFORE any filesystem access on a
-   `file_path` read from the DB.** Phase 2b's Qodo round established this
-   order for playback (`artifacts_pane.py:370-381`) precisely because nothing
-   enforces at the schema level that a stored path is safe. Export copies a
-   file OUT of private storage, so getting this order wrong here is a wider
-   hole than the playback bug was -- see `export_feed_directory`'s own
-   per-episode loop, where the safety check is the very first thing done
-   with `file_path`, before `Path(...)`, `.exists()`, or any copy.
+2. **`audio_file_path_is_safe` (imported from `Subscriptions.briefing_audio`,
+   not re-derived) runs BEFORE any filesystem access on a `file_path` read
+   from the DB.** Phase 2b's Qodo round established this order for playback
+   (`artifacts_pane.py`'s own `handle_play_audio_requested`) precisely
+   because nothing enforces at the schema level that a stored path is
+   safe. Export copies a file OUT of private storage, so getting this
+   order wrong here is a wider hole than the playback bug was -- see
+   `export_feed_directory`'s own per-episode loop, where the safety check
+   is the very first thing done with `file_path`, before `Path(...)`,
+   `.exists()`, or any copy. `audio_file_path_is_safe` itself lives beside
+   `briefing_audio_dir()` in `briefing_audio.py` (moved there from
+   `artifacts_pane.py` in this task's review round 1, since a UI-module
+   home made this file's import of it the only `Subscriptions -> UI`
+   import in the package); `artifacts_pane` imports it from there too, so
+   there is exactly one definition for every caller.
 3. **One bad episode is skipped, not fatal.** An unsafe path or a vanished
    source file is recorded as a reason string in `FeedExportResult.skipped`
    and the rest of the export continues -- CLAUDE.md's Error-handling ethos
@@ -68,13 +74,8 @@ from typing import Any
 from loguru import logger
 
 from ..Utils.path_validation import validate_filename, validate_path_simple
+from .briefing_audio import audio_file_path_is_safe
 from .briefing_feed import FeedEpisode, build_feed_xml
-
-# Task 4, Decision 2 above: imported, not re-derived -- this repo's rule for
-# a stored `file_path` is exactly one function, so playback and export both
-# defer to it rather than growing a second copy of the same check that could
-# silently drift from the first.
-from ..UI.Watchlists_Modules.artifacts_pane import audio_file_path_is_safe
 
 
 class BriefingExportError(RuntimeError):
@@ -129,11 +130,13 @@ def _coverage_window(briefing: Mapping[str, Any]) -> str:
 
     Mirrors `artifacts_pane._window_text`'s own two-part shape (the
     `covers_from_ts` floor and the `covers_through_item_id` watermark), but
-    is not that function: `_window_text` is a private UI helper, not a
-    shared security check, so it is not worth this module's one narrow,
-    Task-4-only import of `audio_file_path_is_safe` (see the module
-    docstring's "Feed half" section for why THAT import is warranted). The
-    string is rebuilt here from the same two columns instead.
+    is not that function: this module imports nothing from `UI/` --
+    `audio_file_path_is_safe` (used by the feed half below) lives in
+    `Subscriptions.briefing_audio`, not in `artifacts_pane`, precisely so
+    that stays true (see the module docstring's "Feed half" decision 2).
+    `_window_text` itself is a private UI helper, not a shared security
+    check, so the string is rebuilt here from the same two columns instead
+    of importing it.
     """
     parts: list[str] = []
     covers_from = briefing.get("covers_from_ts")
@@ -230,6 +233,20 @@ def default_briefing_filename(
 _FEED_XML_NAME = "feed.xml"
 _FEED_XML_PARTIAL_NAME = "feed.xml.partial"
 
+#: Task 4 review round 1: the mode every file this module WRITES into the
+#: user's export directory ends up at -- an ordinary, group/other-readable
+#: file, deliberately NOT the `0o600` private-storage mode `briefing_audio_
+#: dir()`'s own contents carry. Applied explicitly (not left to the
+#: process umask) so the result is deterministic regardless of the
+#: caller's environment: `feed.xml`'s partial is created with this mode
+#: directly, and each copied episode file is `chmod`ed to it after
+#: `shutil.copy2` (which would otherwise carry the PRIVATE source file's
+#: mode straight into the user's folder -- see `_copy_episode_audio_file`).
+#: A directory the user means to sync, zip, or serve must be readable by
+#: more than just their own account; Decision 1 already makes this promise
+#: for the directory itself, this pins the same promise for its files.
+_EXPORTED_FILE_MODE = 0o644
+
 
 @dataclass(frozen=True)
 class FeedExportResult:
@@ -278,14 +295,44 @@ def _episode_filename(row: Mapping[str, Any], source_path: Path) -> str:
     return f"{stem}-{audio_id}{suffix}"
 
 
+def _episode_title(row: Mapping[str, Any], published: datetime) -> str:
+    """One episode's `<title>`.
+
+    Task 4 review round 1: `preset_name` alone (the original choice) makes
+    every episode rendered from the same preset identical in a podcast
+    client's episode list, distinguishable only by whatever date field that
+    client happens to expose in its list view -- not a safe bet across
+    clients. Leading with the publish date here fixes that directly: two
+    episodes on the same preset now read as e.g. `"Jan 01, 2026 · Two Host
+    Debate"` and `"Jan 02, 2026 · Two Host Debate"`.
+
+    Args:
+        row: One `list_watchlist_audio_episodes` row.
+        published: The episode's parsed publish timestamp -- the same value
+            passed to `FeedEpisode.published`, so the date shown in the
+            title always matches the date the feed itself claims.
+
+    Returns:
+        A one-line title, date first.
+    """
+    date_text = published.strftime("%b %d, %Y")
+    preset_name = str(row.get("preset_name") or "").strip()
+    if preset_name:
+        return f"{date_text} · {preset_name}"
+    return f"{date_text} · Episode {row.get('audio_id')}"
+
+
 def _episode_description(row: Mapping[str, Any]) -> str:
     """One episode's `<description>` text.
 
     Mirrors `_coverage_window`'s "a status IS the observability" spirit at
     episode grain: a listener choosing between episodes in a podcast client
-    sees the render's preset context (turn count, model), not just a bare
-    date, since `list_watchlist_audio_episodes` carries no separate episode
-    title or summary text of its own.
+    sees the render's preset context (turn count, model) and what window of
+    source material it actually covers, not just a bare date, since
+    `list_watchlist_audio_episodes` carries no separate episode title or
+    summary text of its own. `covers_from_ts` (Task 4 review round 1: was
+    present on the row but unused) answers "what period does this episode
+    actually cover" -- the one question a title alone cannot.
 
     Args:
         row: One `list_watchlist_audio_episodes` row.
@@ -302,7 +349,9 @@ def _episode_description(row: Mapping[str, Any]) -> str:
         details.append(f"model: {model_used}")
     created_at = row.get("briefing_created_at") or "an unknown time"
     suffix = f" ({', '.join(details)})" if details else ""
-    return f"Briefing from {created_at}{suffix}"
+    covers_from = row.get("covers_from_ts")
+    coverage = f" Covers content since {covers_from}." if covers_from else ""
+    return f"Briefing from {created_at}{suffix}.{coverage}"
 
 
 def _published_from_briefing_created_at(value: Any) -> datetime:
@@ -345,6 +394,17 @@ def _copy_episode_audio_file(
     confirmed it via `audio_file_path_is_safe` and `.exists()` (module
     docstring, decision 2).
 
+    Task 4 review round 1: `shutil.copy2` preserves the SOURCE file's
+    permission mode along with its data, and production audio is written
+    by `Utils.private_paths.atomic_private_write_bytes` at `0o600`
+    (application-owned, private-storage semantics). Left alone, every
+    exported episode would inherit that private mode into the user's own
+    folder -- exactly what Decision 1 forbids, just applied to a file
+    instead of the directory, and defeating the entire point of exporting
+    a folder the user means to sync, zip, or serve. The explicit `chmod`
+    below relaxes it back to an ordinary, group/other-readable file
+    regardless of what the source's mode happened to be.
+
     Args:
         source_path: The episode's audio file inside `briefing_audio_dir()`.
         destination_dir: The already-validated feed directory.
@@ -365,6 +425,7 @@ def _copy_episode_audio_file(
     validated_filename = validate_filename(dest_path.name)
     dest_path = validated_parent / validated_filename
     shutil.copy2(source_path, dest_path)
+    os.chmod(dest_path, _EXPORTED_FILE_MODE)
     return dest_path
 
 
@@ -382,6 +443,16 @@ def _write_feed_xml_atomically(destination_dir: Path, xml_bytes: bytes) -> None:
     `chatbook_creator`'s per-export unique output path, `feed.xml` is a
     fixed name reused on every re-export, so leaving a stale partial in
     place would permanently wedge every future export behind `O_EXCL`.
+
+    Task 4 review round 1: the partial used to be opened at `0o600` (copied
+    from the `chatbook_creator` precedent verbatim, without noticing that
+    precedent's own file is APPLICATION-owned, unlike this one) -- and
+    `os.replace` preserves the replaced-in file's mode, so every exported
+    `feed.xml` inherited that private mode into the user's folder. Opened
+    at `_EXPORTED_FILE_MODE` (`0o644`) instead, with an explicit `fchmod`
+    right after creation so the result is deterministic regardless of the
+    calling process's umask -- the same defensive-`fchmod` idiom
+    `chatbook_creator._create_zip_archive` itself uses for its own mode.
 
     Args:
         destination_dir: The validated feed directory (already confirmed to
@@ -411,8 +482,10 @@ def _write_feed_xml_atomically(destination_dir: Path, xml_bytes: bytes) -> None:
     try:
         flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
         flags |= getattr(os, "O_NOFOLLOW", 0)
-        file_fd = os.open(partial_path, flags, 0o600)
+        file_fd = os.open(partial_path, flags, _EXPORTED_FILE_MODE)
         partial_created = True
+        if hasattr(os, "fchmod"):
+            os.fchmod(file_fd, _EXPORTED_FILE_MODE)
         with os.fdopen(file_fd, "wb") as stream:
             file_fd = -1  # ownership transferred to the stream
             stream.write(xml_bytes)
@@ -507,7 +580,8 @@ def export_feed_directory(
         # Decision 2 (module docstring): the safety check is the FIRST
         # thing done with a DB-sourced file_path -- before Path(...),
         # .exists(), or any copy -- exactly the order phase 2b's Qodo round
-        # established for playback (artifacts_pane.py:370-381).
+        # established for playback (artifacts_pane.py's own
+        # handle_play_audio_requested).
         if not audio_file_path_is_safe(file_path):
             skipped.append(f"audio {audio_id}: file path failed the safety check")
             continue
@@ -517,22 +591,38 @@ def export_feed_directory(
             skipped.append(f"audio {audio_id}: source file no longer exists")
             continue
 
+        # Parsed before the copy so a malformed timestamp never leaves a
+        # copied-but-never-listed orphan file behind in the user's
+        # destination directory -- fail fast on bad metadata first.
+        raw_created_at = row.get("briefing_created_at")
+        try:
+            published = _published_from_briefing_created_at(raw_created_at)
+        except ValueError:
+            skipped.append(
+                f"audio {audio_id}: briefing_created_at {raw_created_at!r} "
+                "is not a recognized timestamp"
+            )
+            continue
+
         try:
             filename = _episode_filename(row, source_path)
             dest_path = _copy_episode_audio_file(
                 source_path, validated_destination, filename
             )
             length_bytes = dest_path.stat().st_size
-            published = _published_from_briefing_created_at(
-                row.get("briefing_created_at")
+        except OSError as exc:
+            skipped.append(
+                f"audio {audio_id}: could not copy the audio file "
+                f"({type(exc).__name__})"
             )
-        except (OSError, ValueError) as exc:
-            skipped.append(f"audio {audio_id}: {type(exc).__name__}")
+            continue
+        except ValueError as exc:
+            skipped.append(f"audio {audio_id}: {exc}")
             continue
 
         episodes.append(
             FeedEpisode(
-                title=str(row.get("preset_name") or f"Episode {audio_id}"),
+                title=_episode_title(row, published),
                 filename=filename,
                 length_bytes=length_bytes,
                 duration_seconds=row.get("duration_seconds"),

--- a/tldw_chatbook/Subscriptions/briefing_export.py
+++ b/tldw_chatbook/Subscriptions/briefing_export.py
@@ -1,26 +1,80 @@
-"""Export a briefing as a self-contained markdown document (spec #2 phase 3,
-Task 1).
+"""Export a briefing as markdown, and a watchlist's audio as a podcast feed
+directory (spec #2 phase 3, Tasks 1 and 4).
 
-The UI's `#artifacts-toolbar` Export button (`UI/Watchlists_Modules/
-artifacts_pane.py`) lets a user save the SELECTED briefing's body to a file
-of their own choosing, through a `FileSave` dialog (`WatchlistsCollections
-Screen.handle_export_briefing_requested`). This module is the pure half of
-that flow: turning a `briefings` row into the document text, and turning
-arbitrary (user- or model-authored) text into a filesystem-safe name. It
-does no I/O of its own -- the screen validates the chosen destination
-(`Utils.path_validation.validate_path_simple`) and writes the file, off the
-event loop, itself.
+**Markdown half (Task 1).** The UI's `#artifacts-toolbar` Export button
+(`UI/Watchlists_Modules/artifacts_pane.py`) lets a user save the SELECTED
+briefing's body to a file of their own choosing, through a `FileSave`
+dialog (`WatchlistsCollectionsScreen.handle_export_briefing_requested`).
+`briefing_markdown_document`/`default_briefing_filename` are the pure half
+of that flow: turning a `briefings` row into the document text, and
+turning arbitrary (user- or model-authored) text into a filesystem-safe
+name. They do no I/O of their own -- the screen validates the chosen
+destination (`Utils.path_validation.validate_path_simple`) and writes the
+file, off the event loop, itself.
 
-`safe_export_stem` is reused verbatim by Task 4's feed-directory writer for
-episode filenames, so its contract (alnum/space/-/_ only, a caller-supplied
+`safe_export_stem` is reused verbatim by the feed half below for episode
+filenames, so its contract (alnum/space/-/_ only, a caller-supplied
 fallback when nothing survives) is load-bearing for both callers, not just
 this one.
+
+**Feed half (Task 4).** `export_feed_directory` copies a watchlist's audio
+episodes out of the private `briefing_audio_dir()` into a directory the
+user chose (through Task 5's `ExportFeedRequested` flow), alongside a
+`feed.xml` RSS document built by `briefing_feed.build_feed_xml`. Unlike the
+markdown half above, this DOES do its own I/O -- validating the
+destination, copying files, and writing `feed.xml` atomically -- because
+the deliverable here is several files landing together, not one screen
+writing one file. Three decisions from the phase 3 plan are load-bearing
+for this half specifically:
+
+1. **Never route the destination through `Utils/private_paths.py`.**
+   `secure_private_directory(..., application_owned=True)` chmods its
+   target to `0o700` and raises when not application-owned;
+   `create_private_text` opens `"xb"` and refuses to overwrite. Both are
+   for APPLICATION-owned storage (`briefing_audio_dir()` itself is exactly
+   such a caller). The export destination is the user's OWN folder --
+   applying either helper to it would chmod a directory that isn't ours to
+   chmod, and fail every re-export. `Utils.path_validation.
+   validate_path_simple` plus plain stdlib writes are used instead, the
+   same split `UI/STTS_Window.py:4040` and `UI/library_screen.py:6486`
+   already make for other user-chosen destinations.
+2. **`audio_file_path_is_safe` (imported from `UI.Watchlists_Modules.
+   artifacts_pane`, not re-derived) runs BEFORE any filesystem access on a
+   `file_path` read from the DB.** Phase 2b's Qodo round established this
+   order for playback (`artifacts_pane.py:370-381`) precisely because nothing
+   enforces at the schema level that a stored path is safe. Export copies a
+   file OUT of private storage, so getting this order wrong here is a wider
+   hole than the playback bug was -- see `export_feed_directory`'s own
+   per-episode loop, where the safety check is the very first thing done
+   with `file_path`, before `Path(...)`, `.exists()`, or any copy.
+3. **One bad episode is skipped, not fatal.** An unsafe path or a vanished
+   source file is recorded as a reason string in `FeedExportResult.skipped`
+   and the rest of the export continues -- CLAUDE.md's Error-handling ethos
+   (silence is never a state) applied to "one of many episodes broke",
+   which is an honest partial success, not a reason to hand the user
+   nothing at all.
 """
 
 from __future__ import annotations
 
+import os
+import shutil
 from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+from loguru import logger
+
+from ..Utils.path_validation import validate_filename, validate_path_simple
+from .briefing_feed import FeedEpisode, build_feed_xml
+
+# Task 4, Decision 2 above: imported, not re-derived -- this repo's rule for
+# a stored `file_path` is exactly one function, so playback and export both
+# defer to it rather than growing a second copy of the same check that could
+# silently drift from the first.
+from ..UI.Watchlists_Modules.artifacts_pane import audio_file_path_is_safe
 
 
 class BriefingExportError(RuntimeError):
@@ -75,9 +129,11 @@ def _coverage_window(briefing: Mapping[str, Any]) -> str:
 
     Mirrors `artifacts_pane._window_text`'s own two-part shape (the
     `covers_from_ts` floor and the `covers_through_item_id` watermark), but
-    is not that function: this module is beneath the UI layer (Subscriptions
-    imports nothing from `UI/`), so the string is rebuilt here from the same
-    two columns rather than importing a private UI helper.
+    is not that function: `_window_text` is a private UI helper, not a
+    shared security check, so it is not worth this module's one narrow,
+    Task-4-only import of `audio_file_path_is_safe` (see the module
+    docstring's "Feed half" section for why THAT import is warranted). The
+    string is rebuilt here from the same two columns instead.
     """
     parts: list[str] = []
     covers_from = briefing.get("covers_from_ts")
@@ -166,3 +222,338 @@ def default_briefing_filename(
     fallback = f"briefing-{briefing_id}" if briefing_id is not None else "briefing"
     stem = safe_export_stem(stem_source, fallback=fallback)
     return f"{stem}.md"
+
+
+# --- Feed half (Task 4): writing the feed directory ------------------------
+
+#: `feed.xml`'s own atomic-write pair -- see `_write_feed_xml_atomically`.
+_FEED_XML_NAME = "feed.xml"
+_FEED_XML_PARTIAL_NAME = "feed.xml.partial"
+
+
+@dataclass(frozen=True)
+class FeedExportResult:
+    """The outcome of one `export_feed_directory` call.
+
+    A partial export (some episodes skipped) is a successful result, not an
+    exception -- see the module docstring's numbered decision 3. Only a
+    failure that leaves the directory with no usable `feed.xml` at all (a
+    bad destination, or the atomic write itself failing) raises.
+
+    Attributes:
+        directory: The validated, resolved destination directory the feed
+            was written into.
+        episode_count: How many episodes made it into `feed.xml`.
+        skipped: One human-readable reason per episode that did NOT make
+            it in -- naming the episode's `audio_id` and why (an unsafe
+            path, a vanished file, or a copy failure).
+    """
+
+    directory: Path
+    episode_count: int
+    skipped: list[str]
+
+
+def _episode_filename(row: Mapping[str, Any], source_path: Path) -> str:
+    """The exported filename for one episode's audio file.
+
+    `safe_export_stem` (above, Task 1) turns the row's `preset_name` into a
+    filesystem-safe stem; the `audio_id` is always appended so two
+    briefings that happen to share a preset name -- or both fall back to
+    `safe_export_stem`'s fallback -- can never collide on disk.
+
+    Args:
+        row: One `list_watchlist_audio_episodes` row.
+        source_path: The episode's audio file, already confirmed safe and
+            present. Only its suffix (extension) is reused.
+
+    Returns:
+        A bare filename (no path separator), e.g. `"two-host-debate-42.wav"`.
+    """
+    audio_id = row.get("audio_id")
+    stem = safe_export_stem(
+        str(row.get("preset_name") or ""), fallback=f"episode-{audio_id}"
+    )
+    suffix = source_path.suffix or ".wav"
+    return f"{stem}-{audio_id}{suffix}"
+
+
+def _episode_description(row: Mapping[str, Any]) -> str:
+    """One episode's `<description>` text.
+
+    Mirrors `_coverage_window`'s "a status IS the observability" spirit at
+    episode grain: a listener choosing between episodes in a podcast client
+    sees the render's preset context (turn count, model), not just a bare
+    date, since `list_watchlist_audio_episodes` carries no separate episode
+    title or summary text of its own.
+
+    Args:
+        row: One `list_watchlist_audio_episodes` row.
+
+    Returns:
+        A one-line human-readable description.
+    """
+    details: list[str] = []
+    turn_count = row.get("turn_count")
+    if turn_count:
+        details.append(f"{turn_count} turns")
+    model_used = row.get("model_used")
+    if model_used:
+        details.append(f"model: {model_used}")
+    created_at = row.get("briefing_created_at") or "an unknown time"
+    suffix = f" ({', '.join(details)})" if details else ""
+    return f"Briefing from {created_at}{suffix}"
+
+
+def _published_from_briefing_created_at(value: Any) -> datetime:
+    """A `briefings.created_at` SQLite timestamp as an aware UTC `datetime`.
+
+    SQLite's `CURRENT_TIMESTAMP` default has no explicit timezone, and this
+    database's convention is that it is always UTC -- see `briefing_feed`'s
+    module docstring, "All timestamps must be timezone-aware". A naive
+    value passed straight through would make `build_feed_xml` raise on
+    purpose rather than silently mis-schedule playback, so `timezone.utc`
+    is attached explicitly, once, here.
+
+    Args:
+        value: `row["briefing_created_at"]`, expected in SQLite's
+            `"YYYY-MM-DD HH:MM:SS"` form.
+
+    Returns:
+        The parsed timestamp, tagged `timezone.utc`.
+
+    Raises:
+        ValueError: `value` is not in the expected format. The caller
+            treats this as one bad episode (see decision 3), not a fatal
+            error for the whole export.
+    """
+    naive = datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S")
+    return naive.replace(tzinfo=timezone.utc)
+
+
+def _copy_episode_audio_file(
+    source_path: Path, destination_dir: Path, filename: str
+) -> Path:
+    """Copy one episode's audio file into the feed directory.
+
+    Follows the exact validate-then-copy order `UI/STTS_Window.py:4040-4049`
+    uses for its own user-chosen export destination: validate the full
+    destination path, validate its parent exists and resolve it (catches a
+    symlink swapped in after the caller's own directory-level validation),
+    validate the bare filename, THEN copy. `source_path` is not
+    re-validated here -- by the time this is called, the caller has already
+    confirmed it via `audio_file_path_is_safe` and `.exists()` (module
+    docstring, decision 2).
+
+    Args:
+        source_path: The episode's audio file inside `briefing_audio_dir()`.
+        destination_dir: The already-validated feed directory.
+        filename: The bare filename to write within `destination_dir`.
+
+    Returns:
+        The validated path the file was copied to.
+
+    Raises:
+        ValueError: `destination_dir / filename` fails validation.
+        OSError: The copy itself fails.
+    """
+    dest_path = destination_dir / filename
+    validate_path_simple(dest_path, require_exists=False)
+    validated_parent = validate_path_simple(
+        dest_path.parent, require_exists=True
+    ).resolve()
+    validated_filename = validate_filename(dest_path.name)
+    dest_path = validated_parent / validated_filename
+    shutil.copy2(source_path, dest_path)
+    return dest_path
+
+
+def _write_feed_xml_atomically(destination_dir: Path, xml_bytes: bytes) -> None:
+    """Write `feed.xml` so a crash mid-write never corrupts a valid one.
+
+    The `Chatbooks/chatbook_creator.py:1506` `_create_zip_archive` recipe,
+    applied to a flat byte string instead of a zip stream: open the partial
+    exclusively (`O_EXCL` -- never silently overwrite a concurrent writer;
+    `O_NOFOLLOW` -- never follow a symlink planted at the partial's name),
+    write, `flush()` + `fsync()` to force the bytes to disk, then
+    `os.replace` -- atomic on every platform this app ships on -- to
+    publish it under the real name. A stale partial left behind by a
+    previous crash is removed first (best-effort): unlike
+    `chatbook_creator`'s per-export unique output path, `feed.xml` is a
+    fixed name reused on every re-export, so leaving a stale partial in
+    place would permanently wedge every future export behind `O_EXCL`.
+
+    Args:
+        destination_dir: The validated feed directory (already confirmed to
+            exist by the caller).
+        xml_bytes: The complete RSS document from `build_feed_xml`.
+
+    Raises:
+        OSError: The write or the final `os.replace` fails. Unlike a single
+            episode's copy failure, this is NOT swallowed into `skipped` --
+            a feed directory with no `feed.xml` is not a partial export, it
+            is not an export at all (module docstring, decision 3's carve-out).
+    """
+    final_path = destination_dir / _FEED_XML_NAME
+    partial_path = destination_dir / _FEED_XML_PARTIAL_NAME
+
+    try:
+        if partial_path.exists():
+            partial_path.unlink()
+    except OSError as exc:
+        logger.warning(
+            "Feed export: could not remove a stale partial feed ({}).",
+            type(exc).__name__,
+        )
+
+    file_fd = -1
+    partial_created = False
+    try:
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        file_fd = os.open(partial_path, flags, 0o600)
+        partial_created = True
+        with os.fdopen(file_fd, "wb") as stream:
+            file_fd = -1  # ownership transferred to the stream
+            stream.write(xml_bytes)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(partial_path, final_path)
+        partial_created = False
+    finally:
+        if file_fd >= 0:
+            os.close(file_fd)
+        if partial_created:
+            try:
+                if partial_path.is_file():
+                    partial_path.unlink()
+            except OSError as exc:
+                logger.warning(
+                    "Feed export: could not remove the partial feed after a "
+                    "failed write ({}).",
+                    type(exc).__name__,
+                )
+
+
+def export_feed_directory(
+    db: Any,
+    watchlist_id: int,
+    *,
+    destination: Path,
+    watchlist_name: str,
+    now: datetime,
+) -> FeedExportResult:
+    """Write a watchlist's audio episodes as a self-contained podcast feed.
+
+    The deliverable this whole spec exists to produce: a folder containing
+    `feed.xml` plus a copy of every playable episode's audio, ready to hand
+    to a podcast client, sync, or zip up as-is (`briefing_feed`'s module
+    docstring -- enclosure URLs are bare relative filenames for exactly this
+    reason).
+
+    Per-episode failures (an unsafe `file_path`, a vanished source file, a
+    copy that raises) are never fatal to the whole export -- each is
+    recorded as a reason in the returned `FeedExportResult.skipped` and the
+    remaining episodes still export (module docstring, decision 3). The
+    safety check on each episode's `file_path` runs before ANY filesystem
+    access on it (decision 2) -- no `Path(...)`, `.exists()`, `.stat()`, or
+    `shutil.copy2` until `audio_file_path_is_safe` has passed.
+
+    Args:
+        db: An open `SubscriptionsDB`.
+        watchlist_id: Passed straight to `list_watchlist_audio_episodes`.
+        destination: The user-chosen directory to export into. Must already
+            exist (a `SelectDirectory` dialog, Task 5, only ever dismisses
+            with an existing directory or `None`) -- validated with
+            `Utils.path_validation.validate_path_simple` before anything
+            else runs, so a hostile or malformed path raises before the DB
+            is even queried. NEVER routed through `Utils/private_paths.py`
+            (module docstring, decision 1): this is the user's own folder,
+            not application-owned storage.
+        watchlist_name: Display name, used for the feed channel's title and
+            description.
+        now: Timestamp for the feed's `<lastBuildDate>`. Must be timezone-
+            aware -- see `briefing_feed.build_feed_xml`.
+
+    Returns:
+        `FeedExportResult` naming the resolved directory, how many episodes
+        made it into `feed.xml`, and a reason for each one that did not.
+
+    Raises:
+        ValueError: `destination` fails `validate_path_simple` (including
+            not existing).
+        FeedBuildError: `now` is naive (see `briefing_feed.build_feed_xml`).
+        OSError: `feed.xml` itself could not be written atomically. Unlike
+            a single episode's copy failure, this is fatal -- see
+            `_write_feed_xml_atomically`.
+    """
+    validated_destination = validate_path_simple(
+        destination, require_exists=True
+    ).resolve()
+
+    rows = db.list_watchlist_audio_episodes(watchlist_id)
+
+    episodes: list[FeedEpisode] = []
+    skipped: list[str] = []
+
+    for row in rows:
+        audio_id = row.get("audio_id")
+        file_path = row.get("file_path")
+
+        if not file_path:
+            skipped.append(f"audio {audio_id}: no file path recorded")
+            continue
+
+        # Decision 2 (module docstring): the safety check is the FIRST
+        # thing done with a DB-sourced file_path -- before Path(...),
+        # .exists(), or any copy -- exactly the order phase 2b's Qodo round
+        # established for playback (artifacts_pane.py:370-381).
+        if not audio_file_path_is_safe(file_path):
+            skipped.append(f"audio {audio_id}: file path failed the safety check")
+            continue
+
+        source_path = Path(file_path)
+        if not source_path.exists():
+            skipped.append(f"audio {audio_id}: source file no longer exists")
+            continue
+
+        try:
+            filename = _episode_filename(row, source_path)
+            dest_path = _copy_episode_audio_file(
+                source_path, validated_destination, filename
+            )
+            length_bytes = dest_path.stat().st_size
+            published = _published_from_briefing_created_at(
+                row.get("briefing_created_at")
+            )
+        except (OSError, ValueError) as exc:
+            skipped.append(f"audio {audio_id}: {type(exc).__name__}")
+            continue
+
+        episodes.append(
+            FeedEpisode(
+                title=str(row.get("preset_name") or f"Episode {audio_id}"),
+                filename=filename,
+                length_bytes=length_bytes,
+                duration_seconds=row.get("duration_seconds"),
+                published=published,
+                guid=f"briefing-audio-{audio_id}",
+                description=_episode_description(row),
+            )
+        )
+
+    xml_bytes = build_feed_xml(
+        channel_title=f"{watchlist_name} — Audio Briefings",
+        channel_description=(
+            f'Audio briefings generated from the "{watchlist_name}" watchlist.'
+        ),
+        episodes=episodes,
+        now=now,
+    )
+    _write_feed_xml_atomically(validated_destination, xml_bytes)
+
+    return FeedExportResult(
+        directory=validated_destination,
+        episode_count=len(episodes),
+        skipped=skipped,
+    )

--- a/tldw_chatbook/Subscriptions/briefing_export.py
+++ b/tldw_chatbook/Subscriptions/briefing_export.py
@@ -24,8 +24,10 @@ user chose (through Task 5's `ExportFeedRequested` flow), alongside a
 markdown half above, this DOES do its own I/O -- validating the
 destination, copying files, and writing `feed.xml` atomically -- because
 the deliverable here is several files landing together, not one screen
-writing one file. Three decisions from the phase 3 plan are load-bearing
-for this half specifically:
+writing one file. Five decisions are load-bearing for this half
+specifically: the first three from the phase 3 plan, the fourth (full
+pagination) from this whole-branch review, and the fifth (`0o644`
+permissions) from Task 4's own review round 1:
 
 1. **Never route the destination through `Utils/private_paths.py`.**
    `secure_private_directory(..., application_owned=True)` chmods its
@@ -59,7 +61,20 @@ for this half specifically:
    (silence is never a state) applied to "one of many episodes broke",
    which is an honest partial success, not a reason to hand the user
    nothing at all.
-4. **Exported files get a fixed `0o644`, deliberately ignoring umask.**
+4. **The full watchlist is exported, never silently capped.**
+   `list_watchlist_audio_episodes` defaults its own `limit` to 500 rows
+   per call (CLAUDE.md's pagination rule, for callers that only want one
+   page); a feed export needs EVERY episode, so `export_feed_directory`
+   walks pages (`_EPISODES_PAGE_SIZE` at a time) until the accessor
+   returns an empty page, rather than a single bounded call. Whole-branch
+   review: the original single unbounded call silently truncated at 500
+   and recorded nothing in `skipped` for episode 501+ -- the exact
+   "success toast lies about scope" failure decision 3 above exists to
+   rule out for a single bad episode, just at a coarser grain (an entire
+   tail of episodes, not one). `_EPISODES_PAGE_SIZE` is a module attribute
+   (not an inline literal) specifically so a test can shrink it and
+   exercise the pagination loop without seeding hundreds of real rows.
+5. **Exported files get a fixed `0o644`, deliberately ignoring umask.**
    Audio in `briefing_audio_dir()` is written `0o600` by
    `atomic_private_write_bytes`, and `shutil.copy2` would carry that mode
    into the user's folder -- which silently breaks the entire deliverable:
@@ -248,6 +263,16 @@ def default_briefing_filename(
 _FEED_XML_NAME = "feed.xml"
 _FEED_XML_PARTIAL_NAME = "feed.xml.partial"
 
+#: Whole-branch review (FIX B): `list_watchlist_audio_episodes` defaults
+#: its own `limit` to 500, and the original single unbounded call here
+#: silently dropped episode 501+ with no record in `skipped`. Matches that
+#: same default so a typical watchlist (well under one page) still costs
+#: exactly one query; `export_feed_directory` below pages through as many
+#: calls as it takes to exhaust every episode. A module attribute (not an
+#: inline literal) so a test can shrink it and exercise the pagination
+#: loop itself without seeding hundreds of real rows.
+_EPISODES_PAGE_SIZE = 500
+
 #: Task 4 review round 1: the mode every file this module WRITES into the
 #: user's export directory ends up at -- an ordinary, group/other-readable
 #: file, deliberately NOT the `0o600` private-storage mode `briefing_audio_
@@ -300,7 +325,14 @@ def _episode_filename(row: Mapping[str, Any], source_path: Path) -> str:
             present. Only its suffix (extension) is reused.
 
     Returns:
-        A bare filename (no path separator), e.g. `"two-host-debate-42.wav"`.
+        A bare filename (no path separator), e.g. `"Two Host Debate-42.wav"`
+        for a `preset_name` of `"Two Host Debate"` and `audio_id` `42` --
+        `safe_export_stem` keeps spaces and original casing verbatim (see
+        its own docstring), it does not slugify. Whole-branch review (FIX
+        D): this docstring previously showed a slugified, lowercase-hyphen
+        example (`"two-host-debate-42.wav"`) that described away the exact
+        real-space property `briefing_feed.build_feed_xml` must
+        percent-encode at the `<enclosure>` URL.
     """
     audio_id = row.get("audio_id")
     stem = safe_export_stem(
@@ -547,9 +579,17 @@ def export_feed_directory(
     access on it (decision 2) -- no `Path(...)`, `.exists()`, `.stat()`, or
     `shutil.copy2` until `audio_file_path_is_safe` has passed.
 
+    Every episode is fetched, not just the first `_EPISODES_PAGE_SIZE` of
+    them (module docstring, decision 4) -- `list_watchlist_audio_episodes`
+    is paged through until exhausted, so a watchlist with more episodes
+    than one page is exported (and reported) in full rather than silently
+    truncated.
+
     Args:
         db: An open `SubscriptionsDB`.
-        watchlist_id: Passed straight to `list_watchlist_audio_episodes`.
+        watchlist_id: Passed straight to `list_watchlist_audio_episodes`,
+            paged through in `_EPISODES_PAGE_SIZE`-row chunks until
+            exhausted.
         destination: The user-chosen directory to export into. Must already
             exist (a `SelectDirectory` dialog, Task 5, only ever dismisses
             with an existing directory or `None`) -- validated with
@@ -579,7 +619,22 @@ def export_feed_directory(
         destination, require_exists=True
     ).resolve()
 
-    rows = db.list_watchlist_audio_episodes(watchlist_id)
+    # FIX B (whole-branch review): page through every episode rather than
+    # one bounded call -- `list_watchlist_audio_episodes` defaults to a
+    # 500-row page, and a single call silently truncated any watchlist
+    # with more episodes than that, with the tail recorded nowhere. Walks
+    # until the accessor returns an empty page, so the query cost for a
+    # typical (well-under-one-page) watchlist is still exactly one call.
+    rows: list[Mapping[str, Any]] = []
+    offset = 0
+    while True:
+        page = db.list_watchlist_audio_episodes(
+            watchlist_id, limit=_EPISODES_PAGE_SIZE, offset=offset
+        )
+        if not page:
+            break
+        rows.extend(page)
+        offset += _EPISODES_PAGE_SIZE
 
     episodes: list[FeedEpisode] = []
     skipped: list[str] = []

--- a/tldw_chatbook/Subscriptions/briefing_feed.py
+++ b/tldw_chatbook/Subscriptions/briefing_feed.py
@@ -33,6 +33,24 @@ home directory into a file they distribute. `build_feed_xml` enforces this
 by rejecting any `FeedEpisode.filename` containing a path separator before
 emitting anything.
 
+**Enclosure URLs are percent-encoded at emission -- the on-disk filename is
+not.** Whole-branch review: `FeedEpisode.filename` comes from Task 4's
+`safe_export_stem`, which deliberately KEEPS spaces (pinned by
+`test_stem_keeps_ordinary_characters` for its other caller, the Markdown
+export's save-dialog filename) and, via `str.isalnum()`, also admits
+non-ASCII letters. A raw space in a URI reference is forbidden by RFC 3986;
+a podcast client that sends it in the request line verbatim rather than
+percent-encoding it on resolve gets a 400 and the episode never downloads.
+The fix is applied ONLY where the filename becomes a URL -- `urllib.parse.
+quote` wraps `episode.filename` when it is set as the `enclosure`'s `url`
+attribute below -- never to `FeedEpisode.filename` itself or to any file
+`Task 4` writes to disk: every static file server (including stdlib
+`http.server`, the one this app's docs point users at) unquotes a request
+path before looking up the file, so the file keeps its human-readable,
+space-containing name on disk and the feed stays a valid URI reference.
+`safe_export_stem` itself is untouched -- its space-keeping behavior is
+correct for its other caller.
+
 **All timestamps must be timezone-aware.** `email.utils.format_datetime`
 does *not* treat a naive `datetime` as local time -- it emits the correct
 wall-clock digits tagged `-0000` (RFC 2822's "unverified offset"). The real
@@ -45,6 +63,17 @@ than quietly coercing to UTC (a caller passing naive input has a bug worth
 surfacing, not hiding). **For Task 4:** SQLite's `CURRENT_TIMESTAMP` column
 is UTC but comes back as a naive string -- attach `timezone.utc` explicitly
 when parsing it into a `datetime` for this module.
+
+**`<channel>` carries a `<link>`.** RSS 2.0 requires `title`, `link` and
+`description` on every channel, and validators (and Apple's podcast
+requirements) flag its absence. There is no server URL to point at --
+serving the exported folder is the user's own choice (see the Docs/User
+Guide's own "serve it yourself" note), so this module does not invent one.
+`<link>` is set to `"feed.xml"`, the feed's own filename, as a relative
+reference -- consistent with the whole directory being self-contained
+(episodes are already referenced by bare relative filename, above). This
+must match `briefing_export._FEED_XML_NAME`, the literal name Task 4 writes
+the returned bytes to.
 """
 
 from __future__ import annotations
@@ -54,6 +83,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from email.utils import format_datetime
 from typing import Sequence
+from urllib.parse import quote
 
 _ITUNES_NS = "http://www.itunes.com/dtds/podcast-1.0.dtd"
 _ITUNES_DURATION_TAG = f"{{{_ITUNES_NS}}}duration"
@@ -82,9 +112,15 @@ class FeedEpisode:
     Attributes:
         title: Episode title, emitted verbatim as the `<item>`'s `<title>`.
         filename: Bare relative filename of the episode's audio file within
-            the feed directory (e.g. `"script-1-audio-2.wav"`). Must not
-            contain a path separator (`/` or `\\`) -- :func:`build_feed_xml`
-            raises :class:`FeedBuildError` if it does.
+            the feed directory (e.g. `"script-1-audio-2.wav"`, or
+            `"Two Host Debate-42.wav"` -- Task 4's `safe_export_stem`
+            deliberately keeps spaces). Must not contain a path separator
+            (`/` or `\\`) -- :func:`build_feed_xml` raises
+            :class:`FeedBuildError` if it does. Stored and emitted to disk
+            exactly as given; :func:`build_feed_xml` percent-encodes a
+            COPY of it for the `<enclosure>`'s `url` attribute only (see
+            the module docstring) -- this field itself is never
+            percent-encoded.
         length_bytes: Size of the audio file in bytes, emitted as the
             `<enclosure>`'s `length` attribute.
         duration_seconds: Playback duration in seconds, or `None` if
@@ -169,6 +205,11 @@ def build_feed_xml(
     channel = ET.SubElement(rss, "channel")
 
     ET.SubElement(channel, "title").text = channel_title
+    # RFC 2822/RSS-2.0 conventional order is title, link, description. A
+    # relative reference to the feed's own filename -- there is no server
+    # URL to point at; see the module docstring's "<channel> carries a
+    # <link>" section. Must match `briefing_export._FEED_XML_NAME`.
+    ET.SubElement(channel, "link").text = "feed.xml"
     ET.SubElement(channel, "description").text = channel_description
     ET.SubElement(channel, "lastBuildDate").text = format_datetime(now)
 
@@ -182,7 +223,16 @@ def build_feed_xml(
         ET.SubElement(item, "pubDate").text = format_datetime(episode.published)
 
         enclosure = ET.SubElement(item, "enclosure")
-        enclosure.set("url", episode.filename)
+        # Percent-encode HERE ONLY -- `episode.filename` itself (and the
+        # file Task 4 writes to disk under that exact name) is never
+        # touched. `safe_export_stem` deliberately keeps spaces and,
+        # via `str.isalnum()`, admits non-ASCII letters too; RFC 3986
+        # forbids a raw space in a URI reference, so a client that does
+        # not percent-encode on resolve would send it verbatim and get a
+        # 400. `safe=""` encodes every character outside the unreserved
+        # set (the guard above already rules out `/`, so there is nothing
+        # this would need to leave alone).
+        enclosure.set("url", quote(episode.filename, safe=""))
         enclosure.set("length", str(episode.length_bytes))
         enclosure.set("type", "audio/wav")
 

--- a/tldw_chatbook/Subscriptions/briefing_feed.py
+++ b/tldw_chatbook/Subscriptions/briefing_feed.py
@@ -1,0 +1,174 @@
+"""Build a self-contained podcast RSS feed from a watchlist's audio episodes
+(spec #2 phase 3, Task 3).
+
+Task 2's `SubscriptionsDB.list_watchlist_audio_episodes` finds the rows;
+Task 4 turns each row into a `FeedEpisode`, calls :func:`build_feed_xml`, and
+writes the result to `feed.xml` alongside a copy of each episode's audio
+file. This module does neither of those things -- it has no filesystem
+access and no ambient clock, only pure data in and `bytes` out, which is
+what makes it deterministic and unit-testable without a database or a temp
+directory.
+
+**No `feedgen`.** A survey for phase 3 confirmed nothing in the repo
+generates RSS today (`rss_feed_generator.py` was deliberately deleted; the
+`feedparser` dependency is declared but imported nowhere), so this is
+written from scratch with stdlib `xml.etree.ElementTree`, following the
+`SubElement` + `tostring` precedent at
+`Web_Scraping/Article_Extractor_Lib.py:1141-1152`. A new third-party
+dependency here would inherit phase 2b's three-job CI edit for no benefit.
+`defusedxml` hardens *parsing*, not generation, so it adds nothing to a
+module that only ever writes XML.
+
+**Escaping is ElementTree's job.** Every piece of caller-supplied text
+(titles, descriptions -- ultimately model output derived from remote feed
+content) is set via an element's `.text` attribute and left to
+`ET.tostring` to escape. Nothing in this module hand-escapes `&`, `<`, `>`
+or `]]>`.
+
+**Enclosure URLs are bare relative filenames, never absolute paths.** The
+feed directory Task 4 writes is meant to be self-contained and shareable --
+a user may hand the whole folder to a podcast client, sync it, or zip it up.
+An absolute path would both break on any other machine and leak the user's
+home directory into a file they distribute. `build_feed_xml` enforces this
+by rejecting any `FeedEpisode.filename` containing a path separator before
+emitting anything.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import datetime
+from email.utils import format_datetime
+from typing import Sequence
+
+_ITUNES_NS = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+_ITUNES_DURATION_TAG = f"{{{_ITUNES_NS}}}duration"
+
+# Registering the prefix (rather than leaving ElementTree to invent "ns0")
+# only affects how `itunes:duration` elements are *rendered* -- it has no
+# bearing on parsing, which always resolves by URI regardless of prefix.
+ET.register_namespace("itunes", _ITUNES_NS)
+
+
+class FeedBuildError(RuntimeError):
+    """Raised when episode data cannot be turned into a valid feed.
+
+    Currently raised for exactly one reason: an episode's `filename`
+    contains a path separator, which would let the feed reference a file
+    outside its own directory.
+    """
+
+
+@dataclass(frozen=True)
+class FeedEpisode:
+    """One podcast episode, shaped from a `list_watchlist_audio_episodes` row.
+
+    Attributes:
+        title: Episode title, emitted verbatim as the `<item>`'s `<title>`.
+        filename: Bare relative filename of the episode's audio file within
+            the feed directory (e.g. `"script-1-audio-2.wav"`). Must not
+            contain a path separator (`/` or `\\`) -- :func:`build_feed_xml`
+            raises :class:`FeedBuildError` if it does.
+        length_bytes: Size of the audio file in bytes, emitted as the
+            `<enclosure>`'s `length` attribute.
+        duration_seconds: Playback duration in seconds, or `None` if
+            unknown. Emitted as `<itunes:duration>` only when present.
+        published: The episode's publication timestamp, emitted as the
+            `<item>`'s `<pubDate>` in RFC-822 form.
+        guid: A stable identifier for the episode, emitted verbatim as the
+            `<item>`'s `<guid>`.
+        description: Episode description text, emitted verbatim as the
+            `<item>`'s `<description>`.
+    """
+
+    title: str
+    filename: str
+    length_bytes: int
+    duration_seconds: float | None
+    published: datetime
+    guid: str
+    description: str
+
+
+def build_feed_xml(
+    *,
+    channel_title: str,
+    channel_description: str,
+    episodes: Sequence[FeedEpisode],
+    now: datetime,
+) -> bytes:
+    """Build a self-contained RSS 2.0 podcast feed as UTF-8 encoded bytes.
+
+    Pure and deterministic: no filesystem access, no `datetime.now()` --
+    `now` is the caller's injected timestamp for the channel's
+    `<lastBuildDate>`. Every episode's `filename` is validated *before* any
+    XML is emitted, so a single bad episode fails the whole build rather
+    than silently emitting a feed that is missing it.
+
+    Args:
+        channel_title: Feed/channel title.
+        channel_description: Feed/channel description.
+        episodes: Episodes to include as `<item>` elements, emitted in the
+            order given. An empty sequence still produces a valid channel
+            with zero items.
+        now: Timestamp for the channel's `<lastBuildDate>`.
+
+    Returns:
+        The complete RSS document, UTF-8 encoded.
+
+    Raises:
+        FeedBuildError: If any episode's `filename` contains a path
+            separator (`/` or `\\`) -- naming the offending filename. A feed
+            must never reference outside its own directory.
+    """
+    for episode in episodes:
+        if "/" in episode.filename or "\\" in episode.filename:
+            raise FeedBuildError(
+                "episode filename must be a bare relative name with no "
+                f"path separator, got: {episode.filename}"
+            )
+
+    rss = ET.Element("rss", {"version": "2.0"})
+    channel = ET.SubElement(rss, "channel")
+
+    ET.SubElement(channel, "title").text = channel_title
+    ET.SubElement(channel, "description").text = channel_description
+    ET.SubElement(channel, "lastBuildDate").text = format_datetime(now)
+
+    for episode in episodes:
+        item = ET.SubElement(channel, "item")
+        ET.SubElement(item, "title").text = episode.title
+        ET.SubElement(item, "description").text = episode.description
+        guid_el = ET.SubElement(item, "guid")
+        guid_el.text = episode.guid
+        guid_el.set("isPermaLink", "false")
+        ET.SubElement(item, "pubDate").text = format_datetime(episode.published)
+
+        enclosure = ET.SubElement(item, "enclosure")
+        enclosure.set("url", episode.filename)
+        enclosure.set("length", str(episode.length_bytes))
+        enclosure.set("type", "audio/wav")
+
+        if episode.duration_seconds is not None:
+            ET.SubElement(item, _ITUNES_DURATION_TAG).text = _format_itunes_duration(
+                episode.duration_seconds
+            )
+
+    return ET.tostring(rss, encoding="utf-8")
+
+
+def _format_itunes_duration(duration_seconds: float) -> str:
+    """Format seconds as iTunes's `HH:MM:SS` duration convention.
+
+    Args:
+        duration_seconds: Non-negative duration in seconds.
+
+    Returns:
+        `"H:MM:SS"` (hours unpadded, minutes and seconds zero-padded to two
+        digits), per the iTunes podcast duration convention.
+    """
+    total_seconds = int(round(duration_seconds))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours}:{minutes:02d}:{seconds:02d}"

--- a/tldw_chatbook/Subscriptions/briefing_feed.py
+++ b/tldw_chatbook/Subscriptions/briefing_feed.py
@@ -32,6 +32,19 @@ An absolute path would both break on any other machine and leak the user's
 home directory into a file they distribute. `build_feed_xml` enforces this
 by rejecting any `FeedEpisode.filename` containing a path separator before
 emitting anything.
+
+**All timestamps must be timezone-aware.** `email.utils.format_datetime`
+does *not* treat a naive `datetime` as local time -- it emits the correct
+wall-clock digits tagged `-0000` (RFC 2822's "unverified offset"). The real
+hazard is one hop downstream: `-0000` round-trips through
+`email.utils.parsedate_to_datetime` into a *naive* result, and the common
+`dt.astimezone()` idiom then silently reinterprets those same digits as
+local time -- same digits, wrong instant. `build_feed_xml` forecloses this
+by rejecting a naive `now` or a naive `episode.published` outright rather
+than quietly coercing to UTC (a caller passing naive input has a bug worth
+surfacing, not hiding). **For Task 4:** SQLite's `CURRENT_TIMESTAMP` column
+is UTC but comes back as a naive string -- attach `timezone.utc` explicitly
+when parsing it into a `datetime` for this module.
 """
 
 from __future__ import annotations
@@ -54,9 +67,11 @@ ET.register_namespace("itunes", _ITUNES_NS)
 class FeedBuildError(RuntimeError):
     """Raised when episode data cannot be turned into a valid feed.
 
-    Currently raised for exactly one reason: an episode's `filename`
-    contains a path separator, which would let the feed reference a file
-    outside its own directory.
+    Raised when an episode's `filename` contains a path separator (which
+    would let the feed reference a file outside its own directory), or when
+    `now` or an episode's `published` is a naive `datetime` (no `tzinfo`) --
+    see the module docstring's "All timestamps must be timezone-aware"
+    section for why a naive input is rejected rather than coerced.
     """
 
 
@@ -75,7 +90,9 @@ class FeedEpisode:
         duration_seconds: Playback duration in seconds, or `None` if
             unknown. Emitted as `<itunes:duration>` only when present.
         published: The episode's publication timestamp, emitted as the
-            `<item>`'s `<pubDate>` in RFC-822 form.
+            `<item>`'s `<pubDate>` in RFC-822 form. Must be timezone-aware --
+            :func:`build_feed_xml` raises :class:`FeedBuildError` for a
+            naive value (see the module docstring).
         guid: A stable identifier for the episode, emitted verbatim as the
             `<item>`'s `<guid>`.
         description: Episode description text, emitted verbatim as the
@@ -102,9 +119,9 @@ def build_feed_xml(
 
     Pure and deterministic: no filesystem access, no `datetime.now()` --
     `now` is the caller's injected timestamp for the channel's
-    `<lastBuildDate>`. Every episode's `filename` is validated *before* any
-    XML is emitted, so a single bad episode fails the whole build rather
-    than silently emitting a feed that is missing it.
+    `<lastBuildDate>`. Every episode's `filename` and every timestamp is
+    validated *before* any XML is emitted, so a single bad episode fails the
+    whole build rather than silently emitting a feed that is missing it.
 
     Args:
         channel_title: Feed/channel title.
@@ -112,17 +129,36 @@ def build_feed_xml(
         episodes: Episodes to include as `<item>` elements, emitted in the
             order given. An empty sequence still produces a valid channel
             with zero items.
-        now: Timestamp for the channel's `<lastBuildDate>`.
+        now: Timestamp for the channel's `<lastBuildDate>`. Must be
+            timezone-aware.
 
     Returns:
         The complete RSS document, UTF-8 encoded.
 
     Raises:
-        FeedBuildError: If any episode's `filename` contains a path
-            separator (`/` or `\\`) -- naming the offending filename. A feed
-            must never reference outside its own directory.
+        FeedBuildError: If `now` is a naive `datetime` (naming `now`); if
+            any episode's `published` is a naive `datetime` (naming the
+            episode by its `guid`); or if any episode's `filename` contains
+            a path separator (`/` or `\\`, naming the offending filename) --
+            a feed must never reference outside its own directory.
     """
+    if now.tzinfo is None:
+        raise FeedBuildError(
+            "'now' must be timezone-aware (tzinfo is None); a naive value "
+            "would emit an RFC-2822 '-0000' (unverified offset) that later "
+            "round-trips into a naive datetime and silently shifts under "
+            "`.astimezone()` -- attach `timezone.utc` explicitly."
+        )
+
     for episode in episodes:
+        if episode.published.tzinfo is None:
+            raise FeedBuildError(
+                f"episode {episode.guid!r}'s `published` must be "
+                "timezone-aware (tzinfo is None); a naive value would emit "
+                "an RFC-2822 '-0000' (unverified offset) that later "
+                "round-trips into a naive datetime and silently shifts "
+                "under `.astimezone()` -- attach `timezone.utc` explicitly."
+            )
         if "/" in episode.filename or "\\" in episode.filename:
             raise FeedBuildError(
                 "episode filename must be a bare relative name with no "

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -450,6 +450,27 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # `_cast_in_flight_briefing_id` sibling, so a refusal can name the
         # script actually being synthesized.
         self._audio_in_flight_script_id: int | None = None
+        # Task 1 (phase 3): True from the moment Export is pressed until
+        # the `FileSave` dialog it pushed actually resolves -- via a real
+        # path, a cancel, or a rejected path -- not merely until the dialog
+        # is MOUNTED. Review round 1 (Important #1): a live repro (two
+        # rapid presses) produced `['FileSave', 'FileSave']` on the screen
+        # stack -- Textual stacks a second `push_screen`, it does not
+        # refuse one -- so without this flag a second press before the
+        # first dialog resolves opens a phantom second dialog, and
+        # completing both silently has the second write clobber the
+        # first's file. Claimed in `handle_export_briefing_requested`
+        # BEFORE `run_worker` (the same reason `_briefing_in_flight` is
+        # claimed before its own `run_worker`: a check made after
+        # scheduling leaves a window two presses can both pass). Cleared
+        # in `_write_briefing_export_file`'s `finally` -- not in `_push_
+        # export_briefing_dialog`, whose own `await self.app.push_screen`
+        # returns once the dialog is MOUNTED, long before the user has
+        # picked a path or cancelled -- so every resolution (success,
+        # cancel, rejected path, write failure) re-arms Export, and a
+        # failure to even OPEN the dialog clears it too (see that
+        # method's own `except`).
+        self._briefing_export_in_flight = False
         # The item currently open in the CONTENT reader (Task 4). Held here
         # for the identical reason as `_loaded_items` above: `_build_content_pane`
         # is a factory the workbench calls on every region rebuild, and a
@@ -3796,19 +3817,24 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def handle_export_briefing_requested(
         self, event: ExportBriefingRequested
     ) -> None:
-        """Answer from memory, then dispatch the `FileSave` flow.
+        """Claim the one-export-at-a-time guard, then dispatch.
 
         `ArtifactsPane.compose` already disables Export for no-selection
         and any non-`complete` status, but this handler re-checks both
         anyway: the button's disabled state and the message it posts are
-        two different frames, and (unlike a keyboard-only affordance) a
-        press already in flight when the selection changes underneath it
-        must not be trusted just because it once passed a disabled check.
-        No in-flight guard here, unlike Generate/Cast/Synthesize: exporting
-        touches no database and starts no generation, only a dialog and,
-        once a path is chosen, one file write -- there is nothing for a
-        second press to race against except the same `FileSave` dialog
-        Textual already refuses to stack twice.
+        two different frames, and a press already in flight when the
+        selection changes underneath it must not be trusted just because
+        it once passed a disabled check.
+
+        Review round 1 (Important #1): an earlier draft shipped with no
+        guard at all, reasoning that Textual "refuses to stack" a second
+        `FileSave`. A live repro of two rapid presses disproved that --
+        the screen stack ended up `['FileSave', 'FileSave']`, two live
+        dialogs, not one refused. `_briefing_export_in_flight` is claimed
+        HERE, before `run_worker` -- the same reason `_briefing_in_flight`
+        is claimed before ITS `run_worker` in `handle_generate_briefing_
+        requested`: claiming inside the worker body leaves a window where
+        two presses both pass the check before either sets the flag.
         """
         event.stop()
         briefing = self._selected_briefing
@@ -3821,12 +3847,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 markup=False,
             )
             return
+        if self._briefing_export_in_flight:
+            self._notify_watchlists(
+                "A briefing export is already in progress. Nothing else "
+                "was started.",
+                severity="warning",
+                markup=False,
+            )
+            return
         watchlist_id = briefing.get("watchlist_id")
         watchlist_name = (
             self._watchlist_display_name(watchlist_id)
             if watchlist_id is not None
             else "this watchlist"
         )
+        self._briefing_export_in_flight = True
         self.run_worker(
             self._push_export_briefing_dialog(dict(briefing), watchlist_name),
             group="wl-briefing-export",
@@ -3850,19 +3885,40 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         threaded through as a separate parameter to every downstream
         function: `briefing_markdown_document`/`default_briefing_filename`
         both read it directly off the mapping they are given.
+
+        Does NOT clear `_briefing_export_in_flight` on the ordinary
+        success path: `await self.app.push_screen(...)` returns once the
+        dialog is MOUNTED, not once the user has chosen a path or
+        cancelled -- clearing the guard here would re-open the window a
+        second press could race through while the first dialog is still
+        on screen. `_write_briefing_export_file` (the callback) is what
+        clears it, in its own `finally`, once the dialog actually
+        resolves. The guard IS cleared here on the one path that never
+        reaches that callback at all: a failure to even open the dialog.
         """
-        enriched = {**briefing, "watchlist_name": watchlist_name}
-        default_filename = default_briefing_filename(
-            enriched, watchlist_name=watchlist_name
-        )
-        await self.app.push_screen(
-            FileSave(
-                location=str(Path.home()),
-                title="Export Briefing as Markdown",
-                default_file=default_filename,
-            ),
-            callback=lambda path: self._write_briefing_export_file(path, enriched),
-        )
+        try:
+            enriched = {**briefing, "watchlist_name": watchlist_name}
+            default_filename = default_briefing_filename(
+                enriched, watchlist_name=watchlist_name
+            )
+            await self.app.push_screen(
+                FileSave(
+                    location=str(Path.home()),
+                    title="Export Briefing as Markdown",
+                    default_file=default_filename,
+                ),
+                callback=lambda path: self._write_briefing_export_file(
+                    path, enriched
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 - a worker crash exits the app
+            self._briefing_export_in_flight = False
+            logger.warning(f"Failed to open the export dialog: {type(exc).__name__}")
+            self._notify_watchlists(
+                "Could not open the export dialog.",
+                severity="error",
+                markup=False,
+            )
 
     async def _write_briefing_export_file(
         self, selected_path: Path | None, briefing: Mapping[str, Any]
@@ -3870,13 +3926,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         """Validate the chosen path, build the document, and write it.
 
         Mirrors `_write_library_note_export_file`'s validate -> write ->
-        honest-toasts shape (`library_screen.py:6445`), with two
-        deliberate differences this feature's own rules require: the write
-        itself runs in `asyncio.to_thread` (a `FileSave`-chosen destination
-        can be anywhere, including a slow or network-mounted path, so the
-        write must never block the event loop), and exception logging is
-        type-only -- never `logger.opt(exception=True)`, and never the
-        briefing body.
+        honest-toasts shape (`library_screen.py:6445`), with three
+        deliberate differences this feature's own rules (and review round
+        1) require: the write itself runs in `asyncio.to_thread` (a
+        `FileSave`-chosen destination can be anywhere, including a slow or
+        network-mounted path, so the write must never block the event
+        loop); exception logging is type-only -- never `logger.opt(
+        exception=True)`, and never the briefing body; and the write's
+        `except` is broad (`Exception`, not just `OSError`) -- review
+        round 1 (Important #2) confirmed a `UnicodeEncodeError` (entirely
+        plausible from model/feed-derived body text) escaped uncaught
+        under the narrower catch, a silent failure with no toast at all.
+        `asyncio.CancelledError` is deliberately re-raised rather than
+        caught by that broad except: a cancelled worker must not be
+        reported as a failed export.
+
+        `_briefing_export_in_flight` is cleared in `finally`, on every
+        exit path -- cancelled, rejected path, export-error, write
+        failure, or success alike -- so a cancel or a refusal never wedges
+        Export shut for the rest of the session (review round 1's own
+        re-arm requirement).
 
         Args:
             selected_path: The chosen destination, or `None` if the
@@ -3884,43 +3953,54 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             briefing: The briefing row, with `watchlist_name` merged in by
                 `_push_export_briefing_dialog`.
         """
-        if not selected_path:
-            self._notify_watchlists(
-                "Briefing export cancelled.", severity="information"
-            )
-            return
         try:
-            validated_path = validate_path_simple(selected_path, require_exists=False)
-        except ValueError as exc:
-            logger.warning(
-                f"Rejected briefing export path: {type(exc).__name__}"
-            )
+            if not selected_path:
+                self._notify_watchlists(
+                    "Briefing export cancelled.", severity="information"
+                )
+                return
+            try:
+                validated_path = validate_path_simple(
+                    selected_path, require_exists=False
+                )
+            except ValueError as exc:
+                logger.warning(
+                    f"Rejected briefing export path: {type(exc).__name__}"
+                )
+                self._notify_watchlists(
+                    f"Rejected export path: {exc}",
+                    severity="warning",
+                    markup=False,
+                )
+                return
+            try:
+                document = briefing_markdown_document(briefing)
+            except BriefingExportError as exc:
+                self._notify_watchlists(str(exc), severity="warning", markup=False)
+                return
+            try:
+                await asyncio.to_thread(
+                    validated_path.write_text, document, encoding="utf-8"
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    f"Briefing export write failed: {type(exc).__name__}"
+                )
+                self._notify_watchlists(
+                    f"Error exporting briefing: {type(exc).__name__}",
+                    severity="error",
+                    markup=False,
+                )
+                return
             self._notify_watchlists(
-                f"Rejected export path: {exc}", severity="warning", markup=False,
-            )
-            return
-        try:
-            document = briefing_markdown_document(briefing)
-        except BriefingExportError as exc:
-            self._notify_watchlists(str(exc), severity="warning", markup=False)
-            return
-        try:
-            await asyncio.to_thread(
-                validated_path.write_text, document, encoding="utf-8"
-            )
-        except OSError as exc:
-            logger.warning(f"Briefing export write failed: {type(exc).__name__}")
-            self._notify_watchlists(
-                f"Error exporting briefing: {type(exc).__name__}",
-                severity="error",
+                f"Briefing exported successfully to {validated_path.name}",
+                severity="information",
                 markup=False,
             )
-            return
-        self._notify_watchlists(
-            f"Briefing exported successfully to {validated_path.name}",
-            severity="information",
-            markup=False,
-        )
+        finally:
+            self._briefing_export_in_flight = False
 
     # --- Briefing selection-mode and default-preset pickers (Task 4) -------
     #

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -42,8 +42,14 @@ from ...Subscriptions.briefing_cast import (
     fail_interrupted_scripts,
     generate_script,
 )
+from ...Subscriptions.briefing_export import (
+    BriefingExportError,
+    briefing_markdown_document,
+    default_briefing_filename,
+)
 from ...Subscriptions.briefing_selection import MODE_AUTO_FEATURED, VALID_MODES
 from ...Subscriptions.briefing_service import (
+    STATUS_COMPLETE,
     STATUS_GENERATING,
     extract_citation_ids,
     fail_interrupted_briefings,
@@ -51,8 +57,10 @@ from ...Subscriptions.briefing_service import (
 )
 from ...Subscriptions.watchlist_bundle_service import WatchlistBundleService
 from ...Subscriptions.watchlist_normalizers import normalize_watchlist_item
+from ...Third_Party.textual_fspicker import FileSave
 from ...TTS.audio_player import play_audio_file
 from ...Utils.input_validation import sanitize_string, validate_text_input
+from ...Utils.path_validation import validate_path_simple
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
@@ -79,6 +87,7 @@ from ..Watchlists_Modules.artifacts_pane import (
     BriefingSelected,
     CastScriptRequested,
     CitationActivated,
+    ExportBriefingRequested,
     GenerateBriefingRequested,
     ManagePresetsRequested,
     PlayAudioRequested,
@@ -3779,6 +3788,138 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         event.stop()
         self.run_worker(
             self._load_briefings(), exclusive=True, group="wl-briefings-load"
+        )
+
+    # --- Exporting a briefing as markdown (spec #2 phase 3, Task 1) --------
+
+    @on(ExportBriefingRequested)
+    def handle_export_briefing_requested(
+        self, event: ExportBriefingRequested
+    ) -> None:
+        """Answer from memory, then dispatch the `FileSave` flow.
+
+        `ArtifactsPane.compose` already disables Export for no-selection
+        and any non-`complete` status, but this handler re-checks both
+        anyway: the button's disabled state and the message it posts are
+        two different frames, and (unlike a keyboard-only affordance) a
+        press already in flight when the selection changes underneath it
+        must not be trusted just because it once passed a disabled check.
+        No in-flight guard here, unlike Generate/Cast/Synthesize: exporting
+        touches no database and starts no generation, only a dialog and,
+        once a path is chosen, one file write -- there is nothing for a
+        second press to race against except the same `FileSave` dialog
+        Textual already refuses to stack twice.
+        """
+        event.stop()
+        briefing = self._selected_briefing
+        if briefing is None or str(briefing.get("status") or "").strip().lower() != (
+            STATUS_COMPLETE
+        ):
+            self._notify_watchlists(
+                "Select a completed briefing to export.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        watchlist_id = briefing.get("watchlist_id")
+        watchlist_name = (
+            self._watchlist_display_name(watchlist_id)
+            if watchlist_id is not None
+            else "this watchlist"
+        )
+        self.run_worker(
+            self._push_export_briefing_dialog(dict(briefing), watchlist_name),
+            group="wl-briefing-export",
+        )
+
+    async def _push_export_briefing_dialog(
+        self, briefing: dict[str, Any], watchlist_name: str
+    ) -> None:
+        """Push `FileSave`, seeded with a sanitized default filename.
+
+        Mirrors `_export_library_note`'s flow (`library_screen.py:6428`):
+        a `FileSave` prompt pre-filled with a sanitized default filename,
+        whose callback writes the export once a path is chosen. Imports
+        the VENDORED picker (`Third_Party.textual_fspicker.FileSave`,
+        keyword `default_file`) -- not the enhanced picker in `Widgets/
+        enhanced_file_picker.py`, a different class whose keyword is
+        `default_filename` and which also takes `context=`; mixing the two
+        raises `TypeError`.
+
+        `briefing["watchlist_name"]` is merged in here, once, rather than
+        threaded through as a separate parameter to every downstream
+        function: `briefing_markdown_document`/`default_briefing_filename`
+        both read it directly off the mapping they are given.
+        """
+        enriched = {**briefing, "watchlist_name": watchlist_name}
+        default_filename = default_briefing_filename(
+            enriched, watchlist_name=watchlist_name
+        )
+        await self.app.push_screen(
+            FileSave(
+                location=str(Path.home()),
+                title="Export Briefing as Markdown",
+                default_file=default_filename,
+            ),
+            callback=lambda path: self._write_briefing_export_file(path, enriched),
+        )
+
+    async def _write_briefing_export_file(
+        self, selected_path: Path | None, briefing: Mapping[str, Any]
+    ) -> None:
+        """Validate the chosen path, build the document, and write it.
+
+        Mirrors `_write_library_note_export_file`'s validate -> write ->
+        honest-toasts shape (`library_screen.py:6445`), with two
+        deliberate differences this feature's own rules require: the write
+        itself runs in `asyncio.to_thread` (a `FileSave`-chosen destination
+        can be anywhere, including a slow or network-mounted path, so the
+        write must never block the event loop), and exception logging is
+        type-only -- never `logger.opt(exception=True)`, and never the
+        briefing body.
+
+        Args:
+            selected_path: The chosen destination, or `None` if the
+                dialog was cancelled.
+            briefing: The briefing row, with `watchlist_name` merged in by
+                `_push_export_briefing_dialog`.
+        """
+        if not selected_path:
+            self._notify_watchlists(
+                "Briefing export cancelled.", severity="information"
+            )
+            return
+        try:
+            validated_path = validate_path_simple(selected_path, require_exists=False)
+        except ValueError as exc:
+            logger.warning(
+                f"Rejected briefing export path: {type(exc).__name__}"
+            )
+            self._notify_watchlists(
+                f"Rejected export path: {exc}", severity="warning", markup=False,
+            )
+            return
+        try:
+            document = briefing_markdown_document(briefing)
+        except BriefingExportError as exc:
+            self._notify_watchlists(str(exc), severity="warning", markup=False)
+            return
+        try:
+            await asyncio.to_thread(
+                validated_path.write_text, document, encoding="utf-8"
+            )
+        except OSError as exc:
+            logger.warning(f"Briefing export write failed: {type(exc).__name__}")
+            self._notify_watchlists(
+                f"Error exporting briefing: {type(exc).__name__}",
+                severity="error",
+                markup=False,
+            )
+            return
+        self._notify_watchlists(
+            f"Briefing exported successfully to {validated_path.name}",
+            severity="information",
+            markup=False,
         )
 
     # --- Briefing selection-mode and default-preset pickers (Task 4) -------

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -11,6 +11,7 @@ import asyncio
 import threading
 from collections.abc import Mapping, Sequence
 from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,7 @@ from ...Subscriptions.briefing_export import (
     BriefingExportError,
     briefing_markdown_document,
     default_briefing_filename,
+    export_feed_directory,
 )
 from ...Subscriptions.briefing_selection import MODE_AUTO_FEATURED, VALID_MODES
 from ...Subscriptions.briefing_service import (
@@ -57,7 +59,7 @@ from ...Subscriptions.briefing_service import (
 )
 from ...Subscriptions.watchlist_bundle_service import WatchlistBundleService
 from ...Subscriptions.watchlist_normalizers import normalize_watchlist_item
-from ...Third_Party.textual_fspicker import FileSave
+from ...Third_Party.textual_fspicker import FileSave, SelectDirectory
 from ...TTS.audio_player import play_audio_file
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ...Utils.path_validation import validate_path_simple
@@ -88,6 +90,7 @@ from ..Watchlists_Modules.artifacts_pane import (
     CastScriptRequested,
     CitationActivated,
     ExportBriefingRequested,
+    ExportFeedRequested,
     GenerateBriefingRequested,
     ManagePresetsRequested,
     PlayAudioRequested,
@@ -471,6 +474,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # failure to even OPEN the dialog clears it too (see that
         # method's own `except`).
         self._briefing_export_in_flight = False
+        # Task 5 (phase 3): the identical guard, for exporting a
+        # watchlist's audio as a podcast feed directory. Claimed in
+        # `handle_export_feed_requested` BEFORE `run_worker`, cleared in
+        # `_export_feed_directory`'s `finally` -- not in `_push_export_
+        # feed_dialog`, whose own `await self.app.push_screen` returns
+        # once the `SelectDirectory` dialog is MOUNTED, long before the
+        # user has picked a directory or cancelled. See `handle_export_
+        # feed_requested`'s own docstring for why this mirrors `_briefing_
+        # export_in_flight` rather than reusing it: a briefing export and
+        # a feed export are two independent actions a user could plausibly
+        # run at the same time (different destinations, different files).
+        self._feed_export_in_flight = False
+        # Whether THIS watchlist has at least one export-ready audio
+        # episode -- mirrored onto `ArtifactsPane.has_audio_episodes` by
+        # `_load_briefings`. Read (never written) by `handle_export_feed_
+        # requested`'s own re-check, for the identical reason `handle_
+        # export_briefing_requested`'s docstring gives for re-checking the
+        # selected briefing's status: the button's disabled state and the
+        # message it posts are two different frames.
+        self._watchlist_has_audio_episodes = False
         # The item currently open in the CONTENT reader (Task 4). Held here
         # for the identical reason as `_loaded_items` above: `_build_content_pane`
         # is a factory the workbench calls on every region rebuild, and a
@@ -1410,6 +1433,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             artifacts_pane.script_audio = self._loaded_script_audio
             artifacts_pane.scripts_with_audio = self._scripts_with_audio
             artifacts_pane.citations = self._loaded_citations
+            artifacts_pane.has_audio_episodes = self._watchlist_has_audio_episodes
             children.append(artifacts_pane)
         return Vertical(
             *children,
@@ -3242,6 +3266,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._scripts_with_audio = {}
             self._loaded_citations = []
             self._citation_item_lookup = {}
+            self._watchlist_has_audio_episodes = False
         else:
             try:
                 # Zombie recovery, before the list query, so a row this
@@ -3517,8 +3542,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # whatever presets were already loaded, rather than aborting
             # the whole load -- the briefing list above is real data this
             # failure must not hide.
+            #
+            # Task 5 (phase 3): `has_audio_episodes` rides in the SAME hop
+            # -- one more cheap read bundled alongside the other two,
+            # rather than a fourth separate `to_thread` round trip just for
+            # a boolean the Export Feed button needs. A read failure
+            # degrades to `False` (button stays disabled) rather than
+            # guessing: an export button that might reach a broken query
+            # is worse than one that stays honestly disabled until the
+            # next successful load.
             try:
-                settings_row, preset_rows = await asyncio.to_thread(
+                settings_row, preset_rows, has_audio_episodes = await asyncio.to_thread(
                     self._read_watchlist_briefing_state, db, watchlist_id
                 )
             except Exception as exc:  # noqa: BLE001 - reported, not raised
@@ -3526,7 +3560,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     "Failed to read briefing settings/presets for watchlist "
                     f"{watchlist_id}: {type(exc).__name__}"
                 )
-                settings_row, preset_rows = {}, self._loaded_briefing_presets
+                settings_row, preset_rows, has_audio_episodes = (
+                    {},
+                    self._loaded_briefing_presets,
+                    False,
+                )
             mode = settings_row.get("briefing_selection_mode")
             self._briefing_selection_mode = (
                 str(mode) if mode in VALID_MODES else MODE_AUTO_FEATURED
@@ -3535,6 +3573,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 "default_briefing_preset_id"
             )
             self._loaded_briefing_presets = preset_rows
+            self._watchlist_has_audio_episodes = has_audio_episodes
         if not self.is_mounted:
             return
         try:
@@ -3553,6 +3592,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         pane.script_audio = self._loaded_script_audio
         pane.scripts_with_audio = self._scripts_with_audio
         pane.citations = self._loaded_citations
+        pane.has_audio_episodes = self._watchlist_has_audio_episodes
 
     @staticmethod
     def _read_watchlist_briefing_settings(db: Any, watchlist_id: int) -> dict[str, Any]:
@@ -3576,24 +3616,36 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @staticmethod
     def _read_watchlist_briefing_state(
         db: Any, watchlist_id: int
-    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-        """`_read_watchlist_briefing_settings` plus `list_briefing_presets`,
-        as one synchronous unit for `_load_briefings` to dispatch through a
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], bool]:
+        """`_read_watchlist_briefing_settings` plus `list_briefing_presets`
+        plus whether the watchlist has any export-ready audio, as one
+        synchronous unit for `_load_briefings` to dispatch through a
         SINGLE `asyncio.to_thread` call.
 
-        Both are cheap reads on the same thread-local connection; bundling
-        them here is purely about round trips through the thread pool, not
-        about the SQL itself -- `_load_briefing_presets` still does its own
-        separate `list_briefing_presets` call for its OTHER caller
-        (`_open_briefing_preset_manager`), which has no settings row to
-        read alongside it. Always called through `asyncio.to_thread`; never
-        call this directly from the UI thread.
+        All three are cheap reads on the same thread-local connection;
+        bundling them here is purely about round trips through the thread
+        pool, not about the SQL itself -- `_load_briefing_presets` still
+        does its own separate `list_briefing_presets` call for its OTHER
+        caller (`_open_briefing_preset_manager`), which has no settings
+        row to read alongside it. Always called through `asyncio.
+        to_thread`; never call this directly from the UI thread.
+
+        Returns:
+            `(settings_row, preset_rows, has_audio_episodes)`.
         """
         settings_row = WatchlistsCollectionsScreen._read_watchlist_briefing_settings(
             db, watchlist_id
         )
         preset_rows = [dict(row) for row in db.list_briefing_presets()]
-        return settings_row, preset_rows
+        # Task 5 (phase 3): a `limit=1` probe -- the Export Feed button
+        # only needs a boolean, not the full episode page `export_feed_
+        # directory` itself re-queries at export time, so this avoids
+        # fetching a page nothing here reads (CLAUDE.md Performance Rules:
+        # paginate DB results).
+        has_audio_episodes = bool(
+            db.list_watchlist_audio_episodes(watchlist_id, limit=1)
+        )
+        return settings_row, preset_rows, has_audio_episodes
 
     @staticmethod
     def _read_scripts_with_audio(db: Any, script_ids: list[int]) -> dict[int, str]:
@@ -3893,9 +3945,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         second press could race through while the first dialog is still
         on screen. `_write_briefing_export_file` (the callback) is what
         clears it, in its own `finally`, once the dialog actually
-        resolves. The guard IS cleared here on the one path that never
-        reaches that callback at all: a failure to even open the dialog.
+        resolves. The guard IS cleared here on any path that never reaches
+        that callback at all -- a failure to even open the dialog, or the
+        worker being cancelled while awaiting the push.
+
+        Review round 1 named a real (if not currently exploitable) gap
+        here: the original shape cleared the guard inside `except
+        Exception`, which does NOT catch `asyncio.CancelledError` (a
+        `BaseException` since Python 3.8) -- a worker cancelled mid-`await
+        self.app.push_screen(...)` would skip straight past that `except`
+        with the guard still `True`, stranding Export shut for the rest of
+        this screen instance's life. Not reachable today (nothing cancels
+        this worker's `wl-briefing-export` group, and the flag dies with
+        the screen instance regardless), but `_generate_briefing`'s own
+        try/finally shape fixes it for free: `finally` runs for *every*
+        exit path, including a `BaseException`, so the `pushed` sentinel
+        below -- set only once the dialog has actually mounted -- is
+        enough to tell "never reached the callback" apart from "did" --
+        without needing a second `except` clause for cancellation.
         """
+        pushed = False
         try:
             enriched = {**briefing, "watchlist_name": watchlist_name}
             default_filename = default_briefing_filename(
@@ -3911,14 +3980,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     path, enriched
                 ),
             )
+            pushed = True
         except Exception as exc:  # noqa: BLE001 - a worker crash exits the app
-            self._briefing_export_in_flight = False
             logger.warning(f"Failed to open the export dialog: {type(exc).__name__}")
             self._notify_watchlists(
                 "Could not open the export dialog.",
                 severity="error",
                 markup=False,
             )
+        finally:
+            if not pushed:
+                self._briefing_export_in_flight = False
 
     async def _write_briefing_export_file(
         self, selected_path: Path | None, briefing: Mapping[str, Any]
@@ -4001,6 +4073,210 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
         finally:
             self._briefing_export_in_flight = False
+
+    # --- Exporting a watchlist's podcast feed directory (spec #2 phase -----
+    # 3, Task 5). Sibling of the markdown-export flow immediately above in
+    # every respect that matters: an independent in-flight guard
+    # (`_feed_export_in_flight` -- deliberately its OWN flag, not reused
+    # from `_briefing_export_in_flight`, since a briefing export and a
+    # feed export are two independent actions with two different
+    # destinations a user could plausibly run at the same time), claimed
+    # before `run_worker` for the identical reason
+    # `handle_export_briefing_requested`'s docstring gives, and a picker
+    # pushed via `push_screen(..., callback=...)` rather than `push_
+    # screen_wait` -- NOT `exclusive=True` on the worker either, for the
+    # same reason `_start_tree_write`'s own docstring gives for its five
+    # tree-write verbs: this worker owns a live modal
+    # (`SelectDirectory`), and `exclusive=True` cancels the *previous*
+    # worker in its group rather than refusing the new one -- cancelling
+    # one mid-picker would leave that dialog on the screen stack with
+    # nothing left to dismiss it. The boolean guard below already makes a
+    # second dispatch impossible while one is in flight, so `exclusive`
+    # would only ever fire on a bug in that guard -- and if it ever did,
+    # stranding a modal is a worse failure than the one it would be
+    # "fixing".
+    #
+    # Two differences from the markdown flow, both Task 4's own contract:
+    # the destination must already EXIST (`export_feed_directory`'s own
+    # `validate_path_simple(..., require_exists=True)`, which is exactly
+    # what `SelectDirectory` -- a directory BROWSER, not a name prompt --
+    # ever hands back), and a partial export (some episodes skipped) is a
+    # SUCCESSFUL result, not an error: `FeedExportResult.skipped` exists
+    # precisely so the toast can say "N of M exported" rather than
+    # silently claiming everything landed.
+
+    @on(ExportFeedRequested)
+    def handle_export_feed_requested(self, event: ExportFeedRequested) -> None:
+        """Claim the one-feed-export-at-a-time guard, then dispatch.
+
+        Re-checks `_watchlist_has_audio_episodes` even though `Artifacts
+        Pane.compose` already disables the button for the same reason
+        `handle_export_briefing_requested`'s own docstring gives: the
+        button's disabled state and the message this handler acts on are
+        two different frames, and a press already in flight when the
+        underlying audio changes underneath it must not be trusted just
+        because it once passed a disabled check.
+        """
+        event.stop()
+        db = self._briefings_db()
+        watchlist_id = self._briefing_watchlist_id()
+        if db is None or watchlist_id is None:
+            self._notify_watchlists(
+                "Select a watchlist in the rail to export its feed.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        if not self._watchlist_has_audio_episodes:
+            self._notify_watchlists(
+                "This watchlist has no complete audio episodes to export.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        if self._feed_export_in_flight:
+            self._notify_watchlists(
+                "A feed export is already in progress. Nothing else was "
+                "started.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        watchlist_name = self._watchlist_display_name(watchlist_id)
+        self._feed_export_in_flight = True
+        # `db`/`watchlist_id`/`watchlist_name` are snapshotted here, on the
+        # UI thread, alongside the rest of this synchronous dispatch --
+        # not re-read from `self` later, so a concurrent scope change on
+        # the rail cannot redirect an export already in flight to a
+        # different watchlist's audio.
+        self.run_worker(
+            self._push_export_feed_dialog(db, watchlist_id, watchlist_name),
+            group="wl-feed-export",
+        )
+
+    async def _push_export_feed_dialog(
+        self, db: Any, watchlist_id: int, watchlist_name: str
+    ) -> None:
+        """Push `SelectDirectory`, starting from the user's home directory.
+
+        Mirrors `_push_export_briefing_dialog` exactly, including its own
+        review-round-1 fix: `pushed` is set only once the dialog has
+        actually mounted, so `finally` clears the guard on any path that
+        never reaches `_export_feed_directory` (the callback) at all -- a
+        failure to even open the dialog, or this worker being cancelled
+        while awaiting the push.
+        """
+        pushed = False
+        try:
+            await self.app.push_screen(
+                SelectDirectory(str(Path.home()), title="Export Podcast Feed"),
+                callback=lambda path: self._export_feed_directory(
+                    db, watchlist_id, watchlist_name, path
+                ),
+            )
+            pushed = True
+        except Exception as exc:  # noqa: BLE001 - a worker crash exits the app
+            logger.warning(
+                f"Failed to open the feed export dialog: {type(exc).__name__}"
+            )
+            self._notify_watchlists(
+                "Could not open the feed export dialog.",
+                severity="error",
+                markup=False,
+            )
+        finally:
+            if not pushed:
+                self._feed_export_in_flight = False
+
+    async def _export_feed_directory(
+        self,
+        db: Any,
+        watchlist_id: int,
+        watchlist_name: str,
+        selected_path: Path | None,
+    ) -> None:
+        """Validate the chosen directory, export the feed, and toast honestly.
+
+        All DB and filesystem work -- `export_feed_directory` itself --
+        runs in ONE `asyncio.to_thread` hop; that function does its own
+        destination validation (`require_exists=True`, matching what
+        `SelectDirectory` ever hands back), the per-episode safety checks
+        and copies, and the atomic `feed.xml` write.
+
+        A partial export (`result.skipped` non-empty) is reported as
+        exactly that -- "N of M episodes exported", plus the reasons
+        `export_feed_directory` already wrote in plain language -- never
+        collapsed into a plain success toast. `_feed_export_in_flight` is
+        cleared in `finally`, on every exit path (cancelled, rejected
+        destination, export-error, or success alike), mirroring `_write_
+        briefing_export_file`'s own re-arm guarantee.
+
+        Args:
+            db: Snapshotted by the handler at dispatch time.
+            watchlist_id: Snapshotted by the handler at dispatch time.
+            watchlist_name: Snapshotted by the handler at dispatch time.
+            selected_path: The chosen destination directory, or `None` if
+                the dialog was cancelled.
+        """
+        try:
+            if not selected_path:
+                self._notify_watchlists(
+                    "Feed export cancelled.", severity="information"
+                )
+                return
+            try:
+                result = await asyncio.to_thread(
+                    export_feed_directory,
+                    db,
+                    watchlist_id,
+                    destination=selected_path,
+                    watchlist_name=watchlist_name,
+                    now=datetime.now(timezone.utc),
+                )
+            except asyncio.CancelledError:
+                raise
+            except ValueError as exc:
+                logger.warning(
+                    f"Rejected feed export destination: {type(exc).__name__}"
+                )
+                self._notify_watchlists(
+                    f"Rejected export destination: {exc}",
+                    severity="warning",
+                    markup=False,
+                )
+                return
+            except Exception as exc:
+                logger.warning(f"Feed export failed: {type(exc).__name__}")
+                self._notify_watchlists(
+                    f"Error exporting the feed: {type(exc).__name__}",
+                    severity="error",
+                    markup=False,
+                )
+                return
+            total = result.episode_count + len(result.skipped)
+            if result.skipped:
+                # Honest, not a success toast: this is Task 4's own named
+                # invariant (`FeedExportResult.skipped`'s docstring) applied
+                # at the UI boundary -- a user who exported ten episodes and
+                # got eight must be told, in the reasons `export_feed_
+                # directory` already wrote in plain language.
+                reasons = "; ".join(result.skipped)
+                self._notify_watchlists(
+                    f"Exported {result.episode_count} of {total} episodes "
+                    f"to {result.directory.name} ({reasons}).",
+                    severity="warning",
+                    markup=False,
+                )
+            else:
+                plural = "" if result.episode_count == 1 else "s"
+                self._notify_watchlists(
+                    f"Exported {result.episode_count} episode{plural} to "
+                    f"{result.directory.name}.",
+                    severity="information",
+                    markup=False,
+                )
+        finally:
+            self._feed_export_in_flight = False
 
     # --- Briefing selection-mode and default-preset pickers (Task 4) -------
     #

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -8,6 +8,7 @@ handoffs keep working while Collections moves under Library.
 from __future__ import annotations
 
 import asyncio
+import re
 import threading
 from collections.abc import Mapping, Sequence
 from dataclasses import replace
@@ -4084,17 +4085,29 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     # before `run_worker` for the identical reason
     # `handle_export_briefing_requested`'s docstring gives, and a picker
     # pushed via `push_screen(..., callback=...)` rather than `push_
-    # screen_wait` -- NOT `exclusive=True` on the worker either, for the
-    # same reason `_start_tree_write`'s own docstring gives for its five
-    # tree-write verbs: this worker owns a live modal
-    # (`SelectDirectory`), and `exclusive=True` cancels the *previous*
-    # worker in its group rather than refusing the new one -- cancelling
-    # one mid-picker would leave that dialog on the screen stack with
-    # nothing left to dismiss it. The boolean guard below already makes a
-    # second dispatch impossible while one is in flight, so `exclusive`
-    # would only ever fire on a bug in that guard -- and if it ever did,
-    # stranding a modal is a worse failure than the one it would be
-    # "fixing".
+    # screen_wait` -- NOT `exclusive=True` on the worker either.
+    #
+    # Review round 1: the durable reason, confirmed by the reviewer, is
+    # structural rather than just "the guard already prevents a second
+    # dispatch." `Screen._push_result_callback` wraps the callback in a
+    # `ResultCallback`, and `ResultCallback.__call__` -- what `Screen.
+    # dismiss` invokes -- schedules it via `requester.call_next(...)`,
+    # i.e. onto the REQUESTER's (this screen's) own message pump, never
+    # back inside the `wl-feed-export` worker. `_push_export_feed_dialog`'s
+    # entire life is therefore the single `await self.app.push_screen(...)`
+    # that returns once `SelectDirectory` MOUNTS -- by the time a user
+    # could ever pick a path or cancel, that worker has already finished
+    # and exited; `_export_feed_directory` (where the guard actually
+    # clears) never runs inside it at all. `exclusive=True` cancelling a
+    # "previous" worker in this group is therefore a no-op on every
+    # reachable path: there is nothing long-lived left to cancel, and the
+    # `_start_tree_write`-style zombie-modal failure mode (a live worker
+    # still awaiting a picker's dismissal, cancelled out from under it) is
+    # structurally impossible here -- not merely guarded against. Left
+    # here anyway as belt-and-suspenders should a future refactor route
+    # the guard differently: the boolean check below still makes a second
+    # dispatch impossible while one is in flight, so `exclusive` would
+    # only ever fire on a bug in THAT guard.
     #
     # Two differences from the markdown flow, both Task 4's own contract:
     # the destination must already EXIST (`export_feed_directory`'s own
@@ -4188,6 +4201,41 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if not pushed:
                 self._feed_export_in_flight = False
 
+    #: Task 5 (phase 3), review round 1, Minor #2: the ceiling on how many
+    #: of `FeedExportResult.skipped`'s reasons are inlined into the
+    #: partial-export toast. `export_feed_directory` can skip arbitrarily
+    #: many episodes, and a toast quoting every one of them is unreadable
+    #: long before it gets there -- the headline "N of M" count already
+    #: states the honest outcome; these are just the first few reasons,
+    #: for a user who wants to know why.
+    _MAX_INLINE_SKIP_REASONS = 3
+
+    #: Every reason `export_feed_directory` writes is `f"audio {audio_id}:
+    #: ..."` (that module's own docstring, decision 3) -- the id is
+    #: load-bearing for support/debugging (kept in the log line in
+    #: `_export_feed_directory` below) but means nothing to a user reading
+    #: a toast, so it is stripped before any reason reaches one.
+    _SKIP_REASON_ID_PREFIX = re.compile(r"^audio \d+: ")
+
+    @classmethod
+    def _user_facing_skip_reasons(cls, reasons: list[str]) -> str:
+        """The first `_MAX_INLINE_SKIP_REASONS` of `reasons`, id-stripped
+        and joined for a toast.
+
+        Args:
+            reasons: `FeedExportResult.skipped`, verbatim.
+
+        Returns:
+            `"reason one; reason two; reason three; …and 4 more"` -- or
+            just the id-stripped reasons, joined, with no trailer, when
+            `len(reasons) <= _MAX_INLINE_SKIP_REASONS`.
+        """
+        stripped = [cls._SKIP_REASON_ID_PREFIX.sub("", reason, count=1) for reason in reasons]
+        shown = stripped[: cls._MAX_INLINE_SKIP_REASONS]
+        remaining = len(stripped) - len(shown)
+        text = "; ".join(shown)
+        return f"{text}; …and {remaining} more" if remaining > 0 else text
+
     async def _export_feed_directory(
         self,
         db: Any,
@@ -4204,12 +4252,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         and copies, and the atomic `feed.xml` write.
 
         A partial export (`result.skipped` non-empty) is reported as
-        exactly that -- "N of M episodes exported", plus the reasons
-        `export_feed_directory` already wrote in plain language -- never
-        collapsed into a plain success toast. `_feed_export_in_flight` is
-        cleared in `finally`, on every exit path (cancelled, rejected
-        destination, export-error, or success alike), mirroring `_write_
-        briefing_export_file`'s own re-arm guarantee.
+        exactly that -- "N of M episodes exported", plus up to `_MAX_
+        INLINE_SKIP_REASONS` of the reasons `export_feed_directory` wrote
+        (id-stripped -- see `_user_facing_skip_reasons`), with an honest
+        "…and N more" trailer past that cap -- never collapsed into a
+        plain success toast. `_feed_export_in_flight` is cleared in
+        `finally`, on every exit path (cancelled, rejected destination,
+        export-error, or success alike), mirroring `_write_briefing_
+        export_file`'s own re-arm guarantee.
 
         Args:
             db: Snapshotted by the handler at dispatch time.
@@ -4260,7 +4310,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 # at the UI boundary -- a user who exported ten episodes and
                 # got eight must be told, in the reasons `export_feed_
                 # directory` already wrote in plain language.
-                reasons = "; ".join(result.skipped)
+                #
+                # Review round 1, Minor #2: the FULL list (with each
+                # episode's `audio_id`, useful for support) is logged
+                # here -- these are already-benign, app-generated reason
+                # strings, never model/user content, so this is not the
+                # "type only" rule `logger.warning` calls elsewhere on this
+                # screen apply to an exception. The TOAST gets a separate,
+                # user-facing rendering: capped to `_MAX_INLINE_SKIP_
+                # REASONS` (with an honest "…and N more" trailer) and with
+                # the internal `audio {id}:` prefix stripped, since a raw
+                # database id means nothing to a user.
+                logger.info(
+                    f"Feed export for watchlist {watchlist_id} skipped "
+                    f"{len(result.skipped)} of {total} episode(s): "
+                    f"{'; '.join(result.skipped)}"
+                )
+                reasons = self._user_facing_skip_reasons(result.skipped)
                 self._notify_watchlists(
                     f"Exported {result.episode_count} of {total} episodes "
                     f"to {result.directory.name} ({reasons}).",

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -49,7 +49,7 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Button, DataTable, Select, Static
 
-from ...Subscriptions.briefing_audio import briefing_audio_dir
+from ...Subscriptions.briefing_audio import audio_file_path_is_safe, briefing_audio_dir
 from ...Subscriptions.briefing_selection import (
     MODE_AUTO,
     MODE_AUTO_FEATURED,
@@ -61,7 +61,6 @@ from ...Subscriptions.briefing_service import (
     STATUS_FAILED,
     STATUS_GENERATING,
 )
-from ...Utils.path_validation import is_safe_path
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
 from .table_selection import highlight_is_user_driven
 
@@ -365,29 +364,6 @@ _AUDIO_UNEXPLAINED_FAILURE = "Audio synthesis failed, but recorded no reason."
 def _audio_status_text(row: dict[str, Any]) -> str:
     """One audio render's status, as a bare lowercase string."""
     return str(row.get("status") or "").strip().lower()
-
-
-def audio_file_path_is_safe(file_path: str | Path) -> bool:
-    """Whether `file_path` resolves to somewhere inside `briefing_audio_dir()`.
-
-    Qodo review round 1, FIX B: `file_path` comes from our own DB row today,
-    but nothing enforces that at the schema level, and CLAUDE.md requires
-    every file path to be checked through `Utils/path_validation.py` before
-    the filesystem ever sees it -- a tampered or corrupted row must not let
-    this UI probe (`.exists()`) or play an arbitrary path. Shared by
-    `_audio_file_is_playable` below (disables Play) and
-    `WatchlistsCollectionsScreen.handle_play_audio_requested` (guards the
-    actual playback call), so there is exactly one place this check is
-    made.
-
-    Args:
-        file_path: The candidate path, as stored on a `briefing_audio` row.
-
-    Returns:
-        `True` only when `file_path` resolves (following `..`/symlinks)
-        to a location inside `briefing_audio_dir()`.
-    """
-    return is_safe_path(file_path, briefing_audio_dir())
 
 
 def _audio_file_is_playable(row: dict[str, Any] | None) -> bool:

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -226,12 +226,17 @@ class ExportFeedRequested(Message):
     export is the screen's own scope (`_briefing_watchlist_id`), and
     whether there is anything worth exporting is already mirrored onto
     this pane's own `has_audio_episodes` reactive -- there is nothing this
-    message needs to carry that the screen does not already hold. Posted
-    from the button living in `#artifacts-audio-toolbar` (see the
-    module docstring's placement rationale on `compose`), NOT from a
-    watchlist-wide toolbar, even though the export itself is watchlist-
-    scoped rather than script-scoped -- the pane's height budget has no
-    room for a dedicated row of its own (phase 2b's own measured lesson).
+    message needs to carry that the screen does not already hold.
+
+    Posted from the button living in `#artifacts-toolbar` -- the SAME
+    watchlist-scoped toolbar Generate/Refresh/Task 1's markdown Export
+    already live in, and (review round 1, Important #1) NOT `#artifacts-
+    audio-toolbar`, where an earlier draft placed it: that toolbar only
+    renders once a SCRIPT is selected, but this export is WATCHLIST-
+    scoped (every complete episode across the whole watchlist), so a
+    button hidden behind an unrelated script selection is a button a
+    user cannot find at all -- see `compose`'s own comment at the
+    button's new site.
     """
 
 
@@ -727,6 +732,37 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                     else "Export this briefing as a markdown file."
                 ),
             )
+            # Task 5 (phase 3): review round 1, Important #1. The brief
+            # originally placed this button in `#artifacts-audio-toolbar`,
+            # which only renders once a SCRIPT is selected -- but the feed
+            # export itself is WATCHLIST-scoped (every complete episode
+            # across the whole watchlist), not script-scoped, so a user
+            # could not find it without first selecting some unrelated
+            # script. Moved to THIS toolbar instead: it is the one Task 1's
+            # own watchlist-scoped markdown Export already lives in, and it
+            # renders unconditionally (see `compose`'s own top-level
+            # structure -- unlike the picker/scripts/audio sections below,
+            # nothing gates this `Horizontal` at all), so the button is
+            # discoverable the moment a watchlist is in scope, exactly like
+            # Generate/Refresh/Export are. Still costs zero rows: both are
+            # EXISTING `.destination-filter-strip` toolbars, `height: 1`
+            # either way -- see the pinned geometry tests re-run for this
+            # move (`test_the_list_the_button_and_the_body_are_all_on_
+            # screen`, `test_the_briefings_table_keeps_at_least_three_
+            # usable_rows`).
+            yield Button(
+                "Export Feed…",
+                id="artifacts-export-feed-button",
+                compact=True,
+                disabled=not self.has_audio_episodes,
+                tooltip=(
+                    "This watchlist has no complete audio episodes to "
+                    "export."
+                    if not self.has_audio_episodes
+                    else "Export this watchlist's audio episodes as a "
+                    "podcast feed directory."
+                ),
+            )
 
         if self.can_generate:
             # Task 4: the selection-mode and default-preset pickers, plus
@@ -937,28 +973,6 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                         id="artifacts-stop-button",
                         compact=True,
                         tooltip="Stop this script's audio playback.",
-                    )
-                    # Task 5 (phase 3): watchlist-scoped, not script-scoped
-                    # -- disabled purely on `has_audio_episodes` (the
-                    # WHOLE watchlist's export-ready audio), regardless of
-                    # which script happens to be selected right now. Lives
-                    # in THIS toolbar rather than a new one because the
-                    # pane's height budget is pinned (see the module
-                    # docstring's Task 7 note and this method's own
-                    # comments above); adding a button to an EXISTING
-                    # `.destination-filter-strip` costs zero rows.
-                    yield Button(
-                        "Export Feed…",
-                        id="artifacts-export-feed-button",
-                        compact=True,
-                        disabled=not self.has_audio_episodes,
-                        tooltip=(
-                            "This watchlist has no complete audio episodes "
-                            "to export."
-                            if not self.has_audio_episodes
-                            else "Export this watchlist's audio episodes as "
-                            "a podcast feed directory."
-                        ),
                     )
                 # No separate audio-detail `Static`: its status/duration/
                 # error is folded into `_script_detail_renderable`'s own

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -122,6 +122,17 @@ class RefreshBriefingsRequested(Message):
     """Posted when the user asks to re-read the briefing list."""
 
 
+class ExportBriefingRequested(Message):
+    """Posted when the user asks to export the selected briefing as markdown.
+
+    Carries nothing, same shape as `GenerateBriefingRequested`/`CastScript
+    Requested` and for the same reason: the briefing to export is the
+    screen's own `_selected_briefing`, already mirrored there by `handle_
+    briefing_selected` -- there is nothing this message needs to carry that
+    the screen does not already hold.
+    """
+
+
 class BriefingModeChanged(Message):
     """Posted when the user picks a different selection mode.
 
@@ -687,6 +698,31 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                 compact=True,
                 tooltip="Re-read this watchlist's briefings.",
             )
+            # Task 1 (phase 3): exporting is an action on THE SELECTED
+            # briefing, so -- unlike Generate/Refresh, which are
+            # watchlist-wide -- it is disabled with nothing selected, and
+            # ALSO disabled for any non-`complete` row: a `failed`/`empty`/
+            # `generating` briefing has no body worth exporting (`empty`
+            # writes no body by design, `failed` recorded none, and
+            # `generating` has not finished). Placed in this SAME toolbar
+            # rather than a new `Horizontal` -- adding a row here would cost
+            # height this pane's budget cannot spare (see the module
+            # docstring's own note on the pane's fixed `fr` split).
+            export_disabled = (
+                self.selected_briefing is None
+                or _status_text(self.selected_briefing) != STATUS_COMPLETE
+            )
+            yield Button(
+                "Export…",
+                id="artifacts-export-button",
+                compact=True,
+                disabled=export_disabled,
+                tooltip=(
+                    "Select a completed briefing to export it."
+                    if export_disabled
+                    else "Export this briefing as a markdown file."
+                ),
+            )
 
         if self.can_generate:
             # Task 4: the selection-mode and default-preset pickers, plus
@@ -1159,6 +1195,8 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
             self.post_message(GenerateBriefingRequested())
         elif button_id == "artifacts-refresh-button":
             self.post_message(RefreshBriefingsRequested())
+        elif button_id == "artifacts-export-button":
+            self.post_message(ExportBriefingRequested())
         elif button_id == "artifacts-presets-button":
             self.post_message(ManagePresetsRequested())
         elif button_id == "artifacts-cast-button":

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -217,6 +217,24 @@ class StopAudioRequested(Message):
     """
 
 
+class ExportFeedRequested(Message):
+    """Posted when the user asks to export this watchlist's audio as a
+    podcast feed directory (spec #2 phase 3, Task 5).
+
+    Carries nothing, same shape as `GenerateBriefingRequested`/
+    `SynthesizeAudioRequested` and for the same reason: the watchlist to
+    export is the screen's own scope (`_briefing_watchlist_id`), and
+    whether there is anything worth exporting is already mirrored onto
+    this pane's own `has_audio_episodes` reactive -- there is nothing this
+    message needs to carry that the screen does not already hold. Posted
+    from the button living in `#artifacts-audio-toolbar` (see the
+    module docstring's placement rationale on `compose`), NOT from a
+    watchlist-wide toolbar, even though the export itself is watchlist-
+    scoped rather than script-scoped -- the pane's height budget has no
+    room for a dedicated row of its own (phase 2b's own measured lesson).
+    """
+
+
 class CitationActivated(Message):
     """Posted when the user activates a citation under the briefing body.
 
@@ -525,6 +543,16 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     #: to a successful one. Screen-supplied, resolved alongside `scripts`
     #: inside `_load_briefings`.
     scripts_with_audio = reactive[dict[int, str]]({}, recompose=True)
+    #: Task 5 (phase 3): whether the WHOLE watchlist -- not merely the
+    #: selected script -- has at least one export-ready audio episode
+    #: (`SubscriptionsDB.list_watchlist_audio_episodes`'s own `complete`
+    #: + `file_path IS NOT NULL` predicate). Screen-supplied, resolved
+    #: alongside the rest of `_load_briefings`'s watchlist-scoped reads --
+    #: never computed on this widget, which has no database handle of its
+    #: own. Gates the Export Feed button's disabled state: a dead control
+    #: offering to export nothing is a spec violation (phase 2b shipped a
+    #: disabled Play for exactly this reason).
+    has_audio_episodes = reactive(False, recompose=True)
     #: Task 6: every `[item N]` id the SELECTED briefing's body cites,
     #: resolved once per selection by the screen (`_load_briefings`, via
     #: `get_subscription_items_by_ids`) -- `{"item_id": int, "label": Text,
@@ -910,6 +938,28 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                         compact=True,
                         tooltip="Stop this script's audio playback.",
                     )
+                    # Task 5 (phase 3): watchlist-scoped, not script-scoped
+                    # -- disabled purely on `has_audio_episodes` (the
+                    # WHOLE watchlist's export-ready audio), regardless of
+                    # which script happens to be selected right now. Lives
+                    # in THIS toolbar rather than a new one because the
+                    # pane's height budget is pinned (see the module
+                    # docstring's Task 7 note and this method's own
+                    # comments above); adding a button to an EXISTING
+                    # `.destination-filter-strip` costs zero rows.
+                    yield Button(
+                        "Export Feed…",
+                        id="artifacts-export-feed-button",
+                        compact=True,
+                        disabled=not self.has_audio_episodes,
+                        tooltip=(
+                            "This watchlist has no complete audio episodes "
+                            "to export."
+                            if not self.has_audio_episodes
+                            else "Export this watchlist's audio episodes as "
+                            "a podcast feed directory."
+                        ),
+                    )
                 # No separate audio-detail `Static`: its status/duration/
                 # error is folded into `_script_detail_renderable`'s own
                 # render, right above -- see that method's own comment on
@@ -1183,6 +1233,8 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
             self.post_message(PlayAudioRequested())
         elif button_id == "artifacts-stop-button":
             self.post_message(StopAudioRequested())
+        elif button_id == "artifacts-export-feed-button":
+            self.post_message(ExportFeedRequested())
         event.stop()
 
     def on_select_changed(self, event: Select.Changed) -> None:


### PR DESCRIPTION
## Summary

Phase 3 of spec #2 gets artifacts **out** of the app. Two exports live on the Artifacts section's top toolbar, both writing wherever the user chooses:

- **Export** — the selected briefing as a Markdown file.
- **Export Feed** — a self-contained **podcast feed directory**: `feed.xml` plus a copy of every finished audio episode in the watchlist.

With this, `task-1540`'s phase-3 criterion is met; only phase 4 (scheduling) remains.

**Localhost serving is deliberately not built**, by the project owner's decision, because the spec's premise turned out to be false. `[web_server]` is textual-serve — a mutually exclusive process mode that serves the TUI *itself* to a browser (the app returns instead of running the TUI), whose only static route is hardcoded to textual-serve's own assets, and whose `enabled` key is read by no code at all. There was never a server alongside the TUI to toggle. The spec's own wording already said "the directory is the deliverable"; the user guide now shows the one-line `python3 -m http.server` recipe and states plainly that `[web_server]` is not that thing. `task-1760` scopes in-app serving as the net-new work it actually is, carrying the evidence so nobody re-discovers it.

Design decisions, each recorded beside the code rather than in a review artifact:
- **The destination is never routed through the private-storage helpers.** They chmod their target to `0o700` and refuse overwrites — correct for app-owned storage, wrong for the user's own folder.
- **Exported files are `0o644`, deliberately ignoring umask.** Private audio is written `0o600`, and inheriting that made a folder meant for sharing readable only by the exporting account — the first review round found exactly this, hidden by a fixture that seeded permissive sources.
- **The path-safety check runs before any filesystem access** on a stored path, the ordering phase 2b established for playback; export copies files *out*, so the same mistake here is strictly worse.
- **One bad episode is skipped, not fatal** — reasons are collected and the toast reports "N of M" rather than claiming success. Pagination walks every episode instead of silently truncating at 500.
- **Enclosure URLs are relative and percent-encoded**, so the folder survives copying, syncing or zipping, and a client that sends the raw request line still fetches.

## Test plan

- 758 passing across `Tests/Subscriptions/` and `Tests/Watchlists/` after rebasing onto current dev.
- Every behavioural change carries a revert-confirm-RED-restore mutation check, including the security ordering (its test observes the *absence of I/O*, not merely the absence of a copied file), the file-permission relaxation (fixture now seeds a genuinely `0o600` source), and the export walk's bound (removing it makes the test hang, demonstrating the production failure).
- Six-task subagent-driven build with per-task reviews (four fix rounds) and a whole-branch review on the strongest model, which found a composition defect no single task's gate could see: a filename sanitiser that correctly keeps spaces, reused to name episode files, emitted as an enclosure URL the URI standard forbids — unfetchable by some podcast clients and undiagnosable by the user.
- A follow-up round also replaced a tautological property test (`url == quote(unquote(url))` holds for *any* encoded output, so a double-encoding mutation stayed green) with the property a client actually depends on.

Follow-ups filed: `task-1760` (in-app serving) and `task-1761` (cap the unbounded offset-walk loops shared by four pagination test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Markdown export for selected briefings and a watchlist-wide podcast feed directory export (`feed.xml` + audio files), so users can save and share artifacts outside the app. Completes phase 3 of spec #2 for `task-1540`; phase 4 (scheduling) remains.

- **New Features**
  - Export selected complete briefing as `.md` via `FileSave`, with a safe default filename.
  - Export Feed writes `feed.xml` and copies finished episodes to a chosen folder; RSS is built purely, enclosure URLs are percent-encoded and relative, and the channel includes a `link`.
  - Pagination exports all episodes; skipped items are reported instead of failing the whole export.
  - UI guards one export at a time and surfaces clear toasts for cancel, partial, and errors.

- **Bug Fixes**
  - Path safety check runs before any I/O via `audio_file_path_is_safe` (moved to `Subscriptions.briefing_audio`).
  - Exported files use mode `0o644`; `feed.xml` is written atomically.
  - Feed generation rejects naive datetimes; timestamps must be timezone-aware.
  - Destination paths are validated; exports never route through private-storage writers.

<sup>Written for commit d4a37440d22e8b51d4d6be7904236982cea40060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

