### PR TITLE
fix: briefings phase-4 residuals — Scheduling-screen visibility, audio blocking refusal, schedule-gate honesty (tasks 1810-1812)

### DIFF
--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -83,7 +83,20 @@ A few things worth knowing before turning it on:
   running scheduler only re-reads watchlists' cadences periodically, not
   the instant you change one, so a cadence you just picked can sit inert
   for up to one reload cycle before the schedule actually takes effect.
+- **An app-level setting can turn scheduling off entirely.** The
+  `[scheduling] briefing_schedules_enabled` setting in `config.toml` (`true`
+  by default, hand-edit only today — there is no in-app control for it)
+  gates whether this app ever fires ANY scheduled briefing, for every
+  watchlist at once. Turning it off does not clear a watchlist's stored
+  cadence: the cadence picker in Artifacts still shows what is stored, but
+  greys out, and the schedule resumes exactly where it left off the moment
+  the setting is turned back on.
 
 The Artifacts section's scope line states plainly which of these applies:
-"on request" when scheduling is off, or the actual cadence — "scheduled
-daily while the app is open", for example — when it is on.
+"on request" when no cadence is stored, the actual cadence — "scheduled
+daily while the app is open", for example — when one is stored and
+scheduling is enabled for the app, or, when a cadence is stored but
+`briefing_schedules_enabled` is off, a third line naming the stored cadence
+and stating plainly that it will not fire — "stored to run daily, but
+scheduled briefings are turned off for this app — this schedule will not
+fire", for example.

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -79,6 +79,10 @@ A few things worth knowing before turning it on:
   next period — but it also doesn't retry right away. The next attempt
   lands one cadence period after the failure, the same timing a normal
   run would have used.
+- **A freshly picked cadence can take up to ~30 minutes to start.** The
+  running scheduler only re-reads watchlists' cadences periodically, not
+  the instant you change one, so a cadence you just picked can sit inert
+  for up to one reload cycle before the schedule actually takes effect.
 
 The Artifacts section's scope line states plainly which of these applies:
 "on request" when scheduling is off, or the actual cadence — "scheduled

--- a/Tests/Scheduling/test_config_flags.py
+++ b/Tests/Scheduling/test_config_flags.py
@@ -67,30 +67,54 @@ def test_briefing_projection_is_only_wired_when_the_flag_is_on() -> None:
     pins the *pattern* ``app.py`` must keep instead -- the exact shape
     already established for ``watchlist_handler``/``watchlist_projection``
     (``watchlist_projection if watchlist_handler is not None else None``):
-    a handler is constructed only inside the flag's own ``if``, and
+    a handler is constructed only when a live projection exists, and
     ``SchedulerLoop`` is handed the projection only when that handler
     exists. ``Tests/Scheduling/test_scheduler_loop.py``'s
     ``test_queue_with_no_briefing_projection_loads_no_briefing_jobs`` pins
     the other half: that passing ``None`` genuinely loads nothing,
     regardless of what the projection would otherwise report.
