### PR TITLE
Approval: a refused tool call is no longer overwritten by an approval of the same tool

### DIFF
--- a/Tests/Agents/test_agent_runtime_review_hook.py
+++ b/Tests/Agents/test_agent_runtime_review_hook.py
@@ -542,7 +542,7 @@ def test_name_keyed_verdicts_still_apply_to_every_matching_call():
 
     `MCPToolProvider.apply_batch_decisions` and every current test emit
     name-keyed verdicts, and the fence path builds ToolCalls with NO call_id
-    at all (`agent_runtime._fence_call`). A name-keyed verdict must therefore
+    at all (`agent_runtime.parse_tool_call`). A name-keyed verdict must therefore
     still stop every matching call, or this change breaks the MCP gate.
     """
     calls = [

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1916,7 +1916,9 @@ class _FakeReviewProvider:
         self.apply_batch_decisions_calls: list[dict[str, str]] = []
         self._stamped: dict[str, str] = {}
 
-    def pending_gate_for(self, name: str, args: dict) -> MCPPendingCall | None:
+    def pending_gate_for(
+        self, name: str, args: dict, call_id: str = ""
+    ) -> MCPPendingCall | None:
         if name not in self._gated_names:
             return None
         return MCPPendingCall(
@@ -1925,6 +1927,10 @@ class _FakeReviewProvider:
             tool_name=name,
             server_label="Srv",
             arguments=dict(args or {}),
+            # TASK-1861: the double must mirror the real provider, which
+            # carries the per-call key so the card can offer one decision per
+            # TARGET instead of one per tool name.
+            call_id=call_id,
             reason="ask",
         )
 

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -2494,3 +2494,59 @@ def test_a_refusal_never_stamps_the_name_even_when_it_is_decided_last():
     assert verdicts.get("c-no", "proceed") != "proceed", (
         f"secrets.md must still be refused per call: {verdicts}"
     )
+
+
+@pytest.mark.unit
+def test_the_broadest_approval_scope_for_a_tool_survives_collapsing():
+    """TASK-1861: per-call rows can disagree on SCOPE, not just allow/refuse.
+
+    A session or always grant belongs to the TOOL, so the stamp can hold only
+    one scope per name. Collapsing them last-write-wins silently downgraded
+    "Approve for session" to "approve once" whenever a later row of the same
+    tool was approved once -- dropping the grant the user explicitly asked
+    for and re-prompting for it on the next call.
+
+    The user picking "for session" on any call of a tool IS choosing to grant
+    that tool for the session (that is what the control means, and the label
+    says so), so the broadest chosen scope wins.
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
+
+    stamped: list[tuple[str, str]] = []
+
+    class _Gate:
+        def begin_turn(self): pass
+        def resolve(self, tool):
+            return SimpleNamespace(state="ask", risk_floored=False)
+        def stamp(self, name, decision): stamped.append((name, decision))
+        def is_session_approved(self, name): return False
+        def options_for(self, tool):
+            return ("approve_once", "approve_session", "deny")
+
+    class _Provider:
+        def tool_for(self, name): return SimpleNamespace(name=name)
+
+    def request_approvals(pending):
+        # Broad scope FIRST, narrow second -- the ordering that used to lose it.
+        return {
+            row.call_id: (
+                "approve_session" if row.call_id == "c1" else "approve_once"
+            )
+            for row in pending
+        }
+
+    hook = build_tool_review_hook(
+        _Gate(), _Provider(), None, request_approvals, workspace_id=None
+    )
+    hook([
+        ToolCall(name="read_file", args={"path": "a.md"}, call_id="c1"),
+        ToolCall(name="read_file", args={"path": "b.md"}, call_id="c2"),
+    ])
+
+    assert stamped == [("read_file", "approve_session")], (
+        "the session grant the user chose was downgraded to approve_once, so "
+        f"the next call re-prompts: {stamped}"
+    )

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -2322,3 +2322,175 @@ async def test_armed_deadline_is_visible_on_the_mounted_card():
         card.set_batch(_sample_calls(), timeout_seconds=0)
         await pilot.pause()
         assert not app.query_one("#approval-deadline", Static).display
