### PR TITLE
Model browser follow-ups: broken Escape binding, three disagreeing byte formatters, progress lost on recompose (TASK-596)

### DIFF
--- a/Tests/UI/test_library_ingest_guardrail_modal.py
+++ b/Tests/UI/test_library_ingest_guardrail_modal.py
@@ -85,6 +85,33 @@ async def test_guardrail_modal_cancel(sample_warnings, sample_counts):
 
 
 @pytest.mark.asyncio
+async def test_guardrail_modal_escape_dismisses(sample_warnings, sample_counts):
+    """TASK-596 Task 7: BINDINGS used ``dismiss(false)`` (lowercase) --
+
+    ``textual.actions.parse`` runs ``ast.literal_eval`` on the action's
+    argument text, and lowercase ``false`` is not a Python literal, so
+    pressing Escape raised ``ActionError: unable to parse 'false' in
+    action 'dismiss(false)'`` instead of ever dismissing the modal.
+    Confirmed directly against ``textual.actions.parse`` before fixing it
+    to ``dismiss(False)``. This test exercises the real key binding
+    through ``pilot.press`` -- not the mapped Python callable directly --
+    so it would have caught the bug: before the fix, this raises instead
+    of reaching the ``assert``.
+    """
+    app = GuardrailApp()
+    async with app.run_test() as pilot:
+        captured: list[bool] = []
+        modal = IngestGuardrailModal(sample_warnings, sample_counts)
+        await app.push_screen(modal, lambda result: captured.append(result))
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert captured == [False]
+
+
+@pytest.mark.asyncio
 async def test_guardrail_modal_copy_command(sample_warnings, sample_counts):
     app = GuardrailApp()
     async with app.run_test() as pilot:

--- a/Tests/UI/test_library_ingest_guardrail_modal.py
+++ b/Tests/UI/test_library_ingest_guardrail_modal.py
@@ -97,6 +97,12 @@ async def test_guardrail_modal_escape_dismisses(sample_warnings, sample_counts):
     through ``pilot.press`` -- not the mapped Python callable directly --
     so it would have caught the bug: before the fix, this raises instead
     of reaching the ``assert``.
+
+    Args:
+        sample_warnings: Fixture; two representative guardrail warnings
+            (PDF processing, OCR extraction) the modal renders.
+        sample_counts: Fixture; per-feature affected-file counts shown
+            alongside each warning.
     """
     app = GuardrailApp()
     async with app.run_test() as pilot:

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -232,6 +232,11 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
     See test_curated_install_progress_renders_exactly_once_per_tick below
     for the call-counting half of this fix (Review Important #1, fix
     round 1).
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture, used to stub the
+            network-capable acquisition service so this test never
+            performs real I/O; reverted automatically after the test.
     """
     import asyncio
     from unittest.mock import MagicMock
@@ -259,14 +264,36 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
         Only ``.provision`` is exercised; it delivers one progress tick,
         waits for the test to force a screen-level recompose, then
         delivers a second tick -- all through the real ``progress``
-        callback ``CuratedView._provision`` built, so the dual-delivery
-        fix under test runs unmodified.
+        callback ``CuratedView._provision`` built, so ``_deliver``'s fix
+        under test runs unmodified.
         """
 
         def __init__(self, _service) -> None:
-            pass
+            """Accept and discard the managed-store service the real
+            constructor takes.
+
+            Args:
+                _service: The managed-store service (unused by the fake).
+            """
 
         async def provision(self, root, consent, registry, *, sources, progress):
+            """Deliver two progress ticks with the recompose in between.
+
+            Args:
+                root: The reference this closure is rooted at (unused; the
+                    fake never inspects it beyond receiving it).
+                consent: The granted consent object (unused).
+                registry: The curated registry (unused).
+                sources: File source map (unused).
+                progress: The real ``deliver`` callback ``CuratedView.
+                    _provision`` built; called synchronously, twice, exactly
+                    as the real acquisition service would call it from its
+                    own await points.
+
+            Returns:
+                A sentinel standing in for the real installed-path result;
+                its value is never asserted on.
+            """
             progress(first_progress)
             await resume.wait()
             progress(second_progress)
@@ -349,6 +376,140 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
 
 
 @pytest.mark.asyncio
+async def test_curated_install_progress_after_recompose_still_mirrors_into_installed_view(
+    monkeypatch,
+):
+    """PR #1185 automated review, Important #1 (fix round 2).
+
+    ``CuratedView._deliver``'s durable fallback used to post straight at
+    the captured Screen. Textual only ever bubbles a message UP from
+    wherever it is posted, never back down, and ``LLMManagementWindow``
+    (which owns the ``InstallProgressed``/``InstallStatusChanged``
+    handlers that mirror progress and lifecycle into ``InstalledView``,
+    see ``LLM_Management_Window.py``) sits BELOW the Screen. Posting at
+    the Screen therefore entered the tree above that mirroring node, so
+    it silently never ran after a recompose: Curated kept updating (the
+    two tests above only ever checked Curated), while Installed silently
+    stopped receiving ticks/completion. This test is the one the review
+    asked for: it checks the MIRRORING handler's own effect on
+    ``InstalledView``, not the curated side, after a real recompose.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture, used to stub the
+            network-capable acquisition service so this test never
+            performs real I/O; reverted automatically after the test.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    first_progress = AcquisitionProgress(
+        "fetch", reference, "encoder.onnx", 100 * 1024 * 1024, 600 * 1024 * 1024
+    )
+    second_progress = AcquisitionProgress(
+        "fetch", reference, "decoder.onnx", 400 * 1024 * 1024, 600 * 1024 * 1024
+    )
+    resume = asyncio.Event()
+
+    class _FakeAcquisitionService:
+        """Stands in for the real, network-capable acquisition service."""
+
+        def __init__(self, _service) -> None:
+            """Accept and discard the managed-store service the real
+            constructor takes.
+
+            Args:
+                _service: The managed-store service (unused by the fake).
+            """
+
+        async def provision(self, root, consent, registry, *, sources, progress):
+            """Deliver two progress ticks with the recompose in between.
+
+            Args:
+                root: The reference this closure is rooted at (unused).
+                consent: The granted consent object (unused).
+                registry: The curated registry (unused).
+                sources: File source map (unused).
+                progress: The real ``deliver`` callback ``CuratedView.
+                    _provision`` built.
+
+            Returns:
+                A sentinel standing in for the real installed-path result;
+                its value is never asserted on.
+            """
+            progress(first_progress)
+            await resume.wait()
+            progress(second_progress)
+            return object()
+
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
+    )
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+        window = screen.query_one(LLMManagementWindow)
+        curated = window.query_one(CuratedView)
+        installed = window.query_one(InstalledView)
+
+        curated._operation_reference = reference
+        curated._progress_screen = curated.screen
+        curated._service_for_worker = MagicMock()
+        curated._registry_for_worker = MagicMock()
+        curated._source_map = MagicMock(return_value={})
+        fake_report = MagicMock(root=reference)
+
+        provision_task = asyncio.create_task(curated._provision(fake_report))
+        await pilot.pause()
+        await pilot.pause()
+
+        # Sanity check on the normal (no-recompose) path: the FIRST tick
+        # already reaches InstalledView's own mirroring, via the exact
+        # bubble chain _deliver's docstring describes (CuratedView ->
+        # LLMManagementWindow -> LLMScreen).
+        assert installed._install_progress == first_progress
+        assert installed._install_active is True
+
+        screen.refresh(recompose=True)
+        for _ in range(5):
+            await pilot.pause()
+
+        fresh_window = screen.query_one(LLMManagementWindow)
+        fresh_installed = fresh_window.query_one(InstalledView)
+        assert fresh_installed is not installed, (
+            "test setup bug: recompose did not actually replace InstalledView"
+        )
+
+        # The tick under test: delivered by the ORIGINAL (now unmounted,
+        # orphaned) CuratedView instance's own worker, through _deliver's
+        # fallback -- exactly what the real download does after a
+        # mid-install recompose. Before this fix, _deliver posted straight
+        # at the Screen, which never reaches LLMManagementWindow's
+        # mirroring handler; fresh_installed would still show the FIRST
+        # tick's byte counts (or nothing), never the second's.
+        resume.set()
+        await provision_task
+        for _ in range(3):
+            await pilot.pause()
+
+        assert fresh_installed._install_progress == second_progress, (
+            "InstalledView's mirroring handler never observed the "
+            "post-recompose tick -- _deliver's fallback bypassed "
+            "LLMManagementWindow"
+        )
+        assert fresh_installed._install_active is True
+
+
+@pytest.mark.asyncio
 async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatch):
     """TASK-596 delta port, fix round 1 (Review Important #1).
 
@@ -366,6 +527,11 @@ async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatc
     before this fix. The recompose test above only ever asserted eventual
     CONTENT, which cannot distinguish one render from three; this counts
     the actual number of ``apply_progress`` calls instead.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture, used to wrap
+            ``CuratedView.apply_progress`` with a call-counting shim;
+            reverted automatically after the test.
     """
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
     from tldw_chatbook.Model_Artifacts.service import ArtifactRef

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -227,6 +227,11 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
     and a progress tick emitted AFTER the recompose -- delivered through
     the pre-recompose instance's own worker, exactly as the real download
     would -- still reaches and updates the fresh view (not stale).
