### PR TITLE
Console: retire top-strip Save Chatbook; RAG chip opens a Library RAG settings modal

### DIFF
--- a/Tests/UI/test_console_composer_menu.py
+++ b/Tests/UI/test_console_composer_menu.py
@@ -1065,10 +1065,6 @@ def test_artifact_actions_are_disabled_with_a_reason_in_a_temporary_chat():
     proves nothing unless the same call proves it is enabled otherwise.
     """
     from tldw_chatbook.Chat.console_ephemeral import blocked_reason
-    from tldw_chatbook.Widgets.Console.console_workbench_state import (
-        build_console_workbench_state,
-    )
-    from tldw_chatbook.Chat.console_display_state import ConsoleControlState
 
     menu = {
         e.action_id: e
@@ -1081,27 +1077,13 @@ def test_artifact_actions_are_disabled_with_a_reason_in_a_temporary_chat():
     normal = {e.action_id: e for e in build_composer_menu_entries()}
     assert normal[ACTION_GENERATE_IMAGE].enabled is True
 
-    # ConsoleControlState has seven required label fields and no defaults.
-    control_state = ConsoleControlState(
-        provider_label="Provider: stub",
-        model_label="Model: stub",
-        assistant_label="Assistant: General",
-        rag_label="RAG: off",
-        sources_label="Sources: 0",
-        tools_label="Tools: 0",
-        approvals_label="Approvals: 0",
-    )
-
-    def chatbook_action(**kwargs):
-        state = build_console_workbench_state(
-            control_state=control_state, can_save_chatbook=True, **kwargs
-        )
-        return {a.id: a for a in state.actions}["save-chatbook"]
-
-    blocked = chatbook_action(ephemeral=True)
-    assert blocked.disabled is True
-    assert blocked.tooltip == blocked_reason("save-chatbook", ephemeral=True)
-    assert chatbook_action().disabled is False
+    # Save Chatbook's temporary-chat block used to be asserted here on the
+    # top control strip's action too; that button left the strip entirely
+    # (the ☰ menu row above and the Inspector's Artifacts row are the
+    # surviving surfaces, each with its own block coverage).
+    chatbook = menu[ACTION_SAVE_CHATBOOK]
+    assert chatbook.enabled is False
+    assert chatbook.description == blocked_reason("save-chatbook", ephemeral=True)
 
 
 @pytest.mark.integration

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -413,7 +413,9 @@ async def test_console_gate15_keeps_existing_chat_send_control_reachable():
         assert "Send" in text
         assert "Stop" in text
         assert "Attach" in text
-        assert "Save" in text
+        # "Save" left the always-visible chrome entirely (user request
+        # 2026-08-01): Save Chatbook's surviving surfaces are the composer's
+        # ☰ menu and the Inspector's Artifacts row, both asserted below.
         send_controls = [
             button
             for button in console.query(Button)
@@ -425,6 +427,8 @@ async def test_console_gate15_keeps_existing_chat_send_control_reachable():
         # Attach and Save Chatbook now live in the composer's ☰ menu,
         # not this width-bounded row -- see test_console_composer_menu.py.
         assert console.query_one("#console-composer-menu", Button)
+        assert console.query_one("#console-inspector-save-chatbook", Button)
+        assert not list(console.query("#console-control-save-chatbook"))
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -1,0 +1,159 @@
+"""The RAG chip's Library RAG settings modal: gating, results, dismissal.
+
+User request 2026-08-01: clicking "RAG: off" in the status strip opens a
+modal that lets the user set the retrieval query and run it -- instead of
+the query living only in a rail input that may not even be on screen.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, Input
+
+from tldw_chatbook.Widgets.Console.console_rag_settings_modal import (
+    ConsoleRagSettingsModal,
+    ConsoleRagSettingsResult,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_returns_the_query_and_is_gated_on_non_blank_text():
+    """Run is disabled while blank, enables on typing, and returns the query."""
+
+    class RagHost(App):
+        pass
+
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(scope_label="Scope: notes, media"),
+            callback=received.append,
+        )
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, ConsoleRagSettingsModal)
+
+        run = modal.query_one("#console-rag-settings-run", Button)
+        assert run.disabled is True, "blank query must not be runnable"
+
+        query_input = modal.query_one("#console-rag-settings-query", Input)
+        query_input.value = "incident retro notes"
+        await pilot.pause()
+        assert run.disabled is False
+
+        await pilot.click("#console-rag-settings-run")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert received == [
+        ConsoleRagSettingsResult(query="incident retro notes", run=True)
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_prefilled_query_is_runnable_and_enter_submits():
+    """A prefilled modal is one keypress from retrieval (Enter submits)."""
+
+    class RagHost(App):
+        pass
+
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(query="what changed in auth"),
+            callback=received.append,
+        )
+        await pilot.pause()
+        modal = app.screen
+        assert modal.query_one("#console-rag-settings-run", Button).disabled is False
+
+        modal.query_one("#console-rag-settings-query", Input).focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert received == [
+        ConsoleRagSettingsResult(query="what changed in auth", run=True)
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cancel_escape_and_backdrop_all_dismiss_without_changes():
+    """Every no-action exit returns None; inside clicks keep it open."""
+
+    class RagHost(App):
+        pass
+
+    received: list[ConsoleRagSettingsResult | None] = []
+    app = RagHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleRagSettingsModal(query="draft text"),
+            callback=received.append,
+        )
+        await pilot.pause()
+        modal = app.screen
+
+        # A click inside the box (its header line) must not dismiss.
+        box = modal.query_one("#console-rag-settings")
+        await pilot.click(offset=(box.region.x + 2, box.region.y + 1))
+        await pilot.pause()
+        assert app.screen is modal
+
+        # Backdrop click dismisses with no changes.
+        await pilot.click(offset=(1, 1))
+        await pilot.pause()
+        await pilot.pause()
+        assert app.screen is not modal
+
+    assert received == [None]
+
+
+@pytest.mark.unit
+def test_status_copy_is_honest_about_what_on_means():
+    """The modal explains that "on" == staged retrieved evidence."""
+    off = ConsoleRagSettingsModal()
+    assert "RAG is off" in off._status_copy()
+    assert "staged" in off._status_copy()
+
+    on = ConsoleRagSettingsModal(rag_active=True, staged_title="Incident Review")
+    assert "RAG is on" in on._status_copy()
+    assert "Incident Review" in on._status_copy()
+
+
+@pytest.mark.unit
+def test_screen_callback_stores_sanitized_query_and_delegates_run():
+    """The screen-side callback owns sanitization and the run delegation."""
+    from textual.css.query import QueryError
+
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen = Mock()
+    screen._console_library_rag_query = ""
+    screen.query_one = Mock(side_effect=QueryError("not mounted"))
+
+    # Textual QueryError paths are exercised in the mounted tests; here the
+    # bare state contract: sanitize, store, delegate when run=True.
+    ChatScreen._apply_console_rag_settings_choice(
+        screen, ConsoleRagSettingsResult(query="  spaced   query  ", run=True)
+    )
+    assert screen._console_library_rag_query == "spaced query"
+    screen._run_console_library_rag_from_visible_action.assert_called_once()
+
+    screen._run_console_library_rag_from_visible_action.reset_mock()
+    ChatScreen._apply_console_rag_settings_choice(
+        screen, ConsoleRagSettingsResult(query="no run", run=False)
+    )
+    assert screen._console_library_rag_query == "no run"
+    screen._run_console_library_rag_from_visible_action.assert_not_called()
+
+    screen._console_library_rag_query = "unchanged"
+    ChatScreen._apply_console_rag_settings_choice(screen, None)
+    assert screen._console_library_rag_query == "unchanged"

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -139,21 +139,88 @@ def test_screen_callback_stores_sanitized_query_and_delegates_run():
     screen._console_library_rag_query = ""
     screen.query_one = Mock(side_effect=QueryError("not mounted"))
 
