### PR TITLE
Console character avatar: survive monochrome, and repaint when its section re-opens

### DIFF
--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -687,3 +687,46 @@ async def test_available_cols_measures_the_section_not_the_holder(
     )
     assert measured != holder.content_size.width
 
+
+
+@pytest.mark.unit
+def test_expanding_the_character_section_reallows_a_rail_width_avatar():
+    """Re-opening the collapsed Character section must re-render the avatar.
+
+    A user reported "no character image in the Console" and turned out to
+    have the Character rail section COLLAPSED. Clicking it open is the fix
+    -- but two mechanisms interact badly on that path:
+
+    * a collapsed body has ``display: none``, so
+      ``_character_avatar_available_cols()`` measures 0 and
+      ``character_avatar_box(0)`` clamps to the 16-column MINIMUM;
+    * ``_refresh_active_character_avatar_if_scope_changed`` early-returns
+      while ``(character_id, state)`` is unchanged.
+
+    So an avatar first rendered while collapsed stays pinned at 16 columns
+    forever -- exactly the "~50-column rail showing a 16-column portrait"
+    defect task-1661 fixed for a different trigger. Toggling the section
+    open must invalidate the scope guard so the next sync re-measures.
+    """
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen, character_avatar_box
+
+    # The sizing half of the trap, in isolation: a hidden body measures 0.
+    assert character_avatar_box(0) == (16, 8), "collapsed body clamps to minimum"
+    assert character_avatar_box(48)[0] > 16, "an open rail should size larger"
+
+    screen = ChatScreen.__new__(ChatScreen)
+    screen._last_console_avatar_scope = (7, "idle")
+    applied: list[tuple[str, bool]] = []
+    screen._set_console_rail_preference = lambda **kw: applied.append(("pref", True))
+    screen._apply_console_rail_section_open = lambda sid, o: applied.append((sid, o))
+    screen._current_console_rail_state = lambda: type(
+        "S", (), {"character_open": False}
+    )()
+
+    screen._toggle_console_rail_section("character")
+
+    assert ("character", True) in applied, "section did not open"
+    assert screen._last_console_avatar_scope is None, (
+        "opening the Character section must clear the avatar scope guard, or "
+        "the portrait stays at the collapsed 16-column size forever"
+    )

--- a/Tests/Utils/test_mosaic_render.py
+++ b/Tests/Utils/test_mosaic_render.py
@@ -113,3 +113,57 @@ def test_contain_stays_default():
 
     lines = text.plain.split("\n")
     assert len(lines) < 5
