### PR TITLE
Console: reach a tool call's full output from the transcript

### DIFF
--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -3030,3 +3030,60 @@ def test_combine_state_scopes_restores_both_when_the_nested_run_raises():
         raised = True
     assert raised
     assert exited == ["builtin", "mcp"]
+
+
+def test_resumed_markers_carry_the_same_full_output_as_live_ones(
+    tmp_path, monkeypatch
+):
+    """TASK-1860 AC#5: resume is a second door, and it has been missed before.
+
+    `resume_marker_messages` re-derives markers from AgentRunsDB and builds
+    `ConsoleChatMessage` objects DIRECTLY, bypassing the live append path. A
+    resumed transcript whose markers could not be expanded would be the same
+    data loss by a different door -- exactly how TASK-1842's first fix leaked.
+
+    The display cap is forced to its MINIMUM (20) so the ~57-char calculator
+    result is actually truncated. Without that BOTH sides are None and the
+    comparison passes while proving nothing -- which is how this test was
+    first written. A value below the minimum is clamped back to the default,
+    so it must be the real floor, not an arbitrary small number.
+    """
+    from tldw_chatbook.config import MIN_CONSOLE_TOOL_RESULT_DISPLAY_CHARS
+
+    monkeypatch.setenv(
+        "TLDW_CONSOLE_TOOL_RESULT_DISPLAY_CHARS",
+        str(MIN_CONSOLE_TOOL_RESULT_DISPLAY_CHARS),
+    )
+    scripts = [
+        [_fence("calculator", {"expression": "6*7"})],
+        ["It is ", "42."],
+    ]
+    bridge, db, store, session, aid = _bridge(tmp_path, scripts)
+    _run(bridge, store, session, aid)
+    live = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert live, "sanity: the live run left a marker"
+    assert any(m.tool_output_full for m in live), (
+        "precondition: at least one marker must actually hide part of its "
+        f"result, or this test is vacuous: {[m.content for m in live]}"
+    )
+
+    fresh_bridge = ConsoleAgentBridge(
+        agent_runs_db=db, store=None, provider_gateway=None
+    )
+    resumed = [
+        m
+        for _anchor, block in fresh_bridge.resume_marker_messages("conv-1")
+        for m in block
+    ]
+
+    assert [m.content for m in resumed] == [m.content for m in live]
+    assert [m.tool_output_full for m in resumed] == [
+        m.tool_output_full for m in live
+    ], (
+        "a resumed marker exposes a different amount of its result than the "
+        "live one did"
+    )

