### PR TITLE
fix: row-scope the script and audio interrupted sweeps (task-1890)

### DIFF
--- a/Tests/Subscriptions/test_briefing_audio_pipeline.py
+++ b/Tests/Subscriptions/test_briefing_audio_pipeline.py
@@ -47,10 +47,12 @@ from tldw_chatbook.Subscriptions.briefing_audio import (
     STATUS_FAILED,
     STATUS_GENERATING,
     AudioGenerationError,
+    active_audio_claim_row_ids,
     active_audio_claims,
     briefing_audio_dir,
     fail_interrupted_audio,
     generate_script_audio,
+    pending_audio_claim_script_ids,
 )
 from tldw_chatbook.Subscriptions.briefing_audio import TurnSynthesisError
 from tldw_chatbook.Subscriptions.briefing_service import GenerationInFlightError
@@ -739,19 +741,35 @@ def test_active_audio_claims_is_an_empty_snapshot_by_default():
     assert active_audio_claims() == frozenset()
 
 
-def test_fail_interrupted_audio_spares_a_claimed_script_both_directions(tmp_path):
-    """Survey finding (a)'s audio-scoped sibling."""
+def test_fail_interrupted_audio_spares_an_excluded_row_both_directions(tmp_path):
+    """Survey finding (a)'s audio-scoped sibling, updated for task-1890
+    (mirroring task-1812): `exclude` now names the audio ROW to spare, not
+    its script -- a row survives the sweep when its id is passed via
+    `exclude`, and is swept once it is not.
+
+    A padding row is inserted (and finished) first so the row under test's
+    own id is NOT the same integer as the script's id -- proving
+    `exclude={live_row}` protects because of the ROW id, not a
+    coincidental match with the script id (see `test_briefing_service.py`'s
+    identical fixture reasoning).
+    """
     db = _db(tmp_path)
     roster = [_roster_entry(name="Host", voice_profile_id=str(_HOST_PROFILE_ID))]
     script_id = _script_id(db, roster=roster, turns=[{"speaker": "Host", "text": "hi"}])
-    zombie = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+    padding = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+    db.update_briefing_audio(padding, status="complete", file_path="/tmp/x.wav")
+    live_row = db.create_briefing_audio(  # stands in for a live claim's own row
+        script_id, voice_snapshot_json="[]"
+    )
+    assert live_row != script_id, "the fixture must not coincidentally align the ids"
 
-    assert fail_interrupted_audio(db, exclude={script_id}) == 0
-    assert db.get_briefing_audio(zombie)["status"] == "generating"
+    assert fail_interrupted_audio(db, exclude={live_row}) == 0
+    assert db.get_briefing_audio(live_row)["status"] == "generating"
 
+    assert fail_interrupted_audio(db, exclude={live_row}) == 0
     assert fail_interrupted_audio(db) == 1