+
+
+@pytest.mark.unit
+def test_refusing_one_call_does_not_get_overwritten_by_approving_another():
+    """A per-call REFUSAL must reach the runtime, not be flattened away.
+
+    TASK-1861. Verdicts are keyed per `call_id` so the user can allow
+    `spec.md` and refuse `secrets.md` in one batch -- but both enforcement
+    consumers are name-keyed (`builtin_gate.stamp` records a grant against a
+    tool NAME; `apply_batch_decisions` takes llm_names), and the hook
+    returned a flat `{name: "proceed"}`. So two rows of one tool disagreeing
+    resolved LAST-WRITE-WINS on a single name:
+
+        stamped: [("read_file", "deny"), ("read_file", "approve_once")]
+
+    Refuse `secrets.md` first, approve `spec.md` second, and the surviving
+    stamp is `approve_once` -- the file the user explicitly refused is read.
+    This fails OPEN, which is why it is pinned rather than left to the
+    round-trip tests: the card offers a decision the pipeline could not
+    honour.
+
+    The fix enforces refusals PER CALL at the runtime hook (the runtime
+    resolves `call_id` before name, and a non-"proceed" verdict string
+    becomes the call's result without dispatch), leaving the name-keyed
+    stamps to carry only what was APPROVED.
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
+
+    stamped: list[tuple[str, str]] = []
+
+    class _Gate:
+        def begin_turn(self): pass
+        def resolve(self, tool):
+            return SimpleNamespace(state="ask", risk_floored=False)
+        def stamp(self, name, decision): stamped.append((name, decision))
+        def is_session_approved(self, name): return False
+        def options_for(self, tool):
+            return ("approve_once", "approve_session", "deny")
+
+    class _Provider:
+        def tool_for(self, name): return SimpleNamespace(name=name)
+
+    def request_approvals(pending):
+        by_path = {
+            row.call_id: (row.arguments or {}).get("path") for row in pending
+        }
+        # Refuse secrets.md; allow spec.md. Refusal FIRST is the fail-open
+        # ordering -- the later approval used to overwrite it.
+        return {
+            call_id: ("deny" if path == "secrets.md" else "approve_once")
+            for call_id, path in by_path.items()
+        }
+
+    hook = build_tool_review_hook(
+        _Gate(), _Provider(), None, request_approvals, workspace_id=None
+    )
+    verdicts = hook([
+        ToolCall(name="read_file", args={"path": "secrets.md"}, call_id="call-1"),
+        ToolCall(name="read_file", args={"path": "spec.md"}, call_id="call-2"),
+    ])
+
+    refusal = verdicts.get("call-1")
+    assert refusal and refusal != "proceed", (
+        "the refusal of secrets.md never reached the runtime, so the "
+        f"name-keyed approval of spec.md let it through: {verdicts}"
+    )
+    assert verdicts.get("call-2", "proceed") == "proceed", (
+        f"approving spec.md must still let it run: {verdicts}"
+    )
+    assert ("read_file", "deny") not in stamped, (
+        "a refusal must not be stamped against the NAME -- that would also "
+        f"stop the call the user approved: {stamped}"
+    )
+
+
+@pytest.mark.unit
+def test_mcp_rows_carry_their_call_id_so_two_targets_are_two_decisions():
+    """TASK-1861: MCP rows dropped the call id, so `xN` still hid targets.
+
+    `_collect_mcp_pending` walks the batch and calls
+    `provider.pending_gate_for(call.name, call.args)` -- the call's
+    `call_id` was discarded at that boundary, so every MCP pending row
+    carried `call_id=""`. The card then collapsed all same-name MCP calls
+    into ONE `xN` row with one verdict, which is the exact defect the
+    per-call re-key fixed for built-in tools and left standing for MCP.
+    """
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Chat.console_chat_controller import _collect_mcp_pending
+
+    class _Provider:
+        def pending_gate_for(self, llm_name, args, call_id=""):
+            return MCPPendingCall(
+                llm_name=llm_name,
+                server_key="local:fs",
+                tool_name="read_file",
+                server_label="FS",
+                arguments=dict(args or {}),
+                call_id=call_id,
+                reason="ask",
+            )
+
+    rows = _collect_mcp_pending(
+        _Provider(),
+        [
+            ToolCall(name="mcp__fs__read", args={"path": "spec.md"}, call_id="c1"),
+            ToolCall(name="mcp__fs__read", args={"path": "secrets.md"}, call_id="c2"),
+        ],
+    )
+    assert [r.call_id for r in rows] == ["c1", "c2"], (
+        f"the call ids never reached the MCP rows: {[r.call_id for r in rows]}"
+    )
+
+
+@pytest.mark.unit
+def test_a_refusal_never_stamps_the_name_even_when_it_is_decided_last():
+    """TASK-1861, the other ordering -- and the one that fails CLOSED.
+
+    Approve `spec.md`, then refuse `secrets.md`. Both rows share the tool
+    NAME, and the stamp is what `invoke()` peeks at, so stamping the refusal
+    would block the call the user just approved.
+
+    This case is separate because the sibling test cannot catch it: there
+    the refusal is decided FIRST, so a bug that stamps refusals is masked by
+    the later approval overwriting it. Mutation-checked -- stamping every
+    decision regardless of verdict passes that test and fails this one.
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
+
+    stamped: list[tuple[str, str]] = []
+
+    class _Gate:
+        def begin_turn(self): pass
+        def resolve(self, tool):
+            return SimpleNamespace(state="ask", risk_floored=False)
+        def stamp(self, name, decision): stamped.append((name, decision))
+        def is_session_approved(self, name): return False
+        def options_for(self, tool):
+            return ("approve_once", "approve_session", "deny")
+
+    class _Provider:
+        def tool_for(self, name): return SimpleNamespace(name=name)
+
+    def request_approvals(pending):
+        return {
+            row.call_id: (
+                "deny" if (row.arguments or {}).get("path") == "secrets.md"
+                else "approve_session"
+            )
+            for row in pending
+        }
+
+    hook = build_tool_review_hook(
+        _Gate(), _Provider(), None, request_approvals, workspace_id=None
+    )
+    verdicts = hook([
+        ToolCall(name="read_file", args={"path": "spec.md"}, call_id="c-ok"),
+        ToolCall(name="read_file", args={"path": "secrets.md"}, call_id="c-no"),
+    ])
+
+    assert stamped == [("read_file", "approve_session")], (
+        "the refusal was stamped against the tool NAME, which also blocks "
+        f"the call the user approved: {stamped}"
+    )
+    assert verdicts.get("c-no", "proceed") != "proceed", (
+        f"secrets.md must still be refused per call: {verdicts}"
+    )