+
+    Content-only, like this test: it cannot tell one render from three.
+    See test_curated_install_progress_renders_exactly_once_per_tick below
+    for the call-counting half of this fix (Review Important #1, fix
+    round 1).
     """
     import asyncio
     from unittest.mock import MagicMock
@@ -330,15 +335,80 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
         # Half 2 of the fix: still updating. This tick is delivered by the
         # ORIGINAL (now unmounted, orphaned) curated instance's own
         # worker -- exactly what the real download does after a
-        # mid-install recompose. Without the dual-delivery fix this would
-        # be silently dropped (a closed widget's post_message() is a
-        # no-op) and the fresh view would stay on "encoder.onnx".
+        # mid-install recompose. self.post_message on that orphaned
+        # instance now returns False (a closed widget's post_message() is
+        # a no-op), so _deliver falls back to the captured screen; without
+        # that fallback this would be silently dropped and the fresh view
+        # would stay on "encoder.onnx".
         resume.set()
         await provision_task
         await pilot.pause()
         await pilot.pause()
 
         assert "decoder.onnx" in _progress_text(fresh_curated)
+
+
+@pytest.mark.asyncio
+async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatch):
+    """TASK-596 delta port, fix round 1 (Review Important #1).
+
+    ``InstallProgressed`` bubbles by default -- nothing in this codebase
+    ever called ``event.stop()`` on it. Posting one tick to ``CuratedView``
+    used to be handled by ``CuratedView``'s own ``_install_progressed``
+    (rendering the widget), then bubble on, unstopped, through
+    ``LLMManagementWindow`` (unrelated to this bug -- it mirrors into
+    ``InstalledView``, a different widget) up to ``LLMScreen``, whose
+    forwarding (added for the recompose fix above) rendered the SAME,
+    still-mounted ``CuratedView`` a second time via ``apply_progress``.
+    With the since-removed dual delivery (a second, independent
+    ``screen.post_message`` for the very same tick) that was three
+    renders total for one event -- confirmed live via a Pilot probe
+    before this fix. The recompose test above only ever asserted eventual
+    CONTENT, which cannot distinguish one render from three; this counts
+    the actual number of ``apply_progress`` calls instead.
+    """
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.Widgets.ModelArtifacts import InstallProgressed
+
+    calls: list[AcquisitionProgress] = []
+    original_apply_progress = CuratedView.apply_progress
+
+    def counting_apply_progress(self, progress):
+        calls.append(progress)
+        return original_apply_progress(self, progress)
+
+    monkeypatch.setattr(CuratedView, "apply_progress", counting_apply_progress)
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+        window = screen.query_one(LLMManagementWindow)
+        curated = window.query_one(CuratedView)
+
+        reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+        progress = AcquisitionProgress("fetch", reference, "encoder.onnx", 1, 2)
+
+        # Posted to the still-live, currently-mounted CuratedView -- the
+        # steady-state, no-recompose case _deliver's own docstring calls
+        # "the common case": exactly what self.post_message(message) does
+        # inside _deliver when it succeeds. Bubbles through
+        # LLMManagementWindow (mirrors into InstalledView, untouched by
+        # this fix) up to LLMScreen, whose forwarding is now the ONLY
+        # place that calls apply_progress.
+        curated.post_message(InstallProgressed(progress))
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+    assert calls == [progress]
+    assert len(calls) == 1, (
+        f"expected exactly one apply_progress call for one progress tick, "
+        f"got {len(calls)}"
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -207,6 +207,141 @@ async def test_model_install_progress_survives_switch_to_installed():
 
 
 @pytest.mark.asyncio
+async def test_curated_install_progress_survives_a_screen_level_recompose(monkeypatch):
+    """TASK-596 delta port: a curated install must not go blank/stale.
+
+    ``LabScreen.recompose()`` tears down and rebuilds the whole
+    ``LLMManagementWindow`` -- ``CuratedView`` included -- which used to
+    mean a curated install in progress lost its progress display for the
+    rest of the run: the fresh ``CuratedView`` instance starts with no
+    memory of the install, and (since ``CuratedView`` owns its own
+    preflight/provision worker) further progress ticks from the ORIGINAL
+    instance's worker thread were posted to that now-closed instance and
+    silently dropped, never reaching the fresh one either.
+
+    Exercises the real ``CuratedView._provision`` code path (not a
+    simulation of it) against a stubbed ``ArtifactAcquisitionService`` so
+    this test controls exactly when a second progress tick fires relative
+    to the recompose, then asserts both halves of the fix: the freshly
+    (re)mounted view is hydrated with the last known progress (not blank),
+    and a progress tick emitted AFTER the recompose -- delivered through
+    the pre-recompose instance's own worker, exactly as the real download
+    would -- still reaches and updates the fresh view (not stale).
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.Widgets.ModelArtifacts.install_progress import (
+        ModelInstallProgress,
+    )
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    first_progress = AcquisitionProgress(
+        "fetch", reference, "encoder.onnx", 100 * 1024 * 1024, 600 * 1024 * 1024
+    )
+    second_progress = AcquisitionProgress(
+        "fetch", reference, "decoder.onnx", 400 * 1024 * 1024, 600 * 1024 * 1024
+    )
+    resume = asyncio.Event()
+
+    class _FakeAcquisitionService:
+        """Stands in for the real, network-capable acquisition service.
+
+        Only ``.provision`` is exercised; it delivers one progress tick,
+        waits for the test to force a screen-level recompose, then
+        delivers a second tick -- all through the real ``progress``
+        callback ``CuratedView._provision`` built, so the dual-delivery
+        fix under test runs unmodified.
+        """
+
+        def __init__(self, _service) -> None:
+            pass
+
+        async def provision(self, root, consent, registry, *, sources, progress):
+            progress(first_progress)
+            await resume.wait()
+            progress(second_progress)
+            return object()
+
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
+    )
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+        window = screen.query_one(LLMManagementWindow)
+        curated = window.query_one(CuratedView)
+
+        # Mimics _confirm_install's own setup (captures the screen before
+        # the worker starts, bypasses real preflight/registry I/O) --
+        # exercising _provision itself directly, on this test's own event
+        # loop rather than a real background thread, so `resume` can pause
+        # it deterministically at an exact point.
+        curated._operation_reference = reference
+        curated._progress_screen = curated.screen
+        curated._service_for_worker = MagicMock()
+        curated._registry_for_worker = MagicMock()
+        curated._source_map = MagicMock(return_value={})
+        fake_report = MagicMock(root=reference)
+
+        provision_task = asyncio.create_task(curated._provision(fake_report))
+        await pilot.pause()
+        await pilot.pause()
+
+        def _progress_text(view: CuratedView) -> str:
+            widget = view.query_one(
+                "#curated-model-install-progress", ModelInstallProgress
+            )
+            detail = widget.query_one("#model-install-progress-detail", Static)
+            return str(detail.renderable)
+
+        assert "encoder.onnx" in _progress_text(curated)
+
+        # A real screen-level recompose (LabScreen.recompose(), not
+        # CuratedView's own internal refresh(recompose=True)) -- see
+        # test_lab_frame.py::test_screen_level_recompose_repopulates_
+        # rail_inspector_and_body for the same multi-pause shape this
+        # mirrors.
+        screen.refresh(recompose=True)
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        fresh_window = screen.query_one(LLMManagementWindow)
+        fresh_curated = fresh_window.query_one(CuratedView)
+        assert fresh_curated is not curated, (
+            "test setup bug: recompose did not actually replace CuratedView"
+        )
+
+        # Half 1 of the fix: hydration. The fresh instance was never told
+        # about the install directly -- LLMScreen re-applied the last
+        # known progress to it via _hydrate_curated_progress.
+        assert "encoder.onnx" in _progress_text(fresh_curated)
+
+        # Half 2 of the fix: still updating. This tick is delivered by the
+        # ORIGINAL (now unmounted, orphaned) curated instance's own
+        # worker -- exactly what the real download does after a
+        # mid-install recompose. Without the dual-delivery fix this would
+        # be silently dropped (a closed widget's post_message() is a
+        # no-op) and the fresh view would stay on "encoder.onnx".
+        resume.set()
+        await provision_task
+        await pilot.pause()
+        await pilot.pause()
+
+        assert "decoder.onnx" in _progress_text(fresh_curated)
+
+
+@pytest.mark.asyncio
 async def test_the_inspector_rows_refresh_alongside_the_status_chip():
     """Regression test: `refresh_lab_status` used to update only the chip.
 

--- a/Tests/UI/test_model_artifact_widgets.py
+++ b/Tests/UI/test_model_artifact_widgets.py
@@ -18,7 +18,9 @@ def _report(
     *,
     sufficient_space: bool = True,
     gating_errors: tuple[str, ...] = (),
+    repository: str = "publisher/parakeet-v2",
     license_id: str = "CC-BY-4.0",
+    revision: str = "immutable-revision",
 ) -> PreflightReport:
     reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
     return PreflightReport(
@@ -28,8 +30,8 @@ def _report(
             ArtifactPreflightEntry(
                 ref=reference,
                 source_url="https://example.test/model",
-                repository="publisher/parakeet-v2",
-                revision="immutable-revision",
+                repository=repository,
+                revision=revision,
                 license_id=license_id,
                 license_url="https://example.test/license",
                 precision="int8",
@@ -333,3 +335,107 @@ async def test_progress_widget_restores_the_latest_event_after_recompose() -> No
 
     assert "Downloading" in text
     assert "encoder.onnx" in text
+
+
+@pytest.mark.asyncio
+async def test_plan_panel_survives_bracket_bearing_repository_and_license_text(
+    tmp_path: Path,
+) -> None:
+    """Repository ids, license strings, and revisions can contain square
+    brackets (TASK-596 delta port); Rich would otherwise parse them as
+    markup and eat them. ModelPlanPanel renders the whole plan as one
+    ``Static(..., markup=False)`` -- this pins that the raw bracket text
+    actually reaches the screen, not just that construction doesn't raise.
+    """
+    report = _report(
+        tmp_path / "managed",
+        repository="org/model[experimental]",
+        license_id="Custom[v1]",
+        revision="rev[abc]",
+    )
+    app = _PanelApp(report)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        text = "\n".join(str(item.renderable) for item in app.query(Static))
+
+    assert "org/model[experimental]" in text
+    assert "Custom[v1]" in text
+    assert "rev[abc]" in text
+
+
+@pytest.mark.asyncio
+async def test_progress_callback_marshals_across_threads_not_direct_mutation() -> None:
+    """The provision() callback runs on a worker thread; every host screen
+    (CuratedView, InstalledView, LibraryScreen, LLMScreen) wires it as
+    ``post_message -> InstallProgressed -> update_progress`` rather than
+    calling ``update_progress`` directly off-thread. This proves that
+    shared contract end-to-end with a REAL ``threading.Thread``, not just
+    that ``make_progress_callback`` builds a callable that posts a message
+    (already covered above) -- it additionally proves the widget update is
+    only ever QUEUED by the worker thread, never applied by it.
+
+    Deterministic, not a race: ``app.run_test()`` drives this app's entire
+    message loop as an ``asyncio`` Task on the one event loop that also
+    runs this test coroutine. ``thread.join()`` blocks this coroutine
+    (never yielding to that loop) until the worker thread finishes, so
+    nothing the worker thread scheduled onto the loop -- including
+    ``post_message``'s ``call_soon_threadsafe`` hop for a foreign-thread
+    caller -- can be processed until ``join()`` returns and this test
+    reaches its next ``await``. So the instant ``join()`` returns, the
+    posted update is guaranteed to still be sitting unprocessed: a
+    callback that mutated the widget directly instead of posting would
+    already show the new text right there, with no ``await`` involved.
+    """
+    import threading
+
+    from textual import on
+
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Widgets.ModelArtifacts import (
+        InstallProgressed,
+        ModelInstallProgress,
+        make_progress_callback,
+    )
+
+    class _HostApp(App):
+        """Mirrors every real host's own wiring, not CuratedView's specifically."""
+
+        def compose(self) -> ComposeResult:
+            yield ModelInstallProgress(id="progress")
+
+        @on(InstallProgressed)
+        def _forward(self, event: InstallProgressed) -> None:
+            self.query_one(ModelInstallProgress).update_progress(event.progress)
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    event = AcquisitionProgress("fetch", reference, "encoder.onnx", 1_048_576, 2_097_152)
+
+    app = _HostApp()
+    async with app.run_test() as pilot:
+        widget = app.query_one(ModelInstallProgress)
+        await pilot.pause()
+        detail = widget.query_one("#model-install-progress-detail", Static)
+        text_before = str(detail.renderable)
+        assert "encoder.onnx" not in text_before
+
+        callback = make_progress_callback(app.post_message)
+        errors: list[BaseException] = []
+
+        def _invoke_off_thread() -> None:
+            try:
+                callback(event)
+            except BaseException as exc:  # pragma: no cover - fails the assertions below
+                errors.append(exc)
+
+        thread = threading.Thread(target=_invoke_off_thread)
+        thread.start()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+        assert not errors
+
+        # See this test's own docstring for why this is deterministic, not
+        # a race: the widget must NOT have been updated yet.
+        assert str(detail.renderable) == text_before
+
+        await pilot.pause()
+        assert "encoder.onnx" in str(detail.renderable)

--- a/Tests/UI/test_model_artifact_widgets.py
+++ b/Tests/UI/test_model_artifact_widgets.py
@@ -346,6 +346,9 @@ async def test_plan_panel_survives_bracket_bearing_repository_and_license_text(
     markup and eat them. ModelPlanPanel renders the whole plan as one
     ``Static(..., markup=False)`` -- this pins that the raw bracket text
     actually reaches the screen, not just that construction doesn't raise.
+
+    Args:
+        tmp_path: pytest fixture; used only as the plan's destination path.
     """
     report = _report(
         tmp_path / "managed",

--- a/Tests/UI/test_model_browser_state.py
+++ b/Tests/UI/test_model_browser_state.py
@@ -248,29 +248,69 @@ def test_inventory_keeps_assigned_consumer_readiness_copy(tmp_path: Path) -> Non
 
 
 def test_install_failure_messages_are_typed_labeled_and_sanitized() -> None:
-    """Raw acquisition details never reach user notifications."""
+    """Raw acquisition details never reach user notifications.
+
+    TASK-596 delta port: every one of install_failure_message's branches
+    (there are nine: eight typed exceptions plus the untyped fallback) gets
+    its own case here, each asserting the mapped text IS present -- not
+    merely that the message is truthy/nonempty, which would pass even if
+    two different exception types collapsed onto the same generic string
+    -- AND that the injected raw marker is absent, exercised per branch
+    rather than once for the whole batch.
+    """
     from tldw_chatbook.Model_Artifacts.acquisition import (
         AcquisitionBusyError,
         CatalogError,
+        ConsentMismatchError,
+        GatedRepositoryError,
         InsufficientSpaceError,
         PreflightNotGrantableError,
         TransferError,
     )
     from tldw_chatbook.UI.Screens.model_browser_state import install_failure_message
 
-    marker = "SECRET-GATING-DETAIL"
-    errors = (
-        AcquisitionBusyError(marker),
-        CatalogError(marker),
-        InsufficientSpaceError(marker),
-        PreflightNotGrantableError(marker),
-        TransferError(marker, retryable=True),
-    )
-    messages = tuple(
-        install_failure_message(error, model_label="Whisper") for error in errors
-    )
+    marker = "SECRET-GATING-DETAIL-9c31af"
 
-    assert all(marker not in message for message in messages)
-    assert all(message for message in messages)
-    assert "Whisper" in messages[0]
-    assert "Whisper" in messages[1]
+    def _check(exc: BaseException, expected_text: str) -> None:
+        message = install_failure_message(exc, model_label="Whisper")
+        assert expected_text in message
+        assert marker not in message
+
+    _check(
+        InsufficientSpaceError(marker),
+        "Not enough free disk space for this install.",
+    )
+    _check(
+        GatedRepositoryError(marker),
+        "Configure HUGGINGFACE_API_KEY (or HF_TOKEN) and retry.",
+    )
+    _check(
+        AcquisitionBusyError(marker),
+        "Another Whisper install is already in progress. Try again shortly.",
+    )
+    _check(
+        ConsentMismatchError(marker),
+        "The install plan changed. Retry Install to review the current plan.",
+    )
+    _check(
+        PreflightNotGrantableError(marker),
+        "This install plan cannot proceed. Retry Install to review the current plan.",
+    )
+    _check(
+        CatalogError(marker),
+        "The Whisper download source is misconfigured.",
+    )
+    _check(
+        TransferError(marker, retryable=True),
+        "The download was interrupted. Retry Install to resume.",
+    )
+    _check(
+        TransferError(marker, retryable=False),
+        "The download failed and cannot be retried automatically.",
+    )
+    # The untyped fallback: any exception not one of the eight typed cases
+    # above still gets a safe, labeled message rather than leaking str(exc).
+    _check(
+        RuntimeError(marker),
+        "Whisper install failed. See the application log for details.",
+    )

--- a/Tests/UI/test_model_browser_state.py
+++ b/Tests/UI/test_model_browser_state.py
@@ -49,6 +49,49 @@ def _report(destination: Path) -> PreflightReport:
     )
 
 