-    assert db.get_briefing_audio(zombie)["status"] == "failed"
-    assert db.get_briefing_audio(zombie)["error"] == "interrupted"
+    assert db.get_briefing_audio(live_row)["status"] == "failed"
+    assert db.get_briefing_audio(live_row)["error"] == "interrupted"
 
 
 async def test_a_second_synthesis_for_a_claimed_script_raises_before_any_row_insert(
@@ -898,3 +916,226 @@ async def test_a_concurrent_synthesis_for_the_same_script_is_refused(
     row = await first
     assert row["status"] == STATUS_COMPLETE
     assert script_id not in active_audio_claims()
+
+
+# --- Row-scoped sweep exclusion (task-1890, generalizing task-1812) ---------
+#
+# `fail_interrupted_audio`'s `exclude` used to be script-granular: ANY
+# `generating` audio row for a script named in `exclude` survived, on the
+# reasoning that such a row is "a LIVE, in-process render" -- true only if a
+# script can have at most one `generating` audio row at a time. It cannot: a
+# crash-zombie row left by a PRIOR process (that process's own claim died
+# with it) can coexist with a freshly-claimed live row for the SAME script,
+# and script-scoped exclusion incidentally shielded the zombie too. `active_
+# audio_claim_row_ids()` names the live ROW instead, so a same-script
+# zombie is swept exactly as if nothing were claimed at all.
+
+
+def test_active_audio_claim_row_ids_is_an_empty_snapshot_by_default():
+    assert active_audio_claim_row_ids() == frozenset()
+
+
+async def test_row_scoped_exclude_sweeps_a_same_script_zombie_while_sparing_the_live_row(
+    tmp_path, monkeypatch
+) -> None:
+    """The coexistence case the docstring used to over-claim protection
+    for: a crash-zombie audio row and a genuinely live claim, both
+    `generating`, both rendered from the SAME script, in the same sweep.
+    Row-scoped `exclude` must fail the zombie and leave the live row alone
+    -- script-scoped `exclude` (the pre-task-1890 shape) cannot tell them
+    apart and would spare both.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    roster = [_roster_entry(name="Host", voice_profile_id=str(_HOST_PROFILE_ID))]
+    turns = [{"speaker": "Host", "text": "Hello."}]
+    script_id = _script_id(db, roster=roster, turns=turns)
+    profile_service = _FakeProfileService({_HOST_PROFILE_ID: _profile()})
+
+    # Stands in for a row a PRIOR process left behind mid-render: its own
+    # claim died with that process, so nothing in THIS process's
+    # `_ACTIVE_AUDIO_CLAIM_ROW_IDS` will ever name it.
+    zombie_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_synthesize(tts_service, selection, text, *, turn_index):
+        entered.set()
+        await release.wait()
+        return _silence_wav()
+
+    first = asyncio.ensure_future(
+        generate_script_audio(
+            db,
+            script_id,
+            tts_service=object(),
+            profile_service=profile_service,
+            synthesize=_slow_synthesize,
+        )
+    )
+    await entered.wait()
+
+    # The live claim now protects its OWN row, not merely its script.
+    live_ids = active_audio_claim_row_ids()
+    assert live_ids, "a live claim's row must be recorded by the time synthesis runs"
+    assert zombie_id not in live_ids, (
+        "the zombie's id must never be recorded by a claim it did not make"
+    )
+
+    swept = fail_interrupted_audio(db, exclude=live_ids)
+
+    assert swept == 1
+    assert db.get_briefing_audio(zombie_id)["status"] == "failed"
+    assert db.get_briefing_audio(zombie_id)["error"] == "interrupted"
+    live_id = next(iter(live_ids))
+    assert db.get_briefing_audio(live_id)["status"] == "generating", (
+        "row-scoped exclude must not falsify the row a live claim is "
+        "actually writing"
+    )
+
+    release.set()
+    row = await first
+    assert row["status"] == STATUS_COMPLETE
+
+
+# --- The unrecorded-claim sweep window (task-1890, generalizing the ---------
+# whole-branch review fix in chore/briefings-residuals-1810-1812) -----------
+#
+# `generate_script_audio` records `_ACTIVE_AUDIO_CLAIM_ROW_IDS[script_id]`
+# only after `db.create_briefing_audio`'s own `to_thread` call returns. For
+# the span before that call runs (script load, pydub check, voice
+# resolution) no audio row exists yet at all; once the `INSERT` itself has
+# run but before the coroutine resumes to record the id, the row exists,
+# reads `generating`, and `active_audio_claim_row_ids()` alone names
+# nothing that protects it. A sweep at that exact instant used to falsify
+# the row. `pending_audio_claim_script_ids()` closes the window: `_claim_
+# audio(script_id)` with no `audio_id` reproduces the registry state
+# mid-window directly, with no need to block inside `generate_script_audio`
+# itself.
+
+
+def test_pending_audio_claim_script_ids_is_an_empty_snapshot_by_default():
+    assert pending_audio_claim_script_ids() == frozenset()
+
+
+def test_an_audio_claim_with_no_recorded_row_id_yet_is_named_pending(tmp_path):
+    """Direct pin of the accessor: a claim taken via `_claim_audio` without
+    an `audio_id` (exactly the registry state before `generate_script_
+    audio` resumes to record one after `db.create_briefing_audio`'s own
+    `to_thread` call) must appear in `pending_audio_claim_script_ids()`,
+    and must disappear the instant a row id IS recorded.
+    """
+    db = _db(tmp_path)
+    roster = [_roster_entry(name="Host", voice_profile_id=str(_HOST_PROFILE_ID))]
+    script_id = _script_id(db, roster=roster, turns=[{"speaker": "Host", "text": "hi"}])
+
+    with briefing_audio._claim_audio(script_id):
+        assert active_audio_claim_row_ids() == frozenset(), (
+            "no row id has been recorded yet -- this is the window itself"
+        )
+        assert script_id in pending_audio_claim_script_ids()
+
+    assert script_id not in pending_audio_claim_script_ids(), (
+        "the claim released -- nothing should still read as pending"
+    )
+
+    live_row = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+    with briefing_audio._claim_audio(script_id, audio_id=live_row):
+        assert script_id not in pending_audio_claim_script_ids(), (
+            "a claim whose row id IS recorded is no longer pending"
+        )
+
+
+def test_an_audio_claim_with_no_recorded_row_id_yet_survives_a_sweep_of_its_own_row(
+    tmp_path,
+):
+    """The window itself, closed: a `generating` audio row for a script
+    whose claim exists but whose row id is not yet recorded must survive a
+    sweep run at that exact instant -- reproducing the same regression
+    `test_briefing_service.py`'s own analogous test pins for briefings.
+
+    Without `exclude_scripts`, `active_audio_claim_row_ids()` alone is
+    empty here (nothing recorded yet) and the row would be swept as a
+    false zombie -- exactly the regression this pins.
+    """
+    db = _db(tmp_path)
+    roster = [_roster_entry(name="Host", voice_profile_id=str(_HOST_PROFILE_ID))]
+    script_id = _script_id(db, roster=roster, turns=[{"speaker": "Host", "text": "hi"}])
+    # Stands in for the row `db.create_briefing_audio` just wrote, before
+    # `generate_script_audio` resumes on the event loop to record its id.
+    live_row = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+
+    with briefing_audio._claim_audio(script_id):
+        row_ids = active_audio_claim_row_ids()
+        pending = pending_audio_claim_script_ids()
+        assert row_ids == frozenset(), "the row id is not recorded in this window"
+        assert script_id in pending
+
+        swept = fail_interrupted_audio(db, exclude=row_ids, exclude_scripts=pending)
+
+    assert swept == 0
+    assert db.get_briefing_audio(live_row)["status"] == "generating", (
+        "a claim whose row id has not been recorded yet must still spare "
+        "its own row from a concurrent sweep"
+    )
+
+
+async def test_row_scoped_exclude_still_sweeps_a_same_script_zombie_once_the_id_lands(
+    tmp_path, monkeypatch
+) -> None:
+    """The task-1890 coexistence fix, re-asserted alongside the new guard:
+    once a claim's row id IS recorded, `pending_audio_claim_script_ids()`
+    no longer names its script, so `exclude_scripts` goes back to being a
+    no-op for it and row-scoped `exclude` alone decides -- a same-script
+    crash zombie is still swept even though the script itself has a live
+    claim.
+    """
+    _patch_user_data_dir(monkeypatch, tmp_path)
+    db = _db(tmp_path)
+    roster = [_roster_entry(name="Host", voice_profile_id=str(_HOST_PROFILE_ID))]
+    turns = [{"speaker": "Host", "text": "Hello."}]
+    script_id = _script_id(db, roster=roster, turns=turns)
+    profile_service = _FakeProfileService({_HOST_PROFILE_ID: _profile()})
+
+    zombie_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_synthesize(tts_service, selection, text, *, turn_index):
+        entered.set()
+        await release.wait()
+        return _silence_wav()
+
+    first = asyncio.ensure_future(
+        generate_script_audio(
+            db,
+            script_id,
+            tts_service=object(),
+            profile_service=profile_service,
+            synthesize=_slow_synthesize,
+        )
+    )
+    await entered.wait()
+
+    row_ids = active_audio_claim_row_ids()
+    pending = pending_audio_claim_script_ids()
+    assert row_ids, "the live claim's row id must be recorded by the time synthesis runs"
+    assert script_id not in pending, (
+        "once the row id lands, the script is no longer 'pending'"
+    )
+
+    swept = fail_interrupted_audio(db, exclude=row_ids, exclude_scripts=pending)
+
+    assert swept == 1
+    assert db.get_briefing_audio(zombie_id)["status"] == "failed"
+    live_id = next(iter(row_ids))
+    assert db.get_briefing_audio(live_id)["status"] == "generating", (
+        "the live row must survive even with exclude_scripts passed "
+        "alongside row-scoped exclude"
+    )
+
+    release.set()
+    row = await first
+    assert row["status"] == STATUS_COMPLETE

--- a/Tests/Subscriptions/test_briefing_audio_pipeline.py
+++ b/Tests/Subscriptions/test_briefing_audio_pipeline.py
@@ -932,6 +932,7 @@ async def test_a_concurrent_synthesis_for_the_same_script_is_refused(
 
 
 def test_active_audio_claim_row_ids_is_an_empty_snapshot_by_default():
+    """With no audio claims taken, the row-id snapshot is an empty frozenset."""
     assert active_audio_claim_row_ids() == frozenset()
 
 
@@ -1016,6 +1017,7 @@ async def test_row_scoped_exclude_sweeps_a_same_script_zombie_while_sparing_the_
 
 
 def test_pending_audio_claim_script_ids_is_an_empty_snapshot_by_default():
+    """With no audio claims taken, the pending (unrecorded) set is empty."""
     assert pending_audio_claim_script_ids() == frozenset()
 
 

--- a/Tests/Subscriptions/test_briefing_cast.py
+++ b/Tests/Subscriptions/test_briefing_cast.py
@@ -43,6 +43,7 @@ from tldw_chatbook.Subscriptions.briefing_cast import (
     ScriptCastError,
     STATUS_COMPLETE,
     STATUS_FAILED,
+    active_cast_claim_row_ids,
     active_cast_claims,
     active_kept_cast_claims,
     build_cast_prompt,
@@ -52,6 +53,7 @@ from tldw_chatbook.Subscriptions.briefing_cast import (
     generate_script_from_text,
     load_roster,
     parse_script_turns,
+    pending_cast_claim_briefing_ids,
     validate_roster,
 )
 from tldw_chatbook.Subscriptions.briefing_keep import keep_briefing
@@ -735,21 +737,37 @@ def test_active_cast_claims_is_an_empty_snapshot_by_default():
     assert active_cast_claims() == frozenset()
 
 
-def test_fail_interrupted_scripts_spares_a_claimed_briefing_both_directions(tmp_path):
-    """Survey finding (a)'s cast-scoped sibling."""
+def test_fail_interrupted_scripts_spares_an_excluded_row_both_directions(tmp_path):
+    """Survey finding (a)'s cast-scoped sibling, updated for task-1890
+    (mirroring task-1812): `exclude` now names the script ROW to spare, not
+    its briefing -- a row survives the sweep when its id is passed via
+    `exclude`, and is swept once it is not.
+
+    A padding row is inserted (and finished) first so the row under test's
+    own id is NOT the same integer as the briefing's id -- proving
+    `exclude={live_row}` protects because of the ROW id, not a
+    coincidental match with the briefing id (see `test_briefing_service.
+    py`'s identical fixture reasoning).
+    """
     db = _db(tmp_path)
     watchlist = WatchlistBundleService(db).create(name="Security")["id"]
     briefing_id = _complete_briefing(db, watchlist)
-    zombie = db.insert_briefing_script(
+    padding = db.insert_briefing_script(
         briefing_id, preset_id=None, preset_name="Duo", roster_snapshot_json="[]"
     )
+    db.update_briefing_script(padding, status="complete", turns_json="[]")
+    live_row = db.insert_briefing_script(  # stands in for a live claim's own row
+        briefing_id, preset_id=None, preset_name="Duo", roster_snapshot_json="[]"
+    )
+    assert live_row != briefing_id, "the fixture must not coincidentally align the ids"
 
-    assert fail_interrupted_scripts(db, exclude={briefing_id}) == 0
-    assert db.get_briefing_script(zombie)["status"] == "generating"
+    assert fail_interrupted_scripts(db, exclude={live_row}) == 0
+    assert db.get_briefing_script(live_row)["status"] == "generating"
 
+    assert fail_interrupted_scripts(db, exclude={live_row}) == 0
     assert fail_interrupted_scripts(db) == 1
-    assert db.get_briefing_script(zombie)["status"] == "failed"
-    assert db.get_briefing_script(zombie)["error"] == "interrupted"
+    assert db.get_briefing_script(live_row)["status"] == "failed"
+    assert db.get_briefing_script(live_row)["error"] == "interrupted"
 
 
 @pytest.mark.asyncio
@@ -852,6 +870,226 @@ async def test_a_concurrent_cast_for_the_same_briefing_is_refused(tmp_path):
     row = await first
     assert row["status"] == STATUS_COMPLETE
     assert briefing_id not in active_cast_claims()
+
+
+# --- Row-scoped sweep exclusion (task-1890, generalizing task-1812) ---------
+#
+# `fail_interrupted_scripts`'s `exclude` used to be briefing-granular: ANY
+# `generating` script row for a briefing named in `exclude` survived, on the
+# reasoning that such a row is "a LIVE, in-process cast" -- true only if a
+# briefing can have at most one `generating` script at a time. It cannot: a
+# crash-zombie row left by a PRIOR process (that process's own claim died
+# with it) can coexist with a freshly-claimed live row for the SAME
+# briefing, and briefing-scoped exclusion incidentally shielded the zombie
+# too. `active_cast_claim_row_ids()` names the live ROW instead, so a
+# same-briefing zombie is swept exactly as if nothing were claimed at all.
+
+
+def test_active_cast_claim_row_ids_is_an_empty_snapshot_by_default():
+    assert active_cast_claim_row_ids() == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_row_scoped_exclude_sweeps_a_same_briefing_zombie_while_sparing_the_live_row(
+    tmp_path,
+):
+    """The coexistence case the docstring used to over-claim protection
+    for: a crash-zombie script row and a genuinely live claim, both
+    `generating`, both cast from the SAME briefing, in the same sweep.
+    Row-scoped `exclude` must fail the zombie and leave the live row alone
+    -- briefing-scoped `exclude` (the pre-task-1890 shape) cannot tell them
+    apart and would spare both.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+    briefing_id = _complete_briefing(db, watchlist)
+    preset_id = _preset(db)
+
+    # Stands in for a row a PRIOR process left behind mid-cast: its own
+    # claim died with that process, so nothing in THIS process's
+    # `_ACTIVE_CAST_CLAIM_ROW_IDS` will ever name it.
+    zombie_id = db.insert_briefing_script(
+        briefing_id, preset_id=None, preset_name="Duo", roster_snapshot_json="[]"
+    )
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_chat(**kwargs):
+        entered.set()
+        await release.wait()
+        return json.dumps(CANNED_TURNS)
+
+    first = asyncio.ensure_future(
+        generate_script(db, briefing_id, preset_id=preset_id, chat=_slow_chat)
+    )
+    await entered.wait()
+
+    # The live claim now protects its OWN row, not merely its briefing.
+    live_ids = active_cast_claim_row_ids()
+    assert live_ids, "a live claim's row must be recorded by the time chat runs"
+    assert zombie_id not in live_ids, (
+        "the zombie's id must never be recorded by a claim it did not make"
+    )
+
+    swept = fail_interrupted_scripts(db, exclude=live_ids)
+
+    assert swept == 1
+    assert db.get_briefing_script(zombie_id)["status"] == "failed"
+    assert db.get_briefing_script(zombie_id)["error"] == "interrupted"
+    live_id = next(iter(live_ids))
+    assert db.get_briefing_script(live_id)["status"] == "generating", (
+        "row-scoped exclude must not falsify the row a live claim is "
+        "actually writing"
+    )
+
+    release.set()
+    row = await first
+    assert row["status"] == STATUS_COMPLETE
+
+
+# --- The unrecorded-claim sweep window (task-1890, generalizing the ---------
+# whole-branch review fix in chore/briefings-residuals-1810-1812) -----------
+#
+# `generate_script` records `_ACTIVE_CAST_CLAIM_ROW_IDS[briefing_id]` only
+# after the ENTIRE `_start_script` `to_thread` hop returns, but that hop's
+# `INSERT` is its LAST statement -- for the rest of the hop (briefing
+# lookup, preset lookup, roster validation, the roster snapshot) the
+# briefing is claimed but no script row exists yet to protect, and once the
+# `INSERT` itself has run, the row exists, reads `generating`, and `active_
+# cast_claim_row_ids()` alone names nothing that protects it. A sweep at
+# that exact instant used to falsify the row. `pending_cast_claim_
+# briefing_ids()` closes the window: `_claim_cast(briefing_id)` with no
+# `script_id` reproduces the registry state mid-window directly, with no
+# need to block inside `_start_script` itself.
+
+
+def test_pending_cast_claim_briefing_ids_is_an_empty_snapshot_by_default():
+    assert pending_cast_claim_briefing_ids() == frozenset()
+
+
+def test_a_cast_claim_with_no_recorded_row_id_yet_is_named_pending(tmp_path):
+    """Direct pin of the accessor: a claim taken via `_claim_cast` without a
+    `script_id` (exactly the registry state for the span inside `_start_
+    script`'s `to_thread` hop, before `generate_script` resumes to record
+    one) must appear in `pending_cast_claim_briefing_ids()`, and must
+    disappear the instant a row id IS recorded.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+    briefing_id = _complete_briefing(db, watchlist)
+
+    with briefing_cast._claim_cast(briefing_id):
+        assert active_cast_claim_row_ids() == frozenset(), (
+            "no row id has been recorded yet -- this is the window itself"
+        )
+        assert briefing_id in pending_cast_claim_briefing_ids()
+
+    assert briefing_id not in pending_cast_claim_briefing_ids(), (
+        "the claim released -- nothing should still read as pending"
+    )
+
+    live_row = db.insert_briefing_script(
+        briefing_id, preset_id=None, preset_name="Duo", roster_snapshot_json="[]"
+    )
+    with briefing_cast._claim_cast(briefing_id, script_id=live_row):
+        assert briefing_id not in pending_cast_claim_briefing_ids(), (
+            "a claim whose row id IS recorded is no longer pending"
+        )
+
+
+def test_a_cast_claim_with_no_recorded_row_id_yet_survives_a_sweep_of_its_own_row(
+    tmp_path,
+):
+    """The window itself, closed: a `generating` script row for a briefing
+    whose claim exists but whose row id is not yet recorded (mid-`_start_
+    script`, before `generate_script` resumes to record it) must survive a
+    sweep run at that exact instant -- reproducing the same regression
+    `test_briefing_service.py`'s own analogous test pins for briefings.
+
+    Without `exclude_briefings`, `active_cast_claim_row_ids()` alone is
+    empty here (nothing recorded yet) and the row would be swept as a false
+    zombie -- exactly the regression this pins.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+    briefing_id = _complete_briefing(db, watchlist)
+    # Stands in for the row `_start_script`'s `INSERT` just wrote, before
+    # `generate_script` resumes on the event loop to record its id.
+    live_row = db.insert_briefing_script(
+        briefing_id, preset_id=None, preset_name="Duo", roster_snapshot_json="[]"
+    )
+
+    with briefing_cast._claim_cast(briefing_id):
+        row_ids = active_cast_claim_row_ids()
+        pending = pending_cast_claim_briefing_ids()
+        assert row_ids == frozenset(), "the row id is not recorded in this window"
+        assert briefing_id in pending
+
+        swept = fail_interrupted_scripts(
+            db, exclude=row_ids, exclude_briefings=pending
+        )
+
+    assert swept == 0
+    assert db.get_briefing_script(live_row)["status"] == "generating", (
+        "a claim whose row id has not been recorded yet must still spare "
+        "its own row from a concurrent sweep"
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_scoped_exclude_still_sweeps_a_same_briefing_zombie_once_the_id_lands(
+    tmp_path,
+):
+    """The task-1890 coexistence fix, re-asserted alongside the new guard:
+    once a claim's row id IS recorded, `pending_cast_claim_briefing_ids()`
+    no longer names its briefing, so `exclude_briefings` goes back to being
+    a no-op for it and row-scoped `exclude` alone decides -- a
+    same-briefing crash zombie is still swept even though the briefing
+    itself has a live claim.
+    """
+    db = _db(tmp_path)
+    watchlist = WatchlistBundleService(db).create(name="Security")["id"]
+    briefing_id = _complete_briefing(db, watchlist)
+    preset_id = _preset(db)
+
+    zombie_id = db.insert_briefing_script(
+        briefing_id, preset_id=None, preset_name="Duo", roster_snapshot_json="[]"
+    )
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_chat(**kwargs):
+        entered.set()
+        await release.wait()
+        return json.dumps(CANNED_TURNS)
+
+    first = asyncio.ensure_future(
+        generate_script(db, briefing_id, preset_id=preset_id, chat=_slow_chat)
+    )
+    await entered.wait()
+
+    row_ids = active_cast_claim_row_ids()
+    pending = pending_cast_claim_briefing_ids()
+    assert row_ids, "the live claim's row id must be recorded by the time chat runs"
+    assert briefing_id not in pending, (
+        "once the row id lands, the briefing is no longer 'pending'"
+    )
+
+    swept = fail_interrupted_scripts(db, exclude=row_ids, exclude_briefings=pending)
+
+    assert swept == 1
+    assert db.get_briefing_script(zombie_id)["status"] == "failed"
+    live_id = next(iter(row_ids))
+    assert db.get_briefing_script(live_id)["status"] == "generating", (
+        "the live row must survive even with exclude_briefings passed "
+        "alongside row-scoped exclude"
+    )
+
+    release.set()
+    row = await first
+    assert row["status"] == STATUS_COMPLETE
 
 
 # --- generate_script_from_text (task-1780, Task 4) ---------------------------

--- a/Tests/Subscriptions/test_briefing_cast.py
+++ b/Tests/Subscriptions/test_briefing_cast.py
@@ -886,6 +886,7 @@ async def test_a_concurrent_cast_for_the_same_briefing_is_refused(tmp_path):
 
 
 def test_active_cast_claim_row_ids_is_an_empty_snapshot_by_default():
+    """With no cast claims taken, the row-id snapshot is an empty frozenset."""
     assert active_cast_claim_row_ids() == frozenset()
 
 
@@ -965,6 +966,7 @@ async def test_row_scoped_exclude_sweeps_a_same_briefing_zombie_while_sparing_th
 
 
 def test_pending_cast_claim_briefing_ids_is_an_empty_snapshot_by_default():
+    """With no cast claims taken, the pending (unrecorded) set is empty."""
     assert pending_cast_claim_briefing_ids() == frozenset()
 
 

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -2352,9 +2352,16 @@ async def test_a_zombie_generating_script_is_recovered_on_a_plain_artifacts_load
         in_flight_at_call: list[bool] = []
         real_sweep = screen_module.fail_interrupted_scripts
 
-        def _recording_sweep(db_arg, briefing_id_arg=None, *, exclude=()):
+        def _recording_sweep(
+            db_arg, briefing_id_arg=None, *, exclude=(), exclude_briefings=()
+        ):
             in_flight_at_call.append(bool(screen._cast_in_flight))
-            return real_sweep(db_arg, briefing_id_arg, exclude=exclude)
+            return real_sweep(
+                db_arg,
+                briefing_id_arg,
+                exclude=exclude,
+                exclude_briefings=exclude_briefings,
+            )
 
         monkeypatch.setattr(screen_module, "fail_interrupted_scripts", _recording_sweep)
 
@@ -2411,9 +2418,16 @@ async def test_casting_recovers_a_zombie_script_via_its_own_sweep(monkeypatch):
         in_flight_at_call: list[bool] = []
         real_sweep = screen_module.fail_interrupted_scripts
 
-        def _recording_sweep(db_arg, briefing_id_arg=None, *, exclude=()):
+        def _recording_sweep(
+            db_arg, briefing_id_arg=None, *, exclude=(), exclude_briefings=()
+        ):
             in_flight_at_call.append(bool(screen._cast_in_flight))
-            return real_sweep(db_arg, briefing_id_arg, exclude=exclude)
+            return real_sweep(
+                db_arg,
+                briefing_id_arg,
+                exclude=exclude,
+                exclude_briefings=exclude_briefings,
+            )
 
         monkeypatch.setattr(screen_module, "fail_interrupted_scripts", _recording_sweep)
 
@@ -3392,6 +3406,72 @@ async def test_a_synthesis_press_during_a_claimed_script_refuses_not_run_concurr
 
 
 @pytest.mark.asyncio
+async def test_the_blocking_toast_never_names_a_crash_zombie_sharing_the_live_claims_script(
+    monkeypatch,
+):
+    """Task-1890, AC #7: before row-scoping, `fail_interrupted_audio`'s
+    `exclude` was script-granular, so a crash-zombie audio row sharing a
+    `script_id` with a live claim survived `_sweep_and_guard_audio`'s sweep
+    purely because ITS SCRIPT was excluded -- and could then be named by
+    the `blocking` toast as if IT, not the genuinely live row, were what
+    blocked Synthesize. Row-scoping (task-1890) sweeps the zombie before
+    `blocking` is computed, so only the genuinely live row's label can
+    ever appear.
+
+    The live claim's row id is recorded via `_claim_audio`'s `audio_id`
+    parameter -- unlike the sibling test above (which deliberately leaves
+    it unrecorded to pin the pending-claim window), this test pins the
+    steady-state row-scoped case AC #7 names: a claim whose row IS known.
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    briefing_id, script_id = _seed_complete_script(app, watchlist_id)
+    db = app.watchlist_bundle_service.db
+
+    fake_audio = _FakeAudioService()
+    _use_fake_audio_service(monkeypatch, fake_audio)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        await _select_briefing_and_script(screen, pilot, host, briefing_id, script_id)
+
+        # A crash-zombie row: no claim in THIS process will ever name it --
+        # its own claim died with whatever process left it behind.
+        zombie_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+        # The live claim's OWN row, recorded exactly as a real in-flight
+        # `generate_script_audio` call would (`_claim_audio`'s `audio_id`
+        # parameter, task-1890).
+        live_audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+
+        with briefing_audio._claim_audio(script_id, audio_id=live_audio_id):
+            await _press_synthesize(screen, pilot, app, script_id)
+
+        assert fake_audio.calls == [], (
+            "nothing may be synthesized while claimed elsewhere"
+        )
+        assert app.notify.called, "the refusal must be visible, not silent"
+        args, kwargs = app.notify.call_args
+        message = args[0] if args else str(kwargs.get("message", ""))
+        assert kwargs.get("severity") == "warning"
+        assert kwargs.get("markup") is False
+        assert f"audio {live_audio_id} " in message, (
+            "the toast must name the genuinely live row"
+        )
+        assert f"audio {zombie_id} " not in message, (
+            "the toast must never name a crash zombie merely sharing the "
+            "live claim's script_id"
+        )
+        assert db.get_briefing_audio(live_audio_id)["status"] == "generating", (
+            "the live claim's row must not be falsified as interrupted"
+        )
+        assert db.get_briefing_audio(zombie_id)["status"] == "failed", (
+            "the zombie must be swept BEFORE the toast is composed, not "
+            "merely spared alongside the live row"
+        )
+        assert db.get_briefing_audio(zombie_id)["error"] == "interrupted"
+
+
+@pytest.mark.asyncio
 async def test_the_audio_guard_is_claimed_before_the_worker_runs(monkeypatch):
     """Mechanism half, the deterministic sibling of `test_the_cast_guard_
     is_claimed_before_the_worker_runs`: the handler is synchronous with no
@@ -3521,9 +3601,13 @@ async def test_a_zombie_generating_audio_row_is_recovered_on_a_plain_artifacts_l
         in_flight_at_call: list[bool] = []
         real_sweep = screen_module.fail_interrupted_audio
 
-        def _recording_sweep(db_arg, script_id_arg=None, *, exclude=()):
+        def _recording_sweep(
+            db_arg, script_id_arg=None, *, exclude=(), exclude_scripts=()
+        ):
             in_flight_at_call.append(bool(screen._audio_in_flight))
-            return real_sweep(db_arg, script_id_arg, exclude=exclude)
+            return real_sweep(
+                db_arg, script_id_arg, exclude=exclude, exclude_scripts=exclude_scripts
+            )
 
         monkeypatch.setattr(screen_module, "fail_interrupted_audio", _recording_sweep)
 
@@ -3574,9 +3658,13 @@ async def test_synthesizing_recovers_a_zombie_audio_row_via_its_own_sweep(monkey
         in_flight_at_call: list[bool] = []
         real_sweep = screen_module.fail_interrupted_audio
 
-        def _recording_sweep(db_arg, script_id_arg=None, *, exclude=()):
+        def _recording_sweep(
+            db_arg, script_id_arg=None, *, exclude=(), exclude_scripts=()
+        ):
             in_flight_at_call.append(bool(screen._audio_in_flight))
-            return real_sweep(db_arg, script_id_arg, exclude=exclude)
+            return real_sweep(
+                db_arg, script_id_arg, exclude=exclude, exclude_scripts=exclude_scripts
+            )
 
         monkeypatch.setattr(screen_module, "fail_interrupted_audio", _recording_sweep)
 

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -3415,8 +3415,11 @@ async def test_the_blocking_toast_never_names_a_crash_zombie_sharing_the_live_cl
     purely because ITS SCRIPT was excluded -- and could then be named by
     the `blocking` toast as if IT, not the genuinely live row, were what
     blocked Synthesize. Row-scoping (task-1890) sweeps the zombie before
-    `blocking` is computed, so only the genuinely live row's label can
-    ever appear.
+    `blocking` is computed, so once the live claim's row id is recorded
+    (as here), only the genuinely live row's label appears. (In the
+    pre-recording window the pending-claim guard spares the whole script,
+    zombie included -- the deliberate tradeoff inherited from the
+    briefings sweep.)
 
     The live claim's row id is recorded via `_claim_audio`'s `audio_id`
     parameter -- unlike the sibling test above (which deliberately leaves

--- a/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
+++ b/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
@@ -24,8 +24,8 @@ window that fix left open (this branch's own fix wave, Important 1). Both siblin
 in the same family were deliberately left out of that scope and still exclude by the
 coarser key:
 
-- `fail_interrupted_scripts` (`tldw_chatbook/Subscriptions/briefing_cast.py`) excludes by
-  `script_id`, not by the claimed row's own id.
+- `fail_interrupted_scripts` (`tldw_chatbook/Subscriptions/briefing_cast.py`) excluded by
+  `briefing_id` (the claim key), not by the claimed row's own id.
 - `fail_interrupted_audio` (`tldw_chatbook/Subscriptions/briefing_audio.py:1342`, `AND
   script_id NOT IN (...)`) excludes by `script_id` too.
 
@@ -63,7 +63,7 @@ the fix into 1811/1812's own scope.
 - [x] #4 A same-`script_id` crash-zombie script row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (script sweep coexistence test)
 - [x] #5 A same-`script_id` crash-zombie audio row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (audio sweep coexistence test)
 - [x] #6 A claim taken but not yet row-recorded survives a sweep run inside that exact window, for both the script and audio sweeps (window regression tests, mirroring this branch's briefings window test)
-- [x] #7 The Synthesize blocking toast (`watchlists_collections_screen.py`) never names a crash-zombie audio row as "already being synthesized" -- once the audio sweep is row-scoped, a zombie sharing a `script_id` with a live claim is swept before the toast is composed, so only the genuinely live row's label can appear
+- [x] #7 The Synthesize blocking toast (`watchlists_collections_screen.py`) no longer names a crash-zombie audio row as "already being synthesized" once the live claim's row id is recorded -- the row-scoped sweep fails the zombie before the toast is composed, so only the genuinely live row's label appears (in the brief pre-recording window the pending-claim guard deliberately spares the whole script, zombie included -- the same tradeoff as the briefings sweep)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -83,7 +83,7 @@ briefing_cast.py: added `_ACTIVE_CAST_CLAIM_ROW_IDS` (briefing_id -> script_id),
 
 briefing_audio.py: identical shape, keyed by script_id -> audio_id (`_ACTIVE_AUDIO_CLAIM_ROW_IDS`, `active_audio_claim_row_ids()`, `pending_audio_claim_script_ids()`); `_claim_audio` gained an optional `audio_id` param; `generate_script_audio` records the row id immediately after `db.create_briefing_audio`'s own `to_thread` call returns. `fail_interrupted_audio` gained `exclude_scripts`; `exclude` is now `id NOT IN (...)` (was `script_id NOT IN (...)`).
 
-watchlists_collections_screen.py: both sweep call sites per artifact (`_fail_interrupted_scripts_if_safe`/`_sweep_and_guard_cast`/`_cast_script`, and `_fail_interrupted_audio_if_safe`/`_sweep_and_guard_audio`/`_synthesize_audio`) now snapshot the row-id accessor plus the pending accessor and pass both through. `active_cast_claims`/`active_audio_claims` imports dropped from the screen (no longer what the sweep wants); the coarse accessors themselves stay, unchanged, for their existing "is this key claimed" callers/tests.
+watchlists_collections_screen.py: both sweep call sites per artifact (`_fail_interrupted_scripts_if_safe`/`_sweep_and_guard_cast`/`_cast_script`, and `_fail_interrupted_audio_if_safe`/`_sweep_and_guard_audio`/`_synthesize_audio`) now snapshot the row-id accessor plus the pending accessor and pass both through. `active_cast_claims`/`active_audio_claims` imports dropped from the screen (no longer what the sweep wants); the coarse accessors themselves stay unchanged (test-only consumers now; no production callers remain).
 
 Tests: mirrored test_briefing_service.py's three sections (spares-an-excluded-row-both-directions updated to be row-scoped with a padding-row fixture; new row-scoped coexistence test; new pending-claim-window tests) into test_briefing_cast.py and test_briefing_audio_pipeline.py. Widened 4 stale-signature `_recording_sweep` monkeypatch stubs in test_watchlists_artifacts_pane.py (2 cast, 2 audio) to accept the new exclude_briefings/exclude_scripts kwarg -- these would otherwise TypeError once the screen's own call sites pass it. Added one screen-level test for AC #7 (test_the_blocking_toast_never_names_a_crash_zombie_sharing_the_live_claims_script), pinning that a crash-zombie audio row sharing a script_id with a live claim (recorded row id, via _claim_audio's new audio_id param) never appears in the Synthesize blocking toast -- only the genuinely live row's label does, and the zombie is independently confirmed swept (failed/interrupted) rather than merely absent from the message by coincidence.
 

--- a/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
+++ b/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
@@ -4,6 +4,7 @@ title: Row-scope the script and audio interrupted sweeps
 status: In Progress
 assignee: []
 created_date: '2026-08-02'
+updated_date: '2026-08-02 12:10'
 labels:
   - watchlists
   - briefings
@@ -56,13 +57,13 @@ the fix into 1811/1812's own scope.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `fail_interrupted_scripts`'s `exclude` is scoped to the claimed script's own row id, not merely its `script_id`, mirroring `fail_interrupted_briefings`'s row-scoped shape (task-1812)
-- [ ] #2 `fail_interrupted_audio`'s `exclude` is scoped to the claimed audio row's own id, not merely its `script_id`, the same way
-- [ ] #3 Both row-scoped sweeps additionally handle the unrecorded-claim window the same way this branch's briefings fix does (a claim taken before its row id is recorded must still spare that row from a concurrent sweep) -- reference `chore/briefings-residuals-1810-1812`'s `pending_briefing_claim_watchlist_ids()` shape
-- [ ] #4 A same-`script_id` crash-zombie script row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (script sweep coexistence test)
-- [ ] #5 A same-`script_id` crash-zombie audio row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (audio sweep coexistence test)
-- [ ] #6 A claim taken but not yet row-recorded survives a sweep run inside that exact window, for both the script and audio sweeps (window regression tests, mirroring this branch's briefings window test)
-- [ ] #7 The Synthesize blocking toast (`watchlists_collections_screen.py`) never names a crash-zombie audio row as "already being synthesized" -- once the audio sweep is row-scoped, a zombie sharing a `script_id` with a live claim is swept before the toast is composed, so only the genuinely live row's label can appear
+- [x] #1 `fail_interrupted_scripts`'s `exclude` is scoped to the claimed script's own row id, not merely its `script_id`, mirroring `fail_interrupted_briefings`'s row-scoped shape (task-1812)
+- [x] #2 `fail_interrupted_audio`'s `exclude` is scoped to the claimed audio row's own id, not merely its `script_id`, the same way
+- [x] #3 Both row-scoped sweeps additionally handle the unrecorded-claim window the same way this branch's briefings fix does (a claim taken before its row id is recorded must still spare that row from a concurrent sweep) -- reference `chore/briefings-residuals-1810-1812`'s `pending_briefing_claim_watchlist_ids()` shape
+- [x] #4 A same-`script_id` crash-zombie script row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (script sweep coexistence test)
+- [x] #5 A same-`script_id` crash-zombie audio row and a live claim coexist in one sweep: the zombie is failed as interrupted, the live row is untouched (audio sweep coexistence test)
+- [x] #6 A claim taken but not yet row-recorded survives a sweep run inside that exact window, for both the script and audio sweeps (window regression tests, mirroring this branch's briefings window test)
+- [x] #7 The Synthesize blocking toast (`watchlists_collections_screen.py`) never names a crash-zombie audio row as "already being synthesized" -- once the audio sweep is row-scoped, a zombie sharing a `script_id` with a live claim is swept before the toast is composed, so only the genuinely live row's label can appear
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -72,3 +73,23 @@ the fix into 1811/1812's own scope.
 2. Update the two sweeps' SQL from key-scoped `NOT IN` to row-id `NOT IN` + pending-key `NOT IN`; update every call site (screen sweeps `_sweep_and_guard_cast`/`_sweep_and_guard_audio` and any handler/service callers) to pass the new exclude pair.
 3. Tests per ACs 4-6 mirroring the briefings coexistence + window tests; AC 7 pinned at the screen: zombie audio row + live claim → toast names only the live row.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Mirrored briefing_service's task-1812/1810-1812 shape into both sibling modules, generalizing "row id, not key" scoping and the unrecorded-claim window guard.
+
+briefing_cast.py: added `_ACTIVE_CAST_CLAIM_ROW_IDS` (briefing_id -> script_id), `active_cast_claim_row_ids()`, `pending_cast_claim_briefing_ids()`; `_claim_cast` gained an optional `script_id` param (mirrors `_claim_briefing`'s `briefing_id` param) and clears the row-id entry in its `finally`; `generate_script` records the row id immediately after `_start_script`'s `to_thread` hop returns (no `await` in between). `fail_interrupted_scripts` gained `exclude_briefings`; `exclude` is now `id NOT IN (...)` (was `briefing_id NOT IN (...)`).
+
+briefing_audio.py: identical shape, keyed by script_id -> audio_id (`_ACTIVE_AUDIO_CLAIM_ROW_IDS`, `active_audio_claim_row_ids()`, `pending_audio_claim_script_ids()`); `_claim_audio` gained an optional `audio_id` param; `generate_script_audio` records the row id immediately after `db.create_briefing_audio`'s own `to_thread` call returns. `fail_interrupted_audio` gained `exclude_scripts`; `exclude` is now `id NOT IN (...)` (was `script_id NOT IN (...)`).
+
+watchlists_collections_screen.py: both sweep call sites per artifact (`_fail_interrupted_scripts_if_safe`/`_sweep_and_guard_cast`/`_cast_script`, and `_fail_interrupted_audio_if_safe`/`_sweep_and_guard_audio`/`_synthesize_audio`) now snapshot the row-id accessor plus the pending accessor and pass both through. `active_cast_claims`/`active_audio_claims` imports dropped from the screen (no longer what the sweep wants); the coarse accessors themselves stay, unchanged, for their existing "is this key claimed" callers/tests.
+
+Tests: mirrored test_briefing_service.py's three sections (spares-an-excluded-row-both-directions updated to be row-scoped with a padding-row fixture; new row-scoped coexistence test; new pending-claim-window tests) into test_briefing_cast.py and test_briefing_audio_pipeline.py. Widened 4 stale-signature `_recording_sweep` monkeypatch stubs in test_watchlists_artifacts_pane.py (2 cast, 2 audio) to accept the new exclude_briefings/exclude_scripts kwarg -- these would otherwise TypeError once the screen's own call sites pass it. Added one screen-level test for AC #7 (test_the_blocking_toast_never_names_a_crash_zombie_sharing_the_live_claims_script), pinning that a crash-zombie audio row sharing a script_id with a live claim (recorded row id, via _claim_audio's new audio_id param) never appears in the Synthesize blocking toast -- only the genuinely live row's label does, and the zombie is independently confirmed swept (failed/interrupted) rather than merely absent from the message by coincidence.
+
+Mutation-tested both sweeps (Edit-revert -> RED -> restore, clean git status between): reverting exclude's SQL from id-scoped back to key-scoped REDs the respective coexistence test (swept count goes from 1 to 2, i.e. protection lost, not merely widened); dropping the exclude_briefings/exclude_scripts SQL clause REDs the respective pending-window test (swept goes from 0 to 1).
+
+Verified: Tests/Subscriptions/ (535 passed), Tests/Watchlists/ (365 passed), Tests/Scheduling/ (264 passed) -- 1164 total, 0 failures.
+
+No deviations from the reference shape: both cast and audio claims turned out to need the identical three-part treatment (row-id registry, frozen-snapshot accessor, pending-claim accessor) despite cast's INSERT landing as the LAST statement of its to_thread hop (briefings' is the FIRST) -- the pending window exists regardless of where in the hop the INSERT falls, since the claim is taken before the hop starts either way.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
+++ b/backlog/tasks/task-1890 - Row-scope-the-script-and-audio-interrupted-sweeps.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1890
 title: Row-scope the script and audio interrupted sweeps
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-02'
 labels:
@@ -64,3 +64,11 @@ the fix into 1811/1812's own scope.
 - [ ] #6 A claim taken but not yet row-recorded survives a sweep run inside that exact window, for both the script and audio sweeps (window regression tests, mirroring this branch's briefings window test)
 - [ ] #7 The Synthesize blocking toast (`watchlists_collections_screen.py`) never names a crash-zombie audio row as "already being synthesized" -- once the audio sweep is row-scoped, a zombie sharing a `script_id` with a live claim is swept before the toast is composed, so only the genuinely live row's label can appear
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Mirror the merged briefings shape (`briefing_service.py`: `_ACTIVE_BRIEFING_CLAIM_ROW_IDS`, `pending_briefing_claim_watchlist_ids()`, row-id `exclude` + `exclude_watchlists` pending-claim guard) into `briefing_cast.py` (`fail_interrupted_scripts`, claims keyed by script/briefing id) and `briefing_audio.py` (`fail_interrupted_audio`, claims keyed by script_id) — same registry-dict + frozen-snapshot + finally-cleared discipline, row id recorded as soon as the INSERT returns.
+2. Update the two sweeps' SQL from key-scoped `NOT IN` to row-id `NOT IN` + pending-key `NOT IN`; update every call site (screen sweeps `_sweep_and_guard_cast`/`_sweep_and_guard_audio` and any handler/service callers) to pass the new exclude pair.
+3. Tests per ACs 4-6 mirroring the briefings coexistence + window tests; AC 7 pinned at the screen: zombie audio row + live claim → toast names only the live row.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Subscriptions/briefing_audio.py
+++ b/tldw_chatbook/Subscriptions/briefing_audio.py
@@ -1463,8 +1463,10 @@ def fail_interrupted_audio(
             actual live row survives, and a same-script zombie is swept
             exactly as if no claim existed at all. This is what closes the
             gap task-1811 made user-visible: `WatchlistsCollectionsScreen`'s
-            Synthesize refusal toast can no longer name a crash-zombie row
-            shielded by an unrelated live claim on the same script.
+            Synthesize refusal toast no longer names a crash-zombie row
+            shielded by an unrelated live claim on the same script (except
+            during that claim's own pre-recording window below, where the
+            whole script is deliberately spared).
         exclude_scripts: Script ids to spare even though a row reads
             `generating`, regardless of that row's own id (task-1890,
             mirroring `fail_interrupted_briefings`'s `exclude_watchlists`).

--- a/tldw_chatbook/Subscriptions/briefing_audio.py
+++ b/tldw_chatbook/Subscriptions/briefing_audio.py
@@ -1121,19 +1121,105 @@ def audio_file_path_is_safe(file_path: str | Path) -> bool:
 
 _ACTIVE_AUDIO_CLAIMS: set[int] = set()
 
+# Task-1890 (generalizing task-1812's briefings-side fix): `script_id ->
+# briefing_audio.id` for the SAME live claim above, but scoped to the actual
+# ROW a live render is writing rather than merely the script it belongs to.
+# `_ACTIVE_AUDIO_CLAIMS` alone cannot tell a fresh live audio row apart from
+# a crash-zombie row left by a PRIOR process for the SAME script (the crash
+# predates the claim) -- both read `generating` and share one `script_id`,
+# so a script-scoped `exclude` incidentally shields the zombie too. An entry
+# here is added only once the row actually exists (`generate_script_audio`
+# records it right after `db.create_briefing_audio`'s own `to_thread` call
+# returns), and popped in `_claim_audio`'s `finally`, alongside the
+# script-level claim itself, so it never outlives the claim it belongs to.
+# `fail_interrupted_audio`'s `exclude` (via `active_audio_claim_row_ids`
+# below) reads from THIS registry, not `_ACTIVE_AUDIO_CLAIMS`.
+_ACTIVE_AUDIO_CLAIM_ROW_IDS: dict[int, int] = {}
+
 
 def active_audio_claims() -> frozenset[int]:
     """Snapshot of script ids a live `generate_script_audio` call currently holds.
 
     See `briefing_service.active_briefing_claims` for the snapshot
-    reasoning; this is its audio-scoped sibling, passed as
-    `fail_interrupted_audio`'s `exclude`.
+    reasoning; this is its audio-scoped sibling.
+
+    NOT what `fail_interrupted_audio`'s `exclude` wants any more
+    (task-1890, generalizing task-1812): a script-scoped snapshot cannot
+    tell a fresh live audio row apart from a crash-zombie row a PRIOR
+    process left behind for the SAME script, so passing this here would
+    incidentally shield the zombie too. Callers of the sweep want
+    `active_audio_claim_row_ids()` instead.
     """
     return frozenset(_ACTIVE_AUDIO_CLAIMS)
 
 
+def active_audio_claim_row_ids() -> frozenset[int]:
+    """Snapshot of `briefing_audio.id`s a live `generate_script_audio` call
+    has actually inserted (task-1890, mirroring `briefing_service.active_
+    briefing_claim_row_ids` exactly, scoped to a script id instead of a
+    watchlist id).
+
+    A plain, already-copied `frozenset` -- safe to read from any thread,
+    unlike `_ACTIVE_AUDIO_CLAIM_ROW_IDS` itself. Callers take this snapshot
+    on the event loop, before handing control to a thread, and pass it as
+    `fail_interrupted_audio`'s `exclude`: that function is sync and runs
+    under `asyncio.to_thread`, while the registry is mutated only on the
+    event loop, so a cross-thread read of the live registry would be racy
+    in a way a snapshot taken beforehand never is.
+
+    Row-scoped, not script-scoped -- see `active_audio_claims`'s own
+    docstring for why that distinction is the whole point: a genuine crash
+    zombie and a fresh live claim can coexist for one script, and only
+    naming the live row itself, rather than its whole script, lets a sweep
+    tell them apart.
+
+    A script whose claim has been taken but whose row has not been
+    recorded yet -- the window between `db.create_briefing_audio`'s own
+    `asyncio.to_thread` call returning and `generate_script_audio`'s
+    coroutine resuming on the event loop to record the id -- is not
+    represented here: there is no id for it to report until `generate_
+    script_audio` records one. `pending_audio_claim_script_ids()` below
+    names exactly those scripts, and `fail_interrupted_audio`'s `exclude_
+    scripts` closes the gap this function's row-scoping alone cannot.
+    """
+    return frozenset(_ACTIVE_AUDIO_CLAIM_ROW_IDS.values())
+
+
+def pending_audio_claim_script_ids() -> frozenset[int]:
+    """Snapshot of script ids with a live claim whose row id is not yet
+    recorded (task-1890, mirroring `briefing_service.pending_briefing_
+    claim_watchlist_ids` exactly, scoped to a script id).
+
+    `_claim_audio` adds `script_id` to `_ACTIVE_AUDIO_CLAIMS` before
+    `generate_script_audio` ever calls `db.create_briefing_audio`, but
+    `generate_script_audio` only records the row id (`_ACTIVE_AUDIO_CLAIM_
+    ROW_IDS[script_id] = audio_id`) once that call's `to_thread` hop
+    returns. For that whole span the script is claimed, but its audio row
+    either does not exist yet or exists with no id recorded to protect it:
+    `active_audio_claim_row_ids()` is empty (no id recorded yet), and
+    `active_audio_claims()` is script-scoped -- passing it as `fail_
+    interrupted_audio`'s row-scoped `exclude` does not even type-check, and
+    passing it as `exclude_scripts` unconditionally would resurrect the
+    exact over-protection this task removes (shielding a genuine
+    same-script crash zombie alongside the live row).
+
+    This is the set difference: claimed, but not yet recorded. Callers pass
+    it as `fail_interrupted_audio`'s `exclude_scripts`, ALONGSIDE
+    `exclude=active_audio_claim_row_ids()`, never instead of it -- the
+    moment a script's row id lands, it drops out of this set and the
+    row-scoped `exclude` alone protects it, which is exactly what keeps the
+    coexistence fix (a zombie and a live claim on the SAME script, swept
+    and spared respectively) intact.
+
+    A plain, already-copied `frozenset`, computed with no `await` between
+    reading the two registries -- safe only when called from the event
+    loop, same as the other two accessors in this section.
+    """
+    return frozenset(_ACTIVE_AUDIO_CLAIMS) - frozenset(_ACTIVE_AUDIO_CLAIM_ROW_IDS)
+
+
 @contextmanager
-def _claim_audio(script_id: int) -> Iterator[None]:
+def _claim_audio(script_id: int, *, audio_id: int | None = None) -> Iterator[None]:
     """Claim `script_id` for the duration of one synthesis attempt.
 
     See `briefing_service._claim_briefing` for the full reasoning (no
@@ -1142,8 +1228,21 @@ def _claim_audio(script_id: int) -> Iterator[None]:
     usable directly by tests that need to simulate another in-process
     caller already holding a script.
 
+    Task-1890: this context manager's `finally` is also where `_ACTIVE_
+    AUDIO_CLAIM_ROW_IDS`' entry for `script_id` is cleared, on every exit
+    path, alongside the script-level claim itself -- so the row-id
+    registry can never outlive the claim it belongs to. `.pop(..., None)`
+    is a safe no-op whenever no id was ever recorded.
+
     Args:
         script_id: The script whose audio is about to be synthesized.
+        audio_id: The `briefing_audio.id` this claim protects, if already
+            known at entry. `generate_script_audio` itself never passes
+            this -- its own row does not exist until AFTER this context
+            manager is entered, so it records the id into `_ACTIVE_AUDIO_
+            CLAIM_ROW_IDS` itself, mid-block, once `db.create_briefing_
+            audio` returns. This parameter exists for tests simulating
+            another in-process claim against a row that already exists.
 
     Raises:
         GenerationInFlightError: If `script_id` is already claimed.
@@ -1153,10 +1252,13 @@ def _claim_audio(script_id: int) -> Iterator[None]:
             f"audio is already being synthesized for script {script_id}"
         )
     _ACTIVE_AUDIO_CLAIMS.add(script_id)
+    if audio_id is not None:
+        _ACTIVE_AUDIO_CLAIM_ROW_IDS[script_id] = audio_id
     try:
         yield
     finally:
         _ACTIVE_AUDIO_CLAIMS.discard(script_id)
+        _ACTIVE_AUDIO_CLAIM_ROW_IDS.pop(script_id, None)
 
 
 async def generate_script_audio(
@@ -1239,6 +1341,25 @@ async def generate_script_audio(
             script_id,
             voice_snapshot_json=dump_voice_snapshot(selections),
         )
+        # Task-1890: record the row THIS claim is now writing, as the very
+        # next statement after the `to_thread` call above returns (no
+        # `await` in between) -- so nothing else on this event loop can
+        # observe the claim without the row it now protects. From here
+        # until `_claim_audio`'s `finally` pops it back out, `fail_
+        # interrupted_audio`'s row-scoped `exclude` (`active_audio_claim_
+        # row_ids`) can tell this row apart from any OTHER `generating` row
+        # on the same script -- in particular a crash-zombie left by a
+        # prior process, which does not belong here and must still be
+        # swept.
+        #
+        # For the whole `to_thread` call above, this script's id sits in
+        # `_ACTIVE_AUDIO_CLAIMS` with no corresponding entry here yet, so
+        # `active_audio_claim_row_ids()` alone cannot protect the row this
+        # exact call is about to insert. That window is what `pending_
+        # audio_claim_script_ids()` names and `fail_interrupted_audio`'s
+        # `exclude_scripts` closes -- every screen call site passes it
+        # alongside `exclude=active_audio_claim_row_ids()`.
+        _ACTIVE_AUDIO_CLAIM_ROW_IDS[script_id] = audio_id
 
         by_speaker: dict[str, VoiceSelection] = {
             selection.speaker: selection for selection in selections
@@ -1303,7 +1424,11 @@ async def generate_script_audio(
 
 
 def fail_interrupted_audio(
-    db: Any, script_id: int | None = None, *, exclude: Collection[int] = ()
+    db: Any,
+    script_id: int | None = None,
+    *,
+    exclude: Collection[int] = (),
+    exclude_scripts: Collection[int] = (),
 ) -> int:
     """Fail every `generating` audio row as `interrupted`; return the count.
 
@@ -1318,12 +1443,41 @@ def fail_interrupted_audio(
         script_id: Scope the sweep to one script's audio rows. `None`
             sweeps every script's audio, which is what a startup pass
             wants.
-        exclude: Script ids to spare even though their audio row reads
-            `generating` -- phase 4's claim-aware sweep. A `generating`
-            row whose script is in this collection is a LIVE, in-process
-            render, not a crash zombie. Callers snapshot
-            `active_audio_claims()` on the event loop and pass the result
-            here. Defaults to `()`, so every pre-phase-4 caller is
+        exclude: `briefing_audio.id`s to spare even though their row reads
+            `generating` -- phase 4's claim-aware sweep, row-scoped since
+            task-1890 (generalizing task-1812). A `generating` row whose
+            OWN id is in this collection is a LIVE, in-process render, not
+            a crash zombie, and must survive unconditionally, in every
+            scope. Callers snapshot `active_audio_claim_row_ids()` on the
+            event loop and pass the result here; this function is sync and
+            runs under `asyncio.to_thread`, so it never reads the live
+            claim registry itself. Defaults to `()`, so every pre-task-1890
+            caller is unchanged.
+
+            Prior to task-1890 this was script-scoped (`active_audio_
+            claims()`), which over-protected: a genuine crash-zombie row
+            left by an earlier process can coexist with a freshly-claimed
+            live row for the SAME script (the crash predates the claim),
+            and a script-scoped `exclude` shielded both rows, not just the
+            live one. Scoping to the row's own id fixes that: only the
+            actual live row survives, and a same-script zombie is swept
+            exactly as if no claim existed at all. This is what closes the
+            gap task-1811 made user-visible: `WatchlistsCollectionsScreen`'s
+            Synthesize refusal toast can no longer name a crash-zombie row
+            shielded by an unrelated live claim on the same script.
+        exclude_scripts: Script ids to spare even though a row reads
+            `generating`, regardless of that row's own id (task-1890,
+            mirroring `fail_interrupted_briefings`'s `exclude_watchlists`).
+            Closes a window row-scoped `exclude` alone cannot: between a
+            claim being taken and its row's id being recorded, `generate_
+            script_audio`'s `to_thread` call has not yet resumed on the
+            event loop to record it -- for that whole span the row (once
+            inserted) reads `generating` and is named by no row id at all.
+            Callers pass `pending_audio_claim_script_ids()` here,
+            snapshotted on the event loop exactly like `exclude` -- NEVER
+            `active_audio_claims()` itself, which would resurrect the
+            pre-task-1890 over-protection `exclude` was narrowed away from.
+            Defaults to `()`, so every caller that predates this fix is
             unchanged.
 
     Returns:
@@ -1339,8 +1493,12 @@ def fail_interrupted_audio(
         params.append(script_id)
     if exclude:
         placeholders = ",".join("?" for _ in exclude)
-        sql += f" AND script_id NOT IN ({placeholders})"
+        sql += f" AND id NOT IN ({placeholders})"
         params.extend(exclude)
+    if exclude_scripts:
+        placeholders = ",".join("?" for _ in exclude_scripts)
+        sql += f" AND script_id NOT IN ({placeholders})"
+        params.extend(exclude_scripts)
 
     with db.transaction() as conn:
         count = conn.execute(sql, params).rowcount

--- a/tldw_chatbook/Subscriptions/briefing_cast.py
+++ b/tldw_chatbook/Subscriptions/briefing_cast.py
@@ -596,19 +596,107 @@ def _finish_script_failure(db: Any, script_id: int, message: str) -> dict[str, A
 
 _ACTIVE_CAST_CLAIMS: set[int] = set()
 
+# Task-1890 (generalizing task-1812's briefings-side fix): `briefing_id ->
+# briefing_scripts.id` for the SAME live claim above, but scoped to the
+# actual ROW a live cast is writing rather than merely the briefing it
+# belongs to. `_ACTIVE_CAST_CLAIMS` alone cannot tell a fresh live script row
+# apart from a crash-zombie row left by a PRIOR process for the SAME
+# briefing (the crash predates the claim) -- both read `generating` and
+# share one `briefing_id`, so a briefing-scoped `exclude` incidentally
+# shields the zombie too. An entry here is added only once the row actually
+# exists (`generate_script` records it right after `_start_script`'s
+# `INSERT` returns), and popped in `_claim_cast`'s `finally`, alongside the
+# briefing-level claim itself, so it never outlives the claim it belongs to.
+# `fail_interrupted_scripts`'s `exclude` (via `active_cast_claim_row_ids`
+# below) reads from THIS registry, not `_ACTIVE_CAST_CLAIMS`.
+_ACTIVE_CAST_CLAIM_ROW_IDS: dict[int, int] = {}
+
 
 def active_cast_claims() -> frozenset[int]:
     """Snapshot of briefing ids a live `generate_script` call currently holds.
 
     See `briefing_service.active_briefing_claims` for the snapshot
-    reasoning; this is its cast-scoped sibling, passed as
-    `fail_interrupted_scripts`'s `exclude`.
+    reasoning; this is its cast-scoped sibling.
+
+    NOT what `fail_interrupted_scripts`'s `exclude` wants any more
+    (task-1890, generalizing task-1812): a briefing-scoped snapshot cannot
+    tell a fresh live script row apart from a crash-zombie row a PRIOR
+    process left behind for the SAME briefing, so passing this here would
+    incidentally shield the zombie too. Callers of the sweep want
+    `active_cast_claim_row_ids()` instead.
     """
     return frozenset(_ACTIVE_CAST_CLAIMS)
 
 
+def active_cast_claim_row_ids() -> frozenset[int]:
+    """Snapshot of `briefing_scripts.id`s a live `generate_script` call has
+    actually inserted (task-1890, mirroring `briefing_service.active_
+    briefing_claim_row_ids` exactly, scoped to a briefing id instead of a
+    watchlist id).
+
+    A plain, already-copied `frozenset` -- safe to read from any thread,
+    unlike `_ACTIVE_CAST_CLAIM_ROW_IDS` itself. Callers take this snapshot
+    on the event loop, before handing control to a thread, and pass it as
+    `fail_interrupted_scripts`'s `exclude`: that function is sync and runs
+    under `asyncio.to_thread`, while the registry is mutated only on the
+    event loop, so a cross-thread read of the live registry would be racy
+    in a way a snapshot taken beforehand never is.
+
+    Row-scoped, not briefing-scoped -- see `active_cast_claims`'s own
+    docstring for why that distinction is the whole point: a genuine crash
+    zombie and a fresh live claim can coexist for one briefing, and only
+    naming the live row itself, rather than its whole briefing, lets a
+    sweep tell them apart.
+
+    A briefing whose claim has been taken but whose row has not been
+    recorded yet -- the window inside `_start_script`'s own `asyncio.
+    to_thread` hop, from the moment its `INSERT` runs until `generate_
+    script`'s coroutine resumes on the event loop to record the id -- is
+    not represented here: there is no id for it to report until `generate_
+    script` records one. `pending_cast_claim_briefing_ids()` below names
+    exactly those briefings, and `fail_interrupted_scripts`'s `exclude_
+    briefings` closes the gap this function's row-scoping alone cannot.
+    """
+    return frozenset(_ACTIVE_CAST_CLAIM_ROW_IDS.values())
+
+
+def pending_cast_claim_briefing_ids() -> frozenset[int]:
+    """Snapshot of briefing ids with a live claim whose row id is not yet
+    recorded (task-1890, mirroring `briefing_service.pending_briefing_
+    claim_watchlist_ids` exactly, scoped to a briefing id).
+
+    `_claim_cast` adds `briefing_id` to `_ACTIVE_CAST_CLAIMS` before
+    `generate_script` ever calls `_start_script`, but `generate_script`
+    only records the row id (`_ACTIVE_CAST_CLAIM_ROW_IDS[briefing_id] =
+    script_id`) once that call's WHOLE `asyncio.to_thread` hop returns --
+    and `_start_script`'s `INSERT` is its LAST statement, after the
+    briefing/preset/roster validation and the roster snapshot. For that
+    whole span the briefing is claimed and its row exists (once the
+    `INSERT` itself has run) and reads `generating`, but is named by
+    nothing: `active_cast_claim_row_ids()` is empty (no id recorded yet),
+    and `active_cast_claims()` is briefing-scoped -- passing it as `fail_
+    interrupted_scripts`'s row-scoped `exclude` does not even type-check,
+    and passing it as `exclude_briefings` unconditionally would resurrect
+    the exact over-protection this task removes (shielding a genuine
+    same-briefing crash zombie alongside the live row).
+
+    This is the set difference: claimed, but not yet recorded. Callers pass
+    it as `fail_interrupted_scripts`'s `exclude_briefings`, ALONGSIDE
+    `exclude=active_cast_claim_row_ids()`, never instead of it -- the
+    moment a briefing's row id lands, it drops out of this set and the
+    row-scoped `exclude` alone protects it, which is exactly what keeps the
+    coexistence fix (a zombie and a live claim on the SAME briefing, swept
+    and spared respectively) intact.
+
+    A plain, already-copied `frozenset`, computed with no `await` between
+    reading the two registries -- safe only when called from the event
+    loop, same as the other two accessors in this section.
+    """
+    return frozenset(_ACTIVE_CAST_CLAIMS) - frozenset(_ACTIVE_CAST_CLAIM_ROW_IDS)
+
+
 @contextmanager
-def _claim_cast(briefing_id: int) -> Iterator[None]:
+def _claim_cast(briefing_id: int, *, script_id: int | None = None) -> Iterator[None]:
     """Claim `briefing_id` for the duration of one cast attempt.
 
     See `briefing_service._claim_briefing` for the full reasoning (no
@@ -617,8 +705,21 @@ def _claim_cast(briefing_id: int) -> Iterator[None]:
     of a watchlist id. Also usable directly by tests that need to simulate
     another in-process caller already holding a briefing.
 
+    Task-1890: this context manager's `finally` is also where `_ACTIVE_
+    CAST_CLAIM_ROW_IDS`' entry for `briefing_id` is cleared, on every exit
+    path, alongside the briefing-level claim itself -- so the row-id
+    registry can never outlive the claim it belongs to. `.pop(..., None)`
+    is a safe no-op whenever no id was ever recorded.
+
     Args:
         briefing_id: The briefing about to be cast.
+        script_id: The `briefing_scripts.id` this claim protects, if
+            already known at entry. `generate_script` itself never passes
+            this -- its own row does not exist until AFTER this context
+            manager is entered, so it records the id into `_ACTIVE_CAST_
+            CLAIM_ROW_IDS` itself, mid-block, once `_start_script` returns.
+            This parameter exists for tests simulating another in-process
+            claim against a row that already exists.
 
     Raises:
         GenerationInFlightError: If `briefing_id` is already claimed.
@@ -628,10 +729,13 @@ def _claim_cast(briefing_id: int) -> Iterator[None]:
             f"a script is already being cast for briefing {briefing_id}"
         )
     _ACTIVE_CAST_CLAIMS.add(briefing_id)
+    if script_id is not None:
+        _ACTIVE_CAST_CLAIM_ROW_IDS[briefing_id] = script_id
     try:
         yield
     finally:
         _ACTIVE_CAST_CLAIMS.discard(briefing_id)
+        _ACTIVE_CAST_CLAIM_ROW_IDS.pop(briefing_id, None)
 
 
 async def generate_script(
@@ -689,6 +793,26 @@ async def generate_script(
         script_id, briefing, preset, roster, roster_names = await asyncio.to_thread(
             _start_script, db, briefing_id, preset_id, load_character
         )
+        # Task-1890: record the row THIS claim is now writing, as the very
+        # next statement after the `to_thread` hop above returns (no
+        # `await` in between) -- so nothing else on this event loop can
+        # observe the claim without the row it now protects. From here
+        # until `_claim_cast`'s `finally` pops it back out, `fail_
+        # interrupted_scripts`'s row-scoped `exclude` (`active_cast_claim_
+        # row_ids`) can tell this row apart from any OTHER `generating` row
+        # on the same briefing -- in particular a crash-zombie left by a
+        # prior process, which does not belong here and must still be
+        # swept.
+        #
+        # For the ENTIRE `to_thread` hop above, this briefing's id sits in
+        # `_ACTIVE_CAST_CLAIMS` with no corresponding entry here yet, so
+        # `active_cast_claim_row_ids()` alone cannot protect the row this
+        # exact call is about to insert (`_start_script`'s `INSERT` is its
+        # LAST statement). That window is what `pending_cast_claim_
+        # briefing_ids()` names and `fail_interrupted_scripts`'s `exclude_
+        # briefings` closes -- every screen call site passes it alongside
+        # `exclude=active_cast_claim_row_ids()`.
+        _ACTIVE_CAST_CLAIM_ROW_IDS[briefing_id] = script_id
 
         endpoint = provider or preset.get("provider") or _default_provider()
         resolved_model = model or preset.get("model")
@@ -720,7 +844,11 @@ async def generate_script(
 
 
 def fail_interrupted_scripts(
-    db: Any, briefing_id: int | None = None, *, exclude: Collection[int] = ()
+    db: Any,
+    briefing_id: int | None = None,
+    *,
+    exclude: Collection[int] = (),
+    exclude_briefings: Collection[int] = (),
 ) -> int:
     """Fail every `generating` script as `interrupted`; return the count.
 
@@ -735,13 +863,38 @@ def fail_interrupted_scripts(
         briefing_id: Scope the sweep to one briefing's scripts. `None`
             sweeps every briefing's scripts, which is what a startup pass
             wants.
-        exclude: Briefing ids to spare even though their script row reads
-            `generating` -- phase 4's claim-aware sweep. A `generating`
-            script whose briefing is in this collection is a LIVE,
-            in-process cast, not a crash zombie. Callers snapshot
-            `active_cast_claims()` on the event loop and pass the result
-            here. Defaults to `()`, so every pre-phase-4 caller is
-            unchanged.
+        exclude: `briefing_scripts.id`s to spare even though their row
+            reads `generating` -- phase 4's claim-aware sweep, row-scoped
+            since task-1890 (generalizing task-1812). A `generating` row
+            whose OWN id is in this collection is a LIVE, in-process cast,
+            not a crash zombie, and must survive unconditionally, in every
+            scope. Callers snapshot `active_cast_claim_row_ids()` on the
+            event loop and pass the result here; this function is sync and
+            runs under `asyncio.to_thread`, so it never reads the live
+            claim registry itself. Defaults to `()`, so every pre-task-1890
+            caller is unchanged.
+
+            Prior to task-1890 this was briefing-scoped (`active_cast_
+            claims()`), which over-protected: a genuine crash-zombie row
+            left by an earlier process can coexist with a freshly-claimed
+            live row for the SAME briefing (the crash predates the claim),
+            and a briefing-scoped `exclude` shielded both rows, not just
+            the live one. Scoping to the row's own id fixes that: only the
+            actual live row survives, and a same-briefing zombie is swept
+            exactly as if no claim existed at all.
+        exclude_briefings: Briefing ids to spare even though a row reads
+            `generating`, regardless of that row's own id (task-1890,
+            mirroring `fail_interrupted_briefings`'s `exclude_watchlists`).
+            Closes a window row-scoped `exclude` alone cannot: between a
+            claim being taken and its row's id being recorded, `generate_
+            script`'s `to_thread` hop has not yet resumed on the event loop
+            to record it -- for that whole span the row (once inserted)
+            reads `generating` and is named by no row id at all. Callers
+            pass `pending_cast_claim_briefing_ids()` here, snapshotted on
+            the event loop exactly like `exclude` -- NEVER `active_cast_
+            claims()` itself, which would resurrect the pre-task-1890
+            over-protection `exclude` was narrowed away from. Defaults to
+            `()`, so every caller that predates this fix is unchanged.
 
     Returns:
         How many rows were failed.
@@ -756,8 +909,12 @@ def fail_interrupted_scripts(
         params.append(briefing_id)
     if exclude:
         placeholders = ",".join("?" for _ in exclude)
-        sql += f" AND briefing_id NOT IN ({placeholders})"
+        sql += f" AND id NOT IN ({placeholders})"
         params.extend(exclude)
+    if exclude_briefings:
+        placeholders = ",".join("?" for _ in exclude_briefings)
+        sql += f" AND briefing_id NOT IN ({placeholders})"
+        params.extend(exclude_briefings)
 
     with db.transaction() as conn:
         count = conn.execute(sql, params).rowcount

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -5817,9 +5817,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         fresh synthesis -- the same press both recovers the zombie AND
         synthesizes real audio (`test_synthesizing_recovers_a_zombie_audio_
         row_via_its_own_sweep`). Row-scoping (task-1890) also means this
-        `blocking` toast can no longer name a crash-zombie row shielded by
-        an unrelated live claim on the same script -- the zombie is swept
-        by the same call, before `blocking` is computed.
+        `blocking` toast no longer names a crash-zombie row shielded by an
+        unrelated live claim on the same script -- the zombie is swept by
+        the same call, before `blocking` is computed -- once that claim's
+        row id is recorded. In the brief window before recording, the
+        pending-claim guard deliberately spares the whole script (zombie
+        included), so the toast can still name one there.
         """
         try:
             try:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -37,15 +37,17 @@ from ...config import get_cli_setting
 from ...runtime_policy.types import PolicyDeniedError
 from ...Subscriptions.briefing_audio import (
     AudioGenerationError,
-    active_audio_claims,
+    active_audio_claim_row_ids,
     fail_interrupted_audio,
     generate_script_audio,
+    pending_audio_claim_script_ids,
 )
 from ...Subscriptions.briefing_cast import (
     ScriptCastError,
-    active_cast_claims,
+    active_cast_claim_row_ids,
     fail_interrupted_scripts,
     generate_script,
+    pending_cast_claim_briefing_ids,
 )
 from ...Subscriptions.briefing_export import (
     BriefingExportError,
@@ -5290,7 +5292,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     # runs in the same TWO seams it always has: `_load_briefings` whenever
     # Artifacts loads (gated on `_cast_sweep_is_safe`), and `_cast_script`
     # below at the front of every cast -- both now claim-aware via
-    # `active_cast_claims()`, exactly like Generate's own sweeps.
+    # `active_cast_claim_row_ids()`, exactly like Generate's own sweeps
+    # (task-1890: row-scoped, not merely briefing-scoped, mirroring
+    # task-1812's briefings-side fix).
 
     def _cast_sweep_is_safe(self) -> bool:
         """Whether `fail_interrupted_scripts` may run right now.
@@ -5309,15 +5313,28 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         UI thread. Sibling of `_fail_interrupted_briefings_if_safe`, scoped
         to one briefing's scripts rather than one watchlist's briefings.
 
-        `active_cast_claims()` is snapshotted HERE, on the UI thread, before
-        the sweep is dispatched -- see that method's own docstring for why
-        a snapshot, not a live read, is required.
+        `active_cast_claim_row_ids()` is snapshotted HERE, on the UI
+        thread, before the sweep is dispatched -- see `_fail_interrupted_
+        briefings_if_safe`'s own docstring for why a snapshot, not a live
+        read, is required, and row-scoped rather than briefing-scoped
+        (task-1890, mirroring task-1812's `active_briefing_claim_row_ids`).
+
+        `pending_cast_claim_briefing_ids()` is snapshotted here too, same
+        thread, same instant, closing the window `exclude` alone cannot: a
+        claim taken but whose row id has not yet been recorded, still
+        inside `_start_script`'s own `to_thread` hop. Passed as `exclude_
+        briefings`, never in place of `exclude`.
         """
         if not self._cast_sweep_is_safe():
             return 0
-        claims = active_cast_claims()
+        claims = active_cast_claim_row_ids()
+        pending = pending_cast_claim_briefing_ids()
         return await asyncio.to_thread(
-            fail_interrupted_scripts, db, briefing_id, exclude=claims
+            fail_interrupted_scripts,
+            db,
+            briefing_id,
+            exclude=claims,
+            exclude_briefings=pending,
         )
 
     @staticmethod
@@ -5332,13 +5349,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         )
 
     def _sweep_and_guard_cast(
-        self, db: Any, briefing_id: int, exclude: Collection[int]
+        self,
+        db: Any,
+        briefing_id: int,
+        exclude: Collection[int],
+        exclude_briefings: Collection[int] = (),
     ) -> tuple[list[str], list[str]]:
         """Zombie sweep, then the generating-check, for a cast. Runs off the
         UI thread. Sibling of `_sweep_and_guard` -- see that method's own
         docstring for the full reasoning; this is the identical shape,
         scoped to one briefing's scripts instead of one watchlist's
-        briefings (phase 4 Task 1, survey finding (c)).
+        briefings (phase 4 Task 1, survey finding (c); row-scoped since
+        task-1890).
+
+        `exclude_briefings` -- the caller's `pending_cast_claim_briefing_
+        ids()` snapshot, taken at the same instant as `exclude` -- closes
+        the same window `exclude` alone cannot for another in-process
+        caller: if it is still inside `_start_script`'s own `to_thread`
+        hop, its row (once inserted) reads `generating` but has no id
+        recorded yet, so only naming its briefing (not yet its row) spares
+        it here.
 
         Returns:
             `(recovered, blocking)`, exactly like `_sweep_and_guard`.
@@ -5348,7 +5378,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             for row in db.list_briefing_scripts(briefing_id)
             if str(row.get("status") or "").strip().lower() == STATUS_GENERATING
         ]
-        fail_interrupted_scripts(db, briefing_id, exclude=exclude)
+        fail_interrupted_scripts(
+            db, briefing_id, exclude=exclude, exclude_briefings=exclude_briefings
+        )
         blocking = [
             self._script_row_label(row)
             for row in db.list_briefing_scripts(briefing_id)
@@ -5522,7 +5554,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         try:
             try:
                 _recovered, blocking = await asyncio.to_thread(
-                    self._sweep_and_guard_cast, db, briefing_id, active_cast_claims()
+                    self._sweep_and_guard_cast,
+                    db,
+                    briefing_id,
+                    active_cast_claim_row_ids(),
+                    pending_cast_claim_briefing_ids(),
                 )
             except Exception as exc:  # noqa: BLE001 - reported, not raised
                 logger.warning(
@@ -5595,9 +5631,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     # Artifacts loads (gated on `_audio_sweep_is_safe`), and `_synthesize_
     # audio` below sweeps again at its own front, exactly where `_cast_
     # script` sweeps for Cast. Both are now claim-aware via
-    # `active_audio_claims()` (phase 4 Task 1), so a live in-process render
-    # -- this screen's own, or another in-process caller's -- survives
-    # either sweep unconditionally.
+    # `active_audio_claim_row_ids()` (phase 4 Task 1; row-scoped, not
+    # merely script-scoped, since task-1890 -- mirroring task-1812's
+    # briefings-side fix), so a live in-process render -- this screen's
+    # own, or another in-process caller's -- survives either sweep
+    # unconditionally.
     #
     # Phase 4 Task 1 investigated whether Synthesize needs the SAME
     # `blocking` refusal Cast just gained (survey finding (c)'s sibling
@@ -5624,16 +5662,29 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         thread. Sibling of `_fail_interrupted_scripts_if_safe`, scoped to
         one script's audio renders rather than one briefing's scripts.
 
-        `active_audio_claims()` is snapshotted HERE, on the UI thread,
-        before the sweep is dispatched -- see `_fail_interrupted_briefings_
-        if_safe`'s own docstring for why a snapshot, not a live read, is
-        required.
+        `active_audio_claim_row_ids()` is snapshotted HERE, on the UI
+        thread, before the sweep is dispatched -- see `_fail_interrupted_
+        briefings_if_safe`'s own docstring for why a snapshot, not a live
+        read, is required, and row-scoped rather than script-scoped
+        (task-1890, mirroring task-1812's `active_briefing_claim_row_ids`).
+
+        `pending_audio_claim_script_ids()` is snapshotted here too, same
+        thread, same instant, closing the window `exclude` alone cannot: a
+        claim taken but whose row id has not yet been recorded, still
+        inside `generate_script_audio`'s own `db.create_briefing_audio`
+        `to_thread` call. Passed as `exclude_scripts`, never in place of
+        `exclude`.
         """
         if not self._audio_sweep_is_safe():
             return 0
-        claims = active_audio_claims()
+        claims = active_audio_claim_row_ids()
+        pending = pending_audio_claim_script_ids()
         return await asyncio.to_thread(
-            fail_interrupted_audio, db, script_id, exclude=claims
+            fail_interrupted_audio,
+            db,
+            script_id,
+            exclude=claims,
+            exclude_scripts=pending,
         )
 
     @staticmethod
@@ -5648,14 +5699,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         )
 
     def _sweep_and_guard_audio(
-        self, db: Any, script_id: int, exclude: Collection[int]
+        self,
+        db: Any,
+        script_id: int,
+        exclude: Collection[int],
+        exclude_scripts: Collection[int] = (),
     ) -> tuple[list[str], list[str]]:
         """Zombie sweep, then the generating-check, for a synthesis. Runs
         off the UI thread. Sibling of `_sweep_and_guard_cast` -- see that
         method's own docstring for the full reasoning; this is the
         identical shape, scoped to one script's audio renders instead of
         one briefing's scripts (task-1811, mirroring Cast's own `blocking`
-        refusal from phase 4 Task 1 onto Synthesize).
+        refusal from phase 4 Task 1 onto Synthesize; row-scoped `exclude`
+        plus `exclude_scripts` since task-1890 -- see `_sweep_and_guard_
+        cast`'s own docstring for the identical `exclude_briefings`
+        reasoning).
 
         Returns:
             `(recovered, blocking)`, exactly like `_sweep_and_guard_cast`.
@@ -5665,7 +5723,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             for row in db.list_briefing_audio(script_id)
             if str(row.get("status") or "").strip().lower() == STATUS_GENERATING
         ]
-        fail_interrupted_audio(db, script_id, exclude=exclude)
+        fail_interrupted_audio(
+            db, script_id, exclude=exclude, exclude_scripts=exclude_scripts
+        )
         blocking = [
             self._audio_row_label(row)
             for row in db.list_briefing_audio(script_id)
@@ -5744,24 +5804,31 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         own docstring), not a database failure to hide behind a generic
         toast.
 
-        The sweep is claim-aware (`active_audio_claims()`), like every
-        other sweep call site (phase 4 Task 1), and is now followed by a
-        `blocking` check, mirroring `_cast_script`'s own (task-1811): a row
-        that SURVIVES `_sweep_and_guard_audio`'s sweep because it is
-        claimed by a live in-process synthesis refuses THIS attempt
-        instead of starting a second, concurrent one over the top of it.
-        Unlike `_cast_script`'s own `recovered` branch, there is no
-        one-COMPLETE-row-per-script invariant here either (a script may be
-        synthesized many times), so a zombie this sweep actually recovers
-        (i.e. NOT `blocking`) does not itself refuse a fresh synthesis --
-        the same press both recovers the zombie AND synthesizes real audio
-        (`test_synthesizing_recovers_a_zombie_audio_row_via_its_own_
-        sweep`).
+        The sweep is claim-aware (`active_audio_claim_row_ids()`, row-scoped
+        since task-1890), like every other sweep call site (phase 4 Task
+        1), and is now followed by a `blocking` check, mirroring `_cast_
+        script`'s own (task-1811): a row that SURVIVES `_sweep_and_guard_
+        audio`'s sweep because it is claimed by a live in-process synthesis
+        refuses THIS attempt instead of starting a second, concurrent one
+        over the top of it. Unlike `_cast_script`'s own `recovered` branch,
+        there is no one-COMPLETE-row-per-script invariant here either (a
+        script may be synthesized many times), so a zombie this sweep
+        actually recovers (i.e. NOT `blocking`) does not itself refuse a
+        fresh synthesis -- the same press both recovers the zombie AND
+        synthesizes real audio (`test_synthesizing_recovers_a_zombie_audio_
+        row_via_its_own_sweep`). Row-scoping (task-1890) also means this
+        `blocking` toast can no longer name a crash-zombie row shielded by
+        an unrelated live claim on the same script -- the zombie is swept
+        by the same call, before `blocking` is computed.
         """
         try:
             try:
                 _recovered, blocking = await asyncio.to_thread(
-                    self._sweep_and_guard_audio, db, script_id, active_audio_claims()
+                    self._sweep_and_guard_audio,
+                    db,
+                    script_id,
+                    active_audio_claim_row_ids(),
+                    pending_audio_claim_script_ids(),
                 )
             except Exception as exc:  # noqa: BLE001 - reported, not raised
                 logger.warning(


### PR DESCRIPTION
## Why

`fail_interrupted_scripts` and `fail_interrupted_audio` still excluded by their coarse claim key (briefing id / script id) — the same bug class task-1812 fixed for the briefings sweep in #1198. A crash-zombie `generating` row sharing a key with a freshly-claimed live row was shielded by the live claim, and task-1811's Synthesize blocking toast gave that a user-visible surface: it could name the dead zombie as the thing "already being synthesized."

## What

The merged briefings shape, mirrored faithfully into both siblings (`briefing_cast.py`, `briefing_audio.py`): a row-id registry populated the moment each INSERT's `to_thread` hop returns and cleared in the same `finally` as its claim; frozen-snapshot accessors; sweep SQL scoped to `id NOT IN (live row ids)` plus a pending-key guard (`claims − recorded ids`) that closes the unrecorded-claim window — the same window the briefings fix was found to open, handled here from the start. All four screen call sites pass the new exclude pair; four monkeypatch stubs widened (the stale-signature-TypeError-under-bare-except trap from #1198's wave, greped for exhaustively this time). The Synthesize toast now names only the genuinely live row once the claim's row id is recorded — the AC and docstrings state the pre-recording window's deliberate whole-script sparing plainly rather than over-claiming "never" (review finding, probe-confirmed).

## Testing

Coexistence tests both directions for each sweep (zombie failed as interrupted, live row untouched), pending-window tests for each, and a screen-level test proving the zombie is swept before the toast is composed (asserted `failed`/`interrupted` AND absent, `blocking` re-read post-sweep — not absent by coincidence). Four mutations each REDding their discriminating test (key-scoped revert → coexistence REDs; pending-guard drop → window test REDs). Full `Tests/Subscriptions/ Tests/Watchlists/ Tests/Scheduling/`: **1164 passed, 0 failed**; reviewer's independent run 900/0 on the two main directories. Opus whole-branch review: CLEAN (one Low copy-accuracy finding, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Row-scoped the script and audio interrupted sweeps so only real in‑process rows are spared and same‑briefing/script crash zombies are swept. Closed the pre‑recording claim window and fixed the Synthesize blocking toast to only name the live row. (Task-1890)

- **Bug Fixes**
  - `fail_interrupted_scripts` and `fail_interrupted_audio` now exclude by row id (`id`) and accept `exclude_briefings`/`exclude_scripts` to guard the unrecorded-claim window.
  - Added row-id registries/accessors: `active_cast_claim_row_ids()`, `active_audio_claim_row_ids()`; pending guards: `pending_cast_claim_briefing_ids()`, `pending_audio_claim_script_ids()`.
  - Updated `watchlists_collections_screen.py` to snapshot and pass both sets at all sweep call sites (Artifacts load and per-action).
  - Synthesize toast now names only the genuinely live audio row; zombies are swept before the toast is composed.
  - Tests cover coexistence (live vs zombie), the pending window, and the screen-level toast behavior.

<sup>Written for commit 2668d636be40297a002abfcd5f83e850729e91f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