--- a/Tests/Chat/test_tool_output_disclosure.py
+++ b/Tests/Chat/test_tool_output_disclosure.py
@@ -1,0 +1,223 @@
+"""TASK-1860: the full tool output must be reachable from the transcript."""
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Chat.console_message_actions import ConsoleMessageActionService
+from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+
+def _marker(full: str | None, content: str = "⚙ read_file → data… (+900 chars)"):
+    return ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL, content=content, tool_output_full=full
+    )
+
+
+@pytest.mark.unit
+def test_a_truncated_tool_marker_offers_a_full_output_action():
+    """AC#1: the route exists, and only where there is something to show."""
+    actions = {
+        a.action_id: a
+        for a in ConsoleMessageActionService().available_actions(
+            _marker("x" * 2000)
+        )
+    }
+    assert "tool-output" in actions, (
+        f"no route to the full result: {sorted(actions)}"
+    )
+    assert actions["tool-output"].enabled
+
+
+@pytest.mark.unit
+def test_a_marker_showing_everything_offers_no_full_output_action():
+    """The affordance must not promise more when there is no more.
+
+    A short result is rendered whole in `content`, so an expand action would
+    open an identical view -- a dead control, which is the same defect as
+    the `Review tool call` entry TASK-1843 removed.
+    """
+    short = "⚙ read_file → ok"
+    actions = [
+        a.action_id
+        for a in ConsoleMessageActionService().available_actions(
+            _marker(None, content=short)
+        )
+    ]
+    assert "tool-output" not in actions, actions
+
+
+@pytest.mark.unit
+def test_non_tool_messages_never_offer_it():
+    for role in (ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT):
+        actions = [
+            a.action_id
+            for a in ConsoleMessageActionService().available_actions(
+                ConsoleChatMessage(role=role, content="hello")
+            )
+        ]
+        assert "tool-output" not in actions, (role, actions)
+
+
+_FULL = "line one\n" + "\n".join(f"result row {n}" for n in range(2, 60))
+
+
+class _TranscriptHarness(App):
+    def compose(self) -> ComposeResult:
+        transcript = ConsoleTranscript(id="console-native-transcript")
+        transcript.set_messages(
+            [
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.USER, content="what is in the file?",
+                    id="u1",
+                ),
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.TOOL,
+                    content="⚙ read_file → line one… (+900 chars)",
+                    id="tool-1",
+                    tool_output_full=_FULL,
+                ),
+            ]
+        )
+        transcript.selected_message_id = "tool-1"
+        yield transcript
+
+
+@pytest.mark.asyncio
+async def test_full_tool_output_is_reachable_from_the_mounted_transcript():
+    """AC#1/#6: drive the real widget, and read what is actually on screen.
+
+    Asserting on a helper would prove nothing here -- the whole defect this
+    closes is that the full result existed in memory while the transcript
+    showed a preview. So this expands the selected marker the way the
+    keyboard does and reads the mounted row.
+    """
+    app = _TranscriptHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        row = app.query_one("#console-message-tool-1")
+
+        assert "result row 59" not in str(row.render()), (
+            "precondition: the collapsed row shows a preview, not everything"
+        )
+
+        transcript.toggle_tool_output("tool-1")
+        await pilot.pause()
+        await pilot.pause()
+
+        expanded = str(app.query_one("#console-message-tool-1").render())
+        assert "result row 59" in expanded, (
+            f"the full result is still unreachable on screen: {expanded[:200]!r}"
+        )
+        assert "line one" in expanded
+
+        transcript.toggle_tool_output("tool-1")
+        await pilot.pause()
+        await pilot.pause()
+        assert "result row 59" not in str(
+            app.query_one("#console-message-tool-1").render()
+        ), "expanding must be reversible"
+
+
+@pytest.mark.asyncio
+async def test_pressing_o_expands_the_selected_marker():
+    """AC#1 in full: 'by keyboard', through the binding and the button.
+
+    The sibling test calls `toggle_tool_output` directly, which proves the
+    rendering but bypasses BOTH the binding and the action button it presses.
+    This drives the key, so a missing binding, a missing action, or an
+    unrouted button press all fail here.
+    """
+    app = _TranscriptHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.focus()
+        await pilot.pause()
+        await pilot.press("o")
+        await pilot.pause()
+        await pilot.pause()
+
+        expanded = str(app.query_one("#console-message-tool-1").render())
+        assert "result row 59" in expanded, (
+            f"pressing 'o' did not reveal the full result: {expanded[:160]!r}"
+        )
+
+
+@pytest.mark.unit
+def test_a_failed_step_still_exposes_what_it_produced():
+    """AC#3: 'even if it failed' was the reported ask.
+
+    A failing call is exactly when the user wants the output -- the question
+    is how far it got, not just that it stopped. An error step's summary IS
+    the produced text, so it becomes the expandable body.
+    """
+    from tldw_chatbook.Chat.console_agent_bridge import (
+        STEP_ERROR,
+        STEP_TOOL_RESULT,
+        full_step_output,
+    )
+
+    long_error = "Traceback:\n" + "\n".join(f"  frame {n}" for n in range(40))
+    assert full_step_output(
+        STEP_ERROR, summary=long_error, marker_text="⚠ Traceback:… (+400 chars)"
+    ) == long_error
+
+    failed_result = "ERROR: permission denied\n" + "x" * 500
+    assert full_step_output(
+        STEP_TOOL_RESULT,
+        result=failed_result,
+        marker_text="⚙ read_file → ERROR:… (+500 chars)",
+    ) == failed_result
+
+
+@pytest.mark.unit
+def test_a_marker_that_already_shows_everything_carries_no_duplicate():
+    """No expand control that opens an identical view (see TASK-1843)."""
+    from tldw_chatbook.Chat.console_agent_bridge import (
+        STEP_TOOL_RESULT,
+        full_step_output,
+    )
+
+    assert (
+        full_step_output(
+            STEP_TOOL_RESULT, result="ok", marker_text="⚙ read_file → ok"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_calls_in_one_turn_expand_independently():
+    """AC#4: expansion is per row, not a single global toggle."""
+    class _TwoCalls(App):
+        def compose(self) -> ComposeResult:
+            transcript = ConsoleTranscript(id="console-native-transcript")
+            transcript.set_messages([
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.TOOL, id="t-a",
+                    content="⚙ read_file → alpha… (+9 chars)",
+                    tool_output_full="alpha UNIQUE-A",
+                ),
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.TOOL, id="t-b",
+                    content="⚙ read_file → beta… (+9 chars)",
+                    tool_output_full="beta UNIQUE-B",
+                ),
+            ])
+            yield transcript
+
+    app = _TwoCalls()
+    async with app.run_test() as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.toggle_tool_output("t-a")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert "UNIQUE-A" in str(app.query_one("#console-message-t-a").render())
+        assert "UNIQUE-B" not in str(app.query_one("#console-message-t-b").render()), (
+            "expanding one call revealed another -- the toggle is not per row"
+        )