-    # Textual QueryError paths are exercised in the mounted tests; here the
-    # bare state contract: sanitize, store, delegate when run=True.
+    # The bare state contract: sanitize, store through the one query
+    # writer (`_set_console_library_rag_query`), delegate when run=True.
     ChatScreen._apply_console_rag_settings_choice(
         screen, ConsoleRagSettingsResult(query="  spaced   query  ", run=True)
     )
-    assert screen._console_library_rag_query == "spaced query"
+    screen._set_console_library_rag_query.assert_called_once_with("spaced query")
     screen._run_console_library_rag_from_visible_action.assert_called_once()
 
+    screen._set_console_library_rag_query.reset_mock()
     screen._run_console_library_rag_from_visible_action.reset_mock()
     ChatScreen._apply_console_rag_settings_choice(
         screen, ConsoleRagSettingsResult(query="no run", run=False)
     )
-    assert screen._console_library_rag_query == "no run"
+    screen._set_console_library_rag_query.assert_called_once_with("no run")
     screen._run_console_library_rag_from_visible_action.assert_not_called()
 
-    screen._console_library_rag_query = "unchanged"
+    screen._set_console_library_rag_query.reset_mock()
     ChatScreen._apply_console_rag_settings_choice(screen, None)
-    assert screen._console_library_rag_query == "unchanged"
+    screen._set_console_library_rag_query.assert_not_called()
+
+
+@pytest.mark.unit
+def test_visible_run_action_falls_back_to_the_composer_draft():
+    """User decision (2026-08-02): with no dedicated query set, the visible
+    Run Library RAG action retrieves with the composer draft instead of
+    demanding a query the collapsed rail gives no place to type. The
+    fallback is STORED so the rail input and this modal agree with what
+    actually ran; with no query anywhere, the warning toast survives."""
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_LIBRARY_RAG_QUERY_EMPTY_MESSAGE,
+        ChatScreen,
+    )
+
+    screen = Mock()
+    screen._console_library_rag_query = ""
+    composer = Mock()
+    composer.draft_text.return_value = "  what   changed in auth  "
+    screen._console_composer_or_none.return_value = composer
+
+    ChatScreen._run_console_library_rag_from_visible_action(screen)
+
+    screen._set_console_library_rag_query.assert_called_once_with(
+        "what changed in auth"
+    )
+    screen.app_instance.notify.assert_not_called()
+    screen._stage_console_library_rag_launch.assert_called_once()
+    launch = screen._stage_console_library_rag_launch.call_args.args[0]
+    assert launch.payload["query"] == "what changed in auth"
+    request = screen._execute_console_library_rag_search.call_args.args[0]
+    assert request.query == "what changed in auth"
+
+    # No dedicated query AND an empty composer: the toast survives.
+    empty = Mock()
+    empty._console_library_rag_query = ""
+    empty_composer = Mock()
+    empty_composer.draft_text.return_value = "   "
+    empty._console_composer_or_none.return_value = empty_composer
+
+    ChatScreen._run_console_library_rag_from_visible_action(empty)
+
+    empty.app_instance.notify.assert_called_once()
+    assert (
+        CONSOLE_LIBRARY_RAG_QUERY_EMPTY_MESSAGE
+        in empty.app_instance.notify.call_args.args
+    )
+    empty._stage_console_library_rag_launch.assert_not_called()
+
+
+@pytest.mark.unit
+def test_dedicated_query_still_wins_over_the_composer_draft():
+    """A query set through the rail or the modal is what runs; the draft
+    fallback only fills a VACANT query, never overrides an explicit one."""
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen = Mock()
+    screen._console_library_rag_query = "explicit query"
+    composer = Mock()
+    composer.draft_text.return_value = "draft text"
+    screen._console_composer_or_none.return_value = composer
+
+    ChatScreen._run_console_library_rag_from_visible_action(screen)
+
+    screen._set_console_library_rag_query.assert_not_called()
+    request = screen._execute_console_library_rag_search.call_args.args[0]
+    assert request.query == "explicit query"

