### PR TITLE
Fix: second "+ New target" press lands on nothing reachable (task-1764)

### DIFF
--- a/Tests/UI/test_evals_bench_editor.py
+++ b/Tests/UI/test_evals_bench_editor.py
@@ -3275,3 +3275,55 @@ async def test_real_toggle_key_flips_the_checkbox_value(
         await pilot.press("enter")
         await pilot.pause()
         assert checkbox.value is False
+
+
+@pytest.mark.asyncio
+async def test_create_target_control_stays_hit_testable_across_many_staged_targets(
+    evals_app_configured, evals_db, bench_with_zero_llama_models
+):
+    """TASK-1764 regression: pressing "+ New target" repeatedly must leave
+    ``#evals-bench-create-target`` HIT-TESTABLE, not merely present in the
+    DOM -- ``Screen.get_widget_at`` resolving its own region's center to
+    itself, the exact check `pilot.click` (and a real mouse) performs
+    before a press does anything.
+
+    Every row `stage_target`/`_on_add_target_pressed` mints lands ABOVE
+    this mini-form (see `_keep_create_control_in_view`'s own docstring),
+    pushing the button just pressed further down each time. This pane's
+    history is three separate regressions of exactly that shape, each
+    previously "fixed" by finding one more row of vertical slack
+    elsewhere in the pane -- which only holds for however many targets
+    happen to fit, and silently breaks again the next time a row is
+    added anywhere above it (task-1710's checkbox was the third: see
+    `_keep_create_control_in_view`'s docstring). A slack-based fix passes
+    at whatever target count the fix author tried and no further; this
+    drives SIX presses -- well past the two
+    `test_evals_steering_e2e.py::
+    test_two_ui_authored_targets_one_steered_light_up_column_mode_delta`
+    (this bug's own closing E2E) exercises -- at the SAME realistic
+    160x45 viewport every other reachability check in this module uses,
+    to prove the fix is viewport/count-independent rather than re-tuned
+    slack.
+    """
+    task_id = bench_with_zero_llama_models
+    async with evals_app_configured.run_test(size=_REALISTIC_SIZE) as pilot:
+        await pilot.pause()
+        evals_app_configured.screen.select(kind="bench", id=task_id)
+        await pilot.pause()
+        screen = evals_app_configured.screen
+
+        for i in range(6):
+            screen.query_one("#evals-target-name", Input).value = f"target {i}"
+            await pilot.click("#evals-bench-create-target")
+            await pilot.pause()
+
+            control = screen.query_one("#evals-bench-create-target", Button)
+            center = control.region.center
+            hit, _ = screen.get_widget_at(int(center[0]), int(center[1]))
+            assert hit is control, (
+                f"create-target control not hit-testable after {i + 1} staged "
+                f"target(s) -- landed on {hit!r} instead"
+            )
+
+        models = evals_db.list_models(provider="llama_cpp")
+        assert len(models) == 6, "each reachable press must mint one additional row"

--- a/backlog/tasks/task-1764 - Second-New-target-press-lands-on-nothing-reachable.md
+++ b/backlog/tasks/task-1764 - Second-New-target-press-lands-on-nothing-reachable.md
@@ -1,0 +1,61 @@
+---
+id: TASK-1764
+title: Second "+ New target" press lands on nothing reachable
+status: Done
+assignee: []
+created_date: '2026-08-01 14:55'
+updated_date: '2026-08-01 14:55'
+labels:
+  - evals
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/UI/test_evals_steering_e2e.py::test_two_ui_authored_targets_one_steered_light_up_column_mode_delta` — task-1611's own closing E2E for the capability "mint an ADDITIONAL, differently-steered target through the UI" — failed at `assert len(created_after_second) == 2, "second Create must mint an ADDITIONAL row"`. Pressing "+ New target" a second time minted no row.
+
+Root cause: `_refresh_targets_section`'s rebuild mounts every new target row (and, once a real `llama_cpp` model exists, `_build_target_add_control`'s Add picker row) ABOVE the "+ New target" mini-form, never below it. Each row added there pushes the just-pressed button down by exactly that many rows. At a realistic 160x45 viewport, `#evals-bench-editor` (the pane's one and only scrollable region — see its own CSS comment) had exactly enough slack for the FIRST create; the second click landed on `#footer-spacer`, not the button — confirmed directly via `Screen.get_widget_at`, the same hit-test a real mouse click and `pilot.click` perform.
+
+This is not a one-off layout bug; it is the same shape of regression for the THIRD time in this pane's history. `_build_create_target_control`'s own docstring already documents two earlier live failures during task-1611 T2's own development, both answered by trimming the mini-form's own shape until it fit. This time it was task-1710's checkbox (`cb0407067`) that tipped the arithmetic over: a `margin-bottom: 1` on `#evals-bench-capture-continuations` spent the pane's one remaining row of 160x45 slack, and it went unnoticed because that row only matters once a target is staged and the Add picker also renders — a state none of task-1710's own tests happened to reach.
+
+Why per-task review missed it each time: every task that touched this pane verified reachability of the ONE control it added or resized, at whatever target count its own tests happened to stage. Nothing tested the general property — that adding a row above the "+ New target" mini-form must not push the mini-form itself out of reach — so each fix was really "buys back enough slack for today's shape," which holds only until the next row is added anywhere above it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A bench author can press "+ New target" repeatedly and mint an additional target row each time, at a realistic viewport, without manual scrolling
+- [x] #2 `test_two_ui_authored_targets_one_steered_light_up_column_mode_delta` passes for the real reason (the control is reachable), not because the test scrolls to it or the assertion was weakened
+- [x] #3 A regression test pins reachability at MORE staged-target counts than the closing E2E happens to exercise, so the fix is proven count-independent rather than re-tuned slack
+- [x] #4 The fix generalizes to any row added above the mini-form (the Add picker, a future field), not just today's target-row count
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the root cause directly: reproduce with `Screen.get_widget_at` on `#evals-bench-create-target`'s own region after a second stage, showing it resolves to `#footer-spacer`.
+2. Add `BenchEditor._keep_create_control_in_view`, called from the two paths that mount a row above the mini-form (`stage_target`, `_on_add_target_pressed`) via `call_after_refresh` (the rebuild's `region` is stale until Textual's next layout pass) — scrolls `#evals-bench-create-target-form` back into `#evals-bench-editor`'s viewport regardless of target count or terminal size. Deliberately not called from remove (list shrank) or a prompt-mode flip (user is at the top of the form).
+3. Judge the uncommitted `_evals.tcss` change (removing `#evals-bench-capture-continuations`'s `margin-bottom: 1`) on its own merits now that the general fix exists: empirically verify whether it is load-bearing.
+4. Add a regression test driving several presses past the E2E's own two, asserting hit-testability (`get_widget_at` on the control's own region center) after each.
+5. Run the full affected suite plus the CSS bundle sync check.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Picked up mid-implementation from a prior session cut off by a quota limit; its diagnosis (documented above) and its `_keep_create_control_in_view` scroll fix were already correct and complete in the working tree — this pass verified, finished, and closed it out.
+
+**The scroll fix (`bench_editor.py`)**: `_keep_create_control_in_view` scrolls `#evals-bench-create-target-form` into view via `self.call_after_refresh(...)` + `scroll_to_widget(..., animate=False)`, called from both `stage_target` (the `CreateTargetRequested` round trip) and `_on_add_target_pressed` (the Add-picker path) — the two places that mount a new row above the mini-form. Left uncalled from `_on_remove_target_pressed` (nothing was pushed anywhere) and `_on_prompt_mode_changed` (would yank the viewport away from the top-of-form control the user is actively looking at).
+
+**The CSS change was reverted, not kept.** The working tree also carried an uncommitted `_evals.tcss`/generated-bundle change removing `#evals-bench-capture-continuations`'s `margin-bottom: 1` to buy back the one row task-1710's checkbox had spent. Verified empirically (bundle temporarily reverted to `HEAD`, scroll fix left in place) that the control stays hit-testable through at least four staged targets with the margin still present — the general scroll mechanism makes that row of slack unnecessary. Keeping a slack-based tweak alongside a fix whose entire point is "stop relying on slack" would reintroduce the exact anti-pattern this task closes out, so both `_evals.tcss` and the generated `tldw_cli_modular.tcss` were restored to their committed `HEAD` state (verified: `git diff` against both is empty; `Tests/UI/test_css_bundle_sync_guard.py` and `test_css_build_integrity.py` both pass with no rebuild needed).
+
+**New regression test**: `Tests/UI/test_evals_bench_editor.py::test_create_target_control_stays_hit_testable_across_many_staged_targets` presses "+ New target" SIX times (the closing E2E only exercises two) and after every press asserts `Screen.get_widget_at(*control.region.center)` resolves to the button itself, at the same 160x45 viewport this module's other reachability checks use. Verified the test actually catches the regression: with the scroll-fix calls temporarily removed, it fails after the FIRST staged target with `landed on Static(id='footer-spacer') instead` — the identical failure mode the bug report describes, not a hypothetical.
+
+Deleted the scratch probe (`Tests/UI/test_zz_probe_1764.py`) the prior session used to characterize the bug before committing.
+
+Full requested suite (`test_evals_steering_e2e.py`, `test_evals_bench_editor.py`, `test_evals_screen.py`, `test_evals_empty_states.py`, `Tests/Evals/character_probe`) — 362 passed. CSS bundle sync guard — 10 passed, no drift.
+
+Modified files: `tldw_chatbook/UI/Evals/bench_editor.py` (fix + module/method docstrings), `Tests/UI/test_evals_bench_editor.py` (new regression test). No CSS files changed in the final diff — the uncommitted `_evals.tcss`/bundle edit was reverted as superseded, not shipped.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Evals/bench_editor.py
+++ b/tldw_chatbook/UI/Evals/bench_editor.py
@@ -122,6 +122,20 @@ convention, reusing ``snippet_editor.render_snippet_cell``) or
 `` · system prompt set`` -- so a bench with multiple, differently-steered
 variants of the same underlying model can actually be told apart at a
 glance; an unsteered row's label is unchanged.