--- a/Tests/Chat/test_tool_output_disclosure.py
+++ b/Tests/Chat/test_tool_output_disclosure.py
@@ -221,3 +221,32 @@ async def test_two_calls_in_one_turn_expand_independently():
         assert "UNIQUE-B" not in str(app.query_one("#console-message-t-b").render()), (
             "expanding one call revealed another -- the toggle is not per row"
         )
+
+
+@pytest.mark.unit
+def test_expanded_state_is_pruned_when_messages_leave_the_transcript():
+    """Expansion is per message id, so it must not outlive the message.
+
+    The state comment claimed it was "dropped when the transcript is rebuilt"
+    -- it was not; `set_messages` pruned the signature cache and left this
+    set growing for the life of the widget. A recycled id would also come
+    back already expanded.
+    """
+    transcript = ConsoleTranscript()
+    kept = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL, id="keep", content="⚙ a → x…",
+        tool_output_full="xxxx",
+    )
+    gone = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL, id="gone", content="⚙ b → y…",
+        tool_output_full="yyyy",
+    )
+    transcript.set_messages([kept, gone])
+    transcript._expanded_tool_output_ids.update({"keep", "gone"})
+
+    transcript.set_messages([kept])
+
+    assert transcript._expanded_tool_output_ids == {"keep"}, (
+        "expansion state outlived the message it belonged to: "
+        f"{transcript._expanded_tool_output_ids}"
+    )

--- a/backlog/tasks/task-1860 - Full-tool-output-is-not-reachable-from-the-transcript.md
+++ b/backlog/tasks/task-1860 - Full-tool-output-is-not-reachable-from-the-transcript.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1860
 title: 'Tool trace: the full output of a call is not reachable from the transcript'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-01 20:45'
 labels:
@@ -30,12 +30,12 @@ Note that TASK-1843 **removed** the Console Inspector's "Review tool call" actio
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The full result of a tool call is reachable from the transcript by keyboard, without changing a setting first
-- [ ] #2 A truncated marker is visibly marked as truncated, so the preview is never mistaken for the whole result
-- [ ] #3 A failed, denied, or timed-out call exposes whatever output it did produce, not only its failure line
-- [ ] #4 Multiple calls in one turn are each independently reachable
-- [ ] #5 The route works for a resumed session, whose markers are re-derived from AgentRunsDB rather than produced live
-- [ ] #6 A test drives the mounted widget and asserts the full (untruncated) text is reachable -- not a helper returning a string
+- [x] #1 The full result of a tool call is reachable from the transcript by keyboard, without changing a setting first
+- [x] #2 A truncated marker is visibly marked as truncated, so the preview is never mistaken for the whole result
+- [x] #3 A failed, denied, or timed-out call exposes whatever output it did produce, not only its failure line
+- [x] #4 Multiple calls in one turn are each independently reachable
+- [x] #5 The route works for a resumed session, whose markers are re-derived from AgentRunsDB rather than produced live
+- [x] #6 A test drives the mounted widget and asserts the full (untruncated) text is reachable -- not a helper returning a string
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -44,4 +44,16 @@ Note that TASK-1843 **removed** the Console Inspector's "Review tool call" actio
 AC #6 is written that way deliberately. Two defects in the TASK-1842..1846 PR were helpers that worked while the screen stayed wrong, each with a passing test that called the helper directly with a shape production never builds. Assert on the mounted widget.
 
 `RunBudget.max_tool_result_chars` governs what the MODEL saw and is a different number from the display cap — do not conflate them when deciding what "full" means. If the model itself only ever received a truncated result, showing the user more than the model got is still correct (it answers "what did the tool return"), but the distinction should be legible rather than silently blurred.