--- a/Tests/UI/test_console_shell_chip_actions.py
+++ b/Tests/UI/test_console_shell_chip_actions.py
@@ -17,6 +17,7 @@ from tldw_chatbook.Widgets.Console.console_status_chips import (
     ConsoleAssistantChip,
     ConsoleChip,
     ConsoleModelChip,
+    ConsoleRagChip,
 )
 
 _CSS = (
@@ -44,6 +45,19 @@ def test_assistant_chip_is_an_action_chip():
             binding.key == action for binding in ConsoleAssistantChip.BINDINGS
         ), action
     assert hasattr(ConsoleAssistantChip, "OpenRequested")
+
+
+@pytest.mark.unit
+def test_rag_chip_is_an_action_chip():
+    """The RAG chip opens the Library RAG settings modal (user request
+    2026-08-01): "RAG: off" must be an entry point into enabling it, not
+    an inert status label."""
+    for action in ("enter", "space"):
+        assert any(
+            binding.key == action for binding in ConsoleRagChip.BINDINGS
+        ), action
+    assert issubclass(ConsoleRagChip, ConsoleChip)
+    assert hasattr(ConsoleRagChip, "OpenRequested")
 
 
 @pytest.mark.unit
@@ -98,6 +112,7 @@ def test_screen_subscribes_to_both_new_chip_messages():
     for handler_name, chip in (
         ("_console_model_chip_activated", ConsoleModelChip),
         ("_console_assistant_chip_activated", ConsoleAssistantChip),
+        ("_console_rag_chip_activated", ConsoleRagChip),
     ):
         handler = getattr(ChatScreen, handler_name, None)
         assert handler is not None, handler_name

--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -446,11 +446,15 @@ async def test_console_control_bar_exposes_compact_visible_actions():
             "#console-control-settings",
             "#console-control-attach-context",
             "#console-control-run-library-rag",
-            "#console-control-save-chatbook",
             "#console-control-help",
         ):
             action = console.query_one(selector)
             assert _is_displayed(action), selector
+        # Save Chatbook left the top strip (user request 2026-08-01): it was
+        # disabled at rest for most sessions, spending an always-visible
+        # slot on an almost-always-inert control. The ☰ composer menu and
+        # the Inspector's Artifacts row are the surviving surfaces.
+        assert not list(console.query("#console-control-save-chatbook"))
         assert console.query_one("#console-control-settings").disabled is False
         assert console.query_one("#console-control-attach-context").disabled is False
         assert console.query_one("#console-control-run-library-rag").disabled is False
@@ -859,7 +863,6 @@ def test_console_workbench_state_exposes_core_actions_visibly():
         provider_blocker_copy="",
         can_send=True,
         can_stop=False,