+# ---------------------------------------------------------------------------
+# format_mib -- the one byte formatter every plan/progress/inventory caller
+# shares (TASK-596 delta port). Before this existed, plan_panel.py,
+# install_progress.py, and model_installed_view.py each reimplemented MiB
+# formatting independently and disagreed: install_progress.py additionally
+# switched to KiB/B below 1 MiB, so the same byte count rendered
+# differently in the install plan than in the progress display. Every
+# expected string below is hand-verified against the formula
+# ``size_bytes / (1024 * 1024)`` rounded to one decimal place, not
+# re-derived from the implementation being tested.
+# ---------------------------------------------------------------------------
+
+
+def test_format_mib_renders_zero_bytes() -> None:
+    from tldw_chatbook.UI.Screens.model_browser_state import format_mib
+
+    assert format_mib(0) == "0.0 MiB"
+
+
+def test_format_mib_renders_a_sub_mib_value() -> None:
+    from tldw_chatbook.UI.Screens.model_browser_state import format_mib
+
+    # 512_000 / (1024*1024) = 0.48828125 -- hand-computed, not re-derived
+    # from the division this test checks. This is also the case that used
+    # to render as "500.0 KiB" under install_progress.py's old sub-MiB
+    # branch instead of "0.5 MiB"; format_mib always renders MiB.
+    assert format_mib(512_000) == "0.5 MiB"
+
+
+def test_format_mib_renders_exactly_one_mib() -> None:
+    from tldw_chatbook.UI.Screens.model_browser_state import format_mib
+
+    assert format_mib(1_048_576) == "1.0 MiB"
+
+
+def test_format_mib_renders_exactly_one_gib() -> None:
+    from tldw_chatbook.UI.Screens.model_browser_state import format_mib
+
+    # 1_073_741_824 bytes == exactly 1024 MiB (1 GiB) -- a round number
+    # chosen so the expected string is verifiable by hand.
+    assert format_mib(1_073_741_824) == "1024.0 MiB"
+
+
 def test_plan_rows_and_totals_preserve_every_consent_field(tmp_path: Path) -> None:
     """The render model contains every field required for informed consent."""
     from tldw_chatbook.UI.Screens.model_browser_state import plan_rows, plan_totals

--- a/Tests/UI/test_model_curated_view.py
+++ b/Tests/UI/test_model_curated_view.py
@@ -166,7 +166,12 @@ def _install_buttons(app: App) -> list[Button]:
 async def test_ensure_loaded_triggers_the_catalog_load_and_marks_installed_rows(
     tmp_path: Path,
 ) -> None:
-    """An installed reference is marked as such, never offered a redundant Install."""
+    """An installed reference is marked as such, never offered a redundant Install.
+
+    Args:
+        tmp_path: pytest fixture; the managed store root and the on-disk
+            source directory the installed descriptor is installed from.
+    """
     installed_ref = ArtifactRef("model-a", "a" * 40, "int8")
     not_installed_ref = ArtifactRef("model-b", "b" * 40, "int8")
     installed_descriptor = _descriptor(installed_ref, b"payload-a")