+
+TASK-1764: pressing "+ New target" a SECOND time minted no row -- the
+first create's own rebuild grows the targets section by a row (and, once
+a real ``llama_cpp`` model exists, ``_build_target_add_control``'s Add
+picker row too), both mounted ABOVE the mini-form, pushing the just-
+pressed button down and out of ``#evals-bench-editor``'s viewport; the
+next click landed on nothing reachable. This is the THIRD time a row
+added above this mini-form has pushed it out of reach (see
+``_keep_create_control_in_view``'s own docstring for the first two, both
+during this same mini-form's task-1611 T2 development) -- each prior fix
+bought back exactly one row of slack, which holds only until the next
+row. Fixed generally instead: ``_keep_create_control_in_view`` scrolls
+the mini-form back into view after any rebuild that grows the targets
+list, independent of target count or viewport size.
 """
 
 from __future__ import annotations
@@ -1019,6 +1033,57 @@ class BenchEditor(Vertical):
         await section.mount_all(self._build_targets_section())
         self._clear_form_error()
 
+    def _keep_create_control_in_view(self) -> None:
+        """Scrolls ``#evals-bench-create-target-form`` back into
+        ``#evals-bench-editor``'s viewport after a rebuild that GREW the
+        targets list (TASK-1764) -- called by ``stage_target`` and
+        ``_on_add_target_pressed``, the two paths that add a row ABOVE this
+        mini-form and so push it down by one.
+
+        Without this, pressing "+ New target" moves the very button just
+        pressed out from under the pointer: the new target row (and, on the
+        first create, `_build_target_add_control`'s Add picker, which only
+        renders once a `llama_cpp` row exists at all) both land above it.
+        This pane's own history says that is not a hypothetical -- the
+        create control has now been pushed out of reach THREE separate
+        times by a row added above it (twice while task-1611 T2 was being
+        written, see `_build_create_target_control`'s own docstring, and
+        again by task-1710's checkbox, the TASK-1764 regression). Each of
+        those was answered by finding one more row of vertical slack, which
+        buys exactly one more feature; this scrolls instead, so the control
+        stays reachable at ANY target count and ANY viewport rather than
+        only while the arithmetic happens to work out.
+
+        `call_after_refresh`, not a direct call: `_refresh_targets_section`
+        has only just `mount_all`ed the new rows, so the mini-form's own
+        `region` is still the pre-rebuild one until Textual's next layout
+        pass -- scrolling against that stale geometry computes the wrong
+        offset (or, when the section grew, no offset at all).
+
+        Deliberately NOT called from `_on_remove_target_pressed` (the list
+        SHRANK -- nothing was pushed anywhere) or `_on_prompt_mode_changed`
+        (the user is at the TOP of the form, at the prompt-mode `Select`;
+        yanking the viewport to the bottom of the targets section would
+        move a control they are still reading).
+        """
+        from textual.css.query import QueryError  # noqa: PLC0415 -- narrow, matches this module's other local imports
+
+        def _scroll() -> None:
+            try:
+                control = self.query_one("#evals-bench-create-target-form", Horizontal)
+            except QueryError:
+                # Defensive only: this mini-form renders unconditionally
+                # (see `_build_create_target_control`), but a rebuild that
+                # raced an unmount must not crash the handler that queued
+                # this callback.
+                return
+            # `animate=False`: the very next thing a user does here is press
+            # this button again, and an in-flight scroll animation would
+            # leave the button under the pointer only after it lands.
+            self.scroll_to_widget(control, animate=False)
+
+        self.call_after_refresh(_scroll)
+
     def _capture_pending_target_form(self) -> None:
         """Stashes whatever is currently typed into the "+ New target"
         mini-form's Name/steering ``Input``s onto ``self._pending_target_
@@ -1092,6 +1157,7 @@ class BenchEditor(Vertical):
         self._staged_target_ids.append(target_id)
         self._reset_pending_target_form()
         await self._refresh_targets_section()
+        self._keep_create_control_in_view()
 
     def _show_form_error(self, message: str) -> None:
         """Renders ``message`` in ``#evals-bench-form-error`` IN PLACE --
@@ -1154,6 +1220,7 @@ class BenchEditor(Vertical):
         self._staged_target_ids.append(target_id)
         self._capture_pending_target_form()
         await self._refresh_targets_section()
+        self._keep_create_control_in_view()
 
     @on(Button.Pressed, ".evals-bench-target-remove")
     async def _on_remove_target_pressed(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
## Summary

Fixes a regression on `dev`: pressing **"+ New target"** a second time minted nothing, so a bench could still only ever have one model row — the exact wall task-1611 existed to break, and without a second target the column-mode Δ lens is permanently degenerate.

**Root cause:** every rebuild that stages a target mounts a row *above* the "+ New target" mini-form (the new target row, plus the Add picker once any `llama_cpp` row exists), pushing the just-pressed button out of `#evals-bench-editor`'s viewport at a realistic 160×45 terminal. The second click landed on `#footer-spacer`, not the button. Task-1710's checkbox margin (`cb0407067`) is what finally spent the pane's last row of slack.

**Why the fix scrolls instead of finding more room:** this control has now been pushed out of reach three times — twice while task-1611 was being written, and again here — and each previous answer was to reclaim one more row of vertical slack, which buys exactly one more feature. `BenchEditor._keep_create_control_in_view()` scrolls it back into view after any rebuild that grows the list, so it stays reachable at any target count and any viewport. Deliberately not called on removal (the list shrank) or on a prompt-mode flip (the user is reading a control at the top of the form).

The uncommitted CSS margin-removal from the initial investigation was reverted: it was slack-based experimentation superseded by the general fix.

## Verification

- The failing E2E (`test_two_ui_authored_targets_one_steered_light_up_column_mode_delta`) passes for the right reason — no scroll was added to the test to paper over a control users cannot reach either.
- New regression test drives **six** consecutive presses and asserts `Screen.get_widget_at` resolves the control each time; verified it fails on `#footer-spacer` when the fix is removed.
- 372 passed across the Evals UI, character-probe, and CSS-integrity suites.

**Why per-task reviews missed it:** each task verified *its own* control was reachable. Nothing tested that adding a row above the mini-form keeps the *mini-form* reachable. The new test closes that specific gap.

Filed as task-1764 (Done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-1764: the second press of "+ New target" now reliably creates another row by keeping the mini-form in view after the list grows. This restores multi-target creation and unblocks the column-mode delta lens.

- **Bug Fixes**
  - Added `BenchEditor._keep_create_control_in_view()` to scroll `#evals-bench-create-target-form` into `#evals-bench-editor` after rows are added; uses `call_after_refresh` + `scroll_to_widget(animate=False)`.
  - Called from `stage_target` and `_on_add_target_pressed`; not on removal or prompt-mode changes.
  - New regression test presses the button six times and asserts hit-testing via `Screen.get_widget_at`; the original E2E passes without test-added scrolling.
  - Reverted the experimental CSS margin change; no CSS changes shipped.

<sup>Written for commit fcc54e15910e9af4e6973dfe56bdd63b1bd51c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