-        can_save_chatbook=True,
     )
 
     actions = {action.id: action for action in state.actions}
@@ -869,20 +872,20 @@ def test_console_workbench_state_exposes_core_actions_visibly():
         "Settings",
         "Attach context",
         "Run Library RAG",
-        "Save Chatbook",
         "Help",
     } <= action_labels
+    # Save Chatbook is deliberately absent: it left the top strip for the
+    # ☰ composer menu and the Inspector's Artifacts row.
+    assert "Save Chatbook" not in action_labels
     assert tuple(actions) == (
         "new-tab",
         "settings",
         "attach-context",
         "run-library-rag",
-        "save-chatbook",
         "send",
         "stop",
         "help",
     )
-    assert actions["save-chatbook"].disabled is False
     assert actions["send"].disabled is False
     assert actions["send"].primary is True
     assert actions["stop"].disabled is True
@@ -926,7 +929,6 @@ def test_console_workbench_state_hides_recovery_banner_when_provider_blocked():
         provider_action_label="Choose model",
         can_send=False,
         can_stop=False,
-        can_save_chatbook=False,
     )
 
     assert state.recovery is None
@@ -1027,7 +1029,6 @@ def test_console_workbench_state_disables_send_when_provider_is_blocked():
         provider_blocker_copy="Provider setup needed: choose a model",
         can_send=True,
         can_stop=True,
-        can_save_chatbook=True,
         density="compact",
     )
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -7126,18 +7126,16 @@ class ChatScreen(BaseAppScreen):
             callback=self._apply_console_rag_settings_choice,
         )
 
-    def _apply_console_rag_settings_choice(
-        self, result: ConsoleRagSettingsResult | None
-    ) -> None:
-        """Store the modal's query and optionally run retrieval now.
+    def _set_console_library_rag_query(self, query: str) -> None:
+        """Store the Library RAG query and mirror it into mounted surfaces.
 
-        Mirrors the query into the Inspector's readiness-card input when it
-        is mounted, so the two surfaces cannot disagree about what will be
-        retrieved.
+        Every query write goes through here so the Inspector's
+        readiness-card input, its Run button gating, and the RAG settings
+        modal's next prefill cannot disagree about what will be retrieved.
+
+        Args:
+            query: Already-sanitized retrieval query ("" clears it).
         """
-        if result is None:
-            return
-        query = _sanitize_console_library_rag_query(result.query)
         self._console_library_rag_query = query
         try:
             rail_input = self.query_one("#console-library-rag-query-input", Input)
@@ -7151,6 +7149,16 @@ class ChatScreen(BaseAppScreen):
             pass
         else:
             run_button.disabled = not query
+
+    def _apply_console_rag_settings_choice(
+        self, result: ConsoleRagSettingsResult | None
+    ) -> None:
+        """Store the modal's query and optionally run retrieval now."""
+        if result is None:
+            return
+        self._set_console_library_rag_query(
+            _sanitize_console_library_rag_query(result.query)
+        )
         if result.run:
             self._run_console_library_rag_from_visible_action()
 
@@ -12251,8 +12259,27 @@ class ChatScreen(BaseAppScreen):
         self._run_console_library_rag_from_visible_action()
 
     def _run_console_library_rag_from_visible_action(self) -> None:
-        """Request Library retrieval from the visible Console action surface."""
+        """Request Library retrieval from the visible Console action surface.
+
+        With no dedicated query set, falls back to the composer draft (user
+        decision 2026-08-02): the text about to be sent is what retrieval
+        should look for, and the dedicated query input may not even be on
+        screen while this always-visible action is. The fallback is STORED
+        through ``_set_console_library_rag_query`` so the rail input and
+        the RAG settings modal agree with what actually ran. An explicit
+        query always wins; the empty-everything warning survives.
+        """
         query = _sanitize_console_library_rag_query(self._console_library_rag_query)