+
+## What shipped
+
+`ConsoleChatMessage.tool_output_full` carries the untruncated result; `full_step_output` is the shared resolver so a live and a resumed marker expose the same thing. Expansion is view state owned by `ConsoleTranscript` (`_expanded_tool_output_ids`) and applied at the ONE walk that plans rows, so the renderable, its cached signature and the action row all see the same message -- a row rendering expanded while its signature said collapsed would never repaint.
+
+The `Full output` action is offered only where something is actually hidden, and that is decided ONCE when the marker is built (`marker_text` is passed to `full_step_output`) rather than by comparing against `content` at render time. Comparing at render time reads naturally and is wrong: an EXPANDED row does contain its full text, so the control that collapses it again would disappear.
+
+The button press is intercepted in the transcript rather than routed through `ChatScreen`'s action dispatch: expansion never reaches the store and nothing outside the transcript needs to know about it.
+
+AC#2 needed no work -- `_truncate_step_text` already appends `... (+N chars)`.
+
+**Two tests were vacuous before they were useful.** The resume test compared `tool_output_full` on both sides while the calculator result was short enough that both were `None`: `[None] == [None]`. It now forces the display cap to its MINIMUM (20; a smaller value is clamped back to the default) and asserts a precondition that something is actually hidden. The mounted-widget test also passed on first run, so both it and the keyboard test were mutation-checked -- removing the transform, the binding, the press routing, or the resume passthrough each fails one.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -328,7 +328,7 @@ def _truncate_step_text(text: str, *, limit: int) -> str:
 def full_step_output(
     kind: str,
     *,
-    result=None,
+    result: Any = None,
     summary: str | None = None,
     marker_text: str | None = None,
 ) -> str | None:
