### PR TITLE
Move model_steering to a shared home and pin the import graph (task-1754)

### DIFF
--- a/Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md
+++ b/Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md
@@ -1763,29 +1763,36 @@ git commit -m "feat(evals): persist probe conversations, turn annotations, and r
 
 - `Tests/Evals/character_probe/` passes in full, and `Tests/Evals/word_bench/` is unchanged.
 - A bench can be saved, loaded, and run end to end against a fake chat callable, producing conversations that persist and reload.
-- No module under `character_probe/` references word_bench's measurement concepts — no distribution
-  vocabulary appears anywhere in this package's source or surface.
+- No module under `character_probe/` imports word_bench's capture client, normalizer, or canary
+  code.
 
-  **Amended after the whole-branch review (was: "imports word_bench's capture client, normalizer,
-  or canary code").** `character_probe/targets.py` deliberately imports
-  `word_bench.storage.model_steering`, the app's single existing reader for a target's steering out
-  of an `eval_models` row's `config` JSON. Importing that module pulls word_bench's own imports
+  **Restored to this original absolute wording by TASK-1754 (2026-08-01), which the criterion had
+  been amended to soften.** Between phase 1's whole-branch review and TASK-1754, this line briefly
+  read "references word_bench's measurement concepts — no distribution vocabulary appears anywhere
+  in this package's source or surface": `character_probe/targets.py` deliberately imported
+  `word_bench.storage.model_steering`, the app's one reader for a target's steering out of an
+  `eval_models` row's `config` JSON, and importing that module pulled word_bench's own imports in
   transitively — `storage` → `capture_client` → `normalizer` → `httpx` — so the criterion as
-  originally worded is **not** met by the import graph.
-  The reuse is correct and stays: duplicating that reader is exactly what produced Critical C1, in
-  which the runner read a key no `eval_models` row has ever carried and every real run silently
-  dropped its steering. The criterion's *intent* — that none of the measurement stack's ideas leak
-  into an eval that reads only generated text — is fully met, so the criterion is amended to say
-  what is actually true rather than left silently unmet.
+  originally worded was **not** met by the import graph, only in intent. TASK-1754 moved
+  `model_steering`/`_steering_field` (pure functions of a row dict, with no word_bench dependencies)
+  out of `word_bench.storage` into `Evals/steering.py`, a shared module with no imports beyond the
+  standard library; `character_probe/targets.py` now imports that module directly instead of
+  `word_bench.storage`, and `word_bench.storage` re-exports the old name so its existing callers are
+  unaffected. The reuse this criterion is really about — one steering reader for both bench types,
+  never a second, private implementation — is unchanged and stays correct: duplicating that reader
+  is exactly what produced Critical C1, in which the runner read a key no `eval_models` row has ever
+  carried and every real run silently dropped its steering. With the reader relocated, the import
+  graph now satisfies the criterion as originally written, not merely in spirit, so the absolute
+  wording above is restored rather than left softened.
 
-  **The in-repo hygiene test is weaker than the rule it names.**
+  **The in-repo hygiene test now pins the import graph, not source text.**
   `Tests/Evals/character_probe/test_conversation_storage.py::test_character_probe_never_imports_the_word_bench_measurement_stack`
-  greps each module's SOURCE TEXT for forbidden tokens. It cannot see an import graph at all, so it
-  passes on exactly the situation described above. TASK-1754 tracks both halves of the remedy:
-  moving `model_steering`/`_steering_field` (pure functions of a row dict, with no word_bench
-  dependencies) into a shared home neither package's stack rides on, and strengthening the test to
-  assert on the real import graph — e.g. `sys.modules` after a fresh package import — instead of on
-  tokens.
+  used to grep each module's SOURCE TEXT for forbidden tokens, which cannot see an import graph at
+  all and passed throughout the situation described above. TASK-1754 replaced that with a
+  subprocess-based check — importing every `character_probe` module in a fresh interpreter and
+  asserting `word_bench.capture_client`, `word_bench.normalizer`, and `httpx` are absent from
+  `sys.modules` — proven to fail against the pre-move code and pass after, so this criterion now has
+  a guard that can actually detect a regression of it.
 
 ### Forward-looking caveats for Phase 2
 

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -351,6 +351,20 @@ def test_character_probe_never_imports_the_word_bench_measurement_stack():
     from somewhere other than the repo root -- the previous version's own
     bug: a relative ``pathlib.Path("tldw_chatbook/...")`` glob that matched
     nothing (and therefore asserted nothing) from any other cwd.
+
+    The probe script reports one of three OUTCOMES on stdout, not merely a
+    process exit code, and this function asserts on which one it is rather
+    than on the exit code alone: a non-zero exit is ambiguous by itself --
+    it is what BOTH "a forbidden module loaded" (the thing this test
+    exists to catch) AND "some unrelated import in the walked package
+    raised" (a syntax error, a missing optional dependency, anything else)
+    produce, and conflating the two would send someone hunting a
+    forbidden-import violation that does not exist. ``OK`` is success;
+    ``VIOLATION:<modules>`` names exactly which forbidden modules loaded
+    (this is the failure this test is FOR); ``CRASH`` means the probe
+    itself failed to even finish walking the package, which is a different
+    problem entirely and is reported as one, with the subprocess's own
+    traceback surfaced so it is debuggable as what it actually is.
     """
     import pathlib
     import subprocess
@@ -369,19 +383,33 @@ def test_character_probe_never_imports_the_word_bench_measurement_stack():
     # imports capture_client itself, so any path that still reaches
     # word_bench.storage necessarily also reaches capture_client, which is
     # listed below. Checking the leaf modules covers the whole chain.
+    #
+    # The import loop is wrapped so an unrelated import failure anywhere in
+    # the walked package reports as CRASH (with a full traceback on
+    # stderr), never silently reads as "no forbidden module loaded" (a
+    # false pass) or gets conflated with VIOLATION (a false accusation of
+    # the wrong failure) -- see this function's own docstring.
     probe_script = (
-        "import importlib, pkgutil, sys\n"
-        "import tldw_chatbook.Evals.character_probe as pkg\n"
-        "for info in pkgutil.walk_packages(pkg.__path__, pkg.__name__ + '.'):\n"
-        "    importlib.import_module(info.name)\n"
+        "import importlib, pkgutil, sys, traceback\n"
+        "try:\n"
+        "    import tldw_chatbook.Evals.character_probe as pkg\n"
+        "    for info in pkgutil.walk_packages(pkg.__path__, pkg.__name__ + '.'):\n"
+        "        importlib.import_module(info.name)\n"
+        "except BaseException:\n"
+        "    traceback.print_exc()\n"
+        "    sys.stdout.write('CRASH\\n')\n"
+        "    sys.exit(2)\n"
         "forbidden = [\n"
         "    'tldw_chatbook.Evals.word_bench.capture_client',\n"
         "    'tldw_chatbook.Evals.word_bench.normalizer',\n"
         "    'httpx',\n"
         "]\n"
         "present = sorted(m for m in forbidden if m in sys.modules)\n"
-        "sys.stdout.write('LOADED:' + ','.join(present))\n"
-        "sys.exit(1 if present else 0)\n"
+        "if present:\n"
+        "    sys.stdout.write('VIOLATION:' + ','.join(present) + '\\n')\n"
+        "    sys.exit(1)\n"
+        "sys.stdout.write('OK\\n')\n"
+        "sys.exit(0)\n"
     )
     result = subprocess.run(
         [sys.executable, "-c", probe_script],
@@ -390,10 +418,27 @@ def test_character_probe_never_imports_the_word_bench_measurement_stack():
         text=True,
         timeout=60,
     )
-    assert result.returncode == 0, (
-        "importing tldw_chatbook.Evals.character_probe (every module of it) "
-        "loaded word_bench's measurement stack -- "
-        f"stdout={result.stdout!r} stderr(tail)={result.stderr[-4000:]!r}"
+    stdout = result.stdout
+    stderr_tail = result.stderr[-4000:]
+
+    if stdout.startswith("VIOLATION:"):
+        loaded = stdout[len("VIOLATION:"):].strip()
+        pytest.fail(
+            "importing tldw_chatbook.Evals.character_probe (every module of "
+            f"it) loaded word_bench's measurement stack: {loaded}"
+        )
+    if stdout.startswith("CRASH"):
+        pytest.fail(
+            "the import-graph probe crashed while walking "
+            "tldw_chatbook.Evals.character_probe -- this is NOT evidence of "
+            "a forbidden import (see VIOLATION above for that); it means "
+            "the probe itself, or an unrelated import in the package, "
+            f"failed. Traceback from the subprocess:\n{stderr_tail}"
+        )
+    assert result.returncode == 0 and stdout.strip() == "OK", (
+        "the import-graph probe subprocess ended in an unrecognized state "
+        f"-- returncode={result.returncode} stdout={stdout!r} "
+        f"stderr(tail)={stderr_tail!r}"
     )
 
     # Secondary, cheap check kept alongside the graph assertion above (not

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -327,14 +327,82 @@ def test_a_prefix_steered_target_never_opens_a_run_group(db, bench):
 
 def test_character_probe_never_imports_the_word_bench_measurement_stack():
     """This eval reads generated text only. Importing the capture client,
-    normalizer, or canary code would let distribution vocabulary leak into a
-    surface that has no distributions -- pinned the way
-    Tests/UI/test_evals_bench_editor.py pins the same rule for the editor."""
-    import pathlib
+    normalizer, or canary code (httpx-backed) would let distribution
+    vocabulary leak into a surface that has none -- pinned the way
+    Tests/UI/test_evals_bench_editor.py pins the same rule for the editor.
 
-    package = pathlib.Path("tldw_chatbook/Evals/character_probe")
-    forbidden = ("capture_client", "normalize_logprobs", "CANARY", "top_k", "logprobs")
-    for module in package.glob("*.py"):
+    A source-token grep alone cannot catch this: ``character_probe/targets.py``
+    imports ``model_steering`` (task-1611's steering reader), and until
+    task-1754 relocated that reader out of ``word_bench.storage`` into a
+    shared, stdlib-only module (``Evals/steering.py``), importing it pulled
+    ``word_bench.capture_client`` -> ``normalizer`` -> ``httpx`` in
+    transitively -- with no forbidden token ever appearing in ANY
+    character_probe source file, so the old version of this test passed
+    throughout. The subprocess check below is what actually pins the rule;
+    the token grep after it is a cheap secondary check, not a substitute.
+
+    Runs in a subprocess so an already-populated ``sys.modules`` from other
+    tests in this same session (e.g. ``Tests/Evals/word_bench/*``, which
+    legitimately import word_bench) can never produce a false pass -- a
+    fresh interpreter is the only way to observe what importing
+    character_probe *by itself* actually loads. ``cwd`` is computed from
+    this file's own resolved path, not the process's ambient working
+    directory, so the check cannot silently no-op when pytest is invoked
+    from somewhere other than the repo root -- the previous version's own
+    bug: a relative ``pathlib.Path("tldw_chatbook/...")`` glob that matched
+    nothing (and therefore asserted nothing) from any other cwd.
+    """
+    import pathlib
+    import subprocess
+    import sys
+
+    repo_root = pathlib.Path(__file__).resolve().parents[3]
+    package_dir = repo_root / "tldw_chatbook" / "Evals" / "character_probe"
+    assert package_dir.is_dir(), (
+        f"computed repo root {repo_root!r} does not contain the package "
+        "under test; this test's parents[N] no longer matches this file's "
+        "location on disk"
+    )
+
+    # word_bench.storage is deliberately not listed here even though it is
+    # the module that USED to carry model_steering: it unconditionally
+    # imports capture_client itself, so any path that still reaches
+    # word_bench.storage necessarily also reaches capture_client, which is
+    # listed below. Checking the leaf modules covers the whole chain.
+    probe_script = (
+        "import importlib, pkgutil, sys\n"
+        "import tldw_chatbook.Evals.character_probe as pkg\n"
+        "for info in pkgutil.walk_packages(pkg.__path__, pkg.__name__ + '.'):\n"
+        "    importlib.import_module(info.name)\n"
+        "forbidden = [\n"
+        "    'tldw_chatbook.Evals.word_bench.capture_client',\n"
+        "    'tldw_chatbook.Evals.word_bench.normalizer',\n"
+        "    'httpx',\n"
+        "]\n"
+        "present = sorted(m for m in forbidden if m in sys.modules)\n"
+        "sys.stdout.write('LOADED:' + ','.join(present))\n"
+        "sys.exit(1 if present else 0)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe_script],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        "importing tldw_chatbook.Evals.character_probe (every module of it) "
+        "loaded word_bench's measurement stack -- "
+        f"stdout={result.stdout!r} stderr(tail)={result.stderr[-4000:]!r}"
+    )
+
+    # Secondary, cheap check kept alongside the graph assertion above (not
+    # instead of it -- see the docstring): no forbidden token appears in
+    # this package's own source either. package_dir is computed from
+    # repo_root above, not a relative literal, for the same cwd-independence
+    # reason as the subprocess check.
+    forbidden_tokens = ("capture_client", "normalize_logprobs", "CANARY", "top_k", "logprobs")
+    for module in package_dir.glob("*.py"):
         source = module.read_text()
-        for token in forbidden:
+        for token in forbidden_tokens:
             assert token not in source, f"{module.name} mentions {token}"

--- a/backlog/tasks/task-1754 - Move model_steering to a shared home and pin the import graph.md
+++ b/backlog/tasks/task-1754 - Move model_steering to a shared home and pin the import graph.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1754
 title: Move model_steering to a shared home and pin the import graph
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-01 12:45'
 labels:

--- a/backlog/tasks/task-1754 - Move-model_steering-to-a-shared-home-and-pin-the-import-graph.md
+++ b/backlog/tasks/task-1754 - Move-model_steering-to-a-shared-home-and-pin-the-import-graph.md
@@ -4,6 +4,7 @@ title: Move model_steering to a shared home and pin the import graph
 status: In Progress
 assignee: []
 created_date: '2026-08-01 12:45'
+updated_date: '2026-08-01 22:26'
 labels:
   - evals
 dependencies: []
@@ -52,6 +53,18 @@ needs it, rather than a copy per caller.
 - [ ] #5 The word bench's own behaviour is unchanged: `Tests/Evals/word_bench/` passes untouched
 - [ ] #6 Phase 1 exit criterion 3 in `Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md` is restored to its original absolute wording once the import graph actually satisfies it
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create tldw_chatbook/Evals/steering.py: pure `model_steering`/`_steering_field`, moved verbatim (docstrings intact, references updated) from word_bench/storage.py. Only stdlib imports (json, typing) -- no import of word_bench or character_probe modules.
+2. word_bench/storage.py: delete the local definitions, import `model_steering` from `..steering` instead so `word_bench.storage.model_steering` keeps working for existing callers (bench_editor.py, sample_bench.py, tests) via re-export -- but importing storage.py still pulls capture_client for its own unrelated NEUTRAL_SAMPLER use, so this re-export is for BACKWARD COMPATIBILITY of the old import path only, never used by character_probe.
+3. character_probe/targets.py: import `model_steering` directly from `..steering`, not from `..word_bench.storage`, so importing character_probe never touches word_bench.storage/capture_client/normalizer/httpx.
+4. Verify with a throwaway sys.modules probe (pre- and post-move) that word_bench.capture_client/normalizer/httpx no longer load when importing character_probe.targets.
+5. Rewrite the hygiene test in Tests/Evals/character_probe/test_conversation_storage.py: replace the source-text grep with a subprocess-based import-graph assertion -- launch a clean interpreter (cwd computed from Path(__file__).resolve() so it is cwd-independent), import every character_probe submodule, and assert word_bench.capture_client / word_bench.normalizer / httpx are absent from sys.modules. Confirm the new test FAILS against the pre-move code (temporarily revert targets.py's import) and PASSES after.
+6. Update Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md exit criterion 3: restore the original absolute wording and replace the amendment note with one stating the import graph now satisfies it, moved by task-1754, enforced by the strengthened test.
+7. Run the targeted suites, update task ACs/status, commit.
+<!-- SECTION:PLAN:END -->
 
 ## Notes
 

--- a/backlog/tasks/task-1754 - Move-model_steering-to-a-shared-home-and-pin-the-import-graph.md
+++ b/backlog/tasks/task-1754 - Move-model_steering-to-a-shared-home-and-pin-the-import-graph.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-1754
 title: Move model_steering to a shared home and pin the import graph
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-01 12:45'
-updated_date: '2026-08-01 22:26'
+updated_date: '2026-08-01 22:34'
 labels:
   - evals
 dependencies: []
@@ -46,12 +46,12 @@ needs it, rather than a copy per caller.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `model_steering` and its `_steering_field` helper live in a shared module that imports neither `word_bench`'s nor `character_probe`'s own modules, and both packages read a target's steering through it
-- [ ] #2 No copy of the steering-reading logic remains in `word_bench.storage` or anywhere else — callers of the old name continue to work or are updated, with no second implementation
-- [ ] #3 Importing `tldw_chatbook.Evals.character_probe` (any module of it) does not load `word_bench`'s capture client, normalizer, or `httpx`
-- [ ] #4 The character-probe hygiene test asserts on the real import graph (e.g. inspecting `sys.modules` after a fresh package import in a subprocess) rather than on source tokens, and is proven to FAIL when a forbidden import is reintroduced
-- [ ] #5 The word bench's own behaviour is unchanged: `Tests/Evals/word_bench/` passes untouched
-- [ ] #6 Phase 1 exit criterion 3 in `Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md` is restored to its original absolute wording once the import graph actually satisfies it
+- [x] #1 `model_steering` and its `_steering_field` helper live in a shared module that imports neither `word_bench`'s nor `character_probe`'s own modules, and both packages read a target's steering through it
+- [x] #2 No copy of the steering-reading logic remains in `word_bench.storage` or anywhere else — callers of the old name continue to work or are updated, with no second implementation
+- [x] #3 Importing `tldw_chatbook.Evals.character_probe` (any module of it) does not load `word_bench`'s capture client, normalizer, or `httpx`
+- [x] #4 The character-probe hygiene test asserts on the real import graph (e.g. inspecting `sys.modules` after a fresh package import in a subprocess) rather than on source tokens, and is proven to FAIL when a forbidden import is reintroduced
+- [x] #5 The word bench's own behaviour is unchanged: `Tests/Evals/word_bench/` passes untouched
+- [x] #6 Phase 1 exit criterion 3 in `Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md` is restored to its original absolute wording once the import graph actually satisfies it
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -65,6 +65,48 @@ needs it, rather than a copy per caller.
 6. Update Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md exit criterion 3: restore the original absolute wording and replace the amendment note with one stating the import graph now satisfies it, moved by task-1754, enforced by the strengthened test.
 7. Run the targeted suites, update task ACs/status, commit.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Moved `model_steering`/`_steering_field` (pure functions of an `eval_models` row mapping) out of
+`word_bench.storage` into a new `tldw_chatbook/Evals/steering.py`, whose only imports are stdlib
+(`json`, `typing`). `word_bench.storage` now does `from ..steering import model_steering as
+model_steering` (explicit re-export) so every existing caller spelling it
+`word_bench.storage.model_steering` (bench_editor.py, sample_bench.py, test_storage.py) keeps
+working unchanged; `character_probe/targets.py` now imports `..steering` directly, never through
+`word_bench.storage`, so importing character_probe no longer pulls capture_client/normalizer/httpx
+in transitively. Verified interactively: a `sys.modules` probe importing `character_probe.targets`
+shows word_bench/httpx entries before the move and none after.
+
+Rewrote the hygiene test (`test_character_probe_never_imports_the_word_bench_measurement_stack`) to
+launch a subprocess, walk-import every `character_probe` submodule in a clean interpreter, and
+assert `word_bench.capture_client`/`word_bench.normalizer`/`httpx` are absent from `sys.modules`.
+`cwd` is computed from the test file's own resolved path (`parents[3]`), not the ambient working
+directory, fixing the old test's silent-pass-from-any-other-cwd bug. Proved the new test actually
+tests something: temporarily reverted `targets.py`'s import back to `..word_bench.storage` and
+confirmed the test FAILS with `LOADED:httpx,tldw_chatbook.Evals.word_bench.capture_client,
+tldw_chatbook.Evals.word_bench.normalizer`, then restored the fix and confirmed it passes again.
+Kept the old source-token grep as a secondary, cheap check (also fixed to use an absolute,
+`__file__`-derived package path instead of a relative literal), not as a substitute for the graph
+assertion.
+
+Restored phase 1 exit criterion 3 in
+`Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md` to its original absolute
+wording ("No module under `character_probe/` imports word_bench's capture client, normalizer, or
+canary code") and replaced the amendment note explaining why it was only met in spirit with one
+recording that TASK-1754 closed the gap in both letter and intent, and that the rewritten test now
+enforces it.
+
+Verification: `Tests/Evals/character_probe Tests/Evals/word_bench Tests/UI/test_evals_steering_e2e.py`
+-- 368 passed. Also ran `Tests/UI/test_evals_bench_editor.py` (80 passed) as an extra sanity check
+on the `word_bench.storage.model_steering` re-export path, since that suite exercises it end to end
+through the UI.
+
+Files changed: tldw_chatbook/Evals/steering.py (new), tldw_chatbook/Evals/word_bench/storage.py,
+tldw_chatbook/Evals/character_probe/targets.py, Tests/Evals/character_probe/test_conversation_storage.py,
+Docs/superpowers/plans/2026-08-01-character-probe-phase1-engine.md.
+<!-- SECTION:NOTES:END -->
 
 ## Notes
 

--- a/tldw_chatbook/Evals/character_probe/targets.py
+++ b/tldw_chatbook/Evals/character_probe/targets.py
@@ -13,15 +13,18 @@ run needs from it are NOT top-level columns:
   branch of this package came to drop every target's steering silently while
   a test built its own row shape and passed.
 
-The steering read itself is ``word_bench.storage.model_steering`` -- the one
-existing home for that convention (task-1611), reused rather than
-reimplemented so the two bench types can never drift into disagreeing about
-what a row means. The design spec lists targets "and their steering" among
-the things this eval explicitly DOES reuse, so this import is the sanctioned
-kind; only that one reader is called, and none of word_bench's measurement
-code is referenced here or anywhere else in this package. (Importing that
-module does pull word_bench's own imports in transitively -- unavoidable
-without duplicating the reader, which is the thing worth avoiding.)
+The steering read itself is ``model_steering`` (task-1611's original reader,
+relocated by task-1754 to ``Evals.steering`` -- a shared module with no
+imports beyond the standard library), reused rather than reimplemented so
+the two bench types can never drift into disagreeing about what a row
+means. The design spec lists targets "and their steering" among the things
+this eval explicitly DOES reuse, so this import is the sanctioned kind; only
+that one reader is called, and none of word_bench's measurement code is
+referenced here or anywhere else in this package. Importing ``..steering``
+directly (never ``..word_bench.storage``, which still carries the reader
+under its old name for backward compatibility) means this package never
+loads word_bench's capture client, normalizer, or httpx -- pinned by
+``Tests/Evals/character_probe/test_conversation_storage.py::test_character_probe_never_imports_the_word_bench_measurement_stack``.
 """
 
 from __future__ import annotations
@@ -29,7 +32,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence
 
-from ..word_bench.storage import model_steering
+from ..steering import model_steering
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/Evals/steering.py
+++ b/tldw_chatbook/Evals/steering.py
@@ -1,0 +1,181 @@
+"""Read a target's steering out of its ``eval_models`` row.
+
+Shared home for ``model_steering``/``_steering_field`` (task-1611's original
+reader, relocated here by task-1754). Both are pure functions of a row
+mapping -- they touch nothing else, not even ``Evals_DB`` -- but they
+originally lived inside ``word_bench.storage``, a module whose own imports
+reach ``capture_client``, ``normalizer``, and ``httpx``.
+``character_probe.targets`` needs the exact same reader: reusing it there is
+deliberate, not incidental -- the alternative (a second, private steering
+reader) is exactly the failure mode that produced Critical C1 of the phase 1
+whole-branch review, where a hand-rolled reader looked for
+``row["system_prompt"]``, a key no ``eval_models`` row has ever carried, and
+every real run silently dropped its target's steering while a hand-built
+test fixture agreed with the bug. Duplicating this function is the thing to
+avoid, not importing it.
+
+The cost of importing it from ``word_bench.storage``, though, was dragging
+that module's own imports in transitively -- ``storage`` -> ``capture_client``
+-> ``normalizer`` -> ``httpx`` -- into a package (``character_probe``) that
+must never acquire distribution vocabulary, even in its import graph. Living
+here instead, at the ``Evals`` package's own top level with no imports
+beyond the standard library, lets both ``word_bench`` and ``character_probe``
+read a target's steering through the one function without either dragging
+the other's dependency stack in.
+
+``word_bench.storage`` re-exports ``model_steering`` under its original name
+(``from ..steering import model_steering``) so every existing caller
+(``UI/Evals/bench_editor.py``, ``UI/Evals/sample_bench.py``, and
+``Tests/Evals/word_bench/test_storage.py``, all of which spell it
+``word_bench.storage.model_steering``) keeps working unchanged. That
+re-export is safe precisely because it is backward-only: ``storage.py``
+still imports ``capture_client`` anyway (for ``NEUTRAL_SAMPLER``, used by its
+own ``_snapshot``), so re-exporting costs it nothing further, and
+``character_probe.targets`` imports this module directly rather than through
+``word_bench.storage`` -- see that module's own docstring -- so the
+transitive pull never reaches it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Optional
+
+
+def model_steering(model_row: Mapping[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    """Read a target's steering out of its ``eval_models`` row.
+
+    ``eval_models.config`` (a free-form JSON column -- see
+    ``Evals_DB.create_model``/``get_model``, both of which already parse it
+    into a ``dict`` before this function ever sees it) is this app's ONE
+    home for a target's steering: ``config["prefix"]`` for a raw-mode
+    target, ``config["system_prompt"]`` for a chat-mode one -- the same
+    split ``word_bench.models.Target``/``word_bench.capture_client._build_request``
+    already enforce (see ``Target``'s own docstring: raw mode prepends a
+    literal prefix, chat mode has no prefix slot and instead sends a system
+    message). Steering is immutable per row: ``Evals_DB`` has no
+    ``update_model``, so a differently-steered variant of a target (e.g.
+    the same underlying model with a different prefix) is always a NEW
+    ``eval_models`` row, never an edit of an existing one.
+
+    Args:
+        model_row: An ``eval_models`` row as returned by
+            ``EvalsDB.get_model``/``list_models`` -- ``config`` already
+            parsed into a mapping by those methods. A row with no
+            ``config`` key at all (every ``eval_models`` row written before
+            this convention existed), or an explicit SQL ``NULL``
+            (``config`` present and ``None``), is treated the same as an
+            explicit ``{}``. Every OTHER non-mapping value -- INCLUDING
+            falsy ones like ``0``, ``[]``, ``""``, or ``False`` -- is
+            corrupt, not lenient-unsteered; see Raises. Only genuine
+            absence carries no information, and only a real empty mapping
+            (``{}``) is evidence of "deliberately unsteered"; every other
+            shape is evidence something wrote a non-config value into this
+            column.
+
+    Returns:
+        ``(prefix, system_prompt)``. An unset key or an empty-string value
+        both read as ``None`` for that field alike -- a form field left
+        blank must never be distinguished from one that was cleared back
+        to ``""``. At most one of the pair is ever non-``None`` on a
+        successful return; see Raises for the case where the stored row
+        itself violates that.
+
+    Raises:
+        ValueError: If ``config`` has BOTH ``prefix`` and ``system_prompt``
+            set to a non-empty value. ``word_bench.models.Target.__post_init__``
+            already rejects constructing a ``Target`` with both set, but a
+            row that reached this state some other way (e.g. hand-edited
+            JSON) must be surfaced as the corrupt row it is -- naming the
+            model id -- rather than have this function silently pick one
+            field over the other and hide the inconsistency.
+        ValueError: If ``config`` (once present and non-``None``) is
+            anything other than a JSON object -- e.g. hand-edited into a
+            list, a bare number, a bool, or an empty string -- naming the
+            model id, same as the both-set case above, rather than raising
+            an opaque ``AttributeError`` out of the ``.get()`` calls below,
+            or (for a falsy value) silently reading as "unsteered" as an
+            earlier version of this function did. See Args above: falsy is
+            NOT a synonym for absent here.
+        ValueError: If a present ``prefix`` or ``system_prompt`` value is
+            not itself a string (e.g. ``{"prefix": 5}``) -- naming both the
+            model id and the offending field, so a non-string never reaches
+            ``Target.prefix``/``Target.system_prompt`` and then
+            ``capture_client._build_request``'s string concatenation/
+            message-building as an untyped value.
+    """
+    _unset = object()
+    raw_config = model_row.get("config", _unset)
+    if raw_config is _unset or raw_config is None:
+        # Genuine absence (no "config" key at all -- every eval_models row
+        # written before this convention existed) or an explicit SQL NULL.
+        # Both carry no information about steering and read as unsteered.
+        # Nothing else does -- see the type check below.
+        config: Any = {}
+    elif isinstance(raw_config, str):
+        # Defensive: get_model/list_models always hand back an
+        # already-parsed value, so a caller going through them never lands
+        # here with genuine unparsed JSON text -- this accommodates a
+        # caller passing a raw sqlite row instead (config still literal
+        # JSON text). A value that fails to parse as JSON at all (e.g. the
+        # literal empty string, once ALREADY parsed by get_model out of a
+        # stored `""` config) falls straight through as the original
+        # string, to be rejected by the non-mapping check below with a
+        # message naming the model id -- rather than leaking json.loads's
+        # own JSONDecodeError, which never mentions the row at all.
+        try:
+            config = json.loads(raw_config)
+        except ValueError:
+            config = raw_config
+    else:
+        config = raw_config
+
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"eval_models row {model_row.get('id')!r} has a non-mapping "
+            "config; expected an object with optional 'prefix'/"
+            "'system_prompt'"
+        )
+
+    prefix = _steering_field(config, "prefix", model_row.get("id"))
+    system_prompt = _steering_field(config, "system_prompt", model_row.get("id"))
+    if prefix and system_prompt:
+        raise ValueError(
+            f"eval_models row {model_row.get('id')!r} has both prefix and "
+            "system_prompt set in its config; a target belongs to exactly "
+            "one prompt mode."
+        )
+    return prefix, system_prompt
+
+
+def _steering_field(config: dict, field: str, model_id: Any) -> Optional[str]:
+    """One steering field out of an already-validated ``config`` mapping,
+    type-checked and empty-string-normalized. Shared by ``model_steering``
+    for both ``"prefix"`` and ``"system_prompt"`` so the two can never
+    silently drift in how they validate or normalize.
+
+    Args:
+        config: The row's ``config``, already confirmed to be a ``dict`` by
+            ``model_steering``'s own check.
+        field: ``"prefix"`` or ``"system_prompt"``.
+        model_id: The owning row's id, only for the error message below.
+
+    Returns:
+        The field's string value, or ``None`` if the key is absent, its
+        value is ``None``, or its value is an empty string.
+
+    Raises:
+        ValueError: If the key is present with a non-``None``,
+            non-``str`` value (e.g. ``{"prefix": 5}``) -- naming both
+            ``model_id`` and ``field`` so the corrupt row and the specific
+            offending key are both legible from the message alone.
+    """
+    value = config.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            f"eval_models row {model_id!r} has a non-string {field!r} in "
+            "its config; steering values must be strings."
+        )
+    return value or None

--- a/tldw_chatbook/Evals/word_bench/storage.py
+++ b/tldw_chatbook/Evals/word_bench/storage.py
@@ -18,6 +18,7 @@ import uuid
 from typing import Any, Mapping, Optional, Sequence
 
 from ...DB.Evals_DB import EvalsDB
+from ..steering import model_steering as model_steering  # re-export, see below
 from .capture_client import NEUTRAL_SAMPLER
 from .models import (
     BenchConfig,
@@ -31,144 +32,18 @@ from .models import (
 
 BENCH_TYPE = "word_bench"
 
-
-def model_steering(model_row: Mapping[str, Any]) -> tuple[Optional[str], Optional[str]]:
-    """Read a target's steering out of its ``eval_models`` row.
-
-    ``eval_models.config`` (a free-form JSON column -- see
-    ``Evals_DB.create_model``/``get_model``, both of which already parse it
-    into a ``dict`` before this function ever sees it) is this app's ONE
-    home for a target's steering: ``config["prefix"]`` for a raw-mode
-    target, ``config["system_prompt"]`` for a chat-mode one -- the same
-    split ``models.Target``/``capture_client._build_request`` already
-    enforce (see ``Target``'s own docstring: raw mode prepends a literal
-    prefix, chat mode has no prefix slot and instead sends a system
-    message). Steering is immutable per row: ``Evals_DB`` has no
-    ``update_model``, so a differently-steered variant of a target (e.g.
-    the same underlying model with a different prefix) is always a NEW
-    ``eval_models`` row, never an edit of an existing one.
-
-    Args:
-        model_row: An ``eval_models`` row as returned by
-            ``EvalsDB.get_model``/``list_models`` -- ``config`` already
-            parsed into a mapping by those methods. A row with no
-            ``config`` key at all (every ``eval_models`` row written before
-            this convention existed), or an explicit SQL ``NULL``
-            (``config`` present and ``None``), is treated the same as an
-            explicit ``{}``. Every OTHER non-mapping value -- INCLUDING
-            falsy ones like ``0``, ``[]``, ``""``, or ``False`` -- is
-            corrupt, not lenient-unsteered; see Raises. Only genuine
-            absence carries no information, and only a real empty mapping
-            (``{}``) is evidence of "deliberately unsteered"; every other
-            shape is evidence something wrote a non-config value into this
-            column.
-
-    Returns:
-        ``(prefix, system_prompt)``. An unset key or an empty-string value
-        both read as ``None`` for that field alike -- a form field left
-        blank must never be distinguished from one that was cleared back
-        to ``""``. At most one of the pair is ever non-``None`` on a
-        successful return; see Raises for the case where the stored row
-        itself violates that.
-
-    Raises:
-        ValueError: If ``config`` has BOTH ``prefix`` and ``system_prompt``
-            set to a non-empty value. ``models.Target.__post_init__``
-            already rejects constructing a ``Target`` with both set, but a
-            row that reached this state some other way (e.g. hand-edited
-            JSON) must be surfaced as the corrupt row it is -- naming the
-            model id -- rather than have this function silently pick one
-            field over the other and hide the inconsistency.
-        ValueError: If ``config`` (once present and non-``None``) is
-            anything other than a JSON object -- e.g. hand-edited into a
-            list, a bare number, a bool, or an empty string -- naming the
-            model id, same as the both-set case above, rather than raising
-            an opaque ``AttributeError`` out of the ``.get()`` calls below,
-            or (for a falsy value) silently reading as "unsteered" as an
-            earlier version of this function did. See Args above: falsy is
-            NOT a synonym for absent here.
-        ValueError: If a present ``prefix`` or ``system_prompt`` value is
-            not itself a string (e.g. ``{"prefix": 5}``) -- naming both the
-            model id and the offending field, so a non-string never reaches
-            ``Target.prefix``/``Target.system_prompt`` and then
-            ``capture_client._build_request``'s string concatenation/
-            message-building as an untyped value.
-    """
-    _unset = object()
-    raw_config = model_row.get("config", _unset)
-    if raw_config is _unset or raw_config is None:
-        # Genuine absence (no "config" key at all -- every eval_models row
-        # written before this convention existed) or an explicit SQL NULL.
-        # Both carry no information about steering and read as unsteered.
-        # Nothing else does -- see the type check below.
-        config: Any = {}
-    elif isinstance(raw_config, str):
-        # Defensive: get_model/list_models always hand back an
-        # already-parsed value, so a caller going through them never lands
-        # here with genuine unparsed JSON text -- this accommodates a
-        # caller passing a raw sqlite row instead (config still literal
-        # JSON text). A value that fails to parse as JSON at all (e.g. the
-        # literal empty string, once ALREADY parsed by get_model out of a
-        # stored `""` config) falls straight through as the original
-        # string, to be rejected by the non-mapping check below with a
-        # message naming the model id -- rather than leaking json.loads's
-        # own JSONDecodeError, which never mentions the row at all.
-        try:
-            config = json.loads(raw_config)
-        except ValueError:
-            config = raw_config
-    else:
-        config = raw_config
-
-    if not isinstance(config, dict):
-        raise ValueError(
-            f"eval_models row {model_row.get('id')!r} has a non-mapping "
-            "config; expected an object with optional 'prefix'/"
-            "'system_prompt'"
-        )
-
-    prefix = _steering_field(config, "prefix", model_row.get("id"))
-    system_prompt = _steering_field(config, "system_prompt", model_row.get("id"))
-    if prefix and system_prompt:
-        raise ValueError(
-            f"eval_models row {model_row.get('id')!r} has both prefix and "
-            "system_prompt set in its config; a target belongs to exactly "
-            "one prompt mode."
-        )
-    return prefix, system_prompt
-
-
-def _steering_field(config: dict, field: str, model_id: Any) -> Optional[str]:
-    """One steering field out of an already-validated ``config`` mapping,
-    type-checked and empty-string-normalized. Shared by ``model_steering``
-    for both ``"prefix"`` and ``"system_prompt"`` so the two can never
-    silently drift in how they validate or normalize.
-
-    Args:
-        config: The row's ``config``, already confirmed to be a ``dict`` by
-            ``model_steering``'s own check.
-        field: ``"prefix"`` or ``"system_prompt"``.
-        model_id: The owning row's id, only for the error message below.
-
-    Returns:
-        The field's string value, or ``None`` if the key is absent, its
-        value is ``None``, or its value is an empty string.
-
-    Raises:
-        ValueError: If the key is present with a non-``None``,
-            non-``str`` value (e.g. ``{"prefix": 5}``) -- naming both
-            ``model_id`` and ``field`` so the corrupt row and the specific
-            offending key are both legible from the message alone.
-    """
-    value = config.get(field)
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise ValueError(
-            f"eval_models row {model_id!r} has a non-string {field!r} in "
-            "its config; steering values must be strings."
-        )
-    return value or None
+#: Re-exported from ``..steering`` (task-1754) so every existing caller that
+#: spells it ``word_bench.storage.model_steering`` -- ``UI/Evals/bench_editor.py``,
+#: ``UI/Evals/sample_bench.py``, ``Tests/Evals/word_bench/test_storage.py`` --
+#: keeps working unchanged. The function itself, and its ``_steering_field``
+#: helper, now live in ``..steering`` because that module has no imports
+#: beyond the standard library, while this one imports ``capture_client``
+#: (below, for ``NEUTRAL_SAMPLER``) which in turn imports ``normalizer`` and
+#: ``httpx``. ``character_probe.targets`` imports ``..steering`` directly --
+#: never through this module -- so re-exporting the name here costs this
+#: module nothing further and never lets the transitive pull reach
+#: character_probe. See ``..steering``'s own module docstring for the full
+#: rationale.
 
 
 def _unique_name(base: str) -> str:


### PR DESCRIPTION
## Summary

Closes a rule the character-probe engine was violating in substance while its own test reported green.

The phase-1 plan says no module under `character_probe/` may import word_bench's capture client, normalizer, or canary code — that package reads generated text and has no distributions, so distribution vocabulary must not leak into it. But `targets.py` imported `model_steering` from `word_bench.storage`, which transitively pulled `capture_client`, `normalizer`, and `httpx`. The reuse itself was right — duplicating that reader is what caused the steering Critical during phase 1 — so the fix is to give it a home neither package has to reach through the other for.

- **`tldw_chatbook/Evals/steering.py`** now holds `model_steering`/`_steering_field`, moved verbatim. It imports only `json` and `typing`.
- `word_bench.storage` re-exports it, so its existing callers are untouched.
- `character_probe/targets.py` imports it directly, and no longer drags the measurement stack.

**The test that was supposed to prevent this could not.** It grepped module *source text* for tokens, so a transitive import violated the rule invisibly — and it used a relative path, meaning run from any other working directory its glob was empty and it asserted nothing at all. It is now a subprocess import-graph check on a clean interpreter, asserting `sys.modules`, with its path derived from `__file__`.

**Verified it actually fails against the old code:** reverting `targets.py`'s import to the `word_bench.storage` path makes the new test fail with `LOADED:httpx,tldw_chatbook.Evals.word_bench.capture_client,tldw_chatbook.Evals.word_bench.normalizer`. A pin that passes before and after would have been decoration.

Phase-1 exit criterion 3 is restored to its original absolute wording, replacing the "met in spirit, not in letter" amendment that recorded the gap honestly at the time.

## Verification

368 passed across character-probe, word_bench, and the steering E2E; 80 more in the bench-editor suite as a check on the re-export path.

Out of scope and deliberately excluded from the new assertion so it cannot false-fail: `character_probe` also pulls Textual/Rich transitively via `DB.Evals_DB → config.py`, which is pre-existing and repo-wide.

Task-1754 Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