+        if not query:
+            composer = self._console_composer_or_none()
+            draft_query = (
+                _sanitize_console_library_rag_query(composer.draft_text())
+                if composer is not None
+                else ""
+            )
+            if draft_query:
+                self._set_console_library_rag_query(draft_query)
+                query = draft_query
         if not query:
             self.app_instance.notify(
                 CONSOLE_LIBRARY_RAG_QUERY_EMPTY_MESSAGE,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -361,9 +361,14 @@ from ...Widgets.Console.console_generation_card import (
     ConsoleGenerationCardSpec,
     generation_card_signature,
 )
+from ...Widgets.Console.console_rag_settings_modal import (
+    ConsoleRagSettingsModal,
+    ConsoleRagSettingsResult,
+)
 from ...Widgets.Console.console_status_chips import (
     ConsoleModelChip,
     ConsoleAssistantChip,
+    ConsoleRagChip,
     ConsoleScopeChip,
     ConsoleStatusChips,
     ConsoleTemporaryChip,
@@ -1899,8 +1904,6 @@ class ChatScreen(BaseAppScreen):
             self._set_console_rail_preference(left_open=True)
         elif action_id == "run-library-rag":
             self._run_console_library_rag_from_visible_action()
-        elif action_id == "save-chatbook":
-            self._save_console_chatbook_from_visible_action()
         elif action_id == "send":
             await self._send_console_message_from_visible_action()
         elif action_id == "stop":
@@ -7086,6 +7089,71 @@ class ChatScreen(BaseAppScreen):
         event.stop()
         await self._open_console_character_picker()
 
+    @on(ConsoleRagChip.OpenRequested)
+    def _console_rag_chip_activated(
+        self, event: ConsoleRagChip.OpenRequested
+    ) -> None:
+        """Open Library RAG settings from the RAG chip."""
+        event.stop()
+        self._open_console_rag_settings()
+
+    def _open_console_rag_settings(self) -> None:
+        """Open the Library RAG settings modal, prefilled with the best query.
+
+        The prefill prefers the query already set through any RAG surface;
+        with none set, it falls back to the composer draft -- the text the
+        user is about to send is usually exactly what retrieval should look
+        for, and it was the missing link when "Run Library RAG" demanded a
+        query while the composer visibly held one.
+        """
+        prefill = self._console_library_rag_query
+        if not prefill:
+            composer = self._console_composer_or_none()
+            if composer is not None:
+                prefill = _sanitize_console_library_rag_query(composer.draft_text())
+        pending = self._pending_console_launch_context
+        self.app.push_screen(
+            ConsoleRagSettingsModal(
+                query=prefill,
+                scope_label=self._console_library_rag_scope_label(),
+                # Matches the chip exactly: the chip's "RAG: on" derives from
+                # this same pending-launch source test.
+                rag_active=_source_mentions_rag(
+                    pending.source if pending else None
+                ),
+                staged_title=(pending.title if pending else ""),
+            ),
+            callback=self._apply_console_rag_settings_choice,
+        )
+
+    def _apply_console_rag_settings_choice(
+        self, result: ConsoleRagSettingsResult | None
+    ) -> None:
+        """Store the modal's query and optionally run retrieval now.
+
+        Mirrors the query into the Inspector's readiness-card input when it
+        is mounted, so the two surfaces cannot disagree about what will be
+        retrieved.
+        """
+        if result is None:
+            return
+        query = _sanitize_console_library_rag_query(result.query)
+        self._console_library_rag_query = query
+        try:
+            rail_input = self.query_one("#console-library-rag-query-input", Input)
+        except QueryError:
+            pass
+        else:
+            rail_input.value = query
+        try:
+            run_button = self.query_one("#console-run-library-rag", Button)
+        except QueryError:
+            pass
+        else:
+            run_button.disabled = not query
+        if result.run:
+            self._run_console_library_rag_from_visible_action()
+
     async def _open_console_character_picker(self) -> None:
         """Load characters off-thread and open the picker modal (task-1672)."""
         options = await asyncio.to_thread(self._console_character_picker_options)
@@ -11665,7 +11733,6 @@ class ChatScreen(BaseAppScreen):
             provider_action_label=action_label,
             can_send=can_send,
             can_stop=can_stop,
-            can_save_chatbook=self._console_chatbook_action_available(),
             density=self._console_workbench_density(),
             run_active=self._console_run_active(),
             ephemeral=self._console_active_session_is_ephemeral(),

--- a/tldw_chatbook/Widgets/Console/console_control_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_control_bar.py
@@ -22,7 +22,6 @@ TOP_ACTION_IDS = {
     "settings",
     "attach-context",
     "run-library-rag",
-    "save-chatbook",
     "help",
 }
 CONSOLE_CONTROL_ACTION_WIDGET_IDS = {
@@ -30,7 +29,6 @@ CONSOLE_CONTROL_ACTION_WIDGET_IDS = {
     "settings": "console-control-settings",
     "attach-context": "console-control-attach-context",
     "run-library-rag": "console-control-run-library-rag",
-    "save-chatbook": "console-control-save-chatbook",
     "help": "console-control-help",
 }
 FALLBACK_ACTIONS = (

--- a/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
@@ -1,0 +1,208 @@
+"""Library RAG settings: the RAG chip's enable-and-customize modal.
+
+"RAG: off" in the Console status strip is not a latent toggle -- the chip
+reads "on" once retrieved Library evidence is staged for the next send.
+This modal is where a user makes that happen: it owns the retrieval query
+(the same state the visible "Run Library RAG" actions read) and runs the
+retrieval that stages evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.events import Click
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Static
+
+
+@dataclass(frozen=True)
+class ConsoleRagSettingsResult:
+    """Outcome of the Library RAG settings modal.
+
+    Attributes:
+        query: The retrieval query as typed (the screen sanitizes it).
+        run: Whether to run Library retrieval now with that query.
+    """
+
+    query: str
+    run: bool
+
+
+class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
+    """Edit the Library RAG query and optionally run retrieval now."""
+
+    DEFAULT_CSS = """
+    ConsoleRagSettingsModal {
+        align: center middle;
+    }
+
+    #console-rag-settings {
+        width: 64;
+        height: auto;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    .console-rag-settings-status {
+        margin: 0 0 1 0;
+    }
+
+    #console-rag-settings-query {
+        margin: 0 0 1 0;
+    }
+
+    .console-rag-settings-scope {
+        color: $text-muted;
+        margin: 0 0 1 0;
+    }
+
+    .console-rag-settings-actions {
+        height: 3;
+    }
+
+    .console-rag-settings-actions Button {
+        margin: 0 2 0 0;
+    }
+
+    .console-rag-settings-hint {
+        color: $text-muted;
+        margin: 1 0 0 0;
+    }
+    """
+
+    BINDINGS = [("escape", "dismiss_modal", "Cancel")]
+
+    def __init__(
+        self,
+        *,
+        query: str = "",
+        scope_label: str = "",
+        rag_active: bool = False,
+        staged_title: str = "",
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the modal.
+
+        Args:
+            query: Prefill for the retrieval query input.
+            scope_label: Read-only source-scope line (e.g. ``"Scope: notes,
+                media, conversations"``).
+            rag_active: Whether RAG currently reads "on" (staged evidence).
+            staged_title: Title of the staged evidence when ``rag_active``,
+                for honest status copy.
+            **kwargs: Forwarded to ``ModalScreen``.
+        """
+        super().__init__(**kwargs)
+        self._query = query
+        self._scope_label = scope_label
+        self._rag_active = rag_active
+        self._staged_title = staged_title
+
+    def _status_copy(self) -> str:
+        """Return honest RAG-state copy for the top of the modal."""
+        if self._rag_active:
+            staged = f" ({self._staged_title})" if self._staged_title else ""
+            return (
+                f"RAG is on: retrieved Library evidence{staged} is staged "
+                "for your next send. Running again replaces it."
+            )
+        return (
+            "RAG is off. It turns on once you run retrieval and Library "
+            "evidence is staged for your next send."
+        )
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="console-rag-settings"):
+            yield Static("Library RAG", classes="console-modal-header")
+            yield Static(
+                self._status_copy(),
+                classes="console-rag-settings-status",
+                markup=False,
+            )
+            yield Input(
+                value=self._query,
+                placeholder="What should Library retrieval look for?",
+                id="console-rag-settings-query",
+            )
+            if self._scope_label:
+                yield Static(
+                    self._scope_label,
+                    id="console-rag-settings-scope",
+                    classes="console-rag-settings-scope",
+                    markup=False,
+                )
+            with Horizontal(classes="console-rag-settings-actions"):
+                yield Button(
+                    "Run Library RAG",
+                    id="console-rag-settings-run",
+                    variant="primary",
+                    disabled=not self._query.strip(),
+                )
+                yield Button("Cancel", id="console-rag-settings-cancel")
+            yield Static(
+                "Enter runs retrieval. Esc or a click outside closes "
+                "without changes.",
+                classes="console-rag-settings-hint",
+                markup=False,
+            )
+
+    def _current_query(self) -> str:
+        return self.query_one("#console-rag-settings-query", Input).value
+
+    @on(Input.Changed, "#console-rag-settings-query")
+    def _sync_run_availability(self, event: Input.Changed) -> None:
+        """Keep the Run action gated on a non-blank query."""
+        event.stop()
+        run_button = self.query_one("#console-rag-settings-run", Button)
+        run_button.disabled = not str(event.value or "").strip()
+
+    @on(Input.Submitted, "#console-rag-settings-query")
+    def _submit_query(self, event: Input.Submitted) -> None:
+        """Enter in the query input runs retrieval, matching the hint copy."""
+        event.stop()
+        query = self._current_query()
+        if not query.strip():
+            return
+        self.dismiss(ConsoleRagSettingsResult(query=query, run=True))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id or ""
+        if button_id == "console-rag-settings-run":
+            event.stop()
+            self.dismiss(
+                ConsoleRagSettingsResult(query=self._current_query(), run=True)
+            )
+            return
+        if button_id == "console-rag-settings-cancel":
+            event.stop()
+            self.dismiss(None)
+
+    def on_click(self, event: Click) -> None:
+        """Dismiss with no changes when a click lands on the backdrop.
+
+        Same contract as the composer ☰ menu: containment is tested against
+        the modal box's region, and a click that carries no screen
+        coordinates (synthesized clicks under textual-web) keeps the modal
+        open rather than guessing.
+
+        Args:
+            event: The screen-level click, carrying absolute coordinates.
+        """
+        screen_x = getattr(event, "screen_x", None)
+        screen_y = getattr(event, "screen_y", None)
+        if screen_x is None or screen_y is None:
+            return
+        box = self.query_one("#console-rag-settings")
+        if box.region.contains(screen_x, screen_y):
+            return
+        event.stop()
+        self.dismiss(None)
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)

--- a/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_rag_settings_modal.py
@@ -118,6 +118,14 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         )
 
     def compose(self) -> ComposeResult:
