### PR TITLE
Add bounded Hugging Face GGUF discovery to the managed model browser

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1903,7 +1903,7 @@
     },
     {
       "call_count": 12,
-      "diagnostic_digest": "08abcab092d32116eb7c",
+      "diagnostic_digest": "c90de2db893e655780ec",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/LLM_Management_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2071,9 +2071,16 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "4c6877a72e5ce83888cb",
+      "diagnostic_digest": "9d92528713cb3309ce57",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/model_installed_view.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
+      "diagnostic_digest": "ed0615607952cfd8aadd",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/model_remote_view.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -3196,9 +3203,9 @@
   "schema_version": 1,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 435,
+    "owner_files": 436,
     "persistent_sink_files": 4,
     "task_492_calls": 1073,
-    "task_494_calls": 6700
+    "task_494_calls": 6702
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2085,7 +2085,7 @@
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "ed0615607952cfd8aadd",
+      "diagnostic_digest": "febcad90cd450a36453e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/model_remote_view.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -377,7 +377,7 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "6a9eb23feb7e3cce1918",
+      "diagnostic_digest": "1cf390d6b5d72b4962df",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Subscriptions_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1335,6 +1335,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 4,
+      "diagnostic_digest": "b522b140a7a346d84e56",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Scheduling/scheduler/handlers/briefing_handler.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 14,
       "diagnostic_digest": "465396aaec988ba8acae",
       "owner": "TASK-494",
@@ -1343,7 +1350,7 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "d81c60792e04a1ca9c1e",
+      "diagnostic_digest": "cefe236a94d9a095f4e0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/loop.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1406,14 +1413,14 @@
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "c3e3da2f827e811b0eaf",
+      "diagnostic_digest": "8a13c5fddf8354aaf8d0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_audio.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "194d1911ab0f2662dc6d",
+      "diagnostic_digest": "6cec136d569b27234566",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_cast.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1427,7 +1434,7 @@
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "4c9fa4f0114fb0cc59cc",
+      "diagnostic_digest": "220e465ab4a43aaf3772",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2168,8 +2175,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 64,
-      "diagnostic_digest": "9f357ee7c72ff6346a5b",
+      "call_count": 65,
+      "diagnostic_digest": "560491ce51a6b54c2b50",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/watchlists_collections_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3023,14 +3030,14 @@
     },
     {
       "call_count": 283,
-      "diagnostic_digest": "a0320b8823d96444d780",
+      "diagnostic_digest": "a93c91864ced2a262a37",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 90,
-      "diagnostic_digest": "181f5a7ed2ab45900f7a",
+      "diagnostic_digest": "5a77d8be7e94edcf2c20",
       "owner": "TASK-494",
       "path": "tldw_chatbook/config.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3171,13 +3178,13 @@
         {
           "digest": "567455f2495e9603",
           "kind": "addHandler",
-          "line": 5732,
+          "line": 5748,
           "method": "addHandler"
         },
         {
           "digest": "928f6c554daaf493",
           "kind": "addHandler",
-          "line": 5786,
+          "line": 5802,
           "method": "addHandler"
         }
       ]
@@ -3203,9 +3210,9 @@
   "schema_version": 1,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 436,
+    "owner_files": 437,
     "persistent_sink_files": 4,
     "task_492_calls": 1073,
-    "task_494_calls": 6702
+    "task_494_calls": 6707
   }
 }

--- a/Docs/superpowers/plans/2026-08-01-task-596-1-remote-model-discovery.md
+++ b/Docs/superpowers/plans/2026-08-01-task-596-1-remote-model-discovery.md
@@ -1,0 +1,577 @@
+# TASK-596.1 Remote Model Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users explicitly discover and download pinned Hugging Face GGUF files through the managed model store without activating or presenting arbitrary models as runtime-compatible.
+
+**Architecture:** Add one narrow `httpx` adapter that parses bounded Hugging Face metadata into immutable values and a one-item managed catalog. A lazy Textual Remote view owns search, resolution, and the existing preflight/provision lifecycle. Small additive changes let shared acquisition install without activation and let shared inventory/consent widgets represent an unassigned model honestly.
+
+**Tech Stack:** Python 3.11+, `httpx`, Textual, existing `ModelArtifactService` / `ArtifactAcquisitionService`, pytest, `httpx.MockTransport`.
+
+**Design spec:** `Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md`
+
+**ADR required:** no
+
+**ADR path:** `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+
+**Reason:** ADR-025 already owns remote artifact provenance, managed acquisition, activation, and runtime boundaries. This task adds a Hugging Face adapter and an install-without-activation option inside that boundary.
+
+**Baseline:** The affected pre-change suite passes: 70 tests across stream fetch, provision/install, shared model widgets/state, Installed, and Lab model-screen adoption. Loopback fixture tests require permission to bind local ports in the Codex sandbox.
+
+**Execution precondition:** Before Task 1, fetch and rebase this documentation
+branch onto the latest `origin/dev`, confirm TASK-596.1/spec/plan paths still have
+no collision, and rerun the same 70-test baseline. Stop for a real product
+conflict; resolve only mechanical documentation conflicts without changing the
+approved behavior. Then use the Backlog CLI to add this plan and the approved
+design spec to TASK-596.1's Documentation field and add the implementation-plan
+summary, including the ADR decision above, before changing production code.
+
+---
+
+## File map
+
+**Create**
+
+- `tldw_chatbook/Model_Artifacts/remote_huggingface.py` — bounded Hugging Face metadata adapter, GGUF grouping, descriptor/catalog/source-map construction.
+- `tldw_chatbook/UI/Screens/model_remote_view.py` — idle Remote UI, generation-fenced workers, managed install lifecycle.
+- `Tests/Model_Artifacts/test_remote_huggingface.py` — adapter, parsing, grouping, identity, descriptor, and source-map tests.
+- `Tests/UI/test_model_remote_view.py` — lazy UI, worker fencing, consent, provision policy, and retry tests.
+
+**Modify**
+
+- `tldw_chatbook/Model_Artifacts/fetch.py` — reject HTTPS-to-HTTP redirect downgrade in the existing per-hop loop.
+- `tldw_chatbook/Model_Artifacts/acquisition.py` — add keyword-only `activate: bool = True` to `provision()`.
+- `tldw_chatbook/UI/Screens/model_browser_state.py` — carry `activation_allowed` and unassigned-consumer copy.
+- `tldw_chatbook/UI/Screens/model_installed_view.py` — pass activation policy while retaining Delete.
+- `tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py` — optionally omit only Activate.
+- `tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py` — separate license/reference copy and neutral integrity footer.
+- `tldw_chatbook/Widgets/ModelArtifacts/install_modal.py` — optional required acknowledgment.
+- `tldw_chatbook/UI/LLM_Management_Window.py` — mount/map Remote and preserve no-I/O activation.
+- `tldw_chatbook/UI/Screens/llm_screen.py` — add the Remote rail row.
+- `Tests/Model_Artifacts/test_stream_fetch.py` — downgrade regression.
+- `Tests/Model_Artifacts/test_provision_install.py` — install-without-activation regression.
+- `Tests/UI/test_model_browser_state.py` — unassigned inventory state.
+- `Tests/UI/test_model_installed_view.py` — Delete-without-Activate rendering.
+- `Tests/UI/test_model_artifact_widgets.py` — plan copy and acknowledgment gate.
+- `Tests/UI/test_llm_screen_lab_adoption.py` — Remote rail/mount integration.
+- `backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md` — plan link, completed ACs, and implementation notes.
+
+Do not export the adapter from `Model_Artifacts/__init__.py`, add a provider registry, add a dependency, or touch `Widgets/HuggingFace/`.
+
+---
+
+### Task 1: Add the bounded Hugging Face metadata adapter
+
+**Files:**
+
+- Create: `tldw_chatbook/Model_Artifacts/remote_huggingface.py`
+- Create: `Tests/Model_Artifacts/test_remote_huggingface.py`
+
+- [ ] **Step 1: Write failing tests for fixed-origin request behavior**
+
+Use `httpx.MockTransport` to assert:
+
+- free-text search trims the submitted query and sends it as the `search` query
+  parameter in one explicit GET to `https://huggingface.co/api/models` with a
+  50-result limit;
+- search passes `follow_redirects=False` and attaches a supplied bearer token only to the fixed Hugging Face origin;
+- 401/403, 404, 429, timeout, malformed JSON, and bodies over 2 MiB become one `RemoteDiscoveryError(code, retryable)` without raw upstream content.
+
+Representative test shape:
+
+```python
+@pytest.mark.asyncio
+async def test_search_is_explicit_bounded_and_fixed_origin() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler)
+        )
+    )
+    assert await adapter.search("  whisper  ", token="secret") == ()
+    assert requests[0].url.host == "huggingface.co"
+    assert requests[0].url.params["search"] == "whisper"
+    assert requests[0].url.params["limit"] == "50"
+    assert requests[0].headers["authorization"] == "Bearer secret"
+```
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Model_Artifacts/test_remote_huggingface.py -q
+```
+
+Expected: FAIL because `remote_huggingface` does not exist.
+
+- [ ] **Step 3: Implement only the adapter values, one error type, and bounded JSON reader**
+
+Keep the public surface small:
+
+```python
+@dataclass(frozen=True)
+class RemoteModelSummary:
+    repository: str
+    private: bool
+    gated: Literal["none", "auto", "manual"]
+    downloads: int | None = None
+    likes: int | None = None
+    last_modified: str | None = None
+
+
+class RemoteDiscoveryError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        *,
+        retryable: bool = False,
+        details: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+        self.details = details
+
+
+class HuggingFaceRemoteAdapter:
+    async def search(
+        self, query: str, *, token: str | None = None
+    ) -> tuple[RemoteModelSummary, ...]: ...
+
+
+def is_exact_repository(value: str) -> bool: ...
+```
+
+The private reader streams decoded bytes and stops above 2 MiB before
+`json.loads`. Validate the spec's search/repository/access/text bounds.
+Normalize gated values `False`, `"auto"`, and `"manual"`; omit malformed
+optional popularity/update fields. Keep the same private bounded reader for
+Task 2's repository-resolution request.
+
+- [ ] **Step 4: Add search parsing and exact-ID tests**
+
+Cover private boolean, all gated states, 96-character repository cap, optional
+popularity/update omission, the 50-result cap, and exact `owner/repository`
+classification. Commit, license, file-count, and candidate tests belong to Task
+2 so Task 1 remains independently buildable.
+
+- [ ] **Step 5: Run adapter tests and static checks**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Model_Artifacts/test_remote_huggingface.py -q
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check tldw_chatbook/Model_Artifacts/remote_huggingface.py Tests/Model_Artifacts/test_remote_huggingface.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Model_Artifacts/remote_huggingface.py Tests/Model_Artifacts/test_remote_huggingface.py
+git commit -m "feat: add bounded Hugging Face model metadata adapter"
+```
+
+---
+
+### Task 2: Resolve repositories and GGUF candidates into one managed catalog
+
+**Files:**
+
+- Modify: `tldw_chatbook/Model_Artifacts/remote_huggingface.py`
+- Modify: `Tests/Model_Artifacts/test_remote_huggingface.py`
+
+- [ ] **Step 1: Write failing repository-resolution and grouping tests**
+
+Assert repository resolution sends exactly
+`GET https://huggingface.co/api/models/{owner}/{repository}?blobs=true`, with no
+redirect following and a supplied token only on that same origin. Assert the
+request query contains `blobs=true`; this is required for LFS size/digest
+metadata. Cover exact
+`[0-9a-f]{40}` commit validation, the 2,048-entry refusal,
+`cardData.license`/all `NOASSERTION` shapes, one LFS-backed single `.gguf`, one
+complete three-shard set, malformed/oversized sets, missing LFS metadata,
+directory-aware grouping, deterministic path ordering, and first-100 truncation
+metadata. Rejected shard members must never reappear as singles. Assert that an
+incomplete group produces a bounded warning containing its candidate label and
+missing five-digit indexes; if no eligible candidate remains, assert the same
+warning is carried in `RemoteDiscoveryError.details`.
+
+- [ ] **Step 2: Run grouping tests and verify failure**
+
+Run the new grouping nodes in `Tests/Model_Artifacts/test_remote_huggingface.py`.
+Expected: FAIL because grouping/catalog construction is absent.
+
+- [ ] **Step 3: Implement repository resolution and immutable candidate values**
+
+```python
+_SHARD_RE = re.compile(
+    r"^(?P<stem>.+)-(?P<index>[0-9]{5})-of-(?P<count>[0-9]{5})\.gguf$"
+)
+
+@dataclass(frozen=True)
+class RemoteGGUFFile:
+    upstream_path: str
+    size_bytes: int
+    sha256: str
+
+@dataclass(frozen=True)
+class RemoteGGUFCandidate:
+    label: str
+    files: tuple[RemoteGGUFFile, ...]
+    total_bytes: int
+
+@dataclass(frozen=True)
+class ResolvedRemoteModel:
+    repository: str
+    commit: str
+    license_id: str
+    review_url: str
+    candidates: tuple[RemoteGGUFCandidate, ...]
+    total_candidate_count: int
+    warnings: tuple[str, ...]
+```
+
+Add `HuggingFaceRemoteAdapter.resolve(repository, token=None)` using Task 1's
+bounded reader and the exact model-info request above. Retain at most 20
+display-safe incomplete-shard warnings; bound candidate labels and list only
+missing five-digit indexes. No GGUF header parsing or quantization inference
+belongs here.
+
+- [ ] **Step 4: Write failing descriptor/catalog tests**
+
+Assert full canonical artifact-ID SHA-256, commit revision,
+`not-declared` variant/precision, unassigned fields, only
+`LOCAL_INTEGRITY_RECORDED`, portable managed names, exact sizes/digests,
+first-payload `source_url`, fixed-origin pinned source-map URLs, bounded label,
+license/review URL, no dependencies, and the compatibility warning.
+
+- [ ] **Step 5: Implement the minimal one-item catalog wrapper**
+
+```python
+@dataclass(frozen=True)
+class ResolvedRemoteCatalog:
+    artifact: ArtifactDescriptor
+    sources: Mapping[ArtifactRef, Mapping[str, str]]
+
+    def descriptor(self, ref: ArtifactRef) -> ArtifactDescriptor:
+        if ref != self.artifact.reference:
+            raise KeyError(ref)
+        return self.artifact
+```
+
+Expose one pure `build_remote_catalog(resolved, candidate)` function. Do not add
+a registry, cache, persistence layer, or model inspection.
+
+- [ ] **Step 6: Run tests and commit**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Model_Artifacts/test_remote_huggingface.py -q
+git add tldw_chatbook/Model_Artifacts/remote_huggingface.py Tests/Model_Artifacts/test_remote_huggingface.py
+git commit -m "feat: map remote GGUF candidates to managed artifacts"
+```
+
+---
+
+### Task 3: Add install-only acquisition and HTTPS downgrade protection
+
+**Files:**
+
+- Modify: `tldw_chatbook/Model_Artifacts/acquisition.py:1035-1241`
+- Modify: `tldw_chatbook/Model_Artifacts/fetch.py:148-190`
+- Modify: `Tests/Model_Artifacts/test_provision_install.py`
+- Modify: `Tests/Model_Artifacts/test_stream_fetch.py`
+
+- [ ] **Step 1: Write failing install-without-activation tests**
+
+Provision an already installed root with `activate=False`. Assert `core.activate`
+is not called, no activate progress is emitted, the root is returned, and no
+active selector exists. Keep the existing default-activation test unchanged.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Expected: FAIL because `provision()` does not accept `activate`.
+
+- [ ] **Step 3: Implement the additive keyword**
+
+Add `activate: bool = True` after `progress` and change only the tail:
+
+```python
+if not activate:
+    return root
+activated = await self._run_core_call(
+    "activate", root, functools.partial(self._core.activate, root)
+)
+self._emit_indeterminate_progress(progress_state, "activate", root)
+return activated
+```
+
+Update docstring, return, progress, and error wording. Do not add another method.
+
+- [ ] **Step 4: Write and run a failing HTTPS downgrade test**
+
+Use `httpx.MockTransport` and a patched egress check. Return
+`302 Location: http://storage.example/model.gguf` from an initial HTTPS URL.
+Assert `FetchTransportError` occurs before a second request.
+
+- [ ] **Step 5: Add one guard to the existing redirect loop**
+
+```python
+if origin.scheme == "https" and current.scheme != "https":
+    raise FetchTransportError("HTTPS redirect downgrade")
+```
+
+Do not add a new redirect helper or Remote fetcher.
+
+- [ ] **Step 6: Run affected tests and commit**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Model_Artifacts/test_stream_fetch.py Tests/Model_Artifacts/test_provision_install.py -q
+git add tldw_chatbook/Model_Artifacts/acquisition.py tldw_chatbook/Model_Artifacts/fetch.py Tests/Model_Artifacts/test_provision_install.py Tests/Model_Artifacts/test_stream_fetch.py
+git commit -m "feat: support managed install without activation"
+```
+
+Expected: PASS. In Codex, permit loopback binding for existing fixture tests.
+
+---
+
+### Task 4: Make shared controls honest for unassigned installs
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/model_browser_state.py:59-220`
+- Modify: `tldw_chatbook/UI/Screens/model_installed_view.py:245-285`
+- Modify: `tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py:48-106`
+- Modify: `tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py:39-76`
+- Modify: `tldw_chatbook/Widgets/ModelArtifacts/install_modal.py:49-97`
+- Modify: `Tests/UI/test_model_browser_state.py`
+- Modify: `Tests/UI/test_model_installed_view.py`
+- Modify: `Tests/UI/test_model_artifact_widgets.py`
+
+- [ ] **Step 1: Write failing state/widget tests**
+
+Assert a non-broken unassigned consumer yields `activation_allowed=False` and
+compatibility-not-verified copy even after `ready=True`; broken state still says
+Needs repair; other consumers keep current copy; Delete remains with no
+Activate; `set_pending()` handles absent Activate; plan copy separates License
+and Source review page and uses the neutral footer.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_model_browser_state.py Tests/UI/test_model_installed_view.py Tests/UI/test_model_artifact_widgets.py -q
+```
+
+Expected: FAIL on missing state/control inputs and old copy.
+
+- [ ] **Step 3: Implement the single consumer authority**
+
+Add `activation_allowed: bool` to `InventoryRow` and branch before active/ready:
+
+```python
+activation_allowed = descriptor.consumer != "unassigned"
+if is_broken:
+    action_hint = "Needs repair — Repair"
+elif not activation_allowed:
+    action_hint = "Downloaded · runtime compatibility not verified"
+elif item.active:
+    ...
+```
+
+Do not inspect other sentinel fields in UI code.
+
+- [ ] **Step 4: Add the optional activation flag without losing Delete**
+
+Add `allow_activation: bool = True`. Yield/query Activate only when true; always
+yield Delete. Preserve defaults and intent messages.
+
+- [ ] **Step 5: Add optional unknown-license acknowledgment**
+
+Use Textual's existing `Checkbox`:
+
+```python
+def __init__(..., required_acknowledgment: str | None = None) -> None:
+    self.required_acknowledgment = required_acknowledgment
+    self._acknowledged = required_acknowledgment is None
+
+@on(Checkbox.Changed)
+def _acknowledgment_changed(self, event: Checkbox.Changed) -> None:
+    self._acknowledged = event.value
+    self.query_one(f"#{self.confirm_id}", Button).disabled = self.ungrantable
+```
+
+Include `not self._acknowledged` in `ungrantable`. Existing callers pass nothing.
+
+- [ ] **Step 6: Run tests and commit**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_model_browser_state.py Tests/UI/test_model_installed_view.py Tests/UI/test_model_artifact_widgets.py -q
+git add tldw_chatbook/UI/Screens/model_browser_state.py tldw_chatbook/UI/Screens/model_installed_view.py tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py tldw_chatbook/Widgets/ModelArtifacts/install_modal.py Tests/UI/test_model_browser_state.py Tests/UI/test_model_installed_view.py Tests/UI/test_model_artifact_widgets.py
+git commit -m "feat: represent unassigned managed models honestly"
+```
+
+---
+
+### Task 5: Add the lazy Remote view and managed install wiring
+
+**Files:**
+
+- Create: `tldw_chatbook/UI/Screens/model_remote_view.py`
+- Create: `Tests/UI/test_model_remote_view.py`
+- Modify: `tldw_chatbook/UI/LLM_Management_Window.py:258-269, 907-940, 1106-1137`
+- Modify: `tldw_chatbook/UI/Screens/llm_screen.py:30-51`
+- Modify: `Tests/UI/test_llm_screen_lab_adoption.py:60-79, 271-300`
+
+- [ ] **Step 1: Write failing idle/search fencing tests**
+
+Inject adapter/service/resolver factories. Assert compose/mount calls none;
+pressing Search is required; exact `owner/repository` resolves directly; other
+text searches; later generations discard older search/resolve callbacks; and
+auth/rate-limit/timeout/oversize/no-GGUF errors have sanitized retry copy.
+Use the adapter's pure `is_exact_repository()` helper rather than duplicating its
+identifier grammar in the view. When a result includes shard warnings, assert
+the view renders the bounded candidate name and missing indexes.
+
+- [ ] **Step 2: Run new UI tests and verify failure**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_model_remote_view.py -q
+```
+
+Expected: FAIL because `model_remote_view` does not exist.
+
+- [ ] **Step 3: Implement the smallest stateful Remote view**
+
+Follow `CuratedView`'s worker pattern and retain only:
+
+```python
+self._search_generation = 0
+self._resolve_generation = 0
+self._results: tuple[RemoteModelSummary, ...] = ()
+self._resolved: ResolvedRemoteModel | None = None
+self._selected_catalog: ResolvedRemoteCatalog | None = None
+self._pending_report = None
+self._operation_reference: ArtifactRef | None = None
+```
+
+Use one Input, one Search button, result/candidate buttons, existing progress,
+and plain Statics. No sort, filter, pagination, cache, model card, or details
+screen.
+
+- [ ] **Step 4: Write failing managed-install tests**
+
+Assert candidate selection calls preflight with the exact catalog/source map;
+uses `EnvConfigCredentialResolver`; opens the shared modal with acknowledgment
+only for `NOASSERTION`; provisions the same values with `activate=False`; posts
+existing progress/status messages; shows the compatibility warning; and triggers
+the existing Installed refresh message. Assert Search and candidate controls are
+disabled from preflight start through consent/provision completion (or failure),
+so another search cannot replace the catalog used by the pending operation.
+
+- [ ] **Step 5: Implement by adapting Curated's flow**
+
+The only provision difference is:
+
+```python
+await acquisition.provision(
+    report.root,
+    report.grant(),
+    catalog,
+    sources=catalog.sources,
+    progress=make_progress_callback(self.post_message),
+    activate=False,
+)
+```
+
+Create the credential resolver inside worker paths. Pass a resolved token to
+metadata calls but never store it on the view. Derive control disabled state
+from the existing pending preflight/provision state; do not add another workflow
+object or state machine.
+
+- [ ] **Step 6: Wire rail/mount without eager work**
+
+Add `remote` before `download-models` in mapping and rail order. Compose
+`RemoteView(id="remote-models-view")`. `_start_view_work("remote", ...)` returns
+without search/resolve. Update rail/no-network tests and add a Remote press test
+that still observes zero calls before Search.
+
+- [ ] **Step 7: Run UI integration and commit**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_model_remote_view.py Tests/UI/test_llm_screen_lab_adoption.py -q
+git add tldw_chatbook/UI/Screens/model_remote_view.py tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/Screens/llm_screen.py Tests/UI/test_model_remote_view.py Tests/UI/test_llm_screen_lab_adoption.py
+git commit -m "feat: add managed Remote GGUF discovery view"
+```
+
+---
+
+### Task 6: Verify the slice and close TASK-596.1
+
+**Files:**
+
+- Modify only for findings: files already listed above
+- Modify through Backlog CLI: `backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md`
+
+- [ ] **Step 1: Add one real managed-flow integration test if Task 5 mocks below acquisition**
+
+Use `httpx.MockTransport`, a patched no-network egress check, a temporary managed
+root, tiny GGUF bytes, and the real SHA-256. Resolve metadata, build catalog,
+preflight, grant, and provision with `activate=False`. Assert bytes/manifest,
+local-integrity provenance, unassigned consumer, and no active selector. Never
+download a real model.
+
+- [ ] **Step 2: Run the affected regression gate**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Model_Artifacts Tests/UI/test_model_artifact_widgets.py Tests/UI/test_model_browser_state.py Tests/UI/test_model_installed_view.py Tests/UI/test_model_remote_view.py Tests/UI/test_llm_screen_lab_adoption.py -q
+```
+
+Expected: PASS. In Codex, permit loopback binding for fixture servers.
+
+- [ ] **Step 3: Run static/import-boundary checks**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check tldw_chatbook/Model_Artifacts/remote_huggingface.py tldw_chatbook/Model_Artifacts/fetch.py tldw_chatbook/Model_Artifacts/acquisition.py tldw_chatbook/UI/Screens/model_remote_view.py tldw_chatbook/UI/Screens/model_browser_state.py tldw_chatbook/UI/Screens/model_installed_view.py tldw_chatbook/Widgets/ModelArtifacts tldw_chatbook/UI/LLM_Management_Window.py tldw_chatbook/UI/Screens/llm_screen.py Tests/Model_Artifacts/test_remote_huggingface.py Tests/UI/test_model_remote_view.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m mypy tldw_chatbook/Model_Artifacts/remote_huggingface.py tldw_chatbook/Model_Artifacts/fetch.py tldw_chatbook/Model_Artifacts/acquisition.py tldw_chatbook/UI/Screens/model_remote_view.py tldw_chatbook/UI/Screens/model_browser_state.py tldw_chatbook/UI/Screens/model_installed_view.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Model_Artifacts/test_credentials_and_boundaries.py -q
+git diff --check
+```
+
+Expected: PASS. Do not broaden cleanup to unrelated baseline findings.
+
+- [ ] **Step 4: Perform live macOS evidence without a real model download**
+
+With deterministic mocked/fixture metadata and tiny payload, verify Remote opens
+idle, Search is explicit, candidate renders, unknown license gates Install,
+install completes, Installed says compatibility is unverified, Activate is
+absent, and Delete remains. Record Windows/Linux as preserved CI gates, not
+local evidence.
+
+- [ ] **Step 5: Request final code review**
+
+Use `@superpowers:requesting-code-review`. Address Critical/Important issues,
+rerun the gate, and document advisory deferrals instead of adding machinery.
+
+- [ ] **Step 6: Complete the Backlog task through the CLI**
+
+After verification and review:
+
+```bash
+backlog task edit 596.1 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --check-ac 6
+backlog task edit 596.1 --notes "Implemented bounded Hugging Face GGUF discovery through the shared managed acquisition flow; remote artifacts remain Local integrity recorded, unassigned, and inactive. Added explicit search, pinned LFS metadata resolution, shard grouping, credential-safe downloads, unknown-license consent, focused tests, and platform-neutral UI wiring. ADR-025 remains authoritative."
+backlog task edit 596.1 -s Done
+```
+
+- [ ] **Step 7: Commit closeout and prepare the PR**
+
+```bash
+git add 'backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md'
+git commit -m "docs: close remote GGUF discovery task"
+git status --short
+```
+
+Expected: clean worktree. Push `codex/task-596-remote-model-discovery` and open a
+PR against `dev` only after the user approves execution and final review is clean.

--- a/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+++ b/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
@@ -104,7 +104,7 @@ It exposes typed immutable values:
 - `RemoteGGUFCandidate`: one single file or complete shard set, including
   upstream paths, per-file sizes/digests, and total size.
 - `ResolvedRemoteModel`: repository, immutable commit, license state, and
-  bounded candidates.
+  bounded candidates plus bounded display-safe incomplete-shard warnings.
 - `ResolvedRemoteCatalog`: a minimal one-item wrapper around the selected
   `ArtifactDescriptor` and its complete `ArtifactSourceMap`; its only catalog
   behavior is the `descriptor(ref)` method required by `ArtifactCatalog`.
@@ -158,6 +158,7 @@ bytes, rather than trusting `Content-Length`:
 | repository file entries inspected | 2,048 |
 | GGUF candidates returned | 100 |
 | shards in one set | 64 |
+| incomplete-shard warnings returned | 20 |
 
 Identity and security-bearing JSON values have exact expected types. Repository
 identifiers, commit SHAs, and file paths are independently validated before any
@@ -218,8 +219,11 @@ and declared count. A shard group is eligible only when:
 - `NN` does not exceed 64.
 
 An incomplete, duplicate, inconsistent, or oversized group is rejected as a
-group and none of its members is offered as a single file. Non-sharded GGUF
-files remain independent candidates.
+group and none of its members is offered as a single file. Resolution retains at
+most 20 display-safe warnings containing the bounded candidate label and missing
+five-digit indexes. If no eligible candidate remains, those warnings are carried
+by the `no_eligible_gguf` error; otherwise they render above the eligible list.
+Non-sharded GGUF files remain independent candidates.
 
 ## Pinned source construction
 
@@ -375,9 +379,10 @@ unassigned Remote artifact; this task does not change that core behavior.
 
 Remote inertness therefore never depends on `InstalledArtifact.ready`. Installed
 uses one authority: `activation_allowed` is false when
-`descriptor.consumer == "unassigned"`. Such a descriptor always says
-**Downloaded · runtime compatibility not verified**, even if Repair later sets
-`ready=True`. Add an optional `allow_activation: bool = True` input to
+`descriptor.consumer == "unassigned"`. A non-broken descriptor in that state
+always says **Downloaded · runtime compatibility not verified**, even if Repair
+later sets `ready=True`; existing broken/repair copy still takes precedence. Add
+an optional `allow_activation: bool = True` input to
 `ModelActivationControls`; unassigned-consumer rows pass false, which omits only
 the Activate button while preserving the existing lease-safe Delete action. No
 other installed-row behavior changes. The other sentinel fields remain
@@ -401,9 +406,10 @@ lease guarantees.
 
 ## Errors and recovery
 
-The adapter uses one `RemoteDiscoveryError` carrying a bounded reason code and a
-retryable flag; it does not add an exception hierarchy. The view maps it and
-existing acquisition failures to short sanitized messages:
+The adapter uses one `RemoteDiscoveryError` carrying a bounded reason code, a
+retryable flag, and an optional bounded tuple of already sanitized display
+details; it does not add an exception hierarchy. The view maps it and existing
+acquisition failures to short sanitized messages:
 
 | Failure | User-visible recovery |
 |---|---|

--- a/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+++ b/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
@@ -105,8 +105,9 @@ It exposes typed immutable values:
   upstream paths, per-file sizes/digests, and total size.
 - `ResolvedRemoteModel`: repository, immutable commit, license state, and
   bounded candidates.
-- `ResolvedRemoteCatalog`: the one selected `ArtifactDescriptor` plus its
-  complete `ArtifactSourceMap`; it structurally satisfies `ArtifactCatalog`.
+- `ResolvedRemoteCatalog`: a minimal one-item wrapper around the selected
+  `ArtifactDescriptor` and its complete `ArtifactSourceMap`; its only catalog
+  behavior is the `descriptor(ref)` method required by `ArtifactCatalog`.
 
 The adapter uses existing `httpx`. It does not import the legacy downloader or
 introduce a provider framework.