--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -373,7 +373,16 @@ async def test_console_control_chips_are_focusable_and_reveal_full_label_on_focu
 
 
 @pytest.mark.asyncio
-async def test_console_approvals_chip_activation_focuses_batch_submit_button():
+async def test_console_approvals_chip_activation_focuses_the_decision_not_submit():
+    """TASK-1845: the chip must NOT land the keyboard on the commit control.
+
+    This test previously asserted focus on `#approval-submit`, which made the
+    documented keyboard route jump-to-card + Enter -- one keystroke from
+    granting a tool access to a call the user had not read. Rows are pre-armed
+    to `approve_once` (correct: a blank Select breaks `allow_blank=False`), so
+    the fix was to move the FOCUS target, not the default. The contract is now
+    the row's decision Select, via `ChatApprovalCard.first_focus_widget_id`.
+    """
     app = _build_test_app()
     _configure_native_ready_console(app)
     host = ConsoleHarness(app)
@@ -406,7 +415,13 @@ async def test_console_approvals_chip_activation_focuses_batch_submit_button():
         await pilot.pause(0.1)
 
         focused = host.focused
-        assert getattr(focused, "id", None) == "approval-submit"
+        assert getattr(focused, "id", None) != "approval-submit", (
+            "focus landed on the commit control: Enter would approve an "
+            "unread call"
+        )
+        assert "approval-row-decision" in getattr(focused, "classes", set()), (
+            f"expected the row's decision Select, got {focused!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -508,19 +523,19 @@ async def test_console_inspector_prioritizes_actionable_status_before_secondary_
 
         status_index = ordered_ids.index("console-inspector-run-status-summary")
         approval_action_index = ordered_ids.index("console-inspector-review-approval")
-        tool_action_index = ordered_ids.index("console-inspector-review-tool-call")
         save_action_index = ordered_ids.index("console-inspector-save-chatbook")
         first_secondary_heading_index = ordered_ids.index(
             "console-inspector-selected-conversation-heading"
         )
 
         assert status_index < approval_action_index < first_secondary_heading_index
-        assert status_index < tool_action_index < first_secondary_heading_index
+        # TASK-1843 removed `console-inspector-review-tool-call`: it gated on
+        # a counter nothing ever assigned, so it was permanently disabled
+        # while permanently claiming a reason, and its handler was a notify()
+        # stub. It must stay gone rather than be re-added as a stub.
+        assert "console-inspector-review-tool-call" not in ordered_ids
         assert status_index < save_action_index < first_secondary_heading_index
         assert console.query_one("#console-inspector-review-approval").disabled is False
-        assert (
-            console.query_one("#console-inspector-review-tool-call").disabled is False
-        )
         assert console.query_one("#console-inspector-save-chatbook").disabled is False
 
 

--- a/backlog/tasks/task-1861 - Per-call refusal is overwritten by a same-name approval.md
+++ b/backlog/tasks/task-1861 - Per-call refusal is overwritten by a same-name approval.md
@@ -1,0 +1,58 @@
+---
+id: TASK-1861
+title: 'Approval: refusing one call is overwritten by approving another of the same tool'
+status: In Progress
+assignee: []
+created_date: '2026-08-01 21:30'
+labels:
+  - console
+  - agents
+  - security
+  - regression
+dependencies:
+  - TASK-1845
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Fails open.** The approval card offers a decision per call, but the pipeline could not honour it: a refusal and an approval of the same tool name resolved last-write-wins on a single name-keyed stamp. Refuse `secrets.md`, approve `spec.md`, and the surviving stamp is the approval — the file the user explicitly refused is read.
+
+Introduced by TASK-1845's per-call re-key. Before it, `_collapse_pending_calls` grouped by name and rendered ONE row, so two verdicts could never disagree. Splitting the rows created decisions the enforcement layers could not express.
+
+Both consumers are name-keyed by contract, and correctly so: `builtin_gate.stamp` records a grant against a tool NAME because a session/always grant belongs to a tool, and `MCPToolProvider.apply_batch_decisions` takes llm_names. The gap was that `build_tool_review_hook` returned a flat `{name: "proceed"}` to the runtime, so **no** layer carried the per-call refusal — even though the runtime already resolves `call_id` before name and turns a non-"proceed" verdict into the call's result without dispatching it.
+
+Observed directly:
+
+```
+STAMPED ON THE GATE: [('read_file', 'deny'), ('read_file', 'approve_once')]
+VERDICTS RETURNED TO RUNTIME: {'read_file': 'proceed'}
+```
+
+A shipped comment asserted the opposite ("the per-call refusals are still enforced by the runtime, which reads the call-id keys directly"). That was never true.
+
+Second half of the same defect: MCP rows never carried a `call_id` at all. `_collect_mcp_pending` called `provider.pending_gate_for(call.name, call.args)`, dropping the id at that boundary, so every MCP row collapsed by name into one `xN` row with one verdict — the exact defect the re-key fixed for built-in tools and left standing for MCP.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Refusing one call and approving another of the same tool refuses only the refused target, in either decision order
+- [x] #2 A refusal is never stamped against the tool name while a sibling call of that name is approved
+- [x] #3 A call the runtime cannot address individually (no `call_id`) refuses every same-name call in the batch rather than none
+- [x] #4 MCP pending rows carry their `call_id`, so MCP calls are one decision per target
+- [x] #5 The refusal the model receives names the user as the actor and the tool refused
+- [x] #6 Tests cover both decision orderings, and are mutation-verified to fail when either half is reverted
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Refusals are enforced at the review hook, keyed per `call_id`; stamps carry only what was APPROVED. Stamping an approval while a sibling was refused is safe because the refused call is stopped before dispatch and never reaches `invoke()`. When every call of a name was refused there is no approval to preserve, so `deny` is still stamped as defense in depth.
+
+Rows with no `call_id` fall back to the name key, which stops every same-name call — fail-closed, and the only honest option when the runtime cannot tell them apart.
+
+**AC #6 exists because the first version of the ordering test was vacuous.** It asserted `("read_file", "deny") not in stamped` with the refusal decided FIRST, so a later approval overwrote it and a mutation that stamped every verdict regardless still passed. The deny-decided-LAST case is a separate test; both are mutation-verified.
+
+Also corrects `_fence_call` -> `parse_tool_call` in three comments (two of them shipped): the referenced function never existed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1861 - Per-call refusal is overwritten by a same-name approval.md
+++ b/backlog/tasks/task-1861 - Per-call refusal is overwritten by a same-name approval.md
@@ -43,6 +43,7 @@ Second half of the same defect: MCP rows never carried a `call_id` at all. `_col
 - [x] #4 MCP pending rows carry their `call_id`, so MCP calls are one decision per target
 - [x] #5 The refusal the model receives names the user as the actor and the tool refused
 - [x] #6 Tests cover both decision orderings, and are mutation-verified to fail when either half is reverted
+- [x] #7 Per-call rows approved at different SCOPES keep the broadest scope the user chose
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -55,4 +56,10 @@ Rows with no `call_id` fall back to the name key, which stops every same-name ca
 **AC #6 exists because the first version of the ordering test was vacuous.** It asserted `("read_file", "deny") not in stamped` with the refusal decided FIRST, so a later approval overwrote it and a mutation that stamped every verdict regardless still passed. The deny-decided-LAST case is a separate test; both are mutation-verified.
 
 Also corrects `_fence_call` -> `parse_tool_call` in three comments (two of them shipped): the referenced function never existed.
+
+## Review findings
+
+**A stale test double, and a sweep that missed the obvious file.** Threading `call_id` changed `pending_gate_for`'s signature, and `Tests/Chat/test_console_chat_controller.py`'s `_FakeReviewProvider` still had the 2-arg form, so every MCP review-hook test raised TypeError. My regression covered the approval, agents, bridge and MCP suites but not the controller's OWN test file. The double now mirrors the real provider; no compatibility shim, because the protocol is in-repo only and a shim would hide exactly this drift.
+
+**Scope, not just allow/refuse.** Per-call rows can be approved at different scopes while only ONE scope per name can be stamped (a session/always grant belongs to a tool). Last-write-wins silently downgraded "Approve for session" to "approve once" whenever a later row of the same tool was approved once -- dropping the grant and re-prompting next call. The broadest chosen scope now wins (`always_allow` > `approve_session` > `approve_once`): choosing "for session" on any call of a tool IS choosing to grant that tool for the session, which is what the control means and what its label says.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -673,7 +673,7 @@ def run_agent_loop(
             # The name fallback is load-bearing, not legacy politeness:
             # `MCPToolProvider.apply_batch_decisions` emits name-keyed
             # verdicts, and the fence path builds ToolCalls with NO call_id
-            # at all (`_fence_call`), so a name-keyed verdict must still stop
+            # at all (`parse_tool_call`), so a name-keyed verdict must still stop
             # every matching call or the MCP gate silently opens.
             verdict = "proceed"
             if call.call_id and call.call_id in verdicts:

--- a/tldw_chatbook/Agents/mcp_tool_provider.py
+++ b/tldw_chatbook/Agents/mcp_tool_provider.py
@@ -394,7 +394,9 @@ class MCPToolProvider:
 
     # -- gate resolution for the batch-review hook (worker thread) --------
 
-    def pending_gate_for(self, llm_name: str, args: dict) -> MCPPendingCall | None:
+    def pending_gate_for(
+        self, llm_name: str, args: dict, call_id: str = ""
+    ) -> MCPPendingCall | None:
         """Resolve one call's gate; return a pending descriptor iff it needs asking.
 
         Direct (not main-loop-submitted) call to `gate_tool_test` -- see the
@@ -415,6 +417,12 @@ class MCPToolProvider:
                 the incoming `ToolCall.name`.
             args: The tool call's raw arguments, copied verbatim into the
                 returned `MCPPendingCall.arguments` (never mutated).
+            call_id: The provider's per-call id, carried onto the row so the
+                approval card can offer one decision per TARGET rather than
+                one per tool name. Empty when the model's payload had no id
+                (`ensure_tool_call_ids` fills those in for the native path);
+                an empty id makes the row collapse by name, which shares one
+                verdict across every same-name call in the batch.
 
         Returns:
             An `MCPPendingCall` describing what needs asking, or `None`
@@ -443,6 +451,10 @@ class MCPToolProvider:
             tool_name=tool.name,
             server_label=tool.server_label,
             arguments=dict(args or {}),
+            # TASK-1861: carry the per-call key through, or the card collapses
+            # every same-name MCP call into one `xN` row with one verdict --
+            # the defect the per-call re-key fixed for built-in tools.
+            call_id=call_id,
             reason=_pending_reason(state),
         )
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -138,6 +138,14 @@ _DEFAULT_SKILL_SCRIPT_CONFIRM_TIMEOUT_SECONDS = 120.0
 #: `uuid4()` id -- every genuine round id is a UUID string; this is not.
 _LEGACY_PENDING_APPROVAL_ROUND_ID = "__legacy_pending_approval__"
 
+#: TASK-1861: the tool result a call gets when the user refused it at the
+#: approval card. The runtime turns any non-"proceed" verdict string into the
+#: call's result without dispatching it, so this text is what the MODEL reads
+#: and must say who refused and which tool -- matching the wording
+#: `BuiltinToolGate.check` already uses for a denied tool, so a refusal reads
+#: the same whether it was stopped here or at the gate.
+USER_DENIED_REFUSAL = "tool call denied by the user: {name}"
+
 
 MAX_CONSOLE_DRAFT_LENGTH = 100_000
 CONSOLE_CONTINUE_INSTRUCTION = "Continue and extend the selected message."
@@ -201,7 +209,9 @@ def _collect_mcp_pending(
     """
     pending: list["MCPPendingCall"] = []
     for call in calls:
-        gate = provider.pending_gate_for(call.name, call.args)
+        gate = provider.pending_gate_for(
+            call.name, call.args, str(getattr(call, "call_id", "") or "")
+        )
         if gate is not None:
             pending.append(gate)
     return pending
@@ -534,25 +544,63 @@ def build_tool_review_hook(
                 return decisions[key]
             return decisions.get(row.llm_name)
 
-        if mcp_provider is not None:
-            mcp_decisions: dict[str, str] = {}
-            for row in mcp_pending:
-                if row.llm_name not in mcp_claimed_names:
-                    continue
+        def _stamps_for(rows: "list[MCPPendingCall]") -> dict[str, str]:
+            """Name-keyed stamps for `rows`: approvals win, all-denied denies.
+
+            TASK-1861. A refusal must NOT be stamped against the name when a
+            sibling call of the same tool was approved -- the stamp is what
+            `invoke()` peeks at, and it cannot express "allow this one,
+            refuse that one", so stamping the refusal would also stop the
+            call the user allowed. Refusals are enforced per call by the
+            verdict map below instead.
+
+            Stamping the approval is safe even with a refused sibling,
+            because that sibling is stopped before dispatch and never
+            reaches `invoke()`. When EVERY call of a name was refused there
+            is no approval to preserve, so "deny" is stamped as defense in
+            depth for any path that bypasses the verdict map.
+            """
+            approvals: dict[str, str] = {}
+            denied: set[str] = set()
+            for row in rows:
                 decision = _decision_for(row)
-                if decision is not None:
-                    # Last write wins when several calls of one MCP tool got
-                    # different verdicts: the provider's grant is per NAME, so
-                    # it cannot express "allow this one, refuse that one" --
-                    # the per-call refusals are still enforced by the runtime,
-                    # which reads the call-id keys directly.
-                    mcp_decisions[row.llm_name] = decision
-            mcp_provider.apply_batch_decisions(mcp_decisions)
-        for row in builtin_pending:
-            decision = _decision_for(row)
-            if decision is not None:
-                builtin_gate.stamp(row.llm_name, decision)
-        return {row.llm_name: "proceed" for row in all_pending}
+                if decision is None:
+                    continue
+                if decision == "deny":
+                    denied.add(row.llm_name)
+                else:
+                    approvals[row.llm_name] = decision
+            stamps = dict(approvals)
+            for name in denied:
+                stamps.setdefault(name, "deny")
+            return stamps
+
+        if mcp_provider is not None:
+            mcp_provider.apply_batch_decisions(
+                _stamps_for(
+                    [r for r in mcp_pending if r.llm_name in mcp_claimed_names]
+                )
+            )
+        for name, decision in _stamps_for(builtin_pending).items():
+            builtin_gate.stamp(name, decision)
+
+        # The refusal half, enforced HERE rather than through the stamps.
+        # The runtime resolves `call_id` before name and turns any
+        # non-"proceed" verdict string into that call's result without
+        # dispatching it, so this is the only layer that can refuse one
+        # target while running another.
+        verdicts: dict[str, str] = {row.llm_name: "proceed" for row in all_pending}
+        for row in all_pending:
+            if _decision_for(row) != "deny":
+                continue
+            # Prefer the per-call key. A row with no `call_id` -- the fence
+            # path, or an MCP row whose provider omitted an id -- can only be
+            # addressed by name, which stops every same-name call in the
+            # batch. That is fail-closed, and the only honest option when the
+            # runtime cannot tell those calls apart.
+            key = str(getattr(row, "call_id", "") or "") or row.llm_name
+            verdicts[key] = USER_DENIED_REFUSAL.format(name=row.llm_name)
+        return verdicts
 
     return review_tool_calls
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -146,6 +146,17 @@ _LEGACY_PENDING_APPROVAL_ROUND_ID = "__legacy_pending_approval__"
 #: the same whether it was stopped here or at the gate.
 USER_DENIED_REFUSAL = "tool call denied by the user: {name}"
 
+#: TASK-1861: how broad each approval scope is. A session/always grant is
+#: recorded against a tool NAME, so when per-call rows of one tool are
+#: approved at different scopes only one can be stamped -- and it must be the
+#: broadest the user chose, or the grant they asked for is silently dropped
+#: and re-prompted. Unknown values rank 0 (narrower than anything known).
+_APPROVAL_SCOPE_RANK: dict[str, int] = {
+    "approve_once": 1,
+    "approve_session": 2,
+    "always_allow": 3,
+}
+
 
 MAX_CONSOLE_DRAFT_LENGTH = 100_000
 CONSOLE_CONTINUE_INSTRUCTION = "Continue and extend the selected message."
@@ -568,7 +579,20 @@ def build_tool_review_hook(
                     continue
                 if decision == "deny":
                     denied.add(row.llm_name)
-                else:
+                    continue
+                # Per-call rows can disagree on SCOPE, not just allow/refuse,
+                # and only one scope per name can be stamped. Taking the last
+                # silently downgraded "Approve for session" to "approve once"
+                # whenever a later row of the same tool was approved once --
+                # dropping the grant the user asked for and re-prompting on
+                # the next call. Choosing "for session" on ANY call of a tool
+                # is choosing to grant that tool for the session (that is what
+                # the control means, and its label says so), so the broadest
+                # chosen scope wins.
+                current = approvals.get(row.llm_name)
+                if current is None or _APPROVAL_SCOPE_RANK.get(
+                    decision, 0
+                ) > _APPROVAL_SCOPE_RANK.get(current, 0):
                     approvals[row.llm_name] = decision
             stamps = dict(approvals)
             for name in denied:

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
@@ -154,7 +154,7 @@ def _collapse_pending_calls(calls: Sequence[Mapping[str, Any]]) -> list[dict[str
 
     Calls with NO ``call_id`` still collapse by ``llm_name``, and that is
     deliberate rather than a leftover: the fence path builds ToolCalls
-    without ids (``agent_runtime._fence_call``), so the runtime can only
+    without ids (``agent_runtime.parse_tool_call``), so the runtime can only
     apply a NAME-keyed verdict to them. Splitting those into separate rows
     would offer the user a decision the runtime cannot honour -- the row
     would say "deny this one" and every same-name call would stop.


### PR DESCRIPTION
**Fails open, and the regression came in with TASK-1845's per-call re-key.** Filed as TASK-1861.

The card offers a decision per call so you can allow `spec.md` and refuse `secrets.md` in one batch. It does split the rows — but nothing downstream could express the result:

```
STAMPED ON THE GATE:            [('read_file', 'deny'), ('read_file', 'approve_once')]
VERDICTS RETURNED TO RUNTIME:   {'read_file': 'proceed'}
```

Refuse `secrets.md` first, approve `spec.md` second, and the surviving stamp is the approval — **the file the user explicitly refused is read.** Before the re-key this was unreachable: `_collapse_pending_calls` grouped by name, one row meant verdicts could never disagree.

Both consumers are name-keyed *by contract*, and correctly so — `builtin_gate.stamp` records a grant against a tool NAME because a session/always grant belongs to a tool, and `apply_batch_decisions` takes llm_names. The gap was that `build_tool_review_hook` returned a flat `{name: "proceed"}`, so **no** layer carried the per-call refusal, even though the runtime already resolves `call_id` before name and turns a non-`"proceed"` verdict into the call's result without dispatching it.

A comment I shipped in #1192 asserted the opposite — *"the per-call refusals are still enforced by the runtime, which reads the call-id keys directly."* That was never true. Found by running the path, not by reading it.

## The fix

Refusals are enforced at the hook, keyed per `call_id`. Stamps carry only **approvals**, which is safe because a refused call is stopped before dispatch and never reaches `invoke()`; when every call of a name was refused there is no approval to preserve, so `deny` is still stamped as defense in depth. A row with no `call_id` falls back to the name key and stops every same-name call — fail-closed, the only honest option when the runtime cannot tell them apart.

## The other half of the ×N keying

**MCP rows never carried a `call_id` at all.** `_collect_mcp_pending` called `pending_gate_for(call.name, call.args)` and dropped the id at that boundary, so every MCP row collapsed by name into one `×N` row with one verdict — the exact defect the re-key fixed for built-in tools and left standing for MCP. Threaded through, with the parameter documented.

## On the tests

The first ordering test was **vacuous**: with the refusal decided *first*, a later approval overwrote it, so a mutation that stamped every verdict regardless still passed. The deny-decided-**last** case is a separate test. Both halves are mutation-verified — reverting either now fails one of them.

1353 passed across the approval, agents, bridge and MCP suites.

Also corrects `_fence_call` → `parse_tool_call` in three comments (two of them shipped) — the referenced function never existed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fail-open regression (TASK-1861) where refusing one tool call could be overwritten by approving another of the same tool. Refusals are now enforced per `call_id`, MCP rows carry their `call_id`, and the broadest approval scope is preserved across per-call rows.

- **Bug Fixes**
  - Enforce per-call refusals in `build_tool_review_hook`; verdicts map by `call_id` with a name fallback only when no `call_id` (fail-closed).
  - Stamp names with approvals only; stamp `deny` only if all same-name calls were refused; keep the broadest approval scope (`always_allow` > `approve_session` > `approve_once`); do not stamp refusals.
  - Introduce `USER_DENIED_REFUSAL`, returned as the tool result for refused calls.
  - Thread `call_id` through `_collect_mcp_pending` and `MCPToolProvider.pending_gate_for`; MCP rows now keep their `call_id`, and name-keyed stamps are applied via `apply_batch_decisions`.

<sup>Written for commit ad01613dd9db0e85a853cb748328a51e5a3a0e6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