+        """Build the modal: status copy, query input, scope line, actions.
+
+        The Run action composes disabled when the prefill is blank and is
+        kept in step by the ``Input.Changed`` handler below.
+
+        Yields:
+            The modal's child widgets.
+        """
         with Vertical(id="console-rag-settings"):
             yield Static("Library RAG", classes="console-modal-header")
             yield Static(
@@ -172,6 +180,11 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         self.dismiss(ConsoleRagSettingsResult(query=query, run=True))
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Dismiss with the run result for Run, or no changes for Cancel.
+
+        Args:
+            event: The pressed action button.
+        """
         button_id = event.button.id or ""
         if button_id == "console-rag-settings-run":
             event.stop()
@@ -205,4 +218,5 @@ class ConsoleRagSettingsModal(ModalScreen["ConsoleRagSettingsResult | None"]):
         self.dismiss(None)
 
     def action_dismiss_modal(self) -> None:
+        """Close without changes (Escape), matching the hint copy."""
         self.dismiss(None)

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -143,6 +143,35 @@ class ConsoleScopeChip(ConsoleChip):
         self.post_message(self.OpenRequested())
 
 
+class ConsoleRagChip(ConsoleChip):
+    """RAG readiness chip that opens the Library RAG settings modal.
+
+    Same activation contract as the sibling action chips: Enter/Space while
+    focused, or a click. "RAG: off" is not a latent toggle the chip could
+    flip in place -- RAG reads "on" once retrieved Library evidence is
+    staged for the next send -- so activation opens the modal where the
+    user sets the retrieval query and runs it.
+    """
+
+    BINDINGS = [
+        Binding(
+            "enter", "open_rag_settings", "Open Library RAG settings", show=False
+        ),
+        Binding(
+            "space", "open_rag_settings", "Open Library RAG settings", show=False
+        ),
+    ]
+
+    class OpenRequested(Message):
+        """Posted when the RAG chip is activated from keyboard or mouse."""
+
+    def action_open_rag_settings(self) -> None:
+        self.post_message(self.OpenRequested())
+
+    def _on_click(self, event: events.Click) -> None:
+        self.post_message(self.OpenRequested())
+
+
 class ConsoleTemporaryChip(ConsoleChip):
     """Temporary-chat chip that doubles as the "Save this chat" action.
 
@@ -255,7 +284,11 @@ class ConsoleStatusChips(Horizontal):
             id="console-assistant-chip",
             chip_class=ConsoleAssistantChip,
         )