@@ -158,11 +159,31 @@ bytes, rather than trusting `Content-Length`:
 | GGUF candidates returned | 100 |
 | shards in one set | 64 |
 
-JSON values have exact expected types. Repository identifiers, commit SHAs, and
-file paths are independently validated before any URL or descriptor is built.
+Identity and security-bearing JSON values have exact expected types. Repository
+identifiers, commit SHAs, and file paths are independently validated before any
+URL or descriptor is built.
 A repository identifier must be one bounded `owner/repository` pair using the
 portable Hugging Face identifier character set. The resolved commit must be an
-immutable hexadecimal Git commit identity, not `main`, a tag, or user input.
+immutable value matching `[0-9a-f]{40}`, not `main`, a tag, or user input.
+
+User/upstream text has fixed presentation and request bounds:
+
+| Value | Bound |
+|---|---:|
+| trimmed search input | 256 characters |
+| repository identifier | 96 characters |
+| upstream file path | 1,024 UTF-8 bytes |
+| license identifier | 128 characters |
+| persisted/display model label | 160 characters |
+| optional downloads/likes counter | 0 through 2^63 - 1 |
+| optional last-updated value | 64 characters |
+
+Identity and access-control fields fail closed on an invalid type or bound.
+Hugging Face gated state accepts only `false`, `"auto"`, or `"manual"` and is
+normalized for display; private state must be boolean. Optional popularity and
+update fields are displayed only when they have the expected bounded scalar
+shape, and otherwise are omitted rather than rejecting an otherwise usable
+repository.
 
 A repository response containing more than 2,048 file entries is rejected; it
 is never partially inspected. Eligible candidates are sorted by their exact
@@ -266,6 +287,23 @@ The descriptor is deliberately inert:
 The unassigned OS/architecture sentinels intentionally fail closed. They do not
 claim support for every platform.
 
+The remaining source and inventory fields are pinned as follows:
+
+| Field | Value |
+|---|---|
+| upstream repository | exact repository ID returned by repository resolution |
+| upstream revision | exact resolved commit SHA |
+| source URL | first generated pinned payload URL in managed-file order |
+| expected installed bytes | exact sum of selected LFS file sizes |
+| files | deterministic managed paths with corresponding LFS sizes/digests |
+| license ID | declared bounded ID, otherwise `NOASSERTION` |
+| license URL | pinned repository source-review page |
+
+Using the first payload URL for `source_url` is intentional: every generated
+source-map URL shares its Hugging Face origin, so the existing acquisition
+service can bind repository credentials to that origin before its fetcher strips
+them from cross-origin redirect hops.
+
 ## License behavior
 
 If model metadata declares a non-empty license identifier, the identifier is
@@ -275,6 +313,11 @@ shown. If it does not, the descriptor records `NOASSERTION`.
 does not guarantee a pinned license-document URL. Remote descriptors therefore
 store the pinned repository page as the review URL. User-facing copy calls this
 the **source review page**, never a license document.
+
+The shared plan panel renders these as separate lines for every model:
+
+- `License: <identifier>` (or `Unknown / not declared` for `NOASSERTION`);
+- `Source review page: <URL>`.
 
 For `NOASSERTION`, the shared install modal accepts one optional required
 acknowledgment. Remote supplies: **No license was declared. I reviewed the
@@ -323,15 +366,14 @@ create readiness for any structurally valid ROOT artifact, including an
 unassigned Remote artifact; this task does not change that core behavior.
 
 Remote inertness therefore never depends on `InstalledArtifact.ready`. Installed
-derives `runtime_assigned` from the descriptor's consumer, runtime, OS, and
-architecture fields: it is false when `consumer`, `model_family`, or
-`runtime_name` equals `unassigned`, or either supported-platform tuple contains
-the `unassigned` sentinel. An unassigned descriptor always says **Downloaded ·
-runtime compatibility not verified**, even if Repair later sets `ready=True`.
-Add an optional `allow_activation: bool = True` input to
-`ModelActivationControls`; unassigned rows pass false, which omits only the
-Activate button while preserving the existing lease-safe Delete action. No
-other installed-row behavior changes.
+uses one authority: `activation_allowed` is false when
+`descriptor.consumer == "unassigned"`. Such a descriptor always says
+**Downloaded · runtime compatibility not verified**, even if Repair later sets
+`ready=True`. Add an optional `allow_activation: bool = True` input to
+`ModelActivationControls`; unassigned-consumer rows pass false, which omits only
+the Activate button while preserving the existing lease-safe Delete action. No
+other installed-row behavior changes. The other sentinel fields remain
+defense-in-depth for future runtime consumers, not additional UI branches.
 
 ## Concurrency and cancellation
 
@@ -351,7 +393,9 @@ lease guarantees.
 
 ## Errors and recovery
 
-The adapter and view map typed failures to short sanitized messages:
+The adapter uses one `RemoteDiscoveryError` carrying a bounded reason code and a
+retryable flag; it does not add an exception hierarchy. The view maps it and
+existing acquisition failures to short sanitized messages:
 
 | Failure | User-visible recovery |
 |---|---|
@@ -364,9 +408,10 @@ The adapter and view map typed failures to short sanitized messages:
 | insufficient disk or acquisition gating | existing preflight explanation |
 | transfer or digest mismatch | existing managed-acquisition failure and Retry |
 
-Logs record the operation and a bounded/hash-safe context, not raw search text,
-private repository names, tokens, source bodies, or arbitrary upstream error
-content. UI labels always use `markup=False`.
+Logs record only the operation and, after selection, the already deterministic
+artifact ID. No new logging/hash helper is introduced. Raw search text, private
+repository names, tokens, source bodies, and arbitrary upstream error content
+are excluded. UI labels always use `markup=False`.
 
 ## Portability
 
@@ -385,7 +430,8 @@ coverage that was not run.
 Focused tests cover:
 
 1. Search and exact-repository request construction, token scoping, strict
-   parsing, body/result/file limits, and sanitized failures using
+   parsing (including gated-state normalization), text/body/result/file limits,
+   and sanitized failures using
    `httpx.MockTransport` or equivalent injected clients.
 2. Single GGUFs, complete shard sets, incomplete/duplicate/inconsistent shard
    sets, missing LFS metadata, candidate limits, and deterministic portable

--- a/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+++ b/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
@@ -164,6 +164,12 @@ A repository identifier must be one bounded `owner/repository` pair using the
 portable Hugging Face identifier character set. The resolved commit must be an
 immutable hexadecimal Git commit identity, not `main`, a tag, or user input.
 
+A repository response containing more than 2,048 file entries is rejected; it
+is never partially inspected. Eligible candidates are sorted by their exact
+upstream path tuple before the 100-candidate display cap is applied. When that
+cap truncates the list, the resolved value records the total and the UI says
+that only the first 100 deterministic choices are shown.
+
 ## Eligible GGUF candidates
 
 Only repository entries with all of the following are eligible:
@@ -179,8 +185,11 @@ used to verify the downloaded bytes. Because the digest comes from the same
 origin as the payload metadata, it is recorded as local integrity, not
 independent publisher verification.
 
-Standard shards match `*-00001-of-000NN.gguf`. Grouping includes the containing
-directory, stem, and declared count. A shard group is eligible only when:
+Every standard shard member matches
+`^(?P<stem>.+)-(?P<index>[0-9]{5})-of-(?P<count>[0-9]{5})\.gguf$`.
+Both numeric fields are exactly five digits, with
+`1 <= index <= count <= 64`. Grouping includes the containing directory, stem,
+and declared count. A shard group is eligible only when:
 
 - every index from 1 through `NN` is present exactly once;
 - every shard declares LFS size and SHA-256 metadata;
@@ -217,8 +226,10 @@ loop.
 Remote identifiers are deterministic but never use raw repository or file names
 as managed directory identity:
 
-- `artifact_id`: `hf-gguf-` plus a truncated SHA-256 over the repository ID and
-  ordered selected upstream path set;
+- `artifact_id`: `hf-gguf-` plus the full lowercase SHA-256 of canonical JSON
+  `{"repository": <exact resolved repo ID>, "paths": <exact paths sorted
+  lexicographically>}`, encoded as UTF-8 with sorted keys and compact
+  separators;
 - `revision`: the full resolved repository commit SHA;
 - `variant` and `precision`: `not-declared`.
 
@@ -306,12 +317,21 @@ Add a keyword-only `activate: bool = True` parameter:
 Remote passes `activate=False`. This is an additive extension of ADR-025's
 managed acquisition boundary, not a second installation path.
 
-Because install-only artifacts have no readiness or active record, Installed
-must distinguish unassigned descriptors from corrupt/unverified artifacts.
-Their row says **Downloaded · runtime compatibility not verified**. Add an
-optional `allow_activation: bool = True` input to `ModelActivationControls`;
-Remote rows pass false, which omits only the Activate button while preserving
-the existing lease-safe Delete action. No other installed-row behavior changes.
+Immediately after install-only provisioning, the artifact has no active
+selector and normally no readiness record. Existing `reconcile()` may later
+create readiness for any structurally valid ROOT artifact, including an
+unassigned Remote artifact; this task does not change that core behavior.
+
+Remote inertness therefore never depends on `InstalledArtifact.ready`. Installed
+derives `runtime_assigned` from the descriptor's consumer, runtime, OS, and
+architecture fields: it is false when `consumer`, `model_family`, or
+`runtime_name` equals `unassigned`, or either supported-platform tuple contains
+the `unassigned` sentinel. An unassigned descriptor always says **Downloaded ·
+runtime compatibility not verified**, even if Repair later sets `ready=True`.
+Add an optional `allow_activation: bool = True` input to
+`ModelActivationControls`; unassigned rows pass false, which omits only the
+Activate button while preserving the existing lease-safe Delete action. No
+other installed-row behavior changes.
 
 ## Concurrency and cancellation
 
@@ -381,7 +401,8 @@ Focused tests cover:
    submission does, stale generations are ignored, unknown-license consent is
    gated, failures are retryable, and success refreshes Installed.
 7. Installed state mapping renders unassigned Remote artifacts as downloaded but
-   unconfigured, with no activation affordance and with deletion still present.
+   unconfigured, with no activation affordance and with deletion still present,
+   both before and after reconciliation creates readiness.
 8. One integration test from selected candidate through managed preflight and
    provision using mocked HTTP and a temporary artifact root; no real model
    download is required.

--- a/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+++ b/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
@@ -306,8 +306,11 @@ them from cross-origin redirect hops.
 
 ## License behavior
 
-If model metadata declares a non-empty license identifier, the identifier is
-shown. If it does not, the descriptor records `NOASSERTION`.
+The sole declared-license authority is `cardData.license` from the resolved
+repository response. A bounded non-empty string is shown and persisted as the
+license identifier. Missing or null `cardData`, a non-mapping `cardData`, a
+missing/null license value, or any non-string/empty/over-limit license value
+becomes `NOASSERTION`; tags and other fields are never treated as a license.
 
 `ArtifactDescriptor` requires a non-empty `license_url`, but repository metadata
 does not guarantee a pinned license-document URL. Remote descriptors therefore
@@ -318,6 +321,11 @@ The shared plan panel renders these as separate lines for every model:
 
 - `License: <identifier>` (or `Unknown / not declared` for `NOASSERTION`);
 - `Source review page: <URL>`.
+
+Its existing footer is also made capability-neutral:
+**Every declared file is checked against pinned sizes and SHA-256 digests before
+installation completes.** It must not say that installation makes a model
+usable.
 
 For `NOASSERTION`, the shared install modal accepts one optional required
 acknowledgment. Remote supplies: **No license was declared. I reviewed the

--- a/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+++ b/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
@@ -185,7 +185,7 @@ used to verify the downloaded bytes. Because the digest comes from the same
 origin as the payload metadata, it is recorded as local integrity, not
 independent publisher verification.
 
-Every standard shard member matches
+The basename of every standard shard member matches
 `^(?P<stem>.+)-(?P<index>[0-9]{5})-of-(?P<count>[0-9]{5})\.gguf$`.
 Both numeric fields are exactly five digits, with
 `1 <= index <= count <= 64`. Grouping includes the containing directory, stem,
@@ -229,7 +229,7 @@ as managed directory identity:
 - `artifact_id`: `hf-gguf-` plus the full lowercase SHA-256 of canonical JSON
   `{"repository": <exact resolved repo ID>, "paths": <exact paths sorted
   lexicographically>}`, encoded as UTF-8 with sorted keys and compact
-  separators;
+  separators and `ensure_ascii=False`;
 - `revision`: the full resolved repository commit SHA;
 - `variant` and `precision`: `not-declared`.
 