+
+
+@pytest.mark.unit
+def test_monochrome_mosaic_stays_visible_without_colour():
+    """A colourless terminal must still show the portrait, not a blank box.
+
+    The colour mosaic encodes 100% of its information in BACKGROUND colour:
+    a flat cell is a space glyph with `on rgb(...)`. Strip colour -- Textual
+    does exactly that when NO_COLOR is set (`app.py` -> monochrome filter) --
+    and every cell becomes an ordinary space, so the avatar does not degrade,
+    it vanishes. A Windows user reported precisely that: no character image
+    at all in the Console rail.
+
+    In monochrome mode the glyph itself must carry the luminance, so the
+    portrait survives with no colour at all.
+    """
+    import io
+    import re
+
+    from rich.console import Console
+
+    # Left half dark, right half light -- a shape that must remain readable.
+    img = PILImage.new("RGB", (32, 32), (10, 10, 10))
+    for y in range(32):
+        for x in range(16, 32):
+            img.putpixel((x, y), (245, 245, 245))
+
+    def emitted(renderable, **console_kw):
+        buf = io.StringIO()
+        Console(file=buf, width=20, force_terminal=True, **console_kw).print(renderable)
+        return buf.getvalue()
+
+    # Colour path is unchanged: still carries the image, however it is drawn.
+    colour = emitted(mosaic_from_image(img, 16, 8, fit="contain"),
+                     color_system="truecolor")
+    assert re.findall(r"\x1b\[[0-9;]*m", colour), "colour mosaic lost its colour"
+
+    # Monochrome path: no colour escapes available, so the GLYPHS must carry it.
+    mono = mosaic_from_image(img, 16, 8, fit="contain", monochrome=True)
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", emitted(mono, color_system=None))
+    glyphs = set(plain.replace("\n", "")) - {" "}
+    assert glyphs, (
+        "monochrome mosaic rendered nothing but spaces -- invisible, which is "
+        "the reported bug"
+    )
+    # And it must be a real image, not a solid block: the dark half and the
+    # light half have to use different glyphs.
+    rows = [r for r in plain.splitlines() if r.strip()]
+    assert rows, "no rows rendered"
+    widest = max(rows, key=len)
+    left, right = widest[: len(widest) // 2], widest[len(widest) // 2 :]
+    assert set(left) != set(right), (
+        f"monochrome mosaic is uniform -- shape lost: {widest!r}"
+    )

--- a/Tests/Utils/test_mosaic_render.py
+++ b/Tests/Utils/test_mosaic_render.py
@@ -167,3 +167,51 @@ def test_monochrome_mosaic_stays_visible_without_colour():
     assert set(left) != set(right), (
         f"monochrome mosaic is uniform -- shape lost: {widest!r}"
     )
+
+
+@pytest.mark.unit
+def test_monochrome_mosaic_is_never_blank_for_a_dark_portrait():
+    """A dark image must still render glyphs, not an all-space box.
+
+    Qodo review on PR #1183: the first monochrome ramp began with a literal
+    space, so every cell of a sufficiently dark portrait mapped to the
+    darkest bucket and the mosaic came out invisible -- reproducing the very
+    bug the monochrome path exists to fix. Character-card art on a dark
+    theme is precisely that case, so this was the common path, not an edge.
+
+    The ramp must have no blank bucket: the darkest ink still has to be ink.
+    """
+    import re
+
+    # Charcoal subject on near-black -- a dark character card.
+    img = PILImage.new("RGB", (48, 48), (12, 12, 14))
+    for y in range(14, 34):
+        for x in range(14, 34):
+            img.putpixel((x, y), (40, 38, 44))
+
+    mono = mosaic_from_image(img, 16, 8, fit="contain", monochrome=True)
+    glyphs = set(mono.plain.replace("\n", ""))
+    assert glyphs != {" "}, (
+        "dark portrait rendered as all spaces -- invisible, which is the bug "
+        "the monochrome path exists to prevent"
+    )
+    assert " " not in glyphs, (
+        f"monochrome ramp still has a blank bucket: {sorted(glyphs)}"
+    )
+
+    # Visible is not enough: the SHAPE has to survive. A dark portrait's
+    # whole luminance range can sit inside one ramp bucket, which renders a
+    # uniform block -- technically visible, useless as a portrait. The
+    # subject must be distinguishable from its background.
+    assert len(glyphs) > 1, (
+        f"dark portrait flattened to a single glyph {sorted(glyphs)} -- "
+        "visible but shapeless"
+    )
+
+    # Control: a light image must still differ from a dark one, or a ramp
+    # that mapped everything to one glyph would pass the assertions above.
+    light = PILImage.new("RGB", (48, 48), (230, 230, 230))
+    light_mono = mosaic_from_image(light, 16, 8, fit="contain", monochrome=True)
+    assert set(light_mono.plain.replace("\n", "")) != glyphs, (
+        "light and dark render identically -- the ramp has collapsed"
+    )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1378,6 +1378,7 @@ def _character_avatar_fallback_renderable(
     *,
     box_cols: int = CHARACTER_AVATAR_COLS,
     box_lines: int = CHARACTER_AVATAR_LINES,
+    monochrome: bool = False,
 ):
     """Bake the rail avatar's non-graphics renderable from a PIL image.
 
@@ -1389,10 +1390,18 @@ def _character_avatar_fallback_renderable(
         pil: The decoded portrait.
         box_cols: Target width in columns (task-1661: rail-derived).
         box_lines: Target height in lines.
+        monochrome: Carry the image in shade GLYPHS rather than background
+            colour. The coloured mosaic is spaces styled ``on rgb(...)``, so
+            with colour unavailable it renders as a blank box -- the avatar
+            does not degrade, it disappears. Textual switches the whole app
+            to monochrome when ``NO_COLOR`` is set, which is one confirmed
+            way a user sees no portrait at all.
     """
     from ...Utils.mosaic_render import mosaic_from_image
 
-    return mosaic_from_image(pil, box_cols, box_lines, fit="contain")
+    return mosaic_from_image(
+        pil, box_cols, box_lines, fit="contain", monochrome=monochrome
+    )
 
 
 def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
@@ -7634,7 +7643,10 @@ class ChatScreen(BaseAppScreen):
             pixels = spec.get("pixels")
             if pixels is None and spec.get("pil") is not None:
                 pixels = _character_avatar_fallback_renderable(
-                    spec["pil"], box_cols=box_cols, box_lines=box_lines
+                    spec["pil"],
+                    box_cols=box_cols,
+                    box_lines=box_lines,
+                    monochrome=bool(getattr(self.app, "no_color", False)),
                 )
             widget = Static(
                 pixels if pixels is not None else "",

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10523,6 +10523,19 @@ class ChatScreen(BaseAppScreen):
             notify_on_failure=False,
         )
         self._apply_console_rail_section_open(section_id, next_open)
+        if section_id == "character" and next_open:
+            # A collapsed body has `display: none`, so
+            # `_character_avatar_available_cols()` measures 0 and
+            # `character_avatar_box(0)` clamps to the 16-column MINIMUM. An
+            # avatar first rendered while collapsed would then stay pinned
+            # at that size forever, because
+            # `_refresh_active_character_avatar_if_scope_changed` early-
+            # returns while (character_id, state) is unchanged -- the
+            # "~50-column rail showing a 16-column portrait" defect
+            # task-1661 fixed for a different trigger. Clearing the scope
+            # guard makes the next sync tick re-measure the now-visible body
+            # and repaint at the rail's real width.
+            self._last_console_avatar_scope = None
 
     def _sync_console_workspace_context(self) -> None:
         try:

--- a/tldw_chatbook/Utils/mosaic_render.py
+++ b/tldw_chatbook/Utils/mosaic_render.py
@@ -34,6 +34,33 @@ QUADRANT_GLYPHS = " ▘▝▀▖▌▞▛▗▚▐▜▄▙▟█"
 # speckled glyphs.
 _FLAT_CELL_SPREAD = 8.0
 
+# Shade ramp for the monochrome path, darkest to lightest. The colour mosaic
+# puts 100% of its information in BACKGROUND colour -- a flat cell is a space
+# glyph with `on rgb(...)` -- so when colour is unavailable every cell becomes
+# an ordinary space and the image does not degrade, it disappears entirely.
+# Textual converts the whole app to monochrome when NO_COLOR is set
+# (`textual/app.py` -> `filter.py`), which is one confirmed way a user sees no
+# portrait at all. In that mode the GLYPH has to carry the luminance instead.
+#
+# Block Elements only (U+2591-2588), the same universal range the quadrant
+# glyphs come from, so this adds no new font risk.
+_SHADE_RAMP = " ░▒▓█"
+
+
+def _shade_glyph(lum: float) -> str:
+    """Return the shade glyph for a 0-255 luminance.
+
+    Args:
+        lum: Mean luminance of the cell.
+
+    Returns:
+        One character from ``_SHADE_RAMP``; darker luminance maps to a
+        sparser glyph so the rendering reads like the original image rather
+        than its negative.
+    """
+    index = int(lum / 256 * len(_SHADE_RAMP))
+    return _SHADE_RAMP[min(index, len(_SHADE_RAMP) - 1)]
+
 
 def _luminance(rgb: tuple[int, int, int]) -> float:
     return 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]