@@ -343,6 +343,18 @@ def full_step_output(
     A FAILED or errored step returns its summary: "whatever output it did
     produce" is exactly what the user asks for when a call fails, and for an
     error step the summary IS the produced text.
+
+    Args:
+        kind: The ``AgentStep`` kind this marker was built from.
+        result: The step's raw tool result, for ``STEP_TOOL_RESULT``.
+        summary: The step's summary text, for ``STEP_ERROR``.
+        marker_text: The marker as it will be displayed. When the full text
+            already appears there, ``None`` is returned -- an expand control
+            that opens an identical view is a dead affordance.
+
+    Returns:
+        The untruncated text behind the marker, or ``None`` when the marker
+        already shows everything (or the kind carries no output at all).
     """
     if kind == STEP_TOOL_RESULT:
         text = str(result if result is not None else "")

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -325,6 +325,41 @@ def _truncate_step_text(text: str, *, limit: int) -> str:
     return f"{cut}… (+{hidden} chars)"
 
 
+def full_step_output(
+    kind: str,
+    *,
+    result=None,
+    summary: str | None = None,
+    marker_text: str | None = None,
+) -> str | None:
+    """Return the FULL text behind a step's marker, or None when there is none.
+
+    TASK-1860. `format_agent_step_marker` collapses a result to a preview
+    capped by the Console display setting, so the whole result was
+    unreachable from the transcript. This is the untruncated counterpart,
+    shared by the live run and by resume re-derivation so an expanded marker
+    reads identically either way.
+
+    A FAILED or errored step returns its summary: "whatever output it did
+    produce" is exactly what the user asks for when a call fails, and for an
+    error step the summary IS the produced text.
+    """
+    if kind == STEP_TOOL_RESULT:
+        text = str(result if result is not None else "")
+    elif kind == STEP_ERROR:
+        text = str(summary or "")
+    else:
+        return None
+    if not text:
+        return None
+    if marker_text is not None and text in marker_text:
+        # The marker already shows the whole thing -- carrying it again would
+        # light up an expand control that opens an identical view, the dead
+        # affordance TASK-1843 removed from the Inspector.
+        return None
+    return text
+
+
 #: TASK-1844: transcript marker kind for an approval that expired. Not an
 #: `AgentStep` kind -- the timeout happens in the approval round, before any
 #: step exists -- but it renders through the same formatter so live and
@@ -1655,7 +1690,16 @@ class ConsoleAgentBridge:
                     summary=step.summary,
                 )
                 if marker_text is not None:
-                    self._append_marker(session_id, marker_text)
+                    self._append_marker(
+                        session_id,
+                        marker_text,
+                        full_output=full_step_output(
+                            step.kind,
+                            result=step.result,
+                            summary=step.summary,
+                            marker_text=marker_text,
+                        ),
+                    )
             # Diagnostic logging for every tool call and result. The actual
             # tool invocation lives inside AgentService, so we observe it
             # through the step stream it emits.
@@ -2128,6 +2172,14 @@ class ConsoleAgentBridge:
                             role=ConsoleMessageRole.TOOL,
                             content=text,
                             status="complete",
+                            # AC#5: a resumed marker is as expandable as a
+                            # live one -- the step rows carry the full result.
+                            tool_output_full=full_step_output(
+                                str(step.get("kind") or ""),
+                                result=step.get("result"),
+                                summary=step.get("summary"),
+                                marker_text=text,
+                            ),
                         )
                     )
             blocks.append((record.get("assistant_message_id"), block))
@@ -2135,7 +2187,9 @@ class ConsoleAgentBridge:
 
     # -- internals ------------------------------------------------------
 
-    def _append_marker(self, session_id: str, text: str) -> None:
+    def _append_marker(
+        self, session_id: str, text: str, *, full_output: str | None = None
+    ) -> None:
         # Kept raw (no escaping): both consumers render markup-off --
         # console_transcript.py's _message_render_text builds a Content via
         # Content.assemble (never markup-parsed) and chat_screen.py's legacy
@@ -2145,7 +2199,10 @@ class ConsoleAgentBridge:
         # `fetch \[docs]`).
         try:
             self._store.append_message(
-                session_id, role=ConsoleMessageRole.TOOL, content=text
+                session_id,
+                role=ConsoleMessageRole.TOOL,
+                content=text,
+                tool_output_full=full_output,
             )
         except KeyError:
             pass  # session vanished mid-run; the rail still has the live snapshot

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -424,6 +424,14 @@ class ConsoleChatMessage:
     generation_metadata: tuple["GenerationVariantMeta", ...] = ()
     #: Safe current-session citation UI state. Never persisted or restored.
     citation_presentation: ConsoleCitationPresentation | None = None
+    #: TASK-1860: the FULL, untruncated tool result behind a TOOL marker.
+    #: ``content`` is a preview capped by the Console display setting, so
+    #: without this the whole result was unreachable from the transcript --
+    #: the user could not tell a complete result from its first N characters,
+    #: and a failed call showed only its failure line. None for every message
+    #: that is not a tool marker, and for a marker whose result was short
+    #: enough that ``content`` already shows all of it.
+    tool_output_full: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1019,6 +1019,7 @@ class ConsoleChatStore:
         attachment_label: str | None = None,
         terminal_citation_finalizer: TerminalCitationFinalizer | None = None,
         defer_terminal_persistence: bool = False,
+        tool_output_full: str | None = None,
     ) -> ConsoleChatMessage:
         """Append a message; scalar image kwargs become a one-item tuple."""
         self._session_or_raise(session_id)
@@ -1069,6 +1070,7 @@ class ConsoleChatStore:
             role=role,
             content=content,
             status=self._initial_status(role=role, content=content),
+            tool_output_full=tool_output_full,
         )
         self._set_message_attachments(message, effective)
         if attachment_label and effective and not effective[0].display_name:

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -67,6 +67,13 @@ class ConsoleMessageActionService:
         ("feedback", "Feedback"),
         ("delete", "🗑"),
     )
+    #: TASK-1860: reveals the FULL tool result behind a truncated marker.
+    #: Offered only for a TOOL marker that actually carries more than its
+    #: `content` shows -- an expand control that opens an identical view is
+    #: the same dead affordance TASK-1843 removed from the Inspector.
+    _TOOL_OUTPUT_ACTIONS: tuple[tuple[str, str], ...] = (
+        ("tool-output", "Full output"),
+    )
     _VARIANT_NAV_ACTIONS: tuple[tuple[str, str], ...] = (
         ("variant-previous", "<"),
         ("variant-next", ">"),
@@ -79,6 +86,18 @@ class ConsoleMessageActionService:
     _VIEW_ORIGINAL_ATTEMPT_ACTION: tuple[tuple[str, str], ...] = (
         ("view-original-attempt", "View original attempt"),
     )
+
+    @staticmethod
+    @staticmethod
+    def _has_tool_output(message: ConsoleChatMessage) -> bool:
+        """Whether this row hides tool output its `content` does not show."""
+        if message.role is not ConsoleMessageRole.TOOL:
+            return False
+        # Deliberately NOT "is the full text absent from content": an
+        # EXPANDED row does contain it, and that must not remove the control
+        # that collapses it again. Whether there is more to show is settled
+        # once, when the marker is built.
+        return bool(message.tool_output_full)
 
     @staticmethod
     def _has_image(message: ConsoleChatMessage) -> bool:
@@ -171,6 +190,8 @@ class ConsoleMessageActionService:
             extra_actions.extend(self._VARIANT_NAV_ACTIONS)
         if extra_actions:
             completed_actions = self._base_actions_with(tuple(extra_actions))
+        if self._has_tool_output(message):
+            completed_actions = completed_actions + list(self._TOOL_OUTPUT_ACTIONS)
         if self._has_image(message):
             completed_actions = (
                 completed_actions

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -88,7 +88,6 @@ class ConsoleMessageActionService:
     )
 
     @staticmethod
-    @staticmethod
     def _has_tool_output(message: ConsoleChatMessage) -> bool:
         """Whether this row hides tool output its `content` does not show."""
         if message.role is not ConsoleMessageRole.TOOL:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from time import monotonic
 
 from typing import Iterable, Literal, Mapping
@@ -12,6 +12,7 @@ from typing import Iterable, Literal, Mapping
 from loguru import logger
 from PIL import Image as PILImage
 from rich_pixels import Pixels
+from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Content
@@ -19,6 +20,7 @@ from textual.css.query import NoMatches
 from textual.dom import NoScreen
 from textual.events import Click, Key
 from textual.widget import Widget
+from textual.widgets import Button
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Chat.console_chat_models import (
@@ -74,6 +76,7 @@ _ACTION_TOOLTIPS = {
     "save-as": "Choose a destination for this message, such as Chatbook or Note.",
     "toggle-image-view": "Cycle image view: pixels, graphics, hidden.",
     "save-image": "Save image to disk.",
+    "tool-output": "Show or hide this tool call's full result (o).",
     "retry": "Retry the failed response.",
     "regenerate": "Generate another assistant variant for this turn.",
     "continue": "Continue and extend the selected message.",
@@ -582,6 +585,7 @@ class ConsoleTranscript(VerticalScroll):
         ("c", "invoke_selected_action('copy')", "Copy"),
         ("e", "invoke_selected_action('edit')", "Edit"),
         ("r", "invoke_selected_action('regenerate')", "Regenerate"),
+        ("o", "invoke_selected_action('tool-output')", "Full output"),
     ]
 
     PROTECTED_CLICK_CLASSES: frozenset[str] = frozenset(
@@ -637,6 +641,12 @@ class ConsoleTranscript(VerticalScroll):
         self._generation_card_specs: dict[str, ConsoleGenerationCardSpec] = {}
         self._original_attempt_previews: dict[str, str] = {}
         self._citation_counts: dict[str, int] = {}
+        #: TASK-1860: ids of TOOL markers currently showing their FULL result.
+        #: Pure view state, owned here: expansion never touches the store, is
+        #: per row (so several calls in one turn expand independently), and is
+        #: deliberately dropped when the transcript is rebuilt for another
+        #: session rather than following the user across conversations.
+        self._expanded_tool_output_ids: set[str] = set()
         # TASK-259: per-message render-signature cache. Maps message id ->
         # (cheap change-token, expensive row signature). `_transcript_rows`
         # re-derives the render payload (Content assembly) only when the
@@ -1195,6 +1205,7 @@ class ConsoleTranscript(VerticalScroll):
     def _transcript_rows(self) -> list[_TranscriptRow]:
         rows: list[_TranscriptRow] = []
         for message in self._messages:
+            message = self._with_expanded_tool_output(message)
             selected = message.id == self.selected_message_id
             rows.append(
                 _TranscriptRow(
@@ -1592,6 +1603,48 @@ class ConsoleTranscript(VerticalScroll):
             self._signature_compute_counts.get(message.id, 0) + 1
         )
         return signature
+
+    def _with_expanded_tool_output(
+        self, message: ConsoleChatMessage
+    ) -> ConsoleChatMessage:
+        """Return ``message`` showing its full tool result, when expanded.
+
+        TASK-1860. Applied at the ONE walk that plans rows, so the row
+        renderable, its cached signature and its action row all see the same
+        message -- a row that renders expanded while its signature says
+        collapsed would never repaint.
+        """
+        full = message.tool_output_full
+        if not full or message.id not in self._expanded_tool_output_ids:
+            return message
+        head, separator, _preview = message.content.partition(" \u2192 ")
+        expanded = f"{head}{separator}{full}" if separator else f"{message.content}\n{full}"
+        return replace(message, content=expanded)
+
+    @on(Button.Pressed, ".console-transcript-action-button")
+    def _intercept_tool_output_press(self, event: Button.Pressed) -> None:
+        """Handle the Full-output button here; let every other action bubble.
+
+        Expansion is view state owned by this widget -- it never reaches the
+        store and nothing outside the transcript needs to know about it -- so
+        routing it through the screen's action dispatch would add a hop that
+        carries no information. Every other action id is left untouched and
+        still bubbles to `ChatScreen`.
+        """
+        button_id = event.button.id or ""
+        prefix = "console-message-action-tool-output-"
+        if not button_id.startswith(prefix):
+            return
+        event.stop()
+        self.toggle_tool_output(button_id.removeprefix(prefix))
+
+    def toggle_tool_output(self, message_id: str) -> None:
+        """Expand or collapse one TOOL marker's full result."""
+        if message_id in self._expanded_tool_output_ids:
+            self._expanded_tool_output_ids.discard(message_id)
+        else:
+            self._expanded_tool_output_ids.add(message_id)
+        self.call_later(self.refresh_messages)
 
     @staticmethod
     def _message_row_signature(message: ConsoleChatMessage, *, selected: bool) -> tuple:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -6,7 +6,6 @@ import asyncio
 import re
 from dataclasses import dataclass, replace
 from time import monotonic
-
 from typing import Iterable, Literal, Mapping
 
 from loguru import logger
@@ -20,7 +19,6 @@ from textual.css.query import NoMatches
 from textual.dom import NoScreen
 from textual.events import Click, Key
 from textual.widget import Widget
-from textual.widgets import Button
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Chat.console_chat_models import (
@@ -800,6 +798,11 @@ class ConsoleTranscript(VerticalScroll):
         """
         self._messages = list(messages)
         message_ids = {message.id for message in self._messages}
+        # Expansion is per message id, so ids that left the transcript (a
+        # session switch, a deleted branch) must go with them -- otherwise the
+        # set grows for the life of the widget and a recycled id would come
+        # back already expanded.
+        self._expanded_tool_output_ids &= message_ids
         new_user_send = any(
             message.id not in self._seen_message_ids
             and message.role == ConsoleMessageRole.USER
@@ -1613,6 +1616,13 @@ class ConsoleTranscript(VerticalScroll):
         renderable, its cached signature and its action row all see the same
         message -- a row that renders expanded while its signature says
         collapsed would never repaint.
+
+        Args:
+            message: The transcript message about to be rendered.
+
+        Returns:
+            ``message`` unchanged, or a copy whose ``content`` carries the
+            full tool result when this row is currently expanded.
         """
         full = message.tool_output_full
         if not full or message.id not in self._expanded_tool_output_ids:
@@ -1639,7 +1649,13 @@ class ConsoleTranscript(VerticalScroll):
         self.toggle_tool_output(button_id.removeprefix(prefix))
 
     def toggle_tool_output(self, message_id: str) -> None:
-        """Expand or collapse one TOOL marker's full result."""
+        """Expand or collapse one TOOL marker's full result.
+
+        Args:
+            message_id: Id of the marker row to toggle. Unknown ids are
+                harmless -- the row simply renders collapsed, and
+                ``set_messages`` prunes ids that leave the transcript.
+        """
         if message_id in self._expanded_tool_output_ids:
             self._expanded_tool_output_ids.discard(message_id)
         else:


### PR DESCRIPTION
**TASK-1860**, carved out of TASK-1842 AC#3. That task fixed the *destruction* of tool markers; what the transcript showed was still a preview capped by the Console display setting, with no way to see the rest and no way to tell a whole result from its first N characters.

The original ask was explicit: keep the logs, and give the option to show the full output of a call **"even if it/they failed"** — and a failing call is exactly when it matters, because the question is how far it got, not just that it stopped.

Press **`o`** on a selected marker to expand it, again to collapse. Each call in a turn expands independently.

`ConsoleChatMessage.tool_output_full` carries the untruncated result, and `full_step_output` is the shared resolver so a **resumed** marker exposes the same thing as a live one — resume builds its messages directly, bypassing the append path, which is the door TASK-1842's first fix leaked through.

## Three decisions worth naming

**Whether there is more to show is settled once, when the marker is built.** Deciding it at render time by comparing the full text against `content` reads more naturally and is wrong: an *expanded* row does contain its full text, so the control that collapses it again would vanish.

**The transform is applied at the one walk that plans rows**, so the renderable, its cached signature and the action row all see the same message. A row that rendered expanded while its signature said collapsed would never repaint. Checked rather than assumed — the signature token does include `content`.

**The button press is handled in the transcript**, not routed through `ChatScreen`'s action dispatch. Expansion is view state that never reaches the store and nothing outside the transcript needs it, so the hop would carry no information — and it keeps an 18k-line file untouched.

AC#2 needed no work: `_truncate_step_text` already appends `… (+N chars)`.

## Two of these tests were vacuous first

The resume test compared `tool_output_full` on both sides while the calculator result was short enough that **both were `None`** — `[None] == [None]`, passing while proving nothing. It now forces the display cap to its real minimum (20; anything lower is clamped back to the default) and asserts a precondition that something is genuinely hidden.

The mounted-widget test also passed on first run, so it and the keyboard test were mutation-checked: removing the transform, the binding, the press routing, or the resume passthrough each fails one. The keyboard test exists because the first version called `toggle_tool_output` directly and proved nothing about `o` actually working.

3054 passed across `Tests/Chat` plus the transcript and workbench contracts.

> Note: that sweep also surfaced two failures that pre-existed on `dev` from #1192 (stale contract tests). They are **not** from this branch and are fixed in #1195.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets you view a tool call’s full output from the Console transcript. Press `o` to expand/collapse a selected marker; works per marker, including failures and resumed sessions (TASK-1860).

- New Features
  - Added `ConsoleChatMessage.tool_output_full` to carry the untruncated result.
  - Introduced `full_step_output` so live and resumed markers expose the same full text, including failed calls.
  - Added a “Full output” action and `o` keybinding; shown only when content is actually hidden. Expansion state is owned by `ConsoleTranscript` and never hits the store.
  - Retains the truncation hint “… (+N chars)”.
  - Tests cover keyboard path, mounted transcript rendering, per-row expansion, and resume parity.

- Bug Fixes
  - Prune expanded-state when messages leave the transcript to prevent stale or recycled ids rendering expanded; minor cleanup of a duplicate decorator/import.

<sup>Written for commit 0580e7f7308b4525fb1a853df316bc12f75567cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