--- a/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+++ b/Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
@@ -1,0 +1,414 @@
+# TASK-596.1 — Bounded Hugging Face GGUF discovery: design
+
+**Date:** 2026-08-01
+**Task:** TASK-596.1 — Add bounded Hugging Face GGUF discovery to the managed model browser
+**Parent:** TASK-596 — Renovate the local model artifact browser
+**Depends on:** TASK-595
+**ADR:** `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+**Status:** approved section-by-section on 2026-08-01
+
+## Outcome
+
+Add a **Remote** row to Lab → Models that lets a user explicitly search
+Hugging Face, select one LFS-backed GGUF file or complete standard GGUF shard
+set, and download it through the existing managed-model preflight and
+acquisition flow.
+
+The downloaded model is intentionally inert. Chatbook records and inventories
+the exact bytes, but does not claim that an arbitrary GGUF is compatible with a
+runtime, ready for transcription, or eligible for automatic routing.
+
+## Existing foundation
+
+TASK-596 Phase 1 already provides:
+
+- Curated and Installed model views in Lab;
+- `ArtifactDescriptor`, `ArtifactCatalog`, and `ArtifactSourceMap` contracts;
+- consent-driven `ArtifactAcquisitionService.preflight()` and `provision()`;
+- resumable bounded fetches with per-hop egress checks and cross-origin
+  credential stripping;
+- shared plan, consent, progress, inventory, activation, and deletion controls;
+- lazy view activation through `LLMManagementWindow._start_view_work()`.
+
+Remote discovery is an adapter and UI over that foundation. It does not
+renovate or reuse the legacy `Widgets/HuggingFace/` downloader, which continues
+to exist behind **Download Models** until its separately approved retirement.
+
+## Scope
+
+This slice includes:
+
+1. Explicit Hugging Face model search and exact `owner/repository` resolution.
+2. Immutable repository resolution to a commit SHA.
+3. Bounded discovery of LFS-backed GGUF files and standard complete shard sets.
+4. Conversion of one selected candidate into an in-memory catalog and source
+   map accepted by the managed acquisition service.
+5. Managed preflight, consent, download, digest verification, installation,
+   progress, and Installed-view refresh.
+6. Existing configured Hugging Face credential support for gated and private
+   repositories.
+
+## Non-goals
+
+- Making arbitrary GGUF files runnable or assigning a runtime.
+- Adding arbitrary remote models to STT routing or provider selectors.
+- Inspecting GGUF contents or inferring architecture, quantization, language,
+  or runtime compatibility.
+- Importing local GGUF files; TASK-597 owns that work.
+- Adding or configuring a Hugging Face token in this screen.
+- Search pagination, result caching, model-card/README rendering, compatibility
+  detection, automatic activation, or download recommendations.
+- General remote providers, mirrors, self-hosted repositories, or LAN origins.
+- Adding `huggingface_hub` or another dependency.
+
+Runtime adoption and validation remain with TASK-597 and TASK-604. This task
+only makes remote GGUF bytes discoverable and safely managed.
+
+## User flow
+
+1. The user opens **Remote**. The idle view renders without filesystem or
+   network I/O.
+2. The user enters text and presses **Search**.
+3. If the input is a valid exact `owner/repository` identifier, Chatbook
+   resolves that repository directly. Otherwise it performs a bounded model
+   search and shows at most 50 typed results.
+4. Selecting a search result resolves that repository to an immutable commit
+   and lists at most 100 eligible GGUF choices.
+5. The user selects one single GGUF or complete shard set. Chatbook displays the
+   repository, commit, files, total bytes, declared license state, provenance,
+   and the warning **Runtime compatibility has not been verified.**
+6. The existing managed preflight shows destination, free space, staging,
+   immutable sources, sizes, digests, and provenance.
+7. The user explicitly confirms. If no license was declared, confirmation stays
+   disabled until the user acknowledges that fact.
+8. The existing provision worker downloads and verifies the candidate without
+   activating it.
+9. Success reads: **Model downloaded and managed. Runtime compatibility has not
+   been verified.** Installed refreshes and shows the model as downloaded but
+   unconfigured.
+
+Selecting any shard in a standard shard set represents the entire set. An
+individual shard is never offered as an independently installable model.
+
+## Component boundary
+
+### `Model_Artifacts/remote_huggingface.py`
+
+A narrow, Textual-free adapter owns Hugging Face request construction, bounded
+response reading, strict JSON parsing, GGUF grouping, and conversion to managed
+artifact values. It performs no writes and downloads no model payloads.
+
+It exposes typed immutable values:
+
+- `RemoteModelSummary`: bounded search-result metadata needed by the list.
+- `RemoteGGUFCandidate`: one single file or complete shard set, including
+  upstream paths, per-file sizes/digests, and total size.
+- `ResolvedRemoteModel`: repository, immutable commit, license state, and
+  bounded candidates.
+- `ResolvedRemoteCatalog`: the one selected `ArtifactDescriptor` plus its
+  complete `ArtifactSourceMap`; it structurally satisfies `ArtifactCatalog`.
+
+The adapter uses existing `httpx`. It does not import the legacy downloader or
+introduce a provider framework.
+
+### `UI/Screens/model_remote_view.py`
+
+`RemoteView` owns form state, workers, monotonic generations, the selected
+in-memory catalog, and the managed install lifecycle. It reuses
+`ModelInstallModal`, `ModelInstallProgress`, the existing progress messages,
+`managed_service()`, and `EnvConfigCredentialResolver`.
+
+The view follows the same ownership rule as Curated: widgets and modals return
+intent, while the view owns search, resolution, preflight, and provision
+workers. No network access occurs in `compose()`, `on_mount()`, or merely because
+the parent Models screen was composed.
+
+### Existing integration points
+
+- Add `("remote", "Remote")` before **Download Models** in
+  `MODELS_RAIL_SECTIONS`.
+- Add the corresponding container and view mapping in
+  `LLMManagementWindow`.
+- `_start_view_work("remote", ...)` must not start a request; it may only leave
+  the already composed view idle.
+- Install progress and completion use the existing messages so Installed and
+  the Lab status chip remain synchronized.
+
+## Request and parsing rules
+
+All metadata requests are explicit GET requests to the fixed HTTPS origin
+`https://huggingface.co`:
+
+- bounded model search through the Hugging Face models API;
+- one repository-info request with file metadata when a result is selected or
+  an exact repository is submitted.
+
+Metadata responses do not follow redirects. Request URLs are constructed by the
+adapter from validated components; URLs returned inside response data are never
+trusted or followed.
+
+The adapter enforces all of these limits while streaming decoded response
+bytes, rather than trusting `Content-Length`:
+
+| Limit | Value |
+|---|---:|
+| decoded metadata body | 2 MiB per response |
+| search results | 50 |
+| repository file entries inspected | 2,048 |
+| GGUF candidates returned | 100 |
+| shards in one set | 64 |
+
+JSON values have exact expected types. Repository identifiers, commit SHAs, and
+file paths are independently validated before any URL or descriptor is built.
+A repository identifier must be one bounded `owner/repository` pair using the
+portable Hugging Face identifier character set. The resolved commit must be an
+immutable hexadecimal Git commit identity, not `main`, a tag, or user input.
+
+## Eligible GGUF candidates
+
+Only repository entries with all of the following are eligible:
+
+- a `.gguf` filename;
+- a non-negative declared size;
+- a normalized 64-character lowercase LFS SHA-256 digest from file metadata;
+- a path that can be safely represented as a URL source identifier.
+
+An entry without LFS metadata, size, or digest is ignored and cannot be
+installed. This means Hugging Face Git-LFS metadata provides the expected digest
+used to verify the downloaded bytes. Because the digest comes from the same
+origin as the payload metadata, it is recorded as local integrity, not
+independent publisher verification.
+
+Standard shards match `*-00001-of-000NN.gguf`. Grouping includes the containing
+directory, stem, and declared count. A shard group is eligible only when:
+
+- every index from 1 through `NN` is present exactly once;
+- every shard declares LFS size and SHA-256 metadata;
+- every shard belongs to the same directory/stem/count group;
+- `NN` does not exceed 64.
+
+An incomplete, duplicate, inconsistent, or oversized group is rejected as a
+group and none of its members is offered as a single file. Non-sharded GGUF
+files remain independent candidates.
+
+## Pinned source construction
+
+Payload URLs are generated locally from:
+
+1. the fixed Hugging Face HTTPS origin;
+2. the validated repository identifier;
+3. the repository's resolved commit SHA;
+4. the validated and segment-encoded upstream file path.
+
+No URL from repository metadata is reused. URLs contain no credentials, query,
+fragment, mutable revision, or userinfo. The selected catalog supplies one
+source-map entry for every managed file.
+
+Hugging Face payload endpoints may redirect to storage hosts. The existing
+managed fetcher remains authoritative: it checks every hop, permits only its
+bounded redirect statuses, and strips authorization on every cross-origin hop.
+As a shared security hardening, an initially HTTPS fetch must reject any
+redirect hop whose scheme is not HTTPS; initially HTTP fixture/caller behavior
+is otherwise unchanged. The Remote adapter does not implement a second redirect
+loop.
+
+## Managed identity and descriptor
+
+Remote identifiers are deterministic but never use raw repository or file names
+as managed directory identity:
+
+- `artifact_id`: `hf-gguf-` plus a truncated SHA-256 over the repository ID and
+  ordered selected upstream path set;
+- `revision`: the full resolved repository commit SHA;
+- `variant` and `precision`: `not-declared`.
+
+The persisted `model_id` is a bounded, markup-disabled human label formed from
+the repository ID and candidate filename/stem. It remains understandable in
+Installed after the ephemeral search state is gone.
+
+Upstream paths are display/source identifiers only. Managed payload names are
+portable and deterministic:
+
+- a single file becomes `model.gguf`;
+- a shard set becomes `model-00001-of-000NN.gguf` through
+  `model-NNNNN-of-NNNNN.gguf`.
+
+The source map relates those managed paths to their exact pinned upstream URLs.
+This avoids unsafe, Unicode-dependent, reserved, or case-colliding filesystem
+identity while retaining conventional shard naming.
+
+The descriptor is deliberately inert:
+
+| Field | Value |
+|---|---|
+| role | `ROOT` |
+| format | `GGUF` |
+| consumer | `unassigned` |
+| model family | `unassigned` |
+| runtime name | `unassigned` |
+| runtime version constraint | `none` |
+| supported OS / architectures | `unassigned` sentinel values |
+| provenance | `LOCAL_INTEGRITY_RECORDED` only |
+| dependencies | none |
+| usage notice | runtime compatibility is not verified; configuration is required |
+
+The unassigned OS/architecture sentinels intentionally fail closed. They do not
+claim support for every platform.
+
+## License behavior
+
+If model metadata declares a non-empty license identifier, the identifier is
+shown. If it does not, the descriptor records `NOASSERTION`.
+
+`ArtifactDescriptor` requires a non-empty `license_url`, but repository metadata
+does not guarantee a pinned license-document URL. Remote descriptors therefore
+store the pinned repository page as the review URL. User-facing copy calls this
+the **source review page**, never a license document.
+
+For `NOASSERTION`, the shared install modal accepts one optional required
+acknowledgment. Remote supplies: **No license was declared. I reviewed the
+source and want to continue.** The Install button stays disabled until checked.
+Curated callers pass no acknowledgment and retain their current behavior.
+
+## Credentials and private repositories
+
+Both metadata requests and managed payload requests reuse
+`EnvConfigCredentialResolver`, preserving the existing precedence:
+`HUGGINGFACE_API_KEY`, then `HF_TOKEN`, then `[API] huggingface_api_key`.
+
+The resolved token exists only in request memory. It is never included in a
+descriptor, source map, artifact ID, consent fingerprint, error, notification,
+or log. Metadata requests attach it only to `https://huggingface.co`. Managed
+payload requests already attach it only when the source URL shares the
+descriptor source origin; the fetcher strips it after a cross-origin redirect.
+
+No token-entry or access-approval UI is added. A 401/403 explains that configured
+Hugging Face access is required and offers retry. For a gated repository whose
+terms have not been accepted, the pinned repository page is the recovery
+destination outside this task's UI.
+
+Exact repository submission is required for reliable private/new repository
+access; free-text search is not treated as the only discovery path.
+
+## Acquisition without activation
+
+Today `ArtifactAcquisitionService.provision()` always installs and activates a
+closure. Remote content must be installed without receiving an active selector.
+
+Add a keyword-only `activate: bool = True` parameter:
+
+- the default preserves every existing Curated and Parakeet caller;
+- when true, behavior and progress are unchanged;
+- when false, provision performs the complete fetch, pre-verify, and immutable
+  install phases, then returns the installed root without calling
+  `ModelArtifactService.activate()` or emitting an `activate` progress event.
+
+Remote passes `activate=False`. This is an additive extension of ADR-025's
+managed acquisition boundary, not a second installation path.
+
+Because install-only artifacts have no readiness or active record, Installed
+must distinguish unassigned descriptors from corrupt/unverified artifacts.
+Their row says **Downloaded · runtime compatibility not verified**. Add an
+optional `allow_activation: bool = True` input to `ModelActivationControls`;
+Remote rows pass false, which omits only the Activate button while preserving
+the existing lease-safe Delete action. No other installed-row behavior changes.
+
+## Concurrency and cancellation
+
+Search and repository resolution each use a monotonic generation. A worker may
+apply a result only if its generation and relevant input still match current UI
+state. A new search invalidates any older search or resolution result.
+
+Only one search/resolve request and one managed install operation are presented
+as current. Search controls are disabled during preflight/provision. The
+existing acquisition session lease remains the authority for concurrent model
+downloads across views and processes.
+
+Worker callbacks update widgets only through Textual's thread-safe message or
+`call_from_thread` paths. A dismissed or recomposed view may discard stale
+presentation results, but cannot weaken the acquisition service's staging and
+lease guarantees.
+
+## Errors and recovery
+
+The adapter and view map typed failures to short sanitized messages:
+
+| Failure | User-visible recovery |
+|---|---|
+| authentication or gated access | configure/verify Hugging Face access, then Retry |
+| repository not found | check the exact ID or search again |
+| timeout, rate limit, or network error | Retry |
+| malformed or oversized metadata | repository cannot be safely inspected |
+| no eligible LFS GGUF | explain the LFS size/digest requirement |
+| incomplete shard set | name the candidate and missing shard indexes, bounded |
+| insufficient disk or acquisition gating | existing preflight explanation |
+| transfer or digest mismatch | existing managed-acquisition failure and Retry |
+
+Logs record the operation and a bounded/hash-safe context, not raw search text,
+private repository names, tokens, source bodies, or arbitrary upstream error
+content. UI labels always use `markup=False`.
+
+## Portability
+
+The feature adds only pure Python over existing `httpx`, Textual, and the shared
+artifact service. It introduces no native package, shell command, platform path,
+or external downloader. Managed filenames are portable across the service's
+supported filesystems.
+
+The implementation contract covers every currently wheel-supported platform.
+macOS evidence can be collected locally. Existing Windows and Linux gates remain
+required when those runners are available; the task does not claim local test
+coverage that was not run.
+
+## Verification
+
+Focused tests cover:
+
+1. Search and exact-repository request construction, token scoping, strict
+   parsing, body/result/file limits, and sanitized failures using
+   `httpx.MockTransport` or equivalent injected clients.
+2. Single GGUFs, complete shard sets, incomplete/duplicate/inconsistent shard
+   sets, missing LFS metadata, candidate limits, and deterministic portable
+   managed filenames.
+3. Descriptor identity, `NOASSERTION`, pinned review/source URLs, provenance,
+   unassigned runtime fields, catalog completeness, and source maps.
+4. Existing cross-origin redirect behavior proving a Remote bearer token is
+   stripped on the redirected payload request, plus rejection of an HTTPS to
+   HTTP downgrade.
+5. `provision(activate=False)` installs without an active selector or activate
+   progress; the default still activates and preserves existing behavior.
+6. Textual Pilot coverage proving opening Remote performs no request, explicit
+   submission does, stale generations are ignored, unknown-license consent is
+   gated, failures are retryable, and success refreshes Installed.
+7. Installed state mapping renders unassigned Remote artifacts as downloaded but
+   unconfigured, with no activation affordance and with deletion still present.
+8. One integration test from selected candidate through managed preflight and
+   provision using mocked HTTP and a temporary artifact root; no real model
+   download is required.
+
+Static checks cover the changed files, and the affected Model Artifacts, Lab,
+shared-widget, and Remote suites form the local regression gate.
+
+## ADR check
+
+**ADR required:** no
+**ADR path:** `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+**Reason:** ADR-025 already owns remote artifact provenance, immutable managed
+downloads, consent, activation, and runtime boundaries. The install-without-
+activation option is an additive way to enforce that existing boundary for an
+unassigned remote artifact; it does not introduce a new owner or storage model.
+TASK-1723 does not apply because this slice permits only Hugging Face's public
+HTTPS origin, not self-hosted or private-network origins.
+
+## Rollback
+
+Remote is an independent rail row. If discovery proves unreliable, remove or
+disable that row and adapter while leaving Curated, Installed, the managed store,
+and already downloaded immutable artifacts intact. Never fall back to the legacy
+unverified downloader for a failed Remote install.
+
+## References
+
+- [Hugging Face Hub API model information](https://huggingface.co/docs/huggingface_hub/en/package_reference/hf_api)
+- `Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md`
+- `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`

--- a/Tests/Model_Artifacts/test_provision_install.py
+++ b/Tests/Model_Artifacts/test_provision_install.py
@@ -758,6 +758,42 @@ async def test_provision_activates_already_installed_closure_with_zero_fetch_req
     assert [event.phase for event in events] == ["activate"]
 
 
+@pytest.mark.asyncio
+async def test_provision_install_only_skips_activation_and_active_selector(tmp_path, monkeypatch):
+    """``activate=False`` must leave an installed root usable but unselected.
+
+    This catches a regression that ignores the install-only flag and runs the
+    existing activation tail: activation would invoke the patched core method,
+    emit an ``activate`` event, and write the active-selector file.
+    """
+    root_ref = ArtifactRef("root-model", "r" * 40, "int8")
+    root_body = b"root-bytes-already-installed"
+    root_desc = _descriptor(root_ref, files_body=root_body)
+    core = ModelArtifactService(tmp_path / "root")
+    root_source = tmp_path / "root-source"
+    root_source.mkdir()
+    (root_source / "model.bin").write_bytes(root_body)
+    core.install(root_desc, root_source)
+
+    svc = ArtifactAcquisitionService(core, free_bytes_probe=lambda p: 10**12)
+    catalog = DictCatalog({root_ref: root_desc})
+    consent = grant_consent(svc, root_ref, catalog)
+    events: list[AcquisitionProgress] = []
+
+    def activation_must_not_run(_root: ArtifactRef) -> ArtifactRef:
+        raise AssertionError("install-only provision must not activate")
+
+    monkeypatch.setattr(core, "activate", activation_must_not_run)
+
+    provisioned = await svc.provision(
+        root_ref, consent, catalog, progress=events.append, activate=False
+    )
+
+    assert provisioned == root_ref
+    assert all(event.phase != "activate" for event in events)
+    assert not core.active_path(root_ref.artifact_id).exists()
+
+
 # ---------------------------------------------------------------------------
 # _run_core_call: core.install/core.activate ArtifactError never escapes raw.
 # ---------------------------------------------------------------------------

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import gc
 import hashlib
 import json
 import traceback
+import tracemalloc
 
 import httpx
 import pytest
@@ -17,6 +19,7 @@ from tldw_chatbook.Model_Artifacts.remote_huggingface import (
     RemoteDiscoveryError,
     RemoteModelSummary,
     ResolvedRemoteModel,
+    _read_bounded_json,
     build_remote_catalog,
     is_exact_repository,
 )
@@ -179,6 +182,55 @@ async def test_search_parser_failures_have_no_cause_or_upstream_marker(
     assert raised.value.__cause__ is None
     assert raised.value.__context__ is None
     assert "secret-marker" not in rendered
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"[" + (b"9182736450" * 500) + b"]",
+        (b"[" * 10_000) + b"0" + (b"]" * 10_000),
+    ],
+    ids=["over-limit-integer", "deep-nesting"],
+)
+async def test_search_hostile_json_failures_are_fresh_sanitized_errors(
+    body: bytes,
+) -> None:
+    """Over-limit integers and deep nesting must not escape parser normalization."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(lambda _: httpx.Response(200, content=body))
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("whisper")
+
+    rendered = "".join(traceback.format_exception(raised.value))
+    assert raised.value.code == "invalid_response"
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert "9182736450" not in rendered
+    assert "maximum recursion depth" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_bounded_json_reader_limits_peak_memory_for_one_byte_chunks() -> None:
+    """One-byte chunk delivery must stay within bounded reader memory."""
+    body = b"[" + (b" " * 100_000) + b"]"
+
+    class OneByteResponse:
+        async def aiter_bytes(self):
+            for value in body:
+                yield bytearray((value,))
+
+    gc.collect()
+    tracemalloc.start()
+    try:
+        assert await _read_bounded_json(OneByteResponse()) == []  # type: ignore[arg-type]
+        _, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert peak_bytes < 2_000_000
 
 
 @pytest.mark.asyncio
@@ -631,6 +683,24 @@ async def test_resolve_ignores_gguf_without_complete_lfs_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_rejects_lfs_size_above_signed_64_bit_maximum() -> None:
+    """An oversized declared file must never reach catalog or consent rendering."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(
+                200,
+                json=_model_info([_lfs_file("huge.gguf", size=2**63)]),
+            )
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve("acme/model")
+
+    assert (raised.value.code, raised.value.details) == ("no_eligible_gguf", ())
+
+
+@pytest.mark.asyncio
 async def test_resolve_records_total_before_deterministic_candidate_cap() -> None:
     """Catches a display cap that hides the true candidate count or changes ordering."""
     siblings = [_lfs_file(f"{index:03d}.gguf") for index in range(101, -1, -1)]
@@ -650,15 +720,6 @@ async def test_resolve_records_total_before_deterministic_candidate_cap() -> Non
 
 def test_build_remote_catalog_maps_a_candidate_to_one_inert_pinned_artifact() -> None:
     """Catches mutable IDs/URLs, unsafe names, or compatibility claims for remote bytes."""
-    resolved = ResolvedRemoteModel(
-        repository="acme/model",
-        commit="a" * 40,
-        license_id="apache-2.0",
-        review_url="https://huggingface.co/acme/model/tree/" + ("a" * 40),
-        candidates=(),
-        total_candidate_count=0,
-        warnings=(),
-    )
     candidate = RemoteGGUFCandidate(
         label="acme/model · nested/pack",
         files=(
@@ -666,6 +727,15 @@ def test_build_remote_catalog_maps_a_candidate_to_one_inert_pinned_artifact() ->
             RemoteGGUFFile("nested/pack-00002-of-00002.gguf", 12, "2" * 64),
         ),
         total_bytes=23,
+    )
+    resolved = ResolvedRemoteModel(
+        repository="acme/model",
+        commit="a" * 40,
+        license_id="apache-2.0",
+        review_url="https://huggingface.co/acme/model/tree/" + ("a" * 40),
+        candidates=(candidate,),
+        total_candidate_count=1,
+        warnings=(),
     )
 
     catalog = build_remote_catalog(resolved, candidate)
@@ -714,6 +784,58 @@ def test_build_remote_catalog_maps_a_candidate_to_one_inert_pinned_artifact() ->
         "Runtime compatibility has not been verified. Configuration is required."
     )
     assert catalog.descriptor(artifact.reference) is artifact
+
+
+def test_build_remote_catalog_rejects_candidate_outside_resolution() -> None:
+    """A stale or fabricated candidate must not cross the pure catalog boundary."""
+    selected = RemoteGGUFCandidate(
+        label="acme/model · selected.gguf",
+        files=(RemoteGGUFFile("selected.gguf", 7, "7" * 64),),
+        total_bytes=7,
+    )
+    stale = RemoteGGUFCandidate(
+        label="acme/model · stale.gguf",
+        files=(RemoteGGUFFile("stale.gguf", 8, "8" * 64),),
+        total_bytes=8,
+    )
+    resolved = ResolvedRemoteModel(
+        repository="acme/model",
+        commit="a" * 40,
+        license_id="apache-2.0",
+        review_url="https://huggingface.co/acme/model/tree/" + ("a" * 40),
+        candidates=(selected,),
+        total_candidate_count=1,
+        warnings=(),
+    )
+
+    with pytest.raises(ValueError, match="candidate"):
+        build_remote_catalog(resolved, stale)
+
+
+def test_build_remote_catalog_preserves_single_member_standard_shard_name() -> None:
+    """A valid one-of-one shard must retain the standard managed shard filename."""
+    candidate = RemoteGGUFCandidate(
+        label="acme/model · model",
+        files=(
+            RemoteGGUFFile("model-00001-of-00001.gguf", 9, "9" * 64),
+        ),
+        total_bytes=9,
+    )
+    resolved = ResolvedRemoteModel(
+        repository="acme/model",
+        commit="a" * 40,
+        license_id="apache-2.0",
+        review_url="https://huggingface.co/acme/model/tree/" + ("a" * 40),
+        candidates=(candidate,),
+        total_candidate_count=1,
+        warnings=(),
+    )
+
+    catalog = build_remote_catalog(resolved, candidate)
+
+    assert [item.path for item in catalog.artifact.files] == [
+        "model-00001-of-00001.gguf"
+    ]
 
 
 @pytest.mark.asyncio

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import hashlib
+import json
 import traceback
 
 import httpx
@@ -17,6 +19,11 @@ from tldw_chatbook.Model_Artifacts.remote_huggingface import (
     ResolvedRemoteModel,
     build_remote_catalog,
     is_exact_repository,
+)
+from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
+from tldw_chatbook.Model_Artifacts.service import (
+    ModelArtifactService,
+    ProvenanceClass,
 )
 
 
@@ -707,3 +714,94 @@ def test_build_remote_catalog_maps_a_candidate_to_one_inert_pinned_artifact() ->
         "Runtime compatibility has not been verified. Configuration is required."
     )
     assert catalog.descriptor(artifact.reference) is artifact
+
+
+@pytest.mark.asyncio
+async def test_remote_gguf_flows_through_managed_install_without_activation(
+    tmp_path, monkeypatch
+) -> None:
+    """Catches remote bytes bypassing managed integrity or becoming active.
+
+    A regression that skips the pinned source map, omits the integrity
+    manifest, assigns a consumer, or ignores ``activate=False`` fails this
+    real resolve-to-provision flow. Network transport and egress checks are
+    isolated at their external boundary; metadata parsing, catalog mapping,
+    preflight, consent, fetch, verification, and installation stay real.
+    """
+    payload = b"GGUF\x00managed-test"
+    payload_sha256 = hashlib.sha256(payload).hexdigest()
+    commit = "c" * 40
+    requests: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, str(request.url)))
+        if request.method == "GET" and request.url.path == "/api/models/acme/model":
+            return httpx.Response(
+                200,
+                json=_model_info(
+                    [_lfs_file("tiny-model.gguf", size=len(payload), digest=payload_sha256)],
+                    commit=commit,
+                    card_data=None,
+                ),
+            )
+        if request.url.path == f"/acme/model/resolve/{commit}/tiny-model.gguf":
+            if request.method == "HEAD":
+                return httpx.Response(200, headers={"etag": '"tiny-v1"'})
+            if request.method == "GET":
+                return httpx.Response(200, content=payload, headers={"etag": '"tiny-v1"'})
+        pytest.fail(f"unexpected network request: {request.method} {request.url}")
+
+    async def allow_mocked_egress(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.acquisition.check_url_or_raise_async",
+        allow_mocked_egress,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.fetch.check_url_or_raise_async",
+        allow_mocked_egress,
+    )
+    client_factory = _client_factory(handler)
+
+    resolved = await HuggingFaceRemoteAdapter(client_factory=client_factory).resolve(
+        "acme/model"
+    )
+    catalog = build_remote_catalog(resolved, resolved.candidates[0])
+    core = ModelArtifactService(tmp_path / "managed")
+    acquisition = ArtifactAcquisitionService(
+        core,
+        client_factory=client_factory,
+        free_bytes_probe=lambda _path: 10**12,
+    )
+
+    report = await acquisition.preflight(
+        catalog.artifact.reference, catalog, sources=catalog.sources
+    )
+    assert report.gating_errors == ()
+    provisioned = await acquisition.provision(
+        report.root,
+        report.grant(),
+        catalog,
+        sources=catalog.sources,
+        activate=False,
+    )
+
+    artifact = catalog.artifact
+    assert provisioned == artifact.reference
+    installed_payload = core.artifact_path(artifact.reference) / "model.gguf"
+    manifest_path = core.artifact_path(artifact.reference) / "manifest.json"
+    assert installed_payload.read_bytes() == payload
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["descriptor"]["reference"] == artifact.reference.to_dict()
+    assert manifest["descriptor"]["files"] == [
+        {"path": "model.gguf", "size_bytes": len(payload), "sha256": payload_sha256}
+    ]
+    assert artifact.provenance == (ProvenanceClass.LOCAL_INTEGRITY_RECORDED,)
+    assert artifact.consumer == "unassigned"
+    assert not core.active_path(artifact.reference.artifact_id).exists()
+    assert [(method, httpx.URL(url).path) for method, url in requests] == [
+        ("GET", "/api/models/acme/model"),
+        ("HEAD", f"/acme/model/resolve/{commit}/tiny-model.gguf"),
+        ("GET", f"/acme/model/resolve/{commit}/tiny-model.gguf"),
+    ]

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -130,6 +130,32 @@ async def test_search_timeout_traceback_has_no_upstream_secret_or_cause() -> Non
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        b'{"metadata":"json-secret-marker",}',
+        b'{"metadata":"utf8-secret-marker"}\xff',
+    ],
+    ids=["malformed-json", "invalid-utf8"],
+)
+async def test_search_parser_failures_have_no_cause_or_upstream_marker(
+    body: bytes,
+) -> None:
+    """Catches parser exception chains exposing an upstream response body."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(lambda _: httpx.Response(200, content=body))
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("whisper")
+
+    rendered = "".join(traceback.format_exception(raised.value))
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert "secret-marker" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_search_rejects_redirect_status_as_remote_error() -> None:
     """Catches a redirect response being parsed as trusted search metadata."""
     adapter = HuggingFaceRemoteAdapter(

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -10,8 +10,12 @@ import pytest
 
 from tldw_chatbook.Model_Artifacts.remote_huggingface import (
     HuggingFaceRemoteAdapter,
+    RemoteGGUFCandidate,
+    RemoteGGUFFile,
     RemoteDiscoveryError,
     RemoteModelSummary,
+    ResolvedRemoteModel,
+    build_remote_catalog,
     is_exact_repository,
 )
 
@@ -20,6 +24,21 @@ def _client_factory(
     handler: Callable[[httpx.Request], httpx.Response],
 ) -> Callable[[], httpx.AsyncClient]:
     return lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _model_info(
+    siblings: list[object],
+    *,
+    commit: str = "a" * 40,
+    card_data: object = None,
+) -> dict[str, object]:
+    """Return a complete minimal Hugging Face repository-info response."""
+    return {"sha": commit, "siblings": siblings, "cardData": card_data}
+
+
+def _lfs_file(path: str, *, size: int = 123, digest: str = "b" * 64) -> dict[str, object]:
+    """Return one complete LFS-backed GGUF sibling response entry."""
+    return {"rfilename": path, "lfs": {"size": size, "sha256": digest}}
 
 
 @pytest.mark.asyncio
@@ -176,7 +195,7 @@ async def test_search_rejects_redirect_status_as_remote_error() -> None:
     ("code", "details"),
     [
         ("unexpected", ()),
-        ("invalid_response", ("x" * 513,)),
+        ("invalid_response", ("x" * 553,)),
         ("invalid_response", ("line\nbreak",)),
         ("invalid_response", tuple("warning" for _ in range(21))),
         ("invalid_response", ["warning"]),
@@ -334,3 +353,318 @@ async def test_search_rejects_empty_or_oversized_trimmed_query(query: str) -> No
         False,
         (),
     )
+
+
+@pytest.mark.asyncio
+async def test_resolve_uses_pinned_model_info_request_with_lfs_blobs() -> None:
+    """Catches a mutable, unpinned, or credential-leaking resolution request."""
+    requests: list[httpx.Request] = []
+    redirects: list[bool] = []
+
+    class TrackingClient(httpx.AsyncClient):
+        def stream(self, method: str, url: str | httpx.URL, **kwargs: object):
+            redirects.append(bool(kwargs["follow_redirects"]))
+            return super().stream(method, url, **kwargs)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=_model_info([_lfs_file("model.gguf")]))
+
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=lambda: TrackingClient(transport=httpx.MockTransport(handler))
+    )
+
+    resolved = await adapter.resolve("acme/model", token="secret")
+
+    assert resolved.repository == "acme/model"
+    assert len(requests) == 1
+    assert requests[0].method == "GET"
+    assert str(requests[0].url).split("?")[0] == (
+        "https://huggingface.co/api/models/acme/model"
+    )
+    assert requests[0].url.params == httpx.QueryParams({"blobs": "true"})
+    assert requests[0].headers["authorization"] == "Bearer secret"
+    assert redirects == [False]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("commit", ["main", "A" * 40, "a" * 39, "a" * 41])
+async def test_resolve_rejects_non_immutable_commit(commit: str) -> None:
+    """Catches a branch, tag, or malformed revision becoming an artifact revision."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(200, json=_model_info([], commit=commit))
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve("acme/model")
+
+    assert raised.value.code == "invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_repository_with_over_2048_files() -> None:
+    """Catches silently inspecting only part of an unbounded repository listing."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(
+                200,
+                json=_model_info([_lfs_file(f"model-{index}.gguf") for index in range(2049)]),
+            )
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve("acme/model")
+
+    assert raised.value.code == "invalid_response"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("card_data", "expected"),
+    [
+        ({"license": "apache-2.0"}, "apache-2.0"),
+        (None, "NOASSERTION"),
+        ({}, "NOASSERTION"),
+        ("not-a-mapping", "NOASSERTION"),
+        ({"license": None}, "NOASSERTION"),
+        ({"license": ""}, "NOASSERTION"),
+        ({"license": 12}, "NOASSERTION"),
+        ({"license": "x" * 129}, "NOASSERTION"),
+    ],
+)
+async def test_resolve_uses_only_bounded_card_data_license(
+    card_data: object, expected: str
+) -> None:
+    """Catches license inference from non-authoritative or malformed card fields."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(
+                200,
+                json=_model_info([_lfs_file("model.gguf")], card_data=card_data),
+            )
+        )
+    )
+
+    assert (await adapter.resolve("acme/model")).license_id == expected
+
+
+@pytest.mark.asyncio
+async def test_resolve_groups_complete_shards_and_keeps_single_files_sorted() -> None:
+    """Catches shard members becoming selectable singles or unstable file ordering."""
+    siblings = [
+        _lfs_file("z.gguf", size=9, digest="9" * 64),
+        _lfs_file("nested/pack-00003-of-00003.gguf", size=3, digest="3" * 64),
+        _lfs_file("nested/pack-00001-of-00003.gguf", size=1, digest="1" * 64),
+        _lfs_file("nested/pack-00002-of-00003.gguf", size=2, digest="2" * 64),
+        _lfs_file("a.gguf", size=4, digest="4" * 64),
+    ]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(200, json=_model_info(siblings))
+        )
+    )
+
+    resolved = await adapter.resolve("acme/model")
+
+    assert [(candidate.label, candidate.total_bytes) for candidate in resolved.candidates] == [
+        ("acme/model · a.gguf", 4),
+        ("acme/model · nested/pack", 6),
+        ("acme/model · z.gguf", 9),
+    ]
+    assert [item.upstream_path for item in resolved.candidates[1].files] == [
+        "nested/pack-00001-of-00003.gguf",
+        "nested/pack-00002-of-00003.gguf",
+        "nested/pack-00003-of-00003.gguf",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_incomplete_shards_without_reintroducing_members() -> None:
+    """Catches rejected shard members reappearing as independently installable files."""
+    siblings = [
+        _lfs_file("nested/pack-00001-of-00003.gguf"),
+        _lfs_file("nested/pack-00003-of-00003.gguf"),
+        _lfs_file("single.gguf"),
+    ]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(200, json=_model_info(siblings))
+        )
+    )
+
+    resolved = await adapter.resolve("acme/model")
+
+    assert [candidate.label for candidate in resolved.candidates] == [
+        "acme/model · single.gguf"
+    ]
+    assert resolved.warnings == ("acme/model · nested/pack missing 00002",)
+
+
+@pytest.mark.asyncio
+async def test_resolve_carries_incomplete_shard_warning_when_nothing_is_eligible() -> None:
+    """Catches loss of actionable incomplete-shard context on empty resolution."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(
+                200,
+                json=_model_info([_lfs_file("pack-00001-of-00002.gguf")]),
+            )
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve("acme/model")
+
+    assert raised.value.code == "no_eligible_gguf"
+    assert raised.value.details == ("acme/model · pack missing 00002",)
+
+
+@pytest.mark.asyncio
+async def test_resolve_keeps_all_missing_indexes_for_a_maximum_label_warning() -> None:
+    """Catches truncating required missing shard indexes to fit an error-detail cap."""
+    repository = ("o" * 47) + "/" + ("r" * 48)
+    stem = "s" * 61
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(
+                200,
+                json=_model_info(
+                    [{"rfilename": f"{stem}-00001-of-00064.gguf", "lfs": {}}]
+                ),
+            )
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve(repository)
+
+    warning = raised.value.details[0]
+    assert len(warning) == 552
+    assert warning.startswith(f"{repository} · {stem} missing 00001")
+    assert warning.endswith("00064")
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_malformed_or_oversized_shard_sets() -> None:
+    """Catches invalid shard cardinalities returning an installable candidate."""
+    siblings = [
+        _lfs_file("bad-00000-of-00002.gguf"),
+        _lfs_file("large-00001-of-00065.gguf"),
+    ]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(200, json=_model_info(siblings))
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve("acme/model")
+
+    assert raised.value.code == "no_eligible_gguf"
+
+
+@pytest.mark.asyncio
+async def test_resolve_ignores_gguf_without_complete_lfs_metadata() -> None:
+    """Catches unverified GGUF payload metadata becoming an acquisition candidate."""
+    siblings = [
+        {"rfilename": "missing.gguf", "lfs": {"size": 4}},
+        _lfs_file("valid.gguf", size=5),
+    ]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(200, json=_model_info(siblings))
+        )
+    )
+
+    assert [item.label for item in (await adapter.resolve("acme/model")).candidates] == [
+        "acme/model · valid.gguf"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_records_total_before_deterministic_candidate_cap() -> None:
+    """Catches a display cap that hides the true candidate count or changes ordering."""
+    siblings = [_lfs_file(f"{index:03d}.gguf") for index in range(101, -1, -1)]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(200, json=_model_info(siblings))
+        )
+    )
+
+    resolved = await adapter.resolve("acme/model")
+
+    assert resolved.total_candidate_count == 102
+    assert len(resolved.candidates) == 100
+    assert resolved.candidates[0].files[0].upstream_path == "000.gguf"
+    assert resolved.candidates[-1].files[0].upstream_path == "099.gguf"
+
+
+def test_build_remote_catalog_maps_a_candidate_to_one_inert_pinned_artifact() -> None:
+    """Catches mutable IDs/URLs, unsafe names, or compatibility claims for remote bytes."""
+    resolved = ResolvedRemoteModel(
+        repository="acme/model",
+        commit="a" * 40,
+        license_id="apache-2.0",
+        review_url="https://huggingface.co/acme/model/tree/" + ("a" * 40),
+        candidates=(),
+        total_candidate_count=0,
+        warnings=(),
+    )
+    candidate = RemoteGGUFCandidate(
+        label="acme/model · nested/pack",
+        files=(
+            RemoteGGUFFile("nested/pack-00001-of-00002.gguf", 11, "1" * 64),
+            RemoteGGUFFile("nested/pack-00002-of-00002.gguf", 12, "2" * 64),
+        ),
+        total_bytes=23,
+    )
+
+    catalog = build_remote_catalog(resolved, candidate)
+    artifact = catalog.artifact
+
+    assert artifact.reference.artifact_id == (
+        "hf-gguf-0cac08cf6bec99fb43ebc68340f029996d72b111ec52945b773fbae8d6005e05"
+    )
+    assert (artifact.reference.revision, artifact.reference.variant, artifact.precision) == (
+        "a" * 40,
+        "not-declared",
+        "not-declared",
+    )
+    assert (artifact.consumer, artifact.model_family, artifact.runtime_name) == (
+        "unassigned",
+        "unassigned",
+        "unassigned",
+    )
+    assert artifact.runtime_version_constraint == "none"
+    assert artifact.supported_os == ("unassigned",)
+    assert artifact.supported_architectures == ("unassigned",)
+    assert [item.path for item in artifact.files] == [
+        "model-00001-of-00002.gguf",
+        "model-00002-of-00002.gguf",
+    ]
+    assert [(item.size_bytes, item.sha256) for item in artifact.files] == [
+        (11, "1" * 64),
+        (12, "2" * 64),
+    ]
+    assert artifact.expected_installed_bytes == 23
+    assert artifact.license_id == "apache-2.0"
+    assert artifact.license_url == resolved.review_url
+    assert artifact.source_url == (
+        "https://huggingface.co/acme/model/resolve/" + ("a" * 40)
+        + "/nested/pack-00001-of-00002.gguf"
+    )
+    assert catalog.sources[artifact.reference] == {
+        "model-00001-of-00002.gguf": artifact.source_url,
+        "model-00002-of-00002.gguf": (
+            "https://huggingface.co/acme/model/resolve/" + ("a" * 40)
+            + "/nested/pack-00002-of-00002.gguf"
+        ),
+    }
+    assert artifact.dependencies == ()
+    assert artifact.usage_notice == (
+        "Runtime compatibility has not been verified. Configuration is required."
+    )
+    assert catalog.descriptor(artifact.reference) is artifact

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -567,6 +567,45 @@ async def test_resolve_rejects_malformed_or_oversized_shard_sets() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_rejects_huge_shard_count_without_expanding_warning() -> None:
+    """Catches expanding an attacker-declared shard count into an unbounded warning."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(
+                200,
+                json=_model_info([_lfs_file("model-00001-of-99999.gguf")]),
+            )
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve("acme/model")
+
+    assert (raised.value.code, raised.value.details) == ("no_eligible_gguf", ())
+
+
+@pytest.mark.asyncio
+async def test_resolve_retains_only_twenty_valid_incomplete_shard_warnings() -> None:
+    """Catches retaining more than twenty bounded incomplete-shard warnings."""
+    siblings = [
+        _lfs_file(f"set-{index:02d}-00001-of-00002.gguf") for index in range(21)
+    ]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(200, json=_model_info(siblings))
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.resolve("acme/model")
+
+    assert raised.value.code == "no_eligible_gguf"
+    assert raised.value.details == tuple(
+        f"acme/model · set-{index:02d} missing 00002" for index in range(20)
+    )
+
+
+@pytest.mark.asyncio
 async def test_resolve_ignores_gguf_without_complete_lfs_metadata() -> None:
     """Catches unverified GGUF payload metadata becoming an acquisition candidate."""
     siblings = [

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -732,10 +732,20 @@ async def test_remote_gguf_flows_through_managed_install_without_activation(
     payload_sha256 = hashlib.sha256(payload).hexdigest()
     commit = "c" * 40
     requests: list[tuple[str, str]] = []
+    metadata_url = "https://huggingface.co/api/models/acme/model?blobs=true"
+    payload_url = f"https://huggingface.co/acme/model/resolve/{commit}/tiny-model.gguf"
+    expected_requests = [
+        ("GET", metadata_url),
+        ("HEAD", payload_url),
+        ("GET", payload_url),
+    ]
 
     def handler(request: httpx.Request) -> httpx.Response:
-        requests.append((request.method, str(request.url)))
-        if request.method == "GET" and request.url.path == "/api/models/acme/model":
+        received = (request.method, str(request.url))
+        if len(requests) >= len(expected_requests) or received != expected_requests[len(requests)]:
+            pytest.fail(f"unexpected network request: {request.method} {request.url}")
+        requests.append(received)
+        if received == expected_requests[0]:
             return httpx.Response(
                 200,
                 json=_model_info(
@@ -744,12 +754,9 @@ async def test_remote_gguf_flows_through_managed_install_without_activation(
                     card_data=None,
                 ),
             )
-        if request.url.path == f"/acme/model/resolve/{commit}/tiny-model.gguf":
-            if request.method == "HEAD":
-                return httpx.Response(200, headers={"etag": '"tiny-v1"'})
-            if request.method == "GET":
-                return httpx.Response(200, content=payload, headers={"etag": '"tiny-v1"'})
-        pytest.fail(f"unexpected network request: {request.method} {request.url}")
+        if received == expected_requests[1]:
+            return httpx.Response(200, headers={"etag": '"tiny-v1"'})
+        return httpx.Response(200, content=payload, headers={"etag": '"tiny-v1"'})
 
     async def allow_mocked_egress(*_args, **_kwargs) -> None:
         return None
@@ -800,8 +807,4 @@ async def test_remote_gguf_flows_through_managed_install_without_activation(
     assert artifact.provenance == (ProvenanceClass.LOCAL_INTEGRITY_RECORDED,)
     assert artifact.consumer == "unassigned"
     assert not core.active_path(artifact.reference.artifact_id).exists()
-    assert [(method, httpx.URL(url).path) for method, url in requests] == [
-        ("GET", "/api/models/acme/model"),
-        ("HEAD", f"/acme/model/resolve/{commit}/tiny-model.gguf"),
-        ("GET", f"/acme/model/resolve/{commit}/tiny-model.gguf"),
-    ]
+    assert requests == expected_requests

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import traceback
 
 import httpx
 import pytest
@@ -107,6 +108,69 @@ async def test_search_sanitizes_timeout() -> None:
         (),
     )
     assert "upstream secret" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_search_timeout_traceback_has_no_upstream_secret_or_cause() -> None:
+    """Catches chained HTTPX errors that expose credentials or upstream text."""
+    secret = "upstream-secret-and-token"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout(secret, request=request)
+
+    adapter = HuggingFaceRemoteAdapter(client_factory=_client_factory(handler))
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("whisper", token=secret)
+
+    rendered = "".join(traceback.format_exception(raised.value))
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert secret not in rendered
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_redirect_status_as_remote_error() -> None:
+    """Catches a redirect response being parsed as trusted search metadata."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(lambda _: httpx.Response(302, json=[]))
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("whisper")
+
+    assert (raised.value.code, raised.value.retryable, raised.value.details) == (
+        "remote_error",
+        False,
+        (),
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "details"),
+    [
+        ("unexpected", ()),
+        ("invalid_response", ("x" * 513,)),
+        ("invalid_response", ("line\nbreak",)),
+        ("invalid_response", tuple("warning" for _ in range(21))),
+        ("invalid_response", ["warning"]),
+    ],
+)
+def test_remote_discovery_error_rejects_unbounded_or_unsanitized_values(
+    code: str, details: object
+) -> None:
+    """Catches public error values that could retain arbitrary upstream content."""
+    with pytest.raises(ValueError):
+        RemoteDiscoveryError(code, details=details)  # type: ignore[arg-type]
+
+
+def test_remote_discovery_error_retains_bounded_display_safe_warnings() -> None:
+    """Catches rejection of the bounded warning capacity needed by Task 2."""
+    details = tuple("model.gguf missing 00001" for _ in range(20))
+
+    error = RemoteDiscoveryError("no_eligible_gguf", details=details)
+
+    assert error.details == details
 
 
 @pytest.mark.asyncio

--- a/Tests/Model_Artifacts/test_remote_huggingface.py
+++ b/Tests/Model_Artifacts/test_remote_huggingface.py
@@ -1,0 +1,246 @@
+"""Tests for bounded Hugging Face metadata search (TASK-596.1)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from tldw_chatbook.Model_Artifacts.remote_huggingface import (
+    HuggingFaceRemoteAdapter,
+    RemoteDiscoveryError,
+    RemoteModelSummary,
+    is_exact_repository,
+)
+
+
+def _client_factory(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> Callable[[], httpx.AsyncClient]:
+    return lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_trims_query_and_uses_fixed_bounded_request() -> None:
+    """Catches a wrong endpoint, untrimmed query, or unbounded search."""
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    adapter = HuggingFaceRemoteAdapter(client_factory=_client_factory(handler))
+
+    assert await adapter.search("  whisper  ", token="secret") == ()
+    assert len(requests) == 1
+    assert requests[0].method == "GET"
+    assert str(requests[0].url).split("?")[0] == "https://huggingface.co/api/models"
+    assert requests[0].url.params["search"] == "whisper"
+    assert requests[0].url.params["limit"] == "50"
+    assert requests[0].headers["authorization"] == "Bearer secret"
+
+
+@pytest.mark.asyncio
+async def test_search_disables_redirects() -> None:
+    """Catches a metadata request that could forward credentials via redirects."""
+    recorded: list[bool] = []
+
+    class TrackingClient(httpx.AsyncClient):
+        def stream(self, method: str, url: str | httpx.URL, **kwargs: object):
+            recorded.append(bool(kwargs["follow_redirects"]))
+            return super().stream(method, url, **kwargs)
+
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=lambda: TrackingClient(
+            transport=httpx.MockTransport(lambda _: httpx.Response(200, json=[]))
+        )
+    )
+
+    assert await adapter.search("whisper", token="secret") == ()
+    assert recorded == [False]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "code", "retryable"),
+    [
+        (401, "authentication_required", False),
+        (403, "access_forbidden", False),
+        (404, "repository_not_found", False),
+        (429, "rate_limited", True),
+    ],
+)
+async def test_search_sanitizes_expected_http_errors(
+    status_code: int, code: str, retryable: bool
+) -> None:
+    """Catches raw upstream error propagation or a wrong retry policy."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(
+            lambda _: httpx.Response(status_code, text="upstream secret detail")
+        )
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("whisper")
+
+    assert raised.value.code == code
+    assert raised.value.retryable is retryable
+    assert raised.value.details == ()
+    assert "upstream secret detail" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_search_sanitizes_timeout() -> None:
+    """Catches timeout leakage instead of a recoverable discovery failure."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("upstream secret", request=request)
+
+    adapter = HuggingFaceRemoteAdapter(client_factory=_client_factory(handler))
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("whisper")
+
+    assert (raised.value.code, raised.value.retryable, raised.value.details) == (
+        "network_error",
+        True,
+        (),
+    )
+    assert "upstream secret" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [b"not json", b"[" + (b" " * (2 * 1024 * 1024)) + b"]"],
+)
+async def test_search_rejects_malformed_or_oversized_response(body: bytes) -> None:
+    """Catches decoding before response-size enforcement or raw parse errors."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(lambda _: httpx.Response(200, content=body))
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("whisper")
+
+    assert raised.value.code in {"invalid_response", "response_too_large"}
+    assert raised.value.retryable is False
+    assert raised.value.details == ()
+
+
+@pytest.mark.asyncio
+async def test_search_parses_valid_bounded_metadata() -> None:
+    """Catches loss of valid private/gated metadata or malformed optional fields."""
+    models = [
+        {
+            "modelId": "acme/private",
+            "private": True,
+            "gated": False,
+            "downloads": 42,
+            "likes": 3,
+            "lastModified": "2026-08-01T00:00:00Z",
+        },
+        {
+            "modelId": "acme/auto",
+            "private": False,
+            "gated": "auto",
+            "downloads": -1,
+            "likes": "3",
+            "lastModified": "x" * 65,
+        },
+        {
+            "modelId": "acme/manual",
+            "private": False,
+            "gated": "manual",
+            "downloads": 2**63 - 1,
+            "likes": 0,
+            "lastModified": "updated",
+        },
+    ]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(lambda _: httpx.Response(200, json=models))
+    )
+
+    assert await adapter.search("models") == (
+        RemoteModelSummary(
+            repository="acme/private",
+            private=True,
+            gated="none",
+            downloads=42,
+            likes=3,
+            last_modified="2026-08-01T00:00:00Z",
+        ),
+        RemoteModelSummary(
+            repository="acme/auto", private=False, gated="auto"
+        ),
+        RemoteModelSummary(
+            repository="acme/manual",
+            private=False,
+            gated="manual",
+            downloads=2**63 - 1,
+            likes=0,
+            last_modified="updated",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_caps_results_at_fifty() -> None:
+    """Catches a server response exceeding the declared result limit."""
+    models = [
+        {"modelId": f"owner/model-{index}", "private": False, "gated": False}
+        for index in range(51)
+    ]
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(lambda _: httpx.Response(200, json=models))
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search("models")
+
+    assert (raised.value.code, raised.value.retryable, raised.value.details) == (
+        "invalid_response",
+        False,
+        (),
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("owner/repository", True),
+        ("a/b", True),
+        ("owner/repository/extra", False),
+        ("owner", False),
+        (" owner/repository", False),
+        ("owner/repository ", False),
+        ("owner/" + ("a" * 91), False),
+        ("owner/repo?query", False),
+        ("owner/repo--name", False),
+        ("owner/repo..name", False),
+        ("owner/repo-", False),
+    ],
+)
+def test_is_exact_repository_requires_one_bounded_portable_pair(
+    value: str, expected: bool
+) -> None:
+    """Catches unsafe, ambiguous, or oversized exact repository identifiers."""
+    assert is_exact_repository(value) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["", "x" * 257])
+async def test_search_rejects_empty_or_oversized_trimmed_query(query: str) -> None:
+    """Catches unbounded or blank user input reaching the remote endpoint."""
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=_client_factory(lambda _: pytest.fail("request was sent"))
+    )
+
+    with pytest.raises(RemoteDiscoveryError) as raised:
+        await adapter.search(query)
+
+    assert (raised.value.code, raised.value.retryable, raised.value.details) == (
+        "invalid_query",
+        False,
+        (),
+    )

--- a/Tests/Model_Artifacts/test_stream_fetch.py
+++ b/Tests/Model_Artifacts/test_stream_fetch.py
@@ -8,6 +8,7 @@ from Tests.Model_Artifacts.fixture_http import FixtureArtifactServer
 from tldw_chatbook.Model_Artifacts.fetch import (
     FetchRestartRequired,
     FetchTooLargeError,
+    FetchTransportError,
     FetchValidators,
     stream_fetch,
 )
@@ -266,3 +267,40 @@ def test_strip_headers_mirror_matches_egress():
     from tldw_chatbook.Model_Artifacts import fetch
 
     assert set(fetch._STRIP_HEADERS) == set(egress._STRIP_HEADERS)
+
+
+@pytest.mark.asyncio
+async def test_https_redirect_downgrade_stops_before_second_request(tmp_path, monkeypatch):
+    """An HTTPS-to-HTTP redirect must fail before the HTTP hop is requested.
+
+    This catches a missing downgrade guard: without it, the redirect loop
+    makes a second request to the HTTP storage URL below.
+    """
+    requests: list[str] = []
+
+    async def allow_egress(_url: str, *, trusted_origins: frozenset[str]) -> None:
+        """Keep this transport-only test independent of DNS/egress policy."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(str(request.url))
+        if request.url == httpx.URL("https://catalog.example/model.gguf"):
+            return httpx.Response(
+                302,
+                headers={"Location": "http://storage.example/model.gguf"},
+                request=request,
+            )
+        pytest.fail(f"downgraded redirect made a second request: {request.url}")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Model_Artifacts.fetch.check_url_or_raise_async", allow_egress
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(FetchTransportError, match="HTTPS redirect downgrade"):
+            await stream_fetch(
+                "https://catalog.example/model.gguf",
+                tmp_path / "model.gguf",
+                client=client,
+                max_bytes=1024,
+            )
+
+    assert requests == ["https://catalog.example/model.gguf"]

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -75,6 +75,7 @@ async def test_all_provider_and_model_rows_live_in_the_rail():
             "mlx-lm",
             "curated",
             "installed",
+            "remote",
             "download-models",
         ]
 
@@ -310,3 +311,43 @@ async def test_mounting_models_reaches_no_network_until_the_view_is_opened(monke
         await pilot.pause()
         await pilot.pause()
         assert len(calls) == 1, "re-opening the view browsed again"
+
+
+@pytest.mark.asyncio
+async def test_pressing_remote_still_waits_for_explicit_search(monkeypatch):
+    """Remote activation itself must remain metadata-I/O free."""
+    from tldw_chatbook.Model_Artifacts.remote_huggingface import (
+        HuggingFaceRemoteAdapter,
+    )
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    calls: list[str] = []
+
+    async def counted_search(self, query, *, token=None):
+        calls.append("search")
+        return ()
+
+    async def counted_resolve(self, repository, *, token=None):
+        calls.append("resolve")
+        raise AssertionError("Remote resolve ran before Search")
+
+    monkeypatch.setattr(HuggingFaceRemoteAdapter, "search", counted_search)
+    monkeypatch.setattr(HuggingFaceRemoteAdapter, "resolve", counted_resolve)
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        await pilot.pause()
+        await pilot.pause()
+        remote_row = next(
+            row for row in _rail_rows(screen) if row.lab_view_key == "remote"
+        )
+
+        remote_row.press()
+        await pilot.pause()
+        await pilot.pause()
+
+        window = screen.query_one(LLMManagementWindow)
+        assert window.active_view == "remote"
+        assert window.query_one("#remote-models-view", RemoteView)
+        assert calls == []

--- a/Tests/UI/test_model_artifact_widgets.py
+++ b/Tests/UI/test_model_artifact_widgets.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Button, Static
+from textual.widgets import Button, Checkbox, Static
 
 from tldw_chatbook.Model_Artifacts.acquisition import (
     ArtifactPreflightEntry,
@@ -18,6 +18,7 @@ def _report(
     *,
     sufficient_space: bool = True,
     gating_errors: tuple[str, ...] = (),
+    license_id: str = "CC-BY-4.0",
 ) -> PreflightReport:
     reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
     return PreflightReport(
@@ -29,7 +30,7 @@ def _report(
                 source_url="https://example.test/model",
                 repository="publisher/parakeet-v2",
                 revision="immutable-revision",
-                license_id="CC-BY-4.0",
+                license_id=license_id,
                 license_url="https://example.test/license",
                 precision="int8",
                 total_bytes=1024,
@@ -89,14 +90,37 @@ async def test_plan_panel_renders_every_consent_field(tmp_path: Path) -> None:
     for expected in (
         "publisher/parakeet-v2",
         "immutable-revision",
-        "CC-BY-4.0",
+        "License: CC-BY-4.0",
+        "Source review page: https://example.test/license",
         "int8",
         "4 files",
         str(tmp_path / "managed"),
         "Staging",
         "Enough free space",
+        "Every declared file is checked against pinned sizes and SHA-256 digests "
+        "before installation completes.",
     ):
         assert expected in text
+
+
+@pytest.mark.asyncio
+async def test_plan_panel_labels_noassertion_as_unknown_and_separates_review_url(
+    tmp_path: Path,
+) -> None:
+    """Missing license metadata cannot be mistaken for a declared license.
+
+    This fails if the panel shows the sentinel as a license or combines the
+    source-review page with that license text.
+    """
+    report = _report(tmp_path / "managed", license_id="NOASSERTION")
+    app = _PanelApp(report)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        text = "\n".join(str(item.renderable) for item in app.query(Static))
+
+    assert "License: Unknown / not declared" in text
+    assert "Source review page: https://example.test/license" in text
+    assert "License: NOASSERTION" not in text
 
 
 @pytest.mark.asyncio
@@ -136,6 +160,7 @@ async def test_confirm_and_cancel_return_decisions(tmp_path: Path) -> None:
             decisions.append,
         )
         await pilot.pause()
+        assert app.screen.query_one("#model-install-confirm", Button).disabled is False
         await pilot.click("#model-install-confirm")
         await pilot.pause()
         assert decisions == [True]
@@ -148,6 +173,42 @@ async def test_confirm_and_cancel_return_decisions(tmp_path: Path) -> None:
         await pilot.click("#model-install-cancel")
         await pilot.pause()
         assert decisions == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_install_acknowledgment_gates_only_callers_that_require_it(
+    tmp_path: Path,
+) -> None:
+    """An unknown-license acknowledgment unlocks the shared Install control.
+
+    This fails if the required checkbox does not gate consent, or if the modal
+    fails to render the acknowledgment supplied by a caller.
+    """
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+    report = _report(tmp_path / "managed", license_id="NOASSERTION")
+    app = _ModalApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(
+            ModelInstallModal(
+                report,
+                model_label="Parakeet v2",
+                required_acknowledgment=(
+                    "No license was declared. I reviewed the source and want to continue."
+                ),
+            )
+        )
+        await pilot.pause()
+        confirm = app.screen.query_one("#model-install-confirm", Button)
+        checkbox = app.screen.query_one(Checkbox)
+        assert checkbox.value is False
+        assert confirm.disabled is True
+
+        await pilot.click(Checkbox)
+        await pilot.pause()
+
+        assert checkbox.value is True
+        assert confirm.disabled is False
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_model_artifact_widgets.py
+++ b/Tests/UI/test_model_artifact_widgets.py
@@ -52,14 +52,24 @@ def _report(
 
 
 class _PanelApp(App):
-    def __init__(self, report: PreflightReport) -> None:
+    def __init__(
+        self,
+        report: PreflightReport,
+        *,
+        selected_file_details: tuple[tuple[str, int, str, str], ...] = (),
+    ) -> None:
         self.report = report
+        self.selected_file_details = selected_file_details
         super().__init__()
 
     def compose(self) -> ComposeResult:
         from tldw_chatbook.Widgets.ModelArtifacts import ModelPlanPanel
 
-        yield ModelPlanPanel(self.report, model_label="Parakeet v2")
+        yield ModelPlanPanel(
+            self.report,
+            model_label="Parakeet v2",
+            selected_file_details=self.selected_file_details,
+        )
 
 
 class _ModalApp(App):
@@ -121,6 +131,37 @@ async def test_plan_panel_labels_noassertion_as_unknown_and_separates_review_url
     assert "License: Unknown / not declared" in text
     assert "Source review page: https://example.test/license" in text
     assert "License: NOASSERTION" not in text
+
+
+@pytest.mark.asyncio
+async def test_plan_panel_renders_selected_file_details_as_plain_bounded_text(
+    tmp_path: Path,
+) -> None:
+    """Selected upstream identity and integrity values must be visible before consent."""
+    digest = "a" * 64
+    source = (
+        "https://huggingface.co/owner/repository/resolve/"
+        + ("b" * 40)
+        + "/nested/model%20%5Bq4%5D.gguf"
+    )
+    app = _PanelApp(
+        _report(tmp_path / "managed"),
+        selected_file_details=(
+            ("nested/model [q4].gguf", 1_234_567, digest, source),
+        ),
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        panel = app.query_one(".model-plan-panel", Static)
+        text = str(panel.renderable)
+
+    assert "Selected upstream files:" in text
+    assert "Path: nested/model [q4].gguf" in text
+    assert "Bytes: 1234567" in text
+    assert f"SHA-256: {digest}" in text
+    assert f"Pinned source URL: {source}" in text
+    assert panel._render_markup is False
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_model_browser_state.py
+++ b/Tests/UI/test_model_browser_state.py
@@ -1,5 +1,6 @@
 """Pure state-mapping tests for the managed model browser."""
 
+from dataclasses import replace
 from pathlib import Path
 
 from tldw_chatbook.Model_Artifacts.acquisition import (
@@ -12,6 +13,8 @@ from tldw_chatbook.Model_Artifacts.service import (
     InstalledArtifact,
     ProvenanceClass,
 )
+
+from Tests.Model_Artifacts.test_acquisition_types import make_descriptor
 
 
 def _report(destination: Path) -> PreflightReport:
@@ -114,6 +117,91 @@ def test_inventory_keeps_broken_and_unmanaged_rows_visible(tmp_path: Path) -> No
     assert rows[1].provenance == "Unmanaged — integrity unknown"
     assert rows[1].installed_store_bytes == 100
     assert rows[1].staging_store_bytes == 25
+
+
+def test_inventory_marks_unassigned_models_ineligible_for_activation(
+    tmp_path: Path,
+) -> None:
+    """A downloaded unassigned model never claims runtime compatibility.
+
+    This fails if inventory uses readiness or active state to enable an
+    unassigned descriptor, rather than its consumer authority.
+    """
+    from tldw_chatbook.UI.Screens.model_browser_state import inventory_rows
+
+    descriptor = replace(make_descriptor(), consumer="unassigned")
+    row = inventory_rows(
+        (
+            InstalledArtifact(
+                path=tmp_path / "remote-model",
+                descriptor=descriptor,
+                ready=True,
+                active=True,
+                error=None,
+            ),
+        ),
+        None,
+        (),
+    )[0]
+
+    assert row.activation_allowed is False
+    assert row.action_hint == "Downloaded · runtime compatibility not verified"
+
+
+def test_inventory_keeps_repair_copy_ahead_of_unassigned_compatibility(
+    tmp_path: Path,
+) -> None:
+    """A broken unassigned model remains repairable instead of looking ready.
+
+    This fails if the unassigned compatibility branch precedes the broken
+    branch.
+    """
+    from tldw_chatbook.UI.Screens.model_browser_state import inventory_rows
+
+    descriptor = replace(make_descriptor(), consumer="unassigned")
+    row = inventory_rows(
+        (
+            InstalledArtifact(
+                path=tmp_path / "broken-remote-model",
+                descriptor=descriptor,
+                ready=True,
+                active=True,
+                error="manifest mismatch",
+            ),
+        ),
+        None,
+        (),
+    )[0]
+
+    assert row.activation_allowed is False
+    assert row.action_hint == "Needs repair — Repair"
+
+
+def test_inventory_keeps_assigned_consumer_readiness_copy(tmp_path: Path) -> None:
+    """An assigned ready model retains the existing activation state copy.
+
+    This fails if the unassigned policy suppresses activation for any other
+    consumer.
+    """
+    from tldw_chatbook.UI.Screens.model_browser_state import inventory_rows
+
+    descriptor = make_descriptor()
+    row = inventory_rows(
+        (
+            InstalledArtifact(
+                path=tmp_path / "assigned-model",
+                descriptor=descriptor,
+                ready=True,
+                active=False,
+                error=None,
+            ),
+        ),
+        None,
+        (),
+    )[0]
+
+    assert row.activation_allowed is True
+    assert row.action_hint == "Ready"
 
 
 def test_install_failure_messages_are_typed_labeled_and_sanitized() -> None:

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -105,6 +105,55 @@ async def test_activation_controls_emit_intents_and_refuse_pending_reentry() -> 
         assert app.query_one(".model-delete", Button).disabled is True
 
 
+@pytest.mark.asyncio
+async def test_unassigned_controls_omit_activate_and_keep_delete_available() -> None:
+    """An unassigned inventory row can be deleted but cannot request activation.
+
+    This fails if disabling activation also removes Delete, or if controls
+    render an activation affordance when policy disallows it.
+    """
+    from tldw_chatbook.Widgets.ModelArtifacts.activation_controls import (
+        DeletionRequested,
+        ModelActivationControls,
+    )
+
+    reference = ArtifactRef("remote-gguf", "immutable-revision", "q4_k_m")
+
+    class _ControlsApp(App):
+        def __init__(self) -> None:
+            self.messages = []
+            super().__init__()
+
+        def compose(self) -> ComposeResult:
+            yield ModelActivationControls(
+                reference,
+                active=False,
+                ready=True,
+                allow_activation=False,
+            )
+
+        def on_deletion_requested(self, event: DeletionRequested) -> None:
+            self.messages.append(event)
+
+    app = _ControlsApp()
+    async with app.run_test() as pilot:
+        controls = app.query_one(ModelActivationControls)
+        assert len(app.query(".model-activate")) == 0
+        assert app.query_one(".model-delete", Button).disabled is False
+
+        controls.set_pending(True)
+        await pilot.pause()
+        assert app.query_one(".model-delete", Button).disabled is True
+
+        controls.set_pending(False)
+        await pilot.click(".model-delete")
+        await pilot.pause()
+
+    assert len(app.messages) == 1
+    assert isinstance(app.messages[0], DeletionRequested)
+    assert app.messages[0].reference == reference
+
+
 def test_installed_view_refuses_a_second_lifecycle_operation() -> None:
     """Activation/deletion cannot re-enter while hashing or leasing is pending."""
     from tldw_chatbook.UI.Screens.model_installed_view import InstalledView

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -368,6 +368,59 @@ async def test_same_generation_resolve_rejects_when_repository_input_changes() -
 
 
 @pytest.mark.asyncio
+async def test_resolution_mismatch_removes_stale_rendered_candidate_controls() -> None:
+    """Cleared retained state must also remove previously mounted candidates."""
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+    old_resolved = _resolved("old/repository")
+    new_resolved = _resolved("new/repository")
+
+    async with app.run_test() as pilot:
+        query = view.query_one("#remote-model-query", Input)
+        query.value = "old/repository"
+        view._resolve_generation = 1
+        view._apply_resolve_result(
+            1,
+            "old/repository",
+            "old/repository",
+            old_resolved,
+            None,
+        )
+        await pilot.pause()
+        assert list(view.query(".remote-candidate").results(Button))
+
+        view._resolve_remote = MagicMock()
+        query.value = "new/repository"
+        view._search_submitted()
+        assert "Inspecting repository" in _text(view)
+
+        query.value = "changed/repository"
+        view._apply_resolve_result(
+            2,
+            "new/repository",
+            "new/repository",
+            new_resolved,
+            None,
+        )
+        await pilot.pause()
+
+        stale_controls = list(
+            view.query(".remote-result, .remote-candidate").results(Button)
+        )
+        status = str(view.query_one("#remote-model-status", Static).renderable)
+        search_disabled = view.query_one("#remote-model-search", Button).disabled
+        query_disabled = query.disabled
+
+    assert stale_controls == []
+    assert view._selected_catalog is None
+    assert view._operation_reference is None
+    assert "Inspecting repository" not in status
+    assert "Press Search" in status
+    assert search_disabled is False
+    assert query_disabled is False
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("error", "expected"),
     (

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -25,6 +25,7 @@ from tldw_chatbook.Model_Artifacts.acquisition import (
     AcquisitionProgress,
     ArtifactPreflightEntry,
     PreflightReport,
+    TransferError,
 )
 from tldw_chatbook.Model_Artifacts.service import ProvenanceClass
 
@@ -34,7 +35,9 @@ _DIGEST = "b" * 64
 
 
 class _Resolver:
-    def __init__(self, calls: list[str], token: str | None = "configured-token") -> None:
+    def __init__(
+        self, calls: list[str], token: str | None = "configured-token"
+    ) -> None:
         self.calls = calls
         self.token = token
 
@@ -257,7 +260,9 @@ async def test_free_text_search_resolves_only_after_result_selection() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stale_search_and_resolve_completions_cannot_replace_newer_results() -> None:
+async def test_stale_search_and_resolve_completions_cannot_replace_newer_results() -> (
+    None
+):
     """Removing either generation check must let an older completion overwrite state."""
     view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
     app = _RemoteApp(view)
@@ -299,7 +304,9 @@ async def test_stale_search_and_resolve_completions_cannot_replace_newer_results
 
 
 @pytest.mark.asyncio
-async def test_same_generation_resolve_rejects_a_different_repository_response() -> None:
+async def test_same_generation_resolve_rejects_a_different_repository_response() -> (
+    None
+):
     """An adapter identity mismatch must never expose an installable candidate."""
     adapter = _Adapter(resolved=_resolved("other/repository"))
     view = _view(
@@ -502,6 +509,7 @@ async def test_no_eligible_error_renders_bounded_incomplete_shard_details() -> N
 @pytest.mark.asyncio
 async def test_oversized_lfs_size_recovers_without_rendering_a_candidate() -> None:
     """Hostile declared sizes must be rejected before the Remote view formats them."""
+
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
@@ -518,9 +526,7 @@ async def test_oversized_lfs_size_recovers_without_rendering_a_candidate() -> No
         )
 
     adapter = HuggingFaceRemoteAdapter(
-        client_factory=lambda: httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        )
+        client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
     )
     view = _view(
         adapter_factory=lambda: adapter,
@@ -595,7 +601,9 @@ async def test_candidate_cap_discloses_deterministic_first_hundred() -> None:
 
 
 @pytest.mark.asyncio
-async def test_candidate_selection_freezes_catalog_and_disables_all_replacement_controls() -> None:
+async def test_candidate_selection_freezes_catalog_and_disables_all_replacement_controls() -> (
+    None
+):
     """A pending plan must remain bound to the selected candidate."""
     resolved = _resolved()
     view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
@@ -830,6 +838,55 @@ async def test_provision_reuses_exact_preflight_values_without_activation(
     assert callable(progress)
     assert activate is False
     resolver_factory.assert_called_once_with()
+
+
+@pytest.mark.parametrize("operation", ("preflight", "installation"))
+def test_install_failures_log_safe_classification_without_exception_details(
+    operation: str,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Worker diagnostics classify failures without logging exception details."""
+    from tldw_chatbook.UI.Screens import model_remote_view as module
+
+    marker = "PRIVATE-REMOTE-INSTALL-DETAIL"
+    resolved = _resolved()
+    candidate = resolved.candidates[0]
+    catalog = build_remote_catalog(resolved, candidate)
+    report = _report_for(catalog, tmp_path / "managed")
+    fake_app = MagicMock()
+    fake_logger = MagicMock()
+    monkeypatch.setattr(module.RemoteView, "app", property(lambda self: fake_app))
+    monkeypatch.setattr(module, "logger", fake_logger)
+    view = module.RemoteView()
+
+    if operation == "preflight":
+
+        async def fail_preflight(_catalog):
+            raise TransferError(marker, retryable=True)
+
+        view._preflight = fail_preflight
+        module.RemoteView._preflight_model.__wrapped__(
+            view,
+            catalog,
+            candidate,
+        )
+    else:
+        view._pending_report = report
+        view._selected_catalog = catalog
+
+        async def fail_provision(_report, _catalog):
+            raise TransferError(marker, retryable=True)
+
+        view._provision = fail_provision
+        module.RemoteView._provision_model.__wrapped__(view)
+
+    logged = " ".join(str(value) for value in fake_logger.error.call_args.args)
+    assert "TransferError" in logged
+    assert "retryable" in logged.casefold()
+    assert "True" in logged
+    assert marker not in logged
+    assert marker not in str(fake_app.call_from_thread.call_args)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from threading import Event
 from unittest.mock import MagicMock
 
 import pytest
@@ -274,13 +275,96 @@ async def test_stale_search_and_resolve_completions_cannot_replace_newer_results
         assert "old/result" not in _text(view)
 
         view._resolve_generation = 4
-        view._apply_resolve_result(3, older_resolved, None)
-        view._apply_resolve_result(4, newer_resolved, None)
+        view._apply_resolve_result(
+            3,
+            "old/result",
+            "old query",
+            older_resolved,
+            None,
+        )
+        view._apply_resolve_result(
+            4,
+            "new/result",
+            "new query",
+            newer_resolved,
+            None,
+        )
         await pilot.pause()
         rendered = _text(view)
 
     assert "new/result · model-q4.gguf" in rendered
     assert "old/result · model-q4.gguf" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_same_generation_resolve_rejects_a_different_repository_response() -> None:
+    """An adapter identity mismatch must never expose an installable candidate."""
+    adapter = _Adapter(resolved=_resolved("other/repository"))
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver([]),
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
+        rendered = _text(view)
+        candidate_buttons = list(view.query(".remote-candidate").results(Button))
+        search_disabled = view.query_one("#remote-model-search", Button).disabled
+
+    assert "other/repository · model-q4.gguf" not in rendered
+    assert candidate_buttons == []
+    assert view._selected_catalog is None
+    assert search_disabled is False
+
+
+@pytest.mark.asyncio
+async def test_same_generation_resolve_rejects_when_repository_input_changes() -> None:
+    """Input drift during one request must not make its completion installable."""
+    started = Event()
+    release = Event()
+
+    class _WaitingAdapter(_Adapter):
+        async def resolve(
+            self,
+            repository: str,
+            *,
+            token: str | None = None,
+        ) -> ResolvedRemoteModel:
+            self.resolve_calls.append((repository, token))
+            started.set()
+            release.wait(timeout=2)
+            return self.resolved
+
+    adapter = _WaitingAdapter(resolved=_resolved("owner/repository"))
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver([]),
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        query = view.query_one("#remote-model-query", Input)
+        query.value = "owner/repository"
+        await pilot.click("#remote-model-search")
+        for _attempt in range(20):
+            if started.is_set():
+                break
+            await pilot.pause()
+        assert started.is_set(), "resolve worker did not reach the adapter"
+
+        query.value = "new/repository"
+        release.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = _text(view)
+        candidate_buttons = list(view.query(".remote-candidate").results(Button))
+        search_disabled = view.query_one("#remote-model-search", Button).disabled
+
+    assert "owner/repository · model-q4.gguf" not in rendered
+    assert candidate_buttons == []
+    assert view._selected_catalog is None
+    assert search_disabled is False
 
 
 @pytest.mark.asyncio
@@ -315,8 +399,15 @@ async def test_discovery_errors_render_sanitized_retry_guidance(
     app = _RemoteApp(view)
 
     async with app.run_test() as pilot:
+        view.query_one("#remote-model-query", Input).value = "owner/repository"
         view._resolve_generation = 1
-        view._apply_resolve_result(1, None, error)
+        view._apply_resolve_result(
+            1,
+            "owner/repository",
+            "owner/repository",
+            None,
+            error,
+        )
         await pilot.pause()
         rendered = _text(view)
 
@@ -333,8 +424,15 @@ async def test_incomplete_shard_warnings_render_bounded_candidate_and_indexes() 
     app = _RemoteApp(view)
 
     async with app.run_test() as pilot:
+        view.query_one("#remote-model-query", Input).value = "owner/repository"
         view._resolve_generation = 1
-        view._apply_resolve_result(1, resolved, None)
+        view._apply_resolve_result(
+            1,
+            "owner/repository",
+            "owner/repository",
+            resolved,
+            None,
+        )
         await pilot.pause()
         rendered = _text(view)
 
@@ -350,8 +448,15 @@ async def test_candidate_selection_freezes_catalog_and_disables_all_replacement_
     view._preflight_model = MagicMock()
 
     async with app.run_test() as pilot:
+        view.query_one("#remote-model-query", Input).value = "owner/repository"
         view._resolve_generation = 1
-        view._apply_resolve_result(1, resolved, None)
+        view._apply_resolve_result(
+            1,
+            "owner/repository",
+            "owner/repository",
+            resolved,
+            None,
+        )
         await pilot.pause()
         await pilot.click(".remote-candidate")
         await pilot.pause()

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from threading import Event
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Model_Artifacts.remote_huggingface import (
+    HuggingFaceRemoteAdapter,
     RemoteDiscoveryError,
     RemoteGGUFCandidate,
     RemoteGGUFFile,
@@ -469,6 +471,74 @@ async def test_discovery_errors_render_sanitized_retry_guidance(
 
 
 @pytest.mark.asyncio
+async def test_no_eligible_error_renders_bounded_incomplete_shard_details() -> None:
+    """Validated missing-shard recovery details must follow the generic LFS rule."""
+    detail = "owner/repository · model-q4 missing 00002 00004"
+    error = RemoteDiscoveryError("no_eligible_gguf", details=(detail,))
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        view.query_one("#remote-model-query", Input).value = "owner/repository"
+        view._resolve_generation = 1
+        view._apply_resolve_result(
+            1,
+            "owner/repository",
+            "owner/repository",
+            None,
+            error,
+        )
+        await pilot.pause()
+        status = view.query_one("#remote-model-status", Static)
+        rendered = str(status.renderable)
+
+    generic = "Files must be LFS-backed with size and SHA-256 metadata."
+    assert generic in rendered
+    assert detail in rendered
+    assert rendered.index(generic) < rendered.index(detail)
+    assert status._render_markup is False
+
+
+@pytest.mark.asyncio
+async def test_oversized_lfs_size_recovers_without_rendering_a_candidate() -> None:
+    """Hostile declared sizes must be rejected before the Remote view formats them."""
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "sha": _COMMIT,
+                "siblings": [
+                    {
+                        "rfilename": "huge.gguf",
+                        "lfs": {"size": 2**63, "sha256": _DIGEST},
+                    }
+                ],
+                "cardData": None,
+            },
+        )
+
+    adapter = HuggingFaceRemoteAdapter(
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler)
+        )
+    )
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver([]),
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
+        rendered = _text(view)
+        candidates = list(view.query(".remote-candidate").results(Button))
+
+    assert "No eligible GGUF files were found" in rendered
+    assert str(2**63) not in rendered
+    assert candidates == []
+
+
+@pytest.mark.asyncio
 async def test_incomplete_shard_warnings_render_bounded_candidate_and_indexes() -> None:
     """Dropping resolution warnings must hide the actionable missing-shard evidence."""
     warning = "owner/repository · model-q4 missing 00002 00004"
@@ -490,6 +560,38 @@ async def test_incomplete_shard_warnings_render_bounded_candidate_and_indexes() 
         rendered = _text(view)
 
     assert warning in rendered
+
+
+@pytest.mark.asyncio
+async def test_candidate_cap_discloses_deterministic_first_hundred() -> None:
+    """A truncated candidate list must disclose its deterministic upstream order."""
+    candidates = tuple(
+        RemoteGGUFCandidate(
+            label=f"owner/repository · {index:03d}.gguf",
+            files=(RemoteGGUFFile(f"{index:03d}.gguf", 1, _DIGEST),),
+            total_bytes=1,
+        )
+        for index in range(100)
+    )
+    resolved = ResolvedRemoteModel(
+        repository="owner/repository",
+        commit=_COMMIT,
+        license_id="apache-2.0",
+        review_url=f"https://huggingface.co/owner/repository/tree/{_COMMIT}",
+        candidates=candidates,
+        total_candidate_count=137,
+        warnings=(),
+    )
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        view._resolved = resolved
+        view._refresh_with_status("Select one GGUF candidate.")
+        await pilot.pause()
+        rendered = _text(view)
+
+    assert "First 100 of 137, sorted by upstream path" in rendered
 
 
 @pytest.mark.asyncio
@@ -520,6 +622,32 @@ async def test_candidate_selection_freezes_catalog_and_disables_all_replacement_
         assert view.query_one("#remote-model-query", Input).disabled is True
         assert view.query_one("#remote-model-search", Button).disabled is True
         assert view.query_one(".remote-candidate", Button).disabled is True
+
+
+@pytest.mark.asyncio
+async def test_stale_candidate_press_is_rejected_at_the_ui_boundary() -> None:
+    """A queued button event from an old resolution must not start preflight."""
+    old_resolved = _resolved("old/repository")
+    current_resolved = _resolved("current/repository")
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    view._preflight_model = MagicMock()
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        view._resolved = old_resolved
+        view._refresh_with_status("Old resolution")
+        await pilot.pause()
+        stale_button = view.query_one(".remote-candidate", Button)
+
+        view._resolved = current_resolved
+        view._refresh_with_status("Current resolution")
+        await pilot.pause()
+        view._candidate_pressed(Button.Pressed(stale_button))
+        await pilot.pause()
+
+    view._preflight_model.assert_not_called()
+    assert view._selected_catalog is None
+    assert view._operation_reference is None
 
 
 @pytest.mark.asyncio
@@ -617,7 +745,9 @@ def test_preflight_modal_requires_acknowledgment_only_for_unknown_license(
     from tldw_chatbook.UI.Screens import model_remote_view as module
     from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
 
-    catalog = _catalog(license_id=license_id)
+    resolved = _resolved(license_id=license_id)
+    candidate = resolved.candidates[0]
+    catalog = build_remote_catalog(resolved, candidate)
     report = _report_for(catalog, tmp_path / "managed")
     fake_app = MagicMock()
     monkeypatch.setattr(module.RemoteView, "app", property(lambda self: fake_app))
@@ -625,11 +755,19 @@ def test_preflight_modal_requires_acknowledgment_only_for_unknown_license(
     view._selected_catalog = catalog
     view._operation_reference = report.root
 
-    view._apply_preflight_result(report, None)
+    view._apply_preflight_result(report, None, candidate)
 
     modal, callback = fake_app.push_screen.call_args.args
     assert isinstance(modal, ModelInstallModal)
     assert modal.required_acknowledgment == expected_acknowledgment
+    assert modal.selected_file_details == (
+        (
+            "model-q4.gguf",
+            1024,
+            _DIGEST,
+            f"https://huggingface.co/owner/repository/resolve/{_COMMIT}/model-q4.gguf",
+        ),
+    )
     assert callback == view._confirm_install
 
 

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -1,0 +1,625 @@
+"""Focused behavior tests for lazy managed Remote model discovery."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Static
+
+from tldw_chatbook.Model_Artifacts.remote_huggingface import (
+    RemoteDiscoveryError,
+    RemoteGGUFCandidate,
+    RemoteGGUFFile,
+    RemoteModelSummary,
+    ResolvedRemoteModel,
+    build_remote_catalog,
+)
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    AcquisitionProgress,
+    ArtifactPreflightEntry,
+    PreflightReport,
+)
+from tldw_chatbook.Model_Artifacts.service import ProvenanceClass
+
+
+_COMMIT = "a" * 40
+_DIGEST = "b" * 64
+
+
+class _Resolver:
+    def __init__(self, calls: list[str], token: str | None = "configured-token") -> None:
+        self.calls = calls
+        self.token = token
+
+    def resolve(self, repository: str) -> str | None:
+        self.calls.append(repository)
+        return self.token
+
+
+class _Adapter:
+    def __init__(
+        self,
+        *,
+        search_result: tuple[RemoteModelSummary, ...] = (),
+        resolved: ResolvedRemoteModel | None = None,
+    ) -> None:
+        self.search_result = search_result
+        self.resolved = resolved or _resolved()
+        self.search_calls: list[tuple[str, str | None]] = []
+        self.resolve_calls: list[tuple[str, str | None]] = []
+
+    async def search(
+        self,
+        query: str,
+        *,
+        token: str | None = None,
+    ) -> tuple[RemoteModelSummary, ...]:
+        self.search_calls.append((query, token))
+        return self.search_result
+
+    async def resolve(
+        self,
+        repository: str,
+        *,
+        token: str | None = None,
+    ) -> ResolvedRemoteModel:
+        self.resolve_calls.append((repository, token))
+        return self.resolved
+
+
+def _summary(repository: str = "owner/repository") -> RemoteModelSummary:
+    return RemoteModelSummary(
+        repository=repository,
+        private=False,
+        gated="none",
+        downloads=12,
+        likes=3,
+        last_modified="2026-08-01T00:00:00Z",
+    )
+
+
+def _candidate(label: str = "owner/repository · model-q4.gguf") -> RemoteGGUFCandidate:
+    return RemoteGGUFCandidate(
+        label=label,
+        files=(RemoteGGUFFile("model-q4.gguf", 1024, _DIGEST),),
+        total_bytes=1024,
+    )
+
+
+def _resolved(
+    repository: str = "owner/repository",
+    *,
+    license_id: str = "apache-2.0",
+    warnings: tuple[str, ...] = (),
+) -> ResolvedRemoteModel:
+    return ResolvedRemoteModel(
+        repository=repository,
+        commit=_COMMIT,
+        license_id=license_id,
+        review_url=f"https://huggingface.co/{repository}/tree/{_COMMIT}",
+        candidates=(_candidate(f"{repository} · model-q4.gguf"),),
+        total_candidate_count=1,
+        warnings=warnings,
+    )
+
+
+def _catalog(*, license_id: str = "apache-2.0"):
+    resolved = _resolved(license_id=license_id)
+    return build_remote_catalog(resolved, resolved.candidates[0])
+
+
+def _report_for(catalog, destination: Path) -> PreflightReport:
+    descriptor = catalog.artifact
+    return PreflightReport(
+        root=descriptor.reference,
+        closure_fingerprint="f" * 64,
+        entries=(
+            ArtifactPreflightEntry(
+                ref=descriptor.reference,
+                source_url=descriptor.source_url,
+                repository=descriptor.upstream_repository,
+                revision=descriptor.upstream_revision,
+                license_id=descriptor.license_id,
+                license_url=descriptor.license_url,
+                precision=descriptor.precision,
+                total_bytes=descriptor.expected_installed_bytes,
+                file_count=len(descriptor.files),
+                already_installed=False,
+                provenance=(ProvenanceClass.LOCAL_INTEGRITY_RECORDED,),
+            ),
+        ),
+        download_bytes=descriptor.expected_installed_bytes,
+        already_staged_bytes=0,
+        staging_overhead_bytes=128,
+        retained_bytes=0,
+        destination=destination,
+        free_bytes=4096,
+        required_bytes=descriptor.expected_installed_bytes + 128,
+        sufficient_space=True,
+        gating_errors=(),
+    )
+
+
+class _RemoteApp(App):
+    def __init__(self, view) -> None:
+        self.view = view
+        self.install_statuses: list[object] = []
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield self.view
+
+    def on_install_status_changed(self, event) -> None:
+        self.install_statuses.append(event)
+
+
+def _view(
+    *,
+    adapter_factory: Callable[[], object],
+    resolver_factory: Callable[[], object],
+    service_factory: Callable[[], object] = MagicMock,
+):
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    return RemoteView(
+        adapter_factory=adapter_factory,
+        credential_resolver_factory=resolver_factory,
+        service_factory=service_factory,
+    )
+
+
+async def _submit(app: _RemoteApp, pilot, query: str) -> None:
+    app.view.query_one("#remote-model-query", Input).value = query
+    await pilot.click("#remote-model-search")
+    await app.workers.wait_for_complete()
+    await pilot.pause()
+
+
+def _text(view) -> str:
+    return "\n".join(str(item.renderable) for item in view.query(Static))
+
+
+@pytest.mark.asyncio
+async def test_compose_and_mount_create_no_remote_dependencies_or_io() -> None:
+    """An eager parent mount cannot instantiate any I/O-bearing dependency."""
+    adapter_factory = MagicMock()
+    resolver_factory = MagicMock()
+    service_factory = MagicMock()
+    view = _view(
+        adapter_factory=adapter_factory,
+        resolver_factory=resolver_factory,
+        service_factory=service_factory,
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+    adapter_factory.assert_not_called()
+    resolver_factory.assert_not_called()
+    service_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_exact_repository_submission_resolves_without_searching() -> None:
+    """Changing exact-ID classification must not add an unnecessary search request."""
+    adapter = _Adapter(resolved=_resolved())
+    resolver_calls: list[str] = []
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver(resolver_calls),
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
+        rendered = _text(view)
+
+    assert adapter.search_calls == []
+    assert adapter.resolve_calls == [("owner/repository", "configured-token")]
+    assert resolver_calls == ["owner/repository"]
+    assert "owner/repository · model-q4.gguf" in rendered
+
+
+@pytest.mark.asyncio
+async def test_free_text_search_resolves_only_after_result_selection() -> None:
+    """Free text must remain a search and selection must resolve that exact result."""
+    adapter = _Adapter(search_result=(_summary(),), resolved=_resolved())
+    resolver_calls: list[str] = []
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver(resolver_calls),
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "quantized model")
+        assert adapter.search_calls == [("quantized model", "configured-token")]
+        assert adapter.resolve_calls == []
+        assert "owner/repository" in _text(view)
+
+        await pilot.click(".remote-result")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = _text(view)
+
+    assert adapter.resolve_calls == [("owner/repository", "configured-token")]
+    assert resolver_calls == ["quantized model", "owner/repository"]
+    assert "Runtime compatibility has not been verified." in rendered
+    assert "Local integrity recorded" in rendered
+
+
+@pytest.mark.asyncio
+async def test_stale_search_and_resolve_completions_cannot_replace_newer_results() -> None:
+    """Removing either generation check must let an older completion overwrite state."""
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+    older_summary = _summary("old/result")
+    newer_summary = _summary("new/result")
+    older_resolved = _resolved("old/result")
+    newer_resolved = _resolved("new/result")
+
+    async with app.run_test() as pilot:
+        query = view.query_one("#remote-model-query", Input)
+        query.value = "new query"
+        view._search_generation = 2
+        view._apply_search_result(1, "old query", (older_summary,), None)
+        view._apply_search_result(2, "new query", (newer_summary,), None)
+        await pilot.pause()
+        assert "new/result" in _text(view)
+        assert "old/result" not in _text(view)
+
+        view._resolve_generation = 4
+        view._apply_resolve_result(3, older_resolved, None)
+        view._apply_resolve_result(4, newer_resolved, None)
+        await pilot.pause()
+        rendered = _text(view)
+
+    assert "new/result · model-q4.gguf" in rendered
+    assert "old/result · model-q4.gguf" not in rendered
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    (
+        (
+            RemoteDiscoveryError("authentication_required"),
+            "Configure or verify Hugging Face access, then Retry.",
+        ),
+        (RemoteDiscoveryError("rate_limited", retryable=True), "Retry."),
+        (RemoteDiscoveryError("network_error", retryable=True), "Retry."),
+        (
+            RemoteDiscoveryError("response_too_large"),
+            "cannot be safely inspected",
+        ),
+        (
+            RemoteDiscoveryError(
+                "no_eligible_gguf",
+                details=("owner/repository · model missing 00002",),
+            ),
+            "LFS-backed with size and SHA-256 metadata",
+        ),
+    ),
+)
+async def test_discovery_errors_render_sanitized_retry_guidance(
+    error: RemoteDiscoveryError,
+    expected: str,
+) -> None:
+    """Raw upstream details must never displace bounded recovery guidance."""
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        view._resolve_generation = 1
+        view._apply_resolve_result(1, None, error)
+        await pilot.pause()
+        rendered = _text(view)
+
+    assert expected in rendered
+    assert repr(error) not in rendered
+
+
+@pytest.mark.asyncio
+async def test_incomplete_shard_warnings_render_bounded_candidate_and_indexes() -> None:
+    """Dropping resolution warnings must hide the actionable missing-shard evidence."""
+    warning = "owner/repository · model-q4 missing 00002 00004"
+    resolved = _resolved(warnings=(warning,))
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        view._resolve_generation = 1
+        view._apply_resolve_result(1, resolved, None)
+        await pilot.pause()
+        rendered = _text(view)
+
+    assert warning in rendered
+
+
+@pytest.mark.asyncio
+async def test_candidate_selection_freezes_catalog_and_disables_all_replacement_controls() -> None:
+    """A pending plan must remain bound to the selected candidate."""
+    resolved = _resolved()
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+    view._preflight_model = MagicMock()
+
+    async with app.run_test() as pilot:
+        view._resolve_generation = 1
+        view._apply_resolve_result(1, resolved, None)
+        await pilot.pause()
+        await pilot.click(".remote-candidate")
+        await pilot.pause()
+
+        expected = build_remote_catalog(resolved, resolved.candidates[0])
+        assert view._selected_catalog == expected
+        assert view._operation_reference == expected.artifact.reference
+        assert view.query_one("#remote-model-query", Input).disabled is True
+        assert view.query_one("#remote-model-search", Button).disabled is True
+        assert view.query_one(".remote-candidate", Button).disabled is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_receives_exact_catalog_sources_and_fresh_resolver(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Changing the catalog, source map, or credential seam must fail this boundary."""
+    from tldw_chatbook.UI.Screens import model_remote_view as module
+
+    catalog = _catalog()
+    report = _report_for(catalog, tmp_path / "managed")
+    core = object()
+    resolver = object()
+    captured: dict[str, object] = {}
+
+    class _Acquisition:
+        def __init__(self, received_core, *, credential_resolver) -> None:
+            captured["core"] = received_core
+            captured["resolver"] = credential_resolver
+
+        async def preflight(self, root, received_catalog, *, sources):
+            captured["preflight"] = (root, received_catalog, sources)
+            return report
+
+    monkeypatch.setattr(module, "ArtifactAcquisitionService", _Acquisition)
+    resolver_factory = MagicMock(return_value=resolver)
+    view = _view(
+        adapter_factory=MagicMock(),
+        resolver_factory=resolver_factory,
+        service_factory=lambda: core,
+    )
+
+    actual = await view._preflight(catalog)
+
+    assert actual is report
+    assert captured == {
+        "core": core,
+        "resolver": resolver,
+        "preflight": (
+            catalog.artifact.reference,
+            catalog,
+            catalog.sources,
+        ),
+    }
+    resolver_factory.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_default_preflight_uses_env_config_credential_resolver(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """The production path must not silently fall back to anonymous acquisition."""
+    from tldw_chatbook.Model_Artifacts.acquisition import EnvConfigCredentialResolver
+    from tldw_chatbook.UI.Screens import model_remote_view as module
+
+    catalog = _catalog()
+    report = _report_for(catalog, tmp_path / "managed")
+    captured: list[object] = []
+
+    class _Acquisition:
+        def __init__(self, _core, *, credential_resolver) -> None:
+            captured.append(credential_resolver)
+
+        async def preflight(self, _root, _catalog, *, sources):
+            return report
+
+    monkeypatch.setattr(module, "ArtifactAcquisitionService", _Acquisition)
+    view = module.RemoteView(service_factory=lambda: object())
+
+    await view._preflight(catalog)
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], EnvConfigCredentialResolver)
+
+
+@pytest.mark.parametrize(
+    ("license_id", "expected_acknowledgment"),
+    (
+        (
+            "NOASSERTION",
+            "No license was declared. I reviewed the source and want to continue.",
+        ),
+        ("apache-2.0", None),
+    ),
+)
+def test_preflight_modal_requires_acknowledgment_only_for_unknown_license(
+    license_id: str,
+    expected_acknowledgment: str | None,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Known licenses must not be gated and unknown licenses must be explicit."""
+    from tldw_chatbook.UI.Screens import model_remote_view as module
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+    catalog = _catalog(license_id=license_id)
+    report = _report_for(catalog, tmp_path / "managed")
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.RemoteView, "app", property(lambda self: fake_app))
+    view = module.RemoteView()
+    view._selected_catalog = catalog
+    view._operation_reference = report.root
+
+    view._apply_preflight_result(report, None)
+
+    modal, callback = fake_app.push_screen.call_args.args
+    assert isinstance(modal, ModelInstallModal)
+    assert modal.required_acknowledgment == expected_acknowledgment
+    assert callback == view._confirm_install
+
+
+@pytest.mark.asyncio
+async def test_provision_reuses_exact_preflight_values_without_activation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Any catalog/source substitution or activation would violate reviewed consent."""
+    from tldw_chatbook.UI.Screens import model_remote_view as module
+
+    catalog = _catalog()
+    report = _report_for(catalog, tmp_path / "managed")
+    core = object()
+    resolver = object()
+    captured: dict[str, object] = {}
+
+    class _Acquisition:
+        def __init__(self, received_core, *, credential_resolver) -> None:
+            captured["core"] = received_core
+            captured["resolver"] = credential_resolver
+
+        async def provision(
+            self,
+            root,
+            consent,
+            received_catalog,
+            *,
+            sources,
+            progress,
+            activate,
+        ):
+            captured["provision"] = (
+                root,
+                consent,
+                received_catalog,
+                sources,
+                progress,
+                activate,
+            )
+
+    monkeypatch.setattr(module, "ArtifactAcquisitionService", _Acquisition)
+    resolver_factory = MagicMock(return_value=resolver)
+    view = _view(
+        adapter_factory=MagicMock(),
+        resolver_factory=resolver_factory,
+        service_factory=lambda: core,
+    )
+    view.post_message = MagicMock()
+
+    await view._provision(report, catalog)
+
+    root, consent, actual_catalog, sources, progress, activate = captured["provision"]
+    assert captured["core"] is core
+    assert captured["resolver"] is resolver
+    assert root == report.root
+    assert consent == report.grant()
+    assert actual_catalog is catalog
+    assert sources is catalog.sources
+    assert callable(progress)
+    assert activate is False
+    resolver_factory.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_controls_stay_disabled_through_consent_and_reenable_after_failure(
+    tmp_path: Path,
+) -> None:
+    """Consent must not create a window where Search can replace the plan."""
+    catalog = _catalog()
+    report = _report_for(catalog, tmp_path / "managed")
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+    view._preflight_model = MagicMock()
+    view._provision_model = MagicMock()
+
+    async with app.run_test() as pilot:
+        view._resolved = _resolved()
+        view._refresh_with_status("Select one GGUF candidate.")
+        await pilot.pause()
+        await pilot.click(".remote-candidate")
+        await pilot.pause()
+        view._apply_preflight_result(report, None)
+        await pilot.pause()
+
+        assert view.query_one("#remote-model-search", Button).disabled is True
+        assert view.query_one(".remote-candidate", Button).disabled is True
+
+        await pilot.click("#model-install-confirm")
+        await pilot.pause()
+        assert view.query_one("#remote-model-search", Button).disabled is True
+        assert view.query_one(".remote-candidate", Button).disabled is True
+
+        view._apply_provision_result("Managed download failed. Retry.")
+        await pilot.pause()
+
+        assert view.query_one("#remote-model-search", Button).disabled is False
+        assert view.query_one(".remote-candidate", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_progress_and_completion_publish_shared_lifecycle_and_success_copy(
+    tmp_path: Path,
+) -> None:
+    """Removing progress/completion messages must desynchronize Installed and Lab."""
+    from tldw_chatbook.Widgets.ModelArtifacts import (
+        InstallProgressed,
+        InstallStatusChanged,
+    )
+
+    catalog = _catalog()
+    report = _report_for(catalog, tmp_path / "managed")
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+    notifications: list[tuple[str, str]] = []
+    view._selected_catalog = catalog
+    view._pending_report = report
+    view._operation_reference = report.root
+    view._provision_model = MagicMock()
+
+    async with app.run_test() as pilot:
+        view.notify = lambda message, *, severity: notifications.append(
+            (message, severity)
+        )
+        view._confirm_install(True)
+        progress = AcquisitionProgress("fetch", report.root, "model.gguf", 1, 2)
+        view._install_progressed(InstallProgressed(progress))
+        await pilot.pause()
+        assert "Downloading" in _text(view)
+
+        view._apply_provision_result(None)
+        await pilot.pause()
+
+    statuses = [
+        message
+        for message in app.install_statuses
+        if isinstance(message, InstallStatusChanged)
+    ]
+    assert [(item.active, item.succeeded) for item in statuses] == [
+        (True, None),
+        (False, True),
+    ]
+    assert notifications == [
+        (
+            "Model downloaded and managed. Runtime compatibility has not been verified.",
+            "information",
+        )
+    ]
+    assert view._pending_report is None
+    assert view._operation_reference is None
+    assert view._selected_catalog is None

--- a/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
+++ b/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
@@ -1,0 +1,40 @@
+---
+id: TASK-596.1
+title: Add bounded Hugging Face GGUF discovery to the managed model browser
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-01 21:51'
+updated_date: '2026-08-01 22:00'
+labels:
+  - stt
+  - artifacts
+  - ui
+  - security
+dependencies:
+  - TASK-595
+references:
+  - backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+documentation:
+  - Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md
+  - >-
+    Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+parent_task_id: TASK-596
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let users explicitly find and download remote GGUF models through the shared managed-model flow without implying that arbitrary models are runtime-compatible or independently verified.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening Remote performs no network request; explicit search or exact repository submission runs off the Textual event loop with bounded, generation-fenced results.
+- [ ] #2 A selected repository resolves to an immutable commit and offers only LFS-backed single GGUF files or complete bounded GGUF shard sets with recorded sizes and SHA-256 digests.
+- [ ] #3 A selected candidate reaches the existing managed preflight, consent, download, verification, and installation flow; configured Hugging Face credentials support gated or private repositories without being persisted or forwarded across origins.
+- [ ] #4 Remote models are labeled Local integrity recorded, remain unassigned and inactive, and are never presented as runtime-compatible, transcription-ready, or eligible for automatic routing.
+- [ ] #5 Known license metadata is shown; missing license metadata is recorded as NOASSERTION with a pinned source-review page and requires explicit acknowledgment before download.
+- [ ] #6 Focused adapter, GGUF grouping, Textual, redirect-security, and managed-acquisition tests cover the flow without adding native or platform-specific dependencies; Windows and Linux gates remain required when runners are available.
+<!-- AC:END -->

--- a/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
+++ b/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-01 21:51'
-updated_date: '2026-08-01 22:22'
+updated_date: '2026-08-01 22:46'
 labels:
   - stt
   - artifacts
@@ -19,6 +19,7 @@ documentation:
   - Docs/superpowers/specs/2026-08-01-task-596-model-artifact-browser-design.md
   - >-
     Docs/superpowers/specs/2026-08-01-task-596-1-remote-model-discovery-design.md
+  - Docs/superpowers/plans/2026-08-01-task-596-1-remote-model-discovery.md
 parent_task_id: TASK-596
 priority: high
 ---
@@ -38,3 +39,18 @@ Let users explicitly find and download remote GGUF models through the shared man
 - [ ] #5 Focused adapter, GGUF grouping, Textual, redirect-security, and managed-acquisition tests cover the flow without adding native or platform-specific dependencies; Windows and Linux gates remain required when runners are available.
 - [ ] #6 Remote installation labels the model Local integrity recorded and does not activate it; its descriptor uses consumer=unassigned, Installed offers no activation action for that consumer, and no UI presents it as runtime-compatible, transcription-ready, or eligible for automatic routing.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase onto the latest origin/dev, confirm no TASK-596.1 documentation collision, and rerun the affected baseline.
+2. Add the bounded Hugging Face metadata adapter, exact repository resolution with blobs=true, GGUF grouping, and managed artifact mapping using test-first steps.
+3. Add install-without-activation and reject HTTPS-to-HTTP download redirects while preserving existing defaults.
+4. Update shared inventory, activation, plan, and consent widgets to represent unassigned downloads honestly.
+5. Add the explicit, lazy Remote view with generation fencing, credential-safe metadata requests, and the existing managed preflight/provision flow.
+6. Run focused regression/static gates, collect mocked-payload macOS evidence, request code review, and close TASK-596.1 only after all acceptance criteria pass.
+
+ADR required: no
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
+Reason: ADR-025 already owns remote artifact provenance, managed acquisition, activation, and runtime boundaries; this slice is additive within that boundary.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
+++ b/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-01 21:51'
-updated_date: '2026-08-02 01:47'
+updated_date: '2026-08-02 02:50'
 labels:
   - stt
   - artifacts
@@ -68,10 +68,16 @@ Implemented bounded Hugging Face GGUF discovery through the shared managed-artif
 - Final whole-branch review and scoped fix re-review are clean. After rebasing onto current dev, 576 affected tests passed with one existing Requests dependency warning; 12 credential-boundary and 8 deterministic macOS evidence tests passed. Branch-edited scope passes Ruff, mypy, py_compile, and diff checks. The known fetch.py F401 and acquisition.py:1823 mypy mismatch were verified on dev and remain out of scope. Windows/Linux gates remain required when runners are available.
 
 ADR required: no. ADR-025 remains authoritative for managed acquisition, provenance, activation, and runtime boundaries. No new dependency, provider framework, cache, compatibility detector, or alternate downloader was introduced.
+
+Post-closeout rebase: rebased the 20-commit branch cleanly onto `origin/dev` at `6792b3390`, after TASK-1822/PR #1189 restored the shared diagnostic baseline. Regenerated and reviewed exactly three branch-specific inventory deltas: digest-only line movement in `LLM_Management_Window.py` and `model_installed_view.py`, plus the new `model_remote_view.py` owner with two fixed artifact-identity error diagnostics. The persistent sink topology remains four files; the inventory now records 436 owners, 1,073 TASK-492 calls, and 6,702 TASK-494 calls.
+
+Fresh post-rebase verification: the complete affected matrix passed 576/576 with the required loopback permission; the diagnostic inventory, sentinel matrix, and persistent-boundary gate passed 18/18; JSON validation, py_compile, and both diff checks passed. The first sandboxed affected run passed 522 tests and produced 54 identical loopback-bind denials, all of which disappeared on the exact permitted rerun. Ruff passed every branch-edited Python file except the pre-existing `fetch.py:17` unused Loguru import, verified unchanged on `origin/dev`; excluding that baseline file, all checks passed. No new ADR is required; ADR-025 and ADR-029 remain authoritative.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Users can explicitly discover and securely download pinned Hugging Face GGUF artifacts through the managed model browser without automatic activation or unsupported runtime-compatibility claims.
+
+Rebased cleanly onto dev after the reviewed shared inventory repair. The branch-specific inventory is current, all 576 affected tests and 18 diagnostic/privacy tests pass, and no new Critical or Important review issue remains.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
+++ b/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-01 21:51'
-updated_date: '2026-08-02 02:50'
+updated_date: '2026-08-02 02:57'
 labels:
   - stt
   - artifacts
@@ -72,6 +72,10 @@ ADR required: no. ADR-025 remains authoritative for managed acquisition, provena
 Post-closeout rebase: rebased the 20-commit branch cleanly onto `origin/dev` at `6792b3390`, after TASK-1822/PR #1189 restored the shared diagnostic baseline. Regenerated and reviewed exactly three branch-specific inventory deltas: digest-only line movement in `LLM_Management_Window.py` and `model_installed_view.py`, plus the new `model_remote_view.py` owner with two fixed artifact-identity error diagnostics. The persistent sink topology remains four files; the inventory now records 436 owners, 1,073 TASK-492 calls, and 6,702 TASK-494 calls.
 
 Fresh post-rebase verification: the complete affected matrix passed 576/576 with the required loopback permission; the diagnostic inventory, sentinel matrix, and persistent-boundary gate passed 18/18; JSON validation, py_compile, and both diff checks passed. The first sandboxed affected run passed 522 tests and produced 54 identical loopback-bind denials, all of which disappeared on the exact permitted rerun. Ruff passed every branch-edited Python file except the pre-existing `fetch.py:17` unused Loguru import, verified unchanged on `origin/dev`; excluding that baseline file, all checks passed. No new ADR is required; ADR-025 and ADR-029 remain authoritative.
+
+Latest-dev superseding rebase: while PR #1190 was opening, `dev` advanced to `333ab264a` via Briefings phase 4 (PR #1187). The 21-commit branch rebased cleanly again. That upstream merge contributed nine reviewed inventory deltas: one new four-call briefing-handler owner, one additional fixed watchlist warning, seven digest-only source shifts, and two unchanged `app.py` sink calls moving by 16 lines. TASK-596.1 still contributes only its prior three Model Browser deltas. The combined current inventory records 437 owners, 1,073 TASK-492 calls, 6,707 TASK-494 calls, and the same four sink files with identical sink digests. Ordinary Briefings diagnostics remain excluded by the persistent metadata filter.
+
+Fresh verification on `333ab264a`: 576/576 affected tests passed with loopback fixture permission and the 18/18 diagnostic/privacy matrix passed; no code fix was required by the rebase.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -80,4 +84,6 @@ Fresh post-rebase verification: the complete affected matrix passed 576/576 with
 Users can explicitly discover and securely download pinned Hugging Face GGUF artifacts through the managed model browser without automatic activation or unsupported runtime-compatibility claims.
 
 Rebased cleanly onto dev after the reviewed shared inventory repair. The branch-specific inventory is current, all 576 affected tests and 18 diagnostic/privacy tests pass, and no new Critical or Important review issue remains.
+
+Final PR head is rebased onto `333ab264a`; its reviewed inventory includes the intervening Briefings drift while preserving the unchanged four-file sink topology. The affected and diagnostic gates remain green.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
+++ b/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-596.1
 title: Add bounded Hugging Face GGUF discovery to the managed model browser
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-01 21:51'
-updated_date: '2026-08-01 22:46'
+updated_date: '2026-08-02 01:47'
 labels:
   - stt
   - artifacts
@@ -32,12 +32,12 @@ Let users explicitly find and download remote GGUF models through the shared man
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening Remote performs no network request; explicit search or exact repository submission runs off the Textual event loop with bounded, generation-fenced results.
-- [ ] #2 A selected repository resolves to an immutable commit and offers only LFS-backed single GGUF files or complete bounded GGUF shard sets with recorded sizes and SHA-256 digests.
-- [ ] #3 A selected candidate reaches the existing managed preflight, consent, download, verification, and installation flow; configured Hugging Face credentials support gated or private repositories without being persisted or forwarded across origins.
-- [ ] #4 Known license metadata is shown; missing license metadata is recorded as NOASSERTION with a pinned source-review page and requires explicit acknowledgment before download.
-- [ ] #5 Focused adapter, GGUF grouping, Textual, redirect-security, and managed-acquisition tests cover the flow without adding native or platform-specific dependencies; Windows and Linux gates remain required when runners are available.
-- [ ] #6 Remote installation labels the model Local integrity recorded and does not activate it; its descriptor uses consumer=unassigned, Installed offers no activation action for that consumer, and no UI presents it as runtime-compatible, transcription-ready, or eligible for automatic routing.
+- [x] #1 Opening Remote performs no network request; explicit search or exact repository submission runs off the Textual event loop with bounded, generation-fenced results.
+- [x] #2 A selected repository resolves to an immutable commit and offers only LFS-backed single GGUF files or complete bounded GGUF shard sets with recorded sizes and SHA-256 digests.
+- [x] #3 A selected candidate reaches the existing managed preflight, consent, download, verification, and installation flow; configured Hugging Face credentials support gated or private repositories without being persisted or forwarded across origins.
+- [x] #4 Known license metadata is shown; missing license metadata is recorded as NOASSERTION with a pinned source-review page and requires explicit acknowledgment before download.
+- [x] #5 Focused adapter, GGUF grouping, Textual, redirect-security, and managed-acquisition tests cover the flow without adding native or platform-specific dependencies; Windows and Linux gates remain required when runners are available.
+- [x] #6 Remote installation labels the model Local integrity recorded and does not activate it; its descriptor uses consumer=unassigned, Installed offers no activation action for that consumer, and no UI presents it as runtime-compatible, transcription-ready, or eligible for automatic routing.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -54,3 +54,24 @@ ADR required: no
 ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md
 Reason: ADR-025 already owns remote artifact provenance, managed acquisition, activation, and runtime boundaries; this slice is additive within that boundary.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented bounded Hugging Face GGUF discovery through the shared managed-artifact flow.
+
+- Added explicit fixed-origin search and exact-repository resolution with streamed metadata limits, immutable commit pinning, LFS size/SHA-256 validation, complete bounded shard grouping, deterministic artifact identity, pinned source maps, license handling, and sanitized recovery errors.
+- Added additive install-without-activation support and HTTPS-to-HTTP redirect rejection while preserving existing callers and credential stripping.
+- Added a lazy Remote Textual view with generation and identity fencing, worker-local configured credentials, frozen preflight/consent/provision state, unknown-license acknowledgment, exact selected-file integrity/source review, and Installed refresh. Remote artifacts remain LOCAL_INTEGRITY_RECORDED, consumer=unassigned, inactive, and explicitly compatibility-unverified.
+- Updated shared inventory, activation, plan, and consent controls through backward-compatible optional/default inputs; Delete remains available and Activate is absent for unassigned models.
+- Added focused adapter/grouping/security/UI tests plus a real mocked-payload resolve-to-managed-install integration test.
+- Final whole-branch review and scoped fix re-review are clean. After rebasing onto current dev, 576 affected tests passed with one existing Requests dependency warning; 12 credential-boundary and 8 deterministic macOS evidence tests passed. Branch-edited scope passes Ruff, mypy, py_compile, and diff checks. The known fetch.py F401 and acquisition.py:1823 mypy mismatch were verified on dev and remain out of scope. Windows/Linux gates remain required when runners are available.
+
+ADR required: no. ADR-025 remains authoritative for managed acquisition, provenance, activation, and runtime boundaries. No new dependency, provider framework, cache, compatibility detector, or alternate downloader was introduced.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Users can explicitly discover and securely download pinned Hugging Face GGUF artifacts through the managed model browser without automatic activation or unsupported runtime-compatibility claims.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
+++ b/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
@@ -76,6 +76,8 @@ Fresh post-rebase verification: the complete affected matrix passed 576/576 with
 Latest-dev superseding rebase: while PR #1190 was opening, `dev` advanced to `333ab264a` via Briefings phase 4 (PR #1187). The 21-commit branch rebased cleanly again. That upstream merge contributed nine reviewed inventory deltas: one new four-call briefing-handler owner, one additional fixed watchlist warning, seven digest-only source shifts, and two unchanged `app.py` sink calls moving by 16 lines. TASK-596.1 still contributes only its prior three Model Browser deltas. The combined current inventory records 437 owners, 1,073 TASK-492 calls, 6,707 TASK-494 calls, and the same four sink files with identical sink digests. Ordinary Briefings diagnostics remain excluded by the persistent metadata filter.
 
 Fresh verification on `333ab264a`: 576/576 affected tests passed with loopback fixture permission and the 18/18 diagnostic/privacy matrix passed; no code fix was required by the rebase.
+
+PR review follow-up: addressed all three Qodo findings by completing the two public API docstrings and adding privacy-safe preflight/install failure classification (`error_type` and retryable posture only). A test-first regression check proves exception details remain absent from diagnostics and UI handoff. The focused Remote adapter/UI suite passes 92/92, the diagnostic/privacy matrix passes 18/18, and Ruff passes the changed Python files. The regenerated inventory changes only the existing `model_remote_view.py` diagnostic digest; call count and persistent sink topology are unchanged.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -86,4 +88,6 @@ Users can explicitly discover and securely download pinned Hugging Face GGUF art
 Rebased cleanly onto dev after the reviewed shared inventory repair. The branch-specific inventory is current, all 576 affected tests and 18 diagnostic/privacy tests pass, and no new Critical or Important review issue remains.
 
 Final PR head is rebased onto `333ab264a`; its reviewed inventory includes the intervening Briefings drift while preserving the unchanged four-file sink topology. The affected and diagnostic gates remain green.
+
+All Qodo findings are addressed with regression coverage and privacy-safe logging; no raw exception text is recorded.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
+++ b/backlog/tasks/task-596.1 - Add-bounded-Hugging-Face-GGUF-discovery-to-the-managed-model-browser.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-01 21:51'
-updated_date: '2026-08-01 22:00'
+updated_date: '2026-08-01 22:22'
 labels:
   - stt
   - artifacts
@@ -34,7 +34,7 @@ Let users explicitly find and download remote GGUF models through the shared man
 - [ ] #1 Opening Remote performs no network request; explicit search or exact repository submission runs off the Textual event loop with bounded, generation-fenced results.
 - [ ] #2 A selected repository resolves to an immutable commit and offers only LFS-backed single GGUF files or complete bounded GGUF shard sets with recorded sizes and SHA-256 digests.
 - [ ] #3 A selected candidate reaches the existing managed preflight, consent, download, verification, and installation flow; configured Hugging Face credentials support gated or private repositories without being persisted or forwarded across origins.
-- [ ] #4 Remote models are labeled Local integrity recorded, remain unassigned and inactive, and are never presented as runtime-compatible, transcription-ready, or eligible for automatic routing.
-- [ ] #5 Known license metadata is shown; missing license metadata is recorded as NOASSERTION with a pinned source-review page and requires explicit acknowledgment before download.
-- [ ] #6 Focused adapter, GGUF grouping, Textual, redirect-security, and managed-acquisition tests cover the flow without adding native or platform-specific dependencies; Windows and Linux gates remain required when runners are available.
+- [ ] #4 Known license metadata is shown; missing license metadata is recorded as NOASSERTION with a pinned source-review page and requires explicit acknowledgment before download.
+- [ ] #5 Focused adapter, GGUF grouping, Textual, redirect-security, and managed-acquisition tests cover the flow without adding native or platform-specific dependencies; Windows and Linux gates remain required when runners are available.
+- [ ] #6 Remote installation labels the model Local integrity recorded and does not activate it; its descriptor uses consumer=unassigned, Installed offers no activation action for that consumer, and no UI presents it as runtime-compatible, transcription-ready, or eligible for automatic routing.
 <!-- AC:END -->

--- a/tldw_chatbook/Model_Artifacts/acquisition.py
+++ b/tldw_chatbook/Model_Artifacts/acquisition.py
@@ -1040,8 +1040,9 @@ class ArtifactAcquisitionService:
         *,
         sources: ArtifactSourceMap | None = None,
         progress: Callable[[AcquisitionProgress], None] | None = None,
+        activate: bool = True,
     ) -> ArtifactRef:
-        """Acquire and activate one consented closure, resuming idempotently.
+        """Acquire one consented closure and optionally activate it, resuming idempotently.
 
         Serializes against every other ``provision()`` call twice over: an
         in-process ``asyncio.Lock`` queues same-process callers first (so
@@ -1050,7 +1051,7 @@ class ArtifactAcquisitionService:
         exclusive, non-blocking ``ACQUISITION_SESSION_LEASE_KEY`` lease
         serializes against every other OS process. The session lease is
         held for this call's ENTIRE run -- acquired before any phase runs,
-        released only in a ``finally`` after activation succeeds or any step
+        released only in a ``finally`` after provision completes or any step
         raises -- because ``reconcile()``'s managed-staging GC
         (``service.py``'s ``_gc_managed_staging``) treats a free session
         lease as permission to delete orphaned download staging; releasing
@@ -1077,8 +1078,9 @@ class ArtifactAcquisitionService:
         phases strictly in order -- fetch (Task 7), pre-verify (Task 8),
         install (Task 8) -- before the loop moves to the next artifact; a
         ``verify-install`` progress event follows each artifact's install.
-        Once every artifact is installed, the whole closure is activated
-        (``core.activate``) and a final ``activate`` progress event fires.
+        When ``activate`` is true, once every artifact is installed, the
+        whole closure is activated (``core.activate``) and a final
+        ``activate`` progress event fires.
 
         Args:
             root: The root artifact reference to provision.
@@ -1099,10 +1101,14 @@ class ArtifactAcquisitionService:
             progress: Optional sink for ``AcquisitionProgress`` events
                 emitted by every phase: real byte detail for ``fetch`` and
                 ``pre-verify``, indeterminate per-artifact events for
-                ``verify-install`` and ``activate``.
+                ``verify-install``, and an indeterminate ``activate`` event
+                when activation is requested.
+            activate: Whether to select the provisioned root for use after
+                installing its closure. Defaults to ``True`` for existing
+                callers.
 
         Returns:
-            The activated root artifact reference.
+            The provisioned root artifact reference.
 
         Raises:
             AcquisitionBusyError: Another acquisition session -- in this
@@ -1117,11 +1123,10 @@ class ArtifactAcquisitionService:
                 re-walk.
             TransferError: A file failed to fetch, a staged file failed
                 pre-verify a second time after one automatic refetch, or
-                ``core.install``/``core.activate`` raised a core
-                ``ArtifactError`` (integrity, conflict, or state/lease
+                ``core.install`` or requested ``core.activate`` raised a
+                core ``ArtifactError`` (integrity, conflict, or state/lease
                 contention -- see ``_run_core_call``). Nothing further is
-                installed or activated for that artifact once this is
-                raised.
+                installed or activated for that artifact once this is raised.
         """
         async with self._lock:
             loop = asyncio.get_running_loop()
@@ -1234,6 +1239,8 @@ class ArtifactAcquisitionService:
                         progress_state, "verify-install", descriptor.reference
                     )
 
+                if not activate:
+                    return root
                 activated = await self._run_core_call(
                     "activate", root, functools.partial(self._core.activate, root)
                 )

--- a/tldw_chatbook/Model_Artifacts/fetch.py
+++ b/tldw_chatbook/Model_Artifacts/fetch.py
@@ -193,6 +193,8 @@ async def stream_fetch(
                 if not location:
                     raise FetchTransportError("redirect without location")
                 current = current.join(location)
+                if origin.scheme == "https" and current.scheme != "https":
+                    raise FetchTransportError("HTTPS redirect downgrade")
                 continue
             if resume_from and response.status_code != 206:
                 # Server ignored Range (200 full body / no support).

--- a/tldw_chatbook/Model_Artifacts/remote_huggingface.py
+++ b/tldw_chatbook/Model_Artifacts/remote_huggingface.py
@@ -317,7 +317,11 @@ def _parse_search_result(item: object) -> RemoteModelSummary:
     repository = item.get("modelId")
     private = item.get("private")
     gated = item.get("gated")
-    if not is_exact_repository(repository) or type(private) is not bool:
+    if (
+        not isinstance(repository, str)
+        or not is_exact_repository(repository)
+        or type(private) is not bool
+    ):
         raise RemoteDiscoveryError("invalid_response")
     normalized_gated = _normalized_gated(gated)
     if normalized_gated is None:

--- a/tldw_chatbook/Model_Artifacts/remote_huggingface.py
+++ b/tldw_chatbook/Model_Artifacts/remote_huggingface.py
@@ -34,6 +34,8 @@ _MAX_PATH_BYTES = 1_024
 _MAX_LICENSE_CHARACTERS = 128
 _MAX_LABEL_CHARACTERS = 160
 _MAX_COUNTER = (2**63) - 1
+# Hugging Face LFS byte counts must fit the signed 64-bit artifact size domain.
+_MAX_LFS_SIZE_BYTES = (2**63) - 1
 _MAX_LAST_MODIFIED_CHARACTERS = 64
 _MAX_ERROR_DETAILS = 20
 _MAX_ERROR_DETAIL_CHARACTERS = 552
@@ -75,7 +77,7 @@ class RemoteModelSummary:
 
 @dataclass(frozen=True)
 class RemoteGGUFFile:
-    """One LFS-backed GGUF payload eligible for managed acquisition."""
+    """One LFS-backed GGUF payload with a signed 64-bit byte count."""
 
     upstream_path: str
     size_bytes: int
@@ -279,18 +281,22 @@ def _raise_for_status(status_code: int) -> None:
 
 async def _read_bounded_json(response: httpx.Response) -> object:
     """Read one decoded metadata JSON body without exceeding its byte budget."""
-    chunks: list[bytes] = []
-    size = 0
+    body = bytearray()
     async for chunk in response.aiter_bytes():
-        size += len(chunk)
-        if size > _MAX_METADATA_BYTES:
+        if len(body) + len(chunk) > _MAX_METADATA_BYTES:
             raise RemoteDiscoveryError("response_too_large")
-        chunks.append(chunk)
+        body.extend(chunk)
     try:
-        return json.loads(b"".join(chunks).decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        parse_error = RemoteDiscoveryError("invalid_response")
-    raise parse_error
+        decoded = bytes(body).decode("utf-8")
+    except UnicodeDecodeError:
+        decoded = None
+    body.clear()
+    if decoded is not None:
+        try:
+            return json.loads(decoded)
+        except (ValueError, RecursionError):
+            decoded = None
+    raise RemoteDiscoveryError("invalid_response")
 
 
 def _validate_error_details(details: tuple[str, ...]) -> None:
@@ -495,6 +501,7 @@ def _parse_sibling(sibling: object) -> tuple[str | None, RemoteGGUFFile | None]:
     if (
         type(size_bytes) is not int
         or size_bytes < 0
+        or size_bytes > _MAX_LFS_SIZE_BYTES
         or not isinstance(sha256, str)
         or _SHA256_RE.fullmatch(sha256) is None
     ):
@@ -567,10 +574,16 @@ def build_remote_catalog(
     """
     if type(resolved) is not ResolvedRemoteModel or type(candidate) is not RemoteGGUFCandidate:
         raise ValueError("resolved and candidate must be remote discovery values")
+    if candidate not in resolved.candidates:
+        raise ValueError("candidate is not part of the resolved model")
     if not is_exact_repository(resolved.repository) or _COMMIT_RE.fullmatch(resolved.commit) is None:
         raise ValueError("resolved repository identity is invalid")
     files = tuple(sorted(candidate.files, key=lambda item: item.upstream_path))
-    if not files or any(type(item) is not RemoteGGUFFile for item in files):
+    if (
+        not files
+        or len(files) > _MAX_SHARDS
+        or any(type(item) is not RemoteGGUFFile for item in files)
+    ):
         raise ValueError("candidate files are invalid")
     if (
         candidate.total_bytes != sum(item.size_bytes for item in files)
@@ -578,6 +591,7 @@ def build_remote_catalog(
             not _is_valid_upstream_path(item.upstream_path)
             or type(item.size_bytes) is not int
             or item.size_bytes < 0
+            or item.size_bytes > _MAX_LFS_SIZE_BYTES
             or _SHA256_RE.fullmatch(item.sha256) is None
             for item in files
         )
@@ -637,7 +651,8 @@ def _bounded_candidate_label(label: str) -> str:
 
 
 def _managed_paths(files: tuple[RemoteGGUFFile, ...]) -> tuple[str, ...]:
-    if len(files) == 1:
+    first_match = _SHARD_RE.fullmatch(files[0].upstream_path.rsplit("/", 1)[-1])
+    if len(files) == 1 and first_match is None:
         return ("model.gguf",)
     paths: list[str] = []
     for remote_file in files:

--- a/tldw_chatbook/Model_Artifacts/remote_huggingface.py
+++ b/tldw_chatbook/Model_Artifacts/remote_huggingface.py
@@ -1,0 +1,205 @@
+"""Bounded metadata requests to Hugging Face's fixed public API origin."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+import httpx
+
+_API_MODELS_URL = "https://huggingface.co/api/models"
+_MAX_METADATA_BYTES = 2 * 1024 * 1024
+_MAX_SEARCH_RESULTS = 50
+_MAX_QUERY_CHARACTERS = 256
+_MAX_REPOSITORY_CHARACTERS = 96
+_MAX_COUNTER = (2**63) - 1
+_MAX_LAST_MODIFIED_CHARACTERS = 64
+_REPOSITORY_COMPONENT_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+@dataclass(frozen=True)
+class RemoteModelSummary:
+    """Safe metadata used to present a remote repository search result."""
+
+    repository: str
+    private: bool
+    gated: Literal["none", "auto", "manual"]
+    downloads: int | None = None
+    likes: int | None = None
+    last_modified: str | None = None
+
+
+class RemoteDiscoveryError(RuntimeError):
+    """A stable, display-safe failure from remote metadata discovery."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        retryable: bool = False,
+        details: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+        self.details = details
+
+
+class HuggingFaceRemoteAdapter:
+    """Perform narrow, non-redirecting Hugging Face metadata searches."""
+
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] = httpx.AsyncClient,
+    ) -> None:
+        self._client_factory = client_factory
+
+    async def search(
+        self, query: str, *, token: str | None = None
+    ) -> tuple[RemoteModelSummary, ...]:
+        """Search the fixed Hugging Face models endpoint.
+
+        Args:
+            query: Free-text search input, limited after whitespace trimming.
+            token: Optional Hugging Face token for this fixed-origin request.
+
+        Returns:
+            At most fifty validated remote model summaries.
+
+        Raises:
+            RemoteDiscoveryError: Input is invalid or remote metadata is unusable.
+        """
+        normalized_query = _validated_query(query)
+        headers = _authorization_header(token)
+        try:
+            async with self._client_factory() as client:
+                async with client.stream(
+                    "GET",
+                    _API_MODELS_URL,
+                    params={"search": normalized_query, "limit": str(_MAX_SEARCH_RESULTS)},
+                    headers=headers,
+                    follow_redirects=False,
+                ) as response:
+                    _raise_for_status(response.status_code)
+                    payload = await _read_bounded_json(response)
+        except RemoteDiscoveryError:
+            raise
+        except httpx.TimeoutException as error:
+            raise RemoteDiscoveryError("network_error", retryable=True) from error
+        except httpx.HTTPError as error:
+            raise RemoteDiscoveryError("network_error", retryable=True) from error
+
+        return _parse_search_results(payload)
+
+
+def is_exact_repository(value: str) -> bool:
+    """Return whether ``value`` is one bounded portable owner/repository pair."""
+    if not isinstance(value, str) or len(value) > _MAX_REPOSITORY_CHARACTERS:
+        return False
+    parts = value.split("/")
+    return len(parts) == 2 and all(
+        _REPOSITORY_COMPONENT_RE.fullmatch(part)
+        and "--" not in part
+        and ".." not in part
+        for part in parts
+    )
+
+
+def _validated_query(query: str) -> str:
+    if not isinstance(query, str):
+        raise RemoteDiscoveryError("invalid_query")
+    normalized = query.strip()
+    if not normalized or len(normalized) > _MAX_QUERY_CHARACTERS:
+        raise RemoteDiscoveryError("invalid_query")
+    return normalized
+
+
+def _authorization_header(token: str | None) -> dict[str, str]:
+    if token is None:
+        return {}
+    if not isinstance(token, str) or not token or "\r" in token or "\n" in token:
+        raise RemoteDiscoveryError("invalid_token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _raise_for_status(status_code: int) -> None:
+    if status_code == 401:
+        raise RemoteDiscoveryError("authentication_required")
+    if status_code == 403:
+        raise RemoteDiscoveryError("access_forbidden")
+    if status_code == 404:
+        raise RemoteDiscoveryError("repository_not_found")
+    if status_code == 429:
+        raise RemoteDiscoveryError("rate_limited", retryable=True)
+    if 400 <= status_code < 500:
+        raise RemoteDiscoveryError("remote_error")
+    if status_code >= 500:
+        raise RemoteDiscoveryError("remote_error", retryable=True)
+
+
+async def _read_bounded_json(response: httpx.Response) -> object:
+    """Read one decoded metadata JSON body without exceeding its byte budget."""
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in response.aiter_bytes():
+        size += len(chunk)
+        if size > _MAX_METADATA_BYTES:
+            raise RemoteDiscoveryError("response_too_large")
+        chunks.append(chunk)
+    try:
+        return json.loads(b"".join(chunks).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RemoteDiscoveryError("invalid_response") from error
+
+
+def _parse_search_results(payload: object) -> tuple[RemoteModelSummary, ...]:
+    if not isinstance(payload, list) or len(payload) > _MAX_SEARCH_RESULTS:
+        raise RemoteDiscoveryError("invalid_response")
+    return tuple(_parse_search_result(item) for item in payload)
+
+
+def _parse_search_result(item: object) -> RemoteModelSummary:
+    if not isinstance(item, dict):
+        raise RemoteDiscoveryError("invalid_response")
+    repository = item.get("modelId")
+    private = item.get("private")
+    gated = item.get("gated")
+    if not is_exact_repository(repository) or type(private) is not bool:
+        raise RemoteDiscoveryError("invalid_response")
+    normalized_gated = _normalized_gated(gated)
+    if normalized_gated is None:
+        raise RemoteDiscoveryError("invalid_response")
+    return RemoteModelSummary(
+        repository=repository,
+        private=private,
+        gated=normalized_gated,
+        downloads=_optional_counter(item.get("downloads")),
+        likes=_optional_counter(item.get("likes")),
+        last_modified=_optional_last_modified(item.get("lastModified")),
+    )
+
+
+def _normalized_gated(value: object) -> Literal["none", "auto", "manual"] | None:
+    if value is False:
+        return "none"
+    if value == "auto":
+        return "auto"
+    if value == "manual":
+        return "manual"
+    return None
+
+
+def _optional_counter(value: object) -> int | None:
+    if type(value) is int and 0 <= value <= _MAX_COUNTER:
+        return value
+    return None
+
+
+def _optional_last_modified(value: object) -> str | None:
+    if isinstance(value, str) and len(value) <= _MAX_LAST_MODIFIED_CHARACTERS:
+        return value
+    return None

--- a/tldw_chatbook/Model_Artifacts/remote_huggingface.py
+++ b/tldw_chatbook/Model_Artifacts/remote_huggingface.py
@@ -425,6 +425,8 @@ def _gguf_candidates(
     warnings: list[str] = []
     for group_key in sorted(shard_groups):
         directory, stem, count = group_key
+        if group_key in invalid_groups or not 1 <= count <= _MAX_SHARDS:
+            continue
         members = shard_groups[group_key]
         valid_members = [member for member in members if member is not None]
         by_index: dict[int, RemoteGGUFFile] = {}
@@ -438,11 +440,10 @@ def _gguf_candidates(
                 duplicate = True
             by_index[index] = member
         missing = tuple(index for index in range(1, count + 1) if index not in by_index)
-        if missing:
+        if missing and len(warnings) < _MAX_ERROR_DETAILS:
             warnings.append(_incomplete_warning(repository, directory, stem, missing))
         if (
-            group_key in invalid_groups
-            or len(valid_members) != len(members)
+            len(valid_members) != len(members)
             or duplicate
             or missing
             or len(by_index) != count

--- a/tldw_chatbook/Model_Artifacts/remote_huggingface.py
+++ b/tldw_chatbook/Model_Artifacts/remote_huggingface.py
@@ -2,24 +2,47 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
+from types import MappingProxyType
+from typing import Literal, Mapping
+from urllib.parse import quote
 
 import httpx
+
+from .service import (
+    ArtifactDescriptor,
+    ArtifactFile,
+    ArtifactFormat,
+    ArtifactRef,
+    ArtifactRole,
+    ProvenanceClass,
+)
 
 _API_MODELS_URL = "https://huggingface.co/api/models"
 _MAX_METADATA_BYTES = 2 * 1024 * 1024
 _MAX_SEARCH_RESULTS = 50
 _MAX_QUERY_CHARACTERS = 256
 _MAX_REPOSITORY_CHARACTERS = 96
+_MAX_FILE_ENTRIES = 2_048
+_MAX_GGUF_CANDIDATES = 100
+_MAX_SHARDS = 64
+_MAX_PATH_BYTES = 1_024
+_MAX_LICENSE_CHARACTERS = 128
+_MAX_LABEL_CHARACTERS = 160
 _MAX_COUNTER = (2**63) - 1
 _MAX_LAST_MODIFIED_CHARACTERS = 64
 _MAX_ERROR_DETAILS = 20
-_MAX_ERROR_DETAIL_CHARACTERS = 512
+_MAX_ERROR_DETAIL_CHARACTERS = 552
 _REPOSITORY_COMPONENT_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_SHARD_RE = re.compile(
+    r"^(?P<stem>.+)-(?P<index>[0-9]{5})-of-(?P<count>[0-9]{5})\.gguf$"
+)
 _ERROR_CODES = frozenset(
     {
         "access_forbidden",
@@ -48,6 +71,51 @@ class RemoteModelSummary:
     downloads: int | None = None
     likes: int | None = None
     last_modified: str | None = None
+
+
+@dataclass(frozen=True)
+class RemoteGGUFFile:
+    """One LFS-backed GGUF payload eligible for managed acquisition."""
+
+    upstream_path: str
+    size_bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class RemoteGGUFCandidate:
+    """One independently selectable GGUF file or complete shard set."""
+
+    label: str
+    files: tuple[RemoteGGUFFile, ...]
+    total_bytes: int
+
+
+@dataclass(frozen=True)
+class ResolvedRemoteModel:
+    """Pinned repository metadata and its bounded GGUF choices."""
+
+    repository: str
+    commit: str
+    license_id: str
+    review_url: str
+    candidates: tuple[RemoteGGUFCandidate, ...]
+    total_candidate_count: int
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedRemoteCatalog:
+    """The one-item artifact catalog generated from a remote selection."""
+
+    artifact: ArtifactDescriptor
+    sources: Mapping[ArtifactRef, Mapping[str, str]]
+
+    def descriptor(self, ref: ArtifactRef) -> ArtifactDescriptor:
+        """Return the selected artifact when its exact reference is requested."""
+        if ref != self.artifact.reference:
+            raise KeyError(ref)
+        return self.artifact
 
 
 class RemoteDiscoveryError(RuntimeError):
@@ -119,6 +187,47 @@ class HuggingFaceRemoteAdapter:
             raise network_error
 
         return _parse_search_results(payload)
+
+    async def resolve(
+        self, repository: str, *, token: str | None = None
+    ) -> ResolvedRemoteModel:
+        """Resolve one exact repository into pinned GGUF candidates.
+
+        Args:
+            repository: Exact owner/repository identifier to resolve.
+            token: Optional Hugging Face token for this fixed-origin request.
+
+        Returns:
+            Immutable repository metadata and at most one hundred candidates.
+
+        Raises:
+            RemoteDiscoveryError: The identifier or response is not usable.
+        """
+        if not is_exact_repository(repository):
+            raise RemoteDiscoveryError("invalid_repository")
+        headers = _authorization_header(token)
+        network_error: RemoteDiscoveryError | None = None
+        try:
+            async with self._client_factory() as client:
+                async with client.stream(
+                    "GET",
+                    f"{_API_MODELS_URL}/{repository}",
+                    params={"blobs": "true"},
+                    headers=headers,
+                    follow_redirects=False,
+                ) as response:
+                    _raise_for_status(response.status_code)
+                    payload = await _read_bounded_json(response)
+        except RemoteDiscoveryError:
+            raise
+        except httpx.TimeoutException:
+            network_error = RemoteDiscoveryError("network_error", retryable=True)
+        except httpx.HTTPError:
+            network_error = RemoteDiscoveryError("network_error", retryable=True)
+
+        if network_error is not None:
+            raise network_error
+        return _parse_resolved_model(repository, payload)
 
 
 def is_exact_repository(value: str) -> bool:
@@ -243,3 +352,305 @@ def _optional_last_modified(value: object) -> str | None:
     if isinstance(value, str) and len(value) <= _MAX_LAST_MODIFIED_CHARACTERS:
         return value
     return None
+
+
+def _parse_resolved_model(repository: str, payload: object) -> ResolvedRemoteModel:
+    if not isinstance(payload, dict):
+        raise RemoteDiscoveryError("invalid_response")
+    commit = payload.get("sha")
+    siblings = payload.get("siblings")
+    if (
+        not isinstance(commit, str)
+        or _COMMIT_RE.fullmatch(commit) is None
+        or not isinstance(siblings, list)
+        or len(siblings) > _MAX_FILE_ENTRIES
+    ):
+        raise RemoteDiscoveryError("invalid_response")
+
+    candidates, warnings = _gguf_candidates(repository, siblings)
+    if not candidates:
+        raise RemoteDiscoveryError("no_eligible_gguf", details=warnings)
+    total_candidate_count = len(candidates)
+    displayed_candidates = tuple(candidates[:_MAX_GGUF_CANDIDATES])
+    review_url = f"https://huggingface.co/{repository}/tree/{commit}"
+    return ResolvedRemoteModel(
+        repository=repository,
+        commit=commit,
+        license_id=_license_id(payload.get("cardData")),
+        review_url=review_url,
+        candidates=displayed_candidates,
+        total_candidate_count=total_candidate_count,
+        warnings=warnings,
+    )
+
+
+def _license_id(card_data: object) -> str:
+    if not isinstance(card_data, dict):
+        return "NOASSERTION"
+    license_id = card_data.get("license")
+    if (
+        not isinstance(license_id, str)
+        or not license_id
+        or len(license_id) > _MAX_LICENSE_CHARACTERS
+        or license_id != license_id.strip()
+        or not license_id.isprintable()
+    ):
+        return "NOASSERTION"
+    return license_id
+
+
+def _gguf_candidates(
+    repository: str, siblings: list[object]
+) -> tuple[list[RemoteGGUFCandidate], tuple[str, ...]]:
+    singles: list[RemoteGGUFFile] = []
+    shard_groups: dict[tuple[str, str, int], list[RemoteGGUFFile | None]] = {}
+    invalid_groups: set[tuple[str, str, int]] = set()
+
+    for sibling in siblings:
+        path, remote_file = _parse_sibling(sibling)
+        if path is None:
+            continue
+        shard = _shard_identity(path)
+        if shard is None:
+            if remote_file is not None:
+                singles.append(remote_file)
+            continue
+        directory, stem, index, count = shard
+        group_key = (directory, stem, count)
+        shard_groups.setdefault(group_key, []).append(remote_file)
+        if not (1 <= index <= count <= _MAX_SHARDS):
+            invalid_groups.add(group_key)
+
+    grouped: list[RemoteGGUFCandidate] = []
+    warnings: list[str] = []
+    for group_key in sorted(shard_groups):
+        directory, stem, count = group_key
+        members = shard_groups[group_key]
+        valid_members = [member for member in members if member is not None]
+        by_index: dict[int, RemoteGGUFFile] = {}
+        duplicate = False
+        for member in valid_members:
+            assert member is not None
+            match = _SHARD_RE.fullmatch(member.upstream_path.rsplit("/", 1)[-1])
+            assert match is not None
+            index = int(match.group("index"))
+            if index in by_index:
+                duplicate = True
+            by_index[index] = member
+        missing = tuple(index for index in range(1, count + 1) if index not in by_index)
+        if missing:
+            warnings.append(_incomplete_warning(repository, directory, stem, missing))
+        if (
+            group_key in invalid_groups
+            or len(valid_members) != len(members)
+            or duplicate
+            or missing
+            or len(by_index) != count
+        ):
+            continue
+        files = tuple(by_index[index] for index in range(1, count + 1))
+        grouped.append(
+            RemoteGGUFCandidate(
+                label=_candidate_label(repository, _group_display_path(directory, stem)),
+                files=files,
+                total_bytes=sum(item.size_bytes for item in files),
+            )
+        )
+
+    candidates = [
+        *(
+            RemoteGGUFCandidate(
+                label=_candidate_label(repository, item.upstream_path),
+                files=(item,),
+                total_bytes=item.size_bytes,
+            )
+            for item in singles
+        ),
+        *grouped,
+    ]
+    candidates.sort(key=lambda candidate: tuple(item.upstream_path for item in candidate.files))
+    return candidates, tuple(warnings[:_MAX_ERROR_DETAILS])
+
+
+def _parse_sibling(sibling: object) -> tuple[str | None, RemoteGGUFFile | None]:
+    if not isinstance(sibling, dict):
+        raise RemoteDiscoveryError("invalid_response")
+    path = sibling.get("rfilename")
+    if not isinstance(path, str):
+        raise RemoteDiscoveryError("invalid_response")
+    if not path.endswith(".gguf"):
+        return None, None
+    if not _is_valid_upstream_path(path):
+        raise RemoteDiscoveryError("invalid_response")
+    lfs = sibling.get("lfs")
+    if not isinstance(lfs, dict):
+        return path, None
+    size_bytes = lfs.get("size")
+    sha256 = lfs.get("sha256")
+    if (
+        type(size_bytes) is not int
+        or size_bytes < 0
+        or not isinstance(sha256, str)
+        or _SHA256_RE.fullmatch(sha256) is None
+    ):
+        return path, None
+    return path, RemoteGGUFFile(path, size_bytes, sha256)
+
+
+def _shard_identity(path: str) -> tuple[str, str, int, int] | None:
+    directory, separator, basename = path.rpartition("/")
+    match = _SHARD_RE.fullmatch(basename if separator else path)
+    if match is None:
+        return None
+    return (
+        directory if separator else "",
+        match.group("stem"),
+        int(match.group("index")),
+        int(match.group("count")),
+    )
+
+
+def _is_valid_upstream_path(path: str) -> bool:
+    try:
+        encoded_length = len(path.encode("utf-8"))
+    except UnicodeEncodeError:
+        return False
+    return (
+        0 < encoded_length <= _MAX_PATH_BYTES
+        and path == path.strip()
+        and "\\" not in path
+        and all(
+            component not in {"", ".", ".."}
+            and component.isprintable()
+            for component in path.split("/")
+        )
+    )
+
+
+def _group_display_path(directory: str, stem: str) -> str:
+    return f"{directory}/{stem}" if directory else stem
+
+
+def _candidate_label(repository: str, path: str) -> str:
+    return f"{repository} · {path}"[:_MAX_LABEL_CHARACTERS]
+
+
+def _incomplete_warning(
+    repository: str, directory: str, stem: str, missing: tuple[int, ...]
+) -> str:
+    missing_indexes = " ".join(f"{index:05d}" for index in missing)
+    return (
+        f"{_candidate_label(repository, _group_display_path(directory, stem))} "
+        f"missing {missing_indexes}"
+    )
+
+
+def build_remote_catalog(
+    resolved: ResolvedRemoteModel, candidate: RemoteGGUFCandidate
+) -> ResolvedRemoteCatalog:
+    """Map one resolved candidate into a pinned, inert managed artifact.
+
+    Args:
+        resolved: The immutable repository resolution that produced the candidate.
+        candidate: A selected file or complete shard set from that resolution.
+
+    Returns:
+        A one-item catalog and per-file pinned Hugging Face source map.
+
+    Raises:
+        ValueError: The supplied immutable values cannot form a safe artifact.
+    """
+    if type(resolved) is not ResolvedRemoteModel or type(candidate) is not RemoteGGUFCandidate:
+        raise ValueError("resolved and candidate must be remote discovery values")
+    if not is_exact_repository(resolved.repository) or _COMMIT_RE.fullmatch(resolved.commit) is None:
+        raise ValueError("resolved repository identity is invalid")
+    files = tuple(sorted(candidate.files, key=lambda item: item.upstream_path))
+    if not files or any(type(item) is not RemoteGGUFFile for item in files):
+        raise ValueError("candidate files are invalid")
+    if (
+        candidate.total_bytes != sum(item.size_bytes for item in files)
+        or any(
+            not _is_valid_upstream_path(item.upstream_path)
+            or type(item.size_bytes) is not int
+            or item.size_bytes < 0
+            or _SHA256_RE.fullmatch(item.sha256) is None
+            for item in files
+        )
+    ):
+        raise ValueError("candidate metadata is invalid")
+
+    artifact_paths = _managed_paths(files)
+    canonical_identity = json.dumps(
+        {"repository": resolved.repository, "paths": [item.upstream_path for item in files]},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    reference = ArtifactRef(
+        artifact_id=f"hf-gguf-{hashlib.sha256(canonical_identity).hexdigest()}",
+        revision=resolved.commit,
+        variant="not-declared",
+    )
+    artifact_files = tuple(
+        ArtifactFile(path, remote_file.size_bytes, remote_file.sha256)
+        for path, remote_file in zip(artifact_paths, files, strict=True)
+    )
+    source_items = tuple(
+        (path, _pinned_payload_url(resolved, remote_file.upstream_path))
+        for path, remote_file in zip(artifact_paths, files, strict=True)
+    )
+    sources = MappingProxyType({reference: MappingProxyType(dict(source_items))})
+    artifact = ArtifactDescriptor(
+        reference=reference,
+        model_id=_bounded_candidate_label(candidate.label),
+        role=ArtifactRole.ROOT,
+        format=ArtifactFormat.GGUF,
+        consumer="unassigned",
+        model_family="unassigned",
+        upstream_repository=resolved.repository,
+        upstream_revision=resolved.commit,
+        source_url=source_items[0][1],
+        precision="not-declared",
+        expected_installed_bytes=candidate.total_bytes,
+        license_id=resolved.license_id,
+        license_url=resolved.review_url,
+        usage_notice="Runtime compatibility has not been verified. Configuration is required.",
+        runtime_name="unassigned",
+        runtime_version_constraint="none",
+        supported_os=("unassigned",),
+        supported_architectures=("unassigned",),
+        provenance=(ProvenanceClass.LOCAL_INTEGRITY_RECORDED,),
+        files=artifact_files,
+    )
+    return ResolvedRemoteCatalog(artifact=artifact, sources=sources)
+
+
+def _bounded_candidate_label(label: str) -> str:
+    if not isinstance(label, str) or not label or not label.isprintable():
+        raise ValueError("candidate label is invalid")
+    return label[:_MAX_LABEL_CHARACTERS]
+
+
+def _managed_paths(files: tuple[RemoteGGUFFile, ...]) -> tuple[str, ...]:
+    if len(files) == 1:
+        return ("model.gguf",)
+    paths: list[str] = []
+    for remote_file in files:
+        match = _SHARD_RE.fullmatch(remote_file.upstream_path.rsplit("/", 1)[-1])
+        if match is None:
+            raise ValueError("multi-file candidates must be standard shard sets")
+        paths.append(
+            "model-"
+            f"{int(match.group('index')):05d}-of-{int(match.group('count')):05d}.gguf"
+        )
+    if len(set(paths)) != len(paths):
+        raise ValueError("candidate shard paths are invalid")
+    return tuple(paths)
+
+
+def _pinned_payload_url(resolved: ResolvedRemoteModel, path: str) -> str:
+    encoded_path = "/".join(quote(component, safe="-._~") for component in path.split("/"))
+    return (
+        f"https://huggingface.co/{resolved.repository}/resolve/{resolved.commit}/"
+        f"{encoded_path}"
+    )

--- a/tldw_chatbook/Model_Artifacts/remote_huggingface.py
+++ b/tldw_chatbook/Model_Artifacts/remote_huggingface.py
@@ -17,7 +17,25 @@ _MAX_QUERY_CHARACTERS = 256
 _MAX_REPOSITORY_CHARACTERS = 96
 _MAX_COUNTER = (2**63) - 1
 _MAX_LAST_MODIFIED_CHARACTERS = 64
+_MAX_ERROR_DETAILS = 20
+_MAX_ERROR_DETAIL_CHARACTERS = 512
 _REPOSITORY_COMPONENT_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+_ERROR_CODES = frozenset(
+    {
+        "access_forbidden",
+        "authentication_required",
+        "invalid_query",
+        "invalid_repository",
+        "invalid_response",
+        "invalid_token",
+        "network_error",
+        "no_eligible_gguf",
+        "rate_limited",
+        "remote_error",
+        "repository_not_found",
+        "response_too_large",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -42,6 +60,9 @@ class RemoteDiscoveryError(RuntimeError):
         retryable: bool = False,
         details: tuple[str, ...] = (),
     ) -> None:
+        if code not in _ERROR_CODES:
+            raise ValueError("unsupported remote discovery error code")
+        _validate_error_details(details)
         super().__init__(code)
         self.code = code
         self.retryable = retryable
@@ -75,6 +96,7 @@ class HuggingFaceRemoteAdapter:
         """
         normalized_query = _validated_query(query)
         headers = _authorization_header(token)
+        network_error: RemoteDiscoveryError | None = None
         try:
             async with self._client_factory() as client:
                 async with client.stream(
@@ -88,10 +110,13 @@ class HuggingFaceRemoteAdapter:
                     payload = await _read_bounded_json(response)
         except RemoteDiscoveryError:
             raise
-        except httpx.TimeoutException as error:
-            raise RemoteDiscoveryError("network_error", retryable=True) from error
-        except httpx.HTTPError as error:
-            raise RemoteDiscoveryError("network_error", retryable=True) from error
+        except httpx.TimeoutException:
+            network_error = RemoteDiscoveryError("network_error", retryable=True)
+        except httpx.HTTPError:
+            network_error = RemoteDiscoveryError("network_error", retryable=True)
+
+        if network_error is not None:
+            raise network_error
 
         return _parse_search_results(payload)
 
@@ -127,6 +152,8 @@ def _authorization_header(token: str | None) -> dict[str, str]:
 
 
 def _raise_for_status(status_code: int) -> None:
+    if 300 <= status_code < 400:
+        raise RemoteDiscoveryError("remote_error")
     if status_code == 401:
         raise RemoteDiscoveryError("authentication_required")
     if status_code == 403:
@@ -152,8 +179,21 @@ async def _read_bounded_json(response: httpx.Response) -> object:
         chunks.append(chunk)
     try:
         return json.loads(b"".join(chunks).decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise RemoteDiscoveryError("invalid_response") from error
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        parse_error = RemoteDiscoveryError("invalid_response")
+    raise parse_error
+
+
+def _validate_error_details(details: tuple[str, ...]) -> None:
+    if type(details) is not tuple or len(details) > _MAX_ERROR_DETAILS:
+        raise ValueError("invalid remote discovery error details")
+    if any(
+        not isinstance(detail, str)
+        or len(detail) > _MAX_ERROR_DETAIL_CHARACTERS
+        or not detail.isprintable()
+        for detail in details
+    ):
+        raise ValueError("invalid remote discovery error details")
 
 
 def _parse_search_results(payload: object) -> tuple[RemoteModelSummary, ...]:

--- a/tldw_chatbook/Model_Artifacts/remote_huggingface.py
+++ b/tldw_chatbook/Model_Artifacts/remote_huggingface.py
@@ -114,7 +114,17 @@ class ResolvedRemoteCatalog:
     sources: Mapping[ArtifactRef, Mapping[str, str]]
 
     def descriptor(self, ref: ArtifactRef) -> ArtifactDescriptor:
-        """Return the selected artifact when its exact reference is requested."""
+        """Return the selected artifact for its exact reference.
+
+        Args:
+            ref: Artifact reference requested by the acquisition service.
+
+        Returns:
+            The selected remote artifact descriptor.
+
+        Raises:
+            KeyError: The requested reference is not the selected artifact.
+        """
         if ref != self.artifact.reference:
             raise KeyError(ref)
         return self.artifact
@@ -172,7 +182,10 @@ class HuggingFaceRemoteAdapter:
                 async with client.stream(
                     "GET",
                     _API_MODELS_URL,
-                    params={"search": normalized_query, "limit": str(_MAX_SEARCH_RESULTS)},
+                    params={
+                        "search": normalized_query,
+                        "limit": str(_MAX_SEARCH_RESULTS),
+                    },
                     headers=headers,
                     follow_redirects=False,
                 ) as response:
@@ -233,7 +246,14 @@ class HuggingFaceRemoteAdapter:
 
 
 def is_exact_repository(value: str) -> bool:
-    """Return whether ``value`` is one bounded portable owner/repository pair."""
+    """Check for one bounded portable owner/repository pair.
+
+    Args:
+        value: Candidate repository identifier.
+
+    Returns:
+        True when the value is an exact supported repository identifier.
+    """
     if not isinstance(value, str) or len(value) > _MAX_REPOSITORY_CHARACTERS:
         return False
     parts = value.split("/")
@@ -462,7 +482,9 @@ def _gguf_candidates(
         files = tuple(by_index[index] for index in range(1, count + 1))
         grouped.append(
             RemoteGGUFCandidate(
-                label=_candidate_label(repository, _group_display_path(directory, stem)),
+                label=_candidate_label(
+                    repository, _group_display_path(directory, stem)
+                ),
                 files=files,
                 total_bytes=sum(item.size_bytes for item in files),
             )
@@ -479,7 +501,9 @@ def _gguf_candidates(
         ),
         *grouped,
     ]
-    candidates.sort(key=lambda candidate: tuple(item.upstream_path for item in candidate.files))
+    candidates.sort(
+        key=lambda candidate: tuple(item.upstream_path for item in candidate.files)
+    )
     return candidates, tuple(warnings[:_MAX_ERROR_DETAILS])
 
 
@@ -532,8 +556,7 @@ def _is_valid_upstream_path(path: str) -> bool:
         and path == path.strip()
         and "\\" not in path
         and all(
-            component not in {"", ".", ".."}
-            and component.isprintable()
+            component not in {"", ".", ".."} and component.isprintable()
             for component in path.split("/")
         )
     )
@@ -572,11 +595,17 @@ def build_remote_catalog(
     Raises:
         ValueError: The supplied immutable values cannot form a safe artifact.
     """
-    if type(resolved) is not ResolvedRemoteModel or type(candidate) is not RemoteGGUFCandidate:
+    if (
+        type(resolved) is not ResolvedRemoteModel
+        or type(candidate) is not RemoteGGUFCandidate
+    ):
         raise ValueError("resolved and candidate must be remote discovery values")
     if candidate not in resolved.candidates:
         raise ValueError("candidate is not part of the resolved model")
-    if not is_exact_repository(resolved.repository) or _COMMIT_RE.fullmatch(resolved.commit) is None:
+    if (
+        not is_exact_repository(resolved.repository)
+        or _COMMIT_RE.fullmatch(resolved.commit) is None
+    ):
         raise ValueError("resolved repository identity is invalid")
     files = tuple(sorted(candidate.files, key=lambda item: item.upstream_path))
     if (
@@ -585,22 +614,22 @@ def build_remote_catalog(
         or any(type(item) is not RemoteGGUFFile for item in files)
     ):
         raise ValueError("candidate files are invalid")
-    if (
-        candidate.total_bytes != sum(item.size_bytes for item in files)
-        or any(
-            not _is_valid_upstream_path(item.upstream_path)
-            or type(item.size_bytes) is not int
-            or item.size_bytes < 0
-            or item.size_bytes > _MAX_LFS_SIZE_BYTES
-            or _SHA256_RE.fullmatch(item.sha256) is None
-            for item in files
-        )
+    if candidate.total_bytes != sum(item.size_bytes for item in files) or any(
+        not _is_valid_upstream_path(item.upstream_path)
+        or type(item.size_bytes) is not int
+        or item.size_bytes < 0
+        or item.size_bytes > _MAX_LFS_SIZE_BYTES
+        or _SHA256_RE.fullmatch(item.sha256) is None
+        for item in files
     ):
         raise ValueError("candidate metadata is invalid")
 
     artifact_paths = _managed_paths(files)
     canonical_identity = json.dumps(
-        {"repository": resolved.repository, "paths": [item.upstream_path for item in files]},
+        {
+            "repository": resolved.repository,
+            "paths": [item.upstream_path for item in files],
+        },
         ensure_ascii=False,
         separators=(",", ":"),
         sort_keys=True,
@@ -669,7 +698,9 @@ def _managed_paths(files: tuple[RemoteGGUFFile, ...]) -> tuple[str, ...]:
 
 
 def _pinned_payload_url(resolved: ResolvedRemoteModel, path: str) -> str:
-    encoded_path = "/".join(quote(component, safe="-._~") for component in path.split("/"))
+    encoded_path = "/".join(
+        quote(component, safe="-._~") for component in path.split("/")
+    )
     return (
         f"https://huggingface.co/{resolved.repository}/resolve/{resolved.commit}/"
         f"{encoded_path}"

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -265,6 +265,7 @@ class LLMManagementWindow(Container):
             "mlx-lm": "llm-view-mlx-lm",
             "curated": "llm-view-curated",
             "installed": "llm-view-installed",
+            "remote": "llm-view-remote",
             "download-models": "llm-view-download-models",
         }
 
@@ -925,6 +926,12 @@ class LLMManagementWindow(Container):
                     legacy_dir=legacy_dir,
                     id="installed-models-view",
                 )
+
+            # Remote is explicitly idle until Search is submitted.
+            with Container(id="llm-view-remote", classes="llm-view"):
+                from .Screens.model_remote_view import RemoteView
+
+                yield RemoteView(id="remote-models-view")
 
             # Download Models View (preserved unchanged)
             with Container(id="llm-view-download-models", classes="llm-view"):

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -45,6 +45,7 @@ MODELS_RAIL_SECTIONS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
         (
             ("curated", "Curated"),
             ("installed", "Installed"),
+            ("remote", "Remote"),
             ("download-models", "Download Models"),
         ),
     ),

--- a/tldw_chatbook/UI/Screens/model_browser_state.py
+++ b/tldw_chatbook/UI/Screens/model_browser_state.py
@@ -67,6 +67,7 @@ class InventoryRow:
     dependencies: tuple[ArtifactRef, ...]
     ready: bool
     active: bool
+    activation_allowed: bool
     is_broken: bool
     is_unmanaged: bool
     provenance: str
@@ -176,6 +177,7 @@ def inventory_rows(
                     dependencies=(),
                     ready=False,
                     active=False,
+                    activation_allowed=False,
                     is_broken=True,
                     is_unmanaged=False,
                     provenance="Integrity state unavailable",
@@ -190,8 +192,11 @@ def inventory_rows(
             continue
 
         is_broken = item.error is not None
+        activation_allowed = descriptor.consumer != "unassigned"
         if is_broken:
             action_hint = "Needs repair — Repair"
+        elif not activation_allowed:
+            action_hint = "Downloaded · runtime compatibility not verified"
         elif item.active:
             action_hint = "Active"
         elif item.ready:
@@ -208,6 +213,7 @@ def inventory_rows(
                 dependencies=descriptor.dependencies,
                 ready=item.ready,
                 active=item.active,
+                activation_allowed=activation_allowed,
                 is_broken=is_broken,
                 is_unmanaged=False,
                 provenance=provenance_label(descriptor.provenance),
@@ -230,6 +236,7 @@ def inventory_rows(
             dependencies=(),
             ready=False,
             active=False,
+            activation_allowed=False,
             is_broken=False,
             is_unmanaged=True,
             provenance="Unmanaged — integrity unknown",

--- a/tldw_chatbook/UI/Screens/model_installed_view.py
+++ b/tldw_chatbook/UI/Screens/model_installed_view.py
@@ -273,6 +273,7 @@ class InstalledView(Widget):
                     row.reference,
                     active=row.active,
                     ready=row.ready,
+                    allow_activation=row.activation_allowed,
                     pending=(
                         self._loading
                         or self._operation_reference is not None

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -1,0 +1,586 @@
+"""Lazy Hugging Face GGUF discovery through the managed model store."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from loguru import logger
+from textual import on, work
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
+from textual.widget import Widget
+from textual.widgets import Button, Input, Static
+
+from tldw_chatbook.Model_Artifacts.acquisition import (
+    ArtifactAcquisitionService,
+    EnvConfigCredentialResolver,
+)
+from tldw_chatbook.Model_Artifacts.remote_huggingface import (
+    HuggingFaceRemoteAdapter,
+    RemoteDiscoveryError,
+    RemoteGGUFCandidate,
+    RemoteModelSummary,
+    ResolvedRemoteCatalog,
+    ResolvedRemoteModel,
+    build_remote_catalog,
+    is_exact_repository,
+)
+from tldw_chatbook.Model_Artifacts.service import (
+    ArtifactRef,
+    ModelArtifactService,
+)
+from tldw_chatbook.Model_Artifacts.store import managed_service
+from tldw_chatbook.UI.Screens.model_browser_state import install_failure_message
+from tldw_chatbook.Widgets.ModelArtifacts import (
+    InstallProgressed,
+    InstallStatusChanged,
+    ModelInstallModal,
+    ModelInstallProgress,
+    make_progress_callback,
+)
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Model_Artifacts.acquisition import CredentialResolver
+
+
+class RemoteView(Widget):
+    """Search and explicitly install pinned remote GGUF artifacts."""
+
+    DEFAULT_CSS = """
+    RemoteView {
+        height: 100%;
+    }
+
+    RemoteView .remote-header {
+        height: 3;
+    }
+
+    RemoteView #remote-model-query {
+        width: 1fr;
+    }
+
+    RemoteView #remote-model-search {
+        width: auto;
+    }
+
+    RemoteView .remote-list {
+        height: 1fr;
+    }
+
+    RemoteView .remote-row {
+        height: auto;
+        padding: 1;
+        margin-bottom: 1;
+        border: solid $surface-lighten-1;
+    }
+
+    RemoteView .remote-title {
+        text-style: bold;
+    }
+
+    """
+
+    def __init__(
+        self,
+        *,
+        adapter_factory: Callable[[], HuggingFaceRemoteAdapter] = (
+            HuggingFaceRemoteAdapter
+        ),
+        service_factory: Callable[[], ModelArtifactService] = managed_service,
+        credential_resolver_factory: Callable[[], CredentialResolver] = (
+            EnvConfigCredentialResolver
+        ),
+        id: str | None = None,
+    ) -> None:
+        """Create an idle Remote view without instantiating I/O dependencies.
+
+        Args:
+            adapter_factory: Lazy bounded metadata-adapter factory.
+            service_factory: Lazy managed-store service factory.
+            credential_resolver_factory: Lazy credential resolver factory.
+            id: Optional Textual widget id.
+        """
+        self._adapter_factory = adapter_factory
+        self._service_factory = service_factory
+        self._credential_resolver_factory = credential_resolver_factory
+        self._search_generation = 0
+        self._resolve_generation = 0
+        self._results: tuple[RemoteModelSummary, ...] = ()
+        self._resolved: ResolvedRemoteModel | None = None
+        self._selected_catalog: ResolvedRemoteCatalog | None = None
+        self._pending_report = None
+        self._operation_reference: ArtifactRef | None = None
+        super().__init__(id=id)
+
+    def compose(self) -> ComposeResult:
+        """Compose retained display state without metadata or store access."""
+        disabled = self._operation_reference is not None
+        with Horizontal(classes="remote-header"):
+            yield Input(
+                placeholder="Search or enter owner/repository",
+                id="remote-model-query",
+                disabled=disabled,
+            )
+            yield Button(
+                "Search",
+                id="remote-model-search",
+                variant="primary",
+                disabled=disabled,
+            )
+        progress = ModelInstallProgress(None, id="remote-model-install-progress")
+        progress.display = False
+        yield progress
+        yield Static(self._default_status(), id="remote-model-status", markup=False)
+
+        yield VerticalScroll(
+            *self._content_widgets(disabled=disabled),
+            id="remote-model-content",
+            classes="remote-list",
+        )
+
+    def _default_status(self) -> str:
+        if self._resolved is not None:
+            return (
+                f"Pinned {self._resolved.repository} at "
+                f"{self._resolved.commit}. Select one GGUF candidate."
+            )
+        if self._results:
+            return "Select a repository to inspect its eligible GGUF files."
+        return "Search runs only when you press Search."
+
+    def _result_widget(self, summary: RemoteModelSummary, *, disabled: bool) -> Vertical:
+        button = Button(
+            "Inspect GGUF files",
+            classes="remote-result",
+            variant="primary",
+            disabled=disabled,
+        )
+        button.repository = summary.repository
+        access = "private" if summary.private else "public"
+        return Vertical(
+            Static(summary.repository, classes="remote-title", markup=False),
+            Static(f"{access} · gated: {summary.gated}", markup=False),
+            button,
+            classes="remote-row",
+        )
+
+    def _content_widgets(self, *, disabled: bool):
+        for summary in self._results:
+            yield self._result_widget(summary, disabled=disabled)
+        if self._resolved is not None:
+            yield from self._resolved_widgets(self._resolved, disabled=disabled)
+
+    def _resolved_widgets(
+        self,
+        resolved: ResolvedRemoteModel,
+        *,
+        disabled: bool,
+    ):
+        yield Static(
+            "Runtime compatibility has not been verified.",
+            classes="remote-title",
+            markup=False,
+        )
+        yield Static(f"Repository: {resolved.repository}", markup=False)
+        yield Static(f"Commit: {resolved.commit}", markup=False)
+        license_label = (
+            "Unknown / not declared"
+            if resolved.license_id == "NOASSERTION"
+            else resolved.license_id
+        )
+        yield Static(f"License: {license_label}", markup=False)
+        yield Static(f"Source review page: {resolved.review_url}", markup=False)
+        yield Static("Provenance: Local integrity recorded", markup=False)
+        for warning in resolved.warnings:
+            yield Static(f"Incomplete shard set: {warning}", markup=False)
+        for candidate in resolved.candidates:
+            button = Button(
+                "Review and install…",
+                classes="remote-candidate",
+                variant="primary",
+                disabled=disabled,
+            )
+            button.candidate = candidate
+            yield Vertical(
+                Static(candidate.label, classes="remote-title", markup=False),
+                Static(
+                    f"{len(candidate.files)} file(s) · {candidate.total_bytes} bytes",
+                    markup=False,
+                ),
+                button,
+                classes="remote-row",
+            )
+
+    def _set_status(self, message: str) -> None:
+        self.query_one("#remote-model-status", Static).update(message)
+
+    def _refresh_with_status(self, message: str) -> None:
+        self._set_status(message)
+        content = self.query_one("#remote-model-content", VerticalScroll)
+        content.remove_children()
+        content.mount(
+            *self._content_widgets(disabled=self._operation_reference is not None)
+        )
+
+    def _set_metadata_controls_disabled(self, disabled: bool) -> None:
+        for control in self.query("#remote-model-query, #remote-model-search"):
+            control.disabled = disabled
+        for button in self.query(".remote-result, .remote-candidate").results(Button):
+            button.disabled = disabled
+
+    @on(Button.Pressed, "#remote-model-search")
+    @on(Input.Submitted, "#remote-model-query")
+    def _search_submitted(self) -> None:
+        if self._operation_reference is not None:
+            return
+        query = self.query_one("#remote-model-query", Input).value.strip()
+        self._search_generation += 1
+        self._resolve_generation += 1
+        self._results = ()
+        self._resolved = None
+        self._selected_catalog = None
+        self._set_metadata_controls_disabled(True)
+        if is_exact_repository(query):
+            self._set_status("Inspecting repository…")
+            self._resolve_remote(query, self._resolve_generation)
+            return
+        self._set_status("Searching remote models…")
+        self._search_remote(query, self._search_generation)
+
+    @on(Button.Pressed, ".remote-result")
+    def _result_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._operation_reference is not None:
+            return
+        repository = getattr(event.button, "repository", None)
+        if not isinstance(repository, str):
+            return
+        self._resolve_generation += 1
+        self._resolved = None
+        self._selected_catalog = None
+        self._set_metadata_controls_disabled(True)
+        self._set_status("Inspecting repository…")
+        self._resolve_remote(repository, self._resolve_generation)
+
+    @on(Button.Pressed, ".remote-candidate")
+    def _candidate_pressed(self, event: Button.Pressed) -> None:
+        """Freeze one resolved candidate and begin managed preflight."""
+        event.stop()
+        candidate = getattr(event.button, "candidate", None)
+        if (
+            type(candidate) is not RemoteGGUFCandidate
+            or self._resolved is None
+            or self._operation_reference is not None
+        ):
+            return
+        try:
+            catalog = build_remote_catalog(self._resolved, candidate)
+        except ValueError:
+            self.notify(
+                "This GGUF candidate cannot be safely prepared. Search again.",
+                severity="error",
+            )
+            return
+        self._selected_catalog = catalog
+        self._operation_reference = catalog.artifact.reference
+        self._set_metadata_controls_disabled(True)
+        self._set_status("Preparing the managed install plan…")
+        self._preflight_model(catalog)
+
+    @work(thread=True, group="remote_model_search", exit_on_error=False)
+    def _search_remote(self, query: str, generation: int) -> None:
+        """Search explicit free text off the Textual event loop."""
+        try:
+            resolver = self._credential_resolver_factory()
+            token = resolver.resolve(query)
+            results = asyncio.run(self._adapter_factory().search(query, token=token))
+        except Exception as exc:
+            self.app.call_from_thread(
+                self._apply_search_result,
+                generation,
+                query,
+                (),
+                exc,
+            )
+            return
+        self.app.call_from_thread(
+            self._apply_search_result,
+            generation,
+            query,
+            results,
+            None,
+        )
+
+    def _apply_search_result(
+        self,
+        generation: int,
+        query: str,
+        results: tuple[RemoteModelSummary, ...],
+        error: BaseException | None,
+    ) -> None:
+        """Apply only the current query generation and current input value."""
+        if generation != self._search_generation:
+            return
+        current_query = self.query_one("#remote-model-query", Input).value.strip()
+        if current_query != query:
+            self._set_metadata_controls_disabled(False)
+            return
+        self._set_metadata_controls_disabled(False)
+        if error is not None:
+            self._results = ()
+            self._resolved = None
+            self._refresh_with_status(_discovery_error_message(error))
+            return
+        self._results = results
+        self._resolved = None
+        message = (
+            "Select a repository to inspect its eligible GGUF files."
+            if results
+            else "No matching repositories were found. Try another search."
+        )
+        self._refresh_with_status(message)
+
+    @work(thread=True, group="remote_model_resolve", exit_on_error=False)
+    def _resolve_remote(self, repository: str, generation: int) -> None:
+        """Resolve one exact repository off the Textual event loop."""
+        try:
+            resolver = self._credential_resolver_factory()
+            token = resolver.resolve(repository)
+            resolved = asyncio.run(
+                self._adapter_factory().resolve(repository, token=token)
+            )
+        except Exception as exc:
+            self.app.call_from_thread(
+                self._apply_resolve_result,
+                generation,
+                None,
+                exc,
+            )
+            return
+        self.app.call_from_thread(
+            self._apply_resolve_result,
+            generation,
+            resolved,
+            None,
+        )
+
+    def _apply_resolve_result(
+        self,
+        generation: int,
+        resolved: ResolvedRemoteModel | None,
+        error: BaseException | None,
+    ) -> None:
+        """Apply only the current repository-resolution generation."""
+        if generation != self._resolve_generation:
+            return
+        self._set_metadata_controls_disabled(False)
+        if error is not None or resolved is None:
+            self._resolved = None
+            self._refresh_with_status(
+                _discovery_error_message(error or RuntimeError("resolve failed"))
+            )
+            return
+        self._results = ()
+        self._resolved = resolved
+        self._refresh_with_status(
+            f"Pinned {resolved.repository} at {resolved.commit}. "
+            "Select one GGUF candidate."
+        )
+
+    async def _preflight(self, catalog: ResolvedRemoteCatalog):
+        """Resolve the selected catalog's managed plan on a worker event loop."""
+        resolver = self._credential_resolver_factory()
+        acquisition = ArtifactAcquisitionService(
+            self._service_factory(),
+            credential_resolver=resolver,
+        )
+        return await acquisition.preflight(
+            catalog.artifact.reference,
+            catalog,
+            sources=catalog.sources,
+        )
+
+    @work(thread=True, group="remote_model_install", exclusive=True, exit_on_error=False)
+    def _preflight_model(self, catalog: ResolvedRemoteCatalog) -> None:
+        """Resolve the frozen candidate plan off the Textual event loop."""
+        try:
+            report = asyncio.run(self._preflight(catalog))
+        except Exception as exc:
+            logger.error(
+                "Remote model preflight failed for managed artifact {}",
+                catalog.artifact.reference.artifact_id,
+            )
+            self.app.call_from_thread(
+                self._apply_preflight_result,
+                None,
+                install_failure_message(
+                    exc,
+                    model_label=catalog.artifact.model_id,
+                ),
+            )
+            return
+        self.app.call_from_thread(self._apply_preflight_result, report, None)
+
+    def _apply_preflight_result(self, report, error: str | None) -> None:
+        """Show the shared consent modal or release the frozen selection."""
+        catalog = self._selected_catalog
+        if (
+            error is not None
+            or report is None
+            or catalog is None
+            or report.root != catalog.artifact.reference
+        ):
+            self._pending_report = None
+            self._operation_reference = None
+            self._selected_catalog = None
+            self._set_metadata_controls_disabled(False)
+            message = error or "The install plan changed. Search and review it again."
+            self._set_status(message)
+            self.notify(message, severity="error")
+            return
+        self._pending_report = report
+        acknowledgment = (
+            "No license was declared. I reviewed the source and want to continue."
+            if catalog.artifact.license_id == "NOASSERTION"
+            else None
+        )
+        self.app.push_screen(
+            ModelInstallModal(
+                report,
+                model_label=catalog.artifact.model_id,
+                required_acknowledgment=acknowledgment,
+            ),
+            self._confirm_install,
+        )
+
+    def _confirm_install(self, confirmed: bool) -> None:
+        """Provision only after consent while preserving the frozen catalog."""
+        if not confirmed:
+            self._pending_report = None
+            self._operation_reference = None
+            self._selected_catalog = None
+            self._set_metadata_controls_disabled(False)
+            self._set_status(self._default_status())
+            return
+        if self._operation_reference is not None:
+            self.post_message(
+                InstallStatusChanged(self._operation_reference, active=True)
+            )
+        self._provision_model()
+
+    async def _provision(self, report, catalog: ResolvedRemoteCatalog):
+        """Install the reviewed catalog without activating it."""
+        resolver = self._credential_resolver_factory()
+        acquisition = ArtifactAcquisitionService(
+            self._service_factory(),
+            credential_resolver=resolver,
+        )
+        return await acquisition.provision(
+            report.root,
+            report.grant(),
+            catalog,
+            sources=catalog.sources,
+            progress=make_progress_callback(self.post_message),
+            activate=False,
+        )
+
+    @work(thread=True, group="remote_model_install", exclusive=True, exit_on_error=False)
+    def _provision_model(self) -> None:
+        """Provision the frozen plan and catalog off the Textual event loop."""
+        report = self._pending_report
+        catalog = self._selected_catalog
+        if report is None or catalog is None:
+            self.app.call_from_thread(
+                self._apply_provision_result,
+                "No install plan is available; search and review the model again.",
+            )
+            return
+        try:
+            asyncio.run(self._provision(report, catalog))
+        except Exception as exc:
+            logger.error(
+                "Remote model installation failed for managed artifact {}",
+                report.root.artifact_id,
+            )
+            self.app.call_from_thread(
+                self._apply_provision_result,
+                install_failure_message(
+                    exc,
+                    model_label=catalog.artifact.model_id,
+                ),
+            )
+            return
+        self.app.call_from_thread(self._apply_provision_result, None)
+
+    @on(InstallProgressed)
+    def _install_progressed(self, event: InstallProgressed) -> None:
+        """Render shared acquisition progress in the Remote view."""
+        try:
+            progress = self.query_one(
+                "#remote-model-install-progress",
+                ModelInstallProgress,
+            )
+        except NoMatches:
+            return
+        progress.display = True
+        progress.update_progress(event.progress)
+
+    def _apply_provision_result(self, error: str | None) -> None:
+        """Finish install-only provisioning and publish inventory refresh state."""
+        reference = self._operation_reference
+        self._pending_report = None
+        self._operation_reference = None
+        self._selected_catalog = None
+        try:
+            progress = self.query_one(
+                "#remote-model-install-progress",
+                ModelInstallProgress,
+            )
+        except NoMatches:
+            progress = None
+        if progress is not None:
+            progress.display = False
+        self._set_metadata_controls_disabled(False)
+        if error is not None:
+            self._set_status(error)
+            self.notify(error, severity="error")
+        else:
+            message = (
+                "Model downloaded and managed. Runtime compatibility has not "
+                "been verified."
+            )
+            self._set_status(message)
+            self.notify(message, severity="information")
+        if reference is not None:
+            self.post_message(
+                InstallStatusChanged(
+                    reference,
+                    active=False,
+                    succeeded=error is None,
+                )
+            )
+
+
+def _discovery_error_message(error: BaseException) -> str:
+    """Map metadata failures to fixed recovery copy without raw details."""
+    if not isinstance(error, RemoteDiscoveryError):
+        return "Remote model discovery failed. Retry."
+    if error.code in {"authentication_required", "access_forbidden"}:
+        return "Configure or verify Hugging Face access, then Retry."
+    if error.code == "repository_not_found":
+        return "Repository not found. Check the exact ID or search again."
+    if error.code in {"invalid_response", "response_too_large"}:
+        return "This repository cannot be safely inspected."
+    if error.code == "no_eligible_gguf":
+        return (
+            "No eligible GGUF files were found. Files must be LFS-backed with "
+            "size and SHA-256 metadata."
+        )
+    if error.retryable or error.code in {"network_error", "rate_limited"}:
+        return "Remote request failed. Retry."
+    if error.code in {"invalid_query", "invalid_repository"}:
+        return "Enter a search term or exact owner/repository ID."
+    return "Remote model discovery failed. Retry."

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -17,6 +17,7 @@ from textual.widgets import Button, Input, Static
 from tldw_chatbook.Model_Artifacts.acquisition import (
     ArtifactAcquisitionService,
     EnvConfigCredentialResolver,
+    TransferError,
 )
 from tldw_chatbook.Model_Artifacts.remote_huggingface import (
     HuggingFaceRemoteAdapter,
@@ -151,7 +152,9 @@ class RemoteView(Widget):
             return "Select a repository to inspect its eligible GGUF files."
         return "Search runs only when you press Search."
 
-    def _result_widget(self, summary: RemoteModelSummary, *, disabled: bool) -> Vertical:
+    def _result_widget(
+        self, summary: RemoteModelSummary, *, disabled: bool
+    ) -> Vertical:
         button = Button(
             "Inspect GGUF files",
             classes="remote-result",
@@ -406,10 +409,7 @@ class RemoteView(Widget):
         if (
             current_input != relevant_input
             or not repository_is_current
-            or (
-                resolved is not None
-                and resolved.repository != requested_repository
-            )
+            or (resolved is not None and resolved.repository != requested_repository)
         ):
             self._results = ()
             self._resolved = None
@@ -446,7 +446,9 @@ class RemoteView(Widget):
             sources=catalog.sources,
         )
 
-    @work(thread=True, group="remote_model_install", exclusive=True, exit_on_error=False)
+    @work(
+        thread=True, group="remote_model_install", exclusive=True, exit_on_error=False
+    )
     def _preflight_model(
         self,
         catalog: ResolvedRemoteCatalog,
@@ -457,8 +459,11 @@ class RemoteView(Widget):
             report = asyncio.run(self._preflight(catalog))
         except Exception as exc:
             logger.error(
-                "Remote model preflight failed for managed artifact {}",
+                "Remote model preflight failed for managed artifact {}; "
+                "error_type={}, retryable={}",
                 catalog.artifact.reference.artifact_id,
+                type(exc).__name__,
+                isinstance(exc, TransferError) and exc.retryable,
             )
             self.app.call_from_thread(
                 self._apply_preflight_result,
@@ -564,7 +569,9 @@ class RemoteView(Widget):
             activate=False,
         )
 
-    @work(thread=True, group="remote_model_install", exclusive=True, exit_on_error=False)
+    @work(
+        thread=True, group="remote_model_install", exclusive=True, exit_on_error=False
+    )
     def _provision_model(self) -> None:
         """Provision the frozen plan and catalog off the Textual event loop."""
         report = self._pending_report
@@ -579,8 +586,11 @@ class RemoteView(Widget):
             asyncio.run(self._provision(report, catalog))
         except Exception as exc:
             logger.error(
-                "Remote model installation failed for managed artifact {}",
+                "Remote model installation failed for managed artifact {}; "
+                "error_type={}, retryable={}",
                 report.root.artifact_id,
+                type(exc).__name__,
+                isinstance(exc, TransferError) and exc.retryable,
             )
             self.app.call_from_thread(
                 self._apply_provision_result,

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -404,7 +404,13 @@ class RemoteView(Widget):
                 and resolved.repository != requested_repository
             )
         ):
+            self._results = ()
+            self._resolved = None
+            self._selected_catalog = None
             self._set_metadata_controls_disabled(False)
+            self._refresh_with_status(
+                "Repository selection changed. Press Search to inspect the current ID."
+            )
             return
         self._set_metadata_controls_disabled(False)
         if error is not None or resolved is None:

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -245,7 +245,7 @@ class RemoteView(Widget):
         self._set_metadata_controls_disabled(True)
         if is_exact_repository(query):
             self._set_status("Inspecting repository…")
-            self._resolve_remote(query, self._resolve_generation)
+            self._resolve_remote(query, self._resolve_generation, query)
             return
         self._set_status("Searching remote models…")
         self._search_remote(query, self._search_generation)
@@ -263,7 +263,8 @@ class RemoteView(Widget):
         self._selected_catalog = None
         self._set_metadata_controls_disabled(True)
         self._set_status("Inspecting repository…")
-        self._resolve_remote(repository, self._resolve_generation)
+        relevant_input = self.query_one("#remote-model-query", Input).value.strip()
+        self._resolve_remote(repository, self._resolve_generation, relevant_input)
 
     @on(Button.Pressed, ".remote-candidate")
     def _candidate_pressed(self, event: Button.Pressed) -> None:
@@ -344,7 +345,12 @@ class RemoteView(Widget):
         self._refresh_with_status(message)
 
     @work(thread=True, group="remote_model_resolve", exit_on_error=False)
-    def _resolve_remote(self, repository: str, generation: int) -> None:
+    def _resolve_remote(
+        self,
+        repository: str,
+        generation: int,
+        relevant_input: str,
+    ) -> None:
         """Resolve one exact repository off the Textual event loop."""
         try:
             resolver = self._credential_resolver_factory()
@@ -356,6 +362,8 @@ class RemoteView(Widget):
             self.app.call_from_thread(
                 self._apply_resolve_result,
                 generation,
+                repository,
+                relevant_input,
                 None,
                 exc,
             )
@@ -363,6 +371,8 @@ class RemoteView(Widget):
         self.app.call_from_thread(
             self._apply_resolve_result,
             generation,
+            repository,
+            relevant_input,
             resolved,
             None,
         )
@@ -370,11 +380,31 @@ class RemoteView(Widget):
     def _apply_resolve_result(
         self,
         generation: int,
+        requested_repository: str,
+        relevant_input: str,
         resolved: ResolvedRemoteModel | None,
         error: BaseException | None,
     ) -> None:
-        """Apply only the current repository-resolution generation."""
+        """Apply only the current repository-resolution identity."""
         if generation != self._resolve_generation:
+            return
+        current_input = self.query_one("#remote-model-query", Input).value.strip()
+        repository_is_current = (
+            requested_repository == relevant_input
+            if is_exact_repository(relevant_input)
+            else any(
+                result.repository == requested_repository for result in self._results
+            )
+        )
+        if (
+            current_input != relevant_input
+            or not repository_is_current
+            or (
+                resolved is not None
+                and resolved.repository != requested_repository
+            )
+        ):
+            self._set_metadata_controls_disabled(False)
             return
         self._set_metadata_controls_disabled(False)
         if error is not None or resolved is None:

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -194,6 +194,12 @@ class RemoteView(Widget):
         yield Static(f"License: {license_label}", markup=False)
         yield Static(f"Source review page: {resolved.review_url}", markup=False)
         yield Static("Provenance: Local integrity recorded", markup=False)
+        if resolved.total_candidate_count > len(resolved.candidates):
+            yield Static(
+                f"First {len(resolved.candidates)} of "
+                f"{resolved.total_candidate_count}, sorted by upstream path",
+                markup=False,
+            )
         for warning in resolved.warnings:
             yield Static(f"Incomplete shard set: {warning}", markup=False)
         for candidate in resolved.candidates:
@@ -274,6 +280,7 @@ class RemoteView(Widget):
         if (
             type(candidate) is not RemoteGGUFCandidate
             or self._resolved is None
+            or candidate not in self._resolved.candidates
             or self._operation_reference is not None
         ):
             return
@@ -289,7 +296,7 @@ class RemoteView(Widget):
         self._operation_reference = catalog.artifact.reference
         self._set_metadata_controls_disabled(True)
         self._set_status("Preparing the managed install plan…")
-        self._preflight_model(catalog)
+        self._preflight_model(catalog, candidate)
 
     @work(thread=True, group="remote_model_search", exit_on_error=False)
     def _search_remote(self, query: str, generation: int) -> None:
@@ -440,7 +447,11 @@ class RemoteView(Widget):
         )
 
     @work(thread=True, group="remote_model_install", exclusive=True, exit_on_error=False)
-    def _preflight_model(self, catalog: ResolvedRemoteCatalog) -> None:
+    def _preflight_model(
+        self,
+        catalog: ResolvedRemoteCatalog,
+        candidate: RemoteGGUFCandidate,
+    ) -> None:
         """Resolve the frozen candidate plan off the Textual event loop."""
         try:
             report = asyncio.run(self._preflight(catalog))
@@ -456,11 +467,22 @@ class RemoteView(Widget):
                     exc,
                     model_label=catalog.artifact.model_id,
                 ),
+                candidate,
             )
             return
-        self.app.call_from_thread(self._apply_preflight_result, report, None)
+        self.app.call_from_thread(
+            self._apply_preflight_result,
+            report,
+            None,
+            candidate,
+        )
 
-    def _apply_preflight_result(self, report, error: str | None) -> None:
+    def _apply_preflight_result(
+        self,
+        report,
+        error: str | None,
+        candidate: RemoteGGUFCandidate | None = None,
+    ) -> None:
         """Show the shared consent modal or release the frozen selection."""
         catalog = self._selected_catalog
         if (
@@ -483,11 +505,30 @@ class RemoteView(Widget):
             if catalog.artifact.license_id == "NOASSERTION"
             else None
         )
+        selected_file_details: tuple[tuple[str, int, str, str], ...] = ()
+        if candidate is not None:
+            remote_files = tuple(
+                sorted(candidate.files, key=lambda item: item.upstream_path)
+            )
+            selected_file_details = tuple(
+                (
+                    remote_file.upstream_path,
+                    remote_file.size_bytes,
+                    remote_file.sha256,
+                    catalog.sources[catalog.artifact.reference][artifact_file.path],
+                )
+                for remote_file, artifact_file in zip(
+                    remote_files,
+                    catalog.artifact.files,
+                    strict=True,
+                )
+            )
         self.app.push_screen(
             ModelInstallModal(
                 report,
                 model_label=catalog.artifact.model_id,
                 required_acknowledgment=acknowledgment,
+                selected_file_details=selected_file_details,
             ),
             self._confirm_install,
         )
@@ -611,10 +652,16 @@ def _discovery_error_message(error: BaseException) -> str:
     if error.code in {"invalid_response", "response_too_large"}:
         return "This repository cannot be safely inspected."
     if error.code == "no_eligible_gguf":
-        return (
+        message = (
             "No eligible GGUF files were found. Files must be LFS-backed with "
             "size and SHA-256 metadata."
         )
+        if error.details:
+            details = "\n".join(
+                f"Incomplete shard set: {detail}" for detail in error.details
+            )
+            message = f"{message}\n{details}"
+        return message
     if error.retryable or error.code in {"network_error", "rate_limited"}:
         return "Remote request failed. Retry."
     if error.code in {"invalid_query", "invalid_repository"}:

--- a/tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/activation_controls.py
@@ -52,6 +52,7 @@ class ModelActivationControls(Widget):
         active: bool,
         ready: bool,
         pending: bool = False,
+        allow_activation: bool = True,
     ) -> None:
         """Create controls for one exact installed reference.
 
@@ -60,22 +61,25 @@ class ModelActivationControls(Widget):
             active: Whether this reference is already selected.
             ready: Whether verification/readiness allows activation.
             pending: Whether another lifecycle operation is running.
+            allow_activation: Whether this model is eligible for activation.
         """
         self.reference = reference
         self.active = active
         self.ready = ready
         self.pending = pending
+        self.allow_activation = allow_activation
         super().__init__()
 
     def compose(self) -> ComposeResult:
         """Compose the activation and deletion buttons."""
         with Horizontal():
-            yield Button(
-                "Active" if self.active else "Activate",
-                classes="model-activate",
-                variant="primary",
-                disabled=self.pending or self.active or not self.ready,
-            )
+            if self.allow_activation:
+                yield Button(
+                    "Active" if self.active else "Activate",
+                    classes="model-activate",
+                    variant="primary",
+                    disabled=self.pending or self.active or not self.ready,
+                )
             yield Button(
                 "Delete…",
                 classes="model-delete",
@@ -90,9 +94,9 @@ class ModelActivationControls(Widget):
             pending: Whether activation/deletion is pending.
         """
         self.pending = pending
-        activate = self.query_one(".model-activate", Button)
         delete = self.query_one(".model-delete", Button)
-        activate.disabled = pending or self.active or not self.ready
+        for activate in self.query(".model-activate"):
+            activate.disabled = pending or self.active or not self.ready
         delete.disabled = pending
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
@@ -100,7 +104,12 @@ class ModelActivationControls(Widget):
         event.stop()
         if self.pending:
             return
-        if event.button.has_class("model-activate") and self.ready and not self.active:
+        if (
+            self.allow_activation
+            and event.button.has_class("model-activate")
+            and self.ready
+            and not self.active
+        ):
             self.post_message(ActivationRequested(self.reference))
         elif event.button.has_class("model-delete"):
             self.post_message(DeletionRequested(self.reference))

--- a/tldw_chatbook/Widgets/ModelArtifacts/install_modal.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/install_modal.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button
+from textual.widgets import Button, Checkbox
 
 from .plan_panel import ModelPlanPanel
 
@@ -54,6 +55,7 @@ class ModelInstallModal(ModalScreen[bool]):
         container_id: str = "model-install-modal",
         confirm_id: str = "model-install-confirm",
         cancel_id: str = "model-install-cancel",
+        required_acknowledgment: str | None = None,
     ) -> None:
         """Build a consent prompt from an immutable preflight report.
 
@@ -63,23 +65,33 @@ class ModelInstallModal(ModalScreen[bool]):
             container_id: Container id for the consuming surface.
             confirm_id: Confirm button id for the consuming surface.
             cancel_id: Cancel button id for the consuming surface.
+            required_acknowledgment: Optional text that must be acknowledged
+                before installing.
         """
         self.report = report
         self.model_label = model_label
         self.container_id = container_id
         self.confirm_id = confirm_id
         self.cancel_id = cancel_id
+        self.required_acknowledgment = required_acknowledgment
+        self._acknowledged = required_acknowledgment is None
         super().__init__()
 
     @property
     def ungrantable(self) -> bool:
         """Return whether the report cannot produce valid consent."""
-        return bool(self.report.gating_errors) or not self.report.sufficient_space
+        return (
+            bool(self.report.gating_errors)
+            or not self.report.sufficient_space
+            or not self._acknowledged
+        )
 
     def compose(self) -> ComposeResult:
         """Compose the plan and decision controls."""
         with Vertical(id=self.container_id, classes="model-install-modal"):
             yield ModelPlanPanel(self.report, model_label=self.model_label)
+            if self.required_acknowledgment is not None:
+                yield Checkbox(self.required_acknowledgment)
             with Horizontal(classes="model-install-actions"):
                 yield Button("Cancel", id=self.cancel_id, variant="default")
                 yield Button(
@@ -88,6 +100,12 @@ class ModelInstallModal(ModalScreen[bool]):
                     variant="primary",
                     disabled=self.ungrantable,
                 )
+
+    @on(Checkbox.Changed)
+    def _acknowledgment_changed(self, event: Checkbox.Changed) -> None:
+        """Update consent availability after an optional acknowledgment."""
+        self._acknowledged = event.value
+        self.query_one(f"#{self.confirm_id}", Button).disabled = self.ungrantable
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Dismiss with the decision represented by the pressed control."""

--- a/tldw_chatbook/Widgets/ModelArtifacts/install_modal.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/install_modal.py
@@ -56,6 +56,7 @@ class ModelInstallModal(ModalScreen[bool]):
         confirm_id: str = "model-install-confirm",
         cancel_id: str = "model-install-cancel",
         required_acknowledgment: str | None = None,
+        selected_file_details: tuple[tuple[str, int, str, str], ...] = (),
     ) -> None:
         """Build a consent prompt from an immutable preflight report.
 
@@ -67,6 +68,8 @@ class ModelInstallModal(ModalScreen[bool]):
             cancel_id: Cancel button id for the consuming surface.
             required_acknowledgment: Optional text that must be acknowledged
                 before installing.
+            selected_file_details: Optional selected-only upstream file values
+                to show before confirmation.
         """
         self.report = report
         self.model_label = model_label
@@ -74,6 +77,7 @@ class ModelInstallModal(ModalScreen[bool]):
         self.confirm_id = confirm_id
         self.cancel_id = cancel_id
         self.required_acknowledgment = required_acknowledgment
+        self.selected_file_details = selected_file_details
         self._acknowledged = required_acknowledgment is None
         super().__init__()
 
@@ -89,7 +93,11 @@ class ModelInstallModal(ModalScreen[bool]):
     def compose(self) -> ComposeResult:
         """Compose the plan and decision controls."""
         with Vertical(id=self.container_id, classes="model-install-modal"):
-            yield ModelPlanPanel(self.report, model_label=self.model_label)
+            yield ModelPlanPanel(
+                self.report,
+                model_label=self.model_label,
+                selected_file_details=self.selected_file_details,
+            )
             if self.required_acknowledgment is not None:
                 yield Checkbox(self.required_acknowledgment)
             with Horizontal(classes="model-install-actions"):

--- a/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
@@ -25,6 +25,7 @@ class ModelPlanPanel(Static):
         report: PreflightReport,
         *,
         model_label: str,
+        selected_file_details: tuple[tuple[str, int, str, str], ...] = (),
         id: str | None = None,
     ) -> None:
         """Build the panel from preflight state only.
@@ -32,6 +33,8 @@ class ModelPlanPanel(Static):
         Args:
             report: Immutable acquisition preflight report.
             model_label: User-visible model name.
+            selected_file_details: Optional upstream path, byte count, digest,
+                and pinned source URL values for only the selected candidate.
             id: Optional Textual widget id.
         """
         rows = plan_rows(report)
@@ -56,6 +59,18 @@ class ModelPlanPanel(Static):
                     "",
                 )
             )
+        if selected_file_details:
+            lines.append("Selected upstream files:")
+            for path, size_bytes, sha256, source_url in selected_file_details:
+                lines.extend(
+                    (
+                        f"Path: {path}",
+                        f"Bytes: {size_bytes}",
+                        f"SHA-256: {sha256}",
+                        f"Pinned source URL: {source_url}",
+                        "",
+                    )
+                )
         lines.extend(
             (
                 f"Download: {_mib(totals.download_bytes)}",

--- a/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
+++ b/tldw_chatbook/Widgets/ModelArtifacts/plan_panel.py
@@ -39,11 +39,17 @@ class ModelPlanPanel(Static):
         lines = [f"Install {model_label}?", ""]
         for row in rows:
             installed = " (already installed)" if row.already_installed else ""
+            license_label = (
+                "Unknown / not declared"
+                if row.license_id == "NOASSERTION"
+                else row.license_id
+            )
             lines.extend(
                 (
                     f"Source: {row.repository}{installed}",
                     f"Revision: {row.revision}",
-                    f"License: {row.license_id} — {row.license_url}",
+                    f"License: {license_label}",
+                    f"Source review page: {row.license_url}",
                     f"Precision: {row.precision}",
                     f"Contents: {row.file_count} files, {_mib(row.total_bytes)}",
                     f"Provenance: {row.provenance}",
@@ -72,7 +78,7 @@ class ModelPlanPanel(Static):
             (
                 "",
                 "Every declared file is checked against pinned sizes and "
-                "SHA-256 digests before the model becomes usable.",
+                "SHA-256 digests before installation completes.",
             )
         )
         super().__init__(


### PR DESCRIPTION
## Summary
- add explicit, bounded Hugging Face GGUF search and exact-repository resolution pinned to immutable commits
- map validated LFS-backed single files or complete shard sets into the shared managed-artifact install flow
- install remote artifacts inactive and unassigned, with license review and no runtime-compatibility claims
- reject HTTPS downgrade redirects and preserve credential origin boundaries
- add the lazy, generation-fenced Remote Textual view plus focused adapter, acquisition, security, and UI coverage

## Verification
- 576 passed: Model Artifacts and affected Model Browser/UI adoption matrix
- 18 passed: diagnostic inventory, sentinel matrix, and persistent boundary suites
- 12 credential-boundary tests and 8 deterministic macOS evidence tests passed in the pre-rebase review cycle
- JSON inventory, py_compile, and git diff checks passed
- Ruff clean for all branch-edited files except the pre-existing origin/dev fetch.py:17 F401
- independent final review and fix re-review: no remaining Critical or Important findings

## Architecture
ADR-025 remains authoritative for shared STT artifact provenance, acquisition, activation, and runtime boundaries. ADR-029 covers the reviewed diagnostic inventory update. No new ADR is required.

Closes TASK-596.1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded Hugging Face GGUF discovery to the managed model browser so users can search, pin to a commit, and download exact GGUF files or shard sets without activation. Completes TASK-596.1; installs are inactive and unassigned with license review and no runtime-compatibility claims.

- **New Features**
  - `HuggingFaceRemoteAdapter` using `httpx`, mapping GGUF candidates to managed artifacts; identity fenced to exact repositories and immutable revisions.
  - Lazy Remote view in Lab → Models that does no I/O until search; exact-repo resolution; install-only flow with required license acknowledgment and selected-file details.
  - Install without activation via `activate=False`; inventory/UI gate activation for unassigned models (hide Activate, keep Delete).

- **Bug Fixes**
  - Block HTTPS→HTTP redirect downgrades in `stream_fetch` with `FetchTransportError`.
  - Sanitize remote discovery errors; bound invalid GGUF shard warnings; clear stale resolution controls; preserve credential-origin boundaries.

<sup>Written for commit d4f10ac20ec111b1d21cfccae2e581759a845ee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