@@ -206,6 +211,14 @@ async def test_ensure_loaded_triggers_the_catalog_load_and_marks_installed_rows(
 async def test_ensure_loaded_without_force_does_not_rerun_the_expensive_reads(
     tmp_path: Path, monkeypatch
 ) -> None:
+    """A second ``ensure_loaded()`` without ``force=True`` must not repeat
+    the ``list_installed()`` read; ``force=True`` must.
+
+    Args:
+        tmp_path: pytest fixture; the managed store root.
+        monkeypatch: pytest fixture; wraps ``ModelArtifactService.
+            list_installed`` to record each real invocation.
+    """
     calls: list[str] = []
     original_list_installed = ModelArtifactService.list_installed
 
@@ -242,6 +255,11 @@ async def test_ensure_loaded_without_force_does_not_rerun_the_expensive_reads(
 
 @pytest.mark.asyncio
 async def test_no_user_visible_string_contains_artifact(tmp_path: Path) -> None:
+    """No rendered Static text says "artifact" -- the UI says "model" throughout.
+
+    Args:
+        tmp_path: pytest fixture; the managed store root.
+    """
     registry = _registry_with(_descriptor(ArtifactRef("model-a", "a" * 40, "int8")))
     service = ModelArtifactService(tmp_path / "store")
     view = CuratedView(service_factory=lambda: service, registry_factory=lambda: registry)
@@ -266,6 +284,12 @@ async def test_install_click_reaches_the_shared_consent_modal(
     """A real Install click -- not a direct call to an internal method --
     resolves a plan (through a stubbed acquisition service, so this stays
     network-free) and pushes the exact shared ``ModelInstallModal``.
+
+    Args:
+        tmp_path: pytest fixture; the managed store root and the report's
+            destination path.
+        monkeypatch: pytest fixture; stubs ``ArtifactAcquisitionService``
+            so preflight resolves without real network I/O.
     """
     reference = ArtifactRef("model-a", "a" * 40, "int8")
     descriptor = _descriptor(reference)
@@ -323,6 +347,11 @@ async def test_install_click_reaches_the_shared_consent_modal(
 def test_preflight_failure_notifies_and_does_not_push_a_modal(monkeypatch) -> None:
     """The sibling success path is test_curated_preflight_result_opens_the_
     shared_modal in test_model_installed_view.py; this is its failure branch.
+
+    Args:
+        monkeypatch: pytest fixture; replaces the read-only ``app`` property
+            on the ``CuratedView`` class with a ``MagicMock`` for this bare,
+            unmounted view.
     """
     fake_app = MagicMock()
     # Class-level property patch (Screen/Widget.app is read-only) -- safe

--- a/Tests/UI/test_model_curated_view.py
+++ b/Tests/UI/test_model_curated_view.py
@@ -1,0 +1,359 @@
+"""Dedicated coverage for the Curated view (TASK-596 delta port).
+
+``CuratedView`` already has a handful of tests scattered in
+``Tests/UI/test_model_installed_view.py`` (no-I/O-at-compose, the
+preflight-result-opens-the-modal path, and two recompose-gap tolerance
+tests). This file adds the coverage that was still missing: that
+``ensure_loaded`` actually performs the load and renders rows once
+triggered (not just that it stays idle before that), that an installed
+reference is marked as such rather than offered a redundant Install, that
+no user-visible string contains "artifact", that a real Install click
+reaches the shared consent modal, and two error/decline paths
+(``_apply_preflight_result``'s failure branch and ``_confirm_install``'s
+decline branch) that were not exercised anywhere else.
+
+Adapted from the reference implementation's ``feat/model-artifact-browser``
+branch, NOT copied: that branch's ``CuratedView`` takes ``service_root=``/
+``registry=`` directly, posts an ``InstallRequested`` message, and never
+calls ``preflight()``/``provision()`` itself -- ``LLMScreen`` owns those
+workers there. dev's ``CuratedView`` (this branch) takes
+``service_factory=``/``registry_factory=`` lazy factories and owns its own
+preflight/provision workers directly, so every test here drives dev's
+actual methods (``ensure_loaded``, ``_install_pressed``, ``_preflight_model``,
+``_confirm_install``, ``_apply_preflight_result``) instead of the reference's
+``activate()``/``InstallRequested``/screen-owned-worker shape. Tests that
+only make sense against that other shape (the "no preflight/provision call
+anywhere in this module" AST check, the "only one @work method" AST check,
+and every ``LLMScreen``-owned-worker test) are dropped -- dev's module
+genuinely does call preflight/provision itself, and asserting otherwise
+would just be testing a design dev does not have.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+from tldw_chatbook.Model_Artifacts import (
+    ArtifactDescriptor,
+    ArtifactFile,
+    ArtifactFormat,
+    ArtifactRef,
+    ArtifactRole,
+    ModelArtifactService,
+    ProvenanceClass,
+)
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    ArtifactPreflightEntry,
+    PreflightReport,
+)
+from tldw_chatbook.Model_Artifacts.curated_registry import CuratedRegistry
+from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+
+class _ViewApp(App):
+    def __init__(self, view: CuratedView) -> None:
+        self.view = view
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield self.view
+
+
+async def _wait_until(condition, *, pilot, attempts: int = 100) -> bool:
+    for _ in range(attempts):
+        if condition():
+            return True
+        await pilot.pause()
+    return condition()
+
+
+def _artifact_file(content: bytes, path: str = "model.bin") -> ArtifactFile:
+    return ArtifactFile(path, len(content), hashlib.sha256(content).hexdigest())
+
+
+def _descriptor(reference: ArtifactRef, content: bytes = b"payload") -> ArtifactDescriptor:
+    files = (_artifact_file(content),)
+    return ArtifactDescriptor(
+        reference=reference,
+        model_id=f"example/{reference.artifact_id}",
+        role=ArtifactRole.ROOT,
+        format=ArtifactFormat.GGUF,
+        consumer="stt",
+        model_family=reference.artifact_id,
+        upstream_repository=f"example/{reference.artifact_id}",
+        upstream_revision="main",
+        source_url="https://example.test/model.bin",
+        precision=reference.variant,
+        license_id="mit",
+        license_url="https://example.test/license",
+        usage_notice="Review the upstream model card before use.",
+        runtime_name="onnx-asr",
+        runtime_version_constraint="==0.12.0",
+        supported_os=("linux", "macos", "windows"),
+        supported_architectures=("x86-64", "arm64"),
+        provenance=(ProvenanceClass.CHATBOOK_CURATED, ProvenanceClass.LOCAL_INTEGRITY_RECORDED),
+        files=files,
+        dependencies=(),
+        expected_installed_bytes=sum(f.size_bytes for f in files),
+    )
+
+
+def _registry_with(*descriptors: ArtifactDescriptor) -> CuratedRegistry:
+    registry = CuratedRegistry()
+    for descriptor in descriptors:
+        registry.register(
+            descriptor,
+            sources={file.path: f"https://example.test/{file.path}" for file in descriptor.files},
+        )
+    return registry
+
+
+def _report(reference: ArtifactRef, *, destination: Path) -> PreflightReport:
+    entry = ArtifactPreflightEntry(
+        ref=reference,
+        source_url=f"https://example.test/{reference.artifact_id}/model.bin",
+        repository=f"example/{reference.artifact_id}",
+        revision=reference.revision,
+        license_id="mit",
+        license_url="https://example.test/license",
+        precision=reference.variant,
+        total_bytes=100_000,
+        file_count=1,
+        already_installed=False,
+        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
+    )
+    return PreflightReport(
+        root=reference,
+        closure_fingerprint="f" * 64,
+        entries=(entry,),
+        download_bytes=100_000,
+        already_staged_bytes=0,
+        staging_overhead_bytes=0,
+        retained_bytes=0,
+        destination=destination,
+        free_bytes=10**12,
+        required_bytes=200_000,
+        sufficient_space=True,
+        gating_errors=(),
+    )
+
+
+def _all_text(app: App) -> str:
+    return "\n".join(str(static.renderable) for static in app.screen.query(Static))
+
+
+def _install_buttons(app: App) -> list[Button]:
+    return list(app.screen.query(".curated-install").results(Button))
+
+
+# ---------------------------------------------------------------------------
+# ensure_loaded actually performs the load and renders rows once triggered
+# (test_curated_view_performs_no_io_at_compose_time in
+# test_model_installed_view.py already pins the "stays idle before that"
+# half; this is the other half).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_triggers_the_catalog_load_and_marks_installed_rows(
+    tmp_path: Path,
+) -> None:
+    """An installed reference is marked as such, never offered a redundant Install."""
+    installed_ref = ArtifactRef("model-a", "a" * 40, "int8")
+    not_installed_ref = ArtifactRef("model-b", "b" * 40, "int8")
+    installed_descriptor = _descriptor(installed_ref, b"payload-a")
+    not_installed_descriptor = _descriptor(not_installed_ref, b"payload-b")
+    registry = _registry_with(installed_descriptor, not_installed_descriptor)
+
+    service = ModelArtifactService(tmp_path / "store")
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "model.bin").write_bytes(b"payload-a")
+    service.install(installed_descriptor, source)
+
+    view = CuratedView(
+        service_factory=lambda: service,
+        registry_factory=lambda: registry,
+    )
+    app = _ViewApp(view)
+    async with app.run_test() as pilot:
+        view.ensure_loaded()
+        loaded = await _wait_until(lambda: view._loaded, pilot=pilot)
+        assert loaded
+
+        text = _all_text(app)
+        assert "example/model-a" in text
+        assert "example/model-b" in text
+
+        buttons = _install_buttons(app)
+        assert len(buttons) == 2
+        by_reference = {button.reference: button for button in buttons}
+        assert str(by_reference[installed_ref].label) == "Installed"
+        assert by_reference[installed_ref].disabled is True
+        assert str(by_reference[not_installed_ref].label) == "Review and install…"
+        assert by_reference[not_installed_ref].disabled is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_loaded_without_force_does_not_rerun_the_expensive_reads(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls: list[str] = []
+    original_list_installed = ModelArtifactService.list_installed
+
+    def _tracked(self):
+        calls.append("list_installed")
+        return original_list_installed(self)
+
+    monkeypatch.setattr(ModelArtifactService, "list_installed", _tracked)
+    registry = _registry_with(_descriptor(ArtifactRef("model-a", "a" * 40, "int8")))
+    service = ModelArtifactService(tmp_path / "store")
+
+    view = CuratedView(service_factory=lambda: service, registry_factory=lambda: registry)
+    app = _ViewApp(view)
+    async with app.run_test() as pilot:
+        view.ensure_loaded()
+        loaded = await _wait_until(lambda: view._loaded, pilot=pilot)
+        assert loaded
+        assert calls.count("list_installed") == 1
+
+        view.ensure_loaded()
+        for _ in range(10):
+            await pilot.pause()
+        assert calls.count("list_installed") == 1, (
+            "ensure_loaded() without force=True re-ran list_installed(); "
+            "the _loaded guard is not preventing a repeat load"
+        )
+
+        view.ensure_loaded(force=True)
+        refreshed = await _wait_until(
+            lambda: calls.count("list_installed") == 2, pilot=pilot
+        )
+        assert refreshed
+
+
+@pytest.mark.asyncio
+async def test_no_user_visible_string_contains_artifact(tmp_path: Path) -> None:
+    registry = _registry_with(_descriptor(ArtifactRef("model-a", "a" * 40, "int8")))
+    service = ModelArtifactService(tmp_path / "store")
+    view = CuratedView(service_factory=lambda: service, registry_factory=lambda: registry)
+    app = _ViewApp(view)
+    async with app.run_test() as pilot:
+        view.ensure_loaded()
+        loaded = await _wait_until(lambda: view._loaded, pilot=pilot)
+        assert loaded
+
+        assert "artifact" not in _all_text(app).lower()
+
+
+# ---------------------------------------------------------------------------
+# Install-request flow through to the consent modal.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_click_reaches_the_shared_consent_modal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A real Install click -- not a direct call to an internal method --
+    resolves a plan (through a stubbed acquisition service, so this stays
+    network-free) and pushes the exact shared ``ModelInstallModal``.
+    """
+    reference = ArtifactRef("model-a", "a" * 40, "int8")
+    descriptor = _descriptor(reference)
+    registry = _registry_with(descriptor)
+    service = ModelArtifactService(tmp_path / "store")
+    report = _report(reference, destination=tmp_path / "dest")
+
+    class _FakeAcquisitionService:
+        def __init__(self, _service) -> None:
+            pass
+
+        async def preflight(self, ref, _registry, *, sources):
+            assert ref == reference
+            return report
+
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
+    )
+
+    view = CuratedView(service_factory=lambda: service, registry_factory=lambda: registry)
+
+    app = _ViewApp(view)
+    async with app.run_test() as pilot:
+        # Patched on the real, running app instance (not the CuratedView
+        # class): this test needs the view's own `self.app` to resolve
+        # normally so the real @work threaded worker and pilot.click()
+        # both function -- only push_screen itself is stubbed, to capture
+        # its arguments without actually pushing a screen.
+        monkeypatch.setattr(app, "push_screen", MagicMock())
+
+        view.ensure_loaded()
+        loaded = await _wait_until(lambda: view._loaded, pilot=pilot)
+        assert loaded
+
+        button = _install_buttons(app)[0]
+        await pilot.click(button)
+        await pilot.pause()
+
+        pushed = await _wait_until(lambda: app.push_screen.called, pilot=pilot)
+        assert pushed, "clicking Install never reached push_screen"
+
+        modal, callback = app.push_screen.call_args[0]
+        assert isinstance(modal, ModelInstallModal)
+        assert modal.report is report
+        assert modal.model_label == descriptor.model_id
+        assert callback == view._confirm_install
+        assert view._pending_report is report
+
+
+# ---------------------------------------------------------------------------
+# Error / decline paths not otherwise exercised.
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_failure_notifies_and_does_not_push_a_modal(monkeypatch) -> None:
+    """The sibling success path is test_curated_preflight_result_opens_the_
+    shared_modal in test_model_installed_view.py; this is its failure branch.
+    """
+    fake_app = MagicMock()
+    # Class-level property patch (Screen/Widget.app is read-only) -- safe
+    # here because this view is never mounted inside a real App/run_test(),
+    # unlike test_install_click_reaches_the_shared_consent_modal above.
+    monkeypatch.setattr(CuratedView, "app", property(lambda self: fake_app))
+    view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
+    reference = ArtifactRef("model-a", "a" * 40, "int8")
+    view._operation_reference = reference
+    view.notify = MagicMock()
+    view.refresh = MagicMock()
+
+    view._apply_preflight_result(None, "boom")
+
+    assert view._operation_reference is None
+    view.notify.assert_called_once_with("boom", severity="error")
+    fake_app.push_screen.assert_not_called()
+    view.refresh.assert_called_once_with(recompose=True)
+
+
+def test_declining_the_consent_modal_does_not_start_the_install_worker() -> None:
+    view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
+    reference = ArtifactRef("model-a", "a" * 40, "int8")
+    view._operation_reference = reference
+    view._pending_report = object()
+    view._provision_model = MagicMock()
+    view.refresh = MagicMock()
+
+    view._confirm_install(False)
+
+    assert view._pending_report is None
+    assert view._operation_reference is None
+    view._provision_model.assert_not_called()
+    view.refresh.assert_called_once_with(recompose=True)

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -409,10 +409,16 @@ def test_curated_preflight_result_opens_the_shared_modal(
 
 
 def test_curated_progress_tolerates_recompose_gap() -> None:
-    """A progress event is retained while its widget is temporarily absent."""
+    """A progress event is retained while its widget is temporarily absent.
+
+    ``apply_progress`` (called only by the host screen, ``LLMScreen`` --
+    see its own docstring for why ``CuratedView`` no longer renders
+    itself in response to a bubbled ``InstallProgressed`` -- TASK-596
+    delta port fix round 1) shares this exact tolerance with the
+    self-listening handler it replaced.
+    """
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
     from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
-    from tldw_chatbook.Widgets.ModelArtifacts import InstallProgressed
 
     progress = AcquisitionProgress(
         "fetch",
@@ -425,7 +431,7 @@ def test_curated_progress_tolerates_recompose_gap() -> None:
     view.query_one = MagicMock(side_effect=NoMatches)
     view.refresh = MagicMock()
 
-    view._install_progressed(InstallProgressed(progress))
+    view.apply_progress(progress)
 
     assert view._progress is progress
     view.refresh.assert_called_once_with(recompose=True)

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -297,14 +297,21 @@ async def test_empty_inventory_still_reports_managed_and_staging_space(
     async with app.run_test() as pilot:
         view._apply_inventory(
             (),
-            ArtifactDiskUsage(installed_bytes=0, staging_bytes=2048, free_bytes=4096),
+            ArtifactDiskUsage(
+                installed_bytes=0,
+                staging_bytes=2 * 1024 * 1024,
+                free_bytes=4 * 1024 * 1024,
+            ),
             None,
         )
         await pilot.pause()
         text = "\n".join(str(item.renderable) for item in view.query("Static"))
 
-    assert "2.0 KiB staging" in text
-    assert "4.0 KiB free" in text
+    # All disk totals render through the single shared format_mib formatter
+    # (TASK-596 delta port), which always renders MiB -- 2 MiB and 4 MiB
+    # chosen so the expected strings are distinct and hand-verifiable.
+    assert "2.0 MiB staging" in text
+    assert "4.0 MiB free" in text
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -771,7 +771,7 @@ class IngestGuardrailModal(ModalScreen[bool]):
     }
     """
 
-    BINDINGS = [("escape", "dismiss(false)", "Close")]
+    BINDINGS = [("escape", "dismiss(False)", "Close")]
 
     def __init__(self, warnings: list[dict], affected_counts: dict[str, int]) -> None:
         self.warnings = warnings

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from textual import on
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -21,9 +22,11 @@ from ..Lab_Modules.lab_workbench import LAB_RAIL_ROW_CLASS
 from ..LLM_Management_Window import LLMManagementWindow
 from ..Workbench.workbench_state import WorkbenchHeaderState
 from .lab_frame import LabInspectorRow, LabScreen, LabStatusChip
+from .model_curated_view import CuratedView
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
 
 #: (section title, ((view key, label), ...)) in rail order. The view keys are
 #: exactly LLMManagementWindow.view_mapping's keys.
@@ -81,6 +84,16 @@ class LLMScreen(LabScreen):
         self._model_install_active = False
         self._model_install_phase: str | None = None
         self._model_install_succeeded: bool | None = None
+        #: The last ``AcquisitionProgress`` this screen has seen for the
+        #: active curated install, retained so a freshly (re)mounted
+        #: ``CuratedView`` -- a screen-level ``LabScreen.recompose()``
+        #: tears down and rebuilds the whole ``LLMManagementWindow``,
+        #: ``CuratedView`` included, mid-download -- can be hydrated back
+        #: to it immediately instead of starting blank (TASK-596 delta
+        #: port). Mirrors ``LibraryScreen``'s own retained
+        #: ``_parakeet_v2_install_progress``. Cleared whenever the install
+        #: stops (see ``_model_install_status_changed``).
+        self._model_install_last_progress: "AcquisitionProgress | None" = None
         #: Server rows snapshotted for the duration of one
         #: ``refresh_lab_status`` pass; None outside one. See
         #: :meth:`_current_server_rows`.
@@ -160,11 +173,25 @@ class LLMScreen(LabScreen):
 
     @on(InstallProgressed)
     def _model_install_progressed(self, event: InstallProgressed) -> None:
-        """Keep the Lab chip current while a Curated install runs."""
+        """Keep the Lab chip current, and re-render live progress (TASK-596).
+
+        Forwards the event into whichever ``CuratedView`` is currently
+        mounted -- not only the instance that posted it. ``CuratedView``
+        delivers ``InstallProgressed`` both to itself (unchanged, for the
+        common no-recompose case) and, durably, to the screen it was
+        mounted under (see ``CuratedView._progress_screen``'s docstring),
+        so this handler keeps firing with live updates even after a
+        screen-level recompose has replaced the view that started the
+        install with a fresh instance.
+        """
         self._model_install_active = True
         self._model_install_phase = event.progress.phase
         self._model_install_succeeded = None
+        self._model_install_last_progress = event.progress
         self.refresh_lab_status()
+        view = self._curated_view()
+        if view is not None:
+            view.apply_progress(event.progress)
 
     @on(InstallStatusChanged)
     def _model_install_status_changed(self, event: InstallStatusChanged) -> None:
@@ -173,7 +200,24 @@ class LLMScreen(LabScreen):
         self._model_install_succeeded = event.succeeded
         if not event.active:
             self._model_install_phase = None
+            self._model_install_last_progress = None
         self.refresh_lab_status()
+
+    def _curated_view(self) -> "CuratedView | None":
+        """Return the mounted ``CuratedView``, or None if it cannot be found.
+
+        Returns:
+            The view, or None when the window has not mounted yet, or a
+            screen-level recompose has torn down the previous instance and
+            the fresh one is not mounted yet either (see
+            ``LabScreen.recompose()``).
+        """
+        if self.llm_window is None:
+            return None
+        try:
+            return self.llm_window.query_one(CuratedView)
+        except NoMatches:
+            return None
 
     def compose_lab_rail(self) -> ComposeResult:
         """Yield the two rail sections and their nine provider rows."""
@@ -247,6 +291,39 @@ class LLMScreen(LabScreen):
         if not self._status_poll_started:
             self._status_poll_started = True
             self.set_interval(LAB_SERVER_POLL_SECONDS, self.refresh_lab_status)
+        # This fires on every (re)mount of the body -- first mount AND every
+        # later screen-level recompose (see this method's own docstring) --
+        # which is exactly when a fresh CuratedView instance, with no
+        # memory of an install this screen already knows is running, can
+        # appear mid-download (TASK-596 delta port). call_after_refresh
+        # (rather than calling directly) gives the freshly (re)mounted
+        # LLMManagementWindow's own children -- CuratedView included -- a
+        # chance to finish composing before _hydrate_curated_progress
+        # queries for it.
+        if self._model_install_active:
+            self.call_after_refresh(self._hydrate_curated_progress)
+
+    def _hydrate_curated_progress(self) -> None:
+        """Re-apply the last known curated-install progress after a recompose.
+
+        Without this, a freshly (re)mounted ``CuratedView``'s progress
+        widget -- composed hidden every time a new instance is built, see
+        ``CuratedView.compose`` -- would stay hidden for the rest of an
+        install that outlived a screen-level ``LabScreen.recompose()``,
+        even though ``CuratedView`` itself keeps rendering live updates
+        that reach it (see ``_model_install_progressed``). Scheduled via
+        ``call_after_refresh`` from ``on_lab_body_ready`` (which reruns on
+        every recompose, not only first mount) -- mirroring
+        ``LibraryScreen``'s own ``_hydrate_parakeet_v2_progress`` -- so the
+        fresh ``CuratedView`` has actually finished mounting first.
+        """
+        if not self._model_install_active:
+            return
+        if self._model_install_last_progress is None:
+            return
+        view = self._curated_view()
+        if view is not None:
+            view.apply_progress(self._model_install_last_progress)
 
     def _sync_rail_active(self, active_view: str) -> None:
         """Move the rail highlight to the row matching the active view.

--- a/tldw_chatbook/UI/Screens/model_browser_state.py
+++ b/tldw_chatbook/UI/Screens/model_browser_state.py
@@ -145,6 +145,37 @@ def plan_totals(report: PreflightReport) -> PlanTotals:
     )
 
 
+def format_mib(size_bytes: int) -> str:
+    """Render a byte count as a complete MiB display string, unit included.
+
+    This is the one place that turns a raw byte count (``PlanRow``/
+    ``PlanTotals``/``InventoryRow`` fields, or a live
+    ``AcquisitionProgress`` event) into display text, and it owns the unit
+    as well as the number. Before this function existed, the plan panel,
+    the install-progress widget, and the installed view each reimplemented
+    this conversion independently and disagreed: the install-progress
+    widget additionally switched to B/KiB for sub-MiB values while the
+    other two always rendered MiB, so the same byte count could render as
+    "512.0 KiB" in one view and "0.5 MiB" in another. The sub-MiB
+    switching is deliberately dropped here -- always rendering MiB (even
+    "0.0 MiB" for a tiny or zero count) is the one behaviour every caller
+    now shares, so two screens showing the same report can never disagree
+    about units or precision. Callers must not reimplement the conversion
+    or append their own unit suffix.
+
+    Args:
+        size_bytes: A byte count (expected non-negative; formats without
+            raising for any int).
+
+    Returns:
+        The value divided by 1024*1024, formatted to one decimal place
+        and suffixed with the unit, e.g. ``"630.6 MiB"`` for
+        ``661_191_781``, ``"0.0 MiB"`` for ``0``, and ``"1.0 MiB"`` for
+        exactly ``1_048_576`` (1 MiB).
+    """
+    return f"{size_bytes / (1024 * 1024):.1f} MiB"
+
+
 def inventory_rows(
     installed: Iterable[InstalledArtifact],
     usage: ArtifactDiskUsage | None,

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -341,9 +341,7 @@ class CuratedView(Widget):
         this code posted before ``_progress_screen`` existed.
         ``post_message`` returns ``False`` without raising once this
         instance is closed (torn down by a screen-level recompose, see
-        ``_progress_screen``'s docstring) -- only THEN does this fall back
-        to the captured screen, so the durable channel is used exactly
-        when needed, never in addition to the normal path.
+        ``_progress_screen``'s docstring) -- only THEN does this fall back.
 
         Review Important #1 (this delta port's first round): posting to
         both targets unconditionally, every tick, meant ``LLMScreen``'s own
@@ -355,16 +353,50 @@ class CuratedView(Widget):
         three ``apply_progress`` calls for one tick. Exactly one message
         is posted per tick now, so ``LLMScreen`` renders exactly once.
 
+        Review Important #2 (PR #1185 automated review, fix round 2): the
+        fallback used to post directly at the captured Screen. Textual
+        only bubbles a message UP from wherever it is posted -- never back
+        down -- and ``LLMManagementWindow`` (which owns the
+        ``InstallProgressed``/``InstallStatusChanged`` handlers that mirror
+        progress and lifecycle into ``InstalledView``) sits BELOW the
+        Screen in the tree. Posting at the Screen therefore entered the
+        tree above that mirroring node, so it silently never ran after a
+        recompose: Curated kept updating via ``LLMScreen``, but Installed
+        stopped receiving ticks/completion until some later, unrelated
+        refresh. The fallback now re-enters the tree below that node
+        instead -- at the live ``CuratedView`` if one is mounted (the
+        normal case, restoring the FULL path: mirror at
+        ``LLMManagementWindow``, then render at ``LLMScreen``, in one
+        message), or at the live ``LLMManagementWindow`` if a fresh
+        ``CuratedView`` has not finished (re)mounting yet (the same
+        nested-mount window ``apply_progress`` itself tolerates), and only
+        as a last resort -- neither found -- at the Screen itself, exactly
+        as the reviewer specified.
+
         Args:
             message: The event to deliver; a fresh instance per call (never
-                reused across the two targets, so no Message ever needs
-                its ``_prevent`` set merged across two different posts).
+                reused across two different posts, so no Message ever
+                needs its ``_prevent`` set merged from two different
+                targets).
         """
         if self.post_message(message):
             return
         screen = self._progress_screen
-        if screen is not None:
-            screen.post_message(message)
+        if screen is None:
+            return
+        # Local import: avoids a module-scope cycle with
+        # LLM_Management_Window, which itself only imports this module
+        # locally (inside its own compose()), for the same reason.
+        from tldw_chatbook.UI.LLM_Management_Window import LLMManagementWindow
+
+        try:
+            target: Widget = screen.query_one(CuratedView)
+        except NoMatches:
+            try:
+                target = screen.query_one(LLMManagementWindow)
+            except NoMatches:
+                target = screen
+        target.post_message(message)
 
     async def _provision(self, report):
         """Provision the consented report on the worker's event loop."""

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from loguru import logger
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
+from textual.dom import NoScreen
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -35,6 +37,11 @@ from tldw_chatbook.Widgets.ModelArtifacts import (
     ModelInstallProgress,
     make_progress_callback,
 )
+
+if TYPE_CHECKING:
+    from textual.screen import Screen
+
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
 
 
 @dataclass(frozen=True)
@@ -106,6 +113,18 @@ class CuratedView(Widget):
         self._operation_reference: ArtifactRef | None = None
         self._pending_report = None
         self._progress = None
+        #: The screen this view was mounted under when its current install
+        #: started, captured by ``_confirm_install`` on the main thread
+        #: before the worker starts. Unlike this exact ``CuratedView``
+        #: instance, the screen survives a screen-level
+        #: ``LabScreen.recompose()`` that tears down and rebuilds the whole
+        #: ``LLMManagementWindow`` (this view included) mid-download, so
+        #: ``_provision`` posts progress there too -- not only to
+        #: ``self`` -- letting the host screen re-apply live progress to
+        #: whichever ``CuratedView`` instance is mounted next (see
+        #: ``LLMScreen._hydrate_curated_progress``) instead of the
+        #: download going silently unrendered for the rest of its run.
+        self._progress_screen: "Screen | None" = None
         super().__init__(id=id)
 
     def compose(self) -> ComposeResult:
@@ -300,6 +319,13 @@ class CuratedView(Widget):
             self.post_message(
                 InstallStatusChanged(self._operation_reference, active=True)
             )
+        # See _progress_screen's own docstring: captured here, on the main
+        # thread, before the worker starts -- not inside _provision, which
+        # runs on the worker thread.
+        try:
+            self._progress_screen = self.screen
+        except NoScreen:
+            self._progress_screen = None
         self._provision_model()
 
     async def _provision(self, report):
@@ -307,12 +333,30 @@ class CuratedView(Widget):
         from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
 
         acquisition = ArtifactAcquisitionService(self._service_for_worker())
+        # Dual delivery (TASK-596 delta port -- curated install progress
+        # survives a screen-level recompose): render_here preserves this
+        # exact instance's own self-rendering (_install_progressed) for the
+        # common no-recompose case, unchanged from before. render_on_screen
+        # additionally reaches the mounting screen directly -- see
+        # _progress_screen's own docstring for why that one survives a
+        # recompose that this instance would not.
+        render_here = make_progress_callback(self.post_message)
+        screen = self._progress_screen
+        render_on_screen = (
+            make_progress_callback(screen.post_message) if screen is not None else None
+        )
+
+        def deliver(progress: "AcquisitionProgress") -> None:
+            render_here(progress)
+            if render_on_screen is not None:
+                render_on_screen(progress)
+
         return await acquisition.provision(
             report.root,
             report.grant(),
             self._registry_for_worker(),
             sources=self._source_map(),
-            progress=make_progress_callback(self.post_message),
+            progress=deliver,
         )
 
     @work(thread=True, group="curated_model_install", exclusive=True, exit_on_error=False)
@@ -347,17 +391,46 @@ class CuratedView(Widget):
     @on(InstallProgressed)
     def _install_progressed(self, event: InstallProgressed) -> None:
         """Retain and render worker progress outside the modal."""
-        self._progress = event.progress
+        self.apply_progress(event.progress)
+
+    def apply_progress(self, progress: "AcquisitionProgress") -> None:
+        """Render one acquisition progress event, retaining it for later.
+
+        Shares its rendering with ``_install_progressed`` (the in-process
+        path for a progress event this exact instance's own worker just
+        posted to itself). The host screen (``LLMScreen``) also calls this
+        directly -- via ``_hydrate_curated_progress`` and its own
+        ``InstallProgressed`` handler -- to re-apply the last known (or
+        latest live) progress to whichever ``CuratedView`` instance is
+        currently mounted, including a freshly (re)mounted one after a
+        screen-level recompose tore the previous instance down mid-download
+        (see ``_progress_screen``'s docstring).
+
+        ``self._progress`` is retained before either branch below runs, so
+        a fallback ``refresh(recompose=True)`` still picks up the correct
+        value on CuratedView's next (complete) compose pass: this method
+        can run (via ``_hydrate_curated_progress``, scheduled by
+        ``call_after_refresh``) at a point where CuratedView itself has
+        (re)mounted but its own ``ModelInstallProgress`` child has not yet
+        finished composing ITS OWN children -- a widget that ``query_one``
+        finds but whose own ``update_progress`` call then raises
+        ``NoMatches`` reaching into it. That is the same "temporarily
+        absent" gap ``_install_progressed`` always tolerated for the outer
+        widget; this also tolerates it one level deeper.
+
+        Args:
+            progress: The acquisition progress event to render.
+        """
+        self._progress = progress
         try:
-            progress = self.query_one(
+            widget = self.query_one(
                 "#curated-model-install-progress",
                 ModelInstallProgress,
             )
+            widget.display = True
+            widget.update_progress(progress)
         except NoMatches:
             self.refresh(recompose=True)
-            return
-        progress.display = True
-        progress.update_progress(event.progress)
 
     def _apply_provision_result(self, error: str | None) -> None:
         """Finish an installation and refresh curated installed-state."""
@@ -365,6 +438,8 @@ class CuratedView(Widget):
         self._pending_report = None
         self._operation_reference = None
         self._progress = None
+        screen = self._progress_screen
+        self._progress_screen = None
         try:
             progress = self.query_one(
                 "#curated-model-install-progress",
@@ -386,4 +461,20 @@ class CuratedView(Widget):
                     succeeded=error is None,
                 )
             )
+            # Dual delivery, mirroring _provision's own progress delivery:
+            # if a screen-level recompose orphaned this exact instance
+            # mid-download, the message above never bubbles anywhere (a
+            # closed widget's post_message() is a silent no-op), so the
+            # host screen would otherwise never learn the install finished
+            # and would keep re-hydrating a stale "still active" progress
+            # display on every future recompose (see
+            # LLMScreen._hydrate_curated_progress).
+            if screen is not None:
+                screen.post_message(
+                    InstallStatusChanged(
+                        reference,
+                        active=False,
+                        succeeded=error is None,
+                    )
+                )
         self.ensure_loaded(force=True)

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -35,7 +35,6 @@ from tldw_chatbook.Widgets.ModelArtifacts import (
     InstallStatusChanged,
     ModelInstallModal,
     ModelInstallProgress,
-    make_progress_callback,
 )
 
 if TYPE_CHECKING:
@@ -119,9 +118,10 @@ class CuratedView(Widget):
         #: instance, the screen survives a screen-level
         #: ``LabScreen.recompose()`` that tears down and rebuilds the whole
         #: ``LLMManagementWindow`` (this view included) mid-download, so
-        #: ``_provision`` posts progress there too -- not only to
-        #: ``self`` -- letting the host screen re-apply live progress to
-        #: whichever ``CuratedView`` instance is mounted next (see
+        #: ``_deliver`` falls back to posting there -- once this instance
+        #: can no longer receive its own messages -- letting the host
+        #: screen re-apply live progress to whichever ``CuratedView``
+        #: instance is mounted next (see
         #: ``LLMScreen._hydrate_curated_progress``) instead of the
         #: download going silently unrendered for the rest of its run.
         self._progress_screen: "Screen | None" = None
@@ -315,41 +315,65 @@ class CuratedView(Widget):
             self._operation_reference = None
             self.refresh(recompose=True)
             return
-        if self._operation_reference is not None:
-            self.post_message(
-                InstallStatusChanged(self._operation_reference, active=True)
-            )
         # See _progress_screen's own docstring: captured here, on the main
         # thread, before the worker starts -- not inside _provision, which
-        # runs on the worker thread.
+        # runs on the worker thread -- and before the InstallStatusChanged
+        # post below, so _deliver's fallback is available from the very
+        # first message this install produces.
         try:
             self._progress_screen = self.screen
         except NoScreen:
             self._progress_screen = None
+        if self._operation_reference is not None:
+            self._deliver(
+                InstallStatusChanged(self._operation_reference, active=True)
+            )
         self._provision_model()
+
+    def _deliver(self, message: InstallProgressed | InstallStatusChanged) -> None:
+        """Post one message to whichever target can still receive it.
+
+        Tries this instance first -- ``self.post_message`` -- which
+        preserves today's exact bubble path (``CuratedView`` ->
+        ``LLMManagementWindow``, which mirrors progress into
+        ``InstalledView`` -- unrelated to this task -- -> ``LLMScreen``)
+        for the common, no-recompose case: exactly the same single message
+        this code posted before ``_progress_screen`` existed.
+        ``post_message`` returns ``False`` without raising once this
+        instance is closed (torn down by a screen-level recompose, see
+        ``_progress_screen``'s docstring) -- only THEN does this fall back
+        to the captured screen, so the durable channel is used exactly
+        when needed, never in addition to the normal path.
+
+        Review Important #1 (this delta port's first round): posting to
+        both targets unconditionally, every tick, meant ``LLMScreen``'s own
+        forwarding (``_model_install_progressed``/``_hydrate_curated_
+        progress``) re-applied the SAME event to the SAME still-mounted
+        ``CuratedView`` a second (and, with ``InstallProgressed`` also
+        bubbling through this instance's own now-removed self-listening
+        handler, third) time -- confirmed live via a Pilot probe showing
+        three ``apply_progress`` calls for one tick. Exactly one message
+        is posted per tick now, so ``LLMScreen`` renders exactly once.
+
+        Args:
+            message: The event to deliver; a fresh instance per call (never
+                reused across the two targets, so no Message ever needs
+                its ``_prevent`` set merged across two different posts).
+        """
+        if self.post_message(message):
+            return
+        screen = self._progress_screen
+        if screen is not None:
+            screen.post_message(message)
 
     async def _provision(self, report):
         """Provision the consented report on the worker's event loop."""
         from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
 
         acquisition = ArtifactAcquisitionService(self._service_for_worker())
-        # Dual delivery (TASK-596 delta port -- curated install progress
-        # survives a screen-level recompose): render_here preserves this
-        # exact instance's own self-rendering (_install_progressed) for the
-        # common no-recompose case, unchanged from before. render_on_screen
-        # additionally reaches the mounting screen directly -- see
-        # _progress_screen's own docstring for why that one survives a
-        # recompose that this instance would not.
-        render_here = make_progress_callback(self.post_message)
-        screen = self._progress_screen
-        render_on_screen = (
-            make_progress_callback(screen.post_message) if screen is not None else None
-        )
 
         def deliver(progress: "AcquisitionProgress") -> None:
-            render_here(progress)
-            if render_on_screen is not None:
-                render_on_screen(progress)
+            self._deliver(InstallProgressed(progress))
 
         return await acquisition.provision(
             report.root,
@@ -388,23 +412,23 @@ class CuratedView(Widget):
             return
         self.app.call_from_thread(self._apply_provision_result, None)
 
-    @on(InstallProgressed)
-    def _install_progressed(self, event: InstallProgressed) -> None:
-        """Retain and render worker progress outside the modal."""
-        self.apply_progress(event.progress)
-
     def apply_progress(self, progress: "AcquisitionProgress") -> None:
         """Render one acquisition progress event, retaining it for later.
 
-        Shares its rendering with ``_install_progressed`` (the in-process
-        path for a progress event this exact instance's own worker just
-        posted to itself). The host screen (``LLMScreen``) also calls this
-        directly -- via ``_hydrate_curated_progress`` and its own
-        ``InstallProgressed`` handler -- to re-apply the last known (or
-        latest live) progress to whichever ``CuratedView`` instance is
-        currently mounted, including a freshly (re)mounted one after a
-        screen-level recompose tore the previous instance down mid-download
-        (see ``_progress_screen``'s docstring).
+        Called ONLY by the host screen (``LLMScreen``) -- via its own
+        ``InstallProgressed`` handler for a live tick, and via
+        ``_hydrate_curated_progress`` to re-apply the last known progress
+        to a freshly (re)mounted instance after a screen-level recompose
+        (see ``_progress_screen``'s docstring). This view deliberately has
+        no ``@on(InstallProgressed)`` handler of its own: it used to
+        (re-rendering itself on receipt of the very message it had just
+        posted to itself), which meant one tick rendered TWICE on the same
+        still-mounted widget once ``LLMScreen`` started forwarding too --
+        confirmed live via a Pilot probe showing three ``apply_progress``
+        calls for one tick (Review Important #1). ``LLMScreen`` is now the
+        sole caller, giving exactly one render per tick regardless of
+        which delivery path (self or the durable screen fallback,
+        see ``_deliver``) carried it.
 
         ``self._progress`` is retained before either branch below runs, so
         a fallback ``refresh(recompose=True)`` still picks up the correct
@@ -414,9 +438,11 @@ class CuratedView(Widget):
         (re)mounted but its own ``ModelInstallProgress`` child has not yet
         finished composing ITS OWN children -- a widget that ``query_one``
         finds but whose own ``update_progress`` call then raises
-        ``NoMatches`` reaching into it. That is the same "temporarily
-        absent" gap ``_install_progressed`` always tolerated for the outer
-        widget; this also tolerates it one level deeper.
+        ``NoMatches`` reaching into it. Unrelated to the double-render
+        issue above (that was about how many times a fully-mounted widget
+        got re-rendered; this is about a widget still mid-mount) -- kept
+        even now that delivery is single-path, tolerating the outer
+        widget lookup being temporarily absent one level deeper.
 
         Args:
             progress: The acquisition progress event to render.
@@ -438,8 +464,10 @@ class CuratedView(Widget):
         self._pending_report = None
         self._operation_reference = None
         self._progress = None
-        screen = self._progress_screen
-        self._progress_screen = None
+        # _progress_screen itself is cleared only after _deliver (below)
+        # has had a chance to use it as its fallback target for this
+        # exact completion message -- clearing it first would silently
+        # disable the durable path for the one message that most needs it.
         try:
             progress = self.query_one(
                 "#curated-model-install-progress",
@@ -454,27 +482,16 @@ class CuratedView(Widget):
         else:
             self.notify("Model installed and activated.", severity="information")
         if reference is not None:
-            self.post_message(
-                InstallStatusChanged(
-                    reference,
-                    active=False,
-                    succeeded=error is None,
-                )
+            # _deliver (see its own docstring): tries this instance first,
+            # falls back to the captured screen only if a screen-level
+            # recompose already orphaned it -- otherwise this completion
+            # message would never bubble anywhere (a closed widget's
+            # post_message() is a silent no-op), and the host screen would
+            # never learn the install finished, re-hydrating a stale
+            # "still active" progress display on every future recompose
+            # (see LLMScreen._hydrate_curated_progress).
+            self._deliver(
+                InstallStatusChanged(reference, active=False, succeeded=error is None)
             )
-            # Dual delivery, mirroring _provision's own progress delivery:
-            # if a screen-level recompose orphaned this exact instance
-            # mid-download, the message above never bubbles anywhere (a
-            # closed widget's post_message() is a silent no-op), so the
-            # host screen would otherwise never learn the install finished
-            # and would keep re-hydrating a stale "still active" progress
-            # display on every future recompose (see
-            # LLMScreen._hydrate_curated_progress).
-            if screen is not None:
-                screen.post_message(
-                    InstallStatusChanged(
-                        reference,
-                        active=False,
-                        succeeded=error is None,
-                    )
-                )
+        self._progress_screen = None
         self.ensure_loaded(force=True)

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -27,6 +27,7 @@ from tldw_chatbook.Model_Artifacts.store import managed_service
 from tldw_chatbook.UI.Screens.model_browser_state import (
     InventoryRow,
     UnmanagedRow,
+    format_mib,
     inventory_rows,
 )
 from tldw_chatbook.Utils.path_validation import validate_path_simple
@@ -201,9 +202,9 @@ class InstalledView(Widget):
             return Static("Disk usage unavailable.", markup=False)
         return Static(
             "Managed: "
-            f"{self._format_bytes(self._usage.installed_bytes)} installed, "
-            f"{self._format_bytes(self._usage.staging_bytes)} staging · "
-            f"{self._format_bytes(self._usage.free_bytes)} free",
+            f"{format_mib(self._usage.installed_bytes)} installed, "
+            f"{format_mib(self._usage.staging_bytes)} staging · "
+            f"{format_mib(self._usage.free_bytes)} free",
             markup=False,
         )
 
@@ -265,7 +266,7 @@ class InstalledView(Widget):
                     )
                 )
         if row.size_bytes is not None:
-            children.append(Static(f"Size: {self._format_bytes(row.size_bytes)}"))
+            children.append(Static(f"Size: {format_mib(row.size_bytes)}"))
         children.append(Static(row.action_hint, markup=False))
         if row.reference is not None and not row.is_broken:
             children.append(
@@ -283,16 +284,6 @@ class InstalledView(Widget):
                 )
             )
         return Vertical(*children, classes="installed-model-row")
-
-    @staticmethod
-    def _format_bytes(size_bytes: int) -> str:
-        """Format bytes for compact inventory copy."""
-        size = float(size_bytes)
-        for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-            if size < 1024 or unit == "TiB":
-                return f"{size:.1f} {unit}"
-            size /= 1024
-        return f"{size:.1f} TiB"
 
     @staticmethod
     def scan_unmanaged(

--- a/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/install_progress.py
@@ -10,6 +10,8 @@ from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import ProgressBar, Static
 
+from tldw_chatbook.UI.Screens.model_browser_state import format_mib
+
 if TYPE_CHECKING:
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
     from tldw_chatbook.Model_Artifacts.service import ArtifactRef
@@ -67,15 +69,6 @@ def make_progress_callback(
         post_message(InstallProgressed(progress))
 
     return callback
-
-
-def _bytes(size: int) -> str:
-    """Format a nonnegative byte count compactly."""
-    if size < 1024:
-        return f"{size} B"
-    if size < 1024 * 1024:
-        return f"{size / 1024:.1f} KiB"
-    return f"{size / (1024 * 1024):.1f} MiB"
 
 
 class ModelInstallProgress(Widget):
@@ -145,7 +138,8 @@ class ModelInstallProgress(Widget):
         if byte_phase:
             filename = event.file or "Model files"
             detail.update(
-                f"{filename} — {_bytes(event.bytes_done)} / {_bytes(event.bytes_total)}"
+                f"{filename} — {format_mib(event.bytes_done)} / "
+                f"{format_mib(event.bytes_total)}"
             )
             bar.display = True
             bar.update(total=max(event.bytes_total, 1), progress=event.bytes_done)

--- a/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
@@ -6,15 +6,14 @@ from typing import TYPE_CHECKING
 
 from textual.widgets import Static
 
-from tldw_chatbook.UI.Screens.model_browser_state import plan_rows, plan_totals
+from tldw_chatbook.UI.Screens.model_browser_state import (
+    format_mib,
+    plan_rows,
+    plan_totals,
+)
 
 if TYPE_CHECKING:
     from tldw_chatbook.Model_Artifacts.acquisition import PreflightReport
-
-
-def _mib(size_bytes: int) -> str:
-    """Format a byte count as mebibytes."""
-    return f"{size_bytes / (1024 * 1024):.1f} MiB"
 
 
 class ModelPlanPanel(Static):
@@ -54,7 +53,7 @@ class ModelPlanPanel(Static):
                     f"License: {license_label}",
                     f"Source review page: {row.license_url}",
                     f"Precision: {row.precision}",
-                    f"Contents: {row.file_count} files, {_mib(row.total_bytes)}",
+                    f"Contents: {row.file_count} files, {format_mib(row.total_bytes)}",
                     f"Provenance: {row.provenance}",
                     "",
                 )
@@ -73,11 +72,11 @@ class ModelPlanPanel(Static):
                 )
         lines.extend(
             (
-                f"Download: {_mib(totals.download_bytes)}",
-                f"Already staged: {_mib(totals.already_staged_bytes)}",
-                f"Staging overhead: {_mib(totals.staging_overhead_bytes)}",
+                f"Download: {format_mib(totals.download_bytes)}",
+                f"Already staged: {format_mib(totals.already_staged_bytes)}",
+                f"Staging overhead: {format_mib(totals.staging_overhead_bytes)}",
                 f"Destination: {totals.destination}",
-                f"Free space: {_mib(totals.free_bytes)}",
+                f"Free space: {format_mib(totals.free_bytes)}",
             )
         )
         if totals.sufficient_space:
@@ -85,7 +84,7 @@ class ModelPlanPanel(Static):
         else:
             lines.append(
                 f"Not enough free space: this install needs "
-                f"{_mib(totals.required_bytes)} free."
+                f"{format_mib(totals.required_bytes)} free."
             )
         if totals.gating_errors:
             lines.extend(("", *totals.gating_errors))


### PR DESCRIPTION
Follow-up to #1175. Three defects in the merged model browser, plus the test depth to keep them fixed.

TASK-596 Phase 1 was implemented twice in parallel — #1175 merged and is canonical. This PR ports only the genuine improvements from the second implementation (`feat/model-artifact-browser`, kept on the remote as the reference). Strictly additive: nothing in #1175's design is restructured or renamed.

## Three defects fixed

**1. Escape raises instead of closing `IngestGuardrailModal`.** It binds `("escape", "dismiss(false)", "Close")`. Lowercase `false` is not a Python literal, so Textual's action parser raises rather than dismissing:

```
>>> parse("dismiss(false)")
ActionError: unable to parse 'false' in action 'dismiss(false)'
```

Fixed to `dismiss(False)`, with a test that presses Escape and asserts the modal dismissed with `False` — not merely that nothing raised. Repo-wide grep confirms no other lowercase action literal.

**2. Three byte formatters that disagree.** `plan_panel.py`, `install_progress.py`, and `model_installed_view._format_bytes` each implemented MiB formatting, and `install_progress` carried a sub-MiB branch the others lacked — so the same byte count rendered differently in the install plan than in the progress display. Collapsed into one public `format_mib` in `model_browser_state.py` (the module every consumer already imports from), returning the complete string including the unit so no caller can disagree about spelling either. 300 KB renders `0.3 MiB`. Unit tests use hand-verified expected strings rather than re-deriving them from the formula under test.

**3. Curated install progress dies on a screen recompose.** The Models screen recomposes on ordinary navigation; mid-download that left progress blank for the rest of the run while events kept arriving.

The root cause is deeper than a missing hydration call: `CuratedView` owns its own `@work` methods, so a recompose orphans the instance that owns the download and its `post_message` becomes a silent no-op. This PR delivers durably — the view tries itself first and falls back to the captured screen when its own `post_message` reports the instance is closed — and makes `LLMScreen` the sole caller of `apply_progress`, hydrating from cached progress after a recompose.

The underlying ownership problem is filed as **TASK-1803**: the design has views post intents while the host screen owns the worker, precisely so a download cannot be orphaned. `InstalledView` and `LibraryScreen` follow that shape; `CuratedView` is the outlier. That task's ACs require removing this PR's compensating delivery once ownership moves.

## Test depth

| file | before | after |
|---|---|---|
| `test_model_browser_state.py` | 4 | 8 |
| `test_model_artifact_widgets.py` | 6 | 8 |
| `test_model_curated_view.py` | — | 6 (new file) |
| `test_library_ingest_guardrail_modal.py` | — | new |

Added coverage targets what a browser over a download layer has to get right: provenance labels never imply safety, broken inventory rows render rather than crash, every branch of `install_failure_message` asserts the mapped text is present **and** an injected raw marker is absent, the plan's Confirm is disabled on a non-grantable report with the reason shown, descriptor text containing `[...]` survives Rich markup, and the progress callback marshals across threads rather than mutating a widget directly.

Three reference tests were deliberately **not** ported, because #1175's design genuinely differs rather than because they failed: two asserting that views never call `preflight`/`provision` (dev's `CuratedView` does — that is TASK-1803), and one asserting provenance-label order independence (dev joins in tuple order). Porting them would have been asserting a design that isn't there.

## Verification

545 passed, 1 skipped (pre-existing, unrelated) across the model browser, Parakeet install, Lab rail, `Model_Artifacts`, and STT boundary suites.

Each of the three fixes was sabotage-verified — break the fix, confirm the new test goes red, restore. Review found one defect in the first cut of fix 3: `InstallProgressed` bubbles by default, so dual delivery rendered a single tick 2–3× on the same widget for the entire download. Idempotent, so nothing corrupted, but invisible to tests asserting eventual content. Now single-path, pinned by a test that counts `apply_progress` invocations per tick rather than inspecting the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Model Browser issues for TASK-596: Escape now closes the guardrail modal, all views use the same MiB formatter, and curated install progress survives screen recomposes with single renders and correct mirroring into Installed.

- **Bug Fixes**
  - Escape dismisses `IngestGuardrailModal` via `dismiss(False)`.
  - Unified size display with `format_mib`; updated `plan_panel`, `install_progress`, and `model_installed_view`.
  - Curated progress survives `LabScreen.recompose()` and renders exactly once: `CuratedView` captures the mounting screen and delivers via `_deliver` (self first, fallback).
  - Mirroring into Installed continues after recomposes: `_deliver` re-enters below `LLMManagementWindow`; `LLMScreen` retains last progress, forwards ticks, and hydrates a fresh `CuratedView`.

- **Refactors**
  - Added `CuratedView.apply_progress` as the single render entry, hardened for nested mount gaps.
  - Expanded tests: escape binding; MiB formatting (0, sub‑MiB, 1 MiB, 1 GiB); bracketed text survives; off‑thread progress posts; dedicated CuratedView coverage for load/installed markers, consent modal flow, recompose hydration and mirroring, exactly‑once rendering, and error/decline paths.

<sup>Written for commit e3c29714c15cacb3e713dea76134e98cf9ba6b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