-        yield self._chip(self.state.rag_label, id="console-rag-chip")
+        yield self._chip(
+            self.state.rag_label,
+            id="console-rag-chip",
+            chip_class=ConsoleRagChip,
+        )
         yield self._chip(
             self.state.sources_label,
             id="console-sources-chip",

--- a/tldw_chatbook/Widgets/Console/console_workbench_state.py
+++ b/tldw_chatbook/Widgets/Console/console_workbench_state.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from tldw_chatbook.Chat.console_display_state import ConsoleControlState
-from tldw_chatbook.Chat.console_ephemeral import blocked_reason
 from tldw_chatbook.UI.Workbench.workbench_state import (
     Density,
     WorkbenchAction,
@@ -21,7 +20,6 @@ def build_console_workbench_state(
     provider_action_label: str = "Open Settings",
     can_send: bool = False,
     can_stop: bool = False,
-    can_save_chatbook: bool = False,
     density: str = "normal",
     run_active: bool = False,
     ephemeral: bool = False,
@@ -41,10 +39,12 @@ def build_console_workbench_state(
             call sites do not need to change.
         can_send: Whether the visible composer draft can be sent.
         can_stop: Whether an active generation can be stopped.
-        can_save_chatbook: Whether the current session can be saved as a Chatbook.
         density: Requested Workbench density, currently ``normal`` or ``compact``.
-        ephemeral: Whether the active session is temporary, which blocks the
-            actions that would write a derived artifact to disk.
+        ephemeral: Whether the active session is temporary. Retained for
+            callers even though no top action reads it today: Save Chatbook
+            (the last consumer) left this strip for the ☰ composer menu and
+            the Inspector's Artifacts row, which carry their own
+            temporary-chat block.
 
     Returns:
         Immutable shared Workbench state used by Console widgets.
@@ -53,8 +53,12 @@ def build_console_workbench_state(
     workbench_density: Density = "compact" if density == "compact" else "normal"
     provider_status = "blocked" if blocker else "ready"
     send_available = can_send and not blocker
-    chatbook_blocked = blocked_reason("save-chatbook", ephemeral=ephemeral)
 
+    # Save Chatbook is deliberately absent here: as a top-strip button it
+    # was disabled at rest for most sessions (no artifact yet), spending a
+    # always-visible slot on an almost-always-inert control. The action
+    # stays reachable from the ☰ composer menu and the Inspector's
+    # Artifacts row, both of which carry availability copy.
     actions = (
         WorkbenchAction(
             id="new-tab",
@@ -75,12 +79,6 @@ def build_console_workbench_state(
             id="run-library-rag",
             label="Run Library RAG",
             tooltip="Search Library evidence before sending",
-        ),
-        WorkbenchAction(
-            id="save-chatbook",
-            label="Save Chatbook",
-            tooltip=chatbook_blocked or "Save this run as a Chatbook",
-            disabled=chatbook_blocked is not None or not can_save_chatbook,
         ),
         WorkbenchAction(
             id="send",


### PR DESCRIPTION
## What

Two user-requested Console control changes, plus the investigation that motivated the second.

### 1. Save Chatbook leaves the top control strip

The `New tab · Settings · Attach context · Run Library RAG · Help` strip no longer carries Save Chatbook: it sat disabled at rest for most sessions, spending an always-visible slot on an almost-always-inert control. Removed end-to-end (workbench action, control-bar registry, dead dispatch arm), not just hidden. Its two surviving surfaces — the ☰ composer menu row and the Inspector's Artifacts row — each carry availability copy and their own temporary-chat block, and both are pinned by tests.

### 2. "RAG: off" is now an action chip that opens a Library RAG settings modal

**Investigation first** (the user hit "Type a Library RAG query before running retrieval" with text sitting in the composer): the top-bar Run Library RAG action reads `_console_library_rag_query`, which is fed by exactly one widget — a small input at the bottom of the right Inspector rail, hidden whenever the rail is collapsed or evidence is staged. The composer draft was never consulted, so the always-visible button depended on a usually-invisible input. Also: "RAG: on/off" was never a setting — it reports whether staged live-work evidence came from a RAG source.

**The chip fix:** `RAG: off` follows the established Provider/Model/Character action-chip contract (Enter/Space/click) and opens a new `ConsoleRagSettingsModal` that:

- states honestly what "on" means (retrieved Library evidence staged for the next send; shows the staged item's title when on),
- owns the retrieval query — prefilled from the query set through any RAG surface, else **from the composer draft**,
- shows the retrieval scope, and
- runs retrieval through the existing `_run_console_library_rag_from_visible_action` seam (Enter or the primary button; Esc/backdrop close without changes, matching the ☰ menu's backdrop contract including the coordinate-less-click guard).

The modal's query mirrors into the Inspector readiness-card input when mounted, so the two surfaces cannot disagree.

Deliberately NOT changed without a follow-up decision: the top-bar button's own empty-query toast (it could instead fall back to the composer draft, or open this modal).

## Verification

- 14 new/updated tests: modal gating/result/backdrop/Enter-submit, chip activation contract + screen `@on` subscription, control-strip absence pins, workbench-state action tuple, gate15 contract updated to the new Save surfaces.
- Touched suites green post-rebase. The only failures anywhere are the two `test_console_workbench_contract.py` approvals tests broken on `origin/dev` by PR #1192 (verified identical on a pristine dev checkout; untouched by this diff).
- Live-verified in the real TUI: strip without Save Chatbook; chip click opens the modal prefilled with the composer draft; running flips the strip to `RAG: on · Sources: 1 staged` with the staged card; reopening shows the on-state copy. (Note: activating buttons *inside* modals via tmux-synthesized SGR clicks silently no-ops — the shipped first-run wizard shows the same behavior — so the button path is verified via real pilot clicks and the Enter path live.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Save Chatbook from the top control strip and turned the RAG chip into an action that opens a Library RAG settings modal. The Run Library RAG button now falls back to the composer draft when no query is set to keep retrieval easy and consistent.

- **New Features**
  - RAG chip opens a modal to edit the retrieval query and run Library RAG.
  - Prefills from existing RAG state, else the composer draft; mirrors into the Inspector input and gates Run.
  - Shows scope and honest on/off copy; Enter runs; Esc/backdrop dismiss.
  - Visible Run falls back to the composer draft when no query is set; stores it so all surfaces agree; explicit queries still win; the empty warning only shows when both are blank.

- **Refactors**
  - Removed Save Chatbook from the top strip; use the ☰ composer menu or Inspector Artifacts.
  - Deleted the `save-chatbook` workbench action and its dispatch path.
  - Added `ConsoleRagChip` and a screen handler; updated control bar and tests.
  - Added docstrings to `ConsoleRagSettingsModal` public methods.

<sup>Written for commit 8e970284e77688636feca73a7906c16ce8350136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