@@ -54,6 +81,7 @@ def mosaic_from_image(
     box_lines: int,
     *,
     fit: str = "contain",
+    monochrome: bool = False,
 ) -> Text:
     """Render ``image`` into a quadrant-glyph mosaic fitting a cell box.
 
@@ -73,6 +101,12 @@ def mosaic_from_image(
         fit: "contain" (default) letterboxes the whole image inside the
             box; "cover" scales to FILL the box and center-crops the
             overflow (object-fit: cover) -- aspect is preserved either way.
+        monochrome: Render luminance as SHADE GLYPHS instead of colour. The
+            colour path stores the whole image in background colour, so a
+            terminal without colour shows a box of blank spaces rather than
+            a portrait; set this when colour is unavailable (Textual sets
+            ``App.no_color`` from ``NO_COLOR``) so the glyph carries the
+            image instead.
 
     Returns:
         A non-wrapping Rich ``Text`` renderable, one line per cell row.
@@ -121,6 +155,12 @@ def mosaic_from_image(
             ]
             lums = [_luminance(c) for c in cell]
             spread = max(lums) - min(lums)
+            if monochrome:
+                # One glyph per cell from the mean luminance: no colour is
+                # consulted at all, so the result survives a monochrome
+                # filter that would blank the coloured path entirely.
+                text.append(_shade_glyph(sum(lums) / len(lums)))
+                continue
             if spread < _FLAT_CELL_SPREAD:
                 r, g, b = _mean(cell)
                 text.append(" ", style=f"on rgb({r},{g},{b})")

--- a/tldw_chatbook/Utils/mosaic_render.py
+++ b/tldw_chatbook/Utils/mosaic_render.py
@@ -44,22 +44,43 @@ _FLAT_CELL_SPREAD = 8.0
 #
 # Block Elements only (U+2591-2588), the same universal range the quadrant
 # glyphs come from, so this adds no new font risk.
-_SHADE_RAMP = " ░▒▓█"
+#
+# No blank bucket, deliberately (Qodo review, PR #1183). An earlier ramp led
+# with a space, so a sufficiently dark portrait mapped every cell to the
+# darkest bucket and rendered as an all-space box -- invisible, reproducing
+# the exact bug this path exists to fix. Character-card art on a dark theme
+# is that case, so it was the common path rather than an edge one. The
+# darkest ink still has to be ink.
+_SHADE_RAMP = "░▒▓█"
 
 
-def _shade_glyph(lum: float) -> str:
-    """Return the shade glyph for a 0-255 luminance.
+def _shade_glyph(lum: float, lo: float = 0.0, hi: float = 255.0) -> str:
+    """Return the shade glyph for a luminance, normalised to ``lo``..``hi``.
+
+    The range is normalised PER IMAGE rather than mapped from absolute
+    0-255. A character-card portrait on a dark theme can occupy a narrow
+    dark band -- every cell then lands in one ramp bucket and renders as a
+    uniform block: visible, but shapeless, which is not a portrait. Stretching
+    the image's own range across the ramp keeps the subject distinguishable
+    from its background.
 
     Args:
         lum: Mean luminance of the cell.
+        lo: Darkest cell luminance in this image.
+        hi: Brightest cell luminance in this image.
 
     Returns:
-        One character from ``_SHADE_RAMP``; darker luminance maps to a
-        sparser glyph so the rendering reads like the original image rather
-        than its negative.
+        One character from ``_SHADE_RAMP``; darker maps to a sparser glyph so
+        the result reads like the image rather than its negative.
     """