+
+    task-1810 moved ``briefing_projection``'s construction earlier, ahead of
+    ``SchedulingService`` (which now takes it as a constructor argument), so
+    the flag gate on the projection itself is a ternary assigned directly to
+    ``briefing_projection`` rather than a ``None`` placeholder overwritten
+    inside an ``if briefing_schedules_enabled:`` block. ``briefing_handler``
+    still follows the older "placeholder, then overwritten inside a guard"
+    shape -- just gated on the (already flag-derived) projection being
+    non-``None``, rather than re-reading the flag a second time.
     """
     from tldw_chatbook import app as app_module
 
     source = inspect.getsource(app_module)
 
-    assert "briefing_projection = None" in source
-    assert "briefing_handler = None" in source
-
-    # Both assignments live inside one `if briefing_schedules_enabled:` block,
-    # with nothing but simple statements between the `if` and each
-    # assignment -- i.e. neither is reachable when the flag is off.
-    gate_block = re.search(
-        r"if\s+briefing_schedules_enabled:\n((?:[ \t]+\S.*\n)+)",
+    # `briefing_projection` is `None` whenever `briefing_schedules_enabled`
+    # is `False` -- pinned as a ternary assigned straight to the name, since
+    # (unlike `briefing_handler`) there is no separate placeholder-then-
+    # overwrite step for it anymore.
+    projection_gate = re.search(
+        r"briefing_projection\s*=\s*\(\s*"
+        r"BriefingProjection\(subscriptions_db\)\s*"
+        r"if\s+briefing_schedules_enabled\s*"
+        r"else\s+None\s*\)",
         source,
     )
-    assert gate_block is not None, "no `if briefing_schedules_enabled:` block found"
+    assert projection_gate is not None, (
+        "briefing_projection must be None whenever briefing_schedules_enabled is False"
+    )
+
+    assert "briefing_handler = None" in source
+
+    # `briefing_handler` is built only inside a block guarded on the
+    # projection already being live -- i.e. only when the flag was on, never
+    # independently of it.
+    gate_block = re.search(
+        r"if\s+briefing_projection is not None:\n((?:[ \t]+\S.*\n)+)",
+        source,
+    )
+    assert gate_block is not None, (
+        "no `if briefing_projection is not None:` block found"
+    )
     body = gate_block.group(1)
-    assert "briefing_projection = BriefingProjection(" in body
     assert "briefing_handler = BriefingJobHandler(" in body
 
     assert re.search(

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -5,12 +5,15 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduledTask, TaskStatus
 from tldw_chatbook.Scheduling.scheduler.queue import PriorityQueue
 from tldw_chatbook.Scheduling.services import SchedulingServerClient, SchedulingService
+from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
 from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
+from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
 
 
 @pytest.fixture
@@ -453,6 +456,180 @@ async def test_list_tasks_filters_watchlist_by_owner(db):
     projection.list_jobs.assert_called_once_with(owner_id="server:1")
 
 
+# --- briefing projection (task-1810): scheduled briefings on the unified list ---
+#
+# Mirrors the watchlist-projection tests immediately above -- same shape,
+# same sort/merge behavior, one extra source. `_cadenced_watchlist` and
+# `_force_briefing_created_at` mirror the equivalent helpers in
+# `test_briefing_projection.py`.
+
+
+def _cadenced_watchlist(subs_db, name="Watch", cadence_seconds=3600):
+    """Create a watchlist with a non-NULL briefing cadence (opted in)."""
+    watchlist_id = WatchlistBundleService(subs_db).create(name=name)["id"]
+    subs_db.set_watchlist_briefing_settings(
+        watchlist_id, briefing_cadence_seconds=cadence_seconds
+    )
+    return watchlist_id
+
+
+def _force_briefing_created_at(subs_db, briefing_id, timestamp):
+    """Overwrite a `briefings` row's `created_at` directly (second resolution)."""
+    subs_db.conn.execute(
+        "UPDATE briefings SET created_at = ? WHERE id = ?", (timestamp, briefing_id)
+    )
+    subs_db.conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_includes_briefing_projection(db):
+    """list_tasks merges reminders with briefing projections and sorts by
+    next_run_at -- the mock-based structural mirror of
+    test_list_tasks_includes_watchlist_projection above."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    await svc.create_reminder(_reminder_payload("Reminder"))
+
+    projection = MagicMock(spec=BriefingProjection)
+    projection.list_jobs.return_value = [
+        ScheduledTask(
+            id="briefing:1",
+            title="Briefing Job",
+            type="briefing_job",
+            status=TaskStatus.WAITING,
+            next_run_at=datetime(2026, 7, 20, 13, 0, tzinfo=timezone.utc),
+            owner_id="local",
+        )
+    ]
+    svc.briefing_projection = projection
+
+    tasks = await svc.list_tasks()
+
+    assert len(tasks) == 2
+    assert tasks[0].title == "Briefing Job"
+    assert tasks[1].title == "Reminder"
+    projection.list_jobs.assert_called_once_with(owner_id="local")
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_filters_briefing_by_owner(db):
+    """list_tasks passes the current owner_id to the briefing projection too."""
+    svc = SchedulingService(db=db, runtime_source="server:1")
+    projection = MagicMock(spec=BriefingProjection)
+    projection.list_jobs.return_value = []
+    svc.briefing_projection = projection
+
+    tasks = await svc.list_tasks()
+
+    assert tasks == []
+    projection.list_jobs.assert_called_once_with(owner_id="server:1")
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_includes_both_watchlist_and_briefing_projections(db):
+    """The two projections are additive, not mutually exclusive -- both
+    branches extend the same unified list."""
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    watchlist_projection = MagicMock(spec=WatchlistProjection)
+    watchlist_projection.list_jobs.return_value = [
+        ScheduledTask(
+            id="watchlist:1",
+            title="Watchlist Job",
+            type="watchlist_job",
+            status=TaskStatus.WAITING,
+            next_run_at=None,
+            owner_id="local",
+        )
+    ]
+    briefing_projection = MagicMock(spec=BriefingProjection)
+    briefing_projection.list_jobs.return_value = [
+        ScheduledTask(
+            id="briefing:1",
+            title="Briefing Job",
+            type="briefing_job",
+            status=TaskStatus.WAITING,
+            next_run_at=None,
+            owner_id="local",
+        )
+    ]
+    svc.watchlist_projection = watchlist_projection
+    svc.briefing_projection = briefing_projection
+
+    tasks = await svc.list_tasks()
+
+    types = {task.type for task in tasks if isinstance(task, ScheduledTask)}
+    assert types == {"watchlist_job", "briefing_job"}
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_includes_a_cadenced_briefing_schedule_ac1(db, tmp_path):
+    """AC #1: a watchlist with a non-NULL briefing_cadence_seconds shows up
+    as a scheduled task on the unified list, alongside reminders and
+    watchlist checks."""
+    subs_db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    watchlist_id = _cadenced_watchlist(subs_db, name="Acme Watch", cadence_seconds=3600)
+    complete_id = subs_db.insert_briefing(watchlist_id, status="complete")
+    _force_briefing_created_at(subs_db, complete_id, "2026-01-01 00:00:00")
+
+    projection = BriefingProjection(subs_db)
+    svc = SchedulingService(db=db, runtime_source="local", briefing_projection=projection)
+    await svc.create_reminder(_reminder_payload("Reminder"))
+
+    tasks = await svc.list_tasks()
+
+    briefing_tasks = [t for t in tasks if getattr(t, "type", None) == "briefing_job"]
+    assert len(briefing_tasks) == 1
+    assert briefing_tasks[0].id == f"briefing:{watchlist_id}"
+    assert briefing_tasks[0].title == "Acme Watch"
+    reminder_tasks = [t for t in tasks if isinstance(t, ReminderTask)]
+    assert len(reminder_tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_briefing_schedule_next_run_at_matches_the_projection_ac2(db, tmp_path):
+    """AC #2: the projected briefing task's next-run time on the unified
+    list matches BriefingProjection.list_jobs' own calculation for the same
+    data -- asserted against the projection directly, never re-derived
+    here (a re-derivation could independently agree with a broken
+    passthrough by coincidence)."""
+    subs_db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    watchlist_id = _cadenced_watchlist(subs_db, name="Acme Watch", cadence_seconds=7200)
+    complete_id = subs_db.insert_briefing(watchlist_id, status="complete")
+    _force_briefing_created_at(subs_db, complete_id, "2026-01-01 00:00:00")
+
+    projection = BriefingProjection(subs_db)
+    svc = SchedulingService(db=db, runtime_source="local", briefing_projection=projection)
+
+    tasks = await svc.list_tasks()
+    [briefing_task] = [t for t in tasks if getattr(t, "type", None) == "briefing_job"]
+
+    # The projection's OWN calculation for the same data, called
+    # independently -- not a re-derivation of the expected value by hand.
+    # Deterministic (not `now`-dependent) because the watchlist has a
+    # `complete` briefing on record, so `next_run_at` is
+    # `last_completed_at + cadence`, unaffected by wall-clock timing.
+    [expected_task] = projection.list_jobs(owner_id="local")
+    assert briefing_task.next_run_at == expected_task.next_run_at
+    assert briefing_task.next_run_at == datetime(
+        2026, 1, 1, 2, 0, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_null_cadence_watchlist_absent_from_scheduling_screen_ac4(db, tmp_path):
+    """AC #4: a watchlist with a NULL cadence (scheduling off) does not
+    appear on the unified list at all."""
+    subs_db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    WatchlistBundleService(subs_db).create(name="Never Scheduled")  # no cadence set
+
+    projection = BriefingProjection(subs_db)
+    svc = SchedulingService(db=db, runtime_source="local", briefing_projection=projection)
+
+    tasks = await svc.list_tasks()
+
+    assert all(getattr(t, "type", None) != "briefing_job" for t in tasks)
+
+
 @pytest.mark.asyncio
 async def test_created_reminder_is_picked_up_by_priority_queue(db):
     """Locally created reminders must have next_run_at set so the queue loads them."""
@@ -519,3 +696,36 @@ def test_server_client_is_always_present(db):
     svc = SchedulingService(db=db, runtime_source="local", server_client=None)
     assert isinstance(svc.server_client, SchedulingServerClient)
     assert svc.server_client.notifications_service is None
+
+
+def test_app_wiring_briefing_projection_is_live_not_a_frozen_none():
+    """Seam-level liveness proof for the app.py construction-order fix
+    (task-1810): `_wire_watchlists_and_notifications_services` must pass a
+    REAL `BriefingProjection` into `SchedulingService` at construction time,
+    not `None` frozen in because the projection used to be built AFTER the
+    service. That is the exact bug class task-1810's own dispatch brief
+    flags as already having shipped once elsewhere in this same method (the
+    kept-briefings branch's construction-order bug) -- this test reds
+    against the naive fix (pass `briefing_projection=briefing_projection`
+    at the OLD call site, before `briefing_projection` is assigned) just as
+    it would red against never wiring the parameter at all.
+
+    `_build_test_app`'s fake `get_cli_setting` passes through whatever
+    default the caller supplies for any key other than
+    `general.default_tab` (see its own docstring) -- `briefing_schedules_enabled`
+    defaults to `True` in `app.py`, so this exercises the real, enabled-by-
+    default production path, not a special-cased test config.
+    """
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+
+    assert app.scheduling_service.briefing_projection is not None
+    assert isinstance(app.scheduling_service.briefing_projection, BriefingProjection)
+    # And it is the SAME instance `SchedulerLoop`'s queue was wired with --
+    # not two independently constructed projections that happen to both be
+    # real, which would hide a subtler drift between the two consumers.
+    assert (
+        app.scheduling_service.briefing_projection
+        is app.scheduler_loop.queue.briefing_projection
+    )

--- a/Tests/Subscriptions/test_briefing_service.py
+++ b/Tests/Subscriptions/test_briefing_service.py
@@ -46,6 +46,7 @@ from tldw_chatbook.Subscriptions.briefing_service import (
     extract_citation_ids,
     fail_interrupted_briefings,
     generate_briefing,
+    pending_briefing_claim_watchlist_ids,
 )
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
 from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
@@ -1042,6 +1043,139 @@ async def test_row_scoped_exclude_sweeps_a_same_watchlist_zombie_while_sparing_t
     assert db.get_briefing(live_id)["status"] == "generating", (
         "row-scoped exclude must not falsify the row a live claim is "
         "actually writing"
+    )
+
+    release.set()
+    row = await first
+    assert row["status"] == "complete"
+
+
+# --- The unrecorded-claim sweep window (whole-branch review, ----------------
+# chore/briefings-residuals-1810-1812, Important 1) -------------------------
+#
+# `generate_briefing` records `_ACTIVE_BRIEFING_CLAIM_ROW_IDS[watchlist_id]`
+# only after the ENTIRE `_start_generation` `to_thread` hop returns, but that
+# hop's `INSERT` is its FIRST statement -- for the rest of the hop (three more
+# DB reads) the live row exists, reads `generating`, and `active_briefing_
+# claim_row_ids()` alone names nothing that protects it. A sweep at that exact
+# instant used to falsify the row. `pending_briefing_claim_watchlist_ids()`
+# closes the window: `_claim_briefing(watchlist_id)` with no `briefing_id`
+# reproduces the registry state mid-window directly, with no need to block
+# inside `_start_generation` itself.
+
+
+def test_pending_briefing_claim_watchlist_ids_is_an_empty_snapshot_by_default():
+    assert pending_briefing_claim_watchlist_ids() == frozenset()
+
+
+def test_a_claim_with_no_recorded_row_id_yet_is_named_pending(tmp_path):
+    """Direct pin of the accessor: a claim taken via `_claim_briefing`
+    without a `briefing_id` (exactly the registry state for the span inside
+    `_start_generation`'s `to_thread` hop, before `generate_briefing`
+    resumes to record one) must appear in `pending_briefing_claim_
+    watchlist_ids()`, and must disappear the instant a row id IS recorded.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+
+    with briefing_service._claim_briefing(watchlist):
+        assert active_briefing_claim_row_ids() == frozenset(), (
+            "no row id has been recorded yet -- this is the window itself"
+        )
+        assert watchlist in pending_briefing_claim_watchlist_ids()
+
+    assert watchlist not in pending_briefing_claim_watchlist_ids(), (
+        "the claim released -- nothing should still read as pending"
+    )
+
+    live_row = db.insert_briefing(watchlist)
+    with briefing_service._claim_briefing(watchlist, briefing_id=live_row):
+        assert watchlist not in pending_briefing_claim_watchlist_ids(), (
+            "a claim whose row id IS recorded is no longer pending"
+        )
+
+
+def test_a_claim_with_no_recorded_row_id_yet_survives_a_sweep_of_its_own_row(
+    tmp_path,
+):
+    """The window itself, closed: a `generating` row for a watchlist whose
+    claim exists but whose row id is not yet recorded (mid-`_start_
+    generation`, before `generate_briefing` resumes to record it) must
+    survive a sweep run at that exact instant -- reproducing what the
+    reviewer's throwaway probe proved reachable (`swept == 1` against the
+    live row) before this fix.
+
+    Without `exclude_watchlists`, `active_briefing_claim_row_ids()` alone is
+    empty here (nothing recorded yet) and the row would be swept as a false
+    zombie -- exactly the regression this pins.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+    # Stands in for the row `_start_generation`'s `INSERT` just wrote, before
+    # `generate_briefing` resumes on the event loop to record its id.
+    live_row = db.insert_briefing(watchlist)
+
+    with briefing_service._claim_briefing(watchlist):
+        row_ids = active_briefing_claim_row_ids()
+        pending = pending_briefing_claim_watchlist_ids()
+        assert row_ids == frozenset(), "the row id is not recorded in this window"
+        assert watchlist in pending
+
+        swept = fail_interrupted_briefings(
+            db, exclude=row_ids, exclude_watchlists=pending
+        )
+
+    assert swept == 0
+    assert db.get_briefing(live_row)["status"] == "generating", (
+        "a claim whose row id has not been recorded yet must still spare "
+        "its own row from a concurrent sweep"
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_scoped_exclude_still_sweeps_a_same_watchlist_zombie_once_the_id_lands(
+    tmp_path,
+):
+    """The task-1812 coexistence fix, re-asserted alongside the new guard:
+    once a claim's row id IS recorded, `pending_briefing_claim_watchlist_
+    ids()` no longer names its watchlist, so `exclude_watchlists` goes back
+    to being a no-op for it and row-scoped `exclude` alone decides -- a
+    same-watchlist crash zombie is still swept even though the watchlist
+    itself has a live claim.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+    source = _new_source(db, watchlist, "acme")
+    _add_article(db, source, "Something Happened")
+
+    zombie_id = db.insert_briefing(watchlist)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_chat(**kwargs):
+        entered.set()
+        await release.wait()
+        return CANNED_BODY
+
+    first = asyncio.ensure_future(generate_briefing(db, watchlist, chat=_slow_chat))
+    await entered.wait()
+
+    row_ids = active_briefing_claim_row_ids()
+    pending = pending_briefing_claim_watchlist_ids()
+    assert row_ids, "the live claim's row id must be recorded by the time chat runs"
+    assert watchlist not in pending, (
+        "once the row id lands, the watchlist is no longer 'pending'"
+    )
+
+    swept = fail_interrupted_briefings(db, exclude=row_ids, exclude_watchlists=pending)
+
+    assert swept == 1
+    assert db.get_briefing(zombie_id)["status"] == "failed"
+    live_id = next(iter(row_ids))
+    assert db.get_briefing(live_id)["status"] == "generating", (
+        "the live row must survive even with exclude_watchlists passed "
+        "alongside row-scoped exclude"
     )
 
     release.set()

--- a/Tests/Subscriptions/test_briefing_service.py
+++ b/Tests/Subscriptions/test_briefing_service.py
@@ -40,6 +40,7 @@ from tldw_chatbook.Subscriptions.briefing_selection import (
 from tldw_chatbook.Subscriptions.briefing_service import (
     EXCERPT_CHAR_CAP,
     GenerationInFlightError,
+    active_briefing_claim_row_ids,
     active_briefing_claims,
     build_briefing_prompt,
     extract_citation_ids,
@@ -828,31 +829,47 @@ async def test_the_db_work_runs_off_the_event_loop_thread(tmp_path):
 #
 # `generate_briefing` claims `watchlist_id` before doing anything else, and
 # releases it in a `finally` regardless of outcome. `fail_interrupted_
-# briefings` gained an `exclude` so a sweep can spare a watchlist a live
-# claim protects. Every test below is a "load-bearing" test named in the
-# task brief.
+# briefings` gained an `exclude` so a sweep can spare a row a live claim
+# protects. Every test below is a "load-bearing" test named in the task
+# brief. Task-1812 (AC #3) re-scoped `exclude` from watchlist ids to
+# `briefings.id`s -- see the dedicated coexistence tests further down for
+# why.
 
 
 def test_active_briefing_claims_is_an_empty_snapshot_by_default():
     assert active_briefing_claims() == frozenset()
 
 
-def test_fail_interrupted_briefings_spares_a_claimed_watchlist_both_directions(
+def test_fail_interrupted_briefings_spares_an_excluded_row_both_directions(
     tmp_path,
 ):
-    """Survey finding (a): a claimed watchlist's `generating` row survives
-    the sweep when passed via `exclude` -- and is swept when it is not."""
+    """Survey finding (a), updated for task-1812 (AC #3): `exclude` now
+    names the briefing ROW to spare, not its watchlist -- a row survives
+    the sweep when its id is passed via `exclude`, and is swept once it is
+    not.
+
+    A padding row is inserted (and finished) first so the row under test's
+    own id is NOT the same integer as the watchlist's id -- proving
+    `exclude={live_row}` protects because of the ROW id, not a coincidental
+    match with the watchlist id. A single-watchlist, single-row fixture
+    would not catch that: a fresh database hands both id sequences their
+    first value (`1`), so passing the watchlist id where a row id is
+    expected would falsely appear to work.
+    """
     db = _db(tmp_path)
     watchlist = WatchlistBundleService(db).create(name="Security")["id"]
-    zombie = db.insert_briefing(watchlist)  # stands in for a live claim's own row
+    padding = db.insert_briefing(watchlist)
+    db.update_briefing(padding, status="complete", body_markdown="unrelated")
+    live_row = db.insert_briefing(watchlist)  # stands in for a live claim's own row
+    assert live_row != watchlist, "the fixture must not coincidentally align the ids"
 
-    assert fail_interrupted_briefings(db, exclude={watchlist}) == 0
-    assert db.get_briefing(zombie)["status"] == "generating"
+    assert fail_interrupted_briefings(db, exclude={live_row}) == 0
+    assert db.get_briefing(live_row)["status"] == "generating"
 
-    assert fail_interrupted_briefings(db, exclude={watchlist}) == 0
+    assert fail_interrupted_briefings(db, exclude={live_row}) == 0
     assert fail_interrupted_briefings(db) == 1
-    assert db.get_briefing(zombie)["status"] == "failed"
-    assert db.get_briefing(zombie)["error"] == "interrupted"
+    assert db.get_briefing(live_row)["status"] == "failed"
+    assert db.get_briefing(live_row)["error"] == "interrupted"
 
 
 @pytest.mark.asyncio
@@ -958,3 +975,75 @@ async def test_a_concurrent_generation_for_the_same_watchlist_is_refused(tmp_pat
     row = await first
     assert row["status"] == "complete"
     assert watchlist not in active_briefing_claims()
+
+
+# --- Row-scoped sweep exclusion (task-1812, AC #3) --------------------------
+#
+# `fail_interrupted_briefings`'s `exclude` used to be watchlist-granular:
+# ANY `generating` row for a watchlist named in `exclude` survived, on the
+# reasoning that such a row is "a LIVE, in-process generation" -- true only
+# if a watchlist can have at most one `generating` row at a time. It cannot:
+# a crash-zombie row left by a PRIOR process (that process's own claim died
+# with it) can coexist with a freshly-claimed live row for the SAME
+# watchlist, and watchlist-scoped exclusion incidentally shielded the zombie
+# too. `active_briefing_claim_row_ids()` names the live ROW instead, so a
+# same-watchlist zombie is swept exactly as if nothing were claimed at all.
+
+
+def test_active_briefing_claim_row_ids_is_an_empty_snapshot_by_default():
+    assert active_briefing_claim_row_ids() == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_row_scoped_exclude_sweeps_a_same_watchlist_zombie_while_sparing_the_live_row(
+    tmp_path,
+):
+    """The coexistence case the docstring used to over-claim protection for:
+    a crash-zombie row and a genuinely live claim, both `generating`, both
+    on the SAME watchlist, in the same sweep. Row-scoped `exclude` must
+    fail the zombie and leave the live row alone -- watchlist-scoped
+    `exclude` (the pre-task-1812 shape) cannot tell them apart and would
+    spare both.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+    source = _new_source(db, watchlist, "acme")
+    _add_article(db, source, "Something Happened")
+
+    # Stands in for a row a PRIOR process left behind mid-generation: its
+    # own claim died with that process, so nothing in THIS process's
+    # `_ACTIVE_BRIEFING_CLAIM_ROW_IDS` will ever name it.
+    zombie_id = db.insert_briefing(watchlist)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_chat(**kwargs):
+        entered.set()
+        await release.wait()
+        return CANNED_BODY
+
+    first = asyncio.ensure_future(generate_briefing(db, watchlist, chat=_slow_chat))
+    await entered.wait()
+
+    # The live claim now protects its OWN row, not merely its watchlist.
+    live_ids = active_briefing_claim_row_ids()
+    assert live_ids, "a live claim's row must be recorded by the time chat runs"
+    assert zombie_id not in live_ids, (
+        "the zombie's id must never be recorded by a claim it did not make"
+    )
+
+    swept = fail_interrupted_briefings(db, exclude=live_ids)
+
+    assert swept == 1
+    assert db.get_briefing(zombie_id)["status"] == "failed"
+    assert db.get_briefing(zombie_id)["error"] == "interrupted"
+    live_id = next(iter(live_ids))
+    assert db.get_briefing(live_id)["status"] == "generating", (
+        "row-scoped exclude must not falsify the row a live claim is "
+        "actually writing"
+    )
+
+    release.set()
+    row = await first
+    assert row["status"] == "complete"

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -3187,6 +3187,63 @@ async def test_second_synthesis_while_in_flight_refuses_naming_the_running_one()
 
 
 @pytest.mark.asyncio
+async def test_a_synthesis_press_during_a_claimed_script_refuses_not_run_concurrently(
+    monkeypatch,
+):
+    """task-1811, mirroring `test_a_cast_press_during_a_claimed_briefing_
+    refuses_not_run_concurrently` exactly: before this fix, Synthesize had
+    NO refusal for this case (`watchlists_collections_screen.py`'s own
+    comment above `_audio_sweep_is_safe` used to document the gap
+    explicitly) -- a press during a genuinely in-flight synthesis for the
+    SAME script would start a second, concurrent one. Claimed directly via
+    the service (`briefing_audio._claim_audio`), standing in for another
+    in-process caller; `_audio_in_flight` is deliberately untouched, since
+    this is not the SAME screen instance's own dispatch-time guard being
+    exercised (that is `test_second_synthesis_while_in_flight_refuses_
+    naming_the_running_one`, above).
+
+    Asserts the SPECIFIC `blocking` toast (`severity="warning"`, "already
+    being synthesized"), not merely "some refusal happened":
+    `generate_script_audio` itself also refuses a claimed script
+    (`GenerationInFlightError`), so a looser assertion would still pass
+    with the screen's OWN `blocking` check deleted entirely, as long as
+    the worker went on to call `generate_script_audio` and hit ITS claim
+    collision instead -- a different, generic-error-toast path this test
+    must tell apart from the one it names (this is what pins the
+    equivalent of mutation (iii) from the Cast test).
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id, script_id = _seed_complete_script(app, watchlist_id)
+    db = app.watchlist_bundle_service.db
+
+    fake_audio = _FakeAudioService()
+    _use_fake_audio_service(monkeypatch, fake_audio)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
+
+        live_audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+
+        with briefing_audio._claim_audio(script_id):
+            await _press_synthesize(screen, pilot, app, script_id)
+
+        assert fake_audio.calls == [], (
+            "nothing may be synthesized while claimed elsewhere"
+        )
+        assert app.notify.called, "the refusal must be visible, not silent"
+        args, kwargs = app.notify.call_args
+        message = args[0] if args else str(kwargs.get("message", ""))
+        assert kwargs.get("severity") == "warning"
+        assert kwargs.get("markup") is False
+        assert "already being synthesized" in message
+        assert db.get_briefing_audio(live_audio_id)["status"] == "generating", (
+            "the live claim's row must not be falsified as interrupted"
+        )
+
+
+@pytest.mark.asyncio
 async def test_the_audio_guard_is_claimed_before_the_worker_runs(monkeypatch):
     """Mechanism half, the deterministic sibling of `test_the_cast_guard_
     is_claimed_before_the_worker_runs`: the handler is synchronous with no

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -78,6 +78,7 @@ from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import (
     SynthesizeAudioRequested,
     _audio_file_is_playable,
     audio_file_path_is_safe,
+    cadence_scope_phrase,
 )
 from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import TreeScope
@@ -636,7 +637,12 @@ async def test_a_claimed_watchlist_survives_an_artifacts_open():
         assert not screen._briefing_in_flight, (
             "this scenario is a claim with no screen dispatch behind it"
         )
-        with briefing_service._claim_briefing(watchlist_id):
+        # `briefing_id=live_id`: task-1812 (AC #3) made the sweep's exclude
+        # row-scoped rather than watchlist-scoped, so simulating "a live
+        # claim protects this row" now requires telling the claim which row
+        # that is -- exactly what `generate_briefing` itself records mid-
+        # block once its own row exists (see `_claim_briefing`'s docstring).
+        with briefing_service._claim_briefing(watchlist_id, briefing_id=live_id):
             await screen._load_briefings()
             assert db.get_briefing(live_id)["status"] == "generating", (
                 "a claimed watchlist must survive an Artifacts open"
@@ -676,7 +682,11 @@ async def test_generate_during_a_claimed_watchlist_refuses_without_falsifying_th
 
     async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
         live_id = db.insert_briefing(watchlist_id)
-        with briefing_service._claim_briefing(watchlist_id):
+        # `briefing_id=live_id`: see the identical note in
+        # `test_a_claimed_watchlist_survives_an_artifacts_open` -- the sweep
+        # now excludes by row id (task-1812, AC #3), so the claim must name
+        # the row it protects.
+        with briefing_service._claim_briefing(watchlist_id, briefing_id=live_id):
             await _press_generate(screen, pilot, app, watchlist_id)
 
         assert chat.calls == [], "nothing may be generated while claimed elsewhere"
@@ -1772,6 +1782,128 @@ async def test_an_out_of_catalog_cadence_gets_a_synthetic_select_option_and_an_h
         # app is open" promise verbatim, not a silent "on request" lie.
         assert "scheduled every 3600s while the app is open" in pane.scope_label
         assert "on request" not in pane.scope_label
+
+
+# --- 6c. The app-level scheduling kill switch (task-1812, AC #1/#2) --------
+#
+# `[scheduling] briefing_schedules_enabled` gates whether `app.py` ever
+# builds anything that reads a stored cadence back at all -- but nothing on
+# this pane reflected that: the picker stayed enabled and the scope label
+# kept claiming an active schedule even with the flag off. These three
+# tests pin both directions of that fix, plus the activation-delay copy the
+# same review round asked for (AC #2).
+
+
+@pytest.mark.asyncio
+async def test_the_kill_switch_off_disables_the_cadence_select_and_states_scheduling_is_off(
+    monkeypatch,
+):
+    """With a stored cadence and the flag off, the picker must not merely
+    look pickable while nothing would ever act on it: the Select is
+    disabled, and the scope label states scheduling is off at the app
+    level instead of implying an active schedule.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    db = app.watchlist_bundle_service.db
+    db.set_watchlist_briefing_settings(watchlist_id, briefing_cadence_seconds=43_200)
+
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "scheduling" and key == "briefing_schedules_enabled":
+            return False
+        return default
+
+    monkeypatch.setattr(screen_module, "get_cli_setting", _fake_get_cli_setting)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        cadence_select = pane.query_one("#artifacts-cadence-select", Select)
+        assert cadence_select.disabled is True, (
+            "the flag being off must disable the cadence picker, not "
+            "merely explain it"
+        )
+        assert cadence_select.value == 43_200, (
+            "the stored cadence must still be shown, inert, never silently "
+            "cleared"
+        )
+        assert "off for this app" in pane.scope_label
+        assert "scheduled every 12h while the app is open" not in pane.scope_label
+
+
+@pytest.mark.asyncio
+async def test_the_kill_switch_on_leaves_the_cadence_picker_unchanged(monkeypatch):
+    """The other direction: with the flag on (the default), behavior must
+    be unchanged from before this fix -- pinned against the SAME stored
+    cadence as the off-direction test above.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    db = app.watchlist_bundle_service.db
+    db.set_watchlist_briefing_settings(watchlist_id, briefing_cadence_seconds=43_200)
+
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "scheduling" and key == "briefing_schedules_enabled":
+            return True
+        return default
+
+    monkeypatch.setattr(screen_module, "get_cli_setting", _fake_get_cli_setting)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        cadence_select = pane.query_one("#artifacts-cadence-select", Select)
+        assert cadence_select.disabled is False
+        assert cadence_select.value == 43_200
+        assert "scheduled every 12h while the app is open" in pane.scope_label
+        assert "off for this app" not in pane.scope_label
+
+
+@pytest.mark.asyncio
+async def test_the_cadence_pickers_tooltip_states_the_activation_delay():
+    """Task-1812, AC #2: a freshly picked cadence is not instant -- the
+    running scheduler only re-reads schedules once per `queue_reload_
+    interval_ticks` (`Scheduling/scheduler/loop.py`), so a pick made right
+    now can sit inert for up to that long. Pinned against the picker's own
+    enabled-state tooltip, the smallest honest surface for it.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await host.workers.wait_for_complete()
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        cadence_select = pane.query_one("#artifacts-cadence-select", Select)
+        tooltip = str(cadence_select.tooltip)
+        assert "~30 minutes" in tooltip
+        assert "reload cycle" in tooltip
+
+
+def test_cadence_scope_phrase_states_scheduling_is_off_when_the_kill_switch_is_off():
+    """Direct pin of `cadence_scope_phrase`'s own `schedules_enabled`
+    branch (task-1812, AC #1) -- the two async tests above exercise it
+    through the whole screen; this is the fast, no-app-needed pin of the
+    function itself.
+    """
+    assert cadence_scope_phrase(43_200, schedules_enabled=False) == (
+        "stored to run every 12h, but scheduled briefings are turned off "
+        "for this app -- this schedule will not fire"
+    )
+    # `None` (never scheduled) reads identically regardless of the flag --
+    # there is nothing stored to describe either way.
+    assert cadence_scope_phrase(None, schedules_enabled=False) is None
+    assert cadence_scope_phrase(None, schedules_enabled=True) is None
+    # The flag defaults to `True`, so every pre-task-1812 caller (and every
+    # OTHER existing test of this function) reads unchanged.
+    assert (
+        cadence_scope_phrase(43_200) == "scheduled every 12h while the app is open"
+    )
 
 
 # --- 7. Casting a script (spec #2 phase 2a, Task 5) -------------------------

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -505,9 +505,11 @@ async def test_a_stuck_generating_row_is_refused_then_recovered(monkeypatch):
         in_flight_at_call: list[bool] = []
         real_fail = screen_module.fail_interrupted_briefings
 
-        def _recording_fail(db, watchlist_id=None, *, exclude=()):
+        def _recording_fail(db, watchlist_id=None, *, exclude=(), exclude_watchlists=()):
             in_flight_at_call.append(bool(screen._briefing_in_flight))
-            return real_fail(db, watchlist_id, exclude=exclude)
+            return real_fail(
+                db, watchlist_id, exclude=exclude, exclude_watchlists=exclude_watchlists
+            )
 
         monkeypatch.setattr(
             screen_module, "fail_interrupted_briefings", _recording_fail
@@ -1802,6 +1804,12 @@ async def test_the_kill_switch_off_disables_the_cadence_select_and_states_schedu
     look pickable while nothing would ever act on it: the Select is
     disabled, and the scope label states scheduling is off at the app
     level instead of implying an active schedule.
+
+    Whole-branch review (`chore/briefings-residuals-1810-1812`), Minor 4:
+    the Select's own tooltip must also say plainly that a stored cadence
+    survives disablement and will resume firing once the flag is turned
+    back on -- not merely that it "will not fire", which by itself reads
+    as a dead end rather than a paused one.
     """
     app = _build_test_app()
     watchlist_id = _seed_watchlist(app)
@@ -1831,6 +1839,14 @@ async def test_the_kill_switch_off_disables_the_cadence_select_and_states_schedu
         )
         assert "off for this app" in pane.scope_label
         assert "scheduled every 12h while the app is open" not in pane.scope_label
+
+        tooltip = str(cadence_select.tooltip)
+        assert "briefing_schedules_enabled is false" in tooltip
+        assert "stays saved" in tooltip
+        assert "resume firing" in tooltip and "turned back on" in tooltip, (
+            "the disabled tooltip must state plainly that a stored cadence "
+            "survives and will resume, not merely that it is inert"
+        )
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-1810 - Scheduled-briefings-are-invisible-to-the-Scheduling-screen.md
+++ b/backlog/tasks/task-1810 - Scheduled-briefings-are-invisible-to-the-Scheduling-screen.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-1810
 title: Scheduled briefings are invisible to the Scheduling screen
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-01 18:25'
+updated_date: '2026-08-02 08:44'
 labels:
   - watchlists
   - briefings
@@ -41,10 +42,87 @@ report for the same observation.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 A watchlist with a non-NULL `briefing_cadence_seconds` shows up as a scheduled task on the Scheduling screen, alongside reminders and watchlist checks
-- [ ] #2 The projected briefing task's next-run time on the Scheduling screen matches `BriefingProjection.list_jobs`'s own calculation (last completed run + cadence, or immediate if never run)
-- [ ] #3 No new `persist_event` names are introduced (mirror the existing `log_counter`/`log_histogram`-only observability this stream already uses for briefings and watchlist checks)
-- [ ] #4 A watchlist with a NULL cadence (scheduling off) does not appear on the Scheduling screen
+- [x] #1 A watchlist with a non-NULL `briefing_cadence_seconds` shows up as a scheduled task on the Scheduling screen, alongside reminders and watchlist checks
+- [x] #2 The projected briefing task's next-run time on the Scheduling screen matches `BriefingProjection.list_jobs`'s own calculation (last completed run + cadence, or immediate if never run)
+- [x] #3 No new `persist_event` names are introduced (mirror the existing `log_counter`/`log_histogram`-only observability this stream already uses for briefings and watchlist checks)
+- [x] #4 A watchlist with a NULL cadence (scheduling off) does not appear on the Scheduling screen
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add optional `briefing_projection` to `SchedulingService.__init__`; `list_tasks` extends with its jobs the same way `watchlist_projection` does (`scheduling_service.py:136-145`).
+2. Wire it at the `app.py` construction site (`~:4717`), passing the already-constructed `BriefingProjection` when briefing schedules are enabled.
+3. Tests: cadence watchlist appears in the unified list with next-run matching `BriefingProjection.list_jobs`; NULL cadence absent; no new `persist_event` names (log_counter/log_histogram only).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Approach.** Mirrored `watchlist_projection` exactly, per the plan:
+
+- `SchedulingService.__init__` (`Scheduling/services/scheduling_service.py`) gains an optional
+  `briefing_projection: BriefingProjection | None = None`, stored as `self.briefing_projection`.
+- `list_tasks` grows one more guarded branch, parallel to the existing watchlist one:
+  `if self.briefing_projection is not None: tasks.extend(self.briefing_projection.list_jobs(owner_id=self.owner_id))`.
+  No re-derivation of `next_run_at` -- the projection's own `ScheduledTask` objects are
+  extended straight into the unified list, so AC #2 ("matches `BriefingProjection.list_jobs`'s
+  own calculation") holds by construction, not by coincidence.
+- AC #3: no new `persist_event`/metrics calls were added -- `list_tasks` doesn't emit any
+  observability today (for either projection), so there was nothing to mirror.
+
+**Construction-order fix (app.py).** The task's own brief flagged that this exact method
+(`_wire_watchlists_and_notifications_services`) had just shipped a construction-order bug
+elsewhere (the kept-briefings branch) where a projection built *after* the consumer it needed
+to feed froze `None` in forever. The same shape existed here: `briefing_projection` was built
+several lines *after* `SchedulingService(...)` was already constructed. Fixed by moving
+`briefing_schedules_enabled`'s read and `briefing_projection`'s construction up, immediately
+before the `SchedulingService(...)` call, and passing it in directly. This is a pure reorder --
+`briefing_projection` only ever depended on `subscriptions_db`, already created above both the
+old and new call sites -- so `briefing_handler`'s construction (which does need to stay late,
+since `chachanotes_db_getter`'s closure timing matters) was left exactly where it was, now
+gated on `if briefing_projection is not None:` instead of re-reading the flag a second time.
+`SchedulerLoop`'s own `briefing_projection if briefing_handler is not None else None` ternary
+was left untouched (now a tautology given the shared gate, but harmless and lower-diff to leave
+alone).
+
+**Tests** (`Tests/Scheduling/test_scheduling_service.py`): mock-based structural mirrors of the
+existing watchlist-projection tests (`test_list_tasks_includes_briefing_projection`,
+`test_list_tasks_filters_briefing_by_owner`, plus a combined-both-projections test), and three
+AC-driving tests against a real `SubscriptionsDB`/`BriefingProjection`: AC #1
+(`test_list_tasks_includes_a_cadenced_briefing_schedule_ac1`), AC #2
+(`test_briefing_schedule_next_run_at_matches_the_projection_ac2` -- asserts equality against a
+second, independent `projection.list_jobs()` call, not a hand-derived expected value; uses a
+seeded `complete` briefing so the comparison is deterministic rather than `now`-dependent), and
+AC #4 (`test_null_cadence_watchlist_absent_from_scheduling_screen_ac4`). A seam-level liveness
+test (`test_app_wiring_briefing_projection_is_live_not_a_frozen_none`) boots the real app via
+`Tests/UI/app_factory._build_test_app` and asserts `app.scheduling_service.briefing_projection`
+is a live `BriefingProjection`, identical to the one `SchedulerLoop`'s queue holds -- proving the
+app.py reorder, not just the `SchedulingService` unit behavior.
+
+`Tests/Scheduling/test_config_flags.py::test_briefing_projection_is_only_wired_when_the_flag_is_on`
+pinned the *old* literal code pattern (`briefing_projection = None` inside
+`if briefing_schedules_enabled:`) via source inspection; updated to pin the new (still
+flag-gated) pattern instead, preserving the same behavioral intent (flag off -> both
+`briefing_projection` and `briefing_handler` are `None`).
+
+**Mutation checks** (Edit-revert cycles, `git status --short` clean before/after each):
+- Dropped the new `list_tasks` branch entirely -> AC #1 test, the mock-based briefing-inclusion
+  test, and the combined-projections test all REDed (3 failures); AC #4 unaffected. Restored.
+- Broke the next-run "passthrough" by zeroing `next_run_at` on each projected task after
+  `list_jobs()` returned (simulating a future re-derivation bug) -> only AC #2 REDed; AC #1 and
+  AC #4 stayed green, confirming AC #2 is the one that actually discriminates a broken
+  passthrough from a merely-present task. Restored.
+- Hardcoded `briefing_projection=None` at the `SchedulingService(...)` call site (the exact
+  frozen-None bug this task's brief described) -> the app.py wiring liveness test REDed.
+  Restored.
+
+**Files modified:**
+- `tldw_chatbook/Scheduling/services/scheduling_service.py`
+- `tldw_chatbook/app.py`
+- `Tests/Scheduling/test_scheduling_service.py`
+- `Tests/Scheduling/test_config_flags.py`
+
+Full `Tests/Scheduling/` suite: 264 passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1811 - Audio-synthesize-path-lacks-the-blocking-refusal-Cast-gained.md
+++ b/backlog/tasks/task-1811 - Audio-synthesize-path-lacks-the-blocking-refusal-Cast-gained.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-1811
 title: Audio synthesize path lacks the blocking refusal Cast gained
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-01 18:25'
+updated_date: '2026-08-02 08:57'
 labels:
   - watchlists
   - briefings
@@ -40,9 +41,61 @@ isn't gated by `_audio_in_flight`) that Cast now has and audio does not.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 EITHER `_synthesize_audio` gains a `blocking` refusal symmetric to Cast's (a Synthesize press for a script already claimed by `active_audio_claims()` refuses with a specific toast naming the running synthesis, instead of relying solely on `_audio_in_flight`) OR a decision not to add it is recorded here with reasoning, ratified by the project owner or a reviewer
-- [ ] #2 If implemented, a test proves a Synthesize press during a claimed audio synthesis is refused via the specific `blocking` toast, not a generic error toast (mirroring `test_a_cast_press_during_a_claimed_briefing_refuses_not_run_concurrently`)
-- [ ] #3 No change to the claim-aware sweep behavior already shipped in phase 4 task 1 (a live audio claim must continue to survive `fail_interrupted_audio` regardless of this task's outcome)
+- [x] #1 EITHER `_synthesize_audio` gains a `blocking` refusal symmetric to Cast's (a Synthesize press for a script already claimed by `active_audio_claims()` refuses with a specific toast naming the running synthesis, instead of relying solely on `_audio_in_flight`) OR a decision not to add it is recorded here with reasoning, ratified by the project owner or a reviewer
+- [x] #2 If implemented, a test proves a Synthesize press during a claimed audio synthesis is refused via the specific `blocking` toast, not a generic error toast (mirroring `test_a_cast_press_during_a_claimed_briefing_refuses_not_run_concurrently`)
+- [x] #3 No change to the claim-aware sweep behavior already shipped in phase 4 task 1 (a live audio claim must continue to survive `fail_interrupted_audio` regardless of this task's outcome)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Mirror Cast's `blocking` refusal into `_synthesize_audio` in `watchlists_collections_screen.py`: after the front-of-worker sweep, check `active_audio_claims()` and refuse with a specific toast naming the running synthesis.
+2. Test mirroring `test_a_cast_press_during_a_claimed_briefing_refuses_not_run_concurrently`; assert the specific toast, not a generic error.
+3. Verify the claim-aware sweep behavior is untouched (existing live-claim-survives-sweep tests stay green).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Chose AC #1's implementation arm (symmetric blocking refusal), mirroring Cast's
+phase-4 fix exactly: `_synthesize_audio` now runs a new `_sweep_and_guard_audio`
+(sibling of `_sweep_and_guard_cast`, using `db.list_briefing_audio(script_id)` +
+a new `_audio_row_label` helper) instead of a bare `fail_interrupted_audio` call,
+and refuses with a specific `blocking` toast ("... is already being synthesized
+for this script. Nothing else was started.", severity="warning", markup=False)
+when a row survives the sweep because a live in-process claim holds it -- same
+guard placement (after the sweep, before `generate_script_audio`), same
+specific-toast convention as Cast's own fix. No `recovered`-branch refusal was
+added (mirrors `_cast_script`'s own reasoning: `briefing_audio` has no
+one-complete-row-per-script invariant, so a press that recovers a zombie must
+still synthesize real audio in the same press).
+
+Test (AC #2): `test_a_synthesis_press_during_a_claimed_script_refuses_not_run_
+concurrently` in Tests/Watchlists/test_watchlists_artifacts_pane.py, mirroring
+`test_a_cast_press_during_a_claimed_briefing_refuses_not_run_concurrently`:
+claims the script's audio id directly via `briefing_audio._claim_audio`
+(standing in for another in-process caller), presses the real Synthesize
+button, and asserts the specific blocking toast (severity, markup, "already
+being synthesized" substring) plus that `generate_script_audio` was never
+called and the live claim's row was not falsified. Mutation-tested by
+temporarily neutralizing the new `blocking` check (`if False and blocking:`) --
+confirmed the test REDs -- then restored; `git status --short` clean afterward.
+
+AC #3 verified, not re-implemented: the claim-aware sweep behavior from phase 4
+task 1 is untouched (`fail_interrupted_audio` still receives `exclude`d claims
+from `_sweep_and_guard_audio`, same as before from the inline call); existing
+`test_a_zombie_generating_audio_row_is_recovered_on_a_plain_artifacts_load` and
+`test_synthesizing_recovers_a_zombie_audio_row_via_its_own_sweep` stay green
+unchanged.
+
+Verified: the new test, the full `Tests/Watchlists/ -k audio` set (19 passed),
+the whole `test_watchlists_artifacts_pane.py` file (112 passed), and
+`Tests/Subscriptions/test_briefing_audio_db.py` +
+`test_briefing_audio_pipeline.py` + `test_briefing_audio_synthesis.py` (60
+passed, untouched module).
+
+Modified files:
+- tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+- Tests/Watchlists/test_watchlists_artifacts_pane.py
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1812 - Briefing-schedule-gate-UX-residuals.md
+++ b/backlog/tasks/task-1812 - Briefing-schedule-gate-UX-residuals.md
@@ -102,13 +102,22 @@ open`, `test_generate_during_a_claimed_watchlist_refuses_without_falsifying_the_
 were updated to pass it, since row-scoped exclusion made their bare watchlist-only claim
 insufficient to protect the row they assert on.
 
-Residual (documented, not fixed): a narrow window exists between `_start_generation`'s
-`INSERT` committing (inside its `to_thread` hop) and `generate_briefing`'s coroutine
-resuming to record the row id -- during that window a concurrent sweep on the same
-watchlist could theoretically fail the fresh row. Narrowing further would require
-splitting `_start_generation` into two `to_thread` hops, which whole-branch review fix 1
-explicitly rejected (one hop, not one per statement) for an unrelated reason; left as-is,
-matching the task's own suggested shape ("set right after the INSERT").
+Residual (documented at the time, since fixed): a window existed between `_start_
+generation`'s `INSERT` (its FIRST statement, inside its `to_thread` hop) and `generate_
+briefing`'s coroutine resuming to record the row id -- not "right after the INSERT" as
+this note originally (inaccurately) claimed, but after the WHOLE hop, three more DB reads
+later. A whole-branch review of `chore/briefings-residuals-1810-1812` (verdict:
+`.superpowers/sdd/briefings-residuals/whole-branch-verdict.md`, Important 1) proved the
+window reachable -- a probe blocking inside `select_briefing_items` measured `swept == 1`
+against the live row at that exact instant, confirming this was not theoretical. Closed
+in the same branch's fix wave without splitting the `to_thread` hop: `fail_interrupted_
+briefings` gained a second `exclude_watchlists` parameter, fed by a new
+`pending_briefing_claim_watchlist_ids()` accessor (`active_briefing_claims() -
+_ACTIVE_BRIEFING_CLAIM_ROW_IDS.keys()`) -- watchlists claimed but not yet row-recorded.
+The set empties the instant the row id lands, so this task's own AC #3 coexistence fix
+is untouched. See `tldw_chatbook/Subscriptions/briefing_service.py` and the fix-wave
+section of `.superpowers/sdd/briefings-residuals/task-1812-report.md` for the mutation-
+tested detail.
 
 Testing: new tests in Tests/Subscriptions/test_briefing_service.py (row-id snapshot
 default, and the zombie+live-claim coexistence case: zombie swept, live row untouched)

--- a/backlog/tasks/task-1812 - Briefing-schedule-gate-UX-residuals.md
+++ b/backlog/tasks/task-1812 - Briefing-schedule-gate-UX-residuals.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-1812
 title: Briefing schedule gate/UX residuals
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-01 19:08'
+updated_date: '2026-08-02 09:30'
 labels:
   - watchlists
   - briefings
@@ -47,9 +48,92 @@ Filed during the whole-branch review fix wave for the Watchlists briefings phase
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 When `[scheduling] briefing_schedules_enabled` is `false`, the Artifacts cadence picker and the scope label no longer imply an active schedule (disabled control, and/or copy stating scheduling is off at the app level), for a watchlist that already has a stored cadence
-- [ ] #2 The cadence picker's UI copy or the user guide's "Scheduled briefings" section states that a newly picked cadence can take up to one queue-reload cycle to reach the running scheduler
-- [ ] #3 `fail_interrupted_briefings`'s `exclude` (or its docstring) is corrected so a crash-zombie row is swept even when its watchlist has an unrelated live claim -- either by scoping the exclusion to the actual claimed briefing row rather than the whole watchlist, or by an accurate docstring plus a regression test pinning the coexistence case (a zombie row and a live claim on the same watchlist in the same sweep)
+- [x] #1 When `[scheduling] briefing_schedules_enabled` is `false`, the Artifacts cadence picker and the scope label no longer imply an active schedule (disabled control, and/or copy stating scheduling is off at the app level), for a watchlist that already has a stored cadence
+- [x] #2 The cadence picker's UI copy or the user guide's "Scheduled briefings" section states that a newly picked cadence can take up to one queue-reload cycle to reach the running scheduler
+- [x] #3 `fail_interrupted_briefings`'s `exclude` (or its docstring) is corrected so a crash-zombie row is swept even when its watchlist has an unrelated live claim -- either by scoping the exclusion to the actual claimed briefing row rather than the whole watchlist, or by an accurate docstring plus a regression test pinning the coexistence case (a zombie row and a live claim on the same watchlist in the same sweep)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Gate the cadence picker on `[scheduling] briefing_schedules_enabled`: when off, disable the Select and have `cadence_scope_phrase` say scheduling is off at the app level (stored cadence shown but inert).
+2. Document the up-to-one-reload-cycle activation delay in the picker copy and/or `Docs/User_Guide/watchlists.md`.
+3. Fix `fail_interrupted_briefings` exclusion: scope to the actual claimed briefing row if the claim seam can carry the row id cleanly, else correct the docstring and pin the zombie+live-claim coexistence case with a regression test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Approach: all three sub-fixes shipped, ACs 1-3 all closed via the first (preferred) arm named in each.
+
+AC #1 (kill-switch honesty): Added `ArtifactsPane.briefing_schedules_enabled` (reactive,
+default True), screen-injected via a new `WatchlistsCollectionsScreen._briefing_schedules_
+enabled()` reading `get_cli_setting("scheduling", "briefing_schedules_enabled", True)` --
+the identical read `app.py`'s wiring block uses, following the "queries config helper"
+convention (mirrors Tools_Settings_Window/STTS_Window) since no live app-instance handle
+exists for this flag today. Injected at both pane-construction sites (initial build and
+`_load_briefings` reload), same seam `chachanotes_available` uses. `cadence_scope_phrase`
+gained a `schedules_enabled: bool = True` kwarg: when off, a stored cadence reads as
+"stored to run <cadence>, but scheduled briefings are turned off for this app -- this
+schedule will not fire" instead of implying an active schedule; `None` cadence is
+unaffected either way. The cadence `Select` is now `disabled=` the inverse of the flag,
+with a tooltip naming the config key when disabled.
+
+AC #2 (activation delay): folded into the SAME cadence-Select tooltip (enabled branch) --
+"A freshly picked cadence can take up to ~30 minutes (one scheduler reload cycle) to
+start" -- plus a new bullet in Docs/User_Guide/watchlists.md's "Scheduled briefings"
+section. Smallest-honest-surface choice per the AC's own wording.
+
+AC #3 (row-scoped sweep exclusion, first arm taken): `fail_interrupted_briefings`'s
+`exclude` now matches `briefings.id` (`AND id NOT IN (...)`) instead of `watchlist_id`.
+Added `_ACTIVE_BRIEFING_CLAIM_ROW_IDS: dict[watchlist_id, briefing_id]`, populated by
+`generate_briefing` as the very next statement after `_start_generation`'s `to_thread`
+hop returns (no intervening `await`), and popped in `_claim_briefing`'s own `finally`
+alongside the existing watchlist-level claim. New `active_briefing_claim_row_ids()`
+snapshot accessor is what callers now pass as `exclude` (both screen call sites updated;
+`active_briefing_claims()` itself is untouched and still used for its original
+watchlist-granular purposes -- `GenerationInFlightError` and the scheduler's own
+duplicate-dispatch guard in `briefing_handler.py`, neither of which this task touches).
+`_claim_briefing` gained an optional `briefing_id` kwarg so tests that simulate a claim
+directly (without a real `generate_briefing` call) can associate it with an existing row;
+the two existing tests that did this (`test_a_claimed_watchlist_survives_an_artifacts_
+open`, `test_generate_during_a_claimed_watchlist_refuses_without_falsifying_the_row`)
+were updated to pass it, since row-scoped exclusion made their bare watchlist-only claim
+insufficient to protect the row they assert on.
+
+Residual (documented, not fixed): a narrow window exists between `_start_generation`'s
+`INSERT` committing (inside its `to_thread` hop) and `generate_briefing`'s coroutine
+resuming to record the row id -- during that window a concurrent sweep on the same
+watchlist could theoretically fail the fresh row. Narrowing further would require
+splitting `_start_generation` into two `to_thread` hops, which whole-branch review fix 1
+explicitly rejected (one hop, not one per statement) for an unrelated reason; left as-is,
+matching the task's own suggested shape ("set right after the INSERT").
+
+Testing: new tests in Tests/Subscriptions/test_briefing_service.py (row-id snapshot
+default, and the zombie+live-claim coexistence case: zombie swept, live row untouched)
+and Tests/Watchlists/test_watchlists_artifacts_pane.py (kill-switch off disables Select +
+honest phrase; kill-switch on unchanged; tooltip states the activation delay; a plain
+unit test of `cadence_scope_phrase`'s new kwarg). One pre-existing test
+(`test_fail_interrupted_briefings_spares_a_claimed_watchlist_both_directions`) was
+renamed and fixed: it had been passing `exclude={watchlist_id}` against a fresh
+single-watchlist, single-row fixture where the watchlist id and the briefing row id
+coincidentally both equal 1 -- silently masking the semantic change. Rewritten with a
+padding row so the ids provably diverge, and to pass the row id as the new contract
+requires.
+
+Mutation checks performed and reverted (git status clean between): (1) reverted `id NOT
+IN` back to `watchlist_id NOT IN` in `fail_interrupted_briefings` -- both new/updated
+row-scoped tests went RED; (2) forced `schedules_disabled = False` in the pane's
+`compose()` -- the kill-switch-off test went RED, the other three (on-direction,
+tooltip, plain function test) stayed green as expected.
+
+Verification: Tests/Subscriptions/test_briefing_service.py (30 passed), Tests/Scheduling/
+(264 passed), Tests/Watchlists/ (364 passed, full directory) -- all via
+/private/tmp/tldw-briefings/.venv/bin/python -m pytest directly.
+
+Files: tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py,
+tldw_chatbook/UI/Screens/watchlists_collections_screen.py,
+tldw_chatbook/Subscriptions/briefing_service.py, Docs/User_Guide/watchlists.md,
+Tests/Subscriptions/test_briefing_service.py, Tests/Watchlists/test_watchlists_artifacts_pane.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
+++ b/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
@@ -1,0 +1,66 @@
+---
+id: TASK-1890
+title: Row-scope the script and audio interrupted sweeps
+status: To Do
+assignee: []
+created_date: '2026-08-02'
+labels:
+  - watchlists
+  - briefings
+  - audio
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Filed during the whole-branch review fix wave for `chore/briefings-residuals-1810-1812`
+(verdict: `.superpowers/sdd/briefings-residuals/whole-branch-verdict.md`, adjudication (b)),
+which fixed `fail_interrupted_briefings`'s `exclude` to be row-scoped rather than
+watchlist-scoped (task-1812, AC #3) and then closed the residual claim-registration
+window that fix left open (this branch's own fix wave, Important 1). Both sibling sweeps
+in the same family were deliberately left out of that scope and still exclude by the
+coarser key:
+
+- `fail_interrupted_scripts` (`tldw_chatbook/Subscriptions/briefing_cast.py`) excludes by
+  `script_id`, not by the claimed row's own id.
+- `fail_interrupted_audio` (`tldw_chatbook/Subscriptions/briefing_audio.py:1342`, `AND
+  script_id NOT IN (...)`) excludes by `script_id` too.
+
+This is the same bug class task-1812 fixed for briefings: a `script_id` (or, for audio, a
+script whose scripts share one id) can have more than one `generating` row over its
+lifetime -- a crash-zombie row left by a prior process, coexisting with a freshly-claimed
+live row for the SAME key. A coarse, key-scoped `exclude` cannot tell them apart, so it
+shields both rather than only the live one.
+
+Unlike the briefings case, this errs toward *over*-protection, never over-sweeping: a
+row-scoped exclude only ever narrows which rows survive, so leaving the coarse exclude in
+place cannot cause a live row to be falsely marked `interrupted`. There is no correctness
+hole here -- a zombie merely survives longer than it needs to, until a sweep runs while
+its key is entirely unclaimed.
+
+But task-1811 (this same branch) gave the coarse audio exclude a user-visible surface it
+did not have before: `WatchlistsCollectionsScreen`'s Synthesize refusal toast
+(`tldw_chatbook/UI/Screens/watchlists_collections_screen.py:5784`, "is already being
+synthesized for this script") can now name a row that is not actually live -- a
+crash-zombie audio row shielded by an unrelated live claim on the same `script_id`,
+surfaced as if it were the thing blocking Synthesize. The *decision* to refuse is still
+correct (something IS claimed for this script); the *row named in the message* can be
+dishonest.
+
+Reference: task-1812 (the briefings-side fix this generalizes) and this branch's
+whole-branch verdict file for the adjudication that filed this task rather than folding
+the fix into 1811/1812's own scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `fail_interrupted_scripts`'s `exclude` is scoped to the claimed script's own row id, not merely its `script_id`, mirroring `fail_interrupted_briefings`'s row-scoped shape (task-1812)
+- [ ] #2 `fail_interrupted_audio`'s `exclude` is scoped to the claimed audio row's own id, not merely its `script_id`, the same way
+- [ ] #3 Both row-scoped sweeps additionally handle the unrecorded-claim window the same way this branch's briefings fix does (a claim taken before its row id is recorded must still spare that row from a concurrent sweep) -- reference `chore/briefings-residuals-1810-1812`'s `pending_briefing_claim_watchlist_ids()` shape
+- [ ] #4 A same-`script_id` crash-zombie script row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (script sweep coexistence test)
+- [ ] #5 A same-`script_id` crash-zombie audio row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (audio sweep coexistence test)
+- [ ] #6 A claim taken but not yet row-recorded survives a sweep run inside that exact window, for both the script and audio sweeps (window regression tests, mirroring this branch's briefings window test)
+- [ ] #7 The Synthesize blocking toast (`watchlists_collections_screen.py`) never names a crash-zombie audio row as "already being synthesized" -- once the audio sweep is row-scoped, a zombie sharing a `script_id` with a live claim is swept before the toast is composed, so only the genuinely live row's label can appear
+<!-- AC:END -->

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -17,6 +17,7 @@ from loguru import logger
 
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind, ScheduledTask
+from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
     ServerUnavailableError,
@@ -66,12 +67,14 @@ class SchedulingService:
         server_client: SchedulingServerClient | None = None,
         runtime_source: str = "local",
         watchlist_projection: WatchlistProjection | None = None,
+        briefing_projection: BriefingProjection | None = None,
     ) -> None:
         self.db = db
         self.server_client = server_client or SchedulingServerClient()
         self.runtime_source = runtime_source
         self.owner_id = runtime_source
         self.watchlist_projection = watchlist_projection
+        self.briefing_projection = briefing_projection
         self.sync_engine = SyncEngine(db, self.server_client, self.owner_id)
 
     def set_owner(self, owner_id: str) -> None:
@@ -134,10 +137,12 @@ class SchedulingService:
         return [self._row_to_reminder(row) for row in rows]
 
     async def list_tasks(self) -> list[ReminderTask | ScheduledTask]:
-        """Return reminders plus watchlist projections for the current owner."""
+        """Return reminders plus watchlist/briefing projections for the current owner."""
         tasks: list[ReminderTask | ScheduledTask] = list(await self.list_reminders())
         if self.watchlist_projection is not None:
             tasks.extend(self.watchlist_projection.list_jobs(owner_id=self.owner_id))
+        if self.briefing_projection is not None:
+            tasks.extend(self.briefing_projection.list_jobs(owner_id=self.owner_id))
         # Sort by next_run_at (None sorts last)
         tasks.sort(
             key=lambda t: t.next_run_at or datetime.max.replace(tzinfo=timezone.utc)

--- a/tldw_chatbook/Subscriptions/briefing_service.py
+++ b/tldw_chatbook/Subscriptions/briefing_service.py
@@ -432,13 +432,54 @@ def active_briefing_claim_row_ids() -> frozenset[int]:
     sweep tell them apart.
 
     A watchlist whose claim has been taken but whose row has not been
-    inserted yet -- the brief window inside `_start_generation`'s own
-    `asyncio.to_thread` hop, before `generate_briefing`'s coroutine resumes
-    on the event loop to record the id -- is not represented here yet:
-    there is no row for it to protect until the `INSERT` itself has
-    happened and been reported back.
+    recorded yet -- the window inside `_start_generation`'s own
+    `asyncio.to_thread` hop, from the moment its `INSERT` runs until
+    `generate_briefing`'s coroutine resumes on the event loop to record the
+    id -- is not represented here: there is no id for it to report until
+    `generate_briefing` records one. That window is not unprotected,
+    though (whole-branch review, `chore/briefings-residuals-1810-1812`,
+    Important 1): `pending_briefing_claim_watchlist_ids()` below names
+    exactly those watchlists, and `fail_interrupted_briefings`'s
+    `exclude_watchlists` closes the gap this function's row-scoping alone
+    cannot.
     """
     return frozenset(_ACTIVE_BRIEFING_CLAIM_ROW_IDS.values())
+
+
+def pending_briefing_claim_watchlist_ids() -> frozenset[int]:
+    """Snapshot of watchlist ids with a live claim whose row id is not yet
+    recorded (whole-branch review, `chore/briefings-residuals-1810-1812`,
+    Important 1).
+
+    `_claim_briefing` adds `watchlist_id` to `_ACTIVE_BRIEFING_CLAIMS` before
+    `generate_briefing` ever calls `_start_generation`, but `generate_
+    briefing` only records the row id
+    (`_ACTIVE_BRIEFING_CLAIM_ROW_IDS[watchlist_id] = briefing_id`) once that
+    call's WHOLE `asyncio.to_thread` hop returns -- and the `INSERT` is that
+    hop's FIRST statement, with four more DB operations after it
+    (`_selection_mode`, `latest_completed_watermark`, `select_briefing_
+    items`, `get_briefing_preset`). For that whole span the watchlist is
+    claimed and its row exists and reads `generating`, but is named by
+    nothing: `active_briefing_claim_row_ids()` is empty (no id recorded
+    yet), and `active_briefing_claims()` is watchlist-scoped -- passing it
+    as `fail_interrupted_briefings`'s row-scoped `exclude` does not even
+    type-check, and passing it as `exclude_watchlists` unconditionally
+    would resurrect the exact over-protection task-1812 removed (shielding
+    a genuine same-watchlist crash zombie alongside the live row).
+
+    This is the set difference: claimed, but not yet recorded. Callers pass
+    it as `fail_interrupted_briefings`'s `exclude_watchlists`, ALONGSIDE
+    `exclude=active_briefing_claim_row_ids()`, never instead of it -- the
+    moment a watchlist's row id lands, it drops out of this set and the
+    row-scoped `exclude` alone protects it, which is exactly what keeps the
+    task-1812 coexistence fix (a zombie and a live claim on the SAME
+    watchlist, swept and spared respectively) intact.
+
+    A plain, already-copied `frozenset`, computed with no `await` between
+    reading the two registries -- safe only when called from the event
+    loop, same as the other two accessors in this section.
+    """
+    return frozenset(_ACTIVE_BRIEFING_CLAIMS) - frozenset(_ACTIVE_BRIEFING_CLAIM_ROW_IDS)
 
 
 @contextmanager
@@ -776,6 +817,17 @@ async def generate_briefing(
         # row on the same watchlist -- in particular a crash-zombie left by
         # a prior process, which does not belong here and must still be
         # swept.
+        #
+        # Whole-branch review (`chore/briefings-residuals-1810-1812`),
+        # Important 1: for the ENTIRE `to_thread` hop above -- from
+        # `_start_generation`'s `INSERT` through its three other DB reads --
+        # this watchlist's id sits in `_ACTIVE_BRIEFING_CLAIMS` with no
+        # corresponding entry here yet, so `active_briefing_claim_row_ids()`
+        # alone cannot protect the row this exact call just inserted. That
+        # window is what `pending_briefing_claim_watchlist_ids()` names and
+        # `fail_interrupted_briefings`'s `exclude_watchlists` closes -- both
+        # screen call sites pass it alongside `exclude=active_briefing_
+        # claim_row_ids()`.
         _ACTIVE_BRIEFING_CLAIM_ROW_IDS[watchlist_id] = briefing_id
         # The id actually recorded on the row: `None` for both "no preset was
         # requested" and "the requested preset no longer resolves" -- a stale
@@ -872,6 +924,7 @@ def fail_interrupted_briefings(
     watchlist_id: int | None = None,
     *,
     exclude: Collection[int] = (),
+    exclude_watchlists: Collection[int] = (),
 ) -> int:
     """Fail every `generating` briefing as `interrupted`; return the count.
 
@@ -903,6 +956,26 @@ def fail_interrupted_briefings(
             the live one. Scoping to the row's own id fixes that: only the
             actual live row survives, and a same-watchlist zombie is swept
             exactly as if no claim existed at all.
+        exclude_watchlists: Watchlist ids to spare even though a row reads
+            `generating`, regardless of that row's own id (whole-branch
+            review, `chore/briefings-residuals-1810-1812`, Important 1).
+            Closes a window row-scoped `exclude` alone cannot: between a
+            claim being taken and its row's id being recorded,
+            `generate_briefing` has already inserted the row (`_start_
+            generation`'s first statement) but has not yet resumed on the
+            event loop to record it (three more DB reads later) -- for that
+            whole span the row exists, reads `generating`, and is named by
+            no row id at all. Callers pass `pending_briefing_claim_
+            watchlist_ids()` here, snapshotted on the event loop exactly
+            like `exclude` -- NEVER `active_briefing_claims()` itself, which
+            would resurrect the pre-task-1812 over-protection `exclude` was
+            narrowed away from (shielding a same-watchlist crash zombie
+            alongside the live row). The set is empty for any watchlist
+            whose row id has already been recorded, so passing both
+            together preserves the task-1812 coexistence fix: only the
+            watchlist named here for the brief unrecorded window, and only
+            the row named in `exclude` once recorded. Defaults to `()`, so
+            every caller that predates this fix is unchanged.
 
     Returns:
         How many rows were failed.
@@ -919,6 +992,10 @@ def fail_interrupted_briefings(
         placeholders = ",".join("?" for _ in exclude)
         sql += f" AND id NOT IN ({placeholders})"
         params.extend(exclude)
+    if exclude_watchlists:
+        placeholders = ",".join("?" for _ in exclude_watchlists)
+        sql += f" AND watchlist_id NOT IN ({placeholders})"
+        params.extend(exclude_watchlists)
 
     with db.transaction() as conn:
         count = conn.execute(sql, params).rowcount

--- a/tldw_chatbook/Subscriptions/briefing_service.py
+++ b/tldw_chatbook/Subscriptions/briefing_service.py
@@ -363,6 +363,22 @@ def _default_provider() -> str:
 
 _ACTIVE_BRIEFING_CLAIMS: set[int] = set()
 
+# Task-1812, AC #3: `watchlist_id -> briefings.id` for the SAME live claim
+# above, but scoped to the actual ROW a live generation is writing rather
+# than merely the watchlist it belongs to. `_ACTIVE_BRIEFING_CLAIMS` alone
+# cannot tell a fresh live row apart from a crash-zombie row left by a PRIOR
+# process for the SAME watchlist (the crash predates the claim) -- both
+# read `generating` and share one `watchlist_id`, so a watchlist-scoped
+# `exclude` incidentally shields the zombie too. An entry here is added
+# only once the row actually exists (`generate_briefing` records it right
+# after `_start_generation`'s `INSERT` returns -- see that call site's own
+# comment on timing), and popped in `_claim_briefing`'s `finally`, alongside
+# the watchlist-level claim itself, so it never outlives the claim it
+# belongs to. `fail_interrupted_briefings`'s `exclude` (via `active_
+# briefing_claim_row_ids` below) reads from THIS registry, not `_ACTIVE_
+# BRIEFING_CLAIMS`.
+_ACTIVE_BRIEFING_CLAIM_ROW_IDS: dict[int, int] = {}
+
 
 class GenerationInFlightError(RuntimeError):
     """Raised when a watchlist already has a briefing generation claimed.
@@ -382,17 +398,53 @@ def active_briefing_claims() -> frozenset[int]:
 
     A plain, already-copied `frozenset` -- safe to read from any thread,
     unlike `_ACTIVE_BRIEFING_CLAIMS` itself. Callers take this snapshot on
-    the event loop, before handing control to a thread, and pass it as
-    `fail_interrupted_briefings`'s `exclude` (Locked decision 2): that
-    function is sync and runs under `asyncio.to_thread`, while the claim set
-    is mutated only on the event loop, so a cross-thread read of the live
-    set would be racy in a way a snapshot taken beforehand never is.
+    the event loop, before handing control to a thread. Used for the "is
+    THIS watchlist already claimed" question -- the scheduler's own
+    duplicate-dispatch guard (`BriefingJobHandler`) and `_claim_briefing`'s
+    own check below both ask exactly that, watchlist-granular, question.
+
+    NOT what `fail_interrupted_briefings`'s `exclude` wants any more
+    (task-1812, AC #3): a watchlist-scoped snapshot cannot tell a fresh live
+    row apart from a crash-zombie row a PRIOR process left behind for the
+    SAME watchlist, so passing this here would incidentally shield the
+    zombie too. Callers of the sweep want `active_briefing_claim_row_ids()`
+    instead.
     """
     return frozenset(_ACTIVE_BRIEFING_CLAIMS)
 
 
+def active_briefing_claim_row_ids() -> frozenset[int]:
+    """Snapshot of `briefings.id`s a live `generate_briefing` call has
+    actually inserted (task-1812, AC #3).
+
+    A plain, already-copied `frozenset` -- safe to read from any thread,
+    unlike `_ACTIVE_BRIEFING_CLAIM_ROW_IDS` itself. Callers take this
+    snapshot on the event loop, before handing control to a thread, and
+    pass it as `fail_interrupted_briefings`'s `exclude`: that function is
+    sync and runs under `asyncio.to_thread`, while the registry is mutated
+    only on the event loop, so a cross-thread read of the live registry
+    would be racy in a way a snapshot taken beforehand never is.
+
+    Row-scoped, not watchlist-scoped -- see `active_briefing_claims`'s own
+    docstring for why that distinction is the whole point: a genuine crash
+    zombie and a fresh live claim can coexist for one watchlist, and only
+    naming the live row itself, rather than its whole watchlist, lets a
+    sweep tell them apart.
+
+    A watchlist whose claim has been taken but whose row has not been
+    inserted yet -- the brief window inside `_start_generation`'s own
+    `asyncio.to_thread` hop, before `generate_briefing`'s coroutine resumes
+    on the event loop to record the id -- is not represented here yet:
+    there is no row for it to protect until the `INSERT` itself has
+    happened and been reported back.
+    """
+    return frozenset(_ACTIVE_BRIEFING_CLAIM_ROW_IDS.values())
+
+
 @contextmanager
-def _claim_briefing(watchlist_id: int) -> Iterator[None]:
+def _claim_briefing(
+    watchlist_id: int, *, briefing_id: int | None = None
+) -> Iterator[None]:
     """Claim `watchlist_id` for the duration of one generation attempt.
 
     Raises before the caller does anything else -- in particular, before
@@ -407,8 +459,27 @@ def _claim_briefing(watchlist_id: int) -> Iterator[None]:
     to simulate another in-process caller already holding a watchlist (e.g.
     a scheduled run) without going through a real generation.
 
+    Task-1812, AC #3: this context manager's `finally` is also where
+    `_ACTIVE_BRIEFING_CLAIM_ROW_IDS`' entry for `watchlist_id` is cleared,
+    on every exit path, alongside the watchlist-level claim itself -- so
+    the row-id registry can never outlive the claim it belongs to. `.pop(...,
+    None)` is a safe no-op whenever no id was ever recorded (e.g. a
+    `GenerationInFlightError` refusal here, or a DB error inside `_start_
+    generation` before `generate_briefing` gets a chance to record one).
+
     Args:
         watchlist_id: The watchlist about to be generated for.
+        briefing_id: The `briefings.id` this claim protects, if already
+            known at entry. `generate_briefing` itself never passes this --
+            its own row does not exist until AFTER this context manager is
+            entered (`_start_generation`'s `INSERT` runs inside the `with`
+            block), so it records the id into `_ACTIVE_BRIEFING_CLAIM_
+            ROW_IDS` itself, mid-block, once `_start_generation` returns.
+            This parameter exists for the OTHER caller named above: a test
+            simulating another in-process claim against a row that already
+            exists (there is no "generation in progress" to run through) can
+            pass it here so `active_briefing_claim_row_ids()` reports the
+            row exactly as a real claim eventually would.
 
     Raises:
         GenerationInFlightError: If `watchlist_id` is already claimed.
@@ -418,10 +489,13 @@ def _claim_briefing(watchlist_id: int) -> Iterator[None]:
             f"a briefing is already being generated for watchlist {watchlist_id}"
         )
     _ACTIVE_BRIEFING_CLAIMS.add(watchlist_id)
+    if briefing_id is not None:
+        _ACTIVE_BRIEFING_CLAIM_ROW_IDS[watchlist_id] = briefing_id
     try:
         yield
     finally:
         _ACTIVE_BRIEFING_CLAIMS.discard(watchlist_id)
+        _ACTIVE_BRIEFING_CLAIM_ROW_IDS.pop(watchlist_id, None)
 
 
 def _error_text(exc: BaseException) -> str:
@@ -692,6 +766,17 @@ async def generate_briefing(
         briefing_id, mode, prior_watermark, selection, preset = await asyncio.to_thread(
             _start_generation, db, watchlist_id, preset_id, now
         )
+        # Task-1812, AC #3: record the row THIS claim is now writing, as the
+        # very next statement after the `to_thread` hop above returns (no
+        # `await` in between) -- so nothing else on this event loop can
+        # observe the claim without the row it now protects. From here
+        # until `_claim_briefing`'s `finally` pops it back out, `fail_
+        # interrupted_briefings`'s row-scoped `exclude` (`active_briefing_
+        # claim_row_ids`) can tell this row apart from any OTHER `generating`
+        # row on the same watchlist -- in particular a crash-zombie left by
+        # a prior process, which does not belong here and must still be
+        # swept.
+        _ACTIVE_BRIEFING_CLAIM_ROW_IDS[watchlist_id] = briefing_id
         # The id actually recorded on the row: `None` for both "no preset was
         # requested" and "the requested preset no longer resolves" -- a stale
         # back-reference to a deleted preset is worse than no reference at all.
@@ -799,16 +884,25 @@ def fail_interrupted_briefings(
         db: An open `SubscriptionsDB`.
         watchlist_id: Scope the sweep to one watchlist. `None` sweeps all,
             which is what a startup pass wants.
-        exclude: Watchlist ids to spare even though their row reads
-            `generating` -- phase 4's claim-aware sweep (Locked decision 2).
-            A `generating` row whose watchlist is in this collection is a
-            LIVE, in-process generation, not a crash zombie, and must
-            survive unconditionally, in every scope. Callers snapshot
-            `active_briefing_claims()` on the event loop and pass the
-            result here; this function is sync and runs under
-            `asyncio.to_thread`, so it never reads the live claim set
-            itself. Defaults to `()`, so every pre-phase-4 caller is
-            unchanged.
+        exclude: `briefings.id`s to spare even though their row reads
+            `generating` -- phase 4's claim-aware sweep (Locked decision 2),
+            row-scoped since task-1812 (AC #3). A `generating` row whose OWN
+            id is in this collection is a LIVE, in-process generation, not
+            a crash zombie, and must survive unconditionally, in every
+            scope. Callers snapshot `active_briefing_claim_row_ids()` on
+            the event loop and pass the result here; this function is sync
+            and runs under `asyncio.to_thread`, so it never reads the live
+            claim registry itself. Defaults to `()`, so every pre-phase-4
+            caller is unchanged.
+
+            Prior to task-1812 this was watchlist-scoped (`active_briefing_
+            claims()`), which over-protected: a genuine crash-zombie row
+            left by an earlier process can coexist with a freshly-claimed
+            live row for the SAME watchlist (the crash predates the claim),
+            and a watchlist-scoped `exclude` shielded both rows, not just
+            the live one. Scoping to the row's own id fixes that: only the
+            actual live row survives, and a same-watchlist zombie is swept
+            exactly as if no claim existed at all.
 
     Returns:
         How many rows were failed.
@@ -823,7 +917,7 @@ def fail_interrupted_briefings(
         params.append(watchlist_id)
     if exclude:
         placeholders = ",".join("?" for _ in exclude)
-        sql += f" AND watchlist_id NOT IN ({placeholders})"
+        sql += f" AND id NOT IN ({placeholders})"
         params.extend(exclude)
 
     with db.transaction() as conn:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -63,6 +63,7 @@ from ...Subscriptions.briefing_service import (
     extract_citation_ids,
     fail_interrupted_briefings,
     generate_briefing,
+    pending_briefing_claim_watchlist_ids,
 )
 from ...Subscriptions.watchlist_bundle_service import WatchlistBundleService
 from ...Subscriptions.watchlist_normalizers import normalize_watchlist_item
@@ -3274,12 +3275,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         directly via `get_cli_setting` (the "queries config helper"
         convention several other screens/windows already use, e.g.
         `Tools_Settings_Window`/`STTS_Window`) rather than through a live
-        handle on `self.app_instance`: unlike `chachanotes_db`, nothing on
-        the app instance currently mirrors this decision back, because there
-        is no UI control for the flag today and so no prior seam existed to
-        reuse. Defaults to `True`, matching `app.py`'s own default, so a
-        watchlist with a stored cadence still reads as scheduled unless an
-        operator has explicitly turned the flag off.
+        handle on `self.app_instance`, even though one now exists:
+        `self.app_instance.scheduling_service.briefing_projection is not
+        None` is `app.py`'s own live reflection of this identical decision
+        (non-`None` iff the flag is truthy), added by task-1810 -- the
+        first commit on this same branch, two commits before this function
+        -- and asserted by `Tests/Scheduling/test_scheduling_service.py::
+        test_app_wiring_briefing_projection_is_live_not_a_frozen_none`. Kept
+        as a direct config read rather than switched to that mirror: today
+        both resolve identically, but a config reload mid-run (or a future
+        UI control this docstring anticipated) could make them diverge, so
+        a caller that cares about liveness rather than configuration should
+        read the mirror instead. Defaults to `True`, matching `app.py`'s own
+        default, so a watchlist with a stored cadence still reads as
+        scheduled unless an operator has explicitly turned the flag off.
         """
         return bool(
             get_cli_setting("scheduling", "briefing_schedules_enabled", True)
@@ -5069,16 +5078,32 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         row from a prior process for this SAME watchlist must still be
         swept even while a fresh claim is live, and only naming the live
         row itself (not its whole watchlist) lets that happen.
+
+        `pending_briefing_claim_watchlist_ids()` is snapshotted here too,
+        same thread, same instant (whole-branch review, `chore/briefings-
+        residuals-1810-1812`, Important 1): it closes the window `exclude`
+        alone cannot -- a claim taken but whose row id has not yet been
+        recorded, still inside `_start_generation`'s own `to_thread` hop.
+        Passed as `exclude_watchlists`, never in place of `exclude`.
         """
         if not self._zombie_sweep_is_safe():
             return 0
         claims = active_briefing_claim_row_ids()
+        pending = pending_briefing_claim_watchlist_ids()
         return await asyncio.to_thread(
-            fail_interrupted_briefings, db, watchlist_id, exclude=claims
+            fail_interrupted_briefings,
+            db,
+            watchlist_id,
+            exclude=claims,
+            exclude_watchlists=pending,
         )
 
     def _sweep_and_guard(
-        self, db: Any, watchlist_id: int, exclude: Collection[int]
+        self,
+        db: Any,
+        watchlist_id: int,
+        exclude: Collection[int],
+        exclude_watchlists: Collection[int] = (),
     ) -> tuple[list[str], list[str]]:
         """Zombie sweep, then the generating-check. Runs off the UI thread.
 
@@ -5103,6 +5128,15 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         left by a prior process is swept here even while that other live
         row survives, rather than the whole watchlist being spared.
 
+        `exclude_watchlists` -- the caller's `pending_briefing_claim_
+        watchlist_ids()` snapshot, taken at the same instant as `exclude`
+        (whole-branch review, `chore/briefings-residuals-1810-1812`,
+        Important 1) -- closes the same window `exclude` alone cannot for
+        THAT other in-process caller too: if it is still inside `_start_
+        generation`'s own `to_thread` hop, its row exists and reads
+        `generating` but has no id recorded yet, so only naming its
+        watchlist (not yet its row) spares it here.
+
         Returns:
             `(recovered, blocking)` -- labels for the rows this sweep failed
             as interrupted, and labels for any row still `generating`
@@ -5114,7 +5148,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             for row in db.list_briefings(watchlist_id)
             if str(row.get("status") or "").strip().lower() == STATUS_GENERATING
         ]
-        fail_interrupted_briefings(db, watchlist_id, exclude=exclude)
+        fail_interrupted_briefings(
+            db, watchlist_id, exclude=exclude, exclude_watchlists=exclude_watchlists
+        )
         blocking = [
             self._briefing_row_label(row)
             for row in db.list_briefings(watchlist_id)
@@ -5159,6 +5195,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     db,
                     watchlist_id,
                     active_briefing_claim_row_ids(),
+                    pending_briefing_claim_watchlist_ids(),
                 )
             except Exception as exc:  # noqa: BLE001 - reported, not raised
                 logger.warning(

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -5519,12 +5519,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     #
     # Phase 4 Task 1 investigated whether Synthesize needs the SAME
     # `blocking` refusal Cast just gained (survey finding (c)'s sibling
-    # question): structurally, yes -- `_synthesize_audio` has no `blocking`
+    # question): structurally, yes -- `_synthesize_audio` had no `blocking`
     # check either, so two presses could in principle start two concurrent
-    # renders for the same script. It is left AS-IS here: the task's own
-    # scope named Cast specifically, or "sweep gains `exclude`" everywhere,
-    # not a second new blocking check; adding one is a natural, small
-    # follow-up with the identical shape as `_sweep_and_guard_cast`.
+    # renders for the same script. Phase 4 left it AS-IS, deliberately, as a
+    # natural small follow-up; task-1811 is that follow-up: `_synthesize_
+    # audio` below now runs `_sweep_and_guard_audio`, the identical shape as
+    # `_sweep_and_guard_cast`, and refuses on `blocking` exactly like
+    # `_cast_script` does.
 
     def _audio_sweep_is_safe(self) -> bool:
         """Whether `fail_interrupted_audio` may run right now.
@@ -5552,6 +5553,43 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         return await asyncio.to_thread(
             fail_interrupted_audio, db, script_id, exclude=claims
         )
+
+    @staticmethod
+    def _audio_row_label(row: Mapping[str, Any]) -> str:
+        """Name one audio render the way a toast has to: which row, and
+        when. Sibling of `_script_row_label`, for the identical reason
+        (task-1811).
+        """
+        return (
+            f"audio {row.get('id')} "
+            f"(started {row.get('created_at') or 'at an unknown time'})"
+        )
+
+    def _sweep_and_guard_audio(
+        self, db: Any, script_id: int, exclude: Collection[int]
+    ) -> tuple[list[str], list[str]]:
+        """Zombie sweep, then the generating-check, for a synthesis. Runs
+        off the UI thread. Sibling of `_sweep_and_guard_cast` -- see that
+        method's own docstring for the full reasoning; this is the
+        identical shape, scoped to one script's audio renders instead of
+        one briefing's scripts (task-1811, mirroring Cast's own `blocking`
+        refusal from phase 4 Task 1 onto Synthesize).
+
+        Returns:
+            `(recovered, blocking)`, exactly like `_sweep_and_guard_cast`.
+        """
+        stuck = [
+            self._audio_row_label(row)
+            for row in db.list_briefing_audio(script_id)
+            if str(row.get("status") or "").strip().lower() == STATUS_GENERATING
+        ]
+        fail_interrupted_audio(db, script_id, exclude=exclude)
+        blocking = [
+            self._audio_row_label(row)
+            for row in db.list_briefing_audio(script_id)
+            if str(row.get("status") or "").strip().lower() == STATUS_GENERATING
+        ]
+        return stuck, blocking
 
     @on(SynthesizeAudioRequested)
     def handle_synthesize_audio_requested(
@@ -5625,16 +5663,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         toast.
 
         The sweep is claim-aware (`active_audio_claims()`), like every
-        other sweep call site (phase 4 Task 1) -- but, unlike `_cast_
-        script`, there is no `blocking` check after it; see this class's
-        own comment above `_audio_sweep_is_safe` for what was found and why
-        that is left for a follow-up.
+        other sweep call site (phase 4 Task 1), and is now followed by a
+        `blocking` check, mirroring `_cast_script`'s own (task-1811): a row
+        that SURVIVES `_sweep_and_guard_audio`'s sweep because it is
+        claimed by a live in-process synthesis refuses THIS attempt
+        instead of starting a second, concurrent one over the top of it.
+        Unlike `_cast_script`'s own `recovered` branch, there is no
+        one-COMPLETE-row-per-script invariant here either (a script may be
+        synthesized many times), so a zombie this sweep actually recovers
+        (i.e. NOT `blocking`) does not itself refuse a fresh synthesis --
+        the same press both recovers the zombie AND synthesizes real audio
+        (`test_synthesizing_recovers_a_zombie_audio_row_via_its_own_
+        sweep`).
         """
         try:
             try:
-                claims = active_audio_claims()
-                await asyncio.to_thread(
-                    fail_interrupted_audio, db, script_id, exclude=claims
+                _recovered, blocking = await asyncio.to_thread(
+                    self._sweep_and_guard_audio, db, script_id, active_audio_claims()
                 )
             except Exception as exc:  # noqa: BLE001 - reported, not raised
                 logger.warning(
@@ -5645,6 +5690,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     "Failed to check this script's audio. Nothing was "
                     "started.",
                     severity="error",
+                    markup=False,
+                )
+                return
+            if blocking:
+                # Survived the sweep because a live in-process claim holds
+                # it -- not ours to duplicate. Mirrors `_cast_script`'s own
+                # `blocking` refusal; see this method's own docstring for
+                # why there is no `recovered`-branch sibling here.
+                self._notify_watchlists(
+                    f"{', '.join(blocking)} is already being synthesized "
+                    "for this script. Nothing else was started.",
+                    severity="warning",
                     markup=False,
                 )
                 return

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -33,6 +33,7 @@ from ...Constants import (
     WATCHLISTS_NAV_CONTEXT_SECTION,
     WATCHLISTS_SECTION_RUNS,
 )
+from ...config import get_cli_setting
 from ...runtime_policy.types import PolicyDeniedError
 from ...Subscriptions.briefing_audio import (
     AudioGenerationError,
@@ -58,7 +59,7 @@ from ...Subscriptions.briefing_service import (
     GenerationInFlightError,
     STATUS_COMPLETE,
     STATUS_GENERATING,
-    active_briefing_claims,
+    active_briefing_claim_row_ids,
     extract_citation_ids,
     fail_interrupted_briefings,
     generate_briefing,
@@ -1456,6 +1457,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             artifacts_pane.presets = self._loaded_briefing_presets
             artifacts_pane.default_preset_id = self._briefing_default_preset_id
             artifacts_pane.briefing_cadence_seconds = self._briefing_cadence_seconds
+            artifacts_pane.briefing_schedules_enabled = (
+                self._briefing_schedules_enabled()
+            )
             artifacts_pane.scripts = self._loaded_scripts
             artifacts_pane.selected_script = self._selected_script
             artifacts_pane.script_audio = self._loaded_script_audio
@@ -3260,6 +3264,27 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         """
         return getattr(self.app_instance, "chachanotes_db", None)
 
+    def _briefing_schedules_enabled(self) -> bool:
+        """Whether `[scheduling] briefing_schedules_enabled` is on for this
+        run (task-1812, AC #1).
+
+        The identical config read `app.py`'s `_wire_watchlists_and_
+        notifications_services` uses to decide whether to build a
+        `BriefingProjection`/`BriefingJobHandler` pair at all -- read
+        directly via `get_cli_setting` (the "queries config helper"
+        convention several other screens/windows already use, e.g.
+        `Tools_Settings_Window`/`STTS_Window`) rather than through a live
+        handle on `self.app_instance`: unlike `chachanotes_db`, nothing on
+        the app instance currently mirrors this decision back, because there
+        is no UI control for the flag today and so no prior seam existed to
+        reuse. Defaults to `True`, matching `app.py`'s own default, so a
+        watchlist with a stored cadence still reads as scheduled unless an
+        operator has explicitly turned the flag off.
+        """
+        return bool(
+            get_cli_setting("scheduling", "briefing_schedules_enabled", True)
+        )
+
     def _briefing_scope_label(self) -> str:
         """The pane's one-line statement of what it is showing, and from where."""
         watchlist_id = self._briefing_watchlist_id()
@@ -3276,8 +3301,15 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # scheduled) with `None`, so "on request" stays the honest default;
         # anything else names the actual cadence, "while the app is open"
         # and all -- see that function's own docstring for why the phrase
-        # is worded that way.
-        cadence_phrase = cadence_scope_phrase(self._briefing_cadence_seconds)
+        # is worded that way. `schedules_enabled` (task-1812, AC #1) closes
+        # a second honesty gap the same reasoning missed: with the app-level
+        # kill switch off, nothing in this process would ever read a stored
+        # cadence back, so a phrase implying an active schedule would be a
+        # lie of the identical shape.
+        cadence_phrase = cadence_scope_phrase(
+            self._briefing_cadence_seconds,
+            schedules_enabled=self._briefing_schedules_enabled(),
+        )
         provenance = (
             f"written on this device — {cadence_phrase}"
             if cadence_phrase is not None
@@ -3647,6 +3679,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         pane.presets = self._loaded_briefing_presets
         pane.default_preset_id = self._briefing_default_preset_id
         pane.briefing_cadence_seconds = self._briefing_cadence_seconds
+        pane.briefing_schedules_enabled = self._briefing_schedules_enabled()
         pane.scripts = self._loaded_scripts
         pane.selected_script = self._selected_script
         pane.script_audio = self._loaded_script_audio
@@ -4994,20 +5027,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _zombie_sweep_is_safe(self) -> bool:
         """Whether `fail_interrupted_briefings` may run right now.
 
-        `fail_interrupted_briefings`'s own `exclude` (phase 4) now spares any
-        watchlist a LIVE in-process claim holds -- this screen's own, or a
-        future scheduled run's -- so it no longer fails EVERY `generating`
-        row unconditionally the way it did before claims existed. This flag
-        is a narrower, purely local check on top of that: it answers "is
-        THIS screen instance mid-generation", which the Generate path
-        (`_sweep_and_guard`) never needs -- it always runs at the very front
-        of `_generate_briefing`, before that worker's own row is inserted,
-        so there is nothing of "its own" yet to protect. The Artifacts-load
-        path (`_load_briefings`) has no such ordering guarantee -- it can
-        run at any time, including while a generation THIS screen started is
-        still mid-flight -- so it consults this flag too, on top of the
-        claim-aware `exclude`, rather than relying on the claim alone
-        (whole-branch review fix 3).
+        `fail_interrupted_briefings`'s own `exclude` (phase 4) now spares the
+        specific row a LIVE in-process claim is writing -- this screen's
+        own, or a future scheduled run's (task-1812, AC #3: row-scoped, not
+        merely watchlist-scoped, so a genuine crash zombie for the SAME
+        watchlist is not incidentally shielded too) -- so it no longer fails
+        EVERY `generating` row unconditionally the way it did before claims
+        existed. This flag is a narrower, purely local check on top of that:
+        it answers "is THIS screen instance mid-generation", which the
+        Generate path (`_sweep_and_guard`) never needs -- it always runs at
+        the very front of `_generate_briefing`, before that worker's own row
+        is inserted, so there is nothing of "its own" yet to protect. The
+        Artifacts-load path (`_load_briefings`) has no such ordering
+        guarantee -- it can run at any time, including while a generation
+        THIS screen started is still mid-flight -- so it consults this flag
+        too, on top of the claim-aware `exclude`, rather than relying on the
+        claim alone (whole-branch review fix 3).
         """
         return not self._briefing_in_flight
 
@@ -5022,18 +5057,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `_zombie_sweep_is_safe` so a load racing a live generation this
         screen started cannot clobber that generation's own row.
 
-        `active_briefing_claims()` is snapshotted HERE, on the UI thread,
-        before the sweep is dispatched to a worker thread (Locked decision
-        2): the claim set is mutated only on the event loop, so a live read
-        of it from the executor thread `asyncio.to_thread` uses would be
-        racy in a way this snapshot never is. Passed through as `exclude`
-        so a genuinely live claim -- e.g. a scheduled run once phase 4's
-        scheduler exists -- survives an Artifacts open instead of being
-        falsified as interrupted (survey finding (a)).
+        `active_briefing_claim_row_ids()` is snapshotted HERE, on the UI
+        thread, before the sweep is dispatched to a worker thread (Locked
+        decision 2): the claim registry is mutated only on the event loop,
+        so a live read of it from the executor thread `asyncio.to_thread`
+        uses would be racy in a way this snapshot never is. Passed through
+        as `exclude` so a genuinely live claim's OWN row -- e.g. a scheduled
+        run once phase 4's scheduler exists -- survives an Artifacts open
+        instead of being falsified as interrupted (survey finding (a)).
+        Row-scoped, not watchlist-scoped (task-1812, AC #3): a crash-zombie
+        row from a prior process for this SAME watchlist must still be
+        swept even while a fresh claim is live, and only naming the live
+        row itself (not its whole watchlist) lets that happen.
         """
         if not self._zombie_sweep_is_safe():
             return 0
-        claims = active_briefing_claims()
+        claims = active_briefing_claim_row_ids()
         return await asyncio.to_thread(
             fail_interrupted_briefings, db, watchlist_id, exclude=claims
         )
@@ -5049,17 +5088,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         only then asks whether anything is still generating. A row orphaned
         by a crashed worker can therefore never wedge the guard shut.
 
-        `exclude` -- the caller's `active_briefing_claims()` snapshot,
+        `exclude` -- the caller's `active_briefing_claim_row_ids()` snapshot,
         taken before this whole method was dispatched to a worker thread --
         is passed straight to `fail_interrupted_briefings`. This screen's
         own claim for THIS watchlist has not been taken yet at this point
         (`generate_briefing` takes it, later, inside the same worker), so
         the only thing `exclude` can protect here is ANOTHER in-process
-        caller's live claim on the same watchlist. A row that survives the
+        caller's live row on the same watchlist. A row that survives the
         sweep for that reason is not a crash zombie -- it is a live
         generation this screen must not duplicate -- and it correctly ends
         up in `blocking`, triggering the existing refusal toast rather than
         letting Generate proceed over the top of it (survey finding (b)).
+        Row-scoped (task-1812, AC #3): a crash-zombie row for THIS watchlist
+        left by a prior process is swept here even while that other live
+        row survives, rather than the whole watchlist being spared.
 
         Returns:
             `(recovered, blocking)` -- labels for the rows this sweep failed
@@ -5113,7 +5155,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         try:
             try:
                 recovered, blocking = await asyncio.to_thread(
-                    self._sweep_and_guard, db, watchlist_id, active_briefing_claims()
+                    self._sweep_and_guard,
+                    db,
+                    watchlist_id,
+                    active_briefing_claim_row_ids(),
                 )
             except Exception as exc:  # noqa: BLE001 - reported, not raised
                 logger.warning(

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -1025,6 +1025,15 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                 # would ever dispatch it is the exact gap this fix closes;
                 # see `cadence_scope_phrase`'s own AC #1 note for the scope
                 # label's half of the same fix.
+                #
+                # Whole-branch review (`chore/briefings-residuals-1810-
+                # 1812`), Minor 4: the Select stays disabled ON PURPOSE --
+                # its "Off" option is unreachable too, so a stored cadence
+                # cannot be cleared from the UI while the flag is off. That
+                # is deliberate (a stored value is never silently cleared),
+                # but the disabled tooltip must say so plainly: a stored
+                # cadence is not merely inert here, it SURVIVES and will
+                # resume firing the moment the flag is turned back on.
                 schedules_disabled = not self.briefing_schedules_enabled
                 yield Select(
                     self._cadence_select_options(),
@@ -1036,7 +1045,10 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                     tooltip=(
                         "Scheduled briefings are turned off for this app "
                         "([scheduling] briefing_schedules_enabled is "
-                        "false); any cadence stored here will not fire."
+                        "false); a stored cadence stays saved here and "
+                        "cannot be changed while this control is disabled "
+                        "-- it will resume firing as soon as scheduling is "
+                        "turned back on."
                         if schedules_disabled
                         # Task-1812, AC #2: a freshly picked cadence is not
                         # instant -- the running scheduler only re-reads

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -352,7 +352,9 @@ _CADENCE_SCOPE_PHRASES: dict[int, str] = {
 }
 
 
-def cadence_scope_phrase(seconds: int | None) -> str | None:
+def cadence_scope_phrase(
+    seconds: int | None, *, schedules_enabled: bool = True
+) -> str | None:
     """What the Artifacts scope label should say a stored cadence means.
 
     Spec #2 phase 4, Task 4: `WatchlistsCollectionsScreen._briefing_scope_
@@ -365,14 +367,29 @@ def cadence_scope_phrase(seconds: int | None) -> str | None:
     own worker lifecycle) -- see `Docs/User_Guide/watchlists.md`'s
     "Scheduled briefings" note, which states the identical phrase.
 
+    Task-1812, AC #1: `schedules_enabled` retires a SECOND honesty gap the
+    same reasoning above missed -- `[scheduling] briefing_schedules_
+    enabled` (`app.py`'s `_wire_watchlists_and_notifications_services`)
+    gates whether anything in this process ever reads `briefing_cadence_
+    seconds` back at all. With the flag off, a stored cadence is data with
+    no reader: "scheduled ... while the app is open" would claim an active
+    schedule that cannot exist this run, exactly the same shape of lie
+    "on request" was before Task 2 gave the column a writer.
+
     Args:
         seconds: A watchlist's stored `briefing_cadence_seconds` -- `None`
             for "never scheduled".
+        schedules_enabled: Whether `[scheduling] briefing_schedules_
+            enabled` is on for this run. Defaults to `True` so every
+            pre-task-1812 caller reads unchanged. Irrelevant when `seconds`
+            is `None`: there is nothing stored to describe either way.
 
     Returns:
-        `None` for `None` (the caller falls back to "on request"); a
+        `None` for `None` seconds regardless of the flag (the caller falls
+        back to "on request"). For a stored cadence: a phrase stating it is
+        inert when `schedules_enabled` is `False`; otherwise the existing
         "scheduled <cadence> while the app is open" phrase for one of
-        `_CADENCE_OPTIONS`' three cadences; a generic every-N-seconds
+        `_CADENCE_OPTIONS`' three cadences, or a generic every-N-seconds
         phrase for any other positive value -- `set_watchlist_briefing_
         settings` (Task 2) accepts any positive int, so a value this
         picker never offered (hand-written, or a future option this pane
@@ -382,6 +399,11 @@ def cadence_scope_phrase(seconds: int | None) -> str | None:
     if seconds is None:
         return None
     phrase = _CADENCE_SCOPE_PHRASES.get(seconds, f"every {seconds}s")
+    if not schedules_enabled:
+        return (
+            f"stored to run {phrase}, but scheduled briefings are turned "
+            "off for this app -- this schedule will not fire"
+        )
     return f"scheduled {phrase} while the app is open"
 
 
@@ -629,6 +651,18 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     #: watchlist, off by default, since a schedule spends the user's LLM
     #: tokens unattended.
     briefing_cadence_seconds = reactive[int | None](None, recompose=True)
+    #: Task-1812, AC #1: whether `[scheduling] briefing_schedules_enabled`
+    #: is on for this run -- the flag that gates whether `app.py` ever
+    #: builds the `BriefingProjection`/`BriefingJobHandler` pair that makes
+    #: a stored cadence actually fire (there is no UI control for it, so
+    #: this pane cannot infer it from anything else it is given). Screen-
+    #: supplied, exactly like `chachanotes_available`/`has_audio_episodes`
+    #: above -- this widget has no config handle of its own and must not
+    #: read `get_cli_setting` itself (see `WatchlistsCollectionsScreen.
+    #: _briefing_schedules_enabled`, the one reader). Defaults to `True`,
+    #: the flag's own default, so a pane that has not yet heard from the
+    #: screen renders exactly as it did before this flag existed.
+    briefing_schedules_enabled = reactive(True, recompose=True)
     #: Task 5: every `briefing_scripts` row cast from the SELECTED briefing
     #: (newest first, per `list_briefing_scripts`) -- never every script
     #: across the whole watchlist, since a script belongs to exactly one
@@ -985,15 +1019,37 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                         "(LLM, model, and style notes)."
                     ),
                 )
+                # Task-1812, AC #1: disabled -- not merely mis-worded --
+                # when the app-level kill switch is off. A stored cadence
+                # showing as pickable/active while nothing in this process
+                # would ever dispatch it is the exact gap this fix closes;
+                # see `cadence_scope_phrase`'s own AC #1 note for the scope
+                # label's half of the same fix.
+                schedules_disabled = not self.briefing_schedules_enabled
                 yield Select(
                     self._cadence_select_options(),
                     value=self.briefing_cadence_seconds,
                     id="artifacts-cadence-select",
                     allow_blank=False,
                     compact=True,
+                    disabled=schedules_disabled,
                     tooltip=(
-                        "How often this watchlist writes a new briefing on "
-                        "its own, while the app is open. Off by default."
+                        "Scheduled briefings are turned off for this app "
+                        "([scheduling] briefing_schedules_enabled is "
+                        "false); any cadence stored here will not fire."
+                        if schedules_disabled
+                        # Task-1812, AC #2: a freshly picked cadence is not
+                        # instant -- the running scheduler only re-reads
+                        # schedules every `queue_reload_interval_ticks`
+                        # (`Scheduling/scheduler/loop.py`, ~30 minutes by
+                        # default), so a pick made right now can sit inert
+                        # until the next reload. Stated here, and in
+                        # `Docs/User_Guide/watchlists.md`'s "Scheduled
+                        # briefings" section.
+                        else "How often this watchlist writes a new briefing "
+                        "on its own, while the app is open. Off by default. "
+                        "A freshly picked cadence can take up to ~30 minutes "
+                        "(one scheduler reload cycle) to start."
                     ),
                 )
                 yield Button(

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -4714,11 +4714,29 @@ class TldwCli(
         )
         watchlist_projection = WatchlistProjection(subscriptions_db)
 
+        # `briefing_projection` is built here, BEFORE `SchedulingService`, so
+        # it can be passed straight into the constructor (task-1810) rather
+        # than after -- `SchedulingService.list_tasks` needs it live from the
+        # moment the service exists, unlike `briefing_handler` below (built
+        # later; only `SchedulerLoop`, constructed further down this method,
+        # consumes it). Constructing it earlier changes nothing about its
+        # behavior: it only depends on `subscriptions_db`, already created
+        # above.
+        briefing_schedules_enabled = get_cli_setting(
+            "scheduling", "briefing_schedules_enabled", True
+        )
+        briefing_projection = (
+            BriefingProjection(subscriptions_db)
+            if briefing_schedules_enabled
+            else None
+        )
+
         self.scheduling_service = SchedulingService(
             db=ScheduledTasksDB(get_scheduled_tasks_db_path()),
             server_client=server_client,
             runtime_source="local",
             watchlist_projection=watchlist_projection,
+            briefing_projection=briefing_projection,
         )
 
         watchlist_checks_enabled = get_cli_setting(
@@ -4735,13 +4753,8 @@ class TldwCli(
                 shadow_mode=watchlist_checks_shadow,
             )
 
-        briefing_schedules_enabled = get_cli_setting(
-            "scheduling", "briefing_schedules_enabled", True
-        )
-        briefing_projection = None
         briefing_handler = None
-        if briefing_schedules_enabled:
-            briefing_projection = BriefingProjection(subscriptions_db)
+        if briefing_projection is not None:
             # `self.chachanotes_db` is assigned later in `__init__`,
             # strictly AFTER `_wire_watchlists_and_notifications_services`
             # (this method, called earlier in `__init__`) returns -- so it


### PR DESCRIPTION
## Why

Three residuals filed at close-out of the briefings phase-4 plan (spec #2), batched per their own task files: scheduled briefings fired but were invisible to the Scheduling screen (task-1810); audio's Synthesize kept the pre-fix racing shape Cast was already cured of (task-1811); and the schedule gate had three honesty gaps — a cadence picker that ignored the kill switch, an undocumented up-to-one-reload-cycle activation delay, and an interrupted-row sweep whose exclusion over-claimed (task-1812).

## What

- **task-1810** — `SchedulingService` gains an optional `briefing_projection`; the unified task list now shows scheduled briefings beside reminders and watchlist checks, next-run taken from `BriefingProjection.list_jobs`' own calculation. Fixed a real construction-order bug en route: `app.py` built the projection ~20 lines *after* the service that needed it (the same bug class the kept-briefings branch just shipped a lazy-getter for); wiring reordered and liveness pinned by a test that reds a frozen-None call site.
- **task-1811** — `_synthesize_audio` gains the `blocking` refusal Cast got in phase 4: a Synthesize press for a script whose audio is already claimed refuses with the specific in-flight toast instead of relying solely on the screen instance's `_audio_in_flight` reactive (which never protected cross-instance callers). Claim-aware sweep behavior untouched.
- **task-1812** — (1) with `[scheduling] briefing_schedules_enabled` off, the cadence Select disables with a tooltip stating the stored cadence stays saved and resumes on re-enable, and the scope phrase says scheduling is off at the app level instead of implying an active schedule; (2) the activation delay (a fresh cadence pick can wait up to one queue-reload cycle, ~30 min at defaults) is stated in the UI copy and the user guide; (3) `fail_interrupted_briefings`' exclusion re-scoped from watchlist-id to briefing-row-id — a crash-zombie `generating` row is now swept even while the same watchlist has an unrelated live claim.
- **Whole-branch review fix wave** — the row-scoping opened a window the old coarse exclusion never had: between the generation's INSERT and the row id landing in the claim registry, the live row was excluded by nothing (probe-confirmed sweepable). Closed by additionally sparing watchlists whose claim has no recorded row id yet — the spare-set empties the moment the id lands, so the zombie-coexistence fix is fully preserved; both directions mutation-tested. Plus: stale docstring corrected, user-guide third scope state added, trapped-cadence tooltip, and follow-up **task-1890** filed (sibling script/audio sweeps keep the coarse exclude; symptom: the new blocking toast can name a dead zombie audio row).

## Testing

Full `Tests/Scheduling/ Tests/Subscriptions/ Tests/Watchlists/`: **1151 passed, 0 failed.** Every behavioural change mutation-tested (Edit-revert → RED → restore), independently re-verified in scoped re-review. The full-directory run also caught a monkeypatched sweep stub whose stale signature TypeError'd under a bare except — widened and re-verified; grep confirms no other stale stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make scheduled briefings visible on the Scheduling screen, add blocking protection to audio synthesis, and tighten schedule gate and sweep behavior. Covers tasks 1810–1812.

- **New Features**
  - `SchedulingService.list_tasks` now includes scheduled briefings via `BriefingProjection`, shown alongside reminders and watchlist checks.
  - Next-run time comes directly from `BriefingProjection.list_jobs`.

- **Bug Fixes**
  - `_synthesize_audio` adds a blocking refusal when audio is already claimed, with a specific toast; protects cross-instance calls.
  - Cadence picker and scope label honor `[scheduling] briefing_schedules_enabled`; disabled control with a tooltip noting the stored cadence is preserved and resumes when re-enabled.
  - UI and docs state a new cadence can take up to one scheduler reload (~30 min) to start.
  - `fail_interrupted_briefings` now excludes by briefing row id and also spares watchlists with a pending claim before the row id is recorded; prevents sweeping a live row.
  - `app.py` constructs `briefing_projection` before `SchedulingService` so it’s wired and live from service creation.

<sup>Written for commit 400328f2a31c9de5a15942b4fa131a07fd01b00c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

