### PR TITLE
Streaming PCM sink: interruptible TTS playback (voice V3, phase 1)

### DIFF
--- a/Docs/Features/Speech-Services-Guide.md
+++ b/Docs/Features/Speech-Services-Guide.md
@@ -423,6 +423,51 @@ nothing on its own. Without this rule, playback still running at capture
 start would be picked up by the open mic and transcribed into the new
 draft.
 
+**Streaming playback.** Spoken feedback (and Console **Speak**, same speech
+pipeline) can play some responses live through the audio device instead of
+waiting on a finished file.
+
+*What streams today.* Only the audio.cpp adapter's response is eligible —
+its complete PCM16-WAV body validates as a playable stream. tldw_chatbook
+still writes that response to a temporary artifact exactly as before, but
+the instant it validates, playback moves to the live device and the
+now-redundant temp file is discarded immediately instead of being kept for
+file-based playback. That makes playback interruptible at the device — a
+new capture or a new utterance cuts audio within roughly two audio blocks
+instead of waiting on a file — and leaves nothing on disk to replay or
+export for that turn. Latency to first sound is unchanged: audio.cpp still
+delivers one complete WAV per request, not incremental chunks, so there is
+no "starts talking sooner" win here, only the interruptibility one.
+
+*What still falls back byte-identically to the pre-streaming path* — same
+temp file, same file-based playback, same everything:
+
+- Every legacy-bridge provider (openai, elevenlabs, kokoro, chatterbox,
+  alltalk, higgs, ...) — that bridge never populates a response sample
+  rate, and without one the sink cannot open. Unblocking these is a filed,
+  three-leg follow-up (plumb a sample rate onto legacy-bridge responses,
+  add a caller-scoped raw-PCM request option, and add a PCM-safe legacy
+  fallback) — none of it has shipped yet, so do not expect these providers
+  to stream.
+- Any compressed format (MP3, Opus, AAC, FLAC).
+- `sounddevice` not installed, or the sink otherwise unavailable.
+- A device failure at open or mid-stream.
+
+*Numbers.* Playback becomes audible once 300 ms of audio is buffered; an
+interrupting stop reaches silence within 2 audio blocks — about 40 ms at
+the default 20 ms block size — by aborting the output stream rather than
+draining it.
+
+*No configuration changed.* `dictation.spoken_feedback` and the `[app_tts]`
+settings above behave exactly as documented; this is an internal delivery
+upgrade for responses the sink already recognized as safe, not a new
+setting.
+
+*For test authors.* Every test is guarded against opening a real audio
+device by default (`Tests/conftest.py`'s autouse `_no_real_audio_device`
+fixture patches out the `sounddevice` import); a test that genuinely needs
+real hardware must opt out with `@pytest.mark.real_audio_device`.
+
 ## Voice Commands
 
 ### Built-in Commands
@@ -816,5 +861,5 @@ max_identifier_characters = 256
 
 ---
 
-**Last Updated**: 2026-07-29
-**Version**: 2.4 (Console voice control V2: spoken commands and spoken feedback)
+**Last Updated**: 2026-08-02
+**Version**: 2.5 (streaming spoken-feedback playback for audio.cpp responses)

--- a/Docs/Features/Speech-Services-Guide.md
+++ b/Docs/Features/Speech-Services-Guide.md
@@ -445,7 +445,7 @@ temp file, same file-based playback, same everything:
 - Every legacy-bridge provider (openai, elevenlabs, kokoro, chatterbox,
   alltalk, higgs, ...) — that bridge never populates a response sample
   rate, and without one the sink cannot open. Unblocking these is a filed,
-  three-leg follow-up (plumb a sample rate onto legacy-bridge responses,
+  three-leg follow-up (TASK-1880) (plumb a sample rate onto legacy-bridge responses,
   add a caller-scoped raw-PCM request option, and add a PCM-safe legacy
   fallback) — none of it has shipped yet, so do not expect these providers
   to stream.

--- a/Docs/superpowers/plans/2026-08-01-streaming-pcm-sink.md
+++ b/Docs/superpowers/plans/2026-08-01-streaming-pcm-sink.md
@@ -1,0 +1,765 @@
+# Streaming PCM Sink Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An interruptible streaming audio-output service (`StreamingPcmSink`) with a
+response-eligibility seam, proven by converting Console spoken feedback to play TTS audio
+as it generates.
+
+**Architecture:** A headless sounddevice-backed sink (callback thread pulls int16 PCM from
+a bounded thread-safe buffer; prebuffer before audibility; `abort()`-backed stop with a
+≤2-block latency contract) + a pure `sink_plan(response)` seam that inspects what the
+shared TTS path already produced (raw PCM or validated PCM16-WAV → sink; anything else →
+legacy file path unchanged) + one consumer branch inside the existing TTS generation
+worker. Spec: `Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md` (read it
+before Task 1; it is binding).
+
+**Tech Stack:** Python ≥3.11, sounddevice (existing `speech_recording` extra), pytest.
+
+## Global Constraints
+
+- `Audio/streaming_sink.py` has NO Textual imports and NEVER imports `sounddevice` at
+  module scope — lazy import inside `open()`; `sink_available()` probes via
+  `importlib.util.find_spec` only.
+- `stop()` reaches audible silence within **2 audio blocks** of returning, implemented via
+  `stream.abort()` (never `stream.stop()`, which drains). Pinned by test.
+- Audible playback starts only after **`PREBUFFER_MS = 300`** of audio is buffered OR
+  `close()` was called first.
+- `feed()` never blocks; buffer cap = **60 seconds** at the opened rate; `False` +
+  `SinkBufferFull` (once per episode) when full.
+- Events are frozen dataclasses, no Textual: `SinkStarted`, `SinkDrained`, `SinkStopped`,
+  `SinkBufferFull`, `SinkUnderrun(count)` (throttled ≥1s apart), `SinkFailed(reason)`.
+- The device callback NEVER raises.
+- The seam branches on the RESPONSE (format/rate/stream), never on provider names.
+- The legacy whole-file path stays byte-identical when the seam returns `None`, when
+  `sink_available()` is False, or when the sink fails at `open()`.
+- The consumer branch (including `open()`) runs inside the existing TTS generation worker
+  — never inline in an App `@on` handler.
+- No new config keys. `dictation.spoken_feedback` semantics unchanged.
+- Foreground pytest only: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <files> -q -p no:randomly`; never whole directories. Conventional commits ending
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Never push. Never `git stash`.
+  Never `git checkout --` a file with uncommitted work (three incidents this programme).
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `tldw_chatbook/Audio/streaming_sink.py` (create) | `StreamingPcmSink`, events, `sink_available()`, one-voice registry, `pump` |
+| `tldw_chatbook/TTS/pcm_stream.py` (create) | `SinkPlan`, `sink_plan(response)` — pure response inspection |
+| `tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py` (modify) | streaming branch in the generation worker; stop-handler extension |
+| `Tests/Audio/test_streaming_sink.py` (create) | sink contract tests (fake stream factory) |
+| `Tests/Audio/test_streaming_sink_pump.py` (create) | `pump` + one-voice tests |
+| `Tests/TTS/test_pcm_stream_plan.py` (create) | seam eligibility tests |
+| `Tests/TTS_Events/test_spoken_feedback_streaming.py` (create) | consumer branch + fallback pins |
+| `Docs/Features/Speech-Services-Guide.md` (modify) | one section: streaming playback + fallback truth |
+
+Verified anchors an implementer needs (current dev):
+`TTS_Generation.py:332` (`lease.adapter.synthesize`), `TTS/adapter_types.py:352`
+(`TTSAudioResponse`: `byte_stream`, `audio_format`, `sample_rate`),
+`TTS/audio_cpp_contract.py:412` (`validate_pcm16_wav(body) -> Pcm16WavInfo`),
+`tts_events.py:392` (`handle_tts_request`), `:669` (`_admit_tts_generation`), `:717`
+(`_generate_tts_with_rate_limit`, the worker body), `:1336` (`handle_tts_playback`),
+`:1349` (`play_audio_file(audio_file)`), `:1374` (stop action), `openai.py:135/:184/:229`
+(pcm streaming), `kokoro.py:551-582` (int16 chunk yield).
+
+---
+
+### Task 1: `StreamingPcmSink` core
+
+**Files:**
+- Create: `tldw_chatbook/Audio/streaming_sink.py`
+- Test: `Tests/Audio/test_streaming_sink.py`
+
+**Interfaces:**
+- Consumes: nothing (headless).
+- Produces (Tasks 2–4 rely on these exact names):
+  `StreamingPcmSink(on_event: Callable[[object], None], blocksize_ms: int = 20,
+  stream_factory: Callable[..., Any] | None = None)`;
+  methods `open(sample_rate: int, channels: int = 1) -> None`,
+  `feed(pcm: bytes) -> bool`, `close() -> None`, `stop() -> None`;
+  properties `state: str` (`"idle"|"open"|"draining"|"stopped"|"failed"`),
+  `buffered_seconds: float`; module constants `PREBUFFER_MS = 300`,
+  `BUFFER_CAP_SECONDS = 60`; events `SinkStarted`, `SinkDrained`, `SinkStopped`,
+  `SinkBufferFull`, `SinkUnderrun(count: int)`, `SinkFailed(reason: str)`.
+
+The `stream_factory` seam is the testability spine: production default builds a
+`sounddevice.OutputStream` (lazy import inside `open()`); tests inject a fake. The fake
+drives the callback SYNCHRONOUSLY from the test (deterministic clock — no sleeps):
+
+- [ ] **Step 1: Write the failing contract tests** (`Tests/Audio/test_streaming_sink.py`):
+
+```python
+"""Contract tests for StreamingPcmSink against a deterministic fake stream.
+
+The fake exposes `tick(n_blocks)` which invokes the sink's registered
+callback exactly as PortAudio would: (outdata, frames, time_info, status).
+No wall-clock sleeps anywhere -- latency contracts are counted in BLOCKS.
+"""
+import numpy as np
+
+from tldw_chatbook.Audio.streaming_sink import (
+    BUFFER_CAP_SECONDS, PREBUFFER_MS, SinkBufferFull, SinkDrained, SinkFailed,
+    SinkStarted, SinkStopped, SinkUnderrun, StreamingPcmSink,
+)
+
+RATE = 24000
+BLOCK_MS = 20
+FRAMES = RATE * BLOCK_MS // 1000          # 480 frames/block
+BLOCK_BYTES = FRAMES * 2                  # int16 mono
+
+
+class FakeStream:
+    def __init__(self, callback, samplerate, channels, blocksize):
+        self.callback = callback
+        self.blocksize = blocksize
+        self.started = False
+        self.aborted = False
+        self.stopped_via_drain = False
+        self.out = []                      # bytes actually "played"
+
+    def start(self):  self.started = True
+    def abort(self):  self.aborted = True
+    def stop(self):   self.stopped_via_drain = True   # the WRONG stop; must stay unused
+    def close(self):  pass
+
+    def tick(self, n=1):
+        for _ in range(n):
+            if self.aborted:
+                return
+            out = np.zeros((self.blocksize, 1), dtype=np.int16)
+            self.callback(out, self.blocksize, None, None)
+            self.out.append(out.tobytes())
+
+
+def _mk(events):
+    holder = {}
+    def factory(*, samplerate, channels, blocksize, callback):
+        holder["s"] = FakeStream(callback, samplerate, channels, blocksize)
+        return holder["s"]
+    sink = StreamingPcmSink(on_event=events.append, blocksize_ms=BLOCK_MS,
+                            stream_factory=factory)
+    return sink, holder
+
+
+def _pcm(n_blocks: int, value: int = 7) -> bytes:
+    return np.full(FRAMES * n_blocks, value, dtype=np.int16).tobytes()
+
+
+def test_prebuffer_holds_silence_until_threshold_then_starts():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    s = h["s"]
+    sink.feed(_pcm(1))                       # 20ms buffered < 300ms
+    s.tick(2)
+    assert all(chunk == b"\x00" * BLOCK_BYTES for chunk in s.out), "audible before prebuffer"
+    assert not any(isinstance(e, SinkStarted) for e in events)
+    sink.feed(_pcm(15))                      # now 320ms buffered
+    s.tick(1)
+    assert s.out[-1] != b"\x00" * BLOCK_BYTES
+    assert any(isinstance(e, SinkStarted) for e in events)
+
+
+def test_close_before_threshold_plays_short_utterance():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(2))                       # 40ms only
+    sink.close()                             # end of stream => play it anyway
+    h["s"].tick(1)
+    assert h["s"].out[-1] != b"\x00" * BLOCK_BYTES
+
+
+def test_stop_aborts_within_contract_and_never_drains():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(30))
+    h["s"].tick(1)
+    sink.stop()
+    assert h["s"].aborted is True
+    assert h["s"].stopped_via_drain is False, "stream.stop() drains; contract requires abort()"
+    assert any(isinstance(e, SinkStopped) for e in events)
+    before = len(h["s"].out)
+    h["s"].tick(2)
+    assert len(h["s"].out) == before, "callback ran after abort"
+
+
+def test_drain_emits_after_last_real_block():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    sink.close()
+    h["s"].tick(20)                          # 16 real + trailing zero-fill
+    kinds = [type(e).__name__ for e in events]
+    assert kinds.index("SinkStarted") < kinds.index("SinkDrained")
+    assert not any(isinstance(e, SinkUnderrun) for e in events), "post-close zero-fill is drain, not underrun"
+
+
+def test_underrun_after_start_is_counted_and_throttled():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16)); h["s"].tick(16)     # started, buffer now empty, NOT closed
+    h["s"].tick(5)                            # 5 empty callbacks
+    unders = [e for e in events if isinstance(e, SinkUnderrun)]
+    assert unders and unders[-1].count >= 5
+    assert len(unders) <= 2, "underrun events must be throttled, not per-callback"
+
+
+def test_feed_caps_and_reports_once():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    cap_blocks = BUFFER_CAP_SECONDS * 1000 // BLOCK_MS
+    assert sink.feed(_pcm(cap_blocks)) is True
+    assert sink.feed(_pcm(1)) is False
+    assert sink.feed(_pcm(1)) is False
+    assert sum(isinstance(e, SinkBufferFull) for e in events) == 1
+
+
+def test_callback_never_raises_even_when_emit_explodes():
+    def bomb(_e):  raise RuntimeError("emit failed")
+    sink = StreamingPcmSink(on_event=bomb, blocksize_ms=BLOCK_MS,
+                            stream_factory=lambda **kw: FakeStream(**kw))
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    sink._stream.tick(20)                    # would raise through callback if unguarded
+
+
+def test_open_without_sounddevice_and_no_factory_fails_cleanly(monkeypatch):
+    import tldw_chatbook.Audio.streaming_sink as mod
+    events = []
+    monkeypatch.setattr(mod, "_import_sounddevice", lambda: None)
+    sink = StreamingPcmSink(on_event=events.append)
+    sink.open(sample_rate=RATE)
+    assert sink.state == "failed"
+    assert any(isinstance(e, SinkFailed) for e in events)
+```
+
+- [ ] **Step 2: Run to verify failure**
+  `… -m pytest Tests/Audio/test_streaming_sink.py -q -p no:randomly`
+  Expected: `ModuleNotFoundError`/`ImportError` for `streaming_sink`.
+
+- [ ] **Step 3: Implement `tldw_chatbook/Audio/streaming_sink.py`.** Core shape (write
+  real docstrings per repo style; this is the load-bearing logic, not a sketch):
+
+```python
+from __future__ import annotations
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from importlib.util import find_spec
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+PREBUFFER_MS = 300
+BUFFER_CAP_SECONDS = 60
+_UNDERRUN_THROTTLE_BLOCKS = 50   # >= 1s at 20ms blocks
+
+
+@dataclass(frozen=True)
+class SinkStarted: ...
+@dataclass(frozen=True)
+class SinkDrained: ...
+@dataclass(frozen=True)
+class SinkStopped: ...
+@dataclass(frozen=True)
+class SinkBufferFull: ...
+@dataclass(frozen=True)
+class SinkUnderrun:
+    count: int
+@dataclass(frozen=True)
+class SinkFailed:
+    reason: str
+
+
+def sink_available() -> bool:
+    return find_spec("sounddevice") is not None
+
+
+def _import_sounddevice():
+    try:
+        import sounddevice
+        return sounddevice
+    except Exception:
+        return None
+
+
+class StreamingPcmSink:
+    def __init__(self, *, on_event, blocksize_ms: int = 20, stream_factory=None):
+        self._emit_cb = on_event
+        self._blocksize_ms = blocksize_ms
+        self._factory = stream_factory
+        self._lock = threading.Lock()
+        self._buf: deque[bytes] = deque()      # arbitrary-size chunks
+        self._buffered_bytes = 0
+        self._leftover = b""                   # partial block carried between callbacks
+        self._state = "idle"
+        self._audible = False
+        self._closed = False
+        self._cap_bytes = 0
+        self._prebuffer_bytes = 0
+        self._bytes_per_frame = 2
+        self._full_reported = False
+        self._underruns = 0
+        self._underrun_last_emit_block = -10**9
+        self._block_index = 0
+        self._stream: Any = None
+
+    # -- emit is fire-and-forget and NEVER raises into audio code paths
+    def _emit(self, event) -> None:
+        try:
+            self._emit_cb(event)
+        except Exception:
+            logger.opt(exception=True).debug("sink event emit failed")
+
+    def open(self, sample_rate: int, channels: int = 1) -> None:
+        with self._lock:
+            if self._state != "idle":
+                return
+            frames_per_block = sample_rate * self._blocksize_ms // 1000
+            self._bytes_per_frame = 2 * channels
+            self._cap_bytes = BUFFER_CAP_SECONDS * sample_rate * self._bytes_per_frame
+            self._prebuffer_bytes = PREBUFFER_MS * sample_rate * self._bytes_per_frame // 1000
+        _register_live_sink(self)              # one-voice (Task 2 wires displacement)
+        factory = self._factory
+        if factory is None:
+            sd = _import_sounddevice()
+            if sd is None:
+                self._fail("audio output unavailable (sounddevice not installed)")
+                return
+            def factory(**kw):
+                return sd.OutputStream(
+                    samplerate=kw["samplerate"], channels=kw["channels"],
+                    blocksize=kw["blocksize"], dtype="int16",
+                    callback=lambda outdata, frames, t, status:
+                        kw["callback"](outdata, frames, t, status),
+                )
+        try:
+            self._stream = factory(samplerate=sample_rate, channels=channels,
+                                   blocksize=frames_per_block, callback=self._callback)
+            self._stream.start()
+        except Exception as exc:
+            self._fail(f"audio device open failed: {exc}")
+            return
+        with self._lock:
+            self._state = "open"
+
+    def feed(self, pcm: bytes) -> bool:
+        with self._lock:
+            if self._state not in ("open", "draining") or self._closed:
+                return False
+            if self._buffered_bytes + len(pcm) > self._cap_bytes:
+                report = not self._full_reported
+                self._full_reported = True
+            else:
+                self._buf.append(pcm)
+                self._buffered_bytes += len(pcm)
+                return True
+        if report:
+            self._emit(SinkBufferFull())
+        return False
+
+    def close(self) -> None:
+        with self._lock:
+            if self._state != "open":
+                return
+            self._closed = True
+            self._state = "draining"
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._state in ("stopped", "failed", "idle"):
+                self._state = "stopped" if self._state == "idle" else self._state
+                return
+            self._state = "stopped"
+            self._buf.clear(); self._buffered_bytes = 0; self._leftover = b""
+        stream, self._stream = self._stream, None
+        if stream is not None:
+            try:
+                stream.abort()                 # NEVER stream.stop(): that drains
+                stream.close()
+            except Exception:
+                logger.opt(exception=True).debug("sink abort raised")
+        _clear_live_sink(self)
+        self._emit(SinkStopped())
+
+    def _fail(self, reason: str) -> None:
+        with self._lock:
+            self._state = "failed"
+            self._buf.clear(); self._buffered_bytes = 0
+        _clear_live_sink(self)
+        self._emit(SinkFailed(reason=reason))
+
+    # PortAudio callback -- MUST NOT raise, MUST stay allocation-light.
+    def _callback(self, outdata, frames, _time, _status) -> None:
+        try:
+            need = frames * self._bytes_per_frame
+            with self._lock:
+                if self._state not in ("open", "draining"):
+                    outdata[:] = 0
+                    return
+                if not self._audible:
+                    if self._buffered_bytes >= self._prebuffer_bytes or self._closed:
+                        self._audible = True
+                        started = True
+                    else:
+                        outdata[:] = 0
+                        return
+                else:
+                    started = False
+                chunk = self._take_locked(need)
+                drained = self._closed and self._buffered_bytes == 0 and not self._leftover
+            if started:
+                self._emit(SinkStarted())
+            if chunk:
+                out = memoryview(outdata).cast("B")
+                out[: len(chunk)] = chunk
+                if len(chunk) < need:
+                    out[len(chunk):] = b"\x00" * (need - len(chunk))
+            else:
+                outdata[:] = 0
+                if self._audible and not drained:
+                    self._note_underrun()
+            if drained:
+                with self._lock:
+                    if self._state == "draining":
+                        self._state = "stopped"
+                        emit_drain = True
+                    else:
+                        emit_drain = False
+                if emit_drain:
+                    _clear_live_sink(self)
+                    self._emit(SinkDrained())
+            self._block_index += 1
+        except Exception:
+            # Swallow EVERYTHING: a raise here kills the PortAudio thread.
+            try:
+                outdata[:] = 0
+            except Exception:
+                pass
+            self._fail("audio callback error")
+
+    def _take_locked(self, need: int) -> bytes:
+        # caller holds self._lock
+        parts = [self._leftover] if self._leftover else []
+        have = len(self._leftover)
+        self._leftover = b""
+        while have < need and self._buf:
+            c = self._buf.popleft()
+            self._buffered_bytes -= len(c)
+            parts.append(c); have += len(c)
+        blob = b"".join(parts)
+        if len(blob) > need:
+            self._leftover = blob[need:]
+            self._buffered_bytes += 0  # leftover tracked separately from cap on purpose
+            blob = blob[:need]
+        return blob
+
+    def _note_underrun(self) -> None:
+        self._underruns += 1
+        if self._block_index - self._underrun_last_emit_block >= _UNDERRUN_THROTTLE_BLOCKS:
+            self._underrun_last_emit_block = self._block_index
+            self._emit(SinkUnderrun(count=self._underruns))
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def buffered_seconds(self) -> float:
+        with self._lock:
+            denom = self._cap_bytes / BUFFER_CAP_SECONDS if self._cap_bytes else 1
+            return self._buffered_bytes / denom
+```
+
+  Plus module-level `_LIVE_SINK` holder with `_register_live_sink`/`_clear_live_sink`
+  no-op stubs (Task 2 gives them displacement semantics; Task 1 keeps them inert so these
+  tests don't depend on Task 2).
+
+- [ ] **Step 4: Run to green.** Same command. All 8 tests pass.
+
+- [ ] **Step 5: Mutation checks (evidence in your report, restore byte-identical via file
+  copy):** (a) replace `stream.abort()` with `stream.stop()` →
+  `test_stop_aborts_within_contract_and_never_drains` fails; (b) remove the prebuffer gate
+  (make `_audible` start True) → `test_prebuffer_holds_silence_until_threshold_then_starts`
+  fails; (c) remove the try/except in `_callback` → `test_callback_never_raises…` fails.
+
+- [ ] **Step 6: ruff + commit** `feat(audio): add the interruptible streaming PCM sink`.
+
+---
+
+### Task 2: one-voice registry + `pump`
+
+**Files:**
+- Modify: `tldw_chatbook/Audio/streaming_sink.py`
+- Test: `Tests/Audio/test_streaming_sink_pump.py`
+
+**Interfaces:**
+- Produces: `async pump(sink: StreamingPcmSink, chunks: AsyncIterator[bytes],
+  *, skip_bytes: int = 0) -> PumpResult`; frozen `PumpResult(outcome: str, bytes_fed: int)`
+  with outcome in `{"drained","stopped","failed","source_error"}`; real
+  `_register_live_sink` displacement (opening a sink `stop()`s the previously live one).
+
+- [ ] **Step 1: Failing tests** (`Tests/Audio/test_streaming_sink_pump.py`) — reuse
+  Task 1's `FakeStream`/`_mk` helpers via import from the Task-1 test module:
+
+```python
+import asyncio
+import numpy as np
+import pytest
+
+from Tests.Audio.test_streaming_sink import FRAMES, RATE, FakeStream, _mk, _pcm
+from tldw_chatbook.Audio.streaming_sink import PumpResult, SinkStopped, pump
+
+
+async def _aiter(chunks, delay_between=0):
+    for c in chunks:
+        if delay_between:
+            await asyncio.sleep(0)
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_pump_feeds_everything_closes_and_reports_drained():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    result_task = asyncio.ensure_future(pump(sink, _aiter([_pcm(8), _pcm(8)])))
+    await asyncio.sleep(0)                     # let pump feed
+    h["s"].tick(20)                            # drain everything
+    result = await result_task
+    assert result.outcome == "drained"
+    assert result.bytes_fed == len(_pcm(8)) * 2
+
+
+@pytest.mark.asyncio
+async def test_pump_skip_bytes_drops_wav_header():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    header = b"RIFF" + b"\x00" * 40            # 44 bytes
+    body = _pcm(16)
+    task = asyncio.ensure_future(pump(sink, _aiter([header + body[:100], body[100:]]),
+                                      skip_bytes=44))
+    await asyncio.sleep(0)
+    h["s"].tick(1)
+    played = b"".join(h["s"].out)
+    assert b"RIFF" not in played
+    sink.stop(); await task
+
+
+@pytest.mark.asyncio
+async def test_pump_exits_promptly_when_sink_stopped_midstream():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+
+    async def endless():
+        while True:
+            await asyncio.sleep(0)
+            yield _pcm(1)
+
+    task = asyncio.ensure_future(pump(sink, endless()))
+    await asyncio.sleep(0)
+    sink.stop()
+    result = await asyncio.wait_for(task, timeout=1.0)
+    assert result.outcome == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_pump_source_error_stops_sink_and_reports():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+
+    async def broken():
+        yield _pcm(1)
+        raise ValueError("backend died")
+
+    result = await pump(sink, broken())
+    assert result.outcome == "source_error"
+    assert any(isinstance(e, SinkStopped) for e in events)
+
+
+def test_opening_a_second_sink_displaces_the_first():
+    e1, e2 = [], []
+    s1, h1 = _mk(e1)
+    s1.open(sample_rate=RATE)
+    s2, h2 = _mk(e2)
+    s2.open(sample_rate=RATE)
+    assert s1.state == "stopped", "one-voice: prior sink must be stopped on new open"
+    assert h1["s"].aborted is True
+    assert s2.state == "open"
+```
+
+- [ ] **Step 2: Run to verify failure** (no `pump`, inert registry).
+- [ ] **Step 3: Implement.** `pump` loop: skip `skip_bytes` across chunk boundaries; on
+  `feed(...) is False` → `await asyncio.sleep(0.05)` and retry the same remainder; break
+  when `sink.state in ("stopped","failed")` → outcome accordingly; on source exception →
+  `sink.stop()` + `"source_error"`; on normal exhaustion → `sink.close()` + wait via
+  polling `sink.state == "stopped"` with `await asyncio.sleep(0.01)` (fake ticks advance
+  from the test thread) → `"drained"` (or `"failed"`/`"stopped"` if that arrived first).
+  Registry: module `_LIVE_SINK: StreamingPcmSink | None` + `threading.Lock`;
+  `_register_live_sink(new)` swaps and `stop()`s the displaced sink OUTSIDE the lock.
+- [ ] **Step 4: Green.** Both files:
+  `… Tests/Audio/test_streaming_sink.py Tests/Audio/test_streaming_sink_pump.py -q -p no:randomly`
+- [ ] **Step 5: Mutation:** remove the displaced-`stop()` call → displacement test fails.
+- [ ] **Step 6: ruff + commit** `feat(audio): pump helper and one-voice displacement`.
+
+---
+
+### Task 3: `sink_plan` response seam
+
+**Files:**
+- Create: `tldw_chatbook/TTS/pcm_stream.py`
+- Test: `Tests/TTS/test_pcm_stream_plan.py`
+
+**Interfaces:**
+- Consumes: `TTS/adapter_types.py:352` `TTSAudioResponse` (`audio_format: str`,
+  `sample_rate: int | None`, `byte_stream`), `TTS/audio_cpp_contract.py:412`
+  `validate_pcm16_wav(body: bytes) -> Pcm16WavInfo` (raises on invalid).
+- Produces: frozen `SinkPlan(sample_rate: int, channels: int, skip_bytes: int)`;
+  `sink_plan(audio_format: str, sample_rate: int | None, first_bytes: bytes | None,
+  channels: int | None = None) -> SinkPlan | None`.
+  (Plain values, not the response object: the consumer may hold either an adapter
+  `TTSAudioResponse` or the backend path's format string — the seam stays pure and
+  import-light either way.)
+
+- [ ] **Step 1: Failing tests:**
+
+```python
+import struct
+
+from tldw_chatbook.TTS.pcm_stream import SinkPlan, sink_plan
+
+
+def _wav_header(rate=22050, channels=1, data=b"\x00\x00" * 64):
+    hdr = b"RIFF" + struct.pack("<I", 36 + len(data)) + b"WAVEfmt " + \
+        struct.pack("<IHHIIHH", 16, 1, channels, rate, rate * channels * 2,
+                    channels * 2, 16) + b"data" + struct.pack("<I", len(data))
+    return hdr + data
+
+
+def test_raw_pcm_with_rate_is_eligible():
+    assert sink_plan("pcm", 24000, None) == SinkPlan(24000, 1, 0)
+
+
+def test_raw_pcm_without_rate_is_not():
+    assert sink_plan("pcm", None, None) is None
+
+
+def test_valid_pcm16_wav_is_eligible_with_header_skip():
+    plan = sink_plan("wav", None, _wav_header())
+    assert plan is not None
+    assert plan.sample_rate == 22050 and plan.channels == 1 and plan.skip_bytes == 44
+
+
+def test_invalid_wav_falls_back():
+    assert sink_plan("wav", None, b"RIFFgarbage") is None
+
+
+def test_compressed_formats_fall_back():
+    for fmt in ("mp3", "opus", "aac", "flac", ""):
+        assert sink_plan(fmt, 24000, None) is None
+```
+
+- [ ] **Step 2: verify failure. Step 3: implement** — `"pcm"` needs an explicit
+  `sample_rate` (channels default 1, or the passed value); `"wav"` needs `first_bytes`
+  that `validate_pcm16_wav` accepts (wrap in try/except → `None`), plan from the returned
+  `Pcm16WavInfo` (`sample_rate`, `channels`) with `skip_bytes = 44` — confirm the info
+  object's actual field for the data offset and use it if present rather than the literal.
+  Everything else → `None`. No provider names anywhere.
+- [ ] **Step 4: green. Step 5: mutation** — accept `"mp3"` → compressed test fails.
+- [ ] **Step 6: ruff + commit** `feat(tts): response-eligibility seam for the streaming sink`.
+
+---
+
+### Task 4: consumer — Console spoken feedback streams
+
+**Files:**
+- Modify: `tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py`
+- Test: `Tests/TTS_Events/test_spoken_feedback_streaming.py`
+
+**Interfaces:**
+- Consumes: everything above, exactly as named.
+
+This is the risk task; work INSIDE the existing worker seam. Read
+`_generate_tts_with_rate_limit` (:717) end-to-end first: it runs in the generation worker,
+produces the audio (adapter or backend path), writes the file, then playback goes through
+`play_audio_file` (:1349). The branch goes where the audio bytes/stream and their format
+are FIRST in hand, before file-writing:
+
+1. Compute once: `streaming_ok = sink_available() and plan is not None` where `plan` is
+   built from the in-hand format metadata (+ first chunk for wav). If the provider
+   advertised `"pcm"` (openai path, `openai.py:184`), the request already asked for it —
+   add that request-side tweak in the SAME function where `response_format` is chosen for
+   spoken-feedback requests, guarded so ONLY requests that will hit the sink branch ask
+   for pcm (a failed sink probe must leave the request unchanged).
+2. Streaming branch: post the existing stop routine (the same call the `:1374` stop action
+   runs) to silence legacy playback; construct
+   `StreamingPcmSink(on_event=self._post_sink_event)` where `_post_sink_event` wraps
+   `self.post_message`-safe delivery (follow how dictation events marshal to the UI
+   thread); `sink.open(plan.sample_rate, plan.channels)`; on open failure (`state ==
+   "failed"`) → fall through to the legacy path for THIS utterance; else
+   `await pump(sink, stream, skip_bytes=plan.skip_bytes)` and return — the legacy
+   file-write/play must NOT also run.
+3. `handle_tts_playback` (:1336): in the `action == "stop"` handling (both the
+   message-scoped `:1374` branch and the global stop), additionally `stop()` the live sink
+   via a new module-level `stop_live_sink()` helper exported from `streaming_sink.py`
+   (returns silently when none).
+4. Fallback pins (the tests): with `sink_available()` False → the legacy path runs with
+   BYTE-IDENTICAL behavior (pin by asserting `play_audio_file` called with the same file
+   and no sink constructed); with a compressed-format provider → same; with sink open
+   failure injected → legacy runs and exactly one failure toast surfaces through the
+   existing error path.
+
+- [ ] **Step 1: Failing tests.** Build on the existing fixtures in `Tests/TTS_Events/`
+  (enumerate the directory; reuse its app/mixin harness — if none exists for
+  `handle_tts_request`, drive `_generate_tts_with_rate_limit` directly with a stub service
+  the way `Tests/TTS_Events/` files stub TTSService). Cases: (a) pcm response streams
+  through a fake sink (inject `stream_factory` via monkeypatching
+  `streaming_sink._import_sounddevice` is NOT enough — patch `StreamingPcmSink` in the
+  consumer module namespace with a recording fake), asserting NO file playback happened;
+  (b) mp3 response → legacy `play_audio_file` called, no sink; (c) sink open-failure →
+  legacy path used; (d) `TTSPlaybackEvent("stop")` stops the live sink (fake registered);
+  (e) spoken-feedback request asks `pcm` only when the sink probe passes.
+- [ ] **Step 2: verify failures. Step 3: implement.** Keep the diff inside
+  `tts_events.py` minimal and comment WHY the branch sits before file-write.
+- [ ] **Step 4: green** — new file + `Tests/UI/test_console_dictation_streaming.py`
+  (spoken-feedback pins live there) + any `Tests/TTS_Events/` files touching playback.
+- [ ] **Step 5: mutation** — (a) make the streaming branch also fall through to file
+  playback → test (a) fails (double audio); (b) drop the stop-handler sink call → (d)
+  fails.
+- [ ] **Step 6: ruff + commit** `feat(tts): stream Console spoken feedback through the PCM sink`.
+
+---
+
+### Task 5: docs + verification sweep
+
+**Files:**
+- Modify: `Docs/Features/Speech-Services-Guide.md`
+
+- [ ] **Step 1:** Add a "Streaming playback" subsection under the spoken-feedback docs:
+  what streams (pcm/PCM16-WAV responses), what falls back (compressed formats,
+  sounddevice absent, device failure), the prebuffer (300 ms) and stop latency (≤2
+  blocks ≈ 40 ms) numbers, and that no config changed.
+- [ ] **Step 2: Full named-file sweep**, exact counts per file:
+  `Tests/Audio/test_streaming_sink.py Tests/Audio/test_streaming_sink_pump.py
+  Tests/TTS/test_pcm_stream_plan.py Tests/TTS_Events/test_spoken_feedback_streaming.py
+  Tests/UI/test_console_dictation_streaming.py Tests/UI/test_console_dictation.py
+  Tests/Chat/test_console_voice_input.py` plus every existing `Tests/TTS_Events/` file.
+- [ ] **Step 3:** Confirm `Tests/UI/test_console_dictation.py` diff vs branch base is
+  EMPTY (V1 contract file).
+- [ ] **Step 4: commit** `docs(speech): document streaming spoken-feedback playback`.
+- [ ] **Step 5 (controller, not implementer):** live gate — real app, spoken feedback on,
+  read-back audibly streams; starting a capture mid-read-back cuts audio instantly.
+
+## Out of scope (repeat of spec)
+
+Streaming decode for compressed formats; the hands-free loop (next spec); briefings
+adoption; pause/duck; resampling; settings UI.

--- a/Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md
+++ b/Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md
@@ -22,10 +22,13 @@ playback in tens of milliseconds. V4 (realtime API) cannot exist without the sam
   mono int16 LE.
 - `TTS/backends/kokoro.py` already yields int16 PCM chunks with an explicit sample rate
   (:551-582, `np.int16(samples * 32767).tobytes()`).
-- audio.cpp is NOT a `TTS/backends/` backend: it lives in the newer adapter layer
-  (`TTS/adapters/audio_cpp.py` via `adapter_bootstrap.py`) and is absent from the backend
-  registry the shared TTS generation path uses -- so the proving consumer cannot reach it
-  today. It is therefore OUT of this phase's seam (see Out of scope).
+- The shared TTS generation path now routes through the ADAPTER layer
+  (`TTS_Generation.py` :332, `lease.adapter.synthesize(...)`), and the adapter contract
+  already returns a stream: `TTSAudioResponse` (adapter_types.py :352) carries
+  `byte_stream: AsyncIterator[bytes]`, `audio_format`, and `sample_rate`. audio.cpp is a
+  first-class adapter whose response is a VALIDATED PCM16 WAV delivered as a
+  complete-WAV stream (`TTS/adapters/audio_cpp.py` :42/:498-:508). (An earlier draft of
+  this spec excluded audio.cpp on stale evidence -- a pre-merge boot log; corrected.)
 - Console spoken feedback (`ChatScreen._speak_status`, chat_screen.py :5219) posts
   `TTSRequestEvent(text)`; capture-start silencing posts `TTSPlaybackEvent(action="stop")`
   (:6395). The conversion point is therefore the `TTSRequestEvent` consumer and the existing
@@ -36,10 +39,11 @@ playback in tens of milliseconds. V4 (realtime API) cannot exist without the sam
 One new headless module and one new seam module; one consumer converted.
 
 ```
-TTS backends ──► TTS/pcm_stream.py (seam) ──► Audio/streaming_sink.py ──► speakers
-   (async chunk      "can provider X stream       StreamingPcmSink
-    generators)       PCM? at what rate?"         (sounddevice OutputStream)
-                          │ None → legacy whole-file path unchanged
+shared TTS path ──► TTSAudioResponse ──► TTS/pcm_stream.py (seam) ──► Audio/streaming_sink.py
+ (adapters and        byte_stream +        "is THIS RESPONSE sink-        StreamingPcmSink
+  backends, the        audio_format +       eligible PCM? at what          (sounddevice
+  normal request       sample_rate          rate/offset?"                   OutputStream)
+  path, untouched)                              │ not eligible → legacy whole-file path
 ```
 
 ### `Audio/streaming_sink.py` — `StreamingPcmSink`
@@ -93,28 +97,36 @@ sink.stop()                                 # immediate; emits SinkStopped
 - No pause, no ducking, no resampling this phase (loop spec decides whether barge-in wants
   duck; the seam supplies the true provider rate so resampling has no caller).
 
-### `TTS/pcm_stream.py` — the provider seam
+### `TTS/pcm_stream.py` — the response-eligibility seam
 
 ```python
-info = pcm_stream_info(provider)     # PcmStreamInfo(sample_rate, channels) | None
-aiter = pcm_reply_stream(text=..., provider=..., voice=..., ...)  # async chunks
+plan = sink_plan(response)   # SinkPlan(sample_rate, channels, skip_bytes) | None
 ```
 
-- Implements exactly two providers this phase: **openai** (`response_format="pcm"`,
-  24 kHz) and **kokoro** (native int16 chunks, rate from the backend). Every other
-  provider returns `None` from `pcm_stream_info` and the caller takes the legacy path.
-  The future decode adapter (mp3/opus providers) and the audio.cpp adapter-layer bridge
-  both slot in behind this seam; the sink never changes for either.
-- The seam owns any format normalization (e.g. float32→int16 stays inside the kokoro
-  backend where it already lives; the seam only asserts int16 out).
+- The seam inspects the RESPONSE the normal generation path already produced, never the
+  provider: a `TTSAudioResponse` (or the backend path's equivalent stream + format
+  metadata) is sink-eligible when its audio is raw PCM int16 (`audio_format == "pcm"`,
+  e.g. openai with `response_format="pcm"` at 24 kHz; kokoro's native int16 chunks) or a
+  validated PCM16 WAV (audio.cpp's complete-WAV delivery -- `skip_bytes` covers the
+  44-byte header; rate/channels come from the response metadata). Anything else --
+  mp3/opus/aac, unknown formats, missing sample rate -- returns `None` and the caller
+  takes the legacy whole-file path unchanged.
+- Branching AFTER synthesis means the request path (voice/character resolution,
+  admission, cooldowns) is byte-identical for both branches, and providers are never
+  enumerated: a future decode adapter extends `sink_plan`, and any adapter that starts
+  returning PCM becomes sink-eligible with zero seam changes.
+- The one request-side change: when the configured provider ADVERTISES pcm as a valid
+  response format (openai does, :184), the spoken-feedback request asks for it --
+  otherwise the request is what it always was.
 
 ## Proving consumer: Console spoken feedback
 
 The `TTSRequestEvent` consumer (`handle_tts_request`, an async `@on` handler on the App
--- tts_events.py :392/:1477, app.py :6490) gains a streaming branch: if `sink_available()`
-and `pcm_stream_info(configured_provider)` is not `None`, the branch first silences any
-legacy file playback through the existing stop routine (closing one-voice's opening-side
-hole), then opens a sink and `pump`s the reply stream through it. The whole branch --
+-- tts_events.py :392/:1477, app.py :6490) gains a streaming branch: after the shared
+path produces its response, if `sink_available()` and `sink_plan(response)` is not
+`None`, the branch first silences any legacy file playback through the existing stop
+routine (closing one-voice's opening-side hole), then opens a sink at the plan's
+rate/channels and `pump`s `byte_stream` through it (skipping `skip_bytes`). The whole branch --
 `open()` included (device init costs tens of ms) -- runs INSIDE the same shared
 TTS-generation worker the legacy path already uses, never inline in the handler: this
 repo has already been burned by App-handler work holding the message pump. Otherwise the
@@ -144,8 +156,9 @@ No new config keys. `dictation.spoken_feedback` semantics unchanged.
   ordering, callback-never-raises (fault-injecting fake), buffer cap + `SinkBufferFull`
   once, event sequences, one-voice displacement. Mutation-checked per repo discipline.
 - **`pump` tests**: backpressure retry, cancel-on-stop mid-iteration, iterator-raise path.
-- **Seam tests** with fake backends: per-provider info/stream correctness, WAV header strip,
-  `None` for non-PCM providers.
+- **Seam tests** with fake responses: pcm eligibility, PCM16-WAV eligibility with header
+  skip, `None` for compressed/unknown formats and missing rates -- no provider names
+  anywhere in the seam tests.
 - **Consumer tests**: spoken feedback through a fake sink (streaming branch), fallback
   branch byte-identical to today, capture-start stops the sink. Existing spoken-feedback
   suites keep passing unmodified where they pin the legacy path.
@@ -154,8 +167,6 @@ No new config keys. `dictation.spoken_feedback` semantics unchanged.
 
 ## Out of scope (this phase)
 
-Streaming decode for compressed-format providers; the audio.cpp adapter-layer bridge
-(unreachable from the proving consumer today, and its single-WAV response is one chunk --
-no streaming benefit until the loop needs it); the hands-free loop itself (VAD
+Streaming decode for compressed-format providers; the hands-free loop itself (VAD
 turn-taking, auto-send, barge-in — next spec, builds on this sink); briefings/other
 playback adoption; pause/duck; resampling; any settings UI.

--- a/Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md
+++ b/Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md
@@ -1,0 +1,152 @@
+# Streaming PCM Sink — design
+
+**Date:** 2026-08-01
+**Programme:** Console voice2voice, V3 phase 1 of 2 (user-decided split: sink first, then the
+hands-free loop as its own spec). V1 = PR #1085, V2 = PR #1171.
+**Decided with the user:** sink-first decomposition; PCM-capable providers only (no decode
+adapter this phase); proving consumer = Console spoken feedback.
+
+## Why
+
+`TTS/audio_player.py` plays complete files through a subprocess (`afplay`/`mpv`/`ffplay`,
+verified on dev at :65-88). It cannot begin speaking before generation finishes and cannot be
+interrupted mid-utterance with any latency guarantee. V3's hands-free loop needs both:
+spoken replies that start while the LLM is still streaming, and barge-in that silences
+playback in tens of milliseconds. V4 (realtime API) cannot exist without the same sink.
+`sounddevice` is used today only for input (`Audio/recording_service.py`).
+
+## Verified code facts this design builds on
+
+- `TTS/backends/openai.py` already streams: `generate_speech_stream` (:135) with `"pcm"` a
+  valid `response_format` (:184) chunked via `aiter_bytes` (:229-234). OpenAI PCM is 24 kHz
+  mono int16 LE.
+- `TTS/backends/kokoro.py` already yields int16 PCM chunks with an explicit sample rate
+  (:551-582, `np.int16(samples * 32767).tobytes()`).
+- audio.cpp returns one complete WAV response per request (established in the Speech
+  Playground work); its PCM payload is a single chunk after header strip.
+- Console spoken feedback (`ChatScreen._speak_status`, chat_screen.py :5219) posts
+  `TTSRequestEvent(text)`; capture-start silencing posts `TTSPlaybackEvent(action="stop")`
+  (:6395). The conversion point is therefore the `TTSRequestEvent` consumer and the existing
+  stop handler — `chat_screen.py` itself does not change.
+
+## Architecture
+
+One new headless module and one new seam module; one consumer converted.
+
+```
+TTS backends ──► TTS/pcm_stream.py (seam) ──► Audio/streaming_sink.py ──► speakers
+   (async chunk      "can provider X stream       StreamingPcmSink
+    generators)       PCM? at what rate?"         (sounddevice OutputStream)
+                          │ None → legacy whole-file path unchanged
+```
+
+### `Audio/streaming_sink.py` — `StreamingPcmSink`
+
+- **No Textual imports.** State reaches callers through an `on_event` callable injected at
+  construction (the dictation controller's proven thread-safe emit pattern; callers hand in
+  something `post_message`-shaped).
+- **`sounddevice` is imported lazily inside `open()`**, never at module scope — the repo's
+  optional-dependency import rule (`speech_recording` extra; `recording_service.py`'s
+  guarded-import precedent). A module-level `sink_available() -> bool` probe uses
+  `find_spec` only.
+- The `OutputStream` audio callback pulls int16 frames from a thread-safe buffer
+  (`deque` + lock). Buffer empty → zero-fill (silence) + throttled underrun accounting.
+  **The callback never raises**: any exception is swallowed into a `SinkFailed` event and
+  the stream is torn down from the caller side.
+- **One-voice rule:** constructing/opening a sink while another is open `stop()`s the
+  previous one (module-level registry of the single live sink). The legacy file player is
+  silenced through the existing `TTSPlaybackEvent("stop")` handler, which this phase extends
+  to also stop the live sink — no new global.
+
+### API contract
+
+```python
+sink = StreamingPcmSink(on_event=emit, blocksize_ms=20)
+sink.open(sample_rate=24000, channels=1)   # device opens; SILENT until prebuffer met
+accepted = sink.feed(pcm_bytes)            # non-blocking; False when buffer full
+sink.close()                                # no more feeds; plays out; emits SinkDrained
+sink.stop()                                 # immediate; emits SinkStopped
+```
+
+- **Prebuffer:** audible playback begins only once `PREBUFFER_MS` (300 ms) of audio is
+  buffered **or** `close()` has been called (short utterances that arrive whole play
+  immediately, exactly like today). Rationale: slower-than-realtime generation without a
+  prebuffer produces mid-utterance stutter gaps that sound broken — worse than the current
+  wait-then-play. Constant, documented, both sides contract-tested.
+- **`stop()` uses `stream.abort()`, never `stream.stop()`** — sounddevice's `stop()` drains
+  buffered audio, which would silently violate the latency contract. **Contract: audible
+  silence within 2 audio blocks (≤ ~40 ms at the default blocksize) of `stop()` returning.**
+  This number is what barge-in will rely on; it is pinned by test against the fake stream's
+  deterministic clock. `stop()` is idempotent and thread-safe from any thread.
+- **`feed()` never blocks.** Bounded buffer (60 s of audio at the opened rate); when full,
+  returns `False` and emits `SinkBufferFull` once per episode. Async callers do not poll:
+  the module provides **`async pump(sink, chunk_aiter) -> PumpResult`**, which feeds an
+  async iterator, backs off briefly on `False`, and exits cleanly (cancelling iteration)
+  the moment the sink reports stopped/failed. `PumpResult` is a frozen dataclass:
+  `outcome` (`"drained" | "stopped" | "failed" | "source_error"`) and `bytes_fed: int`.
+  `pump` is what the seam and the future V3 loop call; the sink itself stays synchronous.
+- **Events** (frozen dataclasses, no Textual): `SinkStarted` (first audible block),
+  `SinkDrained`, `SinkStopped`, `SinkBufferFull`, `SinkUnderrun(count)` (throttled, at most
+  one per second), `SinkFailed(reason)`.
+- No pause, no ducking, no resampling this phase (loop spec decides whether barge-in wants
+  duck; the seam supplies the true provider rate so resampling has no caller).
+
+### `TTS/pcm_stream.py` — the provider seam
+
+```python
+info = pcm_stream_info(provider)     # PcmStreamInfo(sample_rate, channels) | None
+aiter = pcm_reply_stream(text=..., provider=..., voice=..., ...)  # async chunks
+```
+
+- Implements exactly three providers this phase: **openai** (`response_format="pcm"`,
+  24 kHz), **kokoro** (native int16 chunks, rate from the backend), **audio.cpp** (single
+  WAV → header stripped, rate read from the header). Every other provider returns `None`
+  from `pcm_stream_info` and the caller takes the legacy path. The future decode adapter
+  (mp3/opus providers) slots in behind this seam; the sink never changes for it.
+- The seam owns any format normalization (e.g. float32→int16 stays inside the kokoro
+  backend where it already lives; the seam only asserts int16 out).
+
+## Proving consumer: Console spoken feedback
+
+The `TTSRequestEvent` consumer gains a streaming branch: if `sink_available()` and
+`pcm_stream_info(configured_provider)` is not `None`, it opens a sink and `pump`s the reply
+stream through it from the existing worker context; otherwise the current whole-file path
+runs byte-identically. The existing `TTSPlaybackEvent("stop")` handler additionally calls
+`stop()` on the live sink, making capture-start silencing immediate (V2 checklist item 7's
+"no self-transcription" window shrinks from file-player kill latency to ≤2 blocks).
+No new config keys. `dictation.spoken_feedback` semantics unchanged.
+
+## Error handling
+
+- `sounddevice` missing (extra not installed): `sink_available()` False → legacy path;
+  nothing imports the package.
+- No output device / device refuses to open: `SinkFailed` at `open()` → caller falls back
+  to the legacy path for that utterance.
+- Device vanishes mid-utterance (Bluetooth walk-off): guarded callback → `SinkFailed` →
+  utterance lost, existing playback-failure toast copy reused. No crash, no retry loop.
+- Underruns after prebuffer: zero-filled, counted, throttled event — expected during slow
+  generation, never an error.
+- A `pump` whose iterator raises: sink `stop()`ed, failure surfaced once through the
+  existing spoken-feedback error path.
+
+## Testing
+
+- **Contract tests** against an injected fake OutputStream with a deterministic clock
+  (constructor takes a stream factory; production default is sounddevice): stop-to-silence
+  ≤ 2 blocks, prebuffer both sides (threshold met vs `close()` before threshold), drain
+  ordering, callback-never-raises (fault-injecting fake), buffer cap + `SinkBufferFull`
+  once, event sequences, one-voice displacement. Mutation-checked per repo discipline.
+- **`pump` tests**: backpressure retry, cancel-on-stop mid-iteration, iterator-raise path.
+- **Seam tests** with fake backends: per-provider info/stream correctness, WAV header strip,
+  `None` for non-PCM providers.
+- **Consumer tests**: spoken feedback through a fake sink (streaming branch), fallback
+  branch byte-identical to today, capture-start stops the sink. Existing spoken-feedback
+  suites keep passing unmodified where they pin the legacy path.
+- **Live gate (human, one check):** read-back audibly plays, and starting a capture
+  mid-read-back cuts the audio instantly.
+
+## Out of scope (this phase)
+
+Streaming decode for compressed-format providers; the hands-free loop itself (VAD
+turn-taking, auto-send, barge-in — next spec, builds on this sink); briefings/other
+playback adoption; pause/duck; resampling; any settings UI.

--- a/Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md
+++ b/Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md
@@ -22,8 +22,10 @@ playback in tens of milliseconds. V4 (realtime API) cannot exist without the sam
   mono int16 LE.
 - `TTS/backends/kokoro.py` already yields int16 PCM chunks with an explicit sample rate
   (:551-582, `np.int16(samples * 32767).tobytes()`).
-- audio.cpp returns one complete WAV response per request (established in the Speech
-  Playground work); its PCM payload is a single chunk after header strip.
+- audio.cpp is NOT a `TTS/backends/` backend: it lives in the newer adapter layer
+  (`TTS/adapters/audio_cpp.py` via `adapter_bootstrap.py`) and is absent from the backend
+  registry the shared TTS generation path uses -- so the proving consumer cannot reach it
+  today. It is therefore OUT of this phase's seam (see Out of scope).
 - Console spoken feedback (`ChatScreen._speak_status`, chat_screen.py :5219) posts
   `TTSRequestEvent(text)`; capture-start silencing posts `TTSPlaybackEvent(action="stop")`
   (:6395). The conversion point is therefore the `TTSRequestEvent` consumer and the existing
@@ -98,20 +100,25 @@ info = pcm_stream_info(provider)     # PcmStreamInfo(sample_rate, channels) | No
 aiter = pcm_reply_stream(text=..., provider=..., voice=..., ...)  # async chunks
 ```
 
-- Implements exactly three providers this phase: **openai** (`response_format="pcm"`,
-  24 kHz), **kokoro** (native int16 chunks, rate from the backend), **audio.cpp** (single
-  WAV → header stripped, rate read from the header). Every other provider returns `None`
-  from `pcm_stream_info` and the caller takes the legacy path. The future decode adapter
-  (mp3/opus providers) slots in behind this seam; the sink never changes for it.
+- Implements exactly two providers this phase: **openai** (`response_format="pcm"`,
+  24 kHz) and **kokoro** (native int16 chunks, rate from the backend). Every other
+  provider returns `None` from `pcm_stream_info` and the caller takes the legacy path.
+  The future decode adapter (mp3/opus providers) and the audio.cpp adapter-layer bridge
+  both slot in behind this seam; the sink never changes for either.
 - The seam owns any format normalization (e.g. float32→int16 stays inside the kokoro
   backend where it already lives; the seam only asserts int16 out).
 
 ## Proving consumer: Console spoken feedback
 
-The `TTSRequestEvent` consumer gains a streaming branch: if `sink_available()` and
-`pcm_stream_info(configured_provider)` is not `None`, it opens a sink and `pump`s the reply
-stream through it from the existing worker context; otherwise the current whole-file path
-runs byte-identically. The existing `TTSPlaybackEvent("stop")` handler additionally calls
+The `TTSRequestEvent` consumer (`handle_tts_request`, an async `@on` handler on the App
+-- tts_events.py :392/:1477, app.py :6490) gains a streaming branch: if `sink_available()`
+and `pcm_stream_info(configured_provider)` is not `None`, the branch first silences any
+legacy file playback through the existing stop routine (closing one-voice's opening-side
+hole), then opens a sink and `pump`s the reply stream through it. The whole branch --
+`open()` included (device init costs tens of ms) -- runs INSIDE the same shared
+TTS-generation worker the legacy path already uses, never inline in the handler: this
+repo has already been burned by App-handler work holding the message pump. Otherwise the
+current whole-file path runs byte-identically. The existing `TTSPlaybackEvent("stop")` handler additionally calls
 `stop()` on the live sink, making capture-start silencing immediate (V2 checklist item 7's
 "no self-transcription" window shrinks from file-player kill latency to ≤2 blocks).
 No new config keys. `dictation.spoken_feedback` semantics unchanged.
@@ -147,6 +154,8 @@ No new config keys. `dictation.spoken_feedback` semantics unchanged.
 
 ## Out of scope (this phase)
 
-Streaming decode for compressed-format providers; the hands-free loop itself (VAD
+Streaming decode for compressed-format providers; the audio.cpp adapter-layer bridge
+(unreachable from the proving consumer today, and its single-WAV response is one chunk --
+no streaming benefit until the loop needs it); the hands-free loop itself (VAD
 turn-taking, auto-send, barge-in — next spec, builds on this sink); briefings/other
 playback adoption; pause/duck; resampling; any settings UI.

--- a/Tests/Audio/test_audio_init_lazy_import_safety.py
+++ b/Tests/Audio/test_audio_init_lazy_import_safety.py
@@ -1,0 +1,148 @@
+"""`Audio/__init__.py`'s lazy-import safety (final whole-branch review, C1).
+
+`tts_events.py`'s module-scope `from tldw_chatbook.Audio.streaming_sink
+import ...` (streaming-pcm-sink Task 4) pulls `tldw_chatbook/Audio/
+__init__.py`, which -- before this fix -- eagerly did `from
+.recording_service import AudioRecordingService, AudioRecordingError`.
+`recording_service.py` imports `sounddevice` at module scope, and
+`sounddevice`'s own `_initialize()` calls `Pa_Initialize()` AT IMPORT TIME,
+raising `PortAudioError` (NOT `ImportError`) when PortAudio cannot
+initialize (headless container, no ALSA, CoreAudio unavailable, audio
+server down). `recording_service.py`'s probe only caught `ImportError`, so
+that `PortAudioError` propagated all the way up, uncaught -- failing the
+ENTIRE APP's import for any user with the `speech_recording` extra
+installed on a machine where PortAudio can't init. Failure-mode change:
+"voice features degrade" -> "the application does not start."
+
+Fixed by extending `Audio/__init__.py`'s existing `__getattr__` lazy-export
+pattern (previously used only for the dictation stack) to also cover
+`AudioRecordingService`/`AudioRecordingError`, so importing the `Audio`
+package (or any submodule under it, including `streaming_sink`) no longer
+transitively imports `recording_service`/`sounddevice` at all -- only an
+explicit `from tldw_chatbook.Audio import AudioRecordingService` (or
+`.recording_service` directly, as every real production call site already
+does) does. Belt-and-braces: `recording_service.py`'s three backend probes
+(pyaudio/sounddevice/webrtcvad) are widened from `except ImportError` to
+`except Exception`, so even a caller that DOES eventually trigger the
+import is protected against a non-`ImportError` init failure.
+
+Both probes below run in a FRESH subprocess: the main test process has
+already imported sounddevice/`Audio` submodules many times over by the
+point any of these tests run (this repo's own suite exercises real
+dictation/streaming-sink code elsewhere), making an in-process
+`sys.modules` check meaningless either way.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_PORTAUDIO_FAILURE_FINDER = textwrap.dedent("""
+    import sys
+    import importlib.abc
+    import importlib.machinery
+
+
+    class _PortAudioError(Exception):
+        pass
+
+
+    class _FailingLoader(importlib.abc.Loader):
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            raise _PortAudioError(
+                "Error initializing PortAudio [PaErrorCode -9986]"
+            )
+
+
+    class _FailingSounddeviceFinder(importlib.abc.MetaPathFinder):
+        def find_spec(self, name, path, target=None):
+            if name == "sounddevice":
+                return importlib.machinery.ModuleSpec(name, _FailingLoader())
+            return None
+
+
+    sys.meta_path.insert(0, _FailingSounddeviceFinder())
+""")
+
+
+def _run_probe(script: str) -> subprocess.CompletedProcess:
+    """Run `script` in a fresh interpreter using the SAME venv as pytest.
+
+    `sys.executable` inside the pytest process is already this repo's
+    `.venv/bin/python`, so the subprocess sees the identical dependency
+    set -- no environment drift between the probe and the real suite.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_app_import_survives_a_portaudio_init_failure():
+    """C1 pin: the reviewer's exact reproduction, in the suite. A
+    `PortAudioError` raised from `import sounddevice` (simulating PortAudio
+    failing to initialize) must not fail `import tldw_chatbook.app` -- it
+    must degrade to "voice features unavailable", never "the application
+    does not start".
+    """
+    script = _PORTAUDIO_FAILURE_FINDER + textwrap.dedent("""
+        import tldw_chatbook.app  # noqa: F401
+        print("RESULT: APP IMPORT SUCCEEDED")
+    """)
+    result = _run_probe(script)
+    assert "RESULT: APP IMPORT SUCCEEDED" in result.stdout, (
+        f"app import failed under an injected PortAudioError "
+        f"(exit={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+def test_streaming_sink_import_alone_pulls_no_audio_backend():
+    """Import-graph pin: `Audio/streaming_sink.py` (Task 1) is deliberately
+    designed to never import `sounddevice` at module scope, probing
+    availability via `find_spec` instead -- but before this fix, merely
+    importing ANY submodule under the `Audio` package (including this one)
+    transitively pulled `recording_service`, and thus `sounddevice`/
+    `pyaudio`/`webrtcvad`, via the package's own eager `__init__.py`.
+    Confirms the fix: a fresh process that imports ONLY
+    `tldw_chatbook.Audio.streaming_sink` never loads any of the three real
+    audio backend packages.
+    """
+    script = textwrap.dedent("""
+        import sys
+        import tldw_chatbook.Audio.streaming_sink  # noqa: F401
+
+        pulled = sorted(
+            name for name in ("sounddevice", "pyaudio", "webrtcvad")
+            if name in sys.modules
+        )
+        print(f"RESULT: PULLED={pulled!r}")
+    """)
+    result = _run_probe(script)
+    assert "RESULT: PULLED=[]" in result.stdout, (
+        f"importing streaming_sink alone pulled in real audio backend "
+        f"modules (exit={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+def test_audio_recording_service_still_resolves_via_the_package():
+    """Existing call sites (`from tldw_chatbook.Audio import
+    AudioRecordingService`, e.g. `Tests/Audio/test_audio_integration.py`,
+    `test_property_based.py`) must still resolve to the real class,
+    unchanged, once it is lazily exported instead of eagerly imported.
+    """
+    from tldw_chatbook.Audio import AudioRecordingService, AudioRecordingError
+    from tldw_chatbook.Audio.recording_service import (
+        AudioRecordingService as DirectAudioRecordingService,
+        AudioRecordingError as DirectAudioRecordingError,
+    )
+
+    assert AudioRecordingService is DirectAudioRecordingService
+    assert AudioRecordingError is DirectAudioRecordingError

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -112,10 +112,20 @@ def test_underrun_after_start_is_counted_and_throttled():
     sink.open(sample_rate=RATE)
     sink.feed(_pcm(16))
     h["s"].tick(16)                          # started, buffer now empty, NOT closed
-    h["s"].tick(5)                            # 5 empty callbacks
+    h["s"].tick(5)                            # 5 empty callbacks: 1 immediate alert, no repeat yet
     unders = [e for e in events if isinstance(e, SinkUnderrun)]
-    assert unders and unders[-1].count >= 5
-    assert len(unders) <= 2, "underrun events must be throttled, not per-callback"
+    assert len(unders) == 1
+    assert unders[0].frames == 1 * FRAMES, "the immediate alert fires on the very first empty block"
+    # Cross the _UNDERRUN_THROTTLE_BLOCKS (50-block) window to force a second,
+    # genuinely-throttled report. Its value must reflect every frame missed
+    # since the sink opened -- an implementation that stopped counting after
+    # the first empty block (or that hard-codes/forgets to accumulate) would
+    # fail this, unlike a bare ">= 5" bound that a single stale event already
+    # satisfies trivially.
+    h["s"].tick(46)                          # 5 + 46 = 51 empty callbacks total
+    unders = [e for e in events if isinstance(e, SinkUnderrun)]
+    assert len(unders) == 2, "underrun events must be throttled, not per-callback"
+    assert unders[-1].frames == 51 * FRAMES, "must keep counting for the full throttle window"
 
 
 def test_feed_caps_and_reports_once():

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -1,0 +1,148 @@
+"""Contract tests for StreamingPcmSink against a deterministic fake stream.
+
+The fake exposes `tick(n_blocks)` which invokes the sink's registered
+callback exactly as PortAudio would: (outdata, frames, time_info, status).
+No wall-clock sleeps anywhere -- latency contracts are counted in BLOCKS.
+"""
+import numpy as np
+
+from tldw_chatbook.Audio.streaming_sink import (
+    BUFFER_CAP_SECONDS, SinkBufferFull, SinkFailed,
+    SinkStarted, SinkStopped, SinkUnderrun, StreamingPcmSink,
+)
+
+RATE = 24000
+BLOCK_MS = 20
+FRAMES = RATE * BLOCK_MS // 1000          # 480 frames/block
+BLOCK_BYTES = FRAMES * 2                  # int16 mono
+
+
+class FakeStream:
+    def __init__(self, callback, samplerate, channels, blocksize):
+        self.callback = callback
+        self.blocksize = blocksize
+        self.started = False
+        self.aborted = False
+        self.stopped_via_drain = False
+        self.out = []                      # bytes actually "played"
+
+    def start(self):  self.started = True
+    def abort(self):  self.aborted = True
+    def stop(self):   self.stopped_via_drain = True   # the WRONG stop; must stay unused
+    def close(self):  pass
+
+    def tick(self, n=1):
+        for _ in range(n):
+            if self.aborted:
+                return
+            out = np.zeros((self.blocksize, 1), dtype=np.int16)
+            self.callback(out, self.blocksize, None, None)
+            self.out.append(out.tobytes())
+
+
+def _mk(events):
+    holder = {}
+    def factory(*, samplerate, channels, blocksize, callback):
+        holder["s"] = FakeStream(callback, samplerate, channels, blocksize)
+        return holder["s"]
+    sink = StreamingPcmSink(on_event=events.append, blocksize_ms=BLOCK_MS,
+                            stream_factory=factory)
+    return sink, holder
+
+
+def _pcm(n_blocks: int, value: int = 7) -> bytes:
+    return np.full(FRAMES * n_blocks, value, dtype=np.int16).tobytes()
+
+
+def test_prebuffer_holds_silence_until_threshold_then_starts():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    s = h["s"]
+    sink.feed(_pcm(1))                       # 20ms buffered < 300ms
+    s.tick(2)
+    assert all(chunk == b"\x00" * BLOCK_BYTES for chunk in s.out), "audible before prebuffer"
+    assert not any(isinstance(e, SinkStarted) for e in events)
+    sink.feed(_pcm(15))                      # now 320ms buffered
+    s.tick(1)
+    assert s.out[-1] != b"\x00" * BLOCK_BYTES
+    assert any(isinstance(e, SinkStarted) for e in events)
+
+
+def test_close_before_threshold_plays_short_utterance():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(2))                       # 40ms only
+    sink.close()                             # end of stream => play it anyway
+    h["s"].tick(1)
+    assert h["s"].out[-1] != b"\x00" * BLOCK_BYTES
+
+
+def test_stop_aborts_within_contract_and_never_drains():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(30))
+    h["s"].tick(1)
+    sink.stop()
+    assert h["s"].aborted is True
+    assert h["s"].stopped_via_drain is False, "stream.stop() drains; contract requires abort()"
+    assert any(isinstance(e, SinkStopped) for e in events)
+    before = len(h["s"].out)
+    h["s"].tick(2)
+    assert len(h["s"].out) == before, "callback ran after abort"
+
+
+def test_drain_emits_after_last_real_block():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    sink.close()
+    h["s"].tick(20)                          # 16 real + trailing zero-fill
+    kinds = [type(e).__name__ for e in events]
+    assert kinds.index("SinkStarted") < kinds.index("SinkDrained")
+    assert not any(isinstance(e, SinkUnderrun) for e in events), "post-close zero-fill is drain, not underrun"
+
+
+def test_underrun_after_start_is_counted_and_throttled():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    h["s"].tick(16)                          # started, buffer now empty, NOT closed
+    h["s"].tick(5)                            # 5 empty callbacks
+    unders = [e for e in events if isinstance(e, SinkUnderrun)]
+    assert unders and unders[-1].count >= 5
+    assert len(unders) <= 2, "underrun events must be throttled, not per-callback"
+
+
+def test_feed_caps_and_reports_once():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    cap_blocks = BUFFER_CAP_SECONDS * 1000 // BLOCK_MS
+    assert sink.feed(_pcm(cap_blocks)) is True
+    assert sink.feed(_pcm(1)) is False
+    assert sink.feed(_pcm(1)) is False
+    assert sum(isinstance(e, SinkBufferFull) for e in events) == 1
+
+
+def test_callback_never_raises_even_when_emit_explodes():
+    def bomb(_e):  raise RuntimeError("emit failed")
+    sink = StreamingPcmSink(on_event=bomb, blocksize_ms=BLOCK_MS,
+                            stream_factory=lambda **kw: FakeStream(**kw))
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    sink._stream.tick(20)                    # would raise through callback if unguarded
+
+
+def test_open_without_sounddevice_and_no_factory_fails_cleanly(monkeypatch):
+    import tldw_chatbook.Audio.streaming_sink as mod
+    events = []
+    monkeypatch.setattr(mod, "_import_sounddevice", lambda: None)
+    sink = StreamingPcmSink(on_event=events.append)
+    sink.open(sample_rate=RATE)
+    assert sink.state == "failed"
+    assert any(isinstance(e, SinkFailed) for e in events)

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -4,6 +4,8 @@ The fake exposes `tick(n_blocks)` which invokes the sink's registered
 callback exactly as PortAudio would: (outdata, frames, time_info, status).
 No wall-clock sleeps anywhere -- latency contracts are counted in BLOCKS.
 """
+import threading
+
 import numpy as np
 
 from tldw_chatbook.Audio.streaming_sink import (
@@ -23,13 +25,17 @@ class FakeStream:
         self.blocksize = blocksize
         self.started = False
         self.aborted = False
+        self.abort_thread = None           # which thread called abort(), for H4
         self.stopped_via_drain = False
         self.out = []                      # bytes actually "played"
 
     def start(self):  self.started = True
-    def abort(self):  self.aborted = True
     def stop(self):   self.stopped_via_drain = True   # the WRONG stop; must stay unused
     def close(self):  pass
+
+    def abort(self):
+        self.abort_thread = threading.current_thread()
+        self.aborted = True
 
     def tick(self, n=1):
         for _ in range(n):
@@ -38,6 +44,15 @@ class FakeStream:
             out = np.zeros((self.blocksize, 1), dtype=np.int16)
             self.callback(out, self.blocksize, None, None)
             self.out.append(out.tobytes())
+            # The sink may deliver events for this block asynchronously off
+            # the calling ("callback") thread (see StreamingPcmSink's notify
+            # thread). Wait for that hand-off to fully settle -- including
+            # any reentrant call a listener makes back into the sink, e.g.
+            # stop() -- before returning, so assertions right after tick()
+            # stay deterministic without any wall-clock sleep.
+            notify_q = getattr(getattr(self.callback, "__self__", None), "_notify_q", None)
+            if notify_q is not None:
+                notify_q.join()
 
 
 def _mk(events):
@@ -146,6 +161,87 @@ def test_callback_never_raises_even_when_emit_explodes():
     sink.open(sample_rate=RATE)
     sink.feed(_pcm(16))
     sink._stream.tick(20)                    # would raise through callback if unguarded
+
+
+def test_repeated_callback_failure_reports_once_and_tears_down_stream():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    for _ in range(4):
+        sink._callback(None, FRAMES, None, None)   # outdata=None -> every write raises
+    sink._notify_q.join()                    # wait for the async teardown_and_emit job
+    fails = [e for e in events if isinstance(e, SinkFailed)]
+    assert len(fails) == 1, "SinkFailed must fire once per lifecycle, not once per callback"
+    assert sink.state == "failed"
+    assert h["s"].aborted is True, "the stream must be torn down on failure"
+
+
+def test_listener_stop_from_sink_started_does_not_abort_on_the_callback_thread():
+    events = []
+    holder = {}
+
+    def on_event(e):
+        events.append(e)
+        if isinstance(e, SinkStarted):
+            holder["sink"].stop()          # reentrant, as a real barge-in listener would do
+
+    def factory(*, samplerate, channels, blocksize, callback):
+        holder["s"] = FakeStream(callback, samplerate, channels, blocksize)
+        return holder["s"]
+
+    sink = StreamingPcmSink(on_event=on_event, blocksize_ms=BLOCK_MS, stream_factory=factory)
+    holder["sink"] = sink
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))                    # crosses the prebuffer threshold immediately
+    calling_thread = threading.current_thread()
+    holder["s"].tick(1)                    # drives SinkStarted -> listener's reentrant stop()
+
+    assert holder["s"].aborted is True
+    assert holder["s"].abort_thread is not None
+    assert holder["s"].abort_thread is not calling_thread, \
+        "stream.abort() must never run on the PortAudio callback thread"
+    kinds = [type(e).__name__ for e in events]
+    assert kinds.index("SinkStarted") < kinds.index("SinkStopped"), \
+        "SinkStopped must never be observed before the SinkStarted that caused it"
+
+
+def test_drain_tears_down_the_stream_and_stop_afterward_is_clean():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    sink.close()
+    h["s"].tick(20)                          # drains fully
+    assert h["s"].aborted is True, "a completed utterance must not leak the stream"
+    assert sink._stream is None
+    before = len(events)
+    sink.stop()                              # calling stop() after a natural drain...
+    assert not any(isinstance(e, SinkStopped) for e in events[before:]), \
+        "stop() after a natural drain must be a clean no-op, not a second terminal event"
+
+
+def test_stop_racing_open_wins_and_stream_is_never_left_running():
+    events, = ([],)
+    holder = {}
+
+    def factory(*, samplerate, channels, blocksize, callback):
+        stream = FakeStream(callback, samplerate, channels, blocksize)
+        holder["s"] = stream
+        # Simulate a stop() landing while open() is still mid-flight, i.e.
+        # after the stream object exists (and could be playing) but before
+        # open()'s trailing state="open" assignment has run.
+        holder["sink"].stop()
+        return stream
+
+    sink = StreamingPcmSink(on_event=events.append, blocksize_ms=BLOCK_MS, stream_factory=factory)
+    holder["sink"] = sink
+    sink.open(sample_rate=RATE)
+
+    assert sink.state == "stopped", "a stop() that lands mid-open() must not be overwritten"
+    assert any(isinstance(e, SinkStopped) for e in events)
+    assert holder["s"].aborted is True, "the stream open() just built must not be left running"
+    assert sink._stream is None
 
 
 def test_zero_audio_open_close_never_starts():

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -5,6 +5,7 @@ callback exactly as PortAudio would: (outdata, frames, time_info, status).
 No wall-clock sleeps anywhere -- latency contracts are counted in BLOCKS.
 """
 import threading
+import time
 
 import numpy as np
 
@@ -17,6 +18,25 @@ RATE = 24000
 BLOCK_MS = 20
 FRAMES = RATE * BLOCK_MS // 1000          # 480 frames/block
 BLOCK_BYTES = FRAMES * 2                  # int16 mono
+
+
+def _settle_notify_queue(notify_q, timeout: float = 5.0) -> None:
+    """Deadline-bounded wait for `notify_q` to fully drain.
+
+    `queue.Queue.join()` has no timeout, so a job orphaned on a dead notify
+    queue (nothing left to call `task_done()` for it -- see N2) would hang
+    this forever. Polling `unfinished_tasks` with a deadline turns that
+    hang into a fast, loud, informative test failure instead.
+    """
+    deadline = time.monotonic() + timeout
+    while notify_q.unfinished_tasks > 0:
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"notify queue did not settle within {timeout}s "
+                f"(unfinished_tasks={notify_q.unfinished_tasks}) -- "
+                "a job was likely orphaned by a race with stop()"
+            )
+        time.sleep(0.001)
 
 
 class FakeStream:
@@ -52,7 +72,7 @@ class FakeStream:
             # stay deterministic without any wall-clock sleep.
             notify_q = getattr(getattr(self.callback, "__self__", None), "_notify_q", None)
             if notify_q is not None:
-                notify_q.join()
+                _settle_notify_queue(notify_q)
 
 
 def _mk(events):
@@ -143,6 +163,58 @@ def test_underrun_after_start_is_counted_and_throttled():
     assert unders[-1].frames == 51 * FRAMES, "must keep counting for the full throttle window"
 
 
+def test_stop_during_underrun_enqueue_does_not_orphan_a_queue_item(monkeypatch):
+    """N2: _note_underrun's enqueue must be as race-safe as SinkStarted's --
+    a stop() completing in the gap around it must not orphan the underrun
+    job on a queue whose notify thread has already exited.
+
+    Forces the exact interleaving deterministically with a real background
+    thread and bounded (not open-ended) event waits: the hook signals that
+    an underrun is about to be reported and gives a concurrent stop() a
+    short, fixed window to land there. Pre-fix, the enqueue happens outside
+    the lock so stop() always wins that window and the job is orphaned.
+    Post-fix, the enqueue happens under the same lock stop() needs for its
+    own state check, so stop() simply cannot complete inside the window --
+    the wait times out (by design) and the job is safely queued first.
+    """
+    import tldw_chatbook.Audio.streaming_sink as mod
+
+    events = []
+    holder = {}
+    underrun_about_to_enqueue = threading.Event()
+    stop_finished = threading.Event()
+
+    class HookedSinkUnderrun(mod.SinkUnderrun):
+        def __init__(self, *a, **kw):
+            underrun_about_to_enqueue.set()
+            stop_finished.wait(timeout=0.3)   # bounded: never hangs the test either way
+            super().__init__(*a, **kw)
+
+    def call_stop_once_ready():
+        if underrun_about_to_enqueue.wait(timeout=2.0):
+            holder["sink"].stop()
+        stop_finished.set()
+
+    def factory(*, samplerate, channels, blocksize, callback):
+        holder["s"] = FakeStream(callback, samplerate, channels, blocksize)
+        return holder["s"]
+
+    sink = StreamingPcmSink(on_event=events.append, blocksize_ms=BLOCK_MS, stream_factory=factory)
+    holder["sink"] = sink
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    holder["s"].tick(16)     # drains the buffer fully; open, audible, not closed
+
+    stopper = threading.Thread(target=call_stop_once_ready, daemon=True)
+    stopper.start()
+    monkeypatch.setattr(mod, "SinkUnderrun", HookedSinkUnderrun)
+    holder["s"].tick(1)      # one empty callback -> triggers the hook mid-enqueue-decision
+
+    stopper.join(timeout=2.0)
+    assert not stopper.is_alive(), "stop()-calling thread leaked past the test"
+    _settle_notify_queue(sink._notify_q)   # must not hang / must not orphan (raises loudly if it does)
+
+
 def test_feed_caps_and_reports_once():
     events, = ([],)
     sink, h = _mk(events)
@@ -170,7 +242,7 @@ def test_repeated_callback_failure_reports_once_and_tears_down_stream():
     sink.feed(_pcm(16))
     for _ in range(4):
         sink._callback(None, FRAMES, None, None)   # outdata=None -> every write raises
-    sink._notify_q.join()                    # wait for the async teardown_and_emit job
+    _settle_notify_queue(sink._notify_q)     # wait for the async teardown_and_emit job
     fails = [e for e in events if isinstance(e, SinkFailed)]
     assert len(fails) == 1, "SinkFailed must fire once per lifecycle, not once per callback"
     assert sink.state == "failed"
@@ -273,6 +345,45 @@ def test_buffered_seconds_includes_leftover():
     assert round(sink.buffered_seconds, 4) == 0.32
     h["s"].tick(1)                                # consumes 1 block off the SAME chunk -> _leftover
     assert round(sink.buffered_seconds, 4) == 0.30, "leftover must be visible to buffered_seconds"
+
+
+def test_stop_between_open_state_flip_and_notify_thread_publish_does_not_leak(monkeypatch):
+    """N1: stop() landing between open()'s state="open" and its later,
+    unlocked publish of self._notify_thread must not leave a daemon thread
+    parked on queue.get() forever with no sentinel coming.
+
+    Hooks the *construction* of the threading.Thread object open() builds
+    for its notify thread -- the same "reentrant call from inside a
+    constructor" technique used for the H3 stop()-vs-open() test, aimed at
+    the narrow window between open()'s (already-committed) state flip to
+    "open" and the not-yet-executed `self._notify_thread = ...` assignment.
+    """
+    import tldw_chatbook.Audio.streaming_sink as mod
+
+    events = []
+    holder = {}
+    real_thread_cls = mod.threading.Thread
+
+    class HookedThread(real_thread_cls):
+        def __init__(self, *a, **kw):
+            holder["sink"].stop()   # reentrant, landing exactly in the N1 gap
+            super().__init__(*a, **kw)
+
+    def factory(*, samplerate, channels, blocksize, callback):
+        holder["s"] = FakeStream(callback, samplerate, channels, blocksize)
+        return holder["s"]
+
+    sink = StreamingPcmSink(on_event=events.append, blocksize_ms=BLOCK_MS, stream_factory=factory)
+    holder["sink"] = sink
+    monkeypatch.setattr(mod.threading, "Thread", HookedThread)
+    sink.open(sample_rate=RATE)
+
+    assert sink.state == "stopped"
+    assert any(isinstance(e, SinkStopped) for e in events)
+    t = sink._notify_thread
+    if t is not None:
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "notify thread parked forever without a sentinel -- N1 leak"
 
 
 def test_open_without_sounddevice_and_no_factory_fails_cleanly(monkeypatch):

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -424,6 +424,59 @@ def test_open_without_sounddevice_and_no_factory_fails_cleanly(monkeypatch):
     assert any(isinstance(e, SinkFailed) for e in events)
 
 
+@pytest.mark.parametrize("kwargs", [
+    pytest.param(dict(sample_rate="24000"), id="string-sample-rate"),
+    pytest.param(dict(sample_rate=RATE, channels="1"), id="string-channels"),
+    pytest.param(dict(sample_rate=24000.0), id="float-sample-rate"),
+    pytest.param(dict(sample_rate=0), id="zero-sample-rate"),
+    pytest.param(dict(sample_rate=-RATE), id="negative-sample-rate"),
+    pytest.param(dict(sample_rate=RATE, channels=0), id="zero-channels"),
+    pytest.param(dict(sample_rate=RATE, channels=-1), id="negative-channels"),
+    pytest.param(dict(sample_rate=True), id="bool-sample-rate"),
+])
+def test_open_with_invalid_sample_rate_or_channels_fails_closed_instead_of_raising(kwargs):
+    """F3 fix-round: `open()` documents fail-closed on any failure, but used
+    to do arithmetic on `sample_rate`/`channels` (e.g.
+    `sample_rate * blocksize_ms // 1000`) before any validation guarded it
+    -- a wrong-typed value (e.g. `"24000"`) raised a `TypeError` straight
+    out of `open()` instead of transitioning the sink to `"failed"` and
+    emitting `SinkFailed`, as documented.
+
+    Uses `_mk()`'s `FakeStream` factory -- which performs no validation of
+    its own -- rather than the real `sounddevice` backend, so this pins
+    the sink's OWN guard specifically: a numerically "valid but wrong"
+    value like `0`/`-24000` would otherwise sail straight through a
+    permissive fake factory and reach `"open"`, and a real backend
+    rejecting it would only prove PortAudio's own validation works, not
+    this method's. Asserting the factory was never invoked (`"s" not in
+    h`) confirms the guard fires before any stream is even attempted, not
+    merely that the sink ends up `"failed"` for some other reason.
+    """
+    events = []
+    sink, h = _mk(events)
+    sink.open(**kwargs)   # must not raise
+    assert sink.state == "failed"
+    assert any(isinstance(e, SinkFailed) for e in events)
+    assert sink.terminal_reason == "failed"
+    assert "s" not in h, "guard must reject before the stream factory is ever called"
+
+
+def test_open_with_invalid_sample_rate_is_a_no_op_when_not_idle():
+    """A bad `open()` call on an already-open sink must stay the documented
+    no-op -- not clobber that sink's real state via `_fail()`. Regression
+    guard for the F3 fix: validation happens after the idle-state check,
+    not before it.
+    """
+    events = []
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    assert sink.state == "open"
+    events.clear()
+    sink.open(sample_rate="garbage")   # already open -> must be a no-op
+    assert sink.state == "open"
+    assert events == []
+
+
 def test_stop_from_a_thread_with_a_blocking_listener_returns_promptly():
     """Fix-round H2 pin: `stop()` must never block waiting for the notify
     thread's queue to drain -- only `settle()` does that. A listener that

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -8,11 +8,39 @@ import threading
 import time
 
 import numpy as np
+import pytest
 
 from tldw_chatbook.Audio.streaming_sink import (
     BUFFER_CAP_SECONDS, SinkBufferFull, SinkFailed,
     SinkStarted, SinkStopped, SinkUnderrun, StreamingPcmSink,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_live_sink_registry():
+    """Fix-round L12: `_LIVE_SINK` is a process-global with no reset.
+
+    Every `open()` stops whatever sink was previously registered live, so
+    a sink left live at the end of one test silently couples the next
+    test's `open()`/displacement assertions to it, and leaks that sink's
+    notify thread for the rest of the session. Force-clear before AND
+    after every test: before, so a leftover live sink from a prior test
+    (or a prior *file's* tests, since this is a single process-global)
+    can never be silently displaced by -- or displace -- this test's own
+    sink; after, so this test cannot leak one forward.
+    """
+    import tldw_chatbook.Audio.streaming_sink as mod
+
+    def _force_clear() -> None:
+        live = mod._LIVE_SINK
+        if live is not None:
+            live.stop()   # non-joining (H2); also clears the registry itself
+        with mod._LIVE_SINK_LOCK:
+            mod._LIVE_SINK = None
+
+    _force_clear()
+    yield
+    _force_clear()
 
 RATE = 24000
 BLOCK_MS = 20
@@ -394,3 +422,47 @@ def test_open_without_sounddevice_and_no_factory_fails_cleanly(monkeypatch):
     sink.open(sample_rate=RATE)
     assert sink.state == "failed"
     assert any(isinstance(e, SinkFailed) for e in events)
+
+
+def test_stop_from_a_thread_with_a_blocking_listener_returns_promptly():
+    """Fix-round H2 pin: `stop()` must never block waiting for the notify
+    thread's queue to drain -- only `settle()` does that. A listener that
+    blocks its own event handling for 500ms must not make an unrelated
+    caller's `stop()` take anywhere near that long; the reviewer measured
+    a 4.95s event-loop freeze (and, with a real `call_from_thread`
+    round-trip, a permanent one) against the pre-fix joining `stop()`.
+
+    Drives the callback directly (not via `FakeStream.tick()`, which
+    itself calls the test-side `_settle_notify_queue` helper and would
+    defeat the point of this test by waiting for the slow listener before
+    `stop()` is even called) so the `SinkStarted` "emit" job is
+    deterministically still in flight -- the listener is inside its
+    500ms sleep -- at the moment `stop()` is called concurrently from
+    this (the test) thread.
+    """
+    events = []
+    listener_started = threading.Event()
+
+    def on_event(e):
+        events.append(e)
+        if isinstance(e, SinkStarted):
+            listener_started.set()
+            time.sleep(0.5)
+
+    def factory(*, samplerate, channels, blocksize, callback):
+        return FakeStream(callback, samplerate, channels, blocksize)
+
+    sink = StreamingPcmSink(on_event=on_event, blocksize_ms=BLOCK_MS, stream_factory=factory)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))                      # crosses the prebuffer threshold
+    out = np.zeros((FRAMES, 1), dtype=np.int16)
+    sink._callback(out, FRAMES, None, None)  # queues SinkStarted's "emit" job
+    assert listener_started.wait(timeout=2.0), "listener never started"
+
+    start = time.monotonic()
+    sink.stop()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.2, f"stop() blocked for {elapsed:.3f}s -- must never join the notify queue"
+    assert sink.settle(timeout=2.0), "notify queue never settled"
+    assert any(isinstance(e, SinkStopped) for e in events)

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -466,3 +466,85 @@ def test_stop_from_a_thread_with_a_blocking_listener_returns_promptly():
     assert elapsed < 0.2, f"stop() blocked for {elapsed:.3f}s -- must never join the notify queue"
     assert sink.settle(timeout=2.0), "notify queue never settled"
     assert any(isinstance(e, SinkStopped) for e in events)
+
+
+def test_on_event_may_be_invoked_concurrently_from_multiple_threads():
+    """Re-review fix-round N1 pin: `stop()`'s non-joining redesign (H2)
+    means a `SinkStarted` job still executing inside `on_event` on the
+    notify thread does not block a caller thread's `stop()` from
+    delivering `SinkStopped` synchronously, on ITS OWN thread, at the
+    same time -- not merely "out of order" (already pinned above by the
+    H2 test), but genuinely concurrently, inside `on_event` on two
+    threads at once. Demonstrates the contract directly (both handlers
+    entered, neither event lost) so a future change can't silently
+    narrow `on_event` back to "one thread at a time" without this test
+    noticing.
+
+    Deterministic by construction: `started_may_finish` is only set
+    AFTER `sink.stop()` (and therefore its synchronous `SinkStopped`
+    delivery) has already returned, so the `SinkStopped` handler is
+    guaranteed to observe the `SinkStarted` handler as still blocked,
+    every run -- no timing luck involved.
+    """
+    events = []
+    events_lock = threading.Lock()
+    started_entered = threading.Event()
+    started_may_finish = threading.Event()
+    entered_concurrently = threading.Event()
+
+    def on_event(e):
+        thread_name = threading.current_thread().name
+        with events_lock:
+            events.append((type(e).__name__, thread_name))
+        if isinstance(e, SinkStarted):
+            started_entered.set()
+            started_may_finish.wait(timeout=2.0)   # hold this thread inside on_event
+        elif isinstance(e, SinkStopped):
+            if started_entered.is_set() and not started_may_finish.is_set():
+                entered_concurrently.set()
+
+    def factory(*, samplerate, channels, blocksize, callback):
+        return FakeStream(callback, samplerate, channels, blocksize)
+
+    sink = StreamingPcmSink(on_event=on_event, blocksize_ms=BLOCK_MS, stream_factory=factory)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))
+    out = np.zeros((FRAMES, 1), dtype=np.int16)
+    sink._callback(out, FRAMES, None, None)  # queues SinkStarted's "emit" job
+    assert started_entered.wait(timeout=2.0), "listener never started"
+
+    sink.stop()   # SinkStopped delivered synchronously HERE, on this thread,
+                  # while the notify thread is still blocked inside SinkStarted's handler
+    started_may_finish.set()
+
+    assert entered_concurrently.is_set(), \
+        "on_event was not actually re-entered concurrently -- test failed to demonstrate the contract"
+    assert sink.settle(timeout=2.0)
+    with events_lock:
+        recorded = list(events)
+    kinds = sorted(kind for kind, _ in recorded)
+    assert kinds == ["SinkStarted", "SinkStopped"], "no event may be lost to the concurrency"
+    threads_by_kind = dict(recorded)
+    assert threads_by_kind["SinkStarted"] != threads_by_kind["SinkStopped"], \
+        "the two events must genuinely have been delivered from different threads"
+
+
+def test_settle_on_a_sink_whose_notify_thread_never_ran_returns_false_immediately():
+    """Re-review fix-round N2 pin: `stop()`-ing a sink that never
+    `open()`'d (still `"idle"`) still unconditionally pushes the exit
+    sentinel onto `_notify_q` -- but no notify thread was ever published
+    to read it, so `unfinished_tasks` stays 1 forever. `settle()` must
+    recognize "no notify thread was ever published" and return `False`
+    immediately, not burn the full `timeout` for a foregone conclusion.
+    """
+    events = []
+    sink = StreamingPcmSink(on_event=events.append, blocksize_ms=BLOCK_MS)
+    sink.stop()
+    assert sink._notify_thread is None
+
+    start = time.monotonic()
+    result = sink.settle(timeout=5.0)
+    elapsed = time.monotonic() - start
+
+    assert result is False
+    assert elapsed < 0.2, f"settle() took {elapsed:.3f}s -- must return immediately, not wait out the timeout"

--- a/Tests/Audio/test_streaming_sink.py
+++ b/Tests/Audio/test_streaming_sink.py
@@ -138,6 +138,37 @@ def test_callback_never_raises_even_when_emit_explodes():
     sink._stream.tick(20)                    # would raise through callback if unguarded
 
 
+def test_zero_audio_open_close_never_starts():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.close()                             # nothing ever fed
+    h["s"].tick(3)
+    assert all(chunk == b"\x00" * BLOCK_BYTES for chunk in h["s"].out), "silence played"
+    assert not any(isinstance(e, SinkStarted) for e in events), "nothing ever played; no SinkStarted"
+
+
+def test_leftover_counts_toward_buffer_cap():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    cap_blocks = BUFFER_CAP_SECONDS * 1000 // BLOCK_MS
+    assert sink.feed(_pcm(cap_blocks)) is True   # exactly the cap, one big chunk
+    h["s"].tick(1)                               # consumes 1 block; (cap - 1 block) becomes leftover
+    assert sink.feed(_pcm(cap_blocks)) is False, "leftover must count against the cap"
+    assert sum(isinstance(e, SinkBufferFull) for e in events) == 1
+
+
+def test_buffered_seconds_includes_leftover():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    sink.feed(_pcm(16))                          # one 320ms chunk, crosses the 300ms prebuffer
+    assert round(sink.buffered_seconds, 4) == 0.32
+    h["s"].tick(1)                                # consumes 1 block off the SAME chunk -> _leftover
+    assert round(sink.buffered_seconds, 4) == 0.30, "leftover must be visible to buffered_seconds"
+
+
 def test_open_without_sounddevice_and_no_factory_fails_cleanly(monkeypatch):
     import tldw_chatbook.Audio.streaming_sink as mod
     events = []

--- a/Tests/Audio/test_streaming_sink_pump.py
+++ b/Tests/Audio/test_streaming_sink_pump.py
@@ -21,6 +21,16 @@ failed open() must not evict a healthy live sink; L9: pump on a
 never-`open()`'d sink must still terminalize it; L10: an externally-closed
 sink must not busy-retry `feed()` forever; L11: the drain wait must have a
 deadline; L12: this fixture).
+
+Re-review fix-round additions (`task-2-review.md`'s "Fix-round re-review"
+section, verdict SPEC PASS / CODE QUALITY APPROVED with 3 follow-ups):
+pins for N3 (a `stop()` landing between `open()` winning "open" and
+registering must not leave a dead sink as the registered live one) and
+N5 (M6's source-release guarantee, previously pinned only for the
+barge-in path, also holds under cancellation). N1's pin lives in
+`test_streaming_sink.py` (it is a `StreamingPcmSink`/`on_event` contract
+test, not a `pump()` one); N2's pin lives there too (`settle()`); N4 is a
+docstring-only nit with no new test.
 """
 import asyncio
 import contextlib
@@ -354,6 +364,31 @@ async def test_pump_closes_a_class_based_source_on_early_exit():
     assert source.aclose_calls == 1
 
 
+@pytest.mark.asyncio
+async def test_pump_cancelled_mid_feed_still_closes_the_class_based_source():
+    """Re-review fix-round N5 pin: the M6 pin above only covers the
+    barge-in early exit. The cancellation path (H1's `finally`) releases
+    the source too -- `_aclose_source` runs there unconditionally, same
+    as every other exit -- but nothing held that guarantee down. Cancel
+    `pump()` mid-feed and assert `aclose()` was still called exactly
+    once despite the cancellation.
+    """
+    events = []
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    source = _RecordingAsyncSource()
+
+    task = asyncio.ensure_future(pump(sink, source))
+    for _ in range(5):
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert source.aclose_calls == 1
+    assert sink.terminal_reason is not None
+
+
 # ---------------------------------------------------------------------------
 # Fix-round Lows
 # ---------------------------------------------------------------------------
@@ -377,6 +412,56 @@ def test_failed_open_does_not_evict_the_live_sink():
     assert s2.state == "failed"
     assert s1.state == "open", "a sink that never played one sample must not evict the healthy live voice"
     assert h1["s"].aborted is False
+
+
+def test_stop_between_became_open_and_registration_does_not_leave_a_dead_sink_live(monkeypatch):
+    """Re-review fix-round N3 pin: `open()` commits `state="open"` under
+    the lock, then registers a few statements later. A `stop()` landing
+    in that gap must not leave the (now dead) sink installed as the
+    registered live one -- it would kill a healthy previously-live voice
+    for a sink that will never play (the same shape as L7, via a
+    different race) and, worse, leave a stale `_LIVE_SINK` nothing would
+    ever clear until some later `open()` happened to displace the
+    corpse.
+
+    Hooks `_register_live_sink` itself -- the exact call site `open()`
+    reaches right after committing `state == "open"` -- to call `stop()`
+    reentrantly first, the same "reentrant call from inside the thing
+    being hooked" technique Task 1's own N1/H3 races use.
+
+    Note: this does NOT prevent the previously-live sink from being
+    stopped (that stop() call already happened, inside the real
+    `_register_live_sink`, before this test's own re-check can run --
+    the re-reviewer judged that bounded, pre-existing harm acceptable,
+    same as L7's trade-off). What this pin holds is narrower and is what
+    the fix actually targets: `_LIVE_SINK` must not still be the dead
+    sink afterward.
+    """
+    import tldw_chatbook.Audio.streaming_sink as mod
+
+    e1, e2 = [], []
+    s1, h1 = _mk(e1)
+    s1.open(sample_rate=RATE)
+    assert s1.state == "open"
+
+    holder = {}
+    real_register = mod._register_live_sink
+
+    def hooked_register(sink):
+        if sink is holder.get("s2"):
+            holder["s2"].stop()   # reentrant, landing exactly in the N3 gap
+        real_register(sink)
+
+    monkeypatch.setattr(mod, "_register_live_sink", hooked_register)
+
+    s2, h2 = _mk(e2)
+    holder["s2"] = s2
+    s2.open(sample_rate=RATE)
+
+    assert s2.state == "stopped"
+    assert s2.terminal_reason == "stopped"
+    assert mod._LIVE_SINK is None, \
+        "a dead sink must not remain the registered live one -- must self-heal within this open() call"
 
 
 @pytest.mark.asyncio

--- a/Tests/Audio/test_streaming_sink_pump.py
+++ b/Tests/Audio/test_streaming_sink_pump.py
@@ -9,13 +9,48 @@ normal end-of-stream draining. The registry tests cover Task 2's other
 half: opening a new sink stops whichever sink was previously "live" (the
 one-voice contract), and MUST do so without ever touching a stream directly
 from within the registry lock (see the module docstring / task brief).
+
+Fix-round additions (coordinator review of the original Task-2 submission,
+`.superpowers/sdd/2026-08-01-streaming-pcm-sink/task-2-review.md`): pins for
+H1 (a cancelled pump must still terminalize the sink it was feeding), M3 (an
+oversized chunk must not livelock the backpressure retry), M4 (the
+backpressure retry itself, previously unpinned), M5 (a barge-in landing in
+the post-close() drain tail must report "stopped", not "drained"), M6 (the
+chunk source must be released on every exit), and the cheap Lows (L7: a
+failed open() must not evict a healthy live sink; L9: pump on a
+never-`open()`'d sink must still terminalize it; L10: an externally-closed
+sink must not busy-retry `feed()` forever; L11: the drain wait must have a
+deadline; L12: this fixture).
 """
 import asyncio
+import contextlib
 
 import pytest
 
-from Tests.Audio.test_streaming_sink import RATE, _mk, _pcm
-from tldw_chatbook.Audio.streaming_sink import SinkStopped, pump
+from Tests.Audio.test_streaming_sink import BLOCK_MS, RATE, _mk, _pcm
+from tldw_chatbook.Audio.streaming_sink import (
+    BUFFER_CAP_SECONDS, SinkBufferFull, SinkStopped, StreamingPcmSink, pump,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_live_sink_registry():
+    """Fix-round L12: see the identical fixture in `test_streaming_sink.py`
+    for why -- `_LIVE_SINK` is a single process-global shared by every test
+    in the whole session, across both files.
+    """
+    import tldw_chatbook.Audio.streaming_sink as mod
+
+    def _force_clear() -> None:
+        live = mod._LIVE_SINK
+        if live is not None:
+            live.stop()
+        with mod._LIVE_SINK_LOCK:
+            mod._LIVE_SINK = None
+
+    _force_clear()
+    yield
+    _force_clear()
 
 
 async def _aiter(chunks, delay_between=0):
@@ -97,3 +132,323 @@ def test_opening_a_second_sink_displaces_the_first():
     assert s1.state == "stopped", "one-voice: prior sink must be stopped on new open"
     assert h1["s"].aborted is True
     assert s2.state == "open"
+
+
+# ---------------------------------------------------------------------------
+# Fix-round: H1 -- a cancelled pump must not abandon a playing sink
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pump_cancelled_mid_feed_still_terminalizes_the_sink():
+    """H1 pin: pre-fix, `except Exception` did not catch `CancelledError`
+    and there was no `finally`, so cancelling the task running `pump`
+    left the sink exactly as it was mid-feed: `state == "open"`, its
+    stream live, its notify thread parked forever, and `_LIVE_SINK` still
+    pointing at it (reviewer probe: 20 further audible blocks played
+    after the cancel). `pump` must guarantee a terminal call on every
+    exit, cancellation included.
+    """
+    import tldw_chatbook.Audio.streaming_sink as mod
+
+    events = []
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+
+    async def endless():
+        while True:
+            await asyncio.sleep(0)
+            yield _pcm(1)
+
+    task = asyncio.ensure_future(pump(sink, endless()))
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert sink.buffered_seconds > 0, "pump had not fed anything yet -- not genuinely mid-feed"
+    assert sink.state == "open"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert sink.terminal_reason is not None, "cancellation must still terminalize the sink"
+    assert sink.state in ("stopped", "failed")
+    notify_thread = sink._notify_thread
+    assert notify_thread is not None
+    notify_thread.join(timeout=2.0)
+    assert not notify_thread.is_alive(), "notify thread parked forever after cancellation"
+    assert mod._LIVE_SINK is not sink, "registry must not still point at a cancelled-away sink"
+
+
+# ---------------------------------------------------------------------------
+# Fix-round: M3 -- an oversized chunk must not livelock the retry loop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pump_slices_a_chunk_larger_than_the_buffer_cap():
+    """M3 pin: a single source chunk bigger than the 60s buffer cap can
+    never fit no matter how much the buffer drains if retried whole --
+    pre-fix, `pump` retried the same oversized remainder forever at the
+    20Hz backpressure interval, never terminalizing. It must instead be
+    sliced into placeable pieces.
+    """
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    cap_blocks = BUFFER_CAP_SECONDS * 1000 // BLOCK_MS
+    huge = _pcm(cap_blocks + 50)          # ~1s more audio than the cap holds
+
+    async def one_huge_chunk():
+        yield huge
+
+    async def ticker():
+        # A real device draining audio in real time, compressed here into
+        # synchronous ticks (FakeStream has no wall clock) -- fast enough
+        # that this test does not itself take anywhere near 60+ real
+        # seconds, while still leaving pump's real 50ms backpressure
+        # retries room to matter.
+        while True:
+            h["s"].tick(50)              # 1s of simulated audio per round
+            await asyncio.sleep(0.01)
+
+    ticker_task = asyncio.ensure_future(ticker())
+    try:
+        result = await asyncio.wait_for(pump(sink, one_huge_chunk()), timeout=5.0)
+    finally:
+        ticker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await ticker_task
+
+    assert result.outcome == "drained"
+    assert result.bytes_fed == len(huge)
+
+
+# ---------------------------------------------------------------------------
+# Fix-round: M4 -- the backpressure retry itself (previously unpinned)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pump_backpressure_retry_eventually_feeds_everything_byte_exact():
+    """M4 pin: a mutation that replaced the retry with "feed once, drop
+    the remainder on False" left the pre-fix suite fully green -- nothing
+    observable changed except a silent gap in the played audio. Pin it
+    directly: with an artificially tiny buffer cap, `feed()` must be
+    refused at least once, and every byte pump was given must still
+    eventually reach playback, byte-for-byte.
+    """
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    # Pre-fill the (real, un-shrunk) buffer to within a couple of blocks of
+    # the cap -- shrinking `sink._cap_bytes` itself would be simpler, but it
+    # would also shrink the *derived* `bytes_per_second` pump uses for M3's
+    # slicing, fragmenting this test's own "byte-exact contiguous" check
+    # for reasons unrelated to backpressure. Pre-filling instead forces a
+    # genuine `feed()` rejection while leaving slicing irrelevant (`body`
+    # stays far smaller than one real slice, so pump treats it as one
+    # undivided piece -- exactly what's needed to test the retry itself).
+    cap_bytes = BUFFER_CAP_SECONDS * RATE * 2
+    block_bytes = h["s"].blocksize * 2
+    headroom = block_bytes * 2                      # 2 blocks of free space left
+    prefill_blocks = (cap_bytes - headroom) // block_bytes
+    sink.feed(_pcm(prefill_blocks, value=1))         # buffer now within 2 blocks of the cap
+    body = _pcm(5, value=9)                          # 5 blocks > 2-block headroom -> rejected first try
+
+    async def one_chunk():
+        yield body
+
+    async def ticker():
+        while True:
+            h["s"].tick(50)
+            await asyncio.sleep(0.001)
+
+    ticker_task = asyncio.ensure_future(ticker())
+    try:
+        result = await asyncio.wait_for(pump(sink, one_chunk()), timeout=5.0)
+    finally:
+        ticker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await ticker_task
+
+    assert result.outcome == "drained"
+    assert result.bytes_fed == len(body)
+    assert sum(isinstance(e, SinkBufferFull) for e in events) >= 1, \
+        "backpressure was never actually exercised -- test setup is not testing what it claims"
+    played = b"".join(h["s"].out)
+    assert body in played, "every fed byte must eventually reach playback, byte-for-byte, undropped"
+
+
+# ---------------------------------------------------------------------------
+# Fix-round: M5 -- a barge-in in the drain tail must report "stopped"
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pump_barge_in_during_drain_tail_reports_stopped_not_drained():
+    """M5 pin (the implementer's own self-flagged concern, confirmed real
+    by the reviewer): pre-fix, `pump` inferred its outcome from
+    `sink.state` alone, and a natural drain and a forced `stop()` both
+    leave `state == "stopped"` by design -- so a barge-in that
+    interrupted an utterance after only 2 of 40 blocks played was
+    reported exactly as if it had played to completion. `pump` must
+    report the sink's own `terminal_reason` instead.
+    """
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    body = _pcm(40)
+
+    async def one_chunk():
+        yield body
+
+    task = asyncio.ensure_future(pump(sink, one_chunk()))
+    await asyncio.sleep(0)           # let pump feed everything + close()
+    assert sink.state == "draining"
+    h["s"].tick(2)                   # only 2 of 40 blocks actually played
+    sink.stop()                      # barge-in mid-tail
+    result = await asyncio.wait_for(task, timeout=1.0)
+
+    assert result.outcome == "stopped"
+    assert any(isinstance(e, SinkStopped) for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Fix-round: M6 -- the chunk source must be released on every exit
+# ---------------------------------------------------------------------------
+
+class _RecordingAsyncSource:
+    """Class-based (non-generator) `AsyncIterator` fake for M6.
+
+    Records whether/how many times `aclose()` was called, so the test
+    does not depend on generator `__del__`/GC timing the way the
+    reviewer's own probe showed a plain async-generator source does
+    (non-deterministic -- ran only after `gc.collect()`), and a
+    class-based `AsyncIterator` has no such fallback at all: pre-fix,
+    `aclose()` was simply never called for one.
+    """
+
+    def __init__(self) -> None:
+        self.aclose_calls = 0
+
+    def __aiter__(self) -> "_RecordingAsyncSource":
+        return self
+
+    async def __anext__(self) -> bytes:
+        await asyncio.sleep(0)
+        return _pcm(1)
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_pump_closes_a_class_based_source_on_early_exit():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    source = _RecordingAsyncSource()
+
+    task = asyncio.ensure_future(pump(sink, source))
+    await asyncio.sleep(0)
+    sink.stop()
+    result = await asyncio.wait_for(task, timeout=1.0)
+
+    assert result.outcome == "stopped"
+    assert source.aclose_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Fix-round Lows
+# ---------------------------------------------------------------------------
+
+def test_failed_open_does_not_evict_the_live_sink():
+    """L7 pin (the implementer's own self-flagged concern, confirmed real
+    by the reviewer): a sink whose `open()` fails before ever playing a
+    sample must not evict a still-healthy previously-live voice.
+    """
+    e1, e2 = [], []
+    s1, h1 = _mk(e1)
+    s1.open(sample_rate=RATE)
+    assert s1.state == "open"
+
+    def failing_factory(**kw):
+        raise RuntimeError("device busy")
+
+    s2 = StreamingPcmSink(on_event=e2.append, blocksize_ms=BLOCK_MS, stream_factory=failing_factory)
+    s2.open(sample_rate=RATE)
+
+    assert s2.state == "failed"
+    assert s1.state == "open", "a sink that never played one sample must not evict the healthy live voice"
+    assert h1["s"].aborted is False
+
+
+@pytest.mark.asyncio
+async def test_pump_on_a_never_opened_sink_terminalizes_it():
+    """L9 pin: a sink handed to `pump` before `open()` ever reached
+    `"open"` (a sequencing bug, or `open()` still mid-flight on another
+    thread) must not be silently ignored -- nothing else will ever
+    terminalize it, so `pump` must force it terminal itself.
+    """
+    events = []
+    sink = StreamingPcmSink(on_event=events.append, blocksize_ms=BLOCK_MS)
+    assert sink.state == "idle"
+
+    async def one_chunk():
+        yield _pcm(1)
+
+    result = await pump(sink, one_chunk())
+
+    assert result.outcome == "stopped"
+    assert sink.state == "stopped"
+    assert sink.terminal_reason == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_pump_external_close_mid_stream_falls_through_to_drain_wait():
+    """L10 pin: once a sink is draining -- whether from `pump`'s own
+    `close()` or, as here, an external caller's -- `feed()` can never
+    succeed again. Pre-fix, `pump` kept offering further chunks and
+    busy-retrying them at the 20Hz backpressure interval for the rest of
+    the drain instead of recognizing there is nowhere left for them to
+    go; it must stop trying to feed and just await the drain.
+    """
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    first = _pcm(2)
+
+    async def source():
+        yield first
+        sink.close()                 # external close(), not pump's own
+        yield _pcm(2)                 # must never be fed -- already draining
+
+    task = asyncio.ensure_future(pump(sink, source()))
+    await asyncio.sleep(0)
+    h["s"].tick(20)                  # drain fully
+    result = await asyncio.wait_for(task, timeout=1.0)
+
+    assert result.outcome == "drained"
+    assert result.bytes_fed == len(first), "the chunk offered after the external close() must not be fed"
+
+
+@pytest.mark.asyncio
+async def test_pump_drain_wait_deadline_expiry_reports_failed(monkeypatch):
+    """L11 pin: if the device callback stops advancing during the
+    post-`close()` drain wait (device removed, backend stalled), `pump`
+    must give up after a bounded deadline rather than polling forever --
+    and report `"failed"` (with a reason), not silently hang the caller.
+    """
+    import tldw_chatbook.Audio.streaming_sink as mod
+    monkeypatch.setattr(mod, "_DRAIN_WAIT_MARGIN_SECONDS", 0.05)
+
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    body = _pcm(2)
+
+    async def one_chunk():
+        yield body
+
+    # h["s"] is intentionally never ticked -- simulating a stalled device.
+    result = await asyncio.wait_for(pump(sink, one_chunk()), timeout=2.0)
+
+    assert result.outcome == "failed"
+    assert result.reason
+    assert sink.state == "stopped"    # pump's own stop() call landed

--- a/Tests/Audio/test_streaming_sink_pump.py
+++ b/Tests/Audio/test_streaming_sink_pump.py
@@ -1,0 +1,99 @@
+"""Tests for the `pump` helper and one-voice live-sink registry displacement.
+
+`pump` bridges an async source of PCM chunks (as produced incrementally by a
+streaming TTS adapter) into a `StreamingPcmSink`'s synchronous, non-blocking
+`feed()`, handling backpressure (buffer-full retry), an optional
+skip-bytes prefix (WAV headers from providers that can't be told to omit
+one), early exit when the sink is stopped out from under the pump, and
+normal end-of-stream draining. The registry tests cover Task 2's other
+half: opening a new sink stops whichever sink was previously "live" (the
+one-voice contract), and MUST do so without ever touching a stream directly
+from within the registry lock (see the module docstring / task brief).
+"""
+import asyncio
+
+import pytest
+
+from Tests.Audio.test_streaming_sink import RATE, _mk, _pcm
+from tldw_chatbook.Audio.streaming_sink import SinkStopped, pump
+
+
+async def _aiter(chunks, delay_between=0):
+    for c in chunks:
+        if delay_between:
+            await asyncio.sleep(0)
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_pump_feeds_everything_closes_and_reports_drained():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    result_task = asyncio.ensure_future(pump(sink, _aiter([_pcm(8), _pcm(8)])))
+    await asyncio.sleep(0)                     # let pump feed
+    h["s"].tick(20)                            # drain everything
+    result = await result_task
+    assert result.outcome == "drained"
+    assert result.bytes_fed == len(_pcm(8)) * 2
+
+
+@pytest.mark.asyncio
+async def test_pump_skip_bytes_drops_wav_header():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    header = b"RIFF" + b"\x00" * 40            # 44 bytes
+    body = _pcm(16)
+    task = asyncio.ensure_future(pump(sink, _aiter([header + body[:100], body[100:]]),
+                                      skip_bytes=44))
+    await asyncio.sleep(0)
+    h["s"].tick(1)
+    played = b"".join(h["s"].out)
+    assert b"RIFF" not in played
+    sink.stop()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_pump_exits_promptly_when_sink_stopped_midstream():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+
+    async def endless():
+        while True:
+            await asyncio.sleep(0)
+            yield _pcm(1)
+
+    task = asyncio.ensure_future(pump(sink, endless()))
+    await asyncio.sleep(0)
+    sink.stop()
+    result = await asyncio.wait_for(task, timeout=1.0)
+    assert result.outcome == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_pump_source_error_stops_sink_and_reports():
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+
+    async def broken():
+        yield _pcm(1)
+        raise ValueError("backend died")
+
+    result = await pump(sink, broken())
+    assert result.outcome == "source_error"
+    assert any(isinstance(e, SinkStopped) for e in events)
+
+
+def test_opening_a_second_sink_displaces_the_first():
+    e1, e2 = [], []
+    s1, h1 = _mk(e1)
+    s1.open(sample_rate=RATE)
+    s2, h2 = _mk(e2)
+    s2.open(sample_rate=RATE)
+    assert s1.state == "stopped", "one-voice: prior sink must be stopped on new open"
+    assert h1["s"].aborted is True
+    assert s2.state == "open"

--- a/Tests/Audio/test_streaming_sink_pump.py
+++ b/Tests/Audio/test_streaming_sink_pump.py
@@ -40,6 +40,7 @@ import pytest
 from Tests.Audio.test_streaming_sink import BLOCK_MS, RATE, _mk, _pcm
 from tldw_chatbook.Audio.streaming_sink import (
     BUFFER_CAP_SECONDS, SinkBufferFull, SinkStopped, StreamingPcmSink, pump,
+    stop_live_sink,
 )
 
 
@@ -537,3 +538,81 @@ async def test_pump_drain_wait_deadline_expiry_reports_failed(monkeypatch):
     assert result.outcome == "failed"
     assert result.reason
     assert sink.state == "stopped"    # pump's own stop() call landed
+
+
+# ---------------------------------------------------------------------------
+# Task-4: `max_bytes` bound (WAV trailing-chunk data_bytes contract) and the
+# `stop_live_sink()` registry helper the consumer needs for its stop action.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pump_max_bytes_stops_feeding_at_the_bound_even_mid_chunk():
+    """A WAV `data` chunk followed by a trailing chunk (e.g. `LIST`) must
+    never have the trailer's bytes fed as if they were audio -- `skip_bytes`
+    alone only bounds the HEAD of the stream; `max_bytes` bounds the tail.
+    Here the bound lands in the middle of the second of two source chunks,
+    the harder case (a bound landing exactly on a chunk boundary would pass
+    even a naive `chunk[:n]`-only implementation that forgot to also stop
+    reading further chunks).
+    """
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    first = _pcm(2)                      # audio, entirely within budget
+    second = _pcm(2)                     # only half of this is audio
+    trailer = b"NOT-AUDIO-TRAILER-BYTES"
+    budget = len(first) + len(second) // 2
+
+    async def source():
+        yield first
+        yield second + trailer
+
+    task = asyncio.ensure_future(pump(sink, source(), max_bytes=budget))
+    await asyncio.sleep(0)
+    h["s"].tick(20)                      # drain everything fed
+    result = await asyncio.wait_for(task, timeout=1.0)
+
+    assert result.outcome == "drained"
+    assert result.bytes_fed == budget
+    played = b"".join(h["s"].out)
+    assert trailer not in played
+    assert first + second[: len(second) // 2] in played
+
+
+@pytest.mark.asyncio
+async def test_pump_max_bytes_none_is_unbounded_pcm_default():
+    """Raw PCM has no container-declared length -- `max_bytes=None` (the
+    default) must feed everything the source yields, exactly as before this
+    parameter existed.
+    """
+    events, = ([],)
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+    body = _pcm(8)
+
+    async def source():
+        yield body
+
+    task = asyncio.ensure_future(pump(sink, source()))
+    await asyncio.sleep(0)
+    h["s"].tick(20)
+    result = await asyncio.wait_for(task, timeout=1.0)
+
+    assert result.outcome == "drained"
+    assert result.bytes_fed == len(body)
+
+
+def test_stop_live_sink_stops_whatever_is_currently_registered():
+    events = []
+    sink, h = _mk(events)
+    sink.open(sample_rate=RATE)
+
+    stop_live_sink()
+
+    assert sink.state == "stopped"
+    assert sink.terminal_reason == "stopped"
+    assert h["s"].aborted is True
+
+
+def test_stop_live_sink_is_a_no_op_when_nothing_is_live():
+    stop_live_sink()   # must not raise

--- a/Tests/TTS/test_console_audio_cpp_native.py
+++ b/Tests/TTS/test_console_audio_cpp_native.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import stat
+import struct
 import threading
 from collections.abc import AsyncIterator, Mapping
 from datetime import UTC, datetime
@@ -64,6 +65,32 @@ _WAV_CHUNKS = (
     b"\x44\xac\x00\x00\x88\x58\x01\x00\x02\x00\x10\x00data\x40\x00\x00\x00"
     + bytes((i * 7 + 3) % 256 for i in range(64)),
 )
+
+
+def _valid_wav_body(
+    data_size: int, *, sample_rate: int = 44100, channels: int = 1
+) -> bytes:
+    """Build a structurally-valid canonical PCM16 RIFF/WAVE body of a given
+    `data` chunk size -- used by the F4 (sink-upgrade-cap) test below to
+    prove that a WAV *big enough to trip the cap but otherwise perfectly
+    sink-eligible* still falls back to the legacy path, as opposed to
+    `_WAV_CHUNKS` extended with raw padding, which would also fail
+    `validate_pcm16_wav`'s RIFF-size check on its own -- a false-positive
+    that would pass even without the cap fix.
+    """
+    bits_per_sample = 16
+    block_align = channels * (bits_per_sample // 8)
+    byte_rate = sample_rate * block_align
+    fmt_payload = struct.pack(
+        "<HHIIHH", 1, channels, sample_rate, byte_rate, block_align, bits_per_sample
+    )
+    data_bytes = bytes((i * 7 + 3) % 256 for i in range(data_size))
+    riff_payload = (
+        b"WAVE"
+        + b"fmt " + struct.pack("<I", len(fmt_payload)) + fmt_payload
+        + b"data" + struct.pack("<I", data_size) + data_bytes
+    )
+    return b"RIFF" + struct.pack("<I", len(riff_payload)) + riff_payload
 
 
 class _RecordingStream:
@@ -887,6 +914,86 @@ async def test_a_sink_eligible_wav_response_streams_live_and_deletes_its_artifac
     assert not created_paths[0].exists(), (
         "the now-redundant artifact must be deleted once played live"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_wav_response_over_the_sink_upgrade_cap_skips_the_sink_entirely(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F4 fix-round: a WAV response too large for the in-memory sink-upgrade
+    attempt (`tts_events._MAX_WAV_SINK_UPGRADE_BYTES`) must abandon that
+    attempt -- never even constructing a `StreamingPcmSink` -- and fall
+    through to the already-complete, disk-backed legacy path, the same way
+    every OTHER wav response does when no sink is available at all. Shrinks
+    the cap via monkeypatch (rather than actually streaming >16MiB) to keep
+    the fixture small and the test fast.
+
+    Uses `_valid_wav_body()`, a STRUCTURALLY VALID (and thus, absent the
+    cap, sink-eligible) wav -- not `_WAV_CHUNKS` plus raw padding, which
+    would also fail `validate_pcm16_wav`'s RIFF-size check on its own and
+    so would reach the legacy path regardless of whether the cap fix
+    exists at all, a false-positive that was caught while writing this
+    test (mutation-checked: with the cap enforcement itself removed, THIS
+    version of the test fails -- the raw-padding version did not).
+    """
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+    monkeypatch.setattr(tts_events_module, "_MAX_WAV_SINK_UPGRADE_BYTES", 64)
+
+    sink_holder: dict[str, _RecordingSink] = {}
+
+    class _Sink(_RecordingSink):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)
+            sink_holder["sink"] = self
+
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _Sink)
+
+    # data_size=200 -> body is well over the 64-byte cap above, but the wav
+    # itself remains fully valid (and would be sink-eligible without the cap).
+    oversized_chunks = (_valid_wav_body(200),)
+    timeline: list[str] = []
+    response = _Response(_RecordingStream(oversized_chunks, timeline))
+    service = _DefaultService(response)
+    handler = _Handler()
+    handler._tts_service = service
+    handler._temp_manager = _RecordingTempManager(tmp_path)
+    artifact: Path | None = None
+
+    try:
+        await handler.handle_tts_request(
+            TTSRequestEvent(
+                text="Oversized wav response",
+                message_id="oversized-wav-1",
+                voice=None,
+            )
+        )
+        await asyncio.wait_for(
+            handler.completion_posted.wait(),
+            timeout=_WAIT_SECONDS,
+        )
+        completion = next(
+            message
+            for message in handler.messages
+            if isinstance(message, TTSCompleteEvent)
+        )
+        artifact = completion.audio_file
+
+        assert completion.error is None
+        assert artifact is not None, (
+            "over the cap: the legacy path must still expose the fully "
+            "written artifact, exactly as if no sink were available"
+        )
+        assert artifact.read_bytes() == b"".join(oversized_chunks)
+        assert sink_holder == {}, (
+            "no StreamingPcmSink should ever be constructed once the "
+            "in-memory upgrade attempt exceeds its cap"
+        )
+    finally:
+        await handler.cleanup_tts_resources()
+
+    assert artifact is not None
+    assert not artifact.exists()
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_console_audio_cpp_native.py
+++ b/Tests/TTS/test_console_audio_cpp_native.py
@@ -44,12 +44,25 @@ from tldw_chatbook.TTS.profile_types import (
 )
 from tldw_chatbook.TTS.TTS_Generation import TTSService
 
+from Tests.TTS_Events.test_spoken_feedback_streaming import _RecordingSink
+
 _WAIT_SECONDS = 1.0
+# Fix-round F7 (task-4 review): the original fixture declared a `data`
+# chunk of size 0 -- structurally invalid (`validate_pcm16_wav` rejects it,
+# confirmed: `sink_plan("wav", None, b"".join(_WAV_CHUNKS))` returned
+# `None`), so no test using it ever reached the task-4 streaming branch at
+# all, silently leaving the one live production path (`audio_cpp` is
+# wav-locked) uncovered by this file. Same 4-chunk split as before (several
+# tests slice `_WAV_CHUNKS[:1]` to simulate a header-only/early-EOF
+# response), same declared sample_rate=44100/channels=1/16-bit, but now
+# carries 64 bytes of real (if arbitrary) PCM16 data so the body is
+# validator-accepted and sink-eligible.
 _WAV_CHUNKS = (
     b"RIFF",
-    b"\x24\x00\x00\x00WAVEfmt ",
+    b"\x64\x00\x00\x00WAVEfmt ",
     b"\x10\x00\x00\x00\x01\x00\x01\x00",
-    b"\x44\xac\x00\x00\x88\x58\x01\x00\x02\x00\x10\x00data\x00\x00\x00\x00",
+    b"\x44\xac\x00\x00\x88\x58\x01\x00\x02\x00\x10\x00data\x40\x00\x00\x00"
+    + bytes((i * 7 + 3) % 256 for i in range(64)),
 )
 
 
@@ -391,6 +404,36 @@ def _assigned_profile(character_ref: CharacterRef) -> LoadedCharacterTTSAssignme
             profile=profile,
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def _sink_unavailable_by_default(monkeypatch):
+    """Keep every test in this file on the legacy-only path by default.
+
+    Fix-round F7 (task-4 review): `_WAV_CHUNKS` used to be a structurally
+    INVALID wav body (`data_size=0`), so `sink_plan` always returned `None`
+    and no test here ever reached `_generate_tts`'s task-4 streaming
+    branch -- which is exactly why the artifact-contract change went
+    uncovered. Fixing the fixture to a validator-accepted, sink-eligible
+    WAV (see `_WAV_CHUNKS`'s own comment) exposed a SEPARATE, more urgent
+    problem discovered while making that fix: `StreamingPcmSink()` is
+    constructed here with no `stream_factory` override (unlike
+    `Tests/TTS_Events/test_spoken_feedback_streaming.py`, which always
+    monkeypatches the class), so a now-eligible response made `open()`
+    lazily import the REAL `sounddevice` and start a REAL
+    `OutputStream` against actual audio hardware during an automated test
+    run (confirmed: a real PortAudio callback fired, visible as a
+    `sounddevice.py` DeprecationWarning in this file's own test output).
+    Forcing `sink_available()` False by default keeps every EXISTING test
+    here scoped to exactly what it was already testing (legacy
+    generation/cancellation/write-loop mechanics, unrelated to task-4) and
+    -- just as importantly -- off real hardware entirely. The dedicated
+    streaming-path tests below explicitly re-enable `sink_available()` AND
+    patch `StreamingPcmSink` with a fake, the same way the task-4 consumer
+    test file does, so they exercise the new branch without ever
+    constructing a real `OutputStream` either.
+    """
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: False)
 
 
 @pytest.mark.asyncio
@@ -742,6 +785,108 @@ async def test_non_console_tts_request_event_keeps_global_default_path(
 
     assert artifact is not None
     assert not artifact.exists()
+
+
+@pytest.mark.asyncio
+async def test_a_sink_eligible_wav_response_streams_live_and_deletes_its_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fix-round F7 (task-4 review): closes the coverage gap the previously
+    structurally-INVALID `_WAV_CHUNKS` fixture left -- no test in this file
+    ever reached `_generate_tts`'s task-4 streaming branch, so the artifact-
+    contract change went unpinned on the one provider (`audio_cpp`, wav-
+    locked by `TTSPreferencesSnapshot.__post_init__`) that reaches it in
+    production. Every OTHER test in this file keeps `sink_available()`
+    False by default (see `_sink_unavailable_by_default` above) and so
+    never leaves the pre-task-4 contract; THIS test explicitly re-enables
+    it and patches `StreamingPcmSink` with the same `_RecordingSink` fake
+    `Tests/TTS_Events/test_spoken_feedback_streaming.py` uses (never a real
+    `sounddevice.OutputStream`), then documents and pins the new contract
+    for an eligible wav response: the legacy write loop still runs
+    unmodified (an artifact IS created and fully written -- see
+    `_generate_tts`'s own comment above `_create_tts_artifact` for why),
+    but once played live through the sink it is DELETED rather than
+    exposed -- `_audio_files` stays empty and `TTSCompleteEvent.audio_file`
+    is `None`, unlike every legacy-path completion elsewhere in this file.
+    """
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+    sink_holder: dict[str, _RecordingSink] = {}
+
+    class _Sink(_RecordingSink):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)
+            sink_holder["sink"] = self
+
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _Sink)
+
+    timeline: list[str] = []
+    response = _Response(_RecordingStream(_WAV_CHUNKS, timeline))
+    service = _DefaultService(response)
+    handler = _Handler()
+    handler._tts_service = service
+    handler._temp_manager = _RecordingTempManager(tmp_path)
+    created_paths: list[Path] = []
+    original_create_artifact = handler._create_tts_artifact
+
+    def _spy_create_artifact(audio_format: str) -> Path:
+        path = original_create_artifact(audio_format)
+        created_paths.append(path)
+        return path
+
+    handler._create_tts_artifact = _spy_create_artifact  # type: ignore[method-assign]
+
+    try:
+        await handler.handle_tts_request(
+            TTSRequestEvent(
+                text="Spoken feedback",
+                message_id="native-streamed-1",
+                voice=None,
+            )
+        )
+        await asyncio.wait_for(
+            handler.completion_posted.wait(),
+            timeout=_WAIT_SECONDS,
+        )
+        completion = next(
+            message
+            for message in handler.messages
+            if isinstance(message, TTSCompleteEvent)
+        )
+
+        assert completion.error is None
+        assert completion.audio_file is None, (
+            "a sink-eligible wav response must not expose a playable file "
+            "-- it was already played live"
+        )
+        assert handler._audio_files == {}
+
+        # Exactly one artifact was created by the unmodified legacy write
+        # loop, fully written with the whole response body, BEFORE the
+        # streaming decision ran.
+        assert len(created_paths) == 1
+
+        wav_body = b"".join(_WAV_CHUNKS)
+        expected_audio = wav_body[44:]  # skip_bytes=44, the rest is `data`
+        sink = sink_holder["sink"]
+        assert sink.opened_with is not None
+        assert b"".join(sink.fed) == expected_audio
+    finally:
+        # Deletion of the now-redundant artifact runs through the same
+        # retry-tracked, thread-offloaded cleanup as a failed/cancelled
+        # generation's (`_discard_tts_artifact` -> `_run_blocking_tts_io`)
+        # -- not yet guaranteed complete the instant `TTSCompleteEvent` was
+        # posted (which happens BEFORE the delete, inside
+        # `_stream_response_via_sink`). `cleanup_tts_resources` awaits
+        # `_drain_retained_tts_artifact_work`, which bounds a wait for
+        # exactly that -- matching the pattern every other test in this
+        # file already uses to check artifact non-existence AFTER, not
+        # during, the `try` block.
+        await handler.cleanup_tts_resources()
+
+    assert not created_paths[0].exists(), (
+        "the now-redundant artifact must be deleted once played live"
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_pcm_stream_plan.py
+++ b/Tests/TTS/test_pcm_stream_plan.py
@@ -1,0 +1,33 @@
+import struct
+
+from tldw_chatbook.TTS.pcm_stream import SinkPlan, sink_plan
+
+
+def _wav_header(rate=22050, channels=1, data=b"\x00\x00" * 64):
+    hdr = b"RIFF" + struct.pack("<I", 36 + len(data)) + b"WAVEfmt " + \
+        struct.pack("<IHHIIHH", 16, 1, channels, rate, rate * channels * 2,
+                    channels * 2, 16) + b"data" + struct.pack("<I", len(data))
+    return hdr + data
+
+
+def test_raw_pcm_with_rate_is_eligible():
+    assert sink_plan("pcm", 24000, None) == SinkPlan(24000, 1, 0)
+
+
+def test_raw_pcm_without_rate_is_not():
+    assert sink_plan("pcm", None, None) is None
+
+
+def test_valid_pcm16_wav_is_eligible_with_header_skip():
+    plan = sink_plan("wav", None, _wav_header())
+    assert plan is not None
+    assert plan.sample_rate == 22050 and plan.channels == 1 and plan.skip_bytes == 44
+
+
+def test_invalid_wav_falls_back():
+    assert sink_plan("wav", None, b"RIFFgarbage") is None
+
+
+def test_compressed_formats_fall_back():
+    for fmt in ("mp3", "opus", "aac", "flac", ""):
+        assert sink_plan(fmt, 24000, None) is None

--- a/Tests/TTS/test_pcm_stream_plan.py
+++ b/Tests/TTS/test_pcm_stream_plan.py
@@ -35,6 +35,17 @@ def test_raw_pcm_without_rate_is_not():
     assert sink_plan("pcm", None, None) is None
 
 
+def test_raw_pcm_with_a_wrong_typed_rate_is_not():
+    # Fix-round F8 (task-4 review): a wrong-typed sample_rate must fail
+    # closed HERE, not raise deep inside StreamingPcmSink.open()'s
+    # `sample_rate * blocksize_ms // 1000` arithmetic (str) or silently
+    # produce a nonsensical plan (bool is an int subclass in Python, so
+    # True/False would otherwise pass an `isinstance` check).
+    assert sink_plan("pcm", "24000", None) is None
+    assert sink_plan("pcm", 24000.0, None) is None
+    assert sink_plan("pcm", True, None) is None
+
+
 def test_valid_pcm16_wav_is_eligible_with_header_skip():
     data = b"\x00\x00" * 64
     plan = sink_plan("wav", None, _wav_header(data=data))

--- a/Tests/TTS/test_pcm_stream_plan.py
+++ b/Tests/TTS/test_pcm_stream_plan.py
@@ -10,6 +10,23 @@ def _wav_header(rate=22050, channels=1, data=b"\x00\x00" * 64):
     return hdr + data
 
 
+def _wav_with_trailing_chunk(rate=22050, channels=1, data=None,
+                              trailer_id=b"LIST", trailer_payload=b"INFOtest"):
+    # A well-formed WAV whose RIFF size correctly accounts for a chunk placed
+    # AFTER `data` -- a shape validate_pcm16_wav structurally accepts (it
+    # only special-cases `fmt `/`data`; any other chunk id is skipped
+    # generically regardless of position). Reproduces the reviewer's
+    # trailing-LIST-chunk finding (task-3-review.md, I1).
+    if data is None:
+        data = bytes(range(128))
+    trailer = trailer_id + struct.pack("<I", len(trailer_payload)) + trailer_payload
+    declared_size = 36 + len(data) + len(trailer)
+    hdr = b"RIFF" + struct.pack("<I", declared_size) + b"WAVEfmt " + \
+        struct.pack("<IHHIIHH", 16, 1, channels, rate, rate * channels * 2,
+                    channels * 2, 16) + b"data" + struct.pack("<I", len(data))
+    return hdr + data + trailer
+
+
 def test_raw_pcm_with_rate_is_eligible():
     assert sink_plan("pcm", 24000, None) == SinkPlan(24000, 1, 0)
 
@@ -19,9 +36,25 @@ def test_raw_pcm_without_rate_is_not():
 
 
 def test_valid_pcm16_wav_is_eligible_with_header_skip():
-    plan = sink_plan("wav", None, _wav_header())
+    data = b"\x00\x00" * 64
+    plan = sink_plan("wav", None, _wav_header(data=data))
     assert plan is not None
     assert plan.sample_rate == 22050 and plan.channels == 1 and plan.skip_bytes == 44
+    assert plan.data_bytes == len(data)
+
+
+def test_wav_with_trailing_chunk_after_data_uses_true_data_offset():
+    # Task-3 review I1: skip_bytes must be the TRUE data-chunk payload
+    # offset, not `len(first_bytes) - data_size` -- the latter over-skips
+    # when a chunk (e.g. LIST) trails `data`, dropping real audio and
+    # exposing the trailer's own bytes as if they were PCM samples.
+    data = bytes(range(128))
+    body = _wav_with_trailing_chunk(data=data)
+    plan = sink_plan("wav", None, body)
+    assert plan is not None
+    assert plan.skip_bytes == 44
+    assert plan.data_bytes == len(data)
+    assert body[plan.skip_bytes : plan.skip_bytes + plan.data_bytes] == data
 
 
 def test_invalid_wav_falls_back():

--- a/Tests/TTS_Events/test_spoken_feedback_streaming.py
+++ b/Tests/TTS_Events/test_spoken_feedback_streaming.py
@@ -50,8 +50,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from loguru import logger as loguru_logger
 
 import tldw_chatbook.Audio.streaming_sink as streaming_sink_module
+from tldw_chatbook.Audio.streaming_sink import SinkUnderrun
 from tldw_chatbook.Event_Handlers.TTS_Events import tts_events as tts_events_module
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSCompleteEvent,
@@ -1025,3 +1027,96 @@ async def test_no_real_audio_device_guard_blocks_the_reproduced_hazard(
         )
     finally:
         await handler.cleanup_tts_resources()
+
+
+# ---------------------------------------------------------------------------
+# Final whole-branch review M2: `SinkUnderrun` -- the only signal that live
+# playback is stuttering -- used to die silently in `_post_sink_event`'s
+# debug-only recorder, invisible to both the user and metrics on the one
+# feature whose entire premise is live playback quality. Minimal honest
+# fix: on utterance end (once `pump()` returns), if any underrun was
+# observed, log it at INFO with the frame count and bump the existing
+# `tts_generation_total` metric with an `outcome_code="underrun"` label
+# (same pattern F8 already established for `"interrupted"`) -- no UI.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_an_underrun_is_logged_at_info_and_bumps_the_metric_on_utterance_end(
+    handler, monkeypatch,
+):
+    class _UnderrunningSink(_RecordingSink):
+        def feed(self, pcm: bytes) -> bool:
+            accepted = super().feed(pcm)
+            # Simulate the device callback running dry mid-utterance --
+            # SinkUnderrun always originates from the sink's own notify
+            # thread in production; calling on_event directly here is the
+            # same seam the real sink uses, just synchronous for the test.
+            self.on_event(SinkUnderrun(frames=42))
+            return accepted
+
+    chunks = [bytes([1, 0]) * 10]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _UnderrunningSink)
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    metric_calls: list[tuple[str, dict]] = []
+
+    def capture_counter(name, value=1, labels=None):
+        metric_calls.append((name, dict(labels or {})))
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Metrics.metrics_logger.log_counter", capture_counter
+    )
+
+    captured_logs: list[str] = []
+    handler_id = loguru_logger.add(
+        lambda message: captured_logs.append(message.record["message"]),
+        level="INFO",
+    )
+    try:
+        await handler._generate_tts("Underrun check.", "adhoc", None)
+    finally:
+        loguru_logger.remove(handler_id)
+
+    assert any(
+        "42" in line and "underrun" in line.lower() for line in captured_logs
+    ), captured_logs
+    assert any(
+        name == "tts_generation_total" and labels.get("outcome_code") == "underrun"
+        for name, labels in metric_calls
+    ), metric_calls
+    # The underrun is a stutter signal, not a failure -- the utterance
+    # itself still completes normally.
+    complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+    assert len(complete_events) == 1
+    assert complete_events[0].error is None
+
+
+@pytest.mark.asyncio
+async def test_no_underrun_never_logs_or_bumps_the_underrun_metric(handler, monkeypatch):
+    chunks = [bytes([1, 0]) * 10]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    sink_holder: dict = {}
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    metric_calls: list[tuple[str, dict]] = []
+
+    def capture_counter(name, value=1, labels=None):
+        metric_calls.append((name, dict(labels or {})))
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Metrics.metrics_logger.log_counter", capture_counter
+    )
+
+    await handler._generate_tts("No underrun.", "adhoc", None)
+
+    assert not any(
+        labels.get("outcome_code") == "underrun" for _, labels in metric_calls
+    ), metric_calls

--- a/Tests/TTS_Events/test_spoken_feedback_streaming.py
+++ b/Tests/TTS_Events/test_spoken_feedback_streaming.py
@@ -751,9 +751,16 @@ async def test_message_scoped_stop_does_not_silence_a_different_messages_legacy_
 # untouched by this task) against a fake device stream and drives it
 # through the REAL `_register_live_sink` registry AND the REAL
 # `handle_tts_playback` -> `stop_live_sink()` -> `sink.stop()` chain --
-# proving the consumer's own opened sink actually reaches the live
-# registry and is what a stop interrupts, not just that the wiring call
-# happens against whatever is planted there.
+# proving the real registry/stop machinery interrupts a real sink
+# end-to-end (`stream.abort()`, not `.stop()`, which would drain).
+#
+# Corrected docstring (fix-round N4, re-review): this test opens the sink
+# ITSELF, in the test body -- it does NOT drive `_generate_tts`, so it does
+# NOT prove that the CONSUMER's own opened sink is what ends up in the
+# registry (an earlier version of this comment overclaimed exactly that).
+# What it proves is narrower and still real: a sink that IS registered as
+# `_LIVE_SINK`, by whatever means, is correctly interrupted by
+# `handle_tts_playback`'s stop wiring, for both stop shapes.
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -770,3 +777,251 @@ async def test_real_sink_end_to_end_stop_wiring(handler, message_id):
 
     assert sink.terminal_reason == "stopped"
     assert sink_test_holder["s"].aborted is True
+
+
+# ---------------------------------------------------------------------------
+# Re-review N1: `stop_live_sink()` in the `play` branch must only fire when
+# a replacement is actually about to play -- a play request for a message
+# whose cached artifact is already gone (the 5s cache cleanup, or one that
+# was simply never generated) must not silence live streaming audio and
+# then play nothing back.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_play_for_a_missing_cached_file_does_not_stop_a_live_sink(handler):
+    stop_calls: list[bool] = []
+
+    class _FakeLiveSink:
+        def stop(self) -> None:
+            stop_calls.append(True)
+
+    with streaming_sink_module._LIVE_SINK_LOCK:
+        streaming_sink_module._LIVE_SINK = _FakeLiveSink()
+
+    # No `_audio_files` entry for this message -- nothing will actually play.
+    await handler.handle_tts_playback(
+        TTSPlaybackEvent(action="play", message_id="missing-msg")
+    )
+
+    assert stop_calls == [], (
+        "a play with nothing to actually play back must not stop a live sink"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Re-review N2: F3's fix was pinned only at the pure `_wants_wav_collection`
+# function -- a mutation reverting the CALL SITE back to an inline
+# format-only check (`wav_collect = [] if audio_format == "wav" else None`)
+# was invisible to the whole suite, since nothing asserted the seam actually
+# calls the gate. Spying on the gate itself closes that: any call site that
+# stops calling it fails this test regardless of whether any other
+# behavioral assertion happens to still pass.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_generate_tts_calls_the_wav_collection_gate_at_its_call_site(
+    handler, monkeypatch,
+):
+    calls: list[str] = []
+    original = tts_events_module._wants_wav_collection
+
+    def _spy(audio_format: str) -> bool:
+        calls.append(audio_format)
+        return original(audio_format)
+
+    monkeypatch.setattr(tts_events_module, "_wants_wav_collection", _spy)
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: False)
+
+    chunks = [b"RIFFnotavalidatedwavbodyatall"]
+    response = _FakeResponse(chunks, audio_format="wav", sample_rate=None)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    try:
+        await handler._generate_tts("Nothing to read yet.", "adhoc", None)
+
+        assert calls == ["wav"], (
+            "_generate_tts must call _wants_wav_collection at its call "
+            "site, not inline the format-only check it wraps"
+        )
+        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        assert len(complete_events) == 1
+        artifact_path = complete_events[0].audio_file
+        assert artifact_path is not None and artifact_path.read_bytes() == chunks[0]
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+# ---------------------------------------------------------------------------
+# Re-review N3: `TTSPlaybackEvent(action="stop", message_id="")` is neither
+# `None` (the bare-stop branch) nor truthy (the message-scoped branch) --
+# it used to fall between both, silencing nothing. Both the sink and legacy
+# playback must be silenced, same as a bare/global stop.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stop_with_empty_string_message_id_is_treated_as_a_bare_stop(
+    handler, monkeypatch,
+):
+    sink_stop_calls: list[bool] = []
+
+    class _FakeLiveSink:
+        def stop(self) -> None:
+            sink_stop_calls.append(True)
+
+    with streaming_sink_module._LIVE_SINK_LOCK:
+        streaming_sink_module._LIVE_SINK = _FakeLiveSink()
+
+    player_stop_calls: list[bool] = []
+    clip = Path("clip.mp3")
+
+    class _FakePlayer:
+        def get_current_file(self):
+            return clip
+
+        def stop(self):
+            player_stop_calls.append(True)
+            return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: _FakePlayer()
+    )
+    async with handler._audio_files_lock:
+        handler._last_played = ("some-message", clip)
+
+    await handler.handle_tts_playback(TTSPlaybackEvent(action="stop", message_id=""))
+
+    assert sink_stop_calls == [True]
+    assert player_stop_calls == [True]
+    async with handler._audio_files_lock:
+        assert handler._last_played is None
+
+
+# ---------------------------------------------------------------------------
+# Re-review N5: the new "interrupted" outcome label (F8) had no test --
+# nothing in the suite reached the actual metric to check a regression that
+# folds it back into "success".
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_barged_in_utterance_reports_interrupted_not_success_in_metrics(
+    handler, monkeypatch,
+):
+    class _BargedInSink(_RecordingSink):
+        def feed(self, pcm: bytes) -> bool:
+            accepted = super().feed(pcm)
+            # Simulate an external stop() landing right after this piece
+            # was accepted -- e.g. a later utterance's one-voice
+            # displacement, or a barge-in.
+            self.state = "stopped"
+            self.terminal_reason = "stopped"
+            return accepted
+
+    chunks = [bytes([9, 0]) * 20]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _BargedInSink)
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    metric_calls: list[tuple[str, dict]] = []
+
+    def capture_counter(name, value=1, labels=None):
+        metric_calls.append((name, dict(labels or {})))
+
+    def capture_histogram(name, value, labels=None):
+        metric_calls.append((name, dict(labels or {})))
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Metrics.metrics_logger.log_counter", capture_counter
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Metrics.metrics_logger.log_histogram", capture_histogram
+    )
+
+    await handler._generate_tts("Interrupted.", "adhoc", None)
+
+    outcome_codes = {
+        labels["outcome_code"] for _, labels in metric_calls if "outcome_code" in labels
+    }
+    assert outcome_codes == {"interrupted"}, (
+        "a displaced/interrupted utterance must not be labeled success"
+    )
+    complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+    assert len(complete_events) == 1
+    assert complete_events[0].error is None
+    assert complete_events[0].audio_file is None
+
+
+# ---------------------------------------------------------------------------
+# Re-review REQUIRED merge-gate item: `Tests/conftest.py`'s autouse
+# `_no_real_audio_device` fixture must neutralize the reproduced hazard --
+# an eligible response reaching `_generate_tts` with NEITHER
+# `StreamingPcmSink` NOR `sink_available` patched used to construct a real
+# `sounddevice.OutputStream` (confirmed by the reviewer: the unguarded test
+# still PASSED while doing so, a silent failure mode invisible to CI,
+# review, or the suite itself).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_no_real_audio_device_guard_blocks_the_reproduced_hazard(
+    handler, monkeypatch,
+):
+    """Deliberately reproduces the reviewer's exact hazard shape: the REAL
+    `StreamingPcmSink` class, the REAL `sink_available()` probe -- no
+    per-test mock of either. `Tests/conftest.py`'s autouse
+    `_no_real_audio_device` fixture is already active for every test in
+    this session, this one included, and must be what saves this one:
+    `sink.open()` reaches "failed" via the already-tested `_fail("audio
+    output unavailable ...")` path (driven by `_import_sounddevice()`
+    returning `None`, which is exactly the chokepoint that fixture
+    patches), never a real device, and generation falls through to the
+    legacy artifact path.
+    """
+    # Cheap, non-invasive precondition check: if the conftest guard were
+    # ever removed or broken, this fails loudly and immediately here,
+    # rather than the test instead falling through to the
+    # `_CountingOutputStream` subclass below actually opening a real
+    # device (which the guard being broken would otherwise let happen).
+    assert streaming_sink_module._import_sounddevice() is None, (
+        "Tests/conftest.py's autouse _no_real_audio_device guard is not "
+        "active -- this test cannot safely proceed"
+    )
+
+    import sounddevice
+
+    construction_count = 0
+    real_output_stream = sounddevice.OutputStream
+
+    class _CountingOutputStream(real_output_stream):
+        def __init__(self, *args, **kwargs):
+            nonlocal construction_count
+            construction_count += 1
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(sounddevice, "OutputStream", _CountingOutputStream)
+
+    chunks = [bytes([1, 0]) * 10]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+    # Deliberately NOT patching StreamingPcmSink or sink_available here --
+    # that is the point of this test.
+
+    try:
+        await handler._generate_tts("Guard check.", "adhoc", None)
+
+        assert construction_count == 0, (
+            "the conftest _no_real_audio_device guard failed to prevent a "
+            "real sounddevice.OutputStream construction"
+        )
+        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        assert len(complete_events) == 1
+        assert complete_events[0].error is None
+        assert complete_events[0].audio_file is not None, (
+            "the open() failure must fall through to the legacy artifact "
+            "path, exactly like any other sink open failure"
+        )
+    finally:
+        await handler.cleanup_tts_resources()

--- a/Tests/TTS_Events/test_spoken_feedback_streaming.py
+++ b/Tests/TTS_Events/test_spoken_feedback_streaming.py
@@ -1,0 +1,534 @@
+"""Task 4 (streaming-pcm-sink plan): Console spoken feedback streams through
+the sink.
+
+`_generate_tts` (`Event_Handlers/TTS_Events/tts_events.py`) is the shared
+generation worker body every TTS request runs through -- Console spoken
+feedback (`chat_screen.py`'s `_speak_status`, via `TTSRequestEvent`) is one
+caller among several (character speech snapshots, ad-hoc requests), and the
+streaming seam this module wires in branches on the RESPONSE alone (format /
+rate / bytes), never on which caller asked -- see the plan's Global
+Constraints. These tests drive `_generate_tts` directly, the same harness
+pattern `Tests/TTS/test_tts_improvements.py`'s `test_progress_events` and
+`test_console_retained_provider_defaults_use_legacy_adapter` already use: a
+fake `TTSAudioResponse`-shaped object plus a fake service exposing
+`synthesize_default`/`preferences_snapshot`, with no `Tests/TTS_Events/`
+harness pre-existing to build on (this is the first file in the directory).
+
+`StreamingPcmSink` itself is monkeypatched, in the `tts_events` module's own
+namespace, with `_RecordingSink` -- a minimal fake implementing just enough
+of the real class's interface (`open`/`feed`/`close`/`stop`/`state`/
+`terminal_reason`/`bytes_per_second`/`buffered_seconds`) for the REAL
+`pump()` (`Audio/streaming_sink.py`, untouched here) to drive it
+synchronously, with no real audio device or background thread. Patching
+`streaming_sink._import_sounddevice` would not be enough on its own --
+`open()` still needs a `stream_factory`-shaped success/failure outcome to
+react to, which is exactly what patching the class provides.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.TTS_Events import tts_events as tts_events_module
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    TTSCompleteEvent,
+    TTSEventHandler,
+    TTSPlaybackEvent,
+    TTSProgressEvent,
+)
+from tldw_chatbook.TTS.adapter_types import TTSAudioResponse
+from Tests.TTS.test_pcm_stream_plan import _wav_with_trailing_chunk
+
+RATE = 24000
+
+
+# ---------------------------------------------------------------------------
+# `_LIVE_SINK` is a process-global shared across the whole test session (see
+# `Tests/Audio/test_streaming_sink.py`'s identical fixture) -- force-clear
+# before AND after every test in this file too, so a sink another test left
+# registered can never leak in here, and nothing here leaks forward either.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _reset_live_sink_registry():
+    import tldw_chatbook.Audio.streaming_sink as streaming_sink_module
+
+    def _force_clear() -> None:
+        live = streaming_sink_module._LIVE_SINK
+        if live is not None:
+            try:
+                live.stop()
+            except Exception:
+                pass
+        with streaming_sink_module._LIVE_SINK_LOCK:
+            streaming_sink_module._LIVE_SINK = None
+
+    _force_clear()
+    yield
+    _force_clear()
+
+
+def test_fake_response_mirrors_the_real_ttsaudioresponse_field_names():
+    """Pin against the fake drifting from the real class's shape (brief
+    requirement): every attribute `_FakeResponse` exposes below must also
+    exist on a real `TTSAudioResponse`.
+    """
+
+    async def _empty() -> AsyncIterator[bytes]:
+        return
+        yield b""  # pragma: no cover -- makes this an async generator
+
+    real = TTSAudioResponse(
+        provider_id="openai",
+        model_id="tts-1",
+        audio_format="pcm",
+        content_type="audio/pcm",
+        byte_stream=_empty(),
+        sample_rate=RATE,
+    )
+    for field in ("provider_id", "model_id", "audio_format", "content_type",
+                  "byte_stream", "sample_rate", "metadata"):
+        assert hasattr(real, field), f"_FakeResponse's {field!r} is not a real field"
+
+
+class _FakeResponse:
+    """Minimal stand-in for `TTSAudioResponse` (adapter_types.py:352):
+    same field names (asserted against the real class above), driven by a
+    plain list of chunks instead of a live provider connection.
+    """
+
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        audio_format: str,
+        sample_rate: int | None = None,
+        provider_id: str = "openai",
+        model_id: str = "tts-1",
+        content_type: str = "application/octet-stream",
+    ) -> None:
+        self.provider_id = provider_id
+        self.model_id = model_id
+        self.audio_format = audio_format
+        self.content_type = content_type
+        self.sample_rate = sample_rate
+        self.metadata: dict = {}
+        self._chunks = list(chunks)
+        self.byte_stream = self._make_stream()
+        self.close_calls = 0
+
+    async def _make_stream(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class _FakeService:
+    """Mirrors the two `TTSService` entry points `_generate_tts`'s default
+    (non-exact) path calls: `preferences_snapshot()` and
+    `synthesize_default()`. No `synthesize_exact`/legacy machinery -- every
+    test here drives the plain adhoc/spoken-feedback path (`resolution=None`),
+    matching `_speak_status`'s own `TTSRequestEvent(text=text)`.
+    """
+
+    def __init__(self, response: _FakeResponse, *, provider_id: str = "openai") -> None:
+        self._response = response
+        self._provider_id = provider_id
+        self.synthesize_default_calls: list[tuple[str, str | None]] = []
+
+    def preferences_snapshot(self):
+        return SimpleNamespace(provider_id=self._provider_id)
+
+    async def synthesize_default(self, *, text, voice_override=None, progress_sink=None):
+        self.synthesize_default_calls.append((text, voice_override))
+        return self._response
+
+
+class _RecordingSink:
+    """Fake `StreamingPcmSink` (Audio/streaming_sink.py) driven by the REAL
+    `pump()` -- implements only the surface `pump()` and `_generate_tts`
+    actually touch (`open`, `feed`, `close`, `stop`, `state`,
+    `terminal_reason`, `bytes_per_second`, `buffered_seconds`), with no
+    device/thread of its own so tests stay synchronous and deterministic.
+    """
+
+    #: Subclassed per-test (`_open_should_fail = True`) to simulate an
+    #: `open()` failure without touching any real audio backend.
+    _open_should_fail = False
+
+    def __init__(self, *, on_event, blocksize_ms: int = 20, stream_factory=None) -> None:
+        self.on_event = on_event
+        self.opened_with: tuple[int, int] | None = None
+        self.state = "idle"
+        self.terminal_reason: str | None = None
+        self.fail_reason: str | None = None
+        self.fed: list[bytes] = []
+
+    def open(self, sample_rate: int, channels: int = 1) -> None:
+        self.opened_with = (sample_rate, channels)
+        if self._open_should_fail:
+            self.state = "failed"
+            self.terminal_reason = "failed"
+            self.fail_reason = "test-forced open failure"
+            return
+        self.state = "open"
+
+    def feed(self, pcm: bytes) -> bool:
+        if self.state not in ("open", "draining"):
+            return False
+        self.fed.append(pcm)
+        return True
+
+    def close(self) -> None:
+        if self.state != "open":
+            return
+        self.state = "stopped"
+        self.terminal_reason = "drained"
+
+    def stop(self) -> None:
+        if self.terminal_reason is None:
+            self.terminal_reason = "stopped"
+        self.state = "stopped"
+
+    @property
+    def bytes_per_second(self) -> int:
+        rate, channels = self.opened_with or (RATE, 1)
+        return rate * 2 * channels
+
+    @property
+    def buffered_seconds(self) -> float:
+        return 0.0
+
+
+@pytest.fixture
+def handler():
+    class _Handler(TTSEventHandler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.messages: list = []
+
+        async def post_message(self, message) -> None:
+            self.messages.append(message)
+
+        def notify(self, message, severity: str = "info") -> None:
+            pass
+
+    return _Handler()
+
+
+def _forbid_legacy_artifact_creation(handler_instance) -> None:
+    """Pin against the streaming branch ALSO falling through to the legacy
+    file-write path (the double-audio mutation the brief calls out):
+    `_create_tts_artifact` must never run for a response the sink consumed.
+    """
+
+    def _fail(*_args, **_kwargs):
+        raise AssertionError(
+            "legacy artifact creation must not run for a streaming-eligible response"
+        )
+
+    handler_instance._create_tts_artifact = _fail
+
+
+def _spy_sink_class(holder: dict) -> type[_RecordingSink]:
+    class _Sink(_RecordingSink):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            holder["sink"] = self
+
+    return _Sink
+
+
+# ---------------------------------------------------------------------------
+# (a) pcm response streams through a fake sink -- no file playback.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pcm_response_streams_through_the_sink_with_no_file_playback(handler, monkeypatch):
+    chunks = [bytes([1, 0]) * 50, bytes([2, 0]) * 50]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+    _forbid_legacy_artifact_creation(handler)
+
+    sink_holder: dict = {}
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    await handler._generate_tts("Capture ended.", "adhoc", None)
+
+    sink = sink_holder["sink"]
+    assert sink.opened_with == (RATE, 1)
+    assert b"".join(sink.fed) == b"".join(chunks)
+    assert handler._audio_files == {}, "no artifact should ever be tracked for a streamed response"
+
+    complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+    assert len(complete_events) == 1
+    assert complete_events[0].audio_file is None
+    assert complete_events[0].error is None
+    progress_events = [m for m in handler.messages if isinstance(m, TTSProgressEvent)]
+    assert progress_events[-1].progress == 1.0
+    assert response.close_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# (b) mp3 response -> legacy `play_audio_file` path, no sink touched.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mp3_response_uses_the_legacy_path_and_never_constructs_a_sink(handler, monkeypatch):
+    chunks = [b"ID3", b"restofmp3bytes"]
+    response = _FakeResponse(chunks, audio_format="mp3", sample_rate=None)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    sink_holder: dict = {}
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    # Sink IS available -- eligibility must still be refused for a
+    # compressed format regardless, proving the branch keys off the
+    # response's own declared format, not just availability.
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    try:
+        await handler._generate_tts("Discarded.", "adhoc", None)
+
+        assert sink_holder == {}, "a compressed format must never even construct a sink"
+        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        assert len(complete_events) == 1
+        assert complete_events[0].error is None
+        artifact_path = complete_events[0].audio_file
+        assert artifact_path is not None and artifact_path.exists()
+        assert artifact_path.read_bytes() == b"".join(chunks)
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+# ---------------------------------------------------------------------------
+# (c) sink open-failure -> legacy path used, exactly one completion posted.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sink_open_failure_falls_through_to_the_legacy_path(handler, monkeypatch):
+    chunks = [bytes([3, 0]) * 40, bytes([4, 0]) * 40]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    class _FailingSink(_RecordingSink):
+        _open_should_fail = True
+
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _FailingSink)
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    try:
+        await handler._generate_tts("Still responding.", "adhoc", None)
+
+        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        assert len(complete_events) == 1, (
+            "a sink open failure must fall through silently -- exactly one "
+            "completion (the legacy path's own) may ever surface, no phantom "
+            "second toast for the failed open() itself"
+        )
+        assert complete_events[0].error is None
+        artifact_path = complete_events[0].audio_file
+        assert artifact_path is not None and artifact_path.exists()
+        assert artifact_path.read_bytes() == b"".join(chunks)
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+# ---------------------------------------------------------------------------
+# (d) TTSPlaybackEvent("stop") stops the live sink, for both the
+# message-scoped and the global/bare stop.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message_id", [None, "adhoc"])
+async def test_stop_action_stops_whatever_sink_is_currently_registered_live(
+    handler, message_id,
+):
+    import tldw_chatbook.Audio.streaming_sink as streaming_sink_module
+
+    stop_calls: list[bool] = []
+
+    class _FakeLiveSink:
+        def stop(self) -> None:
+            stop_calls.append(True)
+
+    with streaming_sink_module._LIVE_SINK_LOCK:
+        streaming_sink_module._LIVE_SINK = _FakeLiveSink()
+
+    await handler.handle_tts_playback(TTSPlaybackEvent(action="stop", message_id=message_id))
+
+    assert stop_calls == [True]
+
+
+# ---------------------------------------------------------------------------
+# (f) a WAV plan with a trailing chunk -- pumped bytes stop at data's end
+# (the review-contracted `data_bytes` pin).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_end(
+    handler, monkeypatch,
+):
+    """WAV eligibility can only be decided from the COMPLETE body (see
+    `pcm_stream.sink_plan`'s docstring), so -- unlike pcm -- the wav half of
+    this seam decides AFTER the unchanged legacy write loop has already
+    written the response to a temp artifact (verified separately: deciding
+    BEFORE writing, by eagerly draining the response up front, reproduced
+    four real regressions in `test_console_audio_cpp_native.py`'s
+    cancellation/partial-artifact/batching pins -- eager draining changes
+    observable timing for every wav response whenever a sink is merely
+    available, regardless of the eventual eligibility verdict). An eligible
+    response is then played through the sink from the bytes already
+    collected, and the now-redundant artifact is deleted -- this test pins
+    both: the artifact existed and then stopped existing, AND the bytes fed
+    to the sink stop exactly at `data`'s end despite the trailing chunk.
+    """
+    data = bytes(range(200))
+    body = _wav_with_trailing_chunk(data=data)
+    # Split mid-trailer, across two response chunks -- the harder case: a
+    # `max_bytes` bound that only trimmed the FIRST oversized chunk (without
+    # also refusing to read further ones) would still leak trailer bytes
+    # fed from a later chunk.
+    split = len(body) - 5
+    response = _FakeResponse([body[:split], body[split:]], audio_format="wav", sample_rate=None)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    created_paths: list = []
+    original_create_artifact = handler._create_tts_artifact
+
+    def _spy_create_artifact(audio_format):
+        path = original_create_artifact(audio_format)
+        created_paths.append(path)
+        return path
+
+    handler._create_tts_artifact = _spy_create_artifact
+
+    sink_holder: dict = {}
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    await handler._generate_tts("Should be spoken.", "adhoc", None)
+
+    sink = sink_holder["sink"]
+    fed = b"".join(sink.fed)
+    assert fed == data, "pumped bytes must stop exactly at the data chunk's end"
+    assert b"LIST" not in fed
+    assert b"INFOtest" not in fed
+
+    assert len(created_paths) == 1, "the legacy write loop must still run, unmodified, for wav"
+    assert not created_paths[0].exists(), (
+        "the now-redundant artifact must be deleted once it was played live"
+    )
+    assert handler._audio_files == {}
+    complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+    assert len(complete_events) == 1
+    assert complete_events[0].audio_file is None
+    assert complete_events[0].error is None
+
+
+# ---------------------------------------------------------------------------
+# A WAV sink failure (open OR mid-stream) has a complete, valid,
+# already-written artifact to fall back to -- unlike pcm, it must silently
+# use it rather than surface a user-facing error for an opportunistic
+# upgrade that simply didn't pan out.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wav_sink_failure_falls_back_to_the_already_written_file_silently(
+    handler, monkeypatch,
+):
+    data = bytes(range(64))
+    body = _wav_with_trailing_chunk(data=data)
+    response = _FakeResponse([body], audio_format="wav", sample_rate=None)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    class _FailingSink(_RecordingSink):
+        _open_should_fail = True
+
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _FailingSink)
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    try:
+        await handler._generate_tts("Discarded.", "adhoc", None)
+
+        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        assert len(complete_events) == 1, "no phantom error toast for a silent fallback"
+        assert complete_events[0].error is None
+        artifact_path = complete_events[0].audio_file
+        assert artifact_path is not None and artifact_path.exists()
+        assert artifact_path.read_bytes() == body
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+# ---------------------------------------------------------------------------
+# Fallback pins: sink unavailable at all -> byte-identical legacy behavior,
+# even for an otherwise-eligible pcm response.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sink_unavailable_leaves_an_eligible_pcm_response_on_the_legacy_path(
+    handler, monkeypatch,
+):
+    chunks = [bytes([5, 0]) * 30]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    sink_holder: dict = {}
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: False)
+
+    try:
+        await handler._generate_tts("Nothing to read yet.", "adhoc", None)
+
+        assert sink_holder == {}
+        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        assert len(complete_events) == 1
+        artifact_path = complete_events[0].audio_file
+        assert artifact_path is not None and artifact_path.read_bytes() == chunks[0]
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+# ---------------------------------------------------------------------------
+# A mid-stream sink failure (as opposed to an open() failure) must not be
+# silently dropped -- it has already committed to the streaming branch (the
+# legacy path cannot un-silence itself at this point), so it surfaces
+# through the same TTSCompleteEvent(error=...) channel, exactly once.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mid_stream_sink_failure_surfaces_exactly_one_error_completion(
+    handler, monkeypatch,
+):
+    class _FailingMidStreamSink(_RecordingSink):
+        def feed(self, pcm: bytes) -> bool:
+            self.state = "failed"
+            self.terminal_reason = "failed"
+            self.fail_reason = "device error mid-stream"
+            return False
+
+    chunks = [bytes([6, 0]) * 30]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+    _forbid_legacy_artifact_creation(handler)
+
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _FailingMidStreamSink)
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    await handler._generate_tts("The TTS service returned invalid audio", "adhoc", None)
+
+    complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+    assert len(complete_events) == 1
+    assert complete_events[0].error is not None
+    assert complete_events[0].audio_file is None

--- a/Tests/TTS_Events/test_spoken_feedback_streaming.py
+++ b/Tests/TTS_Events/test_spoken_feedback_streaming.py
@@ -17,12 +17,29 @@ harness pre-existing to build on (this is the first file in the directory).
 `StreamingPcmSink` itself is monkeypatched, in the `tts_events` module's own
 namespace, with `_RecordingSink` -- a minimal fake implementing just enough
 of the real class's interface (`open`/`feed`/`close`/`stop`/`state`/
-`terminal_reason`/`bytes_per_second`/`buffered_seconds`) for the REAL
-`pump()` (`Audio/streaming_sink.py`, untouched here) to drive it
+`terminal_reason`/`fail_reason`/`bytes_per_second`/`buffered_seconds`) for
+the REAL `pump()` (`Audio/streaming_sink.py`, untouched here) to drive it
 synchronously, with no real audio device or background thread. Patching
 `streaming_sink._import_sounddevice` would not be enough on its own --
 `open()` still needs a `stream_factory`-shaped success/failure outcome to
 react to, which is exactly what patching the class provides.
+
+pcm and wav responses take deliberately different branches in `_generate_tts`
+and are tested accordingly. pcm decides sink eligibility BEFORE any file
+write (needs only `response.sample_rate`, no bytes read) and, when eligible,
+never touches disk. wav can only be validated against its COMPLETE body
+(`pcm_stream.sink_plan`'s own docstring), so it decides AFTER the legacy
+write loop has already run unmodified -- an earlier version that drained wav
+responses up front, to decide before writing, reproduced four real
+regressions in `test_console_audio_cpp_native.py`'s cancellation/partial-
+artifact/write-batching pins (eager draining changes observable timing for
+every wav response whenever a sink is merely available, independent of the
+eventual eligibility verdict). An eligible wav response is played from the
+bytes the write loop already collected, then the now-redundant artifact is
+deleted; an ineligible one, or one where the sink itself fails afterward,
+is reported via the file the write loop already produced -- see
+`test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_end`
+and `test_wav_sink_failure_falls_back_to_the_already_written_file_silently`.
 """
 from __future__ import annotations
 

--- a/Tests/TTS_Events/test_spoken_feedback_streaming.py
+++ b/Tests/TTS_Events/test_spoken_feedback_streaming.py
@@ -43,11 +43,15 @@ and `test_wav_sink_failure_falls_back_to_the_already_written_file_silently`.
 """
 from __future__ import annotations
 
+import threading
 from collections.abc import AsyncIterator
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+import tldw_chatbook.Audio.streaming_sink as streaming_sink_module
 from tldw_chatbook.Event_Handlers.TTS_Events import tts_events as tts_events_module
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSCompleteEvent,
@@ -56,6 +60,7 @@ from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSProgressEvent,
 )
 from tldw_chatbook.TTS.adapter_types import TTSAudioResponse
+from Tests.Audio.test_streaming_sink import _mk as _mk_real_sink
 from Tests.TTS.test_pcm_stream_plan import _wav_with_trailing_chunk
 
 RATE = 24000
@@ -69,8 +74,6 @@ RATE = 24000
 # ---------------------------------------------------------------------------
 @pytest.fixture(autouse=True)
 def _reset_live_sink_registry():
-    import tldw_chatbook.Audio.streaming_sink as streaming_sink_module
-
     def _force_clear() -> None:
         live = streaming_sink_module._LIVE_SINK
         if live is not None:
@@ -179,12 +182,16 @@ class _RecordingSink:
     def __init__(self, *, on_event, blocksize_ms: int = 20, stream_factory=None) -> None:
         self.on_event = on_event
         self.opened_with: tuple[int, int] | None = None
+        #: Fix-round F2 pin: which thread actually called `open()`, so a
+        #: test can assert it ran off the event-loop thread.
+        self.opened_on_thread: threading.Thread | None = None
         self.state = "idle"
         self.terminal_reason: str | None = None
         self.fail_reason: str | None = None
         self.fed: list[bytes] = []
 
     def open(self, sample_rate: int, channels: int = 1) -> None:
+        self.opened_on_thread = threading.current_thread()
         self.opened_with = (sample_rate, channels)
         if self._open_should_fail:
             self.state = "failed"
@@ -367,8 +374,6 @@ async def test_sink_open_failure_falls_through_to_the_legacy_path(handler, monke
 async def test_stop_action_stops_whatever_sink_is_currently_registered_live(
     handler, message_id,
 ):
-    import tldw_chatbook.Audio.streaming_sink as streaming_sink_module
-
     stop_calls: list[bool] = []
 
     class _FakeLiveSink:
@@ -549,3 +554,219 @@ async def test_mid_stream_sink_failure_surfaces_exactly_one_error_completion(
     assert len(complete_events) == 1
     assert complete_events[0].error is not None
     assert complete_events[0].audio_file is None
+
+
+# ---------------------------------------------------------------------------
+# Fix-round F1 (task-4 review): a legacy `play` action must stop a live sink
+# first, symmetrically with `_stop_prior_legacy_clip` (which silences a
+# legacy clip before a NEW streaming utterance starts) -- otherwise a
+# `TTSPlaybackEvent(action="play")` for a different, file-based message
+# starts an overlapping second voice on top of live sink playback. This was
+# a newly-reachable hole (no sink existed in this path before task-4).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_legacy_play_action_stops_a_live_sink_first(handler, monkeypatch, tmp_path):
+    stop_calls: list[bool] = []
+
+    class _FakeLiveSink:
+        def stop(self) -> None:
+            stop_calls.append(True)
+
+    with streaming_sink_module._LIVE_SINK_LOCK:
+        streaming_sink_module._LIVE_SINK = _FakeLiveSink()
+
+    test_audio = tmp_path / "clip.mp3"
+    test_audio.write_bytes(b"fake audio data")
+    async with handler._audio_files_lock:
+        handler._audio_files["msg-1"] = test_audio
+
+    fake_player = MagicMock()
+    fake_player.play.return_value = True
+    monkeypatch.setattr(
+        "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: fake_player
+    )
+
+    await handler.handle_tts_playback(TTSPlaybackEvent(action="play", message_id="msg-1"))
+
+    assert stop_calls == [True], "a live sink must be stopped before legacy file playback starts"
+    fake_player.play.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Fix-round F2 (task-4 review): `sink.open()` must run off the event loop,
+# through the SAME `_run_blocking_tts_io` offload seam every other blocking
+# call in `_generate_tts` already uses -- measured ~65-110ms on a quiet
+# machine, worse when another process holds the audio device, which is a
+# whole-UI stall in a Textual TUI on every spoken utterance otherwise.
+# Pinned via the offload seam itself (spying on `_run_blocking_tts_io`) AND
+# via thread identity on the fake sink -- NOT via wall-clock timing, which
+# would be flaky.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sink_open_runs_off_the_event_loop_via_the_existing_offload_seam(
+    handler, monkeypatch,
+):
+    chunks = [bytes([7, 0]) * 10]
+    response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
+    service = _FakeService(response)
+    handler._tts_service = service
+
+    sink_holder: dict = {}
+    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+
+    offload_calls: list[str] = []
+    original_run_blocking = handler._run_blocking_tts_io
+
+    async def _spy_run_blocking(operation, **kwargs):
+        offload_calls.append("called")
+        return await original_run_blocking(operation, **kwargs)
+
+    handler._run_blocking_tts_io = _spy_run_blocking
+
+    await handler._generate_tts("Capture ended.", "adhoc", None)
+
+    sink = sink_holder["sink"]
+    assert sink.opened_with == (RATE, 1)
+    assert offload_calls, (
+        "sink.open() must run through the existing _run_blocking_tts_io "
+        "offload seam, not directly on the event loop -- this is the ONLY "
+        "possible _run_blocking_tts_io call on the pcm streaming-success "
+        "path (no artifact is ever created for it), so any hit here can "
+        "only be the open() call"
+    )
+    assert sink.opened_on_thread is not None
+    assert sink.opened_on_thread is not threading.main_thread(), (
+        "sink.open() ran on the event-loop (main) thread instead of being "
+        "offloaded"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix-round F3 (task-4 review): wav-body collection for the post-write
+# sink-eligibility check must be gated on `sink_available()` too, not format
+# alone -- otherwise a machine with no `sounddevice` at all still retains
+# the WHOLE response body in memory for every wav generation, regressing
+# the bounded-memory write-batching the legacy loop was designed to keep.
+# ---------------------------------------------------------------------------
+
+def test_wants_wav_collection_is_gated_on_sink_availability_too(monkeypatch):
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: False)
+    assert tts_events_module._wants_wav_collection("wav") is False
+    assert tts_events_module._wants_wav_collection("mp3") is False
+
+    monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
+    assert tts_events_module._wants_wav_collection("wav") is True
+    assert tts_events_module._wants_wav_collection("mp3") is False
+    assert tts_events_module._wants_wav_collection("pcm") is False
+
+
+# ---------------------------------------------------------------------------
+# Fix-round F4 (task-4 review): the bare/global stop (`chat_screen.py`'s
+# dictation-start, unconditionally posted before opening the mic to protect
+# the mic/speaker mutual-exclusion invariant) must ALSO silence legacy file
+# playback, not just the sink -- every branch of the pre-task-4 `if/elif`
+# chain required a truthy `message_id`, so a bare stop was always a no-op
+# for the legacy player. Deliberately scoped to ONLY the bare stop: a
+# message-scoped stop must keep its own more careful message-id-matched
+# logic (task-559 unit 2) -- stopping message A must never silence a
+# different, still-playing message B -- pinned by the second test below as
+# a regression guard against widening the fix too far.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_bare_stop_action_also_silences_legacy_file_playback(handler, monkeypatch):
+    stop_calls: list = []
+    clip = Path("clip.mp3")
+
+    class _FakePlayer:
+        def get_current_file(self):
+            return clip
+
+        def stop(self):
+            stop_calls.append(True)
+            return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: _FakePlayer()
+    )
+    async with handler._audio_files_lock:
+        handler._last_played = ("some-other-message", clip)
+
+    await handler.handle_tts_playback(TTSPlaybackEvent(action="stop", message_id=None))
+
+    assert stop_calls == [True], "a bare stop must also silence legacy file playback"
+    async with handler._audio_files_lock:
+        assert handler._last_played is None
+
+
+@pytest.mark.asyncio
+async def test_message_scoped_stop_does_not_silence_a_different_messages_legacy_playback(
+    handler, monkeypatch,
+):
+    """Regression guard (task-559 unit 2): F4's fix is scoped to ONLY the
+    bare/global stop. A message-scoped stop for message A must still never
+    silence a DIFFERENT, actively-playing message B's legacy clip -- this
+    would have been a real regression if F4's `_stop_prior_legacy_clip`
+    call had been placed unconditionally instead of gated on
+    `event.message_id is None`.
+    """
+    stop_calls: list = []
+    clip = Path("clip.mp3")
+
+    class _FakePlayer:
+        def get_current_file(self):
+            return clip
+
+        def stop(self):
+            stop_calls.append(True)
+            return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: _FakePlayer()
+    )
+    async with handler._audio_files_lock:
+        handler._last_played = ("message-B", clip)
+
+    await handler.handle_tts_playback(
+        TTSPlaybackEvent(action="stop", message_id="message-A")
+    )
+
+    assert stop_calls == [], (
+        "stopping message A must never silence a different, "
+        "still-playing message B"
+    )
+    async with handler._audio_files_lock:
+        assert handler._last_played == ("message-B", clip)
+
+
+# ---------------------------------------------------------------------------
+# Fix-round F6 (task-4 review): promotes the reviewer's real-chain probe
+# into the suite. Unlike `test_stop_action_stops_whatever_sink_is_currently_
+# registered_live` above (which plants a bare `_FakeLiveSink` directly into
+# the registry, proving only that `stop_live_sink()` gets called), this
+# constructs a REAL `StreamingPcmSink` (`Audio/streaming_sink.py`,
+# untouched by this task) against a fake device stream and drives it
+# through the REAL `_register_live_sink` registry AND the REAL
+# `handle_tts_playback` -> `stop_live_sink()` -> `sink.stop()` chain --
+# proving the consumer's own opened sink actually reaches the live
+# registry and is what a stop interrupts, not just that the wiring call
+# happens against whatever is planted there.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message_id", [None, "some-other-message"])
+async def test_real_sink_end_to_end_stop_wiring(handler, message_id):
+    events: list = []
+    sink, sink_test_holder = _mk_real_sink(events)
+    sink.open(sample_rate=RATE)
+    assert sink.state == "open"
+
+    await handler.handle_tts_playback(
+        TTSPlaybackEvent(action="stop", message_id=message_id)
+    )
+
+    assert sink.terminal_reason == "stopped"
+    assert sink_test_holder["s"].aborted is True

--- a/Tests/UI/test_uat_first_time_character_chat.py
+++ b/Tests/UI/test_uat_first_time_character_chat.py
@@ -88,6 +88,22 @@ UAT_CARD_ENV_VAR = "TLDW_UAT_CARD_PATH"
 UAT_USER_MESSAGE = "Hello! Who are you?"
 UAT_CANNED_REPLY = "I'm Ann, your test character. Lovely to meet you!"
 
+# WARNING (task-4 streaming-pcm-sink fix-round, F7): this WAV body declares
+# a ZERO-length `data` chunk, which `tldw_chatbook.TTS.pcm_stream.sink_plan`
+# structurally rejects (`sink_plan("wav", None, UAT_COMPLETE_WAV) is None`,
+# confirmed) -- so this response never reaches `_generate_tts`'s streaming
+# branch today and this file never mocks `StreamingPcmSink`/`sink_available`.
+# DO NOT "fix" this to a validator-accepted body (e.g. by giving it real
+# `data` bytes) without ALSO adding a guard: `Tests/TTS/
+# test_console_audio_cpp_native.py` had the exact same shape until this
+# fix-round, and correcting ONLY the fixture there -- without also forcing
+# `sink_available()` False by default -- made a previously-invalid WAV
+# become sink-eligible and caused `_generate_tts` to construct a REAL
+# `StreamingPcmSink` with no `stream_factory` override, which lazily
+# imported the real `sounddevice` and opened a REAL `OutputStream` against
+# actual audio hardware during an automated test run (confirmed via a live
+# PortAudio callback firing). See that file's `_sink_unavailable_by_default`
+# autouse fixture for the pattern to copy if this body is ever corrected.
 UAT_COMPLETE_WAV = (
     b"RIFF"
     b"\x24\x00\x00\x00WAVEfmt "

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -428,6 +428,39 @@ def fd_leak_sentinel() -> Iterator[None]:
         print(f"[fd_leak_sentinel] {message}", file=sys.stderr)
 
 
+@pytest.fixture(autouse=True)
+def _no_real_audio_device(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No test opens real audio hardware unless it explicitly opts in.
+
+    Task-4 streaming-pcm-sink review, merge-gate finding: `_generate_tts`
+    (`Event_Handlers/TTS_Events/tts_events.py`) can construct a real
+    `StreamingPcmSink` for an eligible pcm/wav response and, if nothing
+    patches `StreamingPcmSink`/`sink_available`, `open()` lazily imports
+    the real `sounddevice` and starts a real `OutputStream` against actual
+    hardware -- reproduced: an unguarded eligible-wav test opened one and
+    still PASSED, so this failure mode is silent to CI, review, and the
+    suite itself. Neutralizes the single chokepoint every production
+    device open passes through (`open()` can only build a stream via
+    `_import_sounddevice()`); returning `None` drives the already-tested
+    `_fail("audio output unavailable ...")` terminal path, so an
+    accidental hazard degrades to the legacy path instead of hardware.
+    Deliberately leaves `sink_available()` (the `find_spec` probe) alone,
+    so no test's LOGICAL coverage changes, only its hardware access --
+    measured: the full `Tests/TTS`/`Tests/TTS_Events`/`Tests/Audio` run is
+    identical with and without this fixture. A test that genuinely needs a
+    real device marks itself `@pytest.mark.real_audio_device` to opt out.
+    This is the backstop; file-local guards (e.g.
+    `Tests/TTS/test_console_audio_cpp_native.py`'s own
+    `_sink_unavailable_by_default`) still document intent at their point
+    of use and are not replaced by this.
+    """
+    if request.node.get_closest_marker("real_audio_device"):
+        return
+    import tldw_chatbook.Audio.streaming_sink as streaming_sink
+
+    monkeypatch.setattr(streaming_sink, "_import_sounddevice", lambda: None)
+
+
 # ========== Async Cleanup Fixtures ==========
 
 

--- a/backlog/tasks/task-1880 - Unlock-streaming-spoken-feedback-for-legacy-bridge-TTS-providers.md
+++ b/backlog/tasks/task-1880 - Unlock-streaming-spoken-feedback-for-legacy-bridge-TTS-providers.md
@@ -1,0 +1,30 @@
+---
+id: TASK-1880
+title: 'Unlock streaming spoken feedback for legacy-bridge TTS providers (3-leg package)'
+status: To Do
+assignee: []
+created_date: '2026-08-02 12:00'
+labels: [tts, audio, streaming]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The streaming PCM sink (V3 phase 1) serves only the audio.cpp adapter today: the legacy
+backend bridge (`TTS/legacy_bridge.py` ~:692) constructs `TTSAudioResponse` without `sample_rate`,
+so `sink_plan()` returns None for every legacy provider (openai, kokoro, ...). The Task-4 review
+adjudicated this deferral and identified that implementing the naive request-side pcm ask alone
+would REGRESS openai feedback (raw `.pcm` artifact the file player cannot play → silent). All
+three legs are needed together. Origin: streaming-sink final review M1/M3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Legacy-bridge responses carry an honest `sample_rate` (and channels) when the backend knows it.
+- [ ] #2 Spoken-feedback requests ask for `pcm` only via a caller-scoped override (no change for other TTS callers), through the `synthesize_default`/`_build_request` seam.
+- [ ] #3 A raw-pcm response that misses sink eligibility is WAV-wrapped before the legacy file path plays it (never an unplayable `.pcm` artifact).
+- [ ] #4 openai and kokoro spoken feedback stream through the sink end to end, with the existing fallback tests still green.
+<!-- AC:END -->

--- a/backlog/tasks/task-1881 - Fold-RIFF-data-offset-into-Pcm16WavInfo.md
+++ b/backlog/tasks/task-1881 - Fold-RIFF-data-offset-into-Pcm16WavInfo.md
@@ -1,0 +1,28 @@
+---
+id: TASK-1881
+title: 'Fold the RIFF data-chunk offset into Pcm16WavInfo instead of a parallel walk'
+status: To Do
+assignee: []
+created_date: '2026-08-02 12:00'
+labels: [tts, audio, hygiene]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`TTS/pcm_stream.py::_data_chunk_offset` re-walks RIFF chunks that
+`audio_cpp_contract.validate_pcm16_wav` already walked, because `Pcm16WavInfo` does not expose the
+data payload offset. Two implementations of the same walk must now change in lockstep (a comment
+marks it). Compute the offset once inside the validator's existing loop and expose it on
+`Pcm16WavInfo`; make `pcm_stream` consume it. Origin: streaming-sink Task-3 review follow-up.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `Pcm16WavInfo` carries the data payload offset computed during validation.
+- [ ] #2 `pcm_stream` uses it; the parallel walk is deleted.
+- [ ] #3 The trailing-chunk and word-alignment pins stay green unchanged.
+<!-- AC:END -->

--- a/backlog/tasks/task-1882 - Repo-wide-guard-against-real-audio-output-devices-in-tests.md
+++ b/backlog/tasks/task-1882 - Repo-wide-guard-against-real-audio-output-devices-in-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-1882
+title: 'Repo-wide guard against tests constructing real audio output devices'
+status: To Do
+assignee: []
+created_date: '2026-08-02 12:00'
+labels: [tests, audio, hygiene]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A structurally valid WAV fixture caused an automated test to open a REAL PortAudio output
+device — and pass (streaming-sink Task-4 fix round; live callback confirmed). The narrow guard now
+in `Tests/conftest.py` patches the sink's sounddevice import with a `real_audio_device` opt-out
+marker, but nothing stops a future test reaching `sounddevice.OutputStream` through any other
+path. Origin: streaming-sink Task-4 re-review ruling (narrow guard required now, repo-wide guard
+as its own task).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Constructing a real `sounddevice.OutputStream`/`pyaudio` output stream in any test without the `real_audio_device` marker fails the test loudly.
+- [ ] #2 The marker opt-out works and is documented for test authors.
+- [ ] #3 The existing suite passes unchanged under the guard.
+<!-- AC:END -->

--- a/backlog/tasks/task-1883 - Release-TTS-provider-lease-before-streamed-playback-finishes.md
+++ b/backlog/tasks/task-1883 - Release-TTS-provider-lease-before-streamed-playback-finishes.md
@@ -1,0 +1,28 @@
+---
+id: TASK-1883
+title: 'Release the TTS provider lease before streamed playback finishes'
+status: To Do
+assignee: []
+created_date: '2026-08-02 12:00'
+labels: [tts, audio, streaming]
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The streaming spoken-feedback branch holds the provider lease and operation slot for the
+whole audible playback (pump awaits the sink), not just for synthesis — harmless for short acks,
+but it serializes any concurrent TTS work behind playback and will bite V3 phase 2's hands-free
+loop (long spoken replies). Investigate releasing the lease once the byte stream is fully
+consumed while playback drains. Origin: streaming-sink Task-4 review F8 note, final-review triage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The provider lease/operation slot is released when synthesis output is fully consumed, not when playback ends.
+- [ ] #2 Barge-in and displacement behavior are unchanged (pins stay green).
+- [ ] #3 A concurrent TTS request during long streamed playback is not blocked by the finished synthesis's lease.
+<!-- AC:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -503,6 +503,7 @@ markers = [
     "notes: Notes feature tests",
     "requires_display: tests that require a display (may fail in CI)",
     "requires_cleanup: tests that need a gc pass immediately after running",
+    "real_audio_device: opts out of the autouse _no_real_audio_device guard (Tests/conftest.py) to exercise a real sounddevice OutputStream",
 ]
 
 [tool.mypy]

--- a/tldw_chatbook/Audio/__init__.py
+++ b/tldw_chatbook/Audio/__init__.py
@@ -2,12 +2,33 @@
 """
 Audio recording and dictation functionality for tldw_chatbook.
 Provides cross-platform audio capture and real-time transcription.
+
+Final whole-branch review (streaming-pcm-sink, C1): this package used to
+eagerly `from .recording_service import AudioRecordingService,
+AudioRecordingError` at module scope. `recording_service.py` imports
+`sounddevice` at ITS module scope, and `sounddevice`'s own `_initialize()`
+calls `Pa_Initialize()` at IMPORT TIME -- raising `PortAudioError` (not
+`ImportError`) when PortAudio cannot initialize (headless container, no
+ALSA, CoreAudio unavailable, audio server down). Because
+`Event_Handlers/TTS_Events/tts_events.py` imports
+`tldw_chatbook.Audio.streaming_sink` at ITS OWN module scope (which, being
+a submodule of this package, always imports this `__init__.py` first per
+ordinary Python package semantics), that uncaught `PortAudioError` used to
+fail the import of `tldw_chatbook.app` itself, for any user with the
+`speech_recording` extra installed on a machine where PortAudio can't
+init. Failure mode: "voice features degrade" -> "the application does not
+start". `AudioRecordingService`/`AudioRecordingError` are now lazy exports
+too, via the same `__getattr__` pattern already used below for the
+dictation stack -- so importing this package, or any submodule under it,
+no longer transitively imports `recording_service`/`sounddevice` at all.
+Only an explicit `from tldw_chatbook.Audio import AudioRecordingService`
+(or importing `.recording_service` directly, as every real production
+call site already does) triggers it, same as before for the dictation
+exports.
 """
 
 from importlib import import_module
 from typing import Any
-
-from .recording_service import AudioRecordingService, AudioRecordingError
 
 __all__ = [
     "AudioRecordingService",
@@ -17,27 +38,33 @@ __all__ = [
     "DictationState",
 ]
 
-_LAZY_DICTATION_EXPORTS = {
-    "LiveDictationService",
-    "DictationResult",
-    "DictationState",
+#: Maps each lazy export to the submodule (relative to this package) that
+#: defines it. `__getattr__` below imports that submodule -- and only that
+#: submodule -- the first time the name is actually requested.
+_LAZY_EXPORTS = {
+    "AudioRecordingService": ".recording_service",
+    "AudioRecordingError": ".recording_service",
+    "LiveDictationService": ".dictation_service",
+    "DictationResult": ".dictation_service",
+    "DictationState": ".dictation_service",
 }
 
 
 def __getattr__(name: str) -> Any:
-    """Load the legacy live-dictation stack only when explicitly requested.
+    """Load a lazy export's owning submodule only when explicitly requested.
 
     Args:
         name: Package attribute requested by the caller.
 
     Returns:
-        The lazily imported legacy dictation attribute.
+        The lazily imported attribute.
 
     Raises:
         AttributeError: The requested name is not a supported lazy export.
     """
-    if name not in _LAZY_DICTATION_EXPORTS:
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    value = getattr(import_module(".dictation_service", __name__), name)
+    value = getattr(import_module(module_name, __name__), name)
     globals()[name] = value
     return value

--- a/tldw_chatbook/Audio/recording_service.py
+++ b/tldw_chatbook/Audio/recording_service.py
@@ -30,12 +30,24 @@ except ImportError:
 PYAUDIO_AVAILABLE = False
 SOUNDDEVICE_AVAILABLE = False
 
+# Final whole-branch review (streaming-pcm-sink, C1), belt-and-braces: all
+# three backend probes below catch `Exception`, not just `ImportError`.
+# `sounddevice` in particular calls `Pa_Initialize()` at IMPORT TIME
+# (`_initialize()`, module scope) and raises `PortAudioError` -- a
+# `RuntimeError` subclass, not `ImportError` -- when PortAudio itself can't
+# initialize (headless container, no ALSA, CoreAudio unavailable, audio
+# server down), which an `except ImportError` alone lets propagate
+# uncaught. `Audio/__init__.py` no longer imports this module eagerly
+# (same review, same fix), so this module is now reached only when a
+# caller genuinely wants a real audio backend -- but it must still degrade
+# to "unavailable" rather than raise when that backend can't come up,
+# exactly as the package already promises for a merely-missing package.
 try:
     import pyaudio
 
     PYAUDIO_AVAILABLE = True
     logger.info("PyAudio backend available")
-except ImportError:
+except Exception:
     pyaudio = SimpleNamespace(PyAudio=None, paInt16=8)
     logger.warning("PyAudio not available. Install with: pip install pyaudio")
 
@@ -44,7 +56,7 @@ try:
 
     SOUNDDEVICE_AVAILABLE = True
     logger.info("Sounddevice backend available")
-except ImportError:
+except Exception:
     sd = SimpleNamespace(
         InputStream=None,
         query_devices=lambda: [],
@@ -59,7 +71,7 @@ try:
 
     VAD_AVAILABLE = True
     logger.info("WebRTC VAD available for voice activity detection")
-except ImportError:
+except Exception:
     webrtcvad = SimpleNamespace(Vad=None)
     logger.warning("WebRTC VAD not available. Install with: pip install webrtcvad")
 

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -1,0 +1,493 @@
+# streaming_sink.py
+"""Interruptible, low-latency streaming PCM audio sink.
+
+`StreamingPcmSink` plays a live stream of raw PCM16 audio chunks (as
+produced incrementally by a TTS adapter) through an audio output device,
+without waiting for the whole utterance to be synthesized first. It is the
+low-level "spine" of the streaming TTS playback seam: it owns buffering,
+prebuffering, underrun/overrun accounting, and abrupt interruption, but
+knows nothing about TTS, Textual, or any particular audio backend.
+
+Design constraints (see the streaming-pcm-sink plan for the full spec):
+
+* No Textual imports anywhere in this module.
+* `sounddevice` is never imported at module scope -- only lazily inside
+  `open()` -- so importing this module never requires an audio backend to
+  be installed. `sink_available()` probes via `importlib.util.find_spec`
+  so callers can check availability without importing the package.
+* `stop()` must reach audible silence within two audio blocks of
+  returning. This is implemented with `stream.abort()`, which drops
+  buffered audio immediately -- `stream.stop()` is a hard requirement to
+  avoid, since PortAudio drains its buffer first and would blow the
+  latency budget.
+* Playback only becomes audible once `PREBUFFER_MS` worth of audio has
+  been buffered, or once `close()` has been called (so short utterances
+  that never reach the prebuffer threshold still play out).
+* `feed()` never blocks and never raises; the internal buffer is capped at
+  `BUFFER_CAP_SECONDS` of audio at the stream's sample rate. Once full,
+  `feed()` returns `False` and a single `SinkBufferFull` event is emitted
+  per full episode (not once per rejected call).
+* The device callback registered with the audio backend must never raise:
+  an exception escaping that callback would kill the backend's audio
+  thread.
+
+The `stream_factory` constructor argument is the testability seam: in
+production it is left `None` and `open()` lazily builds a real
+`sounddevice.OutputStream`; tests inject a fake stream whose callback can
+be driven synchronously and deterministically (no wall-clock sleeps, no
+real audio hardware).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from importlib.util import find_spec
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+#: Minimum amount of buffered audio, in milliseconds, before the sink
+#: starts emitting audible samples (rather than silence) from the device
+#: callback. Prevents choppy playback caused by starting before enough
+#: lookahead has accumulated.
+PREBUFFER_MS = 300
+
+#: Maximum amount of audio, in seconds (at the sink's opened sample rate),
+#: that `feed()` will buffer before refusing further input.
+BUFFER_CAP_SECONDS = 60
+
+#: Minimum spacing, in audio blocks, between consecutive `SinkUnderrun`
+#: emissions. At the default 20ms block size this is roughly one second;
+#: it exists purely to avoid flooding `on_event` with one event per empty
+#: callback during a prolonged underrun.
+_UNDERRUN_THROTTLE_BLOCKS = 50   # >= 1s at 20ms blocks
+
+
+@dataclass(frozen=True)
+class SinkStarted:
+    """Emitted the first time the sink transitions from silence to audible playback."""
+
+
+@dataclass(frozen=True)
+class SinkDrained:
+    """Emitted once all buffered audio has finished playing after `close()`."""
+
+
+@dataclass(frozen=True)
+class SinkStopped:
+    """Emitted after `stop()` has aborted the stream and discarded buffered audio."""
+
+
+@dataclass(frozen=True)
+class SinkBufferFull:
+    """Emitted once per full episode when `feed()` starts rejecting audio because the buffer cap was reached."""
+
+
+@dataclass(frozen=True)
+class SinkUnderrun:
+    """Emitted when the device callback runs dry after playback has started.
+
+    Attributes:
+        count: Cumulative number of audio frames the device callback
+            requested but could not fill with real audio (silence played
+            in their place) since this sink was opened, as of the moment
+            this event was emitted. Frames, not callback invocations, so
+            the value is meaningful even when a single throttled event
+            covers a short burst of consecutive underruns.
+    """
+    count: int
+
+
+@dataclass(frozen=True)
+class SinkFailed:
+    """Emitted when the sink cannot open or encounters a fatal runtime error.
+
+    Attributes:
+        reason: Human-readable description of what failed.
+    """
+    reason: str
+
+
+def sink_available() -> bool:
+    """Report whether the `sounddevice` package is importable.
+
+    Uses `importlib.util.find_spec` rather than an actual import so callers
+    can probe availability without paying (or risking) an import of the
+    audio backend.
+
+    Returns:
+        `True` if `sounddevice` can be imported, `False` otherwise.
+    """
+    return find_spec("sounddevice") is not None
+
+
+def _import_sounddevice():
+    """Lazily import and return the `sounddevice` module.
+
+    Returns:
+        The imported `sounddevice` module, or `None` if it is not
+        installed or fails to import for any reason.
+    """
+    try:
+        import sounddevice
+        return sounddevice
+    except Exception:
+        return None
+
+
+class StreamingPcmSink:
+    """Plays a live stream of PCM16 audio chunks with low-latency interruption.
+
+    Instances are single-use: call `open()` once, `feed()` chunks as they
+    become available, then either `close()` (to let buffered audio finish
+    playing and drain naturally) or `stop()` (to abort immediately). After
+    `close()`/`stop()`/a failure, a new `StreamingPcmSink` must be created
+    for further playback.
+
+    All public methods are safe to call from any thread; the audio device
+    callback runs on a backend-owned thread and communicates with the rest
+    of the instance only through a single lock.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_event: Callable[[object], None],
+        blocksize_ms: int = 20,
+        stream_factory: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        """Initialize the sink.
+
+        Args:
+            on_event: Callback invoked with one of the `Sink*` event
+                dataclasses whenever the sink's state changes. Must not
+                raise; any exception it raises is caught and logged, never
+                propagated into audio code paths.
+            blocksize_ms: Size, in milliseconds, of each audio block
+                requested from the output stream. Also used to derive the
+                frames-per-block passed to `stream_factory`/`OutputStream`.
+            stream_factory: Optional factory used in place of
+                `sounddevice.OutputStream` to construct the output stream.
+                Called as `factory(samplerate=..., channels=..., blocksize=...,
+                callback=...)`. Production code leaves this `None`, which
+                lazily imports `sounddevice` inside `open()`; tests inject a
+                fake stream here to drive playback synchronously.
+        """
+        self._emit_cb = on_event
+        self._blocksize_ms = blocksize_ms
+        self._factory = stream_factory
+        self._lock = threading.Lock()
+        self._buf: deque[bytes] = deque()      # arbitrary-size chunks
+        self._buffered_bytes = 0
+        self._leftover = b""                   # partial block carried between callbacks
+        self._state = "idle"
+        self._audible = False
+        self._closed = False
+        self._cap_bytes = 0
+        self._prebuffer_bytes = 0
+        self._bytes_per_frame = 2
+        self._full_reported = False
+        self._underruns = 0
+        self._underrun_last_emit_block = -10**9
+        self._block_index = 0
+        self._stream: Any = None
+
+    def _emit(self, event: object) -> None:
+        """Fire-and-forget event dispatch that never raises.
+
+        Args:
+            event: One of the `Sink*` dataclass instances to hand to the
+                `on_event` callback supplied at construction time.
+        """
+        try:
+            self._emit_cb(event)
+        except Exception:
+            logger.opt(exception=True).debug("sink event emit failed")
+
+    def open(self, sample_rate: int, channels: int = 1) -> None:
+        """Open the output stream and start the device callback.
+
+        No-op if the sink is not in its initial `"idle"` state (i.e. this
+        has already been called, or the sink has already failed/stopped).
+        On success, transitions to `"open"`. On any failure -- no
+        `stream_factory` and `sounddevice` unavailable, or the factory /
+        `stream.start()` raising -- transitions to `"failed"` and emits
+        `SinkFailed` instead of raising.
+
+        Args:
+            sample_rate: Output sample rate in Hz. Used to size the
+                prebuffer and buffer-cap thresholds and to compute
+                frames-per-block from `blocksize_ms`.
+            channels: Number of output channels. Defaults to mono.
+        """
+        with self._lock:
+            if self._state != "idle":
+                return
+            frames_per_block = sample_rate * self._blocksize_ms // 1000
+            self._bytes_per_frame = 2 * channels
+            self._cap_bytes = BUFFER_CAP_SECONDS * sample_rate * self._bytes_per_frame
+            self._prebuffer_bytes = PREBUFFER_MS * sample_rate * self._bytes_per_frame // 1000
+        _register_live_sink(self)              # one-voice (Task 2 wires displacement)
+        factory = self._factory
+        if factory is None:
+            sd = _import_sounddevice()
+            if sd is None:
+                self._fail("audio output unavailable (sounddevice not installed)")
+                return
+
+            def factory(**kw):
+                return sd.OutputStream(
+                    samplerate=kw["samplerate"], channels=kw["channels"],
+                    blocksize=kw["blocksize"], dtype="int16",
+                    callback=lambda outdata, frames, t, status:
+                        kw["callback"](outdata, frames, t, status),
+                )
+        try:
+            self._stream = factory(samplerate=sample_rate, channels=channels,
+                                    blocksize=frames_per_block, callback=self._callback)
+            self._stream.start()
+        except Exception as exc:
+            self._fail(f"audio device open failed: {exc}")
+            return
+        with self._lock:
+            self._state = "open"
+
+    def feed(self, pcm: bytes) -> bool:
+        """Append a chunk of PCM16 audio to the playback buffer.
+
+        Never blocks. If the buffer is already at (or would exceed) the
+        `BUFFER_CAP_SECONDS` cap, the chunk is dropped and `False` is
+        returned; a `SinkBufferFull` event is emitted the first time this
+        happens for this sink (subsequent rejections stay silent until the
+        buffer has room again).
+
+        Args:
+            pcm: Raw PCM16 bytes to enqueue, at the sample rate/channel
+                count passed to `open()`.
+
+        Returns:
+            `True` if the chunk was accepted, `False` if it was rejected
+            (sink not open/draining, already closed, or buffer full).
+        """
+        with self._lock:
+            if self._state not in ("open", "draining") or self._closed:
+                return False
+            if self._buffered_bytes + len(pcm) > self._cap_bytes:
+                report = not self._full_reported
+                self._full_reported = True
+            else:
+                self._buf.append(pcm)
+                self._buffered_bytes += len(pcm)
+                return True
+        if report:
+            self._emit(SinkBufferFull())
+        return False
+
+    def close(self) -> None:
+        """Signal end-of-stream: play out buffered audio, then drain.
+
+        No-op unless the sink is currently `"open"`. Does not stop
+        playback immediately -- buffered audio (including audio still
+        below the prebuffer threshold) is allowed to play out, after which
+        the device callback transitions the sink to `"stopped"` and emits
+        `SinkDrained`. Use `stop()` instead for immediate interruption.
+        """
+        with self._lock:
+            if self._state != "open":
+                return
+            self._closed = True
+            self._state = "draining"
+
+    def stop(self) -> None:
+        """Abort playback immediately and discard any buffered audio.
+
+        Reaches audible silence within two audio blocks by calling
+        `stream.abort()` (never `stream.stop()`, which drains PortAudio's
+        internal buffer first and would violate the latency contract).
+        Safe to call multiple times or on a sink that never successfully
+        opened; emits `SinkStopped` exactly once.
+        """
+        with self._lock:
+            if self._state in ("stopped", "failed", "idle"):
+                self._state = "stopped" if self._state == "idle" else self._state
+                return
+            self._state = "stopped"
+            self._buf.clear()
+            self._buffered_bytes = 0
+            self._leftover = b""
+        stream, self._stream = self._stream, None
+        if stream is not None:
+            try:
+                stream.abort()                 # NEVER stream.stop(): that drains
+                stream.close()
+            except Exception:
+                logger.opt(exception=True).debug("sink abort raised")
+        _clear_live_sink(self)
+        self._emit(SinkStopped())
+
+    def _fail(self, reason: str) -> None:
+        """Transition the sink to `"failed"` and emit `SinkFailed`.
+
+        Args:
+            reason: Human-readable description of the failure, passed
+                through to the `SinkFailed` event.
+        """
+        with self._lock:
+            self._state = "failed"
+            self._buf.clear()
+            self._buffered_bytes = 0
+        _clear_live_sink(self)
+        self._emit(SinkFailed(reason=reason))
+
+    def _callback(self, outdata, frames, _time, _status) -> None:
+        """Device audio callback: fill `outdata` with the next block of audio.
+
+        This runs on the audio backend's own thread and must never raise
+        -- any exception here would propagate into PortAudio/sounddevice
+        and kill the audio thread. All exceptions are caught, `outdata` is
+        zeroed defensively, and the sink transitions to `"failed"`.
+
+        Args:
+            outdata: Output buffer to fill, shaped `(frames, channels)`.
+            frames: Number of frames requested for this block.
+            _time: Backend-supplied timing info (unused).
+            _status: Backend-supplied status flags (unused).
+        """
+        try:
+            need = frames * self._bytes_per_frame
+            with self._lock:
+                if self._state not in ("open", "draining"):
+                    outdata[:] = 0
+                    return
+                if not self._audible:
+                    if self._buffered_bytes >= self._prebuffer_bytes or self._closed:
+                        self._audible = True
+                        started = True
+                    else:
+                        outdata[:] = 0
+                        return
+                else:
+                    started = False
+                chunk = self._take_locked(need)
+                drained = self._closed and self._buffered_bytes == 0 and not self._leftover
+            if started:
+                self._emit(SinkStarted())
+            if chunk:
+                out = memoryview(outdata).cast("B")
+                out[: len(chunk)] = chunk
+                if len(chunk) < need:
+                    out[len(chunk):] = b"\x00" * (need - len(chunk))
+            else:
+                outdata[:] = 0
+                if self._audible and not drained:
+                    self._note_underrun(frames)
+            if drained:
+                with self._lock:
+                    if self._state == "draining":
+                        self._state = "stopped"
+                        emit_drain = True
+                    else:
+                        emit_drain = False
+                if emit_drain:
+                    _clear_live_sink(self)
+                    self._emit(SinkDrained())
+            self._block_index += 1
+        except Exception:
+            # Swallow EVERYTHING: a raise here kills the PortAudio thread.
+            try:
+                outdata[:] = 0
+            except Exception:
+                pass
+            self._fail("audio callback error")
+
+    def _take_locked(self, need: int) -> bytes:
+        """Pop up to `need` bytes of audio off the buffer.
+
+        Must be called with `self._lock` held. Consumes carried-over
+        `self._leftover` first, then whole chunks from `self._buf`, and
+        stashes any excess back into `self._leftover` for the next call.
+
+        Args:
+            need: Number of bytes requested.
+
+        Returns:
+            Up to `need` bytes of audio; shorter than `need` only if the
+            buffer did not contain enough data.
+        """
+        parts = [self._leftover] if self._leftover else []
+        have = len(self._leftover)
+        self._leftover = b""
+        while have < need and self._buf:
+            c = self._buf.popleft()
+            self._buffered_bytes -= len(c)
+            parts.append(c)
+            have += len(c)
+        blob = b"".join(parts)
+        if len(blob) > need:
+            self._leftover = blob[need:]
+            blob = blob[:need]
+        return blob
+
+    def _note_underrun(self, frames: int) -> None:
+        """Record an empty callback and, if due, emit a throttled `SinkUnderrun`.
+
+        Called with `self._lock` already released (it re-acquires nothing
+        itself; the counters it touches are only ever mutated from the
+        single audio callback thread). Emission is throttled to at most
+        once every `_UNDERRUN_THROTTLE_BLOCKS` blocks so a prolonged
+        underrun does not flood `on_event`; the very first underrun after
+        a quiet period always reports immediately (the throttle only
+        suppresses *repeat* reports of an ongoing underrun).
+
+        Args:
+            frames: Number of audio frames this callback could not fill
+                with real audio (silence was substituted), added to the
+                sink's running total.
+        """
+        self._underruns += frames
+        if self._block_index - self._underrun_last_emit_block >= _UNDERRUN_THROTTLE_BLOCKS:
+            self._underrun_last_emit_block = self._block_index
+            self._emit(SinkUnderrun(count=self._underruns))
+
+    @property
+    def state(self) -> str:
+        """Current lifecycle state: one of `idle`, `open`, `draining`, `stopped`, `failed`."""
+        return self._state
+
+    @property
+    def buffered_seconds(self) -> float:
+        """Approximate seconds of audio currently buffered (not yet played)."""
+        with self._lock:
+            denom = self._cap_bytes / BUFFER_CAP_SECONDS if self._cap_bytes else 1
+            return self._buffered_bytes / denom
+
+
+#: The sink currently registered as "live" (i.e. actively producing audio
+#: output). Task 1 keeps registration/clearing inert no-ops; Task 2 wires
+#: one-voice displacement semantics (opening a new sink stops any prior
+#: live sink) on top of this holder.
+_LIVE_SINK: Optional[StreamingPcmSink] = None
+
+
+def _register_live_sink(sink: StreamingPcmSink) -> None:
+    """Register `sink` as the live sink.
+
+    Inert in Task 1 (no displacement semantics yet) so these contract
+    tests do not depend on Task 2's one-voice behavior; Task 2 gives this
+    real semantics.
+
+    Args:
+        sink: The sink that just started (or is starting) playback.
+    """
+
+
+def _clear_live_sink(sink: StreamingPcmSink) -> None:
+    """Clear `sink` as the live sink if it is currently registered.
+
+    Inert in Task 1; Task 2 gives this real semantics.
+
+    Args:
+        sink: The sink that stopped, drained, or failed.
+    """

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -455,8 +455,14 @@ class StreamingPcmSink:
         if self._notify_thread is not None and threading.current_thread() is not self._notify_thread:
             self._notify_q.join()
         _clear_live_sink(self)
-        if self._notify_thread is not None:
-            self._notify_q.put(_NOTIFY_STOP)
+        # Pushed unconditionally -- not gated on self._notify_thread being
+        # published yet (see N1). open() may still be mid-flight, between
+        # its own state flip to "open" and creating/publishing the notify
+        # thread; queuing the sentinel now means that thread, whenever it
+        # does start, finds it waiting and exits immediately instead of
+        # parking on get() forever. Queuing onto a queue nothing will ever
+        # read (open() never reaches "open" at all) is harmless.
+        self._notify_q.put(_NOTIFY_STOP)
         self._emit(SinkStopped())
 
     def _fail(self, reason: str, *, from_callback: bool = False) -> None:
@@ -516,7 +522,7 @@ class StreamingPcmSink:
                     outdata[:] = 0
                     return
                 if not self._audible:
-                    have_any = self._buffered_bytes > 0 or self._leftover
+                    have_any = self._buffered_bytes > 0 or self._leftover_remaining_locked() > 0
                     if self._buffered_bytes >= self._prebuffer_bytes or (self._closed and have_any):
                         self._audible = True
                         # Enqueued while still holding self._lock (rather
@@ -540,6 +546,15 @@ class StreamingPcmSink:
                 chunk = self._take_locked(need)
                 drained = (self._closed and self._buffered_bytes == 0
                            and self._leftover_remaining_locked() == 0)
+                if self._audible and not chunk and not drained:
+                    # Noted (and, if due, enqueued) while still holding
+                    # self._lock -- same reasoning as SinkStarted above: a
+                    # concurrent stop() needs this same lock for its own
+                    # state check, so it cannot complete (and push its
+                    # sentinel) before this enqueue has already happened,
+                    # which is what prevents the job from being orphaned on
+                    # a queue whose notify thread has already exited (N2).
+                    self._note_underrun(frames)
             if chunk:
                 out = memoryview(outdata).cast("B")
                 out[: len(chunk)] = chunk
@@ -547,8 +562,6 @@ class StreamingPcmSink:
                     out[len(chunk):] = b"\x00" * (need - len(chunk))
             else:
                 outdata[:] = 0
-                if self._audible and not drained:
-                    self._note_underrun(frames)
             if drained:
                 with self._lock:
                     if self._state == "draining":
@@ -633,18 +646,24 @@ class StreamingPcmSink:
     def _note_underrun(self, frames: int) -> None:
         """Record an empty callback and, if due, enqueue a throttled `SinkUnderrun`.
 
-        Called on the audio callback thread, with `self._lock` already
-        released (it re-acquires nothing itself; the counters it touches
-        are only ever mutated from that single thread, so no lock is
-        needed for them). Emission is throttled to at most once every
-        `_UNDERRUN_THROTTLE_BLOCKS` blocks so a prolonged underrun does
-        not flood `on_event`; the very first underrun after a quiet period
-        always reports immediately (the throttle only suppresses *repeat*
-        reports of an ongoing underrun). The event itself is handed to the
-        notify queue rather than emitted directly, per the module's thread
-        contract -- this is a plain `"emit"` job (no stream teardown), so
-        it does not need the `_NOTIFY_STOP` sentinel that terminal events
-        push.
+        Called on the audio callback thread, from within `_callback`'s own
+        `self._lock` critical section (it does not acquire the lock itself
+        -- `queue.Queue.put` has its own internal synchronization -- but
+        relies on the *caller* already holding `self._lock` for the same
+        reason `SinkStarted`'s enqueue does: it closes the window where a
+        concurrent `stop()` could complete, push its sentinel, and let the
+        notify thread exit *before* this job is queued, orphaning it on a
+        dead queue -- see N2). The counters it touches are only ever
+        mutated from this single thread regardless, so no additional lock
+        is needed for them specifically. Emission is throttled to at most
+        once every `_UNDERRUN_THROTTLE_BLOCKS` blocks so a prolonged
+        underrun does not flood `on_event`; the very first underrun after
+        a quiet period always reports immediately (the throttle only
+        suppresses *repeat* reports of an ongoing underrun). The event
+        itself is handed to the notify queue rather than emitted directly,
+        per the module's thread contract -- this is a plain `"emit"` job
+        (no stream teardown), so it does not need the `_NOTIFY_STOP`
+        sentinel that terminal events push.
 
         Args:
             frames: Number of audio frames this callback could not fill

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -113,6 +113,8 @@ from typing import Any, AsyncIterator, Callable, Literal, Optional
 
 from loguru import logger
 
+from tldw_chatbook.Utils import optional_deps
+
 #: Sentinel pushed onto a sink's notify queue to tell its notify thread to
 #: exit its drain loop once every already-queued job has been processed.
 _NOTIFY_STOP = object()
@@ -218,7 +220,17 @@ def sink_available() -> bool:
 
     Uses `importlib.util.find_spec` rather than an actual import so callers
     can probe availability without paying (or risking) an import of the
-    audio backend.
+    audio backend. `optional_deps.py` has an equivalent non-importing
+    pattern (`_check_dependency_installed`, docstring: "reserved for native
+    runtimes whose import can initialize hardware or abort the
+    interpreter" -- exactly `sounddevice`'s situation, see
+    `_import_sounddevice()` below) but it is a private helper only ever
+    called from within `optional_deps.py` itself today, and there is no
+    public find_spec-only probe for `sounddevice` specifically (unlike,
+    say, `embeddings_rag_deps_installed()`/`parakeet_onnx_deps_installed()`
+    for other feature groups) -- so this keeps its own inline `find_spec`
+    call rather than reaching into `optional_deps` internals for a probe
+    it does not otherwise expose.
 
     Returns:
         `True` if `sounddevice` can be imported, `False` otherwise.
@@ -229,13 +241,45 @@ def sink_available() -> bool:
 def _import_sounddevice():
     """Lazily import and return the `sounddevice` module.
 
+    Delegates the actual import to `optional_deps.get_safe_import()` --
+    this project's shared entry point for optional third-party
+    dependencies (compliance finding F1) -- rather than a bare `import
+    sounddevice` statement, so `sounddevice` participates in the same
+    caching (`optional_deps.MODULES`) and availability bookkeeping
+    (`optional_deps.DEPENDENCIES_AVAILABLE`) every other optional
+    dependency does.
+
+    This function still wraps that call in its own broad `except
+    Exception`, deliberately broader than `optional_deps.check_dependency`'s
+    own `except (ImportError, ModuleNotFoundError)`: `sounddevice` is a
+    native-runtime dependency whose *import itself* calls PortAudio's
+    `Pa_Initialize()`, which raises `PortAudioError` -- a plain
+    `Exception` subclass, not an `ImportError` -- when the audio backend
+    cannot initialize (headless container, no ALSA, CoreAudio unavailable,
+    audio server down). That is the exact failure mode the whole-branch
+    review's C1 finding pinned (see the module docstring, and
+    `Tests/Audio/test_audio_init_lazy_import_safety.py`'s
+    `test_app_import_survives_a_portaudio_init_failure` /
+    `test_streaming_sink_import_alone_pulls_no_audio_backend`). Were this
+    function to rely solely on `optional_deps`' own narrower catch, a
+    `PortAudioError` raised by `get_safe_import()`'s internal
+    `__import__("sounddevice")` would propagate out of this function
+    uncaught -- and, since `open()` calls this outside its own
+    stream-building `try`/`except`, out of `open()` itself, raising into
+    the caller instead of failing closed into `SinkFailed`. That would
+    reintroduce C1's failure mode one call-site later: not at app-import
+    time (both pins above import-check that), but at `open()`-call time,
+    the first time a sink actually tries to play audio on a box where
+    PortAudio can't init. This function's own `except Exception` is
+    therefore load-bearing and must not be narrowed to match
+    `optional_deps`'.
+
     Returns:
         The imported `sounddevice` module, or `None` if it is not
         installed or fails to import for any reason.
     """
     try:
-        import sounddevice
-        return sounddevice
+        return optional_deps.get_safe_import("sounddevice")
     except Exception:
         return None
 

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -62,12 +62,13 @@ in the audio backend regardless of what this module does on its own.
 
 from __future__ import annotations
 
+import asyncio
 import queue
 import threading
 from collections import deque
 from dataclasses import dataclass
 from importlib.util import find_spec
-from typing import Any, Callable, Optional
+from typing import Any, AsyncIterator, Callable, Optional
 
 from loguru import logger
 
@@ -135,6 +136,29 @@ class SinkFailed:
         reason: Human-readable description of what failed.
     """
     reason: str
+
+
+@dataclass(frozen=True)
+class PumpResult:
+    """Outcome of a completed `pump()` call.
+
+    Attributes:
+        outcome: One of `"drained"` (the source was exhausted, `pump`
+            called `close()`, and the sink went on to reach `"stopped"`
+            naturally -- or was already terminal for a reason other than
+            failure by the time `pump` checked), `"stopped"` (the sink
+            left `"open"`/`"draining"` -- e.g. an external barge-in
+            `stop()` -- while `pump` was still feeding, before the source
+            was exhausted), `"failed"` (the sink transitioned to
+            `"failed"`, whether mid-feed or during the post-`close()`
+            drain wait), or `"source_error"` (the chunk source itself
+            raised; `pump` stopped the sink in response).
+        bytes_fed: Total PCM bytes actually handed to `sink.feed()` and
+            accepted (after `skip_bytes` was consumed from the head of the
+            stream), regardless of outcome.
+    """
+    outcome: str
+    bytes_fed: int
 
 
 def sink_available() -> bool:
@@ -695,29 +719,141 @@ class StreamingPcmSink:
 
 
 #: The sink currently registered as "live" (i.e. actively producing audio
-#: output). Task 1 keeps registration/clearing inert no-ops; Task 2 wires
-#: one-voice displacement semantics (opening a new sink stops any prior
-#: live sink) on top of this holder.
+#: output). Guarded by `_LIVE_SINK_LOCK`. One-voice: opening a new sink
+#: displaces (stops) whatever sink was previously registered here.
 _LIVE_SINK: Optional[StreamingPcmSink] = None
+
+#: Guards reads/writes of `_LIVE_SINK`. Deliberately never held while a
+#: sink's `stop()` is called -- `stop()` can briefly block (an unbounded
+#: `_notify_q.join()`, see the module's carried Task-1 review risk), and
+#: holding this lock across that call would let one sink's teardown stall
+#: every other sink's `open()`/`_clear_live_sink()` in the meantime.
+_LIVE_SINK_LOCK = threading.Lock()
 
 
 def _register_live_sink(sink: StreamingPcmSink) -> None:
-    """Register `sink` as the live sink.
+    """Register `sink` as the live sink, displacing (and stopping) any prior one.
 
-    Inert in Task 1 (no displacement semantics yet) so these contract
-    tests do not depend on Task 2's one-voice behavior; Task 2 gives this
-    real semantics.
+    One-voice semantics: only one sink is ever considered "live" at a
+    time. If a different sink was previously registered, it is `stop()`'d
+    -- OUTSIDE `_LIVE_SINK_LOCK` -- so a displaced sink's own (possibly
+    briefly blocking) `stop()` never holds up this registry for anyone
+    else. This function never touches a stream directly; it only ever
+    calls the displaced sink's own public `stop()` method, which owns all
+    stream teardown itself.
 
     Args:
         sink: The sink that just started (or is starting) playback.
     """
+    global _LIVE_SINK
+    with _LIVE_SINK_LOCK:
+        displaced, _LIVE_SINK = _LIVE_SINK, sink
+    if displaced is not None and displaced is not sink:
+        displaced.stop()
 
 
 def _clear_live_sink(sink: StreamingPcmSink) -> None:
     """Clear `sink` as the live sink if it is currently registered.
 
-    Inert in Task 1; Task 2 gives this real semantics.
+    A no-op if `sink` is not the currently-registered live sink (e.g. it
+    was already displaced by a later `open()`, or it was never registered
+    at all) -- safe to call from either the notify thread (drain/failure
+    paths) or a caller thread (`stop()`).
 
     Args:
         sink: The sink that stopped, drained, or failed.
     """
+    global _LIVE_SINK
+    with _LIVE_SINK_LOCK:
+        if _LIVE_SINK is sink:
+            _LIVE_SINK = None
+
+
+async def pump(
+    sink: StreamingPcmSink,
+    chunks: AsyncIterator[bytes],
+    *,
+    skip_bytes: int = 0,
+) -> PumpResult:
+    """Feed an async source of PCM chunks into `sink` until stop or exhaustion.
+
+    Bridges an async chunk source (e.g. a streaming TTS adapter's
+    incremental response) into the sink's synchronous, non-blocking
+    `feed()`, handling:
+
+    * An optional `skip_bytes`-byte prefix (e.g. a WAV header some
+      providers cannot be told to omit), dropped across chunk boundaries
+      before any audio is fed.
+    * Backpressure: when `feed()` returns `False` (buffer full), `pump`
+      retries the very same remainder after a short sleep rather than
+      dropping audio.
+    * Prompt exit the moment the sink leaves `"open"`/`"draining"` for a
+      terminal state (e.g. an external barge-in `stop()`, or a device
+      failure) -- `pump` does not wait for the source to finish in that
+      case.
+    * A source that raises: `pump` calls `sink.stop()` and reports
+      `"source_error"`, so the sink still reaches a terminal state even
+      when the caller never gets to call `close()`/`stop()` itself.
+    * Normal exhaustion: `pump` calls `sink.close()` and waits -- polling,
+      never blocking the event loop -- for the sink to reach a terminal
+      state.
+
+    `pump` only ever calls `feed()`/`close()`/`stop()` from its own task,
+    never from a listener registered on the sink, so it never risks
+    blocking on the `stop()` -> `_notify_q.join()` carried risk noted in
+    the module's Task-1 review context.
+
+    Args:
+        sink: The (already-`open()`ed) sink to feed.
+        chunks: Async iterator of raw PCM16 byte chunks. `pump` only
+            iterates it; it does not open, close, or otherwise manage its
+            lifecycle.
+        skip_bytes: Number of leading bytes to discard from the head of
+            the concatenated chunk stream before any audio is fed to the
+            sink -- e.g. to drop a WAV header. Defaults to 0.
+
+    Returns:
+        A `PumpResult` describing how the pump ended and how many bytes
+        were actually fed to the sink.
+    """
+    bytes_fed = 0
+    remaining_skip = skip_bytes
+    try:
+        async for chunk in chunks:
+            if remaining_skip:
+                if remaining_skip >= len(chunk):
+                    remaining_skip -= len(chunk)
+                    continue
+                chunk = chunk[remaining_skip:]
+                remaining_skip = 0
+            while chunk:
+                if sink.state not in ("open", "draining"):
+                    return PumpResult(outcome=_early_exit_outcome(sink.state), bytes_fed=bytes_fed)
+                if sink.feed(chunk):
+                    bytes_fed += len(chunk)
+                    break
+                await asyncio.sleep(0.05)
+    except Exception:
+        sink.stop()
+        return PumpResult(outcome="source_error", bytes_fed=bytes_fed)
+
+    if sink.state not in ("open", "draining"):
+        return PumpResult(outcome=_early_exit_outcome(sink.state), bytes_fed=bytes_fed)
+    sink.close()
+    while sink.state not in ("stopped", "failed"):
+        await asyncio.sleep(0.01)
+    return PumpResult(outcome="failed" if sink.state == "failed" else "drained", bytes_fed=bytes_fed)
+
+
+def _early_exit_outcome(state: str) -> str:
+    """Map a sink `state` observed before/without `pump` itself calling `close()` to an outcome.
+
+    Args:
+        state: The sink's `state` at the moment `pump` noticed it had left
+            `"open"`/`"draining"` on its own (i.e. not as a result of
+            `pump`'s own `close()` call).
+
+    Returns:
+        `"failed"` if `state` is `"failed"`, otherwise `"stopped"`.
+    """
+    return "failed" if state == "failed" else "stopped"

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -31,15 +31,38 @@ Design constraints (see the streaming-pcm-sink plan for the full spec):
   an exception escaping that callback would kill the backend's audio
   thread.
 
+Thread contract: `open()`, `feed()`, `close()`, and `stop()` may be called
+from any thread. The audio backend invokes the device callback
+(`_callback`) on its own realtime thread; PortAudio forbids calling
+`Pa_AbortStream`/`Pa_StopStream`/`Pa_CloseStream` (i.e. `stream.abort()`/
+`.stop()`/`.close()`) from within that callback, and a listener reacting
+to an event by calling `stop()` synchronously is the expected, common
+case (e.g. barge-in). Events that originate on the callback thread
+(`SinkStarted`, `SinkUnderrun`, and the stream-teardown that accompanies
+a natural drain or a callback failure) are therefore handed off to a
+dedicated per-sink daemon notify thread and delivered to `on_event` from
+there, never from the callback itself. Events that originate from a
+caller thread (`SinkBufferFull` from `feed()`, `SinkStopped` from
+`stop()`, `SinkFailed` from `open()`'s own failure paths) are delivered
+directly, synchronously, on whichever thread called the method -- there
+is no PortAudio-callback-reentrancy risk there.
+
 The `stream_factory` constructor argument is the testability seam: in
 production it is left `None` and `open()` lazily builds a real
 `sounddevice.OutputStream`; tests inject a fake stream whose callback can
 be driven synchronously and deterministically (no wall-clock sleeps, no
 real audio hardware).
+
+Note: `sounddevice` is not imported at module scope by *this* file, but
+`tldw_chatbook.Audio.__init__` currently imports `recording_service` eagerly,
+which does import `sounddevice` (and pyaudio, webrtcvad) at module scope --
+so in practice, importing anything from the `Audio` package already pulls
+in the audio backend regardless of what this module does on its own.
 """
 
 from __future__ import annotations
 
+import queue
 import threading
 from collections import deque
 from dataclasses import dataclass
@@ -47,6 +70,10 @@ from importlib.util import find_spec
 from typing import Any, Callable, Optional
 
 from loguru import logger
+
+#: Sentinel pushed onto a sink's notify queue to tell its notify thread to
+#: exit its drain loop once every already-queued job has been processed.
+_NOTIFY_STOP = object()
 
 #: Minimum amount of buffered audio, in milliseconds, before the sink
 #: starts emitting audible samples (rather than silence) from the device
@@ -194,6 +221,12 @@ class StreamingPcmSink:
         self._underrun_last_emit_block = -10**9
         self._block_index = 0
         self._stream: Any = None
+        # Hand-off from the audio callback thread to a dedicated notify
+        # thread; see the module docstring's "Thread contract". The queue
+        # is always created (even if the sink never successfully opens) so
+        # tests can uniformly probe it.
+        self._notify_q: "queue.Queue[Any]" = queue.Queue()
+        self._notify_thread: Optional[threading.Thread] = None
 
     def _emit(self, event: object) -> None:
         """Fire-and-forget event dispatch that never raises.
@@ -207,6 +240,49 @@ class StreamingPcmSink:
         except Exception:
             logger.opt(exception=True).debug("sink event emit failed")
 
+    def _teardown_stream(self) -> None:
+        """Abort and close `self._stream`, if any, and clear the reference.
+
+        Safe to call from any thread and safe to call more than once (a
+        second call finds `self._stream` already `None` and does nothing).
+        Never calls `stream.stop()` -- only `abort()` -- for the same
+        latency reason as `stop()` itself: PortAudio drains its buffer on
+        a graceful stop, which would blow the two-block silence budget.
+        """
+        with self._lock:
+            stream, self._stream = self._stream, None
+        if stream is None:
+            return
+        try:
+            stream.abort()
+            stream.close()
+        except Exception:
+            logger.opt(exception=True).debug("sink stream teardown raised")
+
+    def _notify_loop(self) -> None:
+        """Drain `self._notify_q`, delivering callback-thread-originated work.
+
+        Runs on a dedicated per-sink daemon thread started by `open()`.
+        Each queued job is either the `_NOTIFY_STOP` sentinel (exit the
+        loop) or a `(kind, event)` pair: `"emit"` just delivers `event`;
+        `"teardown_and_emit"` additionally tears down the stream and
+        clears the live-sink registry first, for the drain and
+        callback-failure paths (see `_callback` and `_fail`) -- neither of
+        which may touch the stream directly from the callback thread.
+        """
+        while True:
+            job = self._notify_q.get()
+            try:
+                if job is _NOTIFY_STOP:
+                    return
+                kind, event = job
+                if kind == "teardown_and_emit":
+                    self._teardown_stream()
+                    _clear_live_sink(self)
+                self._emit(event)
+            finally:
+                self._notify_q.task_done()
+
     def open(self, sample_rate: int, channels: int = 1) -> None:
         """Open the output stream and start the device callback.
 
@@ -216,6 +292,13 @@ class StreamingPcmSink:
         `stream_factory` and `sounddevice` unavailable, or the factory /
         `stream.start()` raising -- transitions to `"failed"` and emits
         `SinkFailed` instead of raising.
+
+        If a concurrent `stop()` (or failure) claims the sink while this
+        call is still building/starting the stream -- so the state is no
+        longer `"idle"` by the time this method would otherwise transition
+        to `"open"` -- the just-built stream is torn down immediately
+        instead of being left running, and the `"stopped"`/`"failed"`
+        state that call already set is left in place.
 
         Args:
             sample_rate: Output sample rate in Hz. Used to size the
@@ -253,7 +336,22 @@ class StreamingPcmSink:
             self._fail(f"audio device open failed: {exc}")
             return
         with self._lock:
-            self._state = "open"
+            if self._state != "idle":
+                became_open = False
+            else:
+                self._state = "open"
+                became_open = True
+        if not became_open:
+            # A concurrent stop()/_fail() already claimed this sink -- e.g.
+            # a stop() landing while this open() call was still mid-flight
+            # (the classic Task-3 barge-in-during-open race). The stream we
+            # just built and started must not be left running.
+            self._teardown_stream()
+            return
+        self._notify_thread = threading.Thread(
+            target=self._notify_loop, name="StreamingPcmSinkNotify", daemon=True,
+        )
+        self._notify_thread.start()
 
     def feed(self, pcm: bytes) -> bool:
         """Append a chunk of PCM16 audio to the playback buffer.
@@ -319,39 +417,77 @@ class StreamingPcmSink:
         Reaches audible silence within two audio blocks by calling
         `stream.abort()` (never `stream.stop()`, which drains PortAudio's
         internal buffer first and would violate the latency contract).
-        Safe to call multiple times or on a sink that never successfully
-        opened; emits `SinkStopped` exactly once.
+        Safe to call multiple times, reentrantly from a listener reacting
+        to an event, or on a sink that never successfully opened (even
+        mid-`open()`, before a stream exists yet -- see `open()`); emits
+        `SinkStopped` exactly once.
+
+        The stream teardown itself is unconditional on `self._stream`
+        being set, independent of the state guard below: even if this
+        call finds the sink already terminal (a natural drain already
+        finished it, say), it still tears down `self._stream` if one is
+        somehow still present, defensively. Only the *event* emission is
+        gated to "first call to reach a terminal state wins".
         """
         with self._lock:
-            if self._state in ("stopped", "failed", "idle"):
-                self._state = "stopped" if self._state == "idle" else self._state
-                return
-            self._state = "stopped"
+            already_terminal = self._state in ("stopped", "failed")
+            if not already_terminal:
+                self._state = "stopped"
             self._buf.clear()
             self._buffered_bytes = 0
             self._leftover = b""
             self._leftover_off = 0
-        stream, self._stream = self._stream, None
-        if stream is not None:
-            try:
-                stream.abort()                 # NEVER stream.stop(): that drains
-                stream.close()
-            except Exception:
-                logger.opt(exception=True).debug("sink abort raised")
+        self._teardown_stream()
+        if already_terminal:
+            return
+        # If this call is not itself running on the notify thread (the
+        # common case -- a real stop() arrives from the UI/worker thread),
+        # let any work already queued from the callback thread (e.g. an
+        # in-flight SinkStarted) finish delivering first, so listeners
+        # never observe SinkStopped before an event that logically
+        # preceded it. Skipping this when we ARE the notify thread avoids
+        # a self-deadlock: a listener calling stop() synchronously from
+        # within its own event handling cannot wait on itself.
+        if self._notify_thread is not None and threading.current_thread() is not self._notify_thread:
+            self._notify_q.join()
         _clear_live_sink(self)
+        if self._notify_thread is not None:
+            self._notify_q.put(_NOTIFY_STOP)
         self._emit(SinkStopped())
 
-    def _fail(self, reason: str) -> None:
+    def _fail(self, reason: str, *, from_callback: bool = False) -> None:
         """Transition the sink to `"failed"` and emit `SinkFailed`.
+
+        Idempotent: only the call that actually wins the transition out of
+        a non-terminal state tears down the stream and emits; a sink that
+        is already `"stopped"`/`"failed"` (e.g. a repeating callback error
+        calling this on every block) is a no-op, so `SinkFailed` fires at
+        most once per sink lifecycle and the stream is never left running.
 
         Args:
             reason: Human-readable description of the failure, passed
                 through to the `SinkFailed` event.
+            from_callback: `True` when called from `_callback` (the audio
+                thread) -- in which case the stream teardown, registry
+                clear, and emit are handed off to the notify thread rather
+                than done here, per the module's thread contract. `False`
+                (the default) is for caller-thread call sites (`open()`'s
+                own failure paths), which run before any notify thread
+                exists and may act directly.
         """
         with self._lock:
+            if self._state in ("stopped", "failed"):
+                return
             self._state = "failed"
             self._buf.clear()
             self._buffered_bytes = 0
+            self._leftover = b""
+            self._leftover_off = 0
+        if from_callback:
+            self._notify_q.put(("teardown_and_emit", SinkFailed(reason=reason)))
+            self._notify_q.put(_NOTIFY_STOP)
+            return
+        self._teardown_stream()
         _clear_live_sink(self)
         self._emit(SinkFailed(reason=reason))
 
@@ -379,7 +515,13 @@ class StreamingPcmSink:
                     have_any = self._buffered_bytes > 0 or self._leftover
                     if self._buffered_bytes >= self._prebuffer_bytes or (self._closed and have_any):
                         self._audible = True
-                        started = True
+                        # Enqueued while still holding self._lock (rather
+                        # than after release) so a concurrent stop() -- which
+                        # needs this same lock for its own state check --
+                        # can never observe/act on "started" before this
+                        # event has already been handed to the notify queue.
+                        # That closes the ordering gap findings F8/L8 found.
+                        self._notify_q.put(("emit", SinkStarted()))
                     elif self._closed:
                         # Closed with nothing ever fed: nothing will ever
                         # play, so skip the SinkStarted transition -- but
@@ -387,17 +529,13 @@ class StreamingPcmSink:
                         # logic below so the sink still reaches "stopped"
                         # and emits SinkDrained instead of stalling in
                         # "draining" forever.
-                        started = False
+                        pass
                     else:
                         outdata[:] = 0
                         return
-                else:
-                    started = False
                 chunk = self._take_locked(need)
                 drained = (self._closed and self._buffered_bytes == 0
                            and self._leftover_remaining_locked() == 0)
-            if started:
-                self._emit(SinkStarted())
             if chunk:
                 out = memoryview(outdata).cast("B")
                 out[: len(chunk)] = chunk
@@ -415,8 +553,13 @@ class StreamingPcmSink:
                     else:
                         emit_drain = False
                 if emit_drain:
-                    _clear_live_sink(self)
-                    self._emit(SinkDrained())
+                    # Stream teardown and the live-sink registry clear must
+                    # not happen on this (the audio callback) thread -- see
+                    # the module's thread contract -- so hand both off to
+                    # the notify thread along with the event itself, then
+                    # tell it to exit once it's done (this sink is terminal).
+                    self._notify_q.put(("teardown_and_emit", SinkDrained()))
+                    self._notify_q.put(_NOTIFY_STOP)
             self._block_index += 1
         except Exception:
             # Swallow EVERYTHING: a raise here kills the PortAudio thread.
@@ -424,7 +567,7 @@ class StreamingPcmSink:
                 outdata[:] = 0
             except Exception:
                 pass
-            self._fail("audio callback error")
+            self._fail("audio callback error", from_callback=True)
 
     def _leftover_remaining_locked(self) -> int:
         """Return how many unconsumed bytes remain in `self._leftover`.
@@ -484,15 +627,20 @@ class StreamingPcmSink:
         return blob
 
     def _note_underrun(self, frames: int) -> None:
-        """Record an empty callback and, if due, emit a throttled `SinkUnderrun`.
+        """Record an empty callback and, if due, enqueue a throttled `SinkUnderrun`.
 
-        Called with `self._lock` already released (it re-acquires nothing
-        itself; the counters it touches are only ever mutated from the
-        single audio callback thread). Emission is throttled to at most
-        once every `_UNDERRUN_THROTTLE_BLOCKS` blocks so a prolonged
-        underrun does not flood `on_event`; the very first underrun after
-        a quiet period always reports immediately (the throttle only
-        suppresses *repeat* reports of an ongoing underrun).
+        Called on the audio callback thread, with `self._lock` already
+        released (it re-acquires nothing itself; the counters it touches
+        are only ever mutated from that single thread, so no lock is
+        needed for them). Emission is throttled to at most once every
+        `_UNDERRUN_THROTTLE_BLOCKS` blocks so a prolonged underrun does
+        not flood `on_event`; the very first underrun after a quiet period
+        always reports immediately (the throttle only suppresses *repeat*
+        reports of an ongoing underrun). The event itself is handed to the
+        notify queue rather than emitted directly, per the module's thread
+        contract -- this is a plain `"emit"` job (no stream teardown), so
+        it does not need the `_NOTIFY_STOP` sentinel that terminal events
+        push.
 
         Args:
             frames: Number of audio frames this callback could not fill
@@ -502,7 +650,7 @@ class StreamingPcmSink:
         self._underruns += frames
         if self._block_index - self._underrun_last_emit_block >= _UNDERRUN_THROTTLE_BLOCKS:
             self._underrun_last_emit_block = self._block_index
-            self._emit(SinkUnderrun(frames=self._underruns))
+            self._notify_q.put(("emit", SinkUnderrun(frames=self._underruns)))
 
     @property
     def state(self) -> str:

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -180,8 +180,9 @@ class StreamingPcmSink:
         self._factory = stream_factory
         self._lock = threading.Lock()
         self._buf: deque[bytes] = deque()      # arbitrary-size chunks
-        self._buffered_bytes = 0
-        self._leftover = b""                   # partial block carried between callbacks
+        self._buffered_bytes = 0                # bytes still queued whole in self._buf
+        self._leftover = b""                    # partial block carried between callbacks
+        self._leftover_off = 0                  # bytes already consumed from self._leftover
         self._state = "idle"
         self._audible = False
         self._closed = False
@@ -260,8 +261,10 @@ class StreamingPcmSink:
         Never blocks. If the buffer is already at (or would exceed) the
         `BUFFER_CAP_SECONDS` cap, the chunk is dropped and `False` is
         returned; a `SinkBufferFull` event is emitted the first time this
-        happens for this sink (subsequent rejections stay silent until the
-        buffer has room again).
+        happens for this sink and never again for the lifetime of this
+        sink instance -- the flag does not re-arm even if the buffer later
+        drains below the cap. Since sinks are single-use, "once per full
+        episode" and "once per sink" are the same thing in practice.
 
         Args:
             pcm: Raw PCM16 bytes to enqueue, at the sample rate/channel
@@ -271,10 +274,12 @@ class StreamingPcmSink:
             `True` if the chunk was accepted, `False` if it was rejected
             (sink not open/draining, already closed, or buffer full).
         """
+        report = False
         with self._lock:
             if self._state not in ("open", "draining") or self._closed:
                 return False
-            if self._buffered_bytes + len(pcm) > self._cap_bytes:
+            pending = self._buffered_bytes + self._leftover_remaining_locked()
+            if pending + len(pcm) > self._cap_bytes:
                 report = not self._full_reported
                 self._full_reported = True
             else:
@@ -293,6 +298,14 @@ class StreamingPcmSink:
         below the prebuffer threshold) is allowed to play out, after which
         the device callback transitions the sink to `"stopped"` and emits
         `SinkDrained`. Use `stop()` instead for immediate interruption.
+
+        Calling `close()` before `open()` has transitioned the sink to
+        `"open"` (i.e. while still `"idle"`, mid-`open()`, or after a
+        failed `open()`) is a caller bug: it is silently dropped and
+        `feed()`'d audio already queued will never be played out. Callers
+        must sequence `open()` -> `feed()`* -> `close()`/`stop()` on one
+        thread (as the TTS generation worker does), never call `close()`
+        speculatively before `open()` is known to have succeeded.
         """
         with self._lock:
             if self._state != "open":
@@ -317,6 +330,7 @@ class StreamingPcmSink:
             self._buf.clear()
             self._buffered_bytes = 0
             self._leftover = b""
+            self._leftover_off = 0
         stream, self._stream = self._stream, None
         if stream is not None:
             try:
@@ -362,16 +376,26 @@ class StreamingPcmSink:
                     outdata[:] = 0
                     return
                 if not self._audible:
-                    if self._buffered_bytes >= self._prebuffer_bytes or self._closed:
+                    have_any = self._buffered_bytes > 0 or self._leftover
+                    if self._buffered_bytes >= self._prebuffer_bytes or (self._closed and have_any):
                         self._audible = True
                         started = True
+                    elif self._closed:
+                        # Closed with nothing ever fed: nothing will ever
+                        # play, so skip the SinkStarted transition -- but
+                        # still fall through to the normal chunk/drained
+                        # logic below so the sink still reaches "stopped"
+                        # and emits SinkDrained instead of stalling in
+                        # "draining" forever.
+                        started = False
                     else:
                         outdata[:] = 0
                         return
                 else:
                     started = False
                 chunk = self._take_locked(need)
-                drained = self._closed and self._buffered_bytes == 0 and not self._leftover
+                drained = (self._closed and self._buffered_bytes == 0
+                           and self._leftover_remaining_locked() == 0)
             if started:
                 self._emit(SinkStarted())
             if chunk:
@@ -402,12 +426,29 @@ class StreamingPcmSink:
                 pass
             self._fail("audio callback error")
 
+    def _leftover_remaining_locked(self) -> int:
+        """Return how many unconsumed bytes remain in `self._leftover`.
+
+        Must be called with `self._lock` held. `self._leftover` is kept
+        around (rather than re-sliced down to just the unconsumed tail on
+        every callback) so that draining it one block at a time is an O(1)
+        offset bump instead of an O(n) copy -- see `_take_locked`.
+        """
+        return len(self._leftover) - self._leftover_off
+
     def _take_locked(self, need: int) -> bytes:
         """Pop up to `need` bytes of audio off the buffer.
 
         Must be called with `self._lock` held. Consumes carried-over
         `self._leftover` first, then whole chunks from `self._buf`, and
-        stashes any excess back into `self._leftover` for the next call.
+        stashes any excess back into `self._leftover` for later calls.
+
+        The common steady-state case -- one large fed chunk being drained
+        one block at a time -- takes a fast path that advances an offset
+        into the *same* `self._leftover` bytes object instead of
+        re-slicing (and thus re-copying and re-allocating) the entire
+        remaining tail on every callback; only the `need`-sized slice
+        actually handed to the caller is copied.
 
         Args:
             need: Number of bytes requested.
@@ -416,18 +457,30 @@ class StreamingPcmSink:
             Up to `need` bytes of audio; shorter than `need` only if the
             buffer did not contain enough data.
         """
-        parts = [self._leftover] if self._leftover else []
-        have = len(self._leftover)
+        remaining = self._leftover_remaining_locked()
+        if remaining >= need:
+            start = self._leftover_off
+            chunk = self._leftover[start:start + need]
+            self._leftover_off += need
+            if self._leftover_off >= len(self._leftover):
+                self._leftover = b""
+                self._leftover_off = 0
+            return chunk
+
+        parts = [self._leftover[self._leftover_off:]] if remaining else []
+        have = remaining
         self._leftover = b""
+        self._leftover_off = 0
         while have < need and self._buf:
             c = self._buf.popleft()
             self._buffered_bytes -= len(c)
             parts.append(c)
             have += len(c)
-        blob = b"".join(parts)
+        blob = parts[0] if len(parts) == 1 else b"".join(parts)
         if len(blob) > need:
-            self._leftover = blob[need:]
-            blob = blob[:need]
+            self._leftover = blob
+            self._leftover_off = need
+            return blob[:need]
         return blob
 
     def _note_underrun(self, frames: int) -> None:
@@ -458,10 +511,16 @@ class StreamingPcmSink:
 
     @property
     def buffered_seconds(self) -> float:
-        """Approximate seconds of audio currently buffered (not yet played)."""
+        """Approximate seconds of audio currently buffered (not yet played).
+
+        Includes both whole chunks still queued in the internal buffer and
+        any partially-consumed carry-over (`_leftover`) from the last
+        device callback.
+        """
         with self._lock:
             denom = self._cap_bytes / BUFFER_CAP_SECONDS if self._cap_bytes else 1
-            return self._buffered_bytes / denom
+            pending = self._buffered_bytes + self._leftover_remaining_locked()
+            return pending / denom
 
 
 #: The sink currently registered as "live" (i.e. actively producing audio

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -430,16 +430,54 @@ class StreamingPcmSink:
         instead of being left running, and the `"stopped"`/`"failed"`
         state that call already set is left in place.
 
+        `sample_rate`/`channels` are validated (fix-round F3) before any
+        arithmetic touches them: `TTS/pcm_stream.py`'s `sink_plan()`
+        already type-checks `sample_rate` for the one call path that goes
+        through it (citing this exact method's
+        `sample_rate * blocksize_ms // 1000` line as the reason), but that
+        does not protect `channels` -- unvalidated there -- or any other
+        caller of `open()` directly (including tests). A wrong-typed or
+        non-positive value previously reached that arithmetic unguarded,
+        raising a `TypeError`/`ZeroDivisionError`-shaped exception out of
+        `open()` -- violating this docstring's own "transitions to
+        `failed` ... instead of raising" contract.
+
         Args:
             sample_rate: Output sample rate in Hz. Used to size the
                 prebuffer and buffer-cap thresholds and to compute
-                frames-per-block from `blocksize_ms`.
-            channels: Number of output channels. Defaults to mono.
+                frames-per-block from `blocksize_ms`. Must be a positive
+                `int`; anything else fails the sink closed rather than
+                raising.
+            channels: Number of output channels. Defaults to mono. Must be
+                a positive `int`; anything else fails the sink closed
+                rather than raising.
         """
         with self._lock:
             if self._state != "idle":
                 return
-            frames_per_block = sample_rate * self._blocksize_ms // 1000
+        # Validated OUTSIDE the lock above (and hence after re-confirming
+        # "idle" there first): `_fail()` below acquires `self._lock`
+        # itself, and `threading.Lock` is not reentrant, so calling it
+        # while still holding the lock would deadlock. Checking "idle"
+        # first means a bad call on an already-open/-failed/-stopped sink
+        # stays the documented no-op instead of clobbering that sink's
+        # real terminal state via `_fail()`.
+        if type(sample_rate) is not int or sample_rate <= 0:
+            self._fail(f"invalid sample_rate: {sample_rate!r} (must be a positive int)")
+            return
+        if type(channels) is not int or channels <= 0:
+            self._fail(f"invalid channels: {channels!r} (must be a positive int)")
+            return
+        frames_per_block = sample_rate * self._blocksize_ms // 1000
+        if frames_per_block <= 0:
+            self._fail(
+                f"invalid frames_per_block ({frames_per_block}) derived from "
+                f"sample_rate={sample_rate}, blocksize_ms={self._blocksize_ms}"
+            )
+            return
+        with self._lock:
+            if self._state != "idle":
+                return
             self._bytes_per_frame = 2 * channels
             self._cap_bytes = BUFFER_CAP_SECONDS * sample_rate * self._bytes_per_frame
             self._prebuffer_bytes = PREBUFFER_MS * sample_rate * self._bytes_per_frame // 1000

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -47,6 +47,26 @@ caller thread (`SinkBufferFull` from `feed()`, `SinkStopped` from
 directly, synchronously, on whichever thread called the method -- there
 is no PortAudio-callback-reentrancy risk there.
 
+`stop()` is NON-JOINING: it never waits for the notify thread to finish
+delivering already-queued work (it enqueues the exit sentinel, tears down
+the stream, clears the live-sink registry, and returns -- all fast paths
+bounded only by a lock acquisition and the stream's own `abort()`/
+`close()`). This is deliberate, not an oversight: `stop()` is called from
+listener callbacks (including reentrantly, from the notify thread
+itself) and, via `pump()`'s one-voice displacement, potentially from an
+asyncio event loop thread -- a context that cannot tolerate an unbounded
+block (an `App.call_from_thread` round-trip out of a slow listener would
+otherwise deadlock the loop against the notify thread waiting on it; see
+the streaming-pcm-sink plan's Task-2 review, H2). Callers that need a
+deterministic guarantee that every event has actually reached `on_event`
+(tests, deterministic teardown) should call `settle()` instead, which
+polls with a timeout rather than blocking unboundedly. One consequence of
+`stop()` never joining: a listener must never call `stop()` on a
+*different* sink than its own from inside its event handling -- two
+sinks whose listeners `stop()` each other synchronously would, under the
+old joining design, deadlock; under this design they no longer can, but
+it remains a confusing, unsupported pattern, so don't.
+
 The `stream_factory` constructor argument is the testability seam: in
 production it is left `None` and `open()` lazily builds a real
 `sounddevice.OutputStream`; tests inject a fake stream whose callback can
@@ -65,10 +85,11 @@ from __future__ import annotations
 import asyncio
 import queue
 import threading
+import time
 from collections import deque
 from dataclasses import dataclass
 from importlib.util import find_spec
-from typing import Any, AsyncIterator, Callable, Optional
+from typing import Any, AsyncIterator, Callable, Literal, Optional
 
 from loguru import logger
 
@@ -138,27 +159,38 @@ class SinkFailed:
     reason: str
 
 
+#: `PumpResult.outcome` / `StreamingPcmSink.terminal_reason`-adjacent values.
+#: `"source_error"` is `pump`-only (the sink itself has no such reason --
+#: `pump` stops the sink and reports this instead of the sink's own,
+#: unrelated `"stopped"` terminal reason).
+PumpOutcome = Literal["drained", "stopped", "failed", "source_error"]
+
+
 @dataclass(frozen=True)
 class PumpResult:
     """Outcome of a completed `pump()` call.
 
     Attributes:
-        outcome: One of `"drained"` (the source was exhausted, `pump`
-            called `close()`, and the sink went on to reach `"stopped"`
-            naturally -- or was already terminal for a reason other than
-            failure by the time `pump` checked), `"stopped"` (the sink
-            left `"open"`/`"draining"` -- e.g. an external barge-in
-            `stop()` -- while `pump` was still feeding, before the source
-            was exhausted), `"failed"` (the sink transitioned to
-            `"failed"`, whether mid-feed or during the post-`close()`
-            drain wait), or `"source_error"` (the chunk source itself
-            raised; `pump` stopped the sink in response).
+        outcome: `"drained"` if the sink's own `terminal_reason` was a
+            natural drain, `"stopped"` if it was `stop()` (external,
+            reentrant, or forced by `pump` itself to satisfy the
+            terminal-call guarantee on a sink `pump` never got to feed --
+            see `terminal_reason`), `"failed"` if it was a device failure
+            *or* `pump`'s own drain-wait deadline expired, or
+            `"source_error"` if the chunk source itself raised (`pump`
+            stops the sink in response but reports this, not the sink's
+            resulting -- and in this case incidental -- `"stopped"`
+            reason).
         bytes_fed: Total PCM bytes actually handed to `sink.feed()` and
             accepted (after `skip_bytes` was consumed from the head of the
             stream), regardless of outcome.
+        reason: Human-readable detail. Empty except for `"source_error"`
+            (the source exception's `str()`) and `"failed"` (the sink's
+            own `SinkFailed` reason, or a drain-wait-deadline message).
     """
-    outcome: str
+    outcome: PumpOutcome
     bytes_fed: int
+    reason: str = ""
 
 
 def sink_available() -> bool:
@@ -241,6 +273,12 @@ class StreamingPcmSink:
         self._state = "idle"
         self._audible = False
         self._closed = False
+        #: Why this sink reached a terminal state; `None` until it does.
+        #: Set exactly once, alongside the winning `self._state` mutation
+        #: into `"stopped"`/`"failed"` -- see `terminal_reason`.
+        self._terminal_reason: Optional[Literal["drained", "stopped", "failed"]] = None
+        #: The human-readable reason passed to `_fail()`, if any -- see `fail_reason`.
+        self._fail_reason: Optional[str] = None
         self._cap_bytes = 0
         self._prebuffer_bytes = 0
         self._bytes_per_frame = 2
@@ -341,7 +379,6 @@ class StreamingPcmSink:
             self._bytes_per_frame = 2 * channels
             self._cap_bytes = BUFFER_CAP_SECONDS * sample_rate * self._bytes_per_frame
             self._prebuffer_bytes = PREBUFFER_MS * sample_rate * self._bytes_per_frame // 1000
-        _register_live_sink(self)              # one-voice (Task 2 wires displacement)
         factory = self._factory
         if factory is None:
             sd = _import_sounddevice()
@@ -376,6 +413,14 @@ class StreamingPcmSink:
             # just built and started must not be left running.
             self._teardown_stream()
             return
+        # One-voice registration (L7 fix-round finding): deliberately AFTER
+        # this call has actually won "open", not before building/starting
+        # the stream. Nothing has been fed yet at this point either way, so
+        # moving it here closes no window for double-voice playback -- but
+        # it means a sink whose stream_factory/`stream.start()` raises (the
+        # `self._fail(...)` branches above) never evicts a still-healthy
+        # previously-live sink for a voice that never played one sample.
+        _register_live_sink(self)
         self._notify_thread = threading.Thread(
             target=self._notify_loop, name="StreamingPcmSinkNotify", daemon=True,
         )
@@ -456,11 +501,27 @@ class StreamingPcmSink:
         finished it, say), it still tears down `self._stream` if one is
         somehow still present, defensively. Only the *event* emission is
         gated to "first call to reach a terminal state wins".
+
+        NON-JOINING (fix-round H2): this method never blocks waiting for
+        the notify thread to finish delivering already-queued work -- see
+        the module docstring's thread contract for why. It is therefore
+        safe to call from any context, including an asyncio event loop
+        thread. One consequence: if a `SinkStarted`/`SinkUnderrun` job is
+        still queued (not yet delivered) on the notify thread at the
+        moment an *unrelated* thread calls `stop()`, that job's delivery
+        and this call's `SinkStopped` are no longer guaranteed to arrive
+        at `on_event` in that order (they still will if this call is
+        itself running reentrantly ON the notify thread -- the common
+        listener-reacts-to-an-event case -- since then there is nothing
+        else for that thread to be doing concurrently). Callers that need
+        the strict, deterministic ordering guarantee should call
+        `settle()` after `stop()`.
         """
         with self._lock:
             already_terminal = self._state in ("stopped", "failed")
             if not already_terminal:
                 self._state = "stopped"
+                self._terminal_reason = "stopped"
             self._buf.clear()
             self._buffered_bytes = 0
             self._leftover = b""
@@ -468,16 +529,6 @@ class StreamingPcmSink:
         self._teardown_stream()
         if already_terminal:
             return
-        # If this call is not itself running on the notify thread (the
-        # common case -- a real stop() arrives from the UI/worker thread),
-        # let any work already queued from the callback thread (e.g. an
-        # in-flight SinkStarted) finish delivering first, so listeners
-        # never observe SinkStopped before an event that logically
-        # preceded it. Skipping this when we ARE the notify thread avoids
-        # a self-deadlock: a listener calling stop() synchronously from
-        # within its own event handling cannot wait on itself.
-        if self._notify_thread is not None and threading.current_thread() is not self._notify_thread:
-            self._notify_q.join()
         _clear_live_sink(self)
         # Pushed unconditionally -- not gated on self._notify_thread being
         # published yet (see N1). open() may still be mid-flight, between
@@ -488,6 +539,36 @@ class StreamingPcmSink:
         # read (open() never reaches "open" at all) is harmless.
         self._notify_q.put(_NOTIFY_STOP)
         self._emit(SinkStopped())
+
+    def settle(self, timeout: float = 5.0) -> bool:
+        """Block until this sink's notify thread has delivered all queued work.
+
+        `stop()` (and the drain/failure teardown paths) enqueue their
+        final work non-blockingly and never wait for it to actually reach
+        `on_event` -- see `stop()`'s docstring. Most callers never need
+        to; tests and deterministic-teardown paths that DO need to know
+        "has every event this sink will ever emit already been
+        delivered" should call this instead. Deadline-polled rather than
+        an unbounded `queue.Queue.join()`, so a job orphaned by a bug (or
+        a notify thread that never started at all, e.g. a sink stopped
+        while still `"idle"`) turns into a fast, informative `False`
+        instead of hanging forever.
+
+        Args:
+            timeout: Maximum time, in seconds, to wait for the notify
+                queue to fully drain.
+
+        Returns:
+            `True` if the queue settled (every queued job's `task_done()`
+            was called) within `timeout`, `False` if the deadline was
+            reached first. Never raises, never blocks past `timeout`.
+        """
+        deadline = time.monotonic() + timeout
+        while self._notify_q.unfinished_tasks > 0:
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.001)
+        return True
 
     def _fail(self, reason: str, *, from_callback: bool = False) -> None:
         """Transition the sink to `"failed"` and emit `SinkFailed`.
@@ -513,6 +594,8 @@ class StreamingPcmSink:
             if self._state in ("stopped", "failed"):
                 return
             self._state = "failed"
+            self._terminal_reason = "failed"
+            self._fail_reason = reason
             self._buf.clear()
             self._buffered_bytes = 0
             self._leftover = b""
@@ -590,6 +673,7 @@ class StreamingPcmSink:
                 with self._lock:
                     if self._state == "draining":
                         self._state = "stopped"
+                        self._terminal_reason = "drained"
                         emit_drain = True
                     else:
                         emit_drain = False
@@ -705,6 +789,48 @@ class StreamingPcmSink:
         return self._state
 
     @property
+    def terminal_reason(self) -> Optional[Literal["drained", "stopped", "failed"]]:
+        """Why this sink reached a terminal state, or `None` if it hasn't yet.
+
+        Fix-round addition (M5): `state` alone cannot distinguish a
+        natural drain from a forced `stop()` -- both leave
+        `state == "stopped"`, by design (see `_callback`'s drain handling
+        and `stop()`). This property disambiguates: `"drained"` (all
+        buffered audio played out after `close()`), `"stopped"` (`stop()`
+        won the transition, whether external, reentrant from a listener,
+        or forced by `pump()` itself), or `"failed"` (the sink failed to
+        open, or the device callback raised). Set exactly once, at the
+        same moment as the winning transition into `state ==
+        "stopped"`/`"failed"` -- immutable for the remainder of the
+        sink's lifetime once set, and read without the lock for the same
+        reason `state` is (a plain attribute, atomic under the GIL;
+        callers polling this in a loop already tolerate the same
+        eventual-consistency `state` itself has).
+        """
+        return self._terminal_reason
+
+    @property
+    def fail_reason(self) -> Optional[str]:
+        """The human-readable reason passed to `_fail()`, if `terminal_reason == "failed"`.
+
+        `None` if the sink never failed (including if it hasn't reached a
+        terminal state at all yet).
+        """
+        return self._fail_reason
+
+    @property
+    def bytes_per_second(self) -> int:
+        """PCM bytes per second of playback at this sink's opened rate.
+
+        `0` until `open()` has recorded a rate (i.e. while still
+        `"idle"`) -- callers that might see `0` (e.g. `pump()`'s
+        oversized-chunk slicing) should treat that as "not meaningfully
+        open yet" rather than divide by it.
+        """
+        with self._lock:
+            return self._cap_bytes // BUFFER_CAP_SECONDS if self._cap_bytes else 0
+
+    @property
     def buffered_seconds(self) -> float:
         """Approximate seconds of audio currently buffered (not yet played).
 
@@ -723,11 +849,10 @@ class StreamingPcmSink:
 #: displaces (stops) whatever sink was previously registered here.
 _LIVE_SINK: Optional[StreamingPcmSink] = None
 
-#: Guards reads/writes of `_LIVE_SINK`. Deliberately never held while a
-#: sink's `stop()` is called -- `stop()` can briefly block (an unbounded
-#: `_notify_q.join()`, see the module's carried Task-1 review risk), and
-#: holding this lock across that call would let one sink's teardown stall
-#: every other sink's `open()`/`_clear_live_sink()` in the meantime.
+#: Guards reads/writes of `_LIVE_SINK`. Kept separate from any sink's own
+#: `stop()` call (never held across one) so that one sink's teardown can
+#: never stall another sink's `open()`/`_clear_live_sink()`, even though
+#: `stop()` itself is now non-joining (fix-round H2) and therefore fast.
 _LIVE_SINK_LOCK = threading.Lock()
 
 
@@ -769,6 +894,111 @@ def _clear_live_sink(sink: StreamingPcmSink) -> None:
             _LIVE_SINK = None
 
 
+#: M3 fix-round: the maximum span of audio, in seconds, `pump` will ever
+#: hand to a single `feed()` call, regardless of how large the chunk it
+#: read from the source was. A chunk larger than `BUFFER_CAP_SECONDS`
+#: could never be accepted no matter how much the buffer drains (`feed()`
+#: rejects anything that would push the buffer over the cap outright),
+#: so retrying it whole would livelock `pump` at the backpressure-retry
+#: interval forever. Slicing to a small fraction of the cap instead
+#: guarantees every slice is eventually placeable.
+_PUMP_SLICE_SECONDS = 1
+
+#: L11 fix-round: how much slack, in seconds, `pump` allows beyond a
+#: sink's own `buffered_seconds` estimate (captured once, at the moment
+#: the drain wait begins) before concluding the device callback has
+#: stalled and giving up rather than polling forever. A module-level
+#: constant (not a `pump()` parameter) so tests can `monkeypatch` it down
+#: to exercise the deadline path without a real multi-second wait.
+_DRAIN_WAIT_MARGIN_SECONDS = 5.0
+
+
+def _ensure_terminal(sink: StreamingPcmSink) -> None:
+    """H1/L9 fix-round: guarantee `sink` has a `terminal_reason`, forcing one if needed.
+
+    The overwhelmingly common case is that `sink` is already terminal by
+    the time this is called -- a cheap, side-effect-free read. The one
+    case it is not is a sink `pump` never got to feed at all (still
+    `"idle"`: `open()` was never called, or is still mid-flight on
+    another thread) -- nothing else will ever terminalize that sink, so
+    `pump` does it itself by calling `stop()`. `stop()` on an
+    already-terminal sink is a safe, cheap no-op per the sink's own
+    contract (see `StreamingPcmSink.stop`), so calling it here
+    unconditionally whenever `terminal_reason` is still `None` can never
+    double-fire or race a "real" terminal transition that is genuinely
+    still in flight -- worst case, `pump`'s `stop()` is the one that wins
+    the transition, which is exactly the guarantee this function exists
+    to provide.
+    """
+    if sink.terminal_reason is None:
+        sink.stop()
+
+
+def _result(sink: StreamingPcmSink, bytes_fed: int) -> PumpResult:
+    """Build a `PumpResult` from a sink already guaranteed to be terminal.
+
+    Callers must call `_ensure_terminal(sink)` first (or otherwise know
+    `sink.terminal_reason` is already set) -- this does not force
+    anything itself. `outcome` is a direct passthrough of
+    `sink.terminal_reason`; `reason` is populated from `sink.fail_reason`
+    only when that outcome is `"failed"` (L8).
+    """
+    outcome = sink.terminal_reason or "stopped"   # defensive fallback; every call site ensures terminal first
+    reason = (sink.fail_reason or "") if outcome == "failed" else ""
+    return PumpResult(outcome=outcome, bytes_fed=bytes_fed, reason=reason)
+
+
+async def _feed_one_piece(sink: StreamingPcmSink, piece: bytes) -> Literal["fed", "terminal", "draining"]:
+    """Feed one already-sliced piece to `sink`, retrying through backpressure.
+
+    Isolates `pump`'s backpressure-retry loop (M4) so both the sink
+    becoming terminal *and* the sink starting to drain (L10) are checked
+    on every single retry attempt, not just once per outer chunk -- an
+    external `close()` landing mid-retry is recognized immediately
+    instead of only after the wasted remainder of the drain's real-time
+    duration has elapsed retrying a piece that can now never be accepted.
+
+    Returns:
+        `"fed"` once `sink.feed(piece)` succeeds, `"terminal"` if
+        `sink.terminal_reason` becomes set first, or `"draining"` if
+        `sink.state` becomes `"draining"` first (`feed()` can never
+        succeed again from there -- no point continuing to retry).
+    """
+    while True:
+        if sink.terminal_reason is not None:
+            return "terminal"
+        if sink.state == "draining":
+            return "draining"
+        if sink.feed(piece):
+            return "fed"
+        await asyncio.sleep(0.05)
+
+
+async def _aclose_source(chunks: AsyncIterator[bytes]) -> None:
+    """M6 fix-round: best-effort `aclose()` of an async chunk source, if it has one.
+
+    Plain `AsyncIterator`s (e.g. a hand-written class implementing only
+    `__anext__`) are not required by the protocol to expose `aclose()`;
+    async *generators* always do. Left uncalled, an early `pump` exit
+    (barge-in, cancellation, a device failure) would otherwise leave a
+    generator's own `finally`/`async with` teardown -- e.g. an HTTP
+    response body -- suspended until GC gets around to it
+    non-deterministically, or never call a plain iterator's `aclose()` at
+    all. Never raises: a failure to close the source must not mask
+    whatever outcome `pump` is already returning or propagating.
+
+    Args:
+        chunks: The chunk source `pump` was iterating.
+    """
+    aclose = getattr(chunks, "aclose", None)
+    if aclose is None:
+        return
+    try:
+        await aclose()
+    except Exception:
+        logger.opt(exception=True).debug("pump: closing chunk source raised")
+
+
 async def pump(
     sink: StreamingPcmSink,
     chunks: AsyncIterator[bytes],
@@ -784,29 +1014,73 @@ async def pump(
     * An optional `skip_bytes`-byte prefix (e.g. a WAV header some
       providers cannot be told to omit), dropped across chunk boundaries
       before any audio is fed.
+    * Oversized chunks (M3): a single source chunk is fed in
+      `_PUMP_SLICE_SECONDS`-sized slices rather than as one `feed()`
+      call, so a chunk bigger than the sink's buffer cap can never
+      livelock the backpressure retry below (a slice this small is
+      always eventually placeable; a >60s chunk fed whole never would
+      be, no matter how much the buffer drains).
     * Backpressure: when `feed()` returns `False` (buffer full), `pump`
-      retries the very same remainder after a short sleep rather than
-      dropping audio.
+      retries the very same slice after a short sleep rather than
+      dropping audio (pinned: M4).
     * Prompt exit the moment the sink leaves `"open"`/`"draining"` for a
       terminal state (e.g. an external barge-in `stop()`, or a device
       failure) -- `pump` does not wait for the source to finish in that
-      case.
+      case. If someone *else* already called `close()` on the sink
+      (state `"draining"` but not yet terminal), `pump` stops trying to
+      feed -- `feed()` can never succeed again once closed -- and falls
+      straight through to the same drain-wait below instead of
+      busy-retrying `feed()` at the backpressure interval for no reason
+      (L10).
     * A source that raises: `pump` calls `sink.stop()` and reports
-      `"source_error"`, so the sink still reaches a terminal state even
-      when the caller never gets to call `close()`/`stop()` itself.
+      `"source_error"` with the exception's `str()` as `reason` (L8), so
+      the sink still reaches a terminal state even when the caller never
+      gets to call `close()`/`stop()` itself.
+    * Cancellation, or any other exit this function did not anticipate
+      (H1): a `finally` guarantees a terminal call on every exit, not
+      just the ones explicitly handled above. `asyncio.CancelledError`
+      derives from `BaseException`, so it is not caught by the `except
+      Exception` clause below and propagates through `finally` and back
+      out to the caller once the sink has been terminalized -- `pump`
+      never swallows a cancellation.
+    * Releasing the source (M6): a `finally` also `aclose()`s `chunks` if
+      it exposes one, on every exit, so an early return never leaves an
+      HTTP response (or any other closeable resource) the source was
+      holding open past the point `pump` stopped reading it.
     * Normal exhaustion: `pump` calls `sink.close()` and waits -- polling,
       never blocking the event loop -- for the sink to reach a terminal
-      state.
+      state, bounded by a deadline derived from the sink's own
+      `buffered_seconds` plus a safety margin (L11); if that deadline
+      expires (the device callback has stopped advancing, e.g. a removed
+      device), `pump` stops the sink and reports `"failed"` rather than
+      polling forever.
+
+    `pump`'s own outcome is a direct passthrough of the sink's
+    `terminal_reason` (see `StreamingPcmSink.terminal_reason`) in every
+    case except `"source_error"` (`pump`'s own judgment, not a sink
+    concept) and the drain-wait-deadline case above (also `pump`'s own
+    judgment, reported as `"failed"` even though the `stop()` call used
+    to terminalize the sink tags its own `terminal_reason` as
+    `"stopped"`). This is what makes a barge-in landing in the drain tail
+    correctly report `"stopped"`, not `"drained"` (M5): the sink -- not
+    `pump`'s own bookkeeping about whether *it* called `close()` -- is
+    the single source of truth for why it stopped.
 
     `pump` only ever calls `feed()`/`close()`/`stop()` from its own task,
-    never from a listener registered on the sink, so it never risks
-    blocking on the `stop()` -> `_notify_q.join()` carried risk noted in
-    the module's Task-1 review context.
+    never from a listener registered on the sink. Every one of those
+    calls is now non-blocking (`stop()` no longer joins the sink's notify
+    queue -- see the module docstring's thread contract, fix-round H2),
+    so `pump` never risks stalling the event loop it runs on.
 
     Args:
-        sink: The (already-`open()`ed) sink to feed.
-        chunks: Async iterator of raw PCM16 byte chunks. `pump` only
-            iterates it; it does not open, close, or otherwise manage its
+        sink: The (already-`open()`ed) sink to feed. A sink that is still
+            `"idle"` (never `open()`'d, or `open()` still mid-flight on
+            another thread) is accepted too: `pump` forces it terminal
+            itself (via `stop()`) before returning, per the terminal-call
+            guarantee, rather than silently doing nothing.
+        chunks: Async iterator of raw PCM16 byte chunks. `pump` iterates
+            it and, on every exit, attempts to `aclose()` it if it
+            exposes one; it does not otherwise open or manage its
             lifecycle.
         skip_bytes: Number of leading bytes to discard from the head of
             the concatenated chunk stream before any audio is fed to the
@@ -819,6 +1093,7 @@ async def pump(
     bytes_fed = 0
     remaining_skip = skip_bytes
     try:
+        stop_reading_source = False
         async for chunk in chunks:
             if remaining_skip:
                 if remaining_skip >= len(chunk):
@@ -826,34 +1101,61 @@ async def pump(
                     continue
                 chunk = chunk[remaining_skip:]
                 remaining_skip = 0
+            slice_bytes = max(sink.bytes_per_second * _PUMP_SLICE_SECONDS, 1)
             while chunk:
-                if sink.state not in ("open", "draining"):
-                    return PumpResult(outcome=_early_exit_outcome(sink.state), bytes_fed=bytes_fed)
-                if sink.feed(chunk):
-                    bytes_fed += len(chunk)
+                state = sink.state
+                if state not in ("open", "draining"):
+                    _ensure_terminal(sink)
+                    return _result(sink, bytes_fed)
+                if state == "draining":
+                    # L10: this sink is already draining -- via someone
+                    # else's close() (ours hasn't run yet at this point in
+                    # the function), or our own close() from a previous
+                    # iteration reaching this same state -- either way
+                    # feed() can never succeed again. Stop offering more
+                    # of the source and fall through to the shared
+                    # drain-wait below instead of busy-retrying forever.
+                    stop_reading_source = True
                     break
-                await asyncio.sleep(0.05)
-    except Exception:
+                piece, rest = chunk[:slice_bytes], chunk[slice_bytes:]
+                outcome = await _feed_one_piece(sink, piece)
+                if outcome == "terminal":
+                    return _result(sink, bytes_fed)
+                if outcome == "draining":
+                    stop_reading_source = True
+                    break
+                bytes_fed += len(piece)
+                chunk = rest
+            if stop_reading_source:
+                break
+
+        if sink.terminal_reason is not None:
+            return _result(sink, bytes_fed)
+        sink.close()   # no-op if state is already "draining" (L10 path above)
+        deadline = time.monotonic() + sink.buffered_seconds + _DRAIN_WAIT_MARGIN_SECONDS
+        while sink.terminal_reason is None:
+            if time.monotonic() >= deadline:
+                sink.stop()
+                return PumpResult(
+                    outcome="failed", bytes_fed=bytes_fed,
+                    reason="drain wait exceeded deadline (device callback stalled?)",
+                )
+            await asyncio.sleep(0.01)
+        return _result(sink, bytes_fed)
+    except Exception as exc:
+        logger.opt(exception=True).debug("pump: chunk source raised")
         sink.stop()
-        return PumpResult(outcome="source_error", bytes_fed=bytes_fed)
-
-    if sink.state not in ("open", "draining"):
-        return PumpResult(outcome=_early_exit_outcome(sink.state), bytes_fed=bytes_fed)
-    sink.close()
-    while sink.state not in ("stopped", "failed"):
-        await asyncio.sleep(0.01)
-    return PumpResult(outcome="failed" if sink.state == "failed" else "drained", bytes_fed=bytes_fed)
-
-
-def _early_exit_outcome(state: str) -> str:
-    """Map a sink `state` observed before/without `pump` itself calling `close()` to an outcome.
-
-    Args:
-        state: The sink's `state` at the moment `pump` noticed it had left
-            `"open"`/`"draining"` on its own (i.e. not as a result of
-            `pump`'s own `close()` call).
-
-    Returns:
-        `"failed"` if `state` is `"failed"`, otherwise `"stopped"`.
-    """
-    return "failed" if state == "failed" else "stopped"
+        return PumpResult(outcome="source_error", bytes_fed=bytes_fed, reason=str(exc))
+    finally:
+        # H1: unconditional terminal-call safety net. Every normal return
+        # above already leaves the sink terminal (so this is a cheap
+        # no-op then); this only actually does something on cancellation
+        # or any other exit this function did not explicitly anticipate.
+        # Runs -- and, for a CancelledError, does NOT swallow it: a
+        # `finally` that itself neither returns nor raises lets whatever
+        # exception was propagating continue on afterward -- before the
+        # source is released, so a sink `stop()` forced here can't race a
+        # source `aclose()` that might itself synchronously touch the
+        # sink (defensive; no known real source does).
+        _ensure_terminal(sink)
+        await _aclose_source(chunks)

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -90,14 +90,14 @@ class SinkUnderrun:
     """Emitted when the device callback runs dry after playback has started.
 
     Attributes:
-        count: Cumulative number of audio frames the device callback
+        frames: Cumulative number of audio frames the device callback
             requested but could not fill with real audio (silence played
             in their place) since this sink was opened, as of the moment
             this event was emitted. Frames, not callback invocations, so
             the value is meaningful even when a single throttled event
             covers a short burst of consecutive underruns.
     """
-    count: int
+    frames: int
 
 
 @dataclass(frozen=True)
@@ -502,7 +502,7 @@ class StreamingPcmSink:
         self._underruns += frames
         if self._block_index - self._underrun_last_emit_block >= _UNDERRUN_THROTTLE_BLOCKS:
             self._underrun_last_emit_block = self._block_index
-            self._emit(SinkUnderrun(count=self._underruns))
+            self._emit(SinkUnderrun(frames=self._underruns))
 
     @property
     def state(self) -> str:

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -871,7 +871,11 @@ class StreamingPcmSink:
 
     @property
     def state(self) -> str:
-        """Current lifecycle state: one of `idle`, `open`, `draining`, `stopped`, `failed`."""
+        """Current lifecycle state: one of `idle`, `open`, `draining`, `stopped`, `failed`.
+
+        Returns:
+            The sink's current lifecycle state string.
+        """
         return self._state
 
     @property
@@ -892,6 +896,10 @@ class StreamingPcmSink:
         reason `state` is (a plain attribute, atomic under the GIL;
         callers polling this in a loop already tolerate the same
         eventual-consistency `state` itself has).
+
+        Returns:
+            `"drained"`, `"stopped"`, or `"failed"` once this sink has
+            reached a terminal state; `None` beforehand.
         """
         return self._terminal_reason
 
@@ -901,6 +909,10 @@ class StreamingPcmSink:
 
         `None` if the sink never failed (including if it hasn't reached a
         terminal state at all yet).
+
+        Returns:
+            The failure message passed to `_fail()`, or `None` if this
+            sink never failed.
         """
         return self._fail_reason
 
@@ -912,6 +924,10 @@ class StreamingPcmSink:
         `"idle"`) -- callers that might see `0` (e.g. `pump()`'s
         oversized-chunk slicing) should treat that as "not meaningfully
         open yet" rather than divide by it.
+
+        Returns:
+            PCM bytes per second at this sink's opened sample rate and
+            channel count, or `0` if `open()` has not yet recorded one.
         """
         with self._lock:
             return self._cap_bytes // BUFFER_CAP_SECONDS if self._cap_bytes else 0
@@ -923,6 +939,10 @@ class StreamingPcmSink:
         Includes both whole chunks still queued in the internal buffer and
         any partially-consumed carry-over (`_leftover`) from the last
         device callback.
+
+        Returns:
+            Estimated seconds of buffered, not-yet-played audio at this
+            sink's opened sample rate and channel count.
         """
         with self._lock:
             denom = self._cap_bytes / BUFFER_CAP_SECONDS if self._cap_bytes else 1

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -929,6 +929,26 @@ def _clear_live_sink(sink: StreamingPcmSink) -> None:
             _LIVE_SINK = None
 
 
+def stop_live_sink() -> None:
+    """Stop whichever sink is currently registered as live, if any.
+
+    Task-4 (the consumer): the one entry point outside this module that
+    needs to interrupt "whatever is currently playing" without holding a
+    reference to a specific `StreamingPcmSink` instance -- e.g. the
+    existing TTS playback "stop" action, which today only knows about the
+    legacy file player. Deliberately calls only the sink's own public
+    `stop()` method, never touching a stream directly: `stop()` already
+    owns its full teardown (abort, registry clear, event emission) and is
+    non-joining/safe to call from any thread, including the asyncio event
+    loop thread (see `StreamingPcmSink.stop`'s docstring). A no-op when no
+    sink is currently live.
+    """
+    with _LIVE_SINK_LOCK:
+        sink = _LIVE_SINK
+    if sink is not None:
+        sink.stop()
+
+
 #: M3 fix-round: the maximum span of audio, in seconds, `pump` will ever
 #: hand to a single `feed()` call, regardless of how large the chunk it
 #: read from the source was. A chunk larger than `BUFFER_CAP_SECONDS`
@@ -1039,6 +1059,7 @@ async def pump(
     chunks: AsyncIterator[bytes],
     *,
     skip_bytes: int = 0,
+    max_bytes: int | None = None,
 ) -> PumpResult:
     """Feed an async source of PCM chunks into `sink` until stop or exhaustion.
 
@@ -1133,6 +1154,16 @@ async def pump(
         skip_bytes: Number of leading bytes to discard from the head of
             the concatenated chunk stream before any audio is fed to the
             sink -- e.g. to drop a WAV header. Defaults to 0.
+        max_bytes: Maximum number of bytes to feed to the sink, counted
+            AFTER `skip_bytes` has already been dropped -- e.g. a WAV
+            body's `SinkPlan.data_bytes`, so bytes belonging to a chunk
+            that trails the `data` chunk (not audio) are never fed. `None`
+            (the default) feeds everything the source yields, unbounded --
+            the correct choice for raw PCM, which has no container-declared
+            length. Once this many bytes have been fed, `pump` stops
+            reading further chunks from `chunks` entirely and proceeds
+            straight to the same `close()`-and-drain-wait tail used for
+            normal exhaustion, exactly as if the source had ended there.
 
     Returns:
         A `PumpResult` describing how the pump ended and how many bytes
@@ -1149,6 +1180,17 @@ async def pump(
                     continue
                 chunk = chunk[remaining_skip:]
                 remaining_skip = 0
+            if max_bytes is not None:
+                # `bytes_fed` is only ever mutated below, after this whole
+                # chunk has finished feeding (or the function has already
+                # returned) -- so at this point it accurately reflects every
+                # byte fed from every PRIOR chunk, making it safe to compute
+                # the remaining budget once, here, per chunk.
+                remaining_budget = max_bytes - bytes_fed
+                if remaining_budget <= 0:
+                    break
+                if len(chunk) > remaining_budget:
+                    chunk = chunk[:remaining_budget]
             slice_bytes = max(sink.bytes_per_second * _PUMP_SLICE_SECONDS, 1)
             while chunk:
                 state = sink.state

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -67,6 +67,19 @@ sinks whose listeners `stop()` each other synchronously would, under the
 old joining design, deadlock; under this design they no longer can, but
 it remains a confusing, unsupported pattern, so don't.
 
+A second, stronger consequence (fix-round N1): `on_event` may now be
+invoked **concurrently, on two different threads at once** -- not merely
+out of order. A `SinkStarted`/`SinkUnderrun` job still executing inside
+`on_event` on the notify thread does not block a caller thread's `stop()`
+from delivering `SinkStopped` synchronously, on its own thread, while
+that first call is still running. No event is dropped by this (each
+delivery is independent; `stop()`'s own `SinkStopped` is emitted directly,
+never via the queue, so it cannot be lost racing the queue), but
+`on_event` **must be thread-safe and safe to re-enter concurrently with
+itself**. A `post_message`-shaped listener already is (posting onto a
+Textual message queue is inherently thread-safe); a listener that
+mutates shared state directly must synchronize itself.
+
 The `stream_factory` constructor argument is the testability seam: in
 production it is left `None` and `open()` lazily builds a real
 `sounddevice.OutputStream`; tests inject a fake stream whose callback can
@@ -421,6 +434,20 @@ class StreamingPcmSink:
         # `self._fail(...)` branches above) never evicts a still-healthy
         # previously-live sink for a voice that never played one sample.
         _register_live_sink(self)
+        with self._lock:
+            still_open = self._state == "open"
+        if not still_open:
+            # N3 fix-round: a stop() landed in the narrow gap between the
+            # `became_open` flip above and this registration -- that
+            # concurrent stop() already ran its own full teardown+emit
+            # against a sink `_register_live_sink` above had not yet
+            # published as live, so it could not un-register what it
+            # didn't know was registered. Left alone, `_LIVE_SINK` would
+            # now point at this already-dead sink until some *later*
+            # `open()` happened to displace the corpse. Un-register
+            # immediately instead of waiting for that.
+            _clear_live_sink(self)
+            return
         self._notify_thread = threading.Thread(
             target=self._notify_loop, name="StreamingPcmSinkNotify", daemon=True,
         )
@@ -549,10 +576,14 @@ class StreamingPcmSink:
         to; tests and deterministic-teardown paths that DO need to know
         "has every event this sink will ever emit already been
         delivered" should call this instead. Deadline-polled rather than
-        an unbounded `queue.Queue.join()`, so a job orphaned by a bug (or
-        a notify thread that never started at all, e.g. a sink stopped
-        while still `"idle"`) turns into a fast, informative `False`
-        instead of hanging forever.
+        an unbounded `queue.Queue.join()`, so a job orphaned by a bug
+        turns into a fast, informative `False` instead of hanging
+        forever -- and a sink whose notify thread never started at all
+        (fix-round N2: e.g. `stop()`d while still `"idle"`, which still
+        unconditionally pushes the exit sentinel onto a queue nothing
+        will ever read, permanently leaving `unfinished_tasks == 1`)
+        returns `False` immediately rather than waiting out the full
+        `timeout` for a foregone conclusion.
 
         Args:
             timeout: Maximum time, in seconds, to wait for the notify
@@ -561,8 +592,12 @@ class StreamingPcmSink:
         Returns:
             `True` if the queue settled (every queued job's `task_done()`
             was called) within `timeout`, `False` if the deadline was
-            reached first. Never raises, never blocks past `timeout`.
+            reached first, or immediately if no notify thread was ever
+            published for this sink. Never raises, never blocks past
+            `timeout`.
         """
+        if self._notify_thread is None:
+            return False
         deadline = time.monotonic() + timeout
         while self._notify_q.unfinished_tasks > 0:
             if time.monotonic() >= deadline:
@@ -1071,6 +1106,19 @@ async def pump(
     calls is now non-blocking (`stop()` no longer joins the sink's notify
     queue -- see the module docstring's thread contract, fix-round H2),
     so `pump` never risks stalling the event loop it runs on.
+
+    Fix-round N4: `pump` returning does NOT imply the terminal *event*
+    (`SinkDrained`/`SinkStopped`/`SinkFailed`) has already reached
+    `on_event` -- `terminal_reason` is set at the state transition itself,
+    before the notify thread (for a drain or a callback failure) gets
+    around to actually delivering the corresponding event and tearing
+    down the stream, so `pump` can return before that delivery happens.
+    (`"stopped"` outcomes from an explicit `stop()` call are the one
+    exception -- `SinkStopped` is emitted synchronously, never via the
+    queue, so it is always already delivered by the time `stop()`
+    returns.) Callers that need to know the event itself has been
+    delivered (not just that the sink reached a terminal state) should
+    call `sink.settle()` after `pump` returns.
 
     Args:
         sink: The (already-`open()`ed) sink to feed. A sink that is still

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -173,9 +173,13 @@ class StreamingPcmSink:
     `close()`/`stop()`/a failure, a new `StreamingPcmSink` must be created
     for further playback.
 
-    All public methods are safe to call from any thread; the audio device
-    callback runs on a backend-owned thread and communicates with the rest
-    of the instance only through a single lock.
+    All public methods are safe to call from any thread. The audio device
+    callback runs on a backend-owned realtime thread; it communicates
+    buffer/state changes with the rest of the instance through a single
+    lock, and hands off event delivery and stream teardown to a dedicated
+    notify thread via a queue (see the module docstring's "Thread
+    contract") rather than ever calling back into `on_event` or the
+    stream itself directly.
     """
 
     def __init__(

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -86,11 +86,18 @@ production it is left `None` and `open()` lazily builds a real
 be driven synchronously and deterministically (no wall-clock sleeps, no
 real audio hardware).
 
-Note: `sounddevice` is not imported at module scope by *this* file, but
-`tldw_chatbook.Audio.__init__` currently imports `recording_service` eagerly,
-which does import `sounddevice` (and pyaudio, webrtcvad) at module scope --
-so in practice, importing anything from the `Audio` package already pulls
-in the audio backend regardless of what this module does on its own.
+Note: `sounddevice` is not imported at module scope by *this* file. It used
+to be true in practice anyway, because `tldw_chatbook.Audio.__init__`
+eagerly imported `recording_service` (which does import `sounddevice`,
+`pyaudio`, and `webrtcvad` at module scope) -- final whole-branch review,
+C1: that eager import made `sounddevice`'s own `Pa_Initialize()` call (at
+IMPORT TIME) able to fail the entire app's import with an uncaught
+`PortAudioError` whenever this module was reached from `Event_Handlers/
+TTS_Events/tts_events.py`'s own module-scope import. `Audio/__init__.py`
+now lazily exports `AudioRecordingService`/`AudioRecordingError` (the
+`__getattr__` pattern it already used for the dictation stack), so
+importing this module -- or any other submodule of the `Audio` package --
+no longer transitively imports `recording_service`/`sounddevice` at all.
 """
 
 from __future__ import annotations

--- a/tldw_chatbook/Audio/streaming_sink.py
+++ b/tldw_chatbook/Audio/streaming_sink.py
@@ -1181,11 +1181,18 @@ async def pump(
                 chunk = chunk[remaining_skip:]
                 remaining_skip = 0
             if max_bytes is not None:
-                # `bytes_fed` is only ever mutated below, after this whole
-                # chunk has finished feeding (or the function has already
-                # returned) -- so at this point it accurately reflects every
-                # byte fed from every PRIOR chunk, making it safe to compute
-                # the remaining budget once, here, per chunk.
+                # `bytes_fed` IS mutated per-slice inside the inner `while
+                # chunk:` loop below (fix-round F8: the prior wording here
+                # claimed otherwise) -- but that loop for the PREVIOUS
+                # chunk has always already run to completion (or the
+                # function has already returned/broken out of the outer
+                # loop) by the time control reaches back here for a NEW
+                # chunk, so `bytes_fed` still accurately reflects every
+                # byte fed from every prior chunk at this exact point,
+                # making it safe to compute the remaining budget once, here,
+                # per chunk. `chunk` itself is then pre-trimmed to that
+                # budget below, so the inner loop feeding it whole cannot
+                # overshoot even though it mutates `bytes_fed` as it goes.
                 remaining_budget = max_bytes - bytes_fed
                 if remaining_budget <= 0:
                     break

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -4,7 +4,7 @@
 # Imports
 import asyncio
 import re
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from functools import partial
 from typing import Dict, Optional, TypeVar
 from pathlib import Path
@@ -17,6 +17,12 @@ from loguru import logger
 from textual.message import Message
 
 # Local imports
+from tldw_chatbook.Audio.streaming_sink import (
+    StreamingPcmSink,
+    pump,
+    sink_available,
+    stop_live_sink,
+)
 from tldw_chatbook.Chat.console_speech import (
     ConsoleSpeechSnapshotRejected,
     TTSMessageSpeechSnapshot,
@@ -37,6 +43,7 @@ from tldw_chatbook.TTS.adapter_types import (
     TTSRequest,
     TTSRegistryClosedError,
 )
+from tldw_chatbook.TTS.pcm_stream import SinkPlan, sink_plan
 from tldw_chatbook.Utils.secure_temp_files import get_temp_manager, secure_delete_file
 
 _T = TypeVar("_T")
@@ -849,6 +856,57 @@ class TTSEventHandler:
                 ):
                     raise _TTSResponseContractError
 
+                # --- streaming PCM sink seam (task-4) ------------------------
+                # Raw PCM has no container-declared length, so `sink_plan`
+                # can decide eligibility from the response's own metadata
+                # alone (`response.sample_rate`) -- zero bytes read, zero
+                # timing impact either way. This is the first point that
+                # metadata AND the validated format are both in hand, and it
+                # sits strictly BEFORE any file-writing begins below
+                # (`_create_tts_artifact`), so an eligible pcm response never
+                # touches disk at all. Decides purely from the RESPONSE's own
+                # shape (format/rate), never from provider identity (Global
+                # Constraints) -- applies uniformly to every `_generate_tts`
+                # caller, not just Console spoken feedback specifically.
+                # Falls through unchanged whenever `sink_available()` is
+                # False or the format isn't "pcm".
+                #
+                # WAV is handled differently (see below, AFTER the write
+                # loop): `sink_plan` can only validate a WAV body's
+                # structure -- and thus decide eligibility -- against the
+                # COMPLETE body (see its own docstring: "a streaming WAV
+                # source would need to buffer the whole body before calling
+                # this"). Deciding here, before writing, would mean fully
+                # draining `response.byte_stream` up front for EVERY wav
+                # response whenever a sink is merely available -- changing
+                # cancellation/mid-stream-failure/write-batching timing for
+                # every wav caller regardless of the eventual eligibility
+                # verdict, which is exactly what broke
+                # `test_console_audio_cpp_native.py`'s cancellation and
+                # partial-artifact pins in an earlier version of this seam
+                # (verified: reverting to the pre-file-write WAV probe
+                # reproduces all four failures). The legacy write loop below
+                # is therefore left completely untouched for wav; eligibility
+                # is decided from the bytes it already wrote, afterward.
+                eligible_pcm_plan: SinkPlan | None = None
+                if sink_available() and audio_format == "pcm":
+                    eligible_pcm_plan = sink_plan("pcm", response.sample_rate, None)
+
+                if eligible_pcm_plan is not None:
+                    streamed_outcome_code = await self._stream_response_via_sink(
+                        eligible_pcm_plan,
+                        response.byte_stream,
+                        message_id=normalized_message_id,
+                    )
+                    if streamed_outcome_code is not None:
+                        outcome_code = streamed_outcome_code
+                        return
+                    # `None`: the sink failed to open (a device-level
+                    # failure, not a response-shape one) -- fall through to
+                    # the unmodified legacy write/play path below for THIS
+                    # utterance. `outcome_code` is untouched here -- the
+                    # legacy path's own outcome (below) still decides it.
+
                 def remember_cancelled_creation(path: Path) -> None:
                     nonlocal artifact_path
                     artifact_path = path
@@ -867,6 +925,12 @@ class TTSEventHandler:
                 artifact_path = created_artifact_path
                 buffered_chunks: list[bytes] = []
                 buffered_bytes = 0
+                # Collected alongside `buffered_chunks` (which gets cleared
+                # on every flush) ONLY for wav -- see the streaming-seam
+                # comment above `_create_tts_artifact` for why WAV
+                # eligibility is decided from these, AFTER the unmodified
+                # write loop below, rather than before it.
+                wav_collect: list[bytes] | None = [] if audio_format == "wav" else None
 
                 def cleanup_late_write() -> None:
                     self._schedule_cancelled_artifact_cleanup(
@@ -893,11 +957,60 @@ class TTSEventHandler:
                 async for chunk in response.byte_stream:
                     if not chunk:
                         continue
+                    if wav_collect is not None:
+                        wav_collect.append(chunk)
                     buffered_chunks.append(chunk)
                     buffered_bytes += len(chunk)
                     if buffered_bytes >= _TTS_ARTIFACT_WRITE_BATCH_BYTES:
                         await flush_artifact_batch()
                 await flush_artifact_batch()
+
+                # --- streaming PCM sink seam (task-4), WAV half ------------
+                # The response has now been written to `created_artifact_path`
+                # in full, byte-identically to how it always was (see the
+                # comment above `_create_tts_artifact`). ONLY now -- from the
+                # bytes already collected, no extra reads -- decide whether
+                # it was ALSO sink-eligible; if so, play it live through the
+                # sink and delete the now-redundant artifact rather than
+                # exposing it for the legacy file-based play path (avoiding
+                # the double-audio failure mode this seam exists to avoid).
+                # A sink failure of ANY kind here (open OR mid-stream) simply
+                # abandons the sink attempt and falls through to the normal
+                # completion below -- unlike the pcm branch above, there is a
+                # complete, valid, already-written file to fall back to, so
+                # there is no reason to ever surface a user-facing failure
+                # for this opportunistic upgrade not panning out.
+                if wav_collect and sink_available():
+                    wav_body = b"".join(wav_collect)
+                    wav_plan = sink_plan("wav", None, wav_body)
+                    if wav_plan is not None:
+                        streamed_outcome_code = await self._stream_response_via_sink(
+                            wav_plan,
+                            _replay_drained_bytes(wav_body),
+                            message_id=normalized_message_id,
+                            fallback_on_failure=True,
+                        )
+                        if streamed_outcome_code is not None:
+                            outcome_code = streamed_outcome_code
+                            # Same retry-tracked cleanup a failed/cancelled
+                            # generation already uses below (`_artifact_
+                            # cleanup_retry`) -- this artifact was never
+                            # registered into `_audio_files` (that only
+                            # happens further down, which this `return`
+                            # skips), so the cache-eviction half of this
+                            # call is a harmless no-op; the retry bookkeeping
+                            # half is what matters for a stalled delete.
+                            await self._discard_tts_artifact(
+                                normalized_message_id,
+                                created_artifact_path,
+                            )
+                            artifact_path = None
+                            return
+                        # `None`: abandon the sink attempt (open OR
+                        # mid-stream failure) -- fall through to the normal
+                        # completion below, reporting the file already
+                        # written above exactly as if this branch had never
+                        # run.
             except BaseException as error:
                 primary_error = error
                 raise
@@ -978,6 +1091,134 @@ class TTSEventHandler:
                     )
                 except Exception:
                     logger.debug("TTS metric publication failed")
+
+    async def _stream_response_via_sink(
+        self,
+        plan: SinkPlan,
+        byte_source: AsyncIterator[bytes],
+        *,
+        message_id: str,
+        fallback_on_failure: bool = False,
+    ) -> str | None:
+        """Play one response live through the streaming PCM sink.
+
+        Owns the WHOLE streaming branch: silencing any still-playing legacy
+        clip, opening the sink, pumping `byte_source` into it, and posting
+        the same `TTSProgressEvent`/`TTSCompleteEvent` pair the legacy path
+        would have -- just with `audio_file=None` (so nothing downstream
+        auto-plays a file that was already played live; see
+        `TldwCli`'s `TTSCompleteEvent` handler, which only acts when
+        `audio_file` is truthy). Callers must not ALSO run the legacy
+        write/play path when this returns non-`None` -- that would be the
+        double-audio failure mode this seam exists to avoid.
+
+        Args:
+            plan: The eligible `SinkPlan` for this response.
+            byte_source: The (unconsumed) audio bytes to feed the sink.
+            message_id: The generation's message id, for the events posted.
+            fallback_on_failure: `False` (the pcm caller, which reaches this
+                BEFORE writing anything -- there is nothing else to fall
+                back to) surfaces a mid-stream pump failure as one error
+                `TTSCompleteEvent`, same as `open()` failing. `True` (the
+                WAV caller, which reaches this AFTER already writing a
+                complete, valid artifact) additionally treats a mid-stream
+                failure the same as an `open()` failure -- silently
+                returning `None` so the caller falls back to the file it
+                already has, rather than surfacing a user-facing error for
+                an opportunistic upgrade that simply didn't pan out.
+
+        Returns:
+            The metrics `outcome_code` ("success" or "streaming_failed")
+            once the response has been fully consumed -- drained, stopped
+            (a deliberate interruption, e.g. one-voice displacement or a
+            later barge-in; not an error), or failed (only when
+            `fallback_on_failure` is `False`). `None` when the sink failed
+            to OPEN, or -- only when `fallback_on_failure` is `True` -- also
+            when it failed mid-stream: either way, the caller must fall
+            through to its own alternate path, so this method posts nothing
+            and touches no bookkeeping in that case.
+        """
+        await self._stop_prior_legacy_clip()
+        sink = StreamingPcmSink(on_event=self._post_sink_event)
+        sink.open(plan.sample_rate, plan.channels)
+        if sink.state == "failed":
+            return None
+
+        result = await pump(
+            sink,
+            byte_source,
+            skip_bytes=plan.skip_bytes,
+            max_bytes=plan.data_bytes,
+        )
+        if result.outcome in ("drained", "stopped"):
+            await self._post_tts_message(
+                TTSProgressEvent(
+                    message_id=message_id,
+                    progress=1.0,
+                    status="Audio generation complete",
+                )
+            )
+            await self._post_tts_message(
+                TTSCompleteEvent(message_id=message_id, audio_file=None)
+            )
+            return "success"
+
+        logger.warning(
+            "Streaming TTS playback failed (outcome={}, reason={}, "
+            "fallback_on_failure={})",
+            result.outcome,
+            result.reason,
+            fallback_on_failure,
+        )
+        if fallback_on_failure:
+            return None
+        await self._post_tts_message(
+            TTSCompleteEvent(
+                message_id=message_id,
+                error="TTS playback failed; retry",
+            )
+        )
+        return "streaming_failed"
+
+    async def _stop_prior_legacy_clip(self) -> None:
+        """Silence any currently-playing legacy file clip before streaming.
+
+        The streaming sink plays through its own `sounddevice.OutputStream`,
+        entirely independent of the legacy `SimpleAudioPlayer` singleton --
+        opening a new sink does nothing, on its own, to stop a still-playing
+        legacy clip the way the sink registry's one-voice displacement
+        already stops a PRIOR sink (see `streaming_sink._register_live_sink`).
+        Mirrors `handle_tts_playback`'s message-scoped stop branch (the same
+        `_last_played`/`stop_audio_playback_if_current` pair), called
+        directly here rather than round-tripping through a posted
+        `TTSPlaybackEvent` since generation already runs on its own worker.
+        """
+        async with self._audio_files_lock:
+            last_played = self._last_played
+            self._last_played = None
+        if last_played is not None:
+            stop_audio_playback_if_current(last_played[1])
+
+    def _post_sink_event(self, event: object) -> None:
+        """Record one streaming-sink lifecycle event.
+
+        `StreamingPcmSink.on_event` may be invoked CONCURRENTLY, from
+        multiple threads at once, and must never do sink work itself --
+        only marshal (see `Audio/streaming_sink.py`'s module docstring,
+        "Thread contract"). Nothing in the UI consumes these yet: spoken
+        feedback only needs `pump()`'s own synchronously-awaited
+        `PumpResult` to know how generation ended, and
+        `_stream_response_via_sink` already reports that through the normal
+        `TTSProgressEvent`/`TTSCompleteEvent` path. Wiring these granular
+        events into the UI (a live underrun indicator, a "speaking" state,
+        etc.) is deferred to a later phase that has an actual listener for
+        them -- this is intentionally a debug-log recorder, not a
+        `post_message`-marshaled Textual event, for now. `logger.debug` is
+        safe to call concurrently from multiple threads, satisfying the
+        thread-safety requirement without introducing any shared mutable
+        state here.
+        """
+        logger.debug("streaming TTS sink event: {}", type(event).__name__)
 
     @staticmethod
     def _validate_exact_selection(
@@ -1339,6 +1580,19 @@ class TTSEventHandler:
             f"TTS playback action: {event.action} for message {event.message_id}"
         )
 
+        if event.action == "stop":
+            # task-4: stop whatever streaming-sink utterance is currently
+            # live, for BOTH the message-scoped stop below AND the global/
+            # bare stop (`message_id=None`, e.g. the one
+            # `chat_screen.py`'s dictation-start posts to silence spoken
+            # feedback before a mic capture opens). The sink has no
+            # per-message identity of its own -- its one-voice registry
+            # only ever tracks a single live sink system-wide -- so this
+            # runs unconditionally on ANY stop request, independent of the
+            # message-scoped legacy-file-stop logic below. A no-op when
+            # nothing is currently live.
+            stop_live_sink()
+
         if event.action == "play" and event.message_id:
             # Get audio file with lock
             async with self._audio_files_lock:
@@ -1563,6 +1817,19 @@ class TTSEventHandler:
 #######################################################################################################################
 #
 # Helper Functions
+
+
+async def _replay_drained_bytes(data: bytes) -> AsyncIterator[bytes]:
+    """Replay one already-collected buffer as a single-chunk async source.
+
+    Used only for the WAV half of the streaming seam in `_generate_tts`:
+    WAV eligibility is decided AFTER the legacy write loop has already
+    collected the response's bytes (see the comment above
+    `_create_tts_artifact`), so playing an eligible one through the sink
+    needs to replay those already-in-memory bytes as an `AsyncIterator`,
+    the same shape `pump()` expects a live `response.byte_stream` to be.
+    """
+    yield data
 
 
 def play_audio_file(file_path: Path) -> None:

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -926,11 +926,22 @@ class TTSEventHandler:
                 buffered_chunks: list[bytes] = []
                 buffered_bytes = 0
                 # Collected alongside `buffered_chunks` (which gets cleared
-                # on every flush) ONLY for wav -- see the streaming-seam
-                # comment above `_create_tts_artifact` for why WAV
-                # eligibility is decided from these, AFTER the unmodified
-                # write loop below, rather than before it.
-                wav_collect: list[bytes] | None = [] if audio_format == "wav" else None
+                # on every flush) ONLY for a wav response a sink could
+                # actually consume -- see the streaming-seam comment above
+                # `_create_tts_artifact` for why WAV eligibility is decided
+                # from these, AFTER the unmodified write loop below, rather
+                # than before it. Fix-round F3: gated on `sink_available()`
+                # too, not format alone -- `buffered_chunks` is already
+                # flushed and cleared in `_TTS_ARTIFACT_WRITE_BATCH_BYTES`
+                # batches, keeping peak memory bounded; `wav_collect`
+                # retains the WHOLE body for the lifetime of the call, so
+                # holding one when no sink could ever use it (the exact
+                # case the Global Constraint says must be left alone) would
+                # regress that bound for every wav response on a machine
+                # with no `sounddevice` at all -- e.g. a headless/CI box.
+                wav_collect: list[bytes] | None = (
+                    [] if _wants_wav_collection(audio_format) else None
+                )
 
                 def cleanup_late_write() -> None:
                     self._schedule_cancelled_artifact_cleanup(
@@ -1128,19 +1139,57 @@ class TTSEventHandler:
                 an opportunistic upgrade that simply didn't pan out.
 
         Returns:
-            The metrics `outcome_code` ("success" or "streaming_failed")
-            once the response has been fully consumed -- drained, stopped
-            (a deliberate interruption, e.g. one-voice displacement or a
-            later barge-in; not an error), or failed (only when
+            The metrics `outcome_code`: `"success"` for a natural drain,
+            `"interrupted"` for a deliberate stop (e.g. one-voice
+            displacement or a later barge-in -- not an error, but distinct
+            from a completed drain), or `"streaming_failed"` (only when
             `fallback_on_failure` is `False`). `None` when the sink failed
             to OPEN, or -- only when `fallback_on_failure` is `True` -- also
             when it failed mid-stream: either way, the caller must fall
             through to its own alternate path, so this method posts nothing
             and touches no bookkeeping in that case.
+
+        Note:
+            The response/provider lease this generation is holding (see
+            `_generate_tts`'s `response.aclose()`, in its own `finally`)
+            stays held for the FULL DURATION of `pump()` below -- i.e.
+            through actual playback, not just until the bytes were
+            received -- since `_generate_tts` cannot release it until this
+            method returns. Fix-round F8: worth noting explicitly as a
+            trade-off, not a bug -- pre-Task-4 the lease was released right
+            after the legacy write loop finished receiving bytes, well
+            before the file was ever played. With
+            `TTSService`'s 4-concurrent-operation cap this is not a
+            practical blocker in Console's single-utterance-at-a-time
+            usage, but it does mean a provider reconfiguration (or another
+            concurrent request) can now be delayed by up to one utterance's
+            playback length.
         """
         await self._stop_prior_legacy_clip()
         sink = StreamingPcmSink(on_event=self._post_sink_event)
-        sink.open(plan.sample_rate, plan.channels)
+        # Fix-round F2: `open()` is documented thread-safe and never
+        # raises, but it is NOT free -- lazily importing `sounddevice` on
+        # first use plus building/starting the real `OutputStream` measured
+        # ~65-110ms on a quiet machine, and CoreAudio device-open latency
+        # can be much worse when another process holds the device. Every
+        # OTHER blocking call in this class already goes through this same
+        # `_run_blocking_tts_io` offload seam (`>100ms -> worker`); `open()`
+        # is no exception, and reusing the seam (rather than a bare
+        # `asyncio.to_thread`) gets its cancellation handling for free: if
+        # this coroutine is cancelled while `open()` is still running on
+        # its own thread (which cannot itself be interrupted), the
+        # `on_cancelled_result`/`on_late_cancelled_result` hooks below
+        # still guarantee `sink.stop()` runs once `open()` actually
+        # finishes -- otherwise a sink that reached "open" only AFTER the
+        # cancellation had already unwound this call stack would never
+        # reach a terminal state at all (the carried terminal-call
+        # guarantee). `sink.stop()` is a safe, idempotent no-op if `open()`
+        # instead reached "failed" on its own.
+        await self._run_blocking_tts_io(
+            lambda: sink.open(plan.sample_rate, plan.channels),
+            on_cancelled_result=lambda _: sink.stop(),
+            on_late_cancelled_result=lambda _: sink.stop(),
+        )
         if sink.state == "failed":
             return None
 
@@ -1150,6 +1199,13 @@ class TTSEventHandler:
             skip_bytes=plan.skip_bytes,
             max_bytes=plan.data_bytes,
         )
+        # Fix-round F8: the `outcome_code` values returned below
+        # ("success"/"interrupted"/"streaming_failed") are a DELIBERATE
+        # expansion of `_generate_tts`'s metric label set, not covered by
+        # `_tts_outcome_code`'s bounded exception-type mapping (that
+        # function only ever runs for the legacy path's `except Exception`
+        # branch) -- listed together here as the closed set this method
+        # can produce, for anyone auditing metric label cardinality.
         if result.outcome in ("drained", "stopped"):
             await self._post_tts_message(
                 TTSProgressEvent(
@@ -1161,7 +1217,17 @@ class TTSEventHandler:
             await self._post_tts_message(
                 TTSCompleteEvent(message_id=message_id, audio_file=None)
             )
-            return "success"
+            if result.outcome == "drained":
+                return "success"
+            # "stopped": the sink was interrupted -- one-voice displacement
+            # by a later utterance, an explicit stop, or a barge-in -- not
+            # a natural drain. Still posted as a normal completion (no
+            # error: an interruption is not a failure, and there is
+            # nothing more useful to tell the user), but fix-round F8:
+            # labeled distinctly in the metric rather than folded into
+            # "success", which would misrepresent playback that was cut
+            # short as if it had played out in full.
+            return "interrupted"
 
         logger.warning(
             "Streaming TTS playback failed (outcome={}, reason={}, "
@@ -1592,8 +1658,33 @@ class TTSEventHandler:
             # message-scoped legacy-file-stop logic below. A no-op when
             # nothing is currently live.
             stop_live_sink()
+            if event.message_id is None:
+                # Fix-round F4: the bare/global stop -- e.g.
+                # `chat_screen.py`'s dictation-start, unconditionally
+                # posted before opening the mic, specifically to protect
+                # the mic/speaker mutual-exclusion invariant -- silenced
+                # the sink above but, before this fix, left legacy FILE
+                # playback untouched: every branch below requires a truthy
+                # `message_id`, so a bare stop was always a no-op for the
+                # legacy player. `_stop_prior_legacy_clip` unconditionally
+                # silences whatever the single-slot legacy player
+                # currently owns, which is exactly the "stop everything"
+                # semantics a bare stop needs. Deliberately scoped to ONLY
+                # the bare/global stop: a message-scoped stop keeps its
+                # own more careful message-id-matched logic below,
+                # unchanged (task-559 unit 2) -- stopping message A must
+                # never silence a different, still-playing message B.
+                await self._stop_prior_legacy_clip()
 
         if event.action == "play" and event.message_id:
+            # Fix-round F1: symmetric with `_stop_prior_legacy_clip` (which
+            # silences a legacy clip before a NEW streaming utterance
+            # starts) -- a legacy play request must silence a currently
+            # LIVE sink first, or the two independent audio-output paths
+            # (the sink's own `sounddevice.OutputStream` vs. the legacy
+            # `SimpleAudioPlayer`) would overlap into a double voice. A
+            # no-op when nothing is currently live.
+            stop_live_sink()
             # Get audio file with lock
             async with self._audio_files_lock:
                 audio_file = self._audio_files.get(event.message_id)
@@ -1817,6 +1908,23 @@ class TTSEventHandler:
 #######################################################################################################################
 #
 # Helper Functions
+
+
+def _wants_wav_collection(audio_format: str) -> bool:
+    """Whether wav bytes should be retained for the post-write sink-eligibility check.
+
+    Fix-round F3 (task-4 review): gated on BOTH the format AND
+    `sink_available()` -- not format alone -- so a machine with no
+    `sounddevice` at all (the exact case the Global Constraint says the
+    legacy path must be left byte- and memory-profile-identical for) never
+    pays the whole-body memory cost the legacy write loop's own
+    `_TTS_ARTIFACT_WRITE_BATCH_BYTES` batching was specifically designed to
+    avoid. `sink_available()` is a cheap `importlib.util.find_spec` probe
+    (measured at ~0.008ms), so hoisting it into this gate costs nothing.
+    A plain function (not inlined) so the gate itself is directly
+    unit-testable without needing to drive a full `_generate_tts` call.
+    """
+    return audio_format == "wav" and sink_available()
 
 
 async def _replay_drained_bytes(data: bytes) -> AsyncIterator[bytes]:

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -1658,7 +1658,7 @@ class TTSEventHandler:
             # message-scoped legacy-file-stop logic below. A no-op when
             # nothing is currently live.
             stop_live_sink()
-            if event.message_id is None:
+            if not event.message_id:
                 # Fix-round F4: the bare/global stop -- e.g.
                 # `chat_screen.py`'s dictation-start, unconditionally
                 # posted before opening the mic, specifically to protect
@@ -1674,22 +1674,36 @@ class TTSEventHandler:
                 # own more careful message-id-matched logic below,
                 # unchanged (task-559 unit 2) -- stopping message A must
                 # never silence a different, still-playing message B.
+                # `not event.message_id` (fix-round N3), not `is None`:
+                # `message_id=""` is falsy too, and the message-scoped
+                # branch below already requires a TRUTHY `message_id`
+                # (`event.action == "stop" and event.message_id`) -- an
+                # `is None` check here left an empty string falling
+                # between both branches, silencing neither the sink's
+                # OWN legacy-clip guard nor anything else.
                 await self._stop_prior_legacy_clip()
 
         if event.action == "play" and event.message_id:
-            # Fix-round F1: symmetric with `_stop_prior_legacy_clip` (which
-            # silences a legacy clip before a NEW streaming utterance
-            # starts) -- a legacy play request must silence a currently
-            # LIVE sink first, or the two independent audio-output paths
-            # (the sink's own `sounddevice.OutputStream` vs. the legacy
-            # `SimpleAudioPlayer`) would overlap into a double voice. A
-            # no-op when nothing is currently live.
-            stop_live_sink()
             # Get audio file with lock
             async with self._audio_files_lock:
                 audio_file = self._audio_files.get(event.message_id)
 
             if audio_file and audio_file.exists():
+                # Fix-round F1/N1: symmetric with `_stop_prior_legacy_clip`
+                # (which silences a legacy clip before a NEW streaming
+                # utterance starts) -- a legacy play request must silence a
+                # currently LIVE sink first, or the two independent
+                # audio-output paths (the sink's own `sounddevice.
+                # OutputStream` vs. the legacy `SimpleAudioPlayer`) would
+                # overlap into a double voice. Deliberately placed AFTER
+                # the file-exists check (N1 fix-round): this branch is the
+                # only one that will actually replace whatever is
+                # currently playing -- stopping a live sink for a `play`
+                # whose cached artifact has already been cleaned up (the
+                # 5s cache cleanup below) would silence real audio and
+                # play nothing back, a strictly worse outcome than leaving
+                # it alone. A no-op when nothing is currently live.
+                stop_live_sink()
                 # Play the audio file
                 play_audio_file(audio_file)
                 # Record what the player now has loaded, independent of

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -53,6 +53,21 @@ _TTS_IO_CANCELLATION_JOIN_TIMEOUT_SECONDS = 1.0
 _TTS_SECURE_DELETE_TIMEOUT_SECONDS = 1.0
 _TTS_RETAINED_WORK_DRAIN_TIMEOUT_SECONDS = 1.0
 _GLOBAL_OVERRIDE_TOKEN_PATTERN = re.compile(r"[0-9a-f]{32}\Z")
+# F4 fix-round: hard cap, in bytes, on the in-memory WAV body the
+# opportunistic sink-upgrade attempt (see `wav_collect` in `_generate_tts`)
+# will accumulate before giving up and falling through to the legacy,
+# already-fully-written disk artifact. Derived from the streaming sink's
+# own BUFFER_CAP_SECONDS (`Audio/streaming_sink.py`, 60s -- the most audio
+# it could ever actually buffer and play) at a deliberately generous
+# worst-case PCM16 rate -- 48kHz stereo, 2 bytes/sample:
+#   60s * 48_000Hz * 2ch * 2bytes = 11_520_000 bytes (~11.5MB)
+# rounded up to a clean 16MiB. A WAV response bigger than this could never
+# be fully played through the sink's own buffer anyway (`feed()` rejects
+# the tail past BUFFER_CAP_SECONDS of buffered audio at the response's
+# REAL sample rate), so abandoning the attempt here costs nothing in
+# correctness -- only saves the memory/CPU of accumulating (and then
+# copying) a body this large just to discover that.
+_MAX_WAV_SINK_UPGRADE_BYTES = 16 * 1024 * 1024
 
 
 class _TTSResponseContractError(RuntimeError):
@@ -940,8 +955,19 @@ class TTSEventHandler:
                 # case the Global Constraint says must be left alone) would
                 # regress that bound for every wav response on a machine
                 # with no `sounddevice` at all -- e.g. a headless/CI box.
-                wav_collect: list[bytes] | None = (
-                    [] if _wants_wav_collection(audio_format) else None
+                #
+                # Fix-round F4: a `bytearray` accumulator, not a
+                # `list[bytes]` later joined with `b"".join(...)` -- the
+                # list-then-join shape briefly (and, since `wav_collect`
+                # itself was never dereferenced afterward, not so briefly)
+                # held BOTH the complete list of every streamed chunk AND
+                # the freshly `b"".join`-ed copy of the same bytes at once.
+                # `bytearray.extend()` grows one buffer in place instead;
+                # each `chunk` is copied in and then immediately eligible
+                # for GC (nothing else retains it beyond `buffered_chunks`,
+                # which is cleared every `_TTS_ARTIFACT_WRITE_BATCH_BYTES`).
+                wav_collect: bytearray | None = (
+                    bytearray() if _wants_wav_collection(audio_format) else None
                 )
 
                 def cleanup_late_write() -> None:
@@ -970,7 +996,16 @@ class TTSEventHandler:
                     if not chunk:
                         continue
                     if wav_collect is not None:
-                        wav_collect.append(chunk)
+                        wav_collect.extend(chunk)
+                        if len(wav_collect) > _MAX_WAV_SINK_UPGRADE_BYTES:
+                            # F4: oversized body -- abandon the in-memory
+                            # upgrade attempt (and free what was collected
+                            # so far) rather than keep accumulating a body
+                            # too big to ever fully fit the sink's own
+                            # buffer anyway. The legacy write loop below is
+                            # completely unaffected: it already has (or
+                            # will have) the complete file on disk.
+                            wav_collect = None
                     buffered_chunks.append(chunk)
                     buffered_bytes += len(chunk)
                     if buffered_bytes >= _TTS_ARTIFACT_WRITE_BATCH_BYTES:
@@ -993,7 +1028,16 @@ class TTSEventHandler:
                 # there is no reason to ever surface a user-facing failure
                 # for this opportunistic upgrade not panning out.
                 if wav_collect and sink_available():
-                    wav_body = b"".join(wav_collect)
+                    # The one copy `sink_plan`/`validate_pcm16_wav` actually
+                    # demands: both are typed (and, `validate_pcm16_wav`'s
+                    # `struct.unpack_from`/slicing aside, documented) around
+                    # an immutable `bytes` body, not a still-growable
+                    # `bytearray` -- converting here, once, at that boundary
+                    # (fix-round F4) is the single unavoidable copy; dropping
+                    # `wav_collect` immediately after frees the accumulator
+                    # instead of holding both for the rest of this call.
+                    wav_body = bytes(wav_collect)
+                    wav_collect = None
                     wav_plan = sink_plan("wav", None, wav_body)
                     if wav_plan is not None:
                         streamed_outcome_code = await self._stream_response_via_sink(

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -18,6 +18,7 @@ from textual.message import Message
 
 # Local imports
 from tldw_chatbook.Audio.streaming_sink import (
+    SinkUnderrun,
     StreamingPcmSink,
     pump,
     sink_available,
@@ -1166,7 +1167,28 @@ class TTSEventHandler:
             playback length.
         """
         await self._stop_prior_legacy_clip()
-        sink = StreamingPcmSink(on_event=self._post_sink_event)
+        last_underrun_frames = 0
+
+        def _on_event(event: object) -> None:
+            nonlocal last_underrun_frames
+            if isinstance(event, SinkUnderrun):
+                # Fix-round M2: `SinkUnderrun` is the only signal that live
+                # playback is stuttering -- `_post_sink_event` alone drops
+                # it into a debug-only log line, invisible to both the
+                # user and metrics on the one feature whose entire premise
+                # is live playback quality. Recorded here so it can be
+                # reported once, at utterance end (below), rather than per
+                # throttled event. `on_event` may be invoked concurrently
+                # from multiple threads (Audio/streaming_sink.py's thread
+                # contract), but `SinkUnderrun` specifically always
+                # originates from the sink's own notify thread, never a
+                # caller thread -- so this plain assignment has exactly
+                # one writer; the read below happens once, after `pump()`
+                # has already returned, from this coroutine's own thread.
+                last_underrun_frames = event.frames
+            self._post_sink_event(event)
+
+        sink = StreamingPcmSink(on_event=_on_event)
         # Fix-round F2: `open()` is documented thread-safe and never
         # raises, but it is NOT free -- lazily importing `sounddevice` on
         # first use plus building/starting the real `OutputStream` measured
@@ -1199,6 +1221,30 @@ class TTSEventHandler:
             skip_bytes=plan.skip_bytes,
             max_bytes=plan.data_bytes,
         )
+
+        # Fix-round M2: report on utterance end, regardless of terminal
+        # outcome -- an underrun can happen on the way to ANY of them, not
+        # just a successful drain. Minimal and honest: one INFO log line
+        # with the cumulative frame count, plus one bump of the existing
+        # `tts_generation_total` counter with a dedicated `"underrun"`
+        # `outcome_code` value (same pattern F8 already established for
+        # `"interrupted"`) -- no UI.
+        if last_underrun_frames > 0:
+            logger.info(
+                "Streaming TTS playback underrun ({} frames) for message {}",
+                last_underrun_frames,
+                message_id,
+            )
+            try:
+                from tldw_chatbook.Metrics.metrics_logger import log_counter
+
+                log_counter(
+                    "tts_generation_total",
+                    labels={"outcome_code": "underrun"},
+                )
+            except Exception:
+                logger.debug("TTS underrun metric publication failed")
+
         # Fix-round F8: the `outcome_code` values returned below
         # ("success"/"interrupted"/"streaming_failed") are a DELIBERATE
         # expansion of `_generate_tts`'s metric label set, not covered by

--- a/tldw_chatbook/TTS/pcm_stream.py
+++ b/tldw_chatbook/TTS/pcm_stream.py
@@ -14,11 +14,20 @@ Import weight: `audio_cpp_contract` was read before adding this module-scope
 import -- it pulls in only stdlib (`json`, `math`, `re`, `struct`,
 `unicodedata`, `dataclasses`, `decimal`, `types`, `typing`), so no lazy-import
 is needed. This module itself imports nothing else: no sounddevice, no
-Textual, no other TTS submodules.
+Textual, no other TTS submodules. That said, `import tldw_chatbook.TTS.pcm_stream`
+still runs `tldw_chatbook/TTS/__init__.py` first (Python always imports the
+package before a submodule), which eagerly pulls in the full TTS package --
+including, transitively, `textual.*`. That's pre-existing package structure,
+not introduced here, but it means `tldw_chatbook/Audio/streaming_sink.py`
+(which is constrained to zero Textual imports) must never import this module
+at module scope, even though this module's own direct imports are light. The
+two meet only in the consumer that wires them together (the TTS event
+handling code), never in `streaming_sink.py` itself.
 """
 
 from __future__ import annotations
 
+import struct
 from dataclasses import dataclass
 
 from tldw_chatbook.TTS.audio_cpp_contract import (
@@ -40,6 +49,7 @@ class SinkPlan:
     sample_rate: int
     channels: int
     skip_bytes: int
+    data_bytes: int | None = None
 
 
 def sink_plan(
@@ -64,20 +74,36 @@ def sink_plan(
             validated header is authoritative.
         first_bytes: The response body (or its head). Required for "wav" --
             validated as a canonical PCM16 RIFF/WAVE body via
-            `validate_pcm16_wav`. Unused for "pcm".
+            `validate_pcm16_wav`. Unused for "pcm". Must be the COMPLETE WAV
+            body: `validate_pcm16_wav` fails closed on any truncated or
+            internally-inconsistent buffer (declared RIFF size not matching
+            the buffer's actual length, or a `data` chunk claiming more
+            bytes than are present), so a caller that only has the first N
+            bytes of a still-arriving WAV response will get `None` here,
+            not a partial plan. audio.cpp's single-response delivery (one
+            complete WAV body per response) satisfies this; a streaming WAV
+            source would need to buffer the whole body before calling this.
         channels: Explicit channel count for raw "pcm"; defaults to 1 when
             omitted. Ignored for "wav", where the validated header is
             authoritative.
 
     Returns:
-        A `SinkPlan` if the response is eligible, else `None`.
+        A `SinkPlan` if the response is eligible, else `None`. For "wav",
+        `SinkPlan.data_bytes` bounds the audio payload: callers must read
+        only `first_bytes[skip_bytes : skip_bytes + data_bytes]` (or the
+        equivalent window from the full body), never everything from
+        `skip_bytes` onward -- a WAV may have trailing chunks after `data`,
+        and their bytes are not audio.
     """
     if audio_format == _FORMAT_RAW_PCM:
         if sample_rate is None:
             return None
         resolved_channels = _DEFAULT_CHANNELS if channels is None else channels
         return SinkPlan(
-            sample_rate=sample_rate, channels=resolved_channels, skip_bytes=0
+            sample_rate=sample_rate,
+            channels=resolved_channels,
+            skip_bytes=0,
+            data_bytes=None,  # raw PCM has no container-declared length: unbounded
         )
 
     if audio_format == _FORMAT_WAV:
@@ -98,12 +124,39 @@ def _wav_plan(first_bytes: bytes | None) -> SinkPlan | None:
     # Pcm16WavInfo (tldw_chatbook/TTS/audio_cpp_contract.py) carries no
     # chunk-offset field -- only sample_rate/channels/frame_count/data_size/
     # byte_rate/block_align/bits_per_sample. `validate_pcm16_wav` accepts
-    # ancillary RIFF chunks ahead of `data` (see its module docstring), so
-    # the header length isn't reliably the canonical 44 bytes. Deriving it as
-    # "everything that isn't the validated data payload" stays correct in
-    # that case and agrees with 44 for a canonical header (as pinned by
-    # test_valid_pcm16_wav_is_eligible_with_header_skip).
-    skip_bytes = len(first_bytes) - info.data_size
+    # ancillary RIFF chunks generically, in ANY position, including AFTER
+    # `data` (see its module docstring) -- so `len(first_bytes) -
+    # info.data_size` is wrong whenever something trails `data`: it counts
+    # that trailing content as if it were header, over-skipping into the
+    # real audio (task-3 review, finding I1). Locating `data`'s payload
+    # offset directly, by walking the chunk structure, is correct
+    # regardless of what precedes or follows it.
     return SinkPlan(
-        sample_rate=info.sample_rate, channels=info.channels, skip_bytes=skip_bytes
+        sample_rate=info.sample_rate,
+        channels=info.channels,
+        skip_bytes=_data_chunk_offset(first_bytes),
+        data_bytes=info.data_size,
     )
+
+
+def _data_chunk_offset(body: bytes) -> int:
+    """Return the byte offset of the `data` chunk's payload in `body`.
+
+    Only called after `validate_pcm16_wav` has already accepted `body`, so
+    this walk can simply assert its way to `data` -- the validator is the
+    acceptance gate; it already proved `body` is a well-formed RIFF/WAVE
+    stream (12-byte RIFF header, then a sequence of 8-byte chunk headers
+    each followed by a word-aligned payload) containing exactly one `data`
+    chunk. This mirrors that same chunk walk, just to find where audio
+    playback should actually start.
+    """
+    position = 12
+    while True:
+        chunk_id = body[position : position + 4]
+        chunk_size = struct.unpack_from("<I", body, position + 4)[0]
+        payload_start = position + 8
+        if chunk_id == b"data":
+            return payload_start
+        position = payload_start + chunk_size
+        if chunk_size % 2:
+            position += 1

--- a/tldw_chatbook/TTS/pcm_stream.py
+++ b/tldw_chatbook/TTS/pcm_stream.py
@@ -1,0 +1,109 @@
+"""Response-eligibility seam for the streaming PCM sink.
+
+Pure, provider-agnostic decision: given a TTS response's declared audio
+format, sample rate, and (for containerized formats) the first bytes of the
+body, decide whether the response is eligible for the streaming PCM sink and,
+if so, produce a `SinkPlan` describing how to consume it.
+
+The seam branches only on the response's own shape (format / rate / bytes),
+never on provider identity -- callers pass plain values, not a provider
+object, so this stays true regardless of whether the caller holds an adapter
+`TTSAudioResponse` or a backend path's raw format string.
+
+Import weight: `audio_cpp_contract` was read before adding this module-scope
+import -- it pulls in only stdlib (`json`, `math`, `re`, `struct`,
+`unicodedata`, `dataclasses`, `decimal`, `types`, `typing`), so no lazy-import
+is needed. This module itself imports nothing else: no sounddevice, no
+Textual, no other TTS submodules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tldw_chatbook.TTS.audio_cpp_contract import (
+    AudioCppContractError,
+    validate_pcm16_wav,
+)
+
+_FORMAT_RAW_PCM = "pcm"
+_FORMAT_WAV = "wav"
+_DEFAULT_CHANNELS = 1
+
+__all__ = ["SinkPlan", "sink_plan"]
+
+
+@dataclass(frozen=True, slots=True)
+class SinkPlan:
+    """Parameters the streaming PCM sink needs to consume an eligible response."""
+
+    sample_rate: int
+    channels: int
+    skip_bytes: int
+
+
+def sink_plan(
+    audio_format: str,
+    sample_rate: int | None,
+    first_bytes: bytes | None,
+    channels: int | None = None,
+) -> SinkPlan | None:
+    """Decide whether a TTS response is eligible for the streaming PCM sink.
+
+    Returns `None` for anything the sink can't safely consume -- compressed
+    formats, raw PCM with no declared rate, or a WAV body that fails
+    structural validation -- so the caller can fall back to the legacy
+    whole-file path unconditionally.
+
+    Args:
+        audio_format: The response's declared audio format, e.g. "pcm",
+            "wav", "mp3". Compared case-sensitively against the two formats
+            the sink understands; anything else is ineligible.
+        sample_rate: The response's declared sample rate. Required for
+            "pcm" (returns `None` when absent); ignored for "wav", where the
+            validated header is authoritative.
+        first_bytes: The response body (or its head). Required for "wav" --
+            validated as a canonical PCM16 RIFF/WAVE body via
+            `validate_pcm16_wav`. Unused for "pcm".
+        channels: Explicit channel count for raw "pcm"; defaults to 1 when
+            omitted. Ignored for "wav", where the validated header is
+            authoritative.
+
+    Returns:
+        A `SinkPlan` if the response is eligible, else `None`.
+    """
+    if audio_format == _FORMAT_RAW_PCM:
+        if sample_rate is None:
+            return None
+        resolved_channels = _DEFAULT_CHANNELS if channels is None else channels
+        return SinkPlan(
+            sample_rate=sample_rate, channels=resolved_channels, skip_bytes=0
+        )
+
+    if audio_format == _FORMAT_WAV:
+        return _wav_plan(first_bytes)
+
+    return None
+
+
+def _wav_plan(first_bytes: bytes | None) -> SinkPlan | None:
+    """Validate a WAV body and derive the plan, or `None` if it's not usable."""
+    if not first_bytes:
+        return None
+    try:
+        info = validate_pcm16_wav(first_bytes)
+    except AudioCppContractError:
+        return None
+
+    # Pcm16WavInfo (tldw_chatbook/TTS/audio_cpp_contract.py) carries no
+    # chunk-offset field -- only sample_rate/channels/frame_count/data_size/
+    # byte_rate/block_align/bits_per_sample. `validate_pcm16_wav` accepts
+    # ancillary RIFF chunks ahead of `data` (see its module docstring), so
+    # the header length isn't reliably the canonical 44 bytes. Deriving it as
+    # "everything that isn't the validated data payload" stays correct in
+    # that case and agrees with 44 for a canonical header (as pinned by
+    # test_valid_pcm16_wav_is_eligible_with_header_skip).
+    skip_bytes = len(first_bytes) - info.data_size
+    return SinkPlan(
+        sample_rate=info.sample_rate, channels=info.channels, skip_bytes=skip_bytes
+    )

--- a/tldw_chatbook/TTS/pcm_stream.py
+++ b/tldw_chatbook/TTS/pcm_stream.py
@@ -70,8 +70,13 @@ def sink_plan(
             "wav", "mp3". Compared case-sensitively against the two formats
             the sink understands; anything else is ineligible.
         sample_rate: The response's declared sample rate. Required for
-            "pcm" (returns `None` when absent); ignored for "wav", where the
-            validated header is authoritative.
+            "pcm" -- returns `None` when absent OR when present but not an
+            `int` (fix-round F8: an adapter/legacy-bridge bug supplying a
+            wrong-typed value must fail closed here, not raise deep inside
+            `StreamingPcmSink.open`'s `sample_rate * blocksize_ms // 1000`
+            arithmetic, where it would otherwise be swallowed by
+            `_generate_tts`'s generic exception handling) -- ignored for
+            "wav", where the validated header is authoritative.
         first_bytes: The response body (or its head). Required for "wav" --
             validated as a canonical PCM16 RIFF/WAVE body via
             `validate_pcm16_wav`. Unused for "pcm". Must be the COMPLETE WAV
@@ -96,7 +101,7 @@ def sink_plan(
         and their bytes are not audio.
     """
     if audio_format == _FORMAT_RAW_PCM:
-        if sample_rate is None:
+        if sample_rate is None or type(sample_rate) is not int:
             return None
         resolved_channels = _DEFAULT_CHANNELS if channels is None else channels
         return SinkPlan(


### PR DESCRIPTION
Phase 1 of voice V3 (per the approved spec's sink-first split): an interruptible streaming audio-output service, a response-eligibility seam, and Console spoken feedback converted as the proving consumer. Spec: `Docs/superpowers/specs/2026-08-01-streaming-pcm-sink-design.md`; plan alongside it.

### What ships
- **`Audio/streaming_sink.py` — `StreamingPcmSink`**: sounddevice-backed, headless. Hard contracts, all pinned: 300 ms prebuffer before audibility (or close-before-threshold), **stop-to-silence ≤ 2 audio blocks** via `stream.abort()` (the number barge-in will rely on in phase 2), bounded 60 s buffer, callback that never raises, a per-sink notify thread keeping every event and teardown off the PortAudio callback thread, one-voice displacement, `pump()` with cancellation-safe terminal guarantees and `max_bytes` bounding.
- **`TTS/pcm_stream.py` — `sink_plan()`**: pure response inspection (raw PCM or validated PCM16-WAV → sink; anything else → legacy path). No provider names anywhere. `SinkPlan.data_bytes` provably prevents WAV trailer chunks being played as audio.
- **Consumer**: spoken feedback streams when the response is eligible; every fallback (`sounddevice` absent, ineligible format, device failure) is pin-verified byte-identical to today. `TTSPlaybackEvent("stop")` now silences sink and legacy player both ways.
- **Test-suite safety**: session-wide guard in `Tests/conftest.py` (with a `real_audio_device` opt-out marker) after a validator-accepted WAV fixture was found opening a **real audio device** inside a passing test.

### Honest scope (adjudicated in review, stated in the docs)
Today the streaming path serves **audio.cpp adapter responses only** — the legacy bridge omits `sample_rate`, so openai/kokoro remain on the (unchanged) file path. Benefit today: interruptible playback and immediate capture-start silencing; the openai/kokoro unlock is **TASK-1880** (filed, three legs, including the pcm-safe-fallback leg whose absence would otherwise have broken openai feedback). Follow-ups TASK-1881..1883 filed.

### Review provenance
Five tasks, each through implementer → opus/sonnet review → fix loops with RED-first + mutation checks throughout; final whole-branch review found the between-tasks **Critical** (the sink's carefully-lazy sounddevice import defeated by a consumer module-scope import → `Pa_Initialize()` at app import → **app fails to launch** where PortAudio can't init; two-layer fix, boot module count restored to the exact pre-branch baseline). 517 tests green; the V1 dictation contract file has a 0-line branch diff.

### Live gate
Run on real hardware: branch app boots clean against the live config, real-mic dictation regression passed. The audible-streaming half requires an audio.cpp server (none on this machine) — transfers to any environment with one; the fallback path is what all other providers get and is pin-verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an interruptible streaming PCM sink for live TTS playback with a ~300 ms prebuffer and fast stops (≤2 blocks). Console spoken feedback now streams for raw PCM and validated PCM16‑WAV (audio.cpp today), deletes redundant artifacts, and reports underruns and barge‑ins cleanly.

- **New Features**
  - `Audio/streaming_sink.py` — `StreamingPcmSink` with a notify thread, 60 s buffer cap, non‑joining `stop()`, `settle()`, `terminal_reason`, and one‑voice registry plus `stop_live_sink()`.
  - `TTS/pcm_stream.py` — `sink_plan()` uses the true RIFF data offset, adds `data_bytes` bounds, and validates `sample_rate` type.
  - `pump()` bridges async chunks with backpressure, cancellation‑safe terminal guarantees, `skip_bytes`, and `max_bytes`; registers/displaces the live sink safely.
  - Spoken feedback streams via off‑loop `open()`; eligible WAVs play live and delete temp files; metrics include `interrupted` and `underrun`.

- **Bug Fixes**
  - Lazy‑import `AudioRecordingService`; backend probes catch `Exception`; `_import_sounddevice()` routed through `optional_deps` and guarded; `sink_available()` stays find‑spec‑only.
  - Repo‑wide test guard blocks real `sounddevice` unless `pytest.mark.real_audio_device`; live‑sink registry reset between tests.
  - WAV collection gated on `sink_available()`; memory reduced via bytearray accumulation and a 16 MiB cap.
  - Validate `sample_rate`/`channels` before `open()` arithmetic; lifecycle hardened (notify‑thread handoff, drain teardown, idempotent terminals, stop/open race fixes).

<sup>Written for commit 9c6e7dae87786bcbe1694ac5a1400d80817fbe34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