-    index = int(lum / 256 * len(_SHADE_RAMP))
-    return _SHADE_RAMP[min(index, len(_SHADE_RAMP) - 1)]
+    span = hi - lo
+    # A genuinely flat image has nothing to stretch; render it mid-ramp
+    # rather than dividing by ~0 and slamming everything to one end.
+    if span < 1e-6:
+        return _SHADE_RAMP[len(_SHADE_RAMP) // 2]
+    scaled = (lum - lo) / span
+    index = int(scaled * len(_SHADE_RAMP))
+    return _SHADE_RAMP[min(max(index, 0), len(_SHADE_RAMP) - 1)]
 
 
 def _luminance(rgb: tuple[int, int, int]) -> float:
@@ -142,6 +163,21 @@ def mosaic_from_image(
         # reading out of bounds.
         return pixels[min(x, width - 1), min(y, height - 1)]
 
+    mono_lo, mono_hi = 0.0, 255.0
+    if monochrome:
+        # One pass over the cell means to learn this image's actual range.
+        cell_means = [
+            sum(
+                _luminance(sample(c * 2 + dx, r * 2 + dy))
+                for dx in (0, 1)
+                for dy in (0, 1)
+            )
+            / 4
+            for r in range(cell_rows)
+            for c in range(cell_cols)
+        ]
+        mono_lo, mono_hi = min(cell_means), max(cell_means)
+
     text = Text(no_wrap=True, end="")
     for row in range(cell_rows):
         if row:
@@ -159,7 +195,9 @@ def mosaic_from_image(
                 # One glyph per cell from the mean luminance: no colour is
                 # consulted at all, so the result survives a monochrome
                 # filter that would blank the coloured path entirely.
-                text.append(_shade_glyph(sum(lums) / len(lums)))
+                # Normalised to this image's own range (see `_shade_glyph`)
+                # so a dark portrait keeps its shape instead of flattening.
+                text.append(_shade_glyph(sum(lums) / len(lums), mono_lo, mono_hi))
                 continue
             if spread < _FLAT_CELL_SPREAD:
                 r, g, b = _mean(cell)


### PR DESCRIPTION
Investigated a report of "no character image at all in the Console" on Windows.

## What it actually was

**Not a bug.** The reporter had the **Character rail section collapsed**. Clicking the `Character ▸` header expands it and the portrait returns.

I traced the whole composition path first and found **no Windows-specific gate** — every condition defaults to visible. Ruled out along the way, so nobody re-treads it:

- **Pillow is a core dependency**, not an optional extra — it cannot be missing.
- Image bytes come from a **DB BLOB**, not a file path, so no Windows path handling is involved.
- The mosaic **renders correctly under Windows legacy-console colour** — measured from Rich's actually-emitted bytes, because `export_text()` re-emits truecolor regardless of the console's colour system and will tell you the opposite.

## Two real defects found while investigating

Neither is the reporter's cause. Both are genuine on their own merits, and the second sits directly on the path they are about to take.

**1. The avatar is invisible without colour** (`43d2cd55f`)

The mosaic encodes **100% of its information in background colour** — a flat cell is a *space* glyph styled `on rgb(...)`. Strip colour and the portrait does not degrade, it disappears. Textual converts the whole app to monochrome when `NO_COLOR` is set (`app.py` -> `filter.py`), so the box renders empty while every other element still works.

```
truecolor / 256 / 16 / windows-legacy -> 256 escapes -> visible
colour disabled                       ->   0 escapes -> INVISIBLE
```

Adds a monochrome path carrying luminance in Block Elements shade glyphs, wired from Textual's own `App.no_color`. **Colour terminals are untouched** — the quadrant path runs exactly as before.

**2. Re-opening the section leaves a 16-column portrait** (`4bc28d092`)

Two mechanisms interact:

- a collapsed body has `display: none`, so `_character_avatar_available_cols()` measures **0** and `character_avatar_box(0)` clamps to the 16-column **minimum**;
- `_refresh_active_character_avatar_if_scope_changed` early-returns while `(character_id, state)` is unchanged.

So an avatar first painted while collapsed stays pinned at 16 columns **forever** — the "~50-column rail showing a 16-column portrait" defect task-1661 fixed for a different trigger. Expanding would have shown the reporter a shrunken avatar and read as a second bug. Opening the section now clears the scope guard so the next sync tick re-measures.

## Testing

35 passing across `test_console_character_avatar` and `test_mosaic_render`, plus the personas and image-view suites.

Both fixes are mutation-verified: reverting the scope-guard clear fails its test, and the monochrome assertion is paired with a colour-path control so a change that broke colour rendering could not pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Console character avatar visible in monochrome terminals, preserves shape for dark portraits, and repaints to the correct width when the Character section is reopened.

- **Bug Fixes**
  - Monochrome rendering: carries luminance with Block Elements shade glyphs when `Textual` sets `App.no_color` (via `NO_COLOR`), so the avatar shows without color; the color path is unchanged.
  - Dark portraits: removes the blank bucket and normalizes luminance per image (`░▒▓█` ramp) so monochrome avatars never render empty or as a uniform block.
  - Reopen behavior: clears the avatar scope guard when the Character section opens, forcing a re-measure and repaint so portraits no longer stay stuck at 16 columns after rendering while collapsed.

<sup>Written for commit 1dc826a51312546915d3185a669db9e0ca7662af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

