### PR TITLE
chore: mark tasks 1810-1812 Done (PR #1198 merged)

### DIFF
--- a/backlog/tasks/task-1810 - Scheduled-briefings-are-invisible-to-the-Scheduling-screen.md
+++ b/backlog/tasks/task-1810 - Scheduled-briefings-are-invisible-to-the-Scheduling-screen.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1810
 title: Scheduled briefings are invisible to the Scheduling screen
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-01 18:25'
 updated_date: '2026-08-02 08:44'

--- a/backlog/tasks/task-1811 - Audio-synthesize-path-lacks-the-blocking-refusal-Cast-gained.md
+++ b/backlog/tasks/task-1811 - Audio-synthesize-path-lacks-the-blocking-refusal-Cast-gained.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1811
 title: Audio synthesize path lacks the blocking refusal Cast gained
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-01 18:25'
 updated_date: '2026-08-02 08:57'

--- a/backlog/tasks/task-1812 - Briefing-schedule-gate-UX-residuals.md
+++ b/backlog/tasks/task-1812 - Briefing-schedule-gate-UX-residuals.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1812
 title: Briefing schedule gate/UX residuals
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-01 19:08'
 updated_date: '2026-08-02 09:30'


### PR DESCRIPTION
Bookkeeping only: flips the three residual tasks merged in #1198 to Done. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked `TASK-1810`, `TASK-1811`, and `TASK-1812` as Done in the backlog after the related changes were merged. No code changes.

<sup>Written for commit 8ed4eca596cd7c8aeacfd191467430c6e3e7b4d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

