### PR TITLE
feat: kept briefings/scripts in chatbook export + recorded sync exclusion (task-1870)

### DIFF
--- a/Docs/superpowers/specs/2026-08-01-kept-briefings-design.md
+++ b/Docs/superpowers/specs/2026-08-01-kept-briefings-design.md
@@ -126,3 +126,54 @@ all checked. Four things worth recording for anyone re-reading this design later
   same bug shape the wider program has caught more than once: a `finally`/recompose path that
   rebuilds the UI from scratch will silently discard any state set moments earlier unless that
   state is threaded through `compose()` rather than assumed to survive it.
+
+## Follow-up decision (2026-08-02, task-1870): sync excluded, chatbook export included
+
+Task-1870 was filed at this spec's close-out (see "Non-goals (v1)" above) to close the silent gap
+on both of this design's deferred fronts — ChaChaNotes sync coverage and chatbook-export coverage
+of `kept_briefings`/`kept_scripts`. Both are now resolved, asymmetrically:
+
+- **ChaChaNotes sync: still excluded, by extension of this spec's original ruling.** The "Schema"
+  section above already decided `kept_briefings`/`kept_scripts` carry no sync columns
+  (`client_id`/`version`/`deleted`) and do not participate in ChaChaNotes's bidirectional sync
+  machinery. Task-1870 does not revisit that call — it stays a deliberate v1 decision, not an
+  oversight. The reason it holds up under the "should a follow-up close this?" question: the sync
+  engine's unit of replication is a row with a `client_id`/`version`/tombstone lineage, and kept
+  rows were designed from the start (this spec's "Schema" section) to be self-interpreting,
+  hard-deleted, denormalized copies with no such lineage. Retrofitting sync columns would be a
+  schema change with its own migration and conflict-resolution design, not a small follow-up: if a
+  future task wants cross-device sync of kept content, it should treat that as a new schema
+  proposal against this spec, not an extension of task-1870.
+- **Chatbook export: now included.** `ContentType.KEPT_BRIEFING` (`Chatbooks/chatbook_models.py`)
+  is a new chatbook content type. `ChatbookCreator._collect_kept_briefings`
+  (`Chatbooks/chatbook_creator.py`) walks a user's selected kept briefings, and — mirroring how a
+  conversation's messages are nested inside the conversation's own exported JSON rather than being
+  independently selectable — nests each briefing's kept scripts inside its own payload. Every
+  provenance column denormalized onto the kept rows by this spec's original schema (source ids,
+  coverage window, model/preset identifiers, origin, original/kept timestamps) is carried into the
+  export unchanged, so an exported kept briefing remains self-interpreting even without the source
+  ChaChaNotes database, matching this spec's "self-interpreting with the subscriptions DB gone
+  entirely" principle. Each briefing exports as both a JSON file (machine-round-trippable) and a
+  companion Markdown file (human-readable), the same split already used for conversations
+  (JSON + citation report) and notes (frontmatter + body).
+
+  Import policy: `source_briefing_id`/`source_script_id` are device-local ids (this spec's
+  "Schema" section is explicit that they are "kept only for tracing", never cross-DB foreign
+  keys), so an incoming row can collide with an unrelated local row that happens to reuse the same
+  source id on a different device. `ChatbookImporter._import_kept_briefings` handles this by
+  trying the insert and catching `ConflictError` — the same "raced keep" pattern this spec's
+  delivery notes already documented for `briefing_keep.py` — then comparing content: byte-identical
+  is treated as an ordinary already-imported row (skipped silently, since re-importing the same
+  chatbook must never duplicate it); differing content is reported as a named conflict in the
+  import summary and the existing local row is never overwritten. `ConflictResolver`'s existing
+  ask/skip/rename/replace machinery (built for display-name-keyed conversations/notes/characters)
+  was deliberately not extended to kept rows — a UNIQUE source-id-keyed idempotent artifact doesn't
+  fit "rename" or "ask per item" semantics, and this codebase already had a working precedent for
+  the right shape in the keep service itself. NULL-source kept scripts (cast directly from a kept
+  briefing, no subscriptions-side source) have no identity to key a `ConflictError` off of, so they
+  are deduped by content match against the parent's pre-existing scripts instead, one-for-one
+  (a matched candidate is consumed so it cannot absorb a second, different incoming script).
+
+  Chatbooks created before this task have no `kept_briefings` section at all; importing one is
+  unaffected — the new code path never runs when `ContentType.KEPT_BRIEFING` is absent from the
+  manifest, and `ChatbookManifest.from_dict` defaults `total_kept_briefings` to 0 for old bundles.

--- a/Tests/Chatbooks/test_chatbook_import_wizard_validation.py
+++ b/Tests/Chatbooks/test_chatbook_import_wizard_validation.py
@@ -1,0 +1,104 @@
+# test_chatbook_import_wizard_validation.py
+# Description: Regression coverage for task-1870 fix-wave F2 (statistics-mismatch false alarm)
+"""
+`PreviewValidationStep._run_validation` (ChatbookImportWizard.py) compares
+`len(manifest.content_items)` against a hand-summed "expected total" of the
+manifest's per-type statistics, and shows a "Statistics mismatch" warning
+when the two disagree. That sum omitted `total_kept_briefings` (this
+feature's own content type) and `total_prompts` (pre-existing), so a
+kept-only chatbook -- precisely the bundle task-1870 exists to produce --
+always showed a false "Statistics mismatch" warning on its own happy path.
+
+The arithmetic is exercised directly via the extracted
+`_expected_content_total` staticmethod rather than by mounting the wizard
+step: `_run_validation` itself calls `self.query_one(...)`, which needs a
+running Textual App, while the mismatch check is pure arithmetic over the
+manifest and does not need a live UI to verify.
+"""
+
+from tldw_chatbook.Chatbooks.chatbook_models import (
+    ChatbookManifest,
+    ChatbookVersion,
+    ContentItem,
+    ContentType,
+)
+from tldw_chatbook.UI.Wizards.ChatbookImportWizard import PreviewValidationStep
+
+
+def _manifest(**totals) -> ChatbookManifest:
+    manifest = ChatbookManifest(
+        version=ChatbookVersion.V1,
+        name="Test Bundle",
+        description="Test",
+    )
+    for field, value in totals.items():
+        setattr(manifest, field, value)
+    return manifest
+
+
+def test_kept_only_manifest_has_no_statistics_mismatch():
+    """The happy path this task exists for: a chatbook containing only kept
+    briefings must not trip the mismatch warning (task-1870 fix-wave F2)."""
+    manifest = _manifest(total_kept_briefings=1)
+    manifest.content_items = [
+        ContentItem(id="1", type=ContentType.KEPT_BRIEFING, title="Kept"),
+    ]
+
+    expected_total = PreviewValidationStep._expected_content_total(manifest)
+
+    assert expected_total == len(manifest.content_items) == 1
+
+
+def test_prompts_only_manifest_has_no_statistics_mismatch():
+    """`total_prompts` was already omitted before this task; folding it into
+    the same fix (per the whole-branch review) must not regress it."""
+    manifest = _manifest(total_prompts=2)
+    manifest.content_items = [
+        ContentItem(id="1", type=ContentType.PROMPT, title="P1"),
+        ContentItem(id="2", type=ContentType.PROMPT, title="P2"),
+    ]
+
+    expected_total = PreviewValidationStep._expected_content_total(manifest)
+
+    assert expected_total == len(manifest.content_items) == 2
+
+
+def test_mixed_manifest_across_every_tracked_content_type_matches():
+    manifest = _manifest(
+        total_conversations=1,
+        total_notes=1,
+        total_characters=1,
+        total_media_items=1,
+        total_prompts=1,
+        total_kept_briefings=1,
+    )
+    manifest.content_items = [
+        ContentItem(id=str(i), type=content_type, title=str(i))
+        for i, content_type in enumerate(
+            [
+                ContentType.CONVERSATION,
+                ContentType.NOTE,
+                ContentType.CHARACTER,
+                ContentType.MEDIA,
+                ContentType.PROMPT,
+                ContentType.KEPT_BRIEFING,
+            ]
+        )
+    ]
+
+    expected_total = PreviewValidationStep._expected_content_total(manifest)
+
+    assert expected_total == len(manifest.content_items) == 6
+
+
+def test_genuine_mismatch_is_still_detected():
+    """The fix must not paper over a REAL mismatch -- only the false alarm
+    caused by the two missing terms."""
+    manifest = _manifest(total_kept_briefings=1)
+    manifest.content_items = []  # manifest claims 1 kept briefing, lists none
+
+    expected_total = PreviewValidationStep._expected_content_total(manifest)
+
+    assert expected_total == 1
+    assert len(manifest.content_items) == 0
+    assert expected_total != len(manifest.content_items)

--- a/Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py
+++ b/Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py
@@ -1,0 +1,394 @@
+"""Chatbook export/import coverage for kept briefings/scripts (task-1870).
+
+Kept briefings and their kept scripts (`kept_briefings`/`kept_scripts` in
+ChaChaNotes, task-1780) previously had no chatbook-export awareness at all --
+silently absent from every exported chatbook. This module covers the new
+`ContentType.KEPT_BRIEFING` content type end to end: export (JSON + Markdown
+per briefing, scripts nested inside), import into a fresh ChaChaNotes
+(byte-faithful round trip of every provenance column), re-import idempotency,
+cross-device source-id collisions (never silently overwritten, honestly
+reported), and backward compatibility with chatbooks that predate this
+content type.
+
+Kept scripts are not independently selectable -- they always ride with their
+parent kept briefing, mirroring how a conversation's messages are nested
+inside the conversation's own exported JSON rather than being their own
+content type.
+"""
+
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Chatbooks.chatbook_creator import ChatbookCreator
+from tldw_chatbook.Chatbooks.chatbook_importer import ChatbookImporter, ImportStatus
+from tldw_chatbook.Chatbooks.chatbook_models import ChatbookManifest, ContentType
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def _db_paths(root: Path) -> dict:
+    root.mkdir(parents=True, exist_ok=True)
+    return {
+        "ChaChaNotes": str(root / "chachanotes.db"),
+        "Prompts": str(root / "prompts.db"),
+        "Media": str(root / "media.db"),
+        "Evals": str(root / "evals.db"),
+        "RAG": str(root / "rag.db"),
+    }
+
+
+@pytest.fixture
+def source_env(tmp_path, chachanotes_template_db):
+    """A source ChaChaNotes DB with one kept briefing and two kept scripts.
+
+    One script carries a subscriptions-side `source_script_id`; the other is
+    `source_script_id=None` (cast directly from the kept briefing, per the
+    kept-briefings design doc) -- covering both idempotency paths import
+    must handle.
+    """
+    import shutil
+
+    db_paths = _db_paths(tmp_path / "source")
+    shutil.copyfile(chachanotes_template_db, db_paths["ChaChaNotes"])
+    db = CharactersRAGDB(db_paths["ChaChaNotes"], "test-source")
+
+    kept_id = db.create_kept_briefing(
+        source_briefing_id=101,
+        watchlist_name="Tech Watch",
+        body_markdown="# Digest\n\nBody text with **markdown**.",
+        covers_through_item_id=555,
+        covers_from_ts="2026-07-25T00:00:00Z",
+        selection_mode="auto",
+        model_used="gpt-test",
+        item_count=12,
+        featured_count=3,
+        overflow_count=2,
+        origin="manual",
+        original_created_at="2026-07-30T10:00:00Z",
+    )
+    db.create_kept_script(
+        kept_id,
+        source_script_id=555,
+        preset_name="duo-cast",
+        roster_snapshot_json='{"roster": ["A", "B"]}',
+        turns_json='[{"speaker": "A", "text": "Hi"}]',
+        model_used="gpt-test",
+        original_created_at="2026-07-30T11:00:00Z",
+    )
+    db.create_kept_script(
+        kept_id,
+        source_script_id=None,
+        preset_name="(app default)",
+        roster_snapshot_json='{"roster": ["Narrator"]}',
+        turns_json='[{"speaker": "Narrator", "text": "Once upon a time"}]',
+        model_used=None,
+        original_created_at=None,
+    )
+    db.close_connection()
+    return db_paths, kept_id
+
+
+def _create_chatbook(db_paths, kept_id, tmp_path, name="kept-round-trip.zip") -> Path:
+    output = tmp_path / name
+    creator = ChatbookCreator(db_paths)
+    ok, message, _details = creator.create_chatbook(
+        name="Kept Briefing Round Trip",
+        description="round trip",
+        content_selections={ContentType.KEPT_BRIEFING: [str(kept_id)]},
+        output_path=output,
+    )
+    assert ok, message
+    return output
+
+
+def _dest_db(dest_paths) -> CharactersRAGDB:
+    return CharactersRAGDB(dest_paths["ChaChaNotes"], "test-dest")
+
+
+# --- Export -----------------------------------------------------------
+
+
+def test_export_writes_kept_briefing_json_and_markdown_and_manifest_entry(
+    source_env, tmp_path
+):
+    db_paths, kept_id = source_env
+    output = _create_chatbook(db_paths, kept_id, tmp_path)
+
+    with zipfile.ZipFile(output) as zf:
+        names = zf.namelist()
+        json_name = f"content/kept_briefings/kept_briefing_{kept_id}.json"
+        md_name = f"content/kept_briefings/kept_briefing_{kept_id}.md"
+        assert json_name in names
+        assert md_name in names
+
+        payload = json.loads(zf.read(json_name))
+        assert payload["source_briefing_id"] == 101
+        assert payload["watchlist_name"] == "Tech Watch"
+        assert payload["body_markdown"] == "# Digest\n\nBody text with **markdown**."
+        assert payload["covers_through_item_id"] == 555
+        assert payload["covers_from_ts"] == "2026-07-25T00:00:00+00:00"
+        assert payload["selection_mode"] == "auto"
+        assert payload["model_used"] == "gpt-test"
+        assert payload["item_count"] == 12
+        assert payload["featured_count"] == 3
+        assert payload["overflow_count"] == 2
+        assert payload["origin"] == "manual"
+        assert payload["original_created_at"] == "2026-07-30T10:00:00+00:00"
+        assert payload["kept_at"]
+
+        scripts = payload["scripts"]
+        assert len(scripts) == 2
+        by_source = {s["source_script_id"]: s for s in scripts}
+        assert by_source[555]["preset_name"] == "duo-cast"
+        assert by_source[555]["roster_snapshot_json"] == '{"roster": ["A", "B"]}'
+        assert by_source[555]["turns_json"] == '[{"speaker": "A", "text": "Hi"}]'
+        assert by_source[None]["preset_name"] == "(app default)"
+
+        # Human-readable rendition present and non-empty; not used on import.
+        md_text = zf.read(md_name).decode("utf-8")
+        assert "Tech Watch" in md_text
+        assert "Digest" in md_text
+
+        manifest_data = json.loads(zf.read("manifest.json"))
+        manifest = ChatbookManifest.from_dict(manifest_data)
+        assert manifest.total_kept_briefings == 1
+        kept_items = [
+            item
+            for item in manifest.content_items
+            if item.type == ContentType.KEPT_BRIEFING
+        ]
+        assert len(kept_items) == 1
+        assert kept_items[0].id == str(kept_id)
+        assert kept_items[0].file_path == json_name
+
+
+def test_export_with_no_kept_briefings_selected_produces_no_kept_section(
+    source_env, tmp_path
+):
+    """Selecting nothing of this type must not create the kept section at
+    all, and must not crash (empty-kept-tables export)."""
+    db_paths, _kept_id = source_env
+    output = tmp_path / "no-kept.zip"
+    creator = ChatbookCreator(db_paths)
+    ok, message, _details = creator.create_chatbook(
+        name="No Kept Selected",
+        description="no kept briefings selected",
+        content_selections={},
+        output_path=output,
+    )
+    assert ok, message
+
+    with zipfile.ZipFile(output) as zf:
+        names = zf.namelist()
+        assert not any(name.startswith("content/kept_briefings/") for name in names)
+        manifest_data = json.loads(zf.read("manifest.json"))
+        manifest = ChatbookManifest.from_dict(manifest_data)
+        assert manifest.total_kept_briefings == 0
+        assert not any(
+            item.type == ContentType.KEPT_BRIEFING for item in manifest.content_items
+        )
+
+
+# --- Import: round trip -------------------------------------------------
+
+
+def test_import_restores_kept_briefing_and_scripts_byte_faithful(source_env, tmp_path):
+    db_paths, kept_id = source_env
+    output = _create_chatbook(db_paths, kept_id, tmp_path)
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    importer = ChatbookImporter(dest_paths)
+    ok, message = importer.import_chatbook(
+        output,
+        content_selections={ContentType.KEPT_BRIEFING: [str(kept_id)]},
+    )
+    assert ok, message
+
+    dest_db = _dest_db(dest_paths)
+    restored = dest_db.get_kept_briefing_by_source(101)
+    assert restored is not None
+    assert restored["watchlist_name"] == "Tech Watch"
+    assert restored["body_markdown"] == "# Digest\n\nBody text with **markdown**."
+    assert restored["covers_through_item_id"] == 555
+    assert restored["covers_from_ts"] == datetime(
+        2026, 7, 25, 0, 0, tzinfo=timezone.utc
+    )
+    assert restored["selection_mode"] == "auto"
+    assert restored["model_used"] == "gpt-test"
+    assert restored["item_count"] == 12
+    assert restored["featured_count"] == 3
+    assert restored["overflow_count"] == 2
+    assert restored["origin"] == "manual"
+    assert restored["original_created_at"] == datetime(
+        2026, 7, 30, 10, 0, tzinfo=timezone.utc
+    )
+
+    scripts = dest_db.list_kept_scripts(restored["id"])
+    assert len(scripts) == 2
+    by_source = {s["source_script_id"]: s for s in scripts}
+    assert by_source[555]["preset_name"] == "duo-cast"
+    assert by_source[555]["roster_snapshot_json"] == '{"roster": ["A", "B"]}'
+    assert by_source[555]["turns_json"] == '[{"speaker": "A", "text": "Hi"}]'
+    assert by_source[555]["model_used"] == "gpt-test"
+    assert by_source[None]["preset_name"] == "(app default)"
+    assert by_source[None]["roster_snapshot_json"] == '{"roster": ["Narrator"]}'
+
+
+def test_reimport_is_idempotent_no_duplicates(source_env, tmp_path):
+    """Importing the same chatbook twice into the same destination must add
+    nothing on the second pass -- neither the briefing nor either script
+    (including the NULL-source script, which has no unique-constraint
+    backstop of its own)."""
+    db_paths, kept_id = source_env
+    output = _create_chatbook(db_paths, kept_id, tmp_path)
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    importer = ChatbookImporter(dest_paths)
+    selections = {ContentType.KEPT_BRIEFING: [str(kept_id)]}
+
+    ok1, message1 = importer.import_chatbook(output, content_selections=selections)
+    assert ok1, message1
+
+    ok2, message2 = importer.import_chatbook(output, content_selections=selections)
+    assert ok2, message2
+
+    dest_db = _dest_db(dest_paths)
+    all_kept = dest_db.list_kept_briefings()
+    assert len(all_kept) == 1
+    scripts = dest_db.list_kept_scripts(all_kept[0]["id"])
+    assert len(scripts) == 2
+
+
+# --- Import: cross-device collision ------------------------------------
+
+
+def test_import_reports_conflict_and_never_overwrites_differing_local_row(
+    source_env, tmp_path
+):
+    """A local kept briefing already exists for the same (device-local)
+    `source_briefing_id` but with genuinely different content -- the
+    existing row must survive unmodified and the conflict must be named in
+    the import summary, never silently absorbed as an ordinary skip."""
+    db_paths, kept_id = source_env
+    output = _create_chatbook(db_paths, kept_id, tmp_path)
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    dest_db = _dest_db(dest_paths)
+    local_kept_id = dest_db.create_kept_briefing(
+        source_briefing_id=101,  # same source id as the incoming briefing
+        watchlist_name="Totally Different Local Watchlist",
+        body_markdown="Local content that does not match the import at all.",
+        origin="scheduled",
+    )
+    dest_db.close_connection()
+
+    importer = ChatbookImporter(dest_paths)
+    status = ImportStatus()
+    ok, message = importer.import_chatbook(
+        output,
+        content_selections={ContentType.KEPT_BRIEFING: [str(kept_id)]},
+        import_status=status,
+    )
+    assert ok, message
+
+    dest_db = _dest_db(dest_paths)
+    unchanged = dest_db.get_kept_briefing_by_source(101)
+    assert unchanged["id"] == local_kept_id
+    assert unchanged["watchlist_name"] == "Totally Different Local Watchlist"
+    assert (
+        unchanged["body_markdown"]
+        == "Local content that does not match the import at all."
+    )
+    assert len(dest_db.list_kept_briefings()) == 1  # no second row for source 101
+
+    assert any(
+        "source_briefing_id=101" in warning and "conflict" in warning.lower()
+        for warning in status.warnings
+    ), status.warnings
+
+
+def test_script_conflict_reported_and_local_row_not_overwritten(source_env, tmp_path):
+    """`kept_scripts.source_script_id` is a table-wide UNIQUE column, so an
+    incoming script can collide with a local script kept under a
+    *different* briefing. That local row must not be overwritten, and the
+    conflict must be named."""
+    db_paths, kept_id = source_env
+    output = _create_chatbook(db_paths, kept_id, tmp_path)
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    dest_db = _dest_db(dest_paths)
+    other_kept_id = dest_db.create_kept_briefing(
+        source_briefing_id=999,  # unrelated briefing, no conflict at that level
+        watchlist_name="Other",
+        body_markdown="Other body",
+        origin="manual",
+    )
+    dest_db.create_kept_script(
+        other_kept_id,
+        source_script_id=555,  # collides with the incoming script's source id
+        preset_name="totally-different-preset",
+        roster_snapshot_json="{}",
+        turns_json="[]",
+    )
+    dest_db.close_connection()
+
+    importer = ChatbookImporter(dest_paths)
+    status = ImportStatus()
+    ok, message = importer.import_chatbook(
+        output,
+        content_selections={ContentType.KEPT_BRIEFING: [str(kept_id)]},
+        import_status=status,
+    )
+    assert ok, message
+
+    dest_db = _dest_db(dest_paths)
+    unchanged = dest_db.get_kept_script_by_source(555)
+    assert unchanged["kept_briefing_id"] == other_kept_id
+    assert unchanged["preset_name"] == "totally-different-preset"
+
+    assert any("kept script(s)" in warning for warning in status.warnings), (
+        status.warnings
+    )
+
+
+# --- Backward compatibility ---------------------------------------------
+
+
+def test_import_bundle_without_kept_section_is_unaffected(tmp_path, chachanotes_template_db):
+    """A chatbook predating this content type has no `kept_briefings`
+    manifest entries and no `content/kept_briefings/` folder at all --
+    importing it (with the default "import everything" selection) must not
+    crash and must leave the destination's kept tables empty."""
+    import shutil
+
+    db_paths = _db_paths(tmp_path / "source")
+    shutil.copyfile(chachanotes_template_db, db_paths["ChaChaNotes"])
+    db = CharactersRAGDB(db_paths["ChaChaNotes"], "test-source")
+    note_id = db.add_note(title="Plain Note", content="Nothing kept here.")
+    db.close_connection()
+
+    output = tmp_path / "legacy.zip"
+    creator = ChatbookCreator(db_paths)
+    ok, message, _details = creator.create_chatbook(
+        name="Legacy Bundle",
+        description="predates kept briefings",
+        content_selections={ContentType.NOTE: [str(note_id)]},
+        output_path=output,
+    )
+    assert ok, message
+
+    with zipfile.ZipFile(output) as zf:
+        assert not any(
+            name.startswith("content/kept_briefings/") for name in zf.namelist()
+        )
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    importer = ChatbookImporter(dest_paths)
+    ok, message = importer.import_chatbook(output, content_selections=None)
+    assert ok, message
+
+    dest_db = _dest_db(dest_paths)
+    assert dest_db.list_kept_briefings() == []

--- a/Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py
+++ b/Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py
@@ -214,6 +214,72 @@ def test_export_with_no_kept_briefings_selected_produces_no_kept_section(
         )
 
 
+def test_export_paginates_past_page_size_no_silent_truncation(
+    monkeypatch, tmp_path, chachanotes_template_db
+):
+    """`_collect_kept_briefings` must page through every kept script rather
+    than fetching a single capped page -- a briefing with more scripts than
+    one page previously exported silently incomplete, with no signal to the
+    user (task-1870 Qodo fix: FIX 1).
+
+    The page size is shrunk to 2 (well below the 5 scripts seeded here) so
+    this exercises multiple pages, including a final short page, without
+    needing to seed anywhere near the real 1000-row page size."""
+    import shutil
+
+    monkeypatch.setattr(ChatbookCreator, "_KEPT_SCRIPTS_EXPORT_PAGE_SIZE", 2)
+
+    db_paths = _db_paths(tmp_path / "source")
+    shutil.copyfile(chachanotes_template_db, db_paths["ChaChaNotes"])
+    db = CharactersRAGDB(db_paths["ChaChaNotes"], "test-source")
+    kept_id = db.create_kept_briefing(
+        source_briefing_id=201,
+        watchlist_name="Paginated Watch",
+        body_markdown="# Body",
+        origin="manual",
+    )
+    for i in range(5):
+        db.create_kept_script(
+            kept_id,
+            source_script_id=1000 + i,
+            preset_name=f"preset-{i}",
+            roster_snapshot_json=json.dumps({"roster": [f"R{i}"]}),
+            turns_json=json.dumps([{"speaker": f"S{i}", "text": f"turn {i}"}]),
+        )
+    db.close_connection()
+
+    output = _create_chatbook(db_paths, kept_id, tmp_path, name="paginated.zip")
+
+    with zipfile.ZipFile(output) as zf:
+        payload = json.loads(
+            zf.read(f"content/kept_briefings/kept_briefing_{kept_id}.json")
+        )
+        scripts = payload["scripts"]
+        assert len(scripts) == 5
+        by_source = {s["source_script_id"]: s for s in scripts}
+        assert set(by_source.keys()) == {1000 + i for i in range(5)}
+        for i in range(5):
+            assert by_source[1000 + i]["preset_name"] == f"preset-{i}"
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    importer = ChatbookImporter(dest_paths)
+    ok, message = importer.import_chatbook(
+        output,
+        content_selections={ContentType.KEPT_BRIEFING: [str(kept_id)]},
+    )
+    assert ok, message
+
+    dest_db = _dest_db(dest_paths)
+    restored = dest_db.get_kept_briefing_by_source(201)
+    assert restored is not None
+    restored_scripts = dest_db.list_kept_scripts(restored["id"])
+    assert len(restored_scripts) == 5
+    by_source_restored = {s["source_script_id"]: s for s in restored_scripts}
+    assert set(by_source_restored.keys()) == {1000 + i for i in range(5)}
+    for i in range(5):
+        assert by_source_restored[1000 + i]["preset_name"] == f"preset-{i}"
+
+
 # --- Import: round trip -------------------------------------------------
 
 

--- a/Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py
+++ b/Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py
@@ -108,6 +108,28 @@ def _dest_db(dest_paths) -> CharactersRAGDB:
     return CharactersRAGDB(dest_paths["ChaChaNotes"], "test-dest")
 
 
+def _replace_kept_json_scripts(
+    source_zip: Path, kept_id, scripts_value, dest_zip: Path
+) -> Path:
+    """Copy `source_zip` to `dest_zip`, replacing the kept briefing's
+    `scripts` field with `scripts_value`.
+
+    Used to simulate a malformed payload (e.g. the importer never validates
+    this field's *type*, mirroring every other chatbook content type's
+    trust model for chatbook payloads -- see the whole-branch review's
+    "Malformed-section containment" notes)."""
+    json_name = f"content/kept_briefings/kept_briefing_{kept_id}.json"
+    with zipfile.ZipFile(source_zip) as src:
+        payload = json.loads(src.read(json_name))
+        payload["scripts"] = scripts_value
+        entries = {name: src.read(name) for name in src.namelist()}
+    entries[json_name] = json.dumps(payload).encode("utf-8")
+    with zipfile.ZipFile(dest_zip, "w") as dst:
+        for name, data in entries.items():
+            dst.writestr(name, data)
+    return dest_zip
+
+
 # --- Export -----------------------------------------------------------
 
 
@@ -237,6 +259,64 @@ def test_import_restores_kept_briefing_and_scripts_byte_faithful(source_env, tmp
     assert by_source[None]["roster_snapshot_json"] == '{"roster": ["Narrator"]}'
 
 
+def test_import_restores_kept_at_faithfully_not_re_stamped(
+    tmp_path, chachanotes_template_db
+):
+    """`kept_at` is exported alongside every other provenance column
+    (`chatbook_creator.py`) and must round-trip just as faithfully --
+    import must not silently re-stamp it with the local import moment
+    (task-1870 fix-wave F4).
+
+    Seeded more than a second in the past on both the briefing and its
+    script: `CURRENT_TIMESTAMP` has second-level resolution, so seeding
+    "now" (as the other round-trip test does, incidentally) cannot tell a
+    faithful restore apart from a re-stamp that happens to land in the same
+    second -- exactly the false pass the whole-branch review's own probe
+    hit. A multi-year gap makes that impossible."""
+    import shutil
+
+    db_paths = _db_paths(tmp_path / "source")
+    shutil.copyfile(chachanotes_template_db, db_paths["ChaChaNotes"])
+    db = CharactersRAGDB(db_paths["ChaChaNotes"], "test-source")
+    kept_id = db.create_kept_briefing(
+        source_briefing_id=102,
+        watchlist_name="Old Watch",
+        body_markdown="Old content",
+        origin="manual",
+        kept_at="2020-01-01T00:00:00+00:00",
+    )
+    db.create_kept_script(
+        kept_id,
+        source_script_id=None,
+        preset_name="old-preset",
+        roster_snapshot_json="{}",
+        turns_json="[]",
+        kept_at="2020-01-02T00:00:00+00:00",
+    )
+    db.close_connection()
+
+    output = _create_chatbook(
+        db_paths, kept_id, tmp_path, name="kept-at-round-trip.zip"
+    )
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    importer = ChatbookImporter(dest_paths)
+    ok, message = importer.import_chatbook(
+        output,
+        content_selections={ContentType.KEPT_BRIEFING: [str(kept_id)]},
+    )
+    assert ok, message
+
+    dest_db = _dest_db(dest_paths)
+    restored = dest_db.get_kept_briefing_by_source(102)
+    assert restored is not None
+    assert restored["kept_at"] == datetime(2020, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+    scripts = dest_db.list_kept_scripts(restored["id"])
+    assert len(scripts) == 1
+    assert scripts[0]["kept_at"] == datetime(2020, 1, 2, 0, 0, tzinfo=timezone.utc)
+
+
 def test_reimport_is_idempotent_no_duplicates(source_env, tmp_path):
     """Importing the same chatbook twice into the same destination must add
     nothing on the second pass -- neither the briefing nor either script
@@ -271,7 +351,14 @@ def test_import_reports_conflict_and_never_overwrites_differing_local_row(
     """A local kept briefing already exists for the same (device-local)
     `source_briefing_id` but with genuinely different content -- the
     existing row must survive unmodified and the conflict must be named in
-    the import summary, never silently absorbed as an ordinary skip."""
+    the import summary, never silently absorbed as an ordinary skip.
+
+    The local briefing also carries its own kept script here (task-1870
+    fix-wave F1 regression coverage): the incoming bundle's two scripts
+    (one `source_script_id=555`, one NULL-source) must never be grafted
+    onto this unrelated local row just because it shares the same
+    `source_briefing_id` -- the whole incoming item, parent AND children,
+    is refused as a unit on a genuine conflict."""
     db_paths, kept_id = source_env
     output = _create_chatbook(db_paths, kept_id, tmp_path)
 
@@ -282,6 +369,13 @@ def test_import_reports_conflict_and_never_overwrites_differing_local_row(
         watchlist_name="Totally Different Local Watchlist",
         body_markdown="Local content that does not match the import at all.",
         origin="scheduled",
+    )
+    dest_db.create_kept_script(
+        local_kept_id,
+        source_script_id=None,
+        preset_name="local-only-preset",
+        roster_snapshot_json='{"roster": ["Local"]}',
+        turns_json='[{"speaker": "Local", "text": "Mine"}]',
     )
     dest_db.close_connection()
 
@@ -303,6 +397,15 @@ def test_import_reports_conflict_and_never_overwrites_differing_local_row(
         == "Local content that does not match the import at all."
     )
     assert len(dest_db.list_kept_briefings()) == 1  # no second row for source 101
+
+    # The conflicting local briefing's own kept scripts must be
+    # byte-unchanged -- none of the incoming bundle's scripts were grafted
+    # onto it (task-1870 fix-wave F1).
+    local_scripts = dest_db.list_kept_scripts(local_kept_id)
+    assert len(local_scripts) == 1
+    assert local_scripts[0]["preset_name"] == "local-only-preset"
+    assert local_scripts[0]["roster_snapshot_json"] == '{"roster": ["Local"]}'
+    assert local_scripts[0]["turns_json"] == '[{"speaker": "Local", "text": "Mine"}]'
 
     assert any(
         "source_briefing_id=101" in warning and "conflict" in warning.lower()
@@ -352,6 +455,49 @@ def test_script_conflict_reported_and_local_row_not_overwritten(source_env, tmp_
     assert any("kept script(s)" in warning for warning in status.warnings), (
         status.warnings
     )
+
+
+# --- Import: partial mid-scripts failure --------------------------------
+
+
+def test_partial_scripts_failure_still_counts_the_briefing_as_imported(
+    source_env, tmp_path
+):
+    """A malformed `scripts` payload (a string instead of a list) raises
+    deep inside `_import_kept_scripts` -- iterating a string yields
+    characters, and the first one's `.get(...)` call raises
+    `AttributeError` -- *after* the kept briefing row is already durably
+    inserted. The import summary must count the briefing as imported and
+    name the script failure as a warning, not report the whole item as
+    failed: reporting it failed would tell a user to retry, and a retry
+    would then see it as an ordinary "already present" skip, hiding that
+    the parent row already exists (task-1870 fix-wave F5)."""
+    db_paths, kept_id = source_env
+    valid_output = _create_chatbook(db_paths, kept_id, tmp_path)
+    malformed_output = _replace_kept_json_scripts(
+        valid_output, kept_id, "not-a-list", tmp_path / "malformed-scripts.zip"
+    )
+
+    dest_paths = _db_paths(tmp_path / "dest")
+    importer = ChatbookImporter(dest_paths)
+    status = ImportStatus()
+    ok, message = importer.import_chatbook(
+        malformed_output,
+        content_selections={ContentType.KEPT_BRIEFING: [str(kept_id)]},
+        import_status=status,
+    )
+    assert ok, message
+    assert status.successful_items == 1
+    assert status.failed_items == 0
+
+    dest_db = _dest_db(dest_paths)
+    restored = dest_db.get_kept_briefing_by_source(101)
+    assert restored is not None  # durably inserted despite the script failure
+
+    assert any(
+        "kept scripts could not be imported" in warning
+        for warning in status.warnings
+    ), status.warnings
 
 
 # --- Backward compatibility ---------------------------------------------

--- a/Tests/Chatbooks/test_chatbook_models.py
+++ b/Tests/Chatbooks/test_chatbook_models.py
@@ -30,6 +30,7 @@ class TestContentType:
         assert ContentType.MEDIA.value == "media"
         assert ContentType.PROMPT.value == "prompt"
         assert ContentType.EMBEDDING.value == "embedding"
+        assert ContentType.KEPT_BRIEFING.value == "kept_briefing"
 
 
 class TestContentItem:
@@ -320,6 +321,46 @@ class TestChatbookManifest:
         assert "created_at" in data
         assert "updated_at" in data
         assert "statistics" in data
+        assert data["statistics"]["total_kept_briefings"] == 0
+
+    def test_manifest_from_dict_defaults_total_kept_briefings_when_absent(self):
+        """Backward compat (task-1870): a manifest written before this
+        content type existed has no "total_kept_briefings" statistics key at
+        all -- `from_dict` must default it rather than raise."""
+        data = {
+            "version": "1.0",
+            "name": "Legacy Chatbook",
+            "description": "predates kept briefings",
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "updated_at": "2024-01-02T00:00:00+00:00",
+            "statistics": {"total_notes": 1},
+        }
+
+        manifest = ChatbookManifest.from_dict(data)
+
+        assert manifest.total_kept_briefings == 0
+
+    def test_manifest_round_trips_kept_briefing_content_item_and_statistic(self):
+        manifest = ChatbookManifest(
+            version=ChatbookVersion.V1,
+            name="Test",
+            description="Test",
+            content_items=[
+                ContentItem(
+                    id="7",
+                    type=ContentType.KEPT_BRIEFING,
+                    title="Kept briefing 7",
+                )
+            ],
+            total_kept_briefings=1,
+        )
+
+        data = manifest.to_dict()
+        assert data["statistics"]["total_kept_briefings"] == 1
+
+        restored = ChatbookManifest.from_dict(data)
+        assert restored.total_kept_briefings == 1
+        assert restored.content_items[0].type == ContentType.KEPT_BRIEFING
 
     def test_manifest_from_dict(self):
         """Test creating manifest from dictionary."""

--- a/Tests/DB/test_chachanotes_kept_briefings.py
+++ b/Tests/DB/test_chachanotes_kept_briefings.py
@@ -127,6 +127,46 @@ def test_create_and_get_kept_briefing_round_trips_all_fields(tmp_path: Path) -> 
         db.close_connection()
 
 
+def test_create_kept_briefing_accepts_explicit_kept_at(tmp_path: Path) -> None:
+    """`kept_at` defaults to `CURRENT_TIMESTAMP`, but the chatbook importer
+    (task-1870) needs to preserve the *originating* device's keep time on a
+    cross-device import rather than silently re-stamp it with the import
+    moment -- an explicit `kept_at` must be honored verbatim, exactly like
+    `original_created_at` already is (task-1870 fix-wave F4)."""
+    db = _make_db(tmp_path)
+    try:
+        kept_id = db.create_kept_briefing(
+            source_briefing_id=201,
+            watchlist_name="W",
+            body_markdown="B",
+            origin="manual",
+            kept_at="2020-01-01T00:00:00Z",
+        )
+        row = db.get_kept_briefing(kept_id)
+        assert row["kept_at"] == datetime(2020, 1, 1, 0, 0, tzinfo=timezone.utc)
+    finally:
+        db.close_connection()
+
+
+def test_create_kept_briefing_without_kept_at_uses_column_default(
+    tmp_path: Path,
+) -> None:
+    """Omitting `kept_at` (every caller except the chatbook importer) must
+    still fall through to the column's own `DEFAULT CURRENT_TIMESTAMP`."""
+    db = _make_db(tmp_path)
+    try:
+        kept_id = db.create_kept_briefing(
+            source_briefing_id=202,
+            watchlist_name="W",
+            body_markdown="B",
+            origin="manual",
+        )
+        row = db.get_kept_briefing(kept_id)
+        assert row["kept_at"] is not None
+    finally:
+        db.close_connection()
+
+
 def test_create_kept_briefing_applies_defaults_for_optional_fields(
     tmp_path: Path,
 ) -> None:
@@ -459,6 +499,34 @@ def test_create_kept_script_round_trips_all_fields(tmp_path: Path) -> None:
         db.close_connection()
 
 
+def test_create_kept_script_accepts_explicit_kept_at(tmp_path: Path) -> None:
+    """Mirrors `create_kept_briefing`'s explicit `kept_at` param -- the
+    chatbook importer (task-1870) needs a kept script's `kept_at` to
+    survive a cross-device import verbatim rather than being re-stamped
+    (task-1870 fix-wave F4)."""
+    db = _make_db(tmp_path)
+    try:
+        kept_id = db.create_kept_briefing(
+            source_briefing_id=203,
+            watchlist_name="W",
+            body_markdown="B",
+            origin="manual",
+        )
+        script_id = db.create_kept_script(
+            kept_id,
+            source_script_id=None,
+            preset_name="p",
+            roster_snapshot_json="{}",
+            turns_json="[]",
+            kept_at="2020-01-02T00:00:00Z",
+        )
+        rows = db.list_kept_scripts(kept_id)
+        row = next(r for r in rows if r["id"] == script_id)
+        assert row["kept_at"] == datetime(2020, 1, 2, 0, 0, tzinfo=timezone.utc)
+    finally:
+        db.close_connection()
+
+
 def test_get_kept_script_by_source_returns_matching_row(tmp_path: Path) -> None:
     """`get_kept_script_by_source` (task-1870) mirrors
     `get_kept_briefing_by_source` -- used by the chatbook importer to
@@ -661,6 +729,115 @@ def test_kept_script_source_ids_excludes_nulls(tmp_path: Path) -> None:
             turns_json="[]",
         )
         assert db.kept_script_source_ids(kept_id) == {200, 201}
+    finally:
+        db.close_connection()
+
+
+def test_kept_script_counts_returns_correct_counts_for_multiple_briefings(
+    tmp_path: Path,
+) -> None:
+    """A grouped `COUNT(*)`, not a per-briefing
+    `len(list_kept_scripts(...))` -- backs the chatbook creation UI's
+    content tree, which used to materialize every kept script's full
+    `turns_json`/`roster_snapshot_json` on the UI thread purely to compute
+    a subtitle count (task-1870 fix-wave F3)."""
+    db = _make_db(tmp_path)
+    try:
+        two_scripts_id = db.create_kept_briefing(
+            source_briefing_id=30,
+            watchlist_name="Two Scripts",
+            body_markdown="B",
+            origin="manual",
+        )
+        one_script_id = db.create_kept_briefing(
+            source_briefing_id=31,
+            watchlist_name="One Script",
+            body_markdown="B",
+            origin="manual",
+        )
+        zero_scripts_id = db.create_kept_briefing(
+            source_briefing_id=32,
+            watchlist_name="Zero Scripts",
+            body_markdown="B",
+            origin="manual",
+        )
+        for _ in range(2):
+            db.create_kept_script(
+                two_scripts_id,
+                source_script_id=None,
+                preset_name="p",
+                roster_snapshot_json="{}",
+                turns_json="[]",
+            )
+        db.create_kept_script(
+            one_script_id,
+            source_script_id=None,
+            preset_name="p",
+            roster_snapshot_json="{}",
+            turns_json="[]",
+        )
+
+        counts = db.kept_script_counts(
+            [two_scripts_id, one_script_id, zero_scripts_id]
+        )
+
+        assert counts == {
+            two_scripts_id: 2,
+            one_script_id: 1,
+            zero_scripts_id: 0,
+        }
+    finally:
+        db.close_connection()
+
+
+def test_kept_script_counts_omits_scripts_for_ids_not_requested(
+    tmp_path: Path,
+) -> None:
+    """A briefing's scripts must not leak into another briefing's count
+    just because both exist in the database -- only requested ids appear,
+    each scoped to its own `kept_briefing_id`."""
+    db = _make_db(tmp_path)
+    try:
+        requested_id = db.create_kept_briefing(
+            source_briefing_id=33,
+            watchlist_name="Requested",
+            body_markdown="B",
+            origin="manual",
+        )
+        other_id = db.create_kept_briefing(
+            source_briefing_id=34,
+            watchlist_name="Not requested",
+            body_markdown="B",
+            origin="manual",
+        )
+        db.create_kept_script(
+            other_id,
+            source_script_id=None,
+            preset_name="p",
+            roster_snapshot_json="{}",
+            turns_json="[]",
+        )
+
+        counts = db.kept_script_counts([requested_id])
+
+        assert counts == {requested_id: 0}
+        assert other_id not in counts
+    finally:
+        db.close_connection()
+
+
+def test_kept_script_counts_returns_zero_for_nonexistent_ids(tmp_path: Path) -> None:
+    db = _make_db(tmp_path)
+    try:
+        assert db.kept_script_counts([9999]) == {9999: 0}
+    finally:
+        db.close_connection()
+
+
+def test_kept_script_counts_returns_empty_dict_for_empty_input(tmp_path: Path) -> None:
+    db = _make_db(tmp_path)
+    try:
+        assert db.kept_script_counts([]) == {}
     finally:
         db.close_connection()
 

--- a/Tests/DB/test_chachanotes_kept_briefings.py
+++ b/Tests/DB/test_chachanotes_kept_briefings.py
@@ -459,6 +459,46 @@ def test_create_kept_script_round_trips_all_fields(tmp_path: Path) -> None:
         db.close_connection()
 
 
+def test_get_kept_script_by_source_returns_matching_row(tmp_path: Path) -> None:
+    """`get_kept_script_by_source` (task-1870) mirrors
+    `get_kept_briefing_by_source` -- used by the chatbook importer to
+    classify a `ConflictError` on `create_kept_script` as already-present
+    vs. a genuine content conflict."""
+    db = _make_db(tmp_path)
+    try:
+        kept_id = db.create_kept_briefing(
+            source_briefing_id=21,
+            watchlist_name="W",
+            body_markdown="B",
+            origin="manual",
+        )
+        db.create_kept_script(
+            kept_id,
+            source_script_id=777,
+            preset_name="duo-cast",
+            roster_snapshot_json='{"roster": ["A", "B"]}',
+            turns_json='[{"speaker": "A", "text": "Hi"}]',
+            model_used="gpt-test",
+            original_created_at="2026-07-30T11:00:00Z",
+        )
+
+        row = db.get_kept_script_by_source(777)
+        assert row is not None
+        assert row["kept_briefing_id"] == kept_id
+        assert row["preset_name"] == "duo-cast"
+        assert row["roster_snapshot_json"] == '{"roster": ["A", "B"]}'
+    finally:
+        db.close_connection()
+
+
+def test_get_kept_script_by_source_returns_none_when_absent(tmp_path: Path) -> None:
+    db = _make_db(tmp_path)
+    try:
+        assert db.get_kept_script_by_source(9999) is None
+    finally:
+        db.close_connection()
+
+
 def test_create_kept_script_rejects_nonexistent_kept_briefing(tmp_path: Path) -> None:
     db = _make_db(tmp_path)
     try:

--- a/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
+++ b/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1870
 title: 'Kept briefings: sync/chatbook-export coverage'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-02 00:16'
 labels:
@@ -49,3 +49,12 @@ somewhere a future reader will find it before assuming coverage that doesn't exi
 - [ ] #2 A user's kept briefings and their kept scripts participate in ChaChaNotes sync between devices, OR a recorded decision explains why they are deliberately excluded
 - [ ] #3 Whatever is decided for #1 and #2 is written down (spec, ADR, or equivalent) so the next reader does not have to reverse-engineer it from the absence of code
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. AC #1 first arm: add kept briefings/scripts as a chatbook content type — creator walks `kept_briefings`+`kept_scripts` into the bundle (readable markdown + structured payload, following the existing per-type conventions in `Chatbooks/chatbook_creator.py`/`chatbook_models.py`); selection surfaced wherever other types are chosen.
+2. Import: ride the house conflict machinery (`conflict_resolver.py`) if it fits kept rows' UNIQUE `source_briefing_id` (device-local id → cross-device collision is DIFFERENT content); otherwise import-when-free + honest per-item skip in the import summary. Re-import idempotent either way.
+3. AC #2 second arm: record sync exclusion as deliberate (extends the owner's 1780 "no sync columns" v1 ruling) — spec delivery-notes update + decision note per AC #3.
+4. Round-trip test (export → import into a fresh ChaChaNotes), collision test, and the recorded-decision docs.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
+++ b/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
@@ -45,9 +45,9 @@ somewhere a future reader will find it before assuming coverage that doesn't exi
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A user's kept briefings and their kept scripts are included when the user exports a chatbook, OR a recorded decision explains why they are deliberately excluded
-- [ ] #2 A user's kept briefings and their kept scripts participate in ChaChaNotes sync between devices, OR a recorded decision explains why they are deliberately excluded
-- [ ] #3 Whatever is decided for #1 and #2 is written down (spec, ADR, or equivalent) so the next reader does not have to reverse-engineer it from the absence of code
+- [x] #1 A user's kept briefings and their kept scripts are included when the user exports a chatbook, OR a recorded decision explains why they are deliberately excluded — **arm taken: included.** New `ContentType.KEPT_BRIEFING`; `ChatbookCreator._collect_kept_briefings` walks selected kept briefings, nests each briefing's kept scripts inside its own JSON payload (scripts are not independently selectable), and also writes a companion human-readable Markdown file per briefing.
+- [x] #2 A user's kept briefings and their kept scripts participate in ChaChaNotes sync between devices, OR a recorded decision explains why they are deliberately excluded — **arm taken: excluded, deliberately.** Extends task-1780's original "no sync columns" v1 ruling; recorded in the follow-up decision block appended to the design spec (see AC #3).
+- [x] #3 Whatever is decided for #1 and #2 is written down (spec, ADR, or equivalent) so the next reader does not have to reverse-engineer it from the absence of code — dated "Follow-up decision (2026-08-02, task-1870)" block appended to `Docs/superpowers/specs/2026-08-01-kept-briefings-design.md` (history not rewritten); `Chatbooks/CHATBOOKS_GUIDE.md` updated with a "Kept Briefings" section (it already enumerated content types).
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -58,3 +58,82 @@ somewhere a future reader will find it before assuming coverage that doesn't exi
 3. AC #2 second arm: record sync exclusion as deliberate (extends the owner's 1780 "no sync columns" v1 ruling) — spec delivery-notes update + decision note per AC #3.
 4. Round-trip test (export → import into a fresh ChaChaNotes), collision test, and the recorded-decision docs.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+**Export (AC #1, included).** `tldw_chatbook/Chatbooks/chatbook_models.py`: new
+`ContentType.KEPT_BRIEFING`, `ChatbookContent.kept_briefings`, and
+`ChatbookManifest.total_kept_briefings` (defaults to 0 in `from_dict` for bundles that predate
+this type — backward compat). `tldw_chatbook/Chatbooks/chatbook_creator.py`:
+`_collect_kept_briefings` walks selected kept briefings via the existing
+`get_kept_briefing`/`list_kept_scripts` CRUD, nests each briefing's kept scripts inside its own
+JSON payload (scripts are NOT independently selectable — mirrors how a conversation's messages
+live inside the conversation's own JSON rather than as a separate content type), and writes a
+companion `.md` (human-readable, never read back on import) alongside the `.json`
+(machine-round-trippable), matching the JSON+report split conversations already use. All
+provenance columns (source ids, coverage window, model/preset identifiers, origin,
+original/kept timestamps) are carried through, so the export is self-interpreting per the 1780
+spec's ethos. README/manifest stats updated. Selection UI wired in both live surfaces: the
+`Chatbooks_Window_Improved` → `ChatbookCreationWizard` → `SmartContentTree` path (checkbox +
+category node + `_load_content` entries) AND the standalone `ChatbookCreationWindow` (reachable
+from Tools & Settings) — a full checkbox in both, not just the service/creator seam.
+
+**Import (AC #1, the "how").** `ChatbookImporter._import_kept_briefings` +
+`_import_kept_scripts`. Did NOT extend `conflict_resolver.py`'s ask/skip/rename/replace
+machinery — that machinery is built for display-name-keyed conversations/notes/characters, and
+doesn't have a sensible "rename" or "ask per item" meaning for a UNIQUE-source-id-keyed
+idempotent artifact. Instead: try the insert, catch `ConflictError` (the same "raced keep"
+pattern the keep service itself already uses per the 1780 delivery notes), then compare content
+— byte-identical is an ordinary silent skip (already present; re-importing the same chatbook
+must never duplicate it), differing content is reported as a named conflict in the import
+summary and the existing local row is never overwritten (there is no update code path at all,
+so "never overwrite" holds by construction; the code's actual contribution is telling the two
+cases apart honestly). Added `CharactersRAGDB.get_kept_script_by_source` (mirrors
+`get_kept_briefing_by_source`) to classify a script-level `ConflictError` the same way — needed
+because `kept_scripts.source_script_id` is a table-wide UNIQUE column, so a script kept under a
+*different* local briefing can collide with an incoming one. NULL-source scripts (cast directly
+from a kept briefing) have no identity to key a `ConflictError` off of, so they're deduped by
+content match against the parent's pre-existing scripts one-for-one (a matched candidate is
+popped from the candidate pool so it can satisfy at most one incoming script — this preserves a
+source export that legitimately contains two distinct byte-identical NULL-source scripts as two
+rows, while still making re-import of the same chatbook idempotent).
+
+**Sync (AC #2, excluded).** No sync columns were ever on the table for these two tables (1780's
+original ruling); this task closes the follow-up by confirming that call still holds rather than
+silently letting it drift, and writes down *why* it holds (schema-shape mismatch with the sync
+engine's row-lineage model, not mere inertia).
+
+**Docs (AC #3).** Dated decision block appended to
+`Docs/superpowers/specs/2026-08-01-kept-briefings-design.md` (no existing history rewritten);
+`Chatbooks/CHATBOOKS_GUIDE.md` structure diagram + a new "Kept Briefings" section.
+
+**Tests.** `Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py` (new): export
+JSON+Markdown+manifest entry, empty-selection export produces no kept section, byte-faithful
+round trip of every provenance column, re-import idempotency (briefing + both a
+subscriptions-sourced and a NULL-source script), briefing-level collision (differing content,
+same `source_briefing_id`, existing row untouched + named warning), script-level collision
+(table-wide `source_script_id` collision across different local parents), and backward
+compatibility (importing a bundle with no `kept_briefings` section at all does not crash).
+`Tests/DB/test_chachanotes_kept_briefings.py`: two new tests for
+`get_kept_script_by_source`. `Tests/Chatbooks/test_chatbook_models.py`: `ContentType` value,
+manifest statistics round-trip, and the backward-compat default. Mutation-tested three
+behavioral guards by disabling each in turn (Edit, confirm RED, Edit-revert, confirm the diff
+returned to exactly the pre-mutation file): the NULL-source script dedup guard (idempotency
+test went RED), the briefing-level conflict-vs-identical classification (collision test's
+warning assertion went RED), and scripts riding with their parent (4 of 7 round-trip tests went
+RED when scripts were excluded from the export payload). Full `Tests/Chatbooks/` +
+`Tests/DB/test_chachanotes_kept_briefings.py` + every UI test file touching the changed modules:
+252 passed, 1 pre-existing skip (needs `--run-slow`). One unrelated pre-existing failure noted
+during a broader `Tests/DB/` sweep (`test_chat_image_db_compatibility.py::test_image_data_integrity`,
+`ModuleNotFoundError: No module named 'numpy'` — a missing optional dependency in this venv, not
+touched by this task).
+
+**Files modified:** `tldw_chatbook/Chatbooks/chatbook_models.py`,
+`tldw_chatbook/Chatbooks/chatbook_creator.py`, `tldw_chatbook/Chatbooks/chatbook_importer.py`,
+`tldw_chatbook/DB/ChaChaNotes_DB.py`, `tldw_chatbook/Chatbooks/CHATBOOKS_GUIDE.md`,
+`tldw_chatbook/UI/ChatbookCreationWindow.py`, `tldw_chatbook/UI/Widgets/SmartContentTree.py`,
+`tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py`,
+`tldw_chatbook/UI/Wizards/ChatbookImportWizard.py`,
+`Docs/superpowers/specs/2026-08-01-kept-briefings-design.md`. **Files added:**
+`Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py`. **Tests modified:**
+`Tests/DB/test_chachanotes_kept_briefings.py`, `Tests/Chatbooks/test_chatbook_models.py`.

--- a/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
+++ b/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
@@ -4,6 +4,7 @@ title: 'Kept briefings: sync/chatbook-export coverage'
 status: In Progress
 assignee: []
 created_date: '2026-08-02 00:16'
+updated_date: '2026-08-02 13:34'
 labels:
   - watchlists
   - briefings
@@ -43,7 +44,6 @@ somewhere a future reader will find it before assuming coverage that doesn't exi
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
 - [x] #1 A user's kept briefings and their kept scripts are included when the user exports a chatbook, OR a recorded decision explains why they are deliberately excluded — **arm taken: included.** New `ContentType.KEPT_BRIEFING`; `ChatbookCreator._collect_kept_briefings` walks selected kept briefings, nests each briefing's kept scripts inside its own JSON payload (scripts are not independently selectable), and also writes a companion human-readable Markdown file per briefing.
 - [x] #2 A user's kept briefings and their kept scripts participate in ChaChaNotes sync between devices, OR a recorded decision explains why they are deliberately excluded — **arm taken: excluded, deliberately.** Extends task-1780's original "no sync columns" v1 ruling; recorded in the follow-up decision block appended to the design spec (see AC #3).
@@ -61,6 +61,7 @@ somewhere a future reader will find it before assuming coverage that doesn't exi
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 **Export (AC #1, included).** `tldw_chatbook/Chatbooks/chatbook_models.py`: new
 `ContentType.KEPT_BRIEFING`, `ChatbookContent.kept_briefings`, and
 `ChatbookManifest.total_kept_briefings` (defaults to 0 in `from_dict` for bundles that predate
@@ -137,3 +138,20 @@ touched by this task).
 `Docs/superpowers/specs/2026-08-01-kept-briefings-design.md`. **Files added:**
 `Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py`. **Tests modified:**
 `Tests/DB/test_chachanotes_kept_briefings.py`, `Tests/Chatbooks/test_chatbook_models.py`.
+
+**Fix wave (2026-08-02, whole-branch review).** A whole-branch review (`.superpowers/sdd/briefings-residuals/task-1870-verdict.md`) found one high-severity defect plus four low/medium findings against the implementation above; all five fixed here.
+
+F1 (HIGH, proven empirically): on a genuine cross-device conflict, `_import_kept_briefings` still called `_import_kept_scripts` unconditionally against `target_kept_id` -- the *unrelated local* briefing sharing the same `source_briefing_id` -- grafting the incoming bundle's scripts onto it while the warning claimed nothing was modified. Fixed: the conflict branch now skips `_import_kept_scripts` entirely (refuses the whole incoming item as a unit, parent AND children) and the warning names both; the byte-identical (non-conflict) branch is unchanged -- scripts still import additively there. Regression test extended with a local script under the conflicting briefing, asserted byte-unchanged; mutation-verified (removing the guard reproduces the reviewer's exact probe: 2 foreign scripts land on the local row).
+
+F2: `ChatbookImportWizard._run_validation`'s statistics-mismatch check summed per-type manifest totals but omitted `total_kept_briefings` (this task's own type) and `total_prompts` (pre-existing) -- a kept-only chatbook always showed a false "Statistics mismatch" warning. Fixed by extracting the sum into `PreviewValidationStep._expected_content_total` (now including both terms), testable without mounting the widget; new `Tests/Chatbooks/test_chatbook_import_wizard_validation.py`, mutation-verified.
+
+F3: `ChatbookCreationWizard`/`ChatbookCreationWindow` computed each kept briefing's script-count subtitle via `len(list_kept_scripts(kept_id, limit=1000))` per row on the UI thread -- up to 200 extra queries materializing full `turns_json`/`roster_snapshot_json` transcripts just to discard them. Added `CharactersRAGDB.kept_script_counts(ids) -> dict[int,int]`, one grouped `COUNT(*)` query, and switched both call sites to it. New CRUD tests in `Tests/DB/test_chachanotes_kept_briefings.py`.
+
+F4: `kept_at` was exported but silently re-stamped with `CURRENT_TIMESTAMP` on import (no param existed to carry it), while the spec/guide/test docstring implied a full provenance round trip; the original round-trip test's `kept_at` assertion could false-pass because both writes landed in the same second. Fixed faithfully rather than just documenting the gap: `create_kept_briefing`/`create_kept_script` both gained an optional `kept_at` param (explicit column added to the INSERT only when provided; no schema change, the column already has `DEFAULT CURRENT_TIMESTAMP`), and the importer now passes the bundle's value through for both the briefing and every script. New test seeds `kept_at` years in the past on both rows so second-resolution coincidence cannot false-pass; mutation-verified.
+
+F5: the briefing success/skip counters incremented only after `_import_kept_scripts` returned, so a script-level exception (e.g. a malformed non-list `scripts` payload) was caught by the outer per-item handler and counted the whole item -- including the already-durably-inserted briefing row -- as failed. Fixed by counting the briefing's outcome before touching its scripts and wrapping `_import_kept_scripts` in its own try/except that adds a warning naming the script failure instead of falsifying the briefing's own outcome. New test reproduces the reviewer's exact scenario (`scripts: "not-a-list"`) and asserts `successful_items == 1`, `failed_items == 0`, and the warning text; mutation-verified.
+
+Verification: full `Tests/Chatbooks/` + `Tests/DB/test_chachanotes_kept_briefings.py` + `Tests/Watchlists/test_kept_briefings_modal.py` + the two other kept-briefings call sites (`Tests/Subscriptions/test_briefing_keep.py`, `test_briefing_cast.py`) -- 239 passed + 85 passed, 1 pre-existing `--run-slow` skip, 0 failed. All five fixes mutation-tested by reverting each guard/param in turn (Edit, confirm RED, Edit-revert, confirm `md5` byte-identical to the pre-mutation file).
+
+**Files modified (fix wave):** `tldw_chatbook/Chatbooks/chatbook_importer.py`, `tldw_chatbook/DB/ChaChaNotes_DB.py`, `tldw_chatbook/UI/Wizards/ChatbookImportWizard.py`, `tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py`, `tldw_chatbook/UI/ChatbookCreationWindow.py`. **Tests modified:** `Tests/Chatbooks/test_chatbook_kept_briefings_round_trip.py`, `Tests/DB/test_chachanotes_kept_briefings.py`. **Tests added:** `Tests/Chatbooks/test_chatbook_import_wizard_validation.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chatbooks/CHATBOOKS_GUIDE.md
+++ b/tldw_chatbook/Chatbooks/CHATBOOKS_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Chatbooks are knowledge packs that allow you to export, share, and import curated collections of content from tldw_chatbook. They provide a way to package conversations, notes, characters, media, and prompts into a portable format.
+Chatbooks are knowledge packs that allow you to export, share, and import curated collections of content from tldw_chatbook. They provide a way to package conversations, notes, characters, media, prompts, and kept briefings (with their cast scripts) into a portable format.
 
 ## Features
 
@@ -135,11 +135,31 @@ chatbook.zip
 │   ├── notes/           # Exported notes
 │   ├── characters/      # Character profiles
 │   ├── media/          # Media files (optional)
-│   └── prompts/        # Custom prompts
+│   ├── prompts/        # Custom prompts
+│   └── kept_briefings/ # Kept briefings (JSON + Markdown; scripts nested inside)
 └── metadata/
     ├── relationships.json  # Content relationships
     └── embeddings/        # Vector embeddings (optional)
 ```
+
+### Kept Briefings
+
+A kept briefing (Watchlists/briefings you chose to keep, plus any cast
+scripts made from it) exports as one JSON file (the machine-round-trippable
+source of truth, including every provenance column) and one companion
+Markdown file (a human-readable rendition) per briefing under
+`content/kept_briefings/`. Kept scripts are not independently selectable in
+the content picker -- they always travel with their parent kept briefing,
+nested inside its JSON payload.
+
+Kept briefings/scripts are local-only for ChaChaNotes sync between devices
+(a deliberate v1 decision -- see
+`Docs/superpowers/specs/2026-08-01-kept-briefings-design.md`); chatbook
+export/import is the supported way to carry them to another device. On
+import, a kept briefing whose `source_briefing_id` already exists locally
+with different content is never silently overwritten -- it is reported as a
+conflict in the import summary, and re-importing the same chatbook never
+creates duplicates.
 
 ### Manifest Schema
 The manifest.json file contains:

--- a/tldw_chatbook/Chatbooks/chatbook_creator.py
+++ b/tldw_chatbook/Chatbooks/chatbook_creator.py
@@ -325,6 +325,20 @@ class ChatbookCreator:
                     content_selections[ContentType.PROMPT], work_dir, manifest, content
                 )
 
+            # Collect kept briefings (task-1870); their kept scripts ride
+            # along nested inside each briefing's own payload, never as a
+            # separately selectable content type.
+            if ContentType.KEPT_BRIEFING in content_selections:
+                logger.info(
+                    f"ChatbookCreator.create_chatbook: Collecting {len(content_selections[ContentType.KEPT_BRIEFING])} kept briefings"
+                )
+                self._collect_kept_briefings(
+                    content_selections[ContentType.KEPT_BRIEFING],
+                    work_dir,
+                    manifest,
+                    content,
+                )
+
             # Auto-discover relationships
             logger.info("ChatbookCreator.create_chatbook: Discovering relationships")
             self._discover_relationships(manifest, content)
@@ -335,8 +349,9 @@ class ChatbookCreator:
             manifest.total_characters = len(content.characters)
             manifest.total_media_items = len(content.media_items)
             manifest.total_prompts = len(content.prompts)
+            manifest.total_kept_briefings = len(content.kept_briefings)
             logger.info(
-                f"ChatbookCreator.create_chatbook: Final stats - conversations={manifest.total_conversations}, notes={manifest.total_notes}, characters={manifest.total_characters}, media={manifest.total_media_items}, prompts={manifest.total_prompts}"
+                f"ChatbookCreator.create_chatbook: Final stats - conversations={manifest.total_conversations}, notes={manifest.total_notes}, characters={manifest.total_characters}, media={manifest.total_media_items}, prompts={manifest.total_prompts}, kept_briefings={manifest.total_kept_briefings}"
             )
 
             # Write manifest
@@ -1325,6 +1340,198 @@ class ChatbookCreator:
             except Exception as e:
                 logger.error(f"Error collecting prompt {prompt_id}: {e}")
 
+    # Kept scripts per briefing are denormalized, small text blobs (preset
+    # name + two JSON strings) -- a page-sized fetch comfortably covers any
+    # realistic cast history for one briefing without risking an unbounded
+    # read on a pathological row.
+    _KEPT_SCRIPTS_EXPORT_LIMIT = 1000
+
+    @staticmethod
+    def _kept_datetime_to_iso(value: Any) -> Optional[str]:
+        """Render a kept-row `DATETIME` column for JSON export.
+
+        `covers_from_ts`/`original_created_at`/`kept_at` come back from
+        `CharactersRAGDB` as real `datetime` objects (the connection's
+        registered `DATETIME` converter -- see `DB/sqlite_datetime_fix.py`),
+        which `json.dump` cannot serialize directly.
+        """
+        if value is None:
+            return None
+        if hasattr(value, "isoformat"):
+            return value.isoformat()
+        return str(value)
+
+    def _collect_kept_briefings(
+        self,
+        kept_briefing_ids: List[str],
+        work_dir: Path,
+        manifest: ChatbookManifest,
+        content: ChatbookContent,
+    ) -> None:
+        """Collect kept briefings and their kept scripts.
+
+        Kept scripts are not independently selectable -- they are nested
+        inside their parent briefing's JSON payload (mirroring how a
+        conversation's messages live inside the conversation's own JSON
+        rather than as separate content items), and a second, purely
+        human-readable Markdown rendition is written alongside it (the same
+        machine-JSON + human-Markdown split conversations use via their
+        citation report, and notes use via a single frontmatter+body file).
+        """
+        db_path = self.db_paths.get("ChaChaNotes")
+        if not db_path:
+            logger.warning(
+                "ChatbookCreator._collect_kept_briefings: ChaChaNotes database path not configured"
+            )
+            return
+
+        db = CharactersRAGDB(db_path, "chatbook_creator")
+        kept_dir = work_dir / "content" / "kept_briefings"
+        kept_dir.mkdir(parents=True, exist_ok=True)
+
+        total = len(kept_briefing_ids)
+        for idx, kept_id_raw in enumerate(kept_briefing_ids):
+            self._check_cancel()
+            self._emit_progress("kept_briefings", idx + 1, total)
+            try:
+                kept_id = int(kept_id_raw)
+                kept = db.get_kept_briefing(kept_id)
+                if not kept:
+                    logger.warning(
+                        f"ChatbookCreator._collect_kept_briefings: Kept briefing {kept_id} not found"
+                    )
+                    continue
+
+                scripts = db.list_kept_scripts(
+                    kept_id, limit=self._KEPT_SCRIPTS_EXPORT_LIMIT
+                )
+                script_payloads = [
+                    {
+                        "source_script_id": script.get("source_script_id"),
+                        "preset_name": script.get("preset_name"),
+                        "roster_snapshot_json": script.get("roster_snapshot_json"),
+                        "turns_json": script.get("turns_json"),
+                        "model_used": script.get("model_used"),
+                        "original_created_at": self._kept_datetime_to_iso(
+                            script.get("original_created_at")
+                        ),
+                        "kept_at": self._kept_datetime_to_iso(script.get("kept_at")),
+                    }
+                    for script in scripts
+                ]
+
+                kept_at_iso = self._kept_datetime_to_iso(kept.get("kept_at"))
+                original_created_at_iso = self._kept_datetime_to_iso(
+                    kept.get("original_created_at")
+                )
+                kept_data = {
+                    "source_briefing_id": kept["source_briefing_id"],
+                    "watchlist_name": kept.get("watchlist_name"),
+                    "body_markdown": kept["body_markdown"],
+                    "covers_through_item_id": kept.get("covers_through_item_id"),
+                    "covers_from_ts": self._kept_datetime_to_iso(
+                        kept.get("covers_from_ts")
+                    ),
+                    "selection_mode": kept.get("selection_mode"),
+                    "model_used": kept.get("model_used"),
+                    "item_count": kept.get("item_count", 0),
+                    "featured_count": kept.get("featured_count", 0),
+                    "overflow_count": kept.get("overflow_count", 0),
+                    "origin": kept.get("origin"),
+                    "original_created_at": original_created_at_iso,
+                    "kept_at": kept_at_iso,
+                    "scripts": script_payloads,
+                }
+
+                kept_file = kept_dir / f"kept_briefing_{kept_id}.json"
+                with open(kept_file, "w", encoding="utf-8") as f:
+                    json.dump(kept_data, f, indent=2, ensure_ascii=False)
+
+                title = kept.get("watchlist_name") or f"Kept briefing {kept_id}"
+                report_file = kept_dir / f"kept_briefing_{kept_id}.md"
+                self._write_kept_briefing_report(
+                    report_file, kept_id, title, kept_data
+                )
+
+                content.kept_briefings.append(kept_data)
+
+                manifest.content_items.append(
+                    ContentItem(
+                        id=str(kept_id),
+                        type=ContentType.KEPT_BRIEFING,
+                        title=title,
+                        description=f"{kept_data['item_count']} items, "
+                        f"{len(script_payloads)} kept script(s)",
+                        created_at=datetime.fromisoformat(original_created_at_iso)
+                        if original_created_at_iso
+                        else datetime.now(),
+                        updated_at=datetime.fromisoformat(kept_at_iso)
+                        if kept_at_iso
+                        else datetime.now(),
+                        metadata={
+                            "origin": kept_data["origin"],
+                            "script_count": len(script_payloads),
+                        },
+                        file_path=f"content/kept_briefings/{kept_file.name}",
+                    )
+                )
+
+            except Exception as e:
+                logger.error(
+                    f"Error collecting kept briefing {kept_id_raw}: {e}"
+                )
+
+    def _write_kept_briefing_report(
+        self,
+        report_file: Path,
+        kept_id: int,
+        title: str,
+        kept_data: Dict[str, Any],
+    ) -> None:
+        """Write a human-readable rendition of a kept briefing + its scripts.
+
+        Purely for human reading -- the importer reconstructs state from the
+        JSON payload written alongside this file, never from this Markdown.
+        """
+        with open(report_file, "w", encoding="utf-8") as f:
+            f.write(f"# Kept Briefing: {self._markdown_report_text(title)}\n\n")
+            f.write(f"- Kept briefing id (local): {kept_id}\n")
+            f.write(
+                f"- Source briefing id: {kept_data['source_briefing_id']}\n"
+            )
+            f.write(f"- Origin: {self._markdown_report_text(kept_data['origin'])}\n")
+            if kept_data.get("model_used"):
+                f.write(
+                    f"- Model used: {self._markdown_report_text(kept_data['model_used'])}\n"
+                )
+            f.write(
+                f"- Items covered: {kept_data['item_count']} "
+                f"(featured {kept_data['featured_count']}, "
+                f"overflow {kept_data['overflow_count']})\n"
+            )
+            if kept_data.get("original_created_at"):
+                f.write(f"- Originally created: {kept_data['original_created_at']}\n")
+            f.write(f"- Kept at: {kept_data['kept_at']}\n\n")
+            f.write("## Body\n\n")
+            f.write(kept_data["body_markdown"])
+            f.write("\n\n")
+
+            scripts = kept_data.get("scripts") or []
+            if scripts:
+                f.write(f"## Kept Scripts ({len(scripts)})\n\n")
+                for script in scripts:
+                    preset_name = self._markdown_report_text(
+                        script.get("preset_name", "unknown")
+                    )
+                    f.write(f"### {preset_name}\n\n")
+                    if script.get("source_script_id") is not None:
+                        f.write(f"- Source script id: {script['source_script_id']}\n")
+                    if script.get("model_used"):
+                        f.write(
+                            f"- Model used: {self._markdown_report_text(script['model_used'])}\n"
+                        )
+                    f.write(f"- Kept at: {script.get('kept_at')}\n\n")
+
     def _add_character_dependency(
         self,
         character_id: int,
@@ -1472,6 +1679,8 @@ class ChatbookCreator:
                 f.write(f"- **Media Items:** {manifest.total_media_items}\n")
             if manifest.total_prompts > 0:
                 f.write(f"- **Prompts:** {manifest.total_prompts}\n")
+            if manifest.total_kept_briefings > 0:
+                f.write(f"- **Kept Briefings:** {manifest.total_kept_briefings}\n")
 
             if manifest.tags:
                 f.write("\n## Tags\n\n")
@@ -1495,6 +1704,10 @@ class ChatbookCreator:
                 f.write("    │   └── metadata/   # Media metadata JSON files\n")
             if manifest.total_prompts > 0:
                 f.write("    ├── prompts/        # Prompts\n")
+            if manifest.total_kept_briefings > 0:
+                f.write(
+                    "    └── kept_briefings/ # Kept briefings (scripts nested inside)\n"
+                )
             f.write("```\n")
 
             f.write("\n## License\n\n")

--- a/tldw_chatbook/Chatbooks/chatbook_creator.py
+++ b/tldw_chatbook/Chatbooks/chatbook_creator.py
@@ -1341,10 +1341,11 @@ class ChatbookCreator:
                 logger.error(f"Error collecting prompt {prompt_id}: {e}")
 
     # Kept scripts per briefing are denormalized, small text blobs (preset
-    # name + two JSON strings) -- a page-sized fetch comfortably covers any
-    # realistic cast history for one briefing without risking an unbounded
-    # read on a pathological row.
-    _KEPT_SCRIPTS_EXPORT_LIMIT = 1000
+    # name + two JSON strings). Export must never silently truncate a
+    # briefing's cast history, so `_collect_kept_briefings` pages through
+    # `list_kept_scripts` this many rows at a time (rather than a single
+    # capped fetch) until a short page signals the end.
+    _KEPT_SCRIPTS_EXPORT_PAGE_SIZE = 1000
 
     @staticmethod
     def _kept_datetime_to_iso(value: Any) -> Optional[str]:
@@ -1402,9 +1403,19 @@ class ChatbookCreator:
                     )
                     continue
 
-                scripts = db.list_kept_scripts(
-                    kept_id, limit=self._KEPT_SCRIPTS_EXPORT_LIMIT
-                )
+                scripts: List[Dict[str, Any]] = []
+                page_offset = 0
+                while True:
+                    page = db.list_kept_scripts(
+                        kept_id,
+                        limit=self._KEPT_SCRIPTS_EXPORT_PAGE_SIZE,
+                        offset=page_offset,
+                    )
+                    scripts.extend(page)
+                    if len(page) < self._KEPT_SCRIPTS_EXPORT_PAGE_SIZE:
+                        break
+                    page_offset += self._KEPT_SCRIPTS_EXPORT_PAGE_SIZE
+
                 script_payloads = [
                     {
                         "source_script_id": script.get("source_script_id"),

--- a/tldw_chatbook/Chatbooks/chatbook_importer.py
+++ b/tldw_chatbook/Chatbooks/chatbook_importer.py
@@ -25,7 +25,7 @@ from ..Chat.chat_conversation_service import ChatConversationService
 from ..Chat.citation_service_factory import (
     build_local_citation_conversation_service,
 )
-from ..DB.ChaChaNotes_DB import CharactersRAGDB
+from ..DB.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from ..DB.Client_Media_DB_v2 import MediaDatabase
 from ..DB.Prompts_DB import PromptsDatabase
 from ..Character_Chat.character_card_formats import detect_and_parse_character_card
@@ -328,6 +328,14 @@ class ChatbookImporter:
                     manifest,
                     content_selections[ContentType.MEDIA],
                     conflict_resolution,
+                    status,
+                )
+
+            if ContentType.KEPT_BRIEFING in content_selections:
+                self._import_kept_briefings(
+                    extract_dir,
+                    manifest,
+                    content_selections[ContentType.KEPT_BRIEFING],
                     status,
                 )
 
@@ -1171,6 +1179,316 @@ class ChatbookImporter:
                 status.failed_items += 1
                 status.add_error(f"Error importing media {media_id}: {str(e)}")
                 logger.error(f"Error importing media {media_id}: {e}")
+
+    # Mirrors ChatbookCreator._KEPT_SCRIPTS_EXPORT_LIMIT: a page-sized read of
+    # one briefing's kept scripts comfortably covers any realistic cast
+    # history without an unbounded fetch.
+    _KEPT_SCRIPTS_IMPORT_LIMIT = 1000
+
+    @staticmethod
+    def _kept_dt_key(value: Any) -> Any:
+        """Normalize a kept-row datetime-ish value for equality comparison.
+
+        The importer's `payload` values are always ISO strings (JSON has no
+        datetime type); a freshly-queried `existing` row's `DATETIME`
+        columns come back as real `datetime` objects (the connection's
+        registered converter). Rendering both sides through `.isoformat()`
+        (when present) lets the two representations compare equal.
+        """
+        if value is None:
+            return None
+        if hasattr(value, "isoformat"):
+            return value.isoformat()
+        return value
+
+    @classmethod
+    def _kept_briefing_content_matches(
+        cls, existing: Mapping[str, Any], payload: Mapping[str, Any]
+    ) -> bool:
+        """True if a locally-existing kept briefing is byte-identical to an
+        incoming one sharing the same `source_briefing_id` (already-present,
+        safe to skip silently) vs. genuinely different content (a conflict
+        that must never be silently overwritten)."""
+        plain_fields = (
+            "watchlist_name",
+            "body_markdown",
+            "covers_through_item_id",
+            "selection_mode",
+            "model_used",
+            "item_count",
+            "featured_count",
+            "overflow_count",
+            "origin",
+        )
+        if any(existing.get(f) != payload.get(f) for f in plain_fields):
+            return False
+        dt_fields = ("covers_from_ts", "original_created_at")
+        return all(
+            cls._kept_dt_key(existing.get(f)) == cls._kept_dt_key(payload.get(f))
+            for f in dt_fields
+        )
+
+    @classmethod
+    def _kept_script_content_matches(
+        cls, existing: Mapping[str, Any], payload: Mapping[str, Any]
+    ) -> bool:
+        """Same byte-identity check as `_kept_briefing_content_matches`, for
+        one kept script."""
+        plain_fields = ("preset_name", "roster_snapshot_json", "turns_json", "model_used")
+        if any(existing.get(f) != payload.get(f) for f in plain_fields):
+            return False
+        return cls._kept_dt_key(existing.get("original_created_at")) == cls._kept_dt_key(
+            payload.get("original_created_at")
+        )
+
+    @staticmethod
+    def _kept_briefing_file_path(
+        extract_dir: Path,
+        kept_dir: Path,
+        manifest: ChatbookManifest,
+        kept_id: str,
+    ) -> Path:
+        for item in manifest.content_items:
+            if (
+                item.id == kept_id
+                and item.type == ContentType.KEPT_BRIEFING
+                and item.file_path
+            ):
+                return ChatbookImporter._safe_manifest_relative_path(
+                    extract_dir, item.file_path
+                )
+        fallback_filename = f"kept_briefing_{kept_id}.json"
+        validate_filename(fallback_filename)
+        return kept_dir / fallback_filename
+
+    def _import_kept_briefings(
+        self,
+        extract_dir: Path,
+        manifest: ChatbookManifest,
+        kept_briefing_ids: List[str],
+        status: ImportStatus,
+    ) -> None:
+        """Import kept briefings and their kept scripts (task-1870).
+
+        Policy: `source_briefing_id` is a device-local Subscriptions_DB id,
+        so a cross-device import can collide with a *different* local kept
+        briefing that happens to share the same source id. Rather than
+        force this through the display-name-keyed ask/skip/rename/replace
+        machinery in `ConflictResolver` (built for conversations/notes/
+        characters, not a UNIQUE-source-id-keyed idempotent artifact), this
+        mirrors the "raced keep" handling the keep service itself already
+        uses (`Subscriptions/briefing_keep.py` -- see the kept-briefings
+        design doc's delivery notes): try the insert; if `create_kept_
+        briefing` raises `ConflictError` because a row for this source id
+        already exists, fall back to the existing row -- silently if its
+        content is byte-identical (an ordinary idempotent re-import), with
+        an honest warning if it differs (a genuine conflict; the existing
+        row is never overwritten). Kept scripts ride under the (possibly
+        pre-existing) parent under the same policy, except NULL-source
+        scripts (cast directly from a kept briefing, no subscriptions-side
+        source) are deduped by content match within the parent instead,
+        since NULL carries no identity of its own.
+        """
+        db_path = self.db_paths.get("ChaChaNotes")
+        if not db_path:
+            logger.error(
+                "ChatbookImporter._import_kept_briefings: ChaChaNotes database path not configured"
+            )
+            status.add_error("ChaChaNotes database path not configured")
+            return
+
+        db = CharactersRAGDB(db_path, "chatbook_importer")
+        kept_dir = extract_dir / "content" / "kept_briefings"
+
+        for kept_id in kept_briefing_ids:
+            status.processed_items += 1
+            try:
+                kept_file = self._kept_briefing_file_path(
+                    extract_dir, kept_dir, manifest, kept_id
+                )
+                if not kept_file.exists():
+                    status.add_warning(
+                        f"Kept briefing file not found: {kept_file.name}"
+                    )
+                    status.failed_items += 1
+                    continue
+
+                with open(kept_file, "r", encoding="utf-8") as f:
+                    payload = json.load(f)
+
+                source_briefing_id = payload["source_briefing_id"]
+
+                newly_inserted = False
+                conflict = False
+                target_kept_id: Optional[int] = None
+                try:
+                    target_kept_id = db.create_kept_briefing(
+                        source_briefing_id=source_briefing_id,
+                        watchlist_name=payload.get("watchlist_name"),
+                        body_markdown=payload["body_markdown"],
+                        covers_through_item_id=payload.get(
+                            "covers_through_item_id"
+                        ),
+                        covers_from_ts=payload.get("covers_from_ts"),
+                        selection_mode=payload.get("selection_mode"),
+                        model_used=payload.get("model_used"),
+                        item_count=payload.get("item_count", 0),
+                        featured_count=payload.get("featured_count", 0),
+                        overflow_count=payload.get("overflow_count", 0),
+                        origin=payload.get("origin", "manual"),
+                        original_created_at=payload.get("original_created_at"),
+                    )
+                    newly_inserted = True
+                except ConflictError:
+                    existing = db.get_kept_briefing_by_source(source_briefing_id)
+                    if existing is None:
+                        # Lost a race with another writer between the
+                        # failed insert and this read -- a hard failure
+                        # rather than a guess.
+                        status.failed_items += 1
+                        status.add_error(
+                            "Kept briefing conflict for "
+                            f"source_briefing_id={source_briefing_id} could not "
+                            "be resolved (row vanished mid-import)."
+                        )
+                        continue
+                    target_kept_id = existing["id"]
+                    if not self._kept_briefing_content_matches(existing, payload):
+                        conflict = True
+
+                scripts_inserted, scripts_present, scripts_conflicted = (
+                    self._import_kept_scripts(
+                        db, target_kept_id, payload.get("scripts") or []
+                    )
+                )
+
+                if newly_inserted:
+                    status.successful_items += 1
+                else:
+                    status.skipped_items += 1
+                    if conflict:
+                        status.add_warning(
+                            "Kept briefing conflict: source_briefing_id="
+                            f"{source_briefing_id} already exists locally with "
+                            "different content; existing kept briefing was not "
+                            "modified."
+                        )
+                if scripts_conflicted:
+                    status.add_warning(
+                        f"Kept briefing (source_briefing_id={source_briefing_id}): "
+                        f"{scripts_conflicted} kept script(s) already present "
+                        "locally with different content and were not modified."
+                    )
+                logger.info(
+                    "ChatbookImporter._import_kept_briefings: kept briefing "
+                    f"source_briefing_id={source_briefing_id} "
+                    f"({'inserted' if newly_inserted else 'already present'}); "
+                    f"scripts inserted={scripts_inserted} present={scripts_present} "
+                    f"conflicted={scripts_conflicted}"
+                )
+
+            except Exception as e:
+                status.failed_items += 1
+                status.add_error(
+                    f"Error importing kept briefing {kept_id}: {str(e)}"
+                )
+                logger.opt(exception=True).error(
+                    "ChatbookImporter._import_kept_briefings: Error importing kept briefing {}",
+                    kept_id,
+                )
+
+    def _import_kept_scripts(
+        self,
+        db: CharactersRAGDB,
+        kept_briefing_id: int,
+        script_payloads: List[Dict[str, Any]],
+    ) -> Tuple[int, int, int]:
+        """Import one kept briefing's kept scripts under its (possibly
+        pre-existing) parent.
+
+        Returns (inserted, already_present, conflicted) counts. These are
+        deliberately kept out of `ImportStatus`'s top-level counters --
+        scripts are not independently selectable content items, so they
+        would inflate the "X/Y items" accounting beyond the selected kept
+        briefing count; the caller surfaces conflicts via a warning and logs
+        the full breakdown instead.
+        """
+        inserted = 0
+        already_present = 0
+        conflicted = 0
+        # Lazily fetched, and only for NULL-source scripts: the DB state for
+        # this kept briefing *before* this call touches it. A matched
+        # candidate is popped out of this pool (not merely flagged) so each
+        # pre-existing row can satisfy at most one incoming script -- two
+        # incoming scripts with genuinely identical content (legal: NULLs
+        # are mutually distinct) still both insert if only one matching row
+        # pre-existed, while re-importing the same chatbook twice matches
+        # one-for-one and adds nothing. Rows inserted earlier in *this same*
+        # loop are deliberately never added to the pool, so a source export
+        # that legitimately contains two distinct byte-identical scripts
+        # still round-trips as two rows, not one.
+        existing_scripts: Optional[List[Dict[str, Any]]] = None
+
+        for script_payload in script_payloads:
+            source_script_id = script_payload.get("source_script_id")
+            preset_name = script_payload.get("preset_name", "")
+            roster_snapshot_json = script_payload.get("roster_snapshot_json", "{}")
+            turns_json = script_payload.get("turns_json", "[]")
+            model_used = script_payload.get("model_used")
+            original_created_at = script_payload.get("original_created_at")
+
+            if source_script_id is not None:
+                try:
+                    db.create_kept_script(
+                        kept_briefing_id,
+                        source_script_id=source_script_id,
+                        preset_name=preset_name,
+                        roster_snapshot_json=roster_snapshot_json,
+                        turns_json=turns_json,
+                        model_used=model_used,
+                        original_created_at=original_created_at,
+                    )
+                    inserted += 1
+                except ConflictError:
+                    existing = db.get_kept_script_by_source(source_script_id)
+                    if existing is not None and self._kept_script_content_matches(
+                        existing, script_payload
+                    ):
+                        already_present += 1
+                    else:
+                        conflicted += 1
+                continue
+
+            if existing_scripts is None:
+                existing_scripts = db.list_kept_scripts(
+                    kept_briefing_id, limit=self._KEPT_SCRIPTS_IMPORT_LIMIT
+                )
+            match_index = next(
+                (
+                    idx
+                    for idx, row in enumerate(existing_scripts)
+                    if row.get("source_script_id") is None
+                    and self._kept_script_content_matches(row, script_payload)
+                ),
+                None,
+            )
+            if match_index is not None:
+                existing_scripts.pop(match_index)
+                already_present += 1
+                continue
+
+            db.create_kept_script(
+                kept_briefing_id,
+                source_script_id=None,
+                preset_name=preset_name,
+                roster_snapshot_json=roster_snapshot_json,
+                turns_json=turns_json,
+                model_used=model_used,
+                original_created_at=original_created_at,
+            )
+            inserted += 1
+
+        return inserted, already_present, conflicted
 
     def _generate_unique_media_title(self, base_title: str, db: MediaDatabase) -> str:
         """Generate a unique media title."""

--- a/tldw_chatbook/Chatbooks/chatbook_importer.py
+++ b/tldw_chatbook/Chatbooks/chatbook_importer.py
@@ -1180,9 +1180,11 @@ class ChatbookImporter:
                 status.add_error(f"Error importing media {media_id}: {str(e)}")
                 logger.error(f"Error importing media {media_id}: {e}")
 
-    # Mirrors ChatbookCreator._KEPT_SCRIPTS_EXPORT_LIMIT: a page-sized read of
-    # one briefing's kept scripts comfortably covers any realistic cast
-    # history without an unbounded fetch.
+    # Mirrors ChatbookCreator._KEPT_SCRIPTS_EXPORT_PAGE_SIZE, but this read is
+    # only used to de-duplicate scripts with no `source_script_id` against
+    # rows already present in the *target* DB (see the match loop below), not
+    # to enumerate every script for export -- a single page is intentional
+    # here, unlike the paginated export path.
     _KEPT_SCRIPTS_IMPORT_LIMIT = 1000
 
     @staticmethod
@@ -1208,7 +1210,14 @@ class ChatbookImporter:
         """True if a locally-existing kept briefing is byte-identical to an
         incoming one sharing the same `source_briefing_id` (already-present,
         safe to skip silently) vs. genuinely different content (a conflict
-        that must never be silently overwritten)."""
+        that must never be silently overwritten).
+
+        `kept_at` is deliberately excluded from this comparison: it is
+        provenance of *when* the briefing was kept, not part of the
+        briefing's content, so the same artifact kept at different moments
+        (e.g. re-exported from a second device) must still compare equal
+        and skip as already-present rather than spuriously conflict.
+        """
         plain_fields = (
             "watchlist_name",
             "body_markdown",
@@ -1233,7 +1242,13 @@ class ChatbookImporter:
         cls, existing: Mapping[str, Any], payload: Mapping[str, Any]
     ) -> bool:
         """Same byte-identity check as `_kept_briefing_content_matches`, for
-        one kept script."""
+        one kept script.
+
+        `kept_at` is deliberately excluded here too, for the same reason:
+        it is provenance of the keeping, not content, so a script kept at
+        different moments must still skip as already-present rather than
+        spam a conflict.
+        """
         plain_fields = ("preset_name", "roster_snapshot_json", "turns_json", "model_used")
         if any(existing.get(f) != payload.get(f) for f in plain_fields):
             return False

--- a/tldw_chatbook/Chatbooks/chatbook_importer.py
+++ b/tldw_chatbook/Chatbooks/chatbook_importer.py
@@ -1337,6 +1337,7 @@ class ChatbookImporter:
                         overflow_count=payload.get("overflow_count", 0),
                         origin=payload.get("origin", "manual"),
                         original_created_at=payload.get("original_created_at"),
+                        kept_at=payload.get("kept_at"),
                     )
                     newly_inserted = True
                 except ConflictError:
@@ -1356,12 +1357,13 @@ class ChatbookImporter:
                     if not self._kept_briefing_content_matches(existing, payload):
                         conflict = True
 
-                scripts_inserted, scripts_present, scripts_conflicted = (
-                    self._import_kept_scripts(
-                        db, target_kept_id, payload.get("scripts") or []
-                    )
-                )
-
+                # Count the briefing's own outcome now, before touching its
+                # kept scripts: the row is already durably present (either
+                # freshly inserted, or an existing row we deliberately left
+                # alone), so a script-level failure below must not turn an
+                # already-successful briefing insert into a false "failed"
+                # count (task-1870 fix-wave F5 -- see the per-item try
+                # around `_import_kept_scripts`).
                 if newly_inserted:
                     status.successful_items += 1
                 else:
@@ -1370,9 +1372,51 @@ class ChatbookImporter:
                         status.add_warning(
                             "Kept briefing conflict: source_briefing_id="
                             f"{source_briefing_id} already exists locally with "
-                            "different content; existing kept briefing was not "
-                            "modified."
+                            "different content; the existing kept briefing "
+                            "and its kept script(s) were not modified."
                         )
+
+                if conflict:
+                    # Refuse the whole incoming item as a unit -- parent AND
+                    # children. `target_kept_id` here is the *unrelated*
+                    # local briefing that merely happens to share the same
+                    # source id, so importing the incoming scripts under it
+                    # would graft someone else's cast history onto the
+                    # user's own briefing while the warning above claims
+                    # nothing was touched (task-1870 fix-wave F1). The
+                    # byte-identical (non-conflict) branch above is
+                    # unaffected -- scripts still import additively there,
+                    # which is the ordinary re-keep/idempotent-import path.
+                    logger.info(
+                        "ChatbookImporter._import_kept_briefings: kept briefing "
+                        f"source_briefing_id={source_briefing_id} conflicts with "
+                        "an existing local row; its kept scripts were not imported."
+                    )
+                    continue
+
+                try:
+                    scripts_inserted, scripts_present, scripts_conflicted = (
+                        self._import_kept_scripts(
+                            db, target_kept_id, payload.get("scripts") or []
+                        )
+                    )
+                except Exception as script_exc:
+                    # The briefing itself is already counted above and is
+                    # durably in the DB -- an honest report says so, and
+                    # names the script failure as a warning instead of
+                    # reporting the whole item as failed (task-1870
+                    # fix-wave F5).
+                    status.add_warning(
+                        f"Kept briefing (source_briefing_id={source_briefing_id}): "
+                        f"kept scripts could not be imported: {script_exc}"
+                    )
+                    logger.opt(exception=True).error(
+                        "ChatbookImporter._import_kept_briefings: Error importing "
+                        "kept scripts for source_briefing_id={}",
+                        source_briefing_id,
+                    )
+                    continue
+
                 if scripts_conflicted:
                     status.add_warning(
                         f"Kept briefing (source_briefing_id={source_briefing_id}): "
@@ -1436,6 +1480,7 @@ class ChatbookImporter:
             turns_json = script_payload.get("turns_json", "[]")
             model_used = script_payload.get("model_used")
             original_created_at = script_payload.get("original_created_at")
+            kept_at = script_payload.get("kept_at")
 
             if source_script_id is not None:
                 try:
@@ -1447,6 +1492,7 @@ class ChatbookImporter:
                         turns_json=turns_json,
                         model_used=model_used,
                         original_created_at=original_created_at,
+                        kept_at=kept_at,
                     )
                     inserted += 1
                 except ConflictError:
@@ -1485,6 +1531,7 @@ class ChatbookImporter:
                 turns_json=turns_json,
                 model_used=model_used,
                 original_created_at=original_created_at,
+                kept_at=kept_at,
             )
             inserted += 1
 

--- a/tldw_chatbook/Chatbooks/chatbook_models.py
+++ b/tldw_chatbook/Chatbooks/chatbook_models.py
@@ -33,6 +33,12 @@ class ContentType(Enum):
     EMBEDDING = "embedding"
     PROMPT = "prompt"
     EVALUATION = "evaluation"
+    # A user's kept briefing (ChaChaNotes `kept_briefings`, task-1780). Kept
+    # scripts (`kept_scripts`) are NOT independently selectable -- they ride
+    # with their parent kept briefing and are nested inside its exported
+    # payload, mirroring how a conversation's messages are nested inside the
+    # conversation's own JSON rather than being their own content type.
+    KEPT_BRIEFING = "kept_briefing"
 
 
 @dataclass
@@ -128,6 +134,7 @@ class ChatbookManifest:
     total_characters: int = 0
     total_media_items: int = 0
     total_prompts: int = 0
+    total_kept_briefings: int = 0
     total_size_bytes: int = 0
 
     # Metadata
@@ -156,6 +163,7 @@ class ChatbookManifest:
                 "total_characters": self.total_characters,
                 "total_media_items": self.total_media_items,
                 "total_prompts": self.total_prompts,
+                "total_kept_briefings": self.total_kept_briefings,
                 "total_size_bytes": self.total_size_bytes,
             },
             "tags": self.tags,
@@ -198,6 +206,11 @@ class ChatbookManifest:
         manifest.total_characters = stats.get("total_characters", 0)
         manifest.total_media_items = stats.get("total_media_items", 0)
         manifest.total_prompts = stats.get("total_prompts", 0)
+        # Backward compat: bundles created before this content type existed
+        # (task-1870) have no "total_kept_briefings" key at all -- default to
+        # 0 rather than raising, same treatment every other statistic here
+        # gets.
+        manifest.total_kept_briefings = stats.get("total_kept_briefings", 0)
         manifest.total_size_bytes = stats.get("total_size_bytes", 0)
 
         # Load metadata
@@ -220,6 +233,7 @@ class ChatbookContent:
     embeddings: List[Dict[str, Any]] = field(default_factory=list)
     prompts: List[Dict[str, Any]] = field(default_factory=list)
     evaluations: List[Dict[str, Any]] = field(default_factory=list)
+    kept_briefings: List[Dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -13025,12 +13025,6 @@ UPDATE db_schema_version
             raise InputError(
                 f"origin must be one of {self._ALLOWED_KEPT_BRIEFING_ORIGINS}, got {origin!r}."
             )
-        columns = [
-            "source_briefing_id", "watchlist_name", "body_markdown",
-            "covers_through_item_id", "covers_from_ts", "selection_mode",
-            "model_used", "item_count", "featured_count", "overflow_count",
-            "origin", "original_created_at",
-        ]
         params: List[Any] = [
             source_briefing_id,
             watchlist_name,
@@ -13044,13 +13038,15 @@ UPDATE db_schema_version
             overflow_count,
             origin,
             original_created_at,
+            kept_at,
         ]
-        if kept_at is not None:
-            columns.append("kept_at")
-            params.append(kept_at)
         query = (
-            f"INSERT INTO kept_briefings({', '.join(columns)}) "
-            f"VALUES ({', '.join(['?'] * len(columns))})"
+            "INSERT INTO kept_briefings("
+            "source_briefing_id, watchlist_name, body_markdown, "
+            "covers_through_item_id, covers_from_ts, selection_mode, "
+            "model_used, item_count, featured_count, overflow_count, "
+            "origin, original_created_at, kept_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))"
         )
         try:
             with self.transaction() as cursor:
@@ -13198,11 +13194,6 @@ UPDATE db_schema_version
                 an existing kept briefing (foreign key violation), or for
                 other database errors.
         """
-        columns = [
-            "kept_briefing_id", "source_script_id", "preset_name",
-            "roster_snapshot_json", "turns_json", "model_used",
-            "original_created_at",
-        ]
         params: List[Any] = [
             kept_briefing_id,
             source_script_id,
@@ -13211,13 +13202,14 @@ UPDATE db_schema_version
             turns_json,
             model_used,
             original_created_at,
+            kept_at,
         ]
-        if kept_at is not None:
-            columns.append("kept_at")
-            params.append(kept_at)
         query = (
-            f"INSERT INTO kept_scripts({', '.join(columns)}) "
-            f"VALUES ({', '.join(['?'] * len(columns))})"
+            "INSERT INTO kept_scripts("
+            "kept_briefing_id, source_script_id, preset_name, "
+            "roster_snapshot_json, turns_json, model_used, "
+            "original_created_at, kept_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))"
         )
         try:
             with self.transaction() as cursor:

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -12973,6 +12973,7 @@ UPDATE db_schema_version
         overflow_count: int = 0,
         origin: str,
         original_created_at: Optional[str] = None,
+        kept_at: Optional[str] = None,
     ) -> int:
         """Insert a new kept briefing row.
 
@@ -13005,6 +13006,12 @@ UPDATE db_schema_version
             original_created_at: The original briefing's `created_at`
                 timestamp, denormalized so it can be displayed without the
                 Subscriptions_DB.
+            kept_at: Explicit keep timestamp. Only the chatbook importer
+                (task-1870) passes this, to preserve the *originating*
+                device's keep time on a cross-device import; every other
+                caller omits it and gets the column's own
+                `DEFAULT CURRENT_TIMESTAMP` (this device's local keep
+                time), which is what an ordinary in-app Keep action wants.
 
         Returns:
             The integer id of the newly inserted `kept_briefings` row.
@@ -13018,15 +13025,13 @@ UPDATE db_schema_version
             raise InputError(
                 f"origin must be one of {self._ALLOWED_KEPT_BRIEFING_ORIGINS}, got {origin!r}."
             )
-        query = """
-            INSERT INTO kept_briefings(
-                source_briefing_id, watchlist_name, body_markdown,
-                covers_through_item_id, covers_from_ts, selection_mode,
-                model_used, item_count, featured_count, overflow_count,
-                origin, original_created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """
-        params = (
+        columns = [
+            "source_briefing_id", "watchlist_name", "body_markdown",
+            "covers_through_item_id", "covers_from_ts", "selection_mode",
+            "model_used", "item_count", "featured_count", "overflow_count",
+            "origin", "original_created_at",
+        ]
+        params: List[Any] = [
             source_briefing_id,
             watchlist_name,
             body_markdown,
@@ -13039,6 +13044,13 @@ UPDATE db_schema_version
             overflow_count,
             origin,
             original_created_at,
+        ]
+        if kept_at is not None:
+            columns.append("kept_at")
+            params.append(kept_at)
+        query = (
+            f"INSERT INTO kept_briefings({', '.join(columns)}) "
+            f"VALUES ({', '.join(['?'] * len(columns))})"
         )
         try:
             with self.transaction() as cursor:
@@ -13145,6 +13157,7 @@ UPDATE db_schema_version
         turns_json: str,
         model_used: Optional[str] = None,
         original_created_at: Optional[str] = None,
+        kept_at: Optional[str] = None,
     ) -> int:
         """Insert a new kept script row under a kept briefing.
 
@@ -13169,6 +13182,11 @@ UPDATE db_schema_version
             original_created_at: The original script's `created_at`
                 timestamp, denormalized so it can be displayed without the
                 Subscriptions_DB.
+            kept_at: Explicit keep timestamp. Mirrors `create_kept_
+                briefing`'s `kept_at` param -- only the chatbook importer
+                (task-1870) passes it, to preserve the originating
+                device's keep time; every other caller omits it and gets
+                the column's own `DEFAULT CURRENT_TIMESTAMP`.
 
         Returns:
             The integer id of the newly inserted `kept_scripts` row.
@@ -13180,14 +13198,12 @@ UPDATE db_schema_version
                 an existing kept briefing (foreign key violation), or for
                 other database errors.
         """
-        query = """
-            INSERT INTO kept_scripts(
-                kept_briefing_id, source_script_id, preset_name,
-                roster_snapshot_json, turns_json, model_used,
-                original_created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-        """
-        params = (
+        columns = [
+            "kept_briefing_id", "source_script_id", "preset_name",
+            "roster_snapshot_json", "turns_json", "model_used",
+            "original_created_at",
+        ]
+        params: List[Any] = [
             kept_briefing_id,
             source_script_id,
             preset_name,
@@ -13195,6 +13211,13 @@ UPDATE db_schema_version
             turns_json,
             model_used,
             original_created_at,
+        ]
+        if kept_at is not None:
+            columns.append("kept_at")
+            params.append(kept_at)
+        query = (
+            f"INSERT INTO kept_scripts({', '.join(columns)}) "
+            f"VALUES ({', '.join(['?'] * len(columns))})"
         )
         try:
             with self.transaction() as cursor:
@@ -13259,6 +13282,39 @@ UPDATE db_schema_version
             (kept_briefing_id, limit, offset),
         )
         return [dict(row) for row in cursor.fetchall()]
+
+    def kept_script_counts(
+        self, kept_briefing_ids: List[int]
+    ) -> Dict[int, int]:
+        """Return the kept-script count for each of the given briefing ids.
+
+        A single grouped `COUNT(*)`, not a per-briefing
+        `len(list_kept_scripts(...))` -- the latter materializes every kept
+        script's full `turns_json`/`roster_snapshot_json` (a complete cast
+        transcript) purely to discard it and keep the length. Callers that
+        only need a "(N scripts)" subtitle for up to 200 kept briefings
+        should use this instead (task-1870 fix-wave F3).
+
+        Args:
+            kept_briefing_ids: The `kept_briefings.id` values to count.
+
+        Returns:
+            A dict mapping every requested id to its kept-script count.
+            Ids with no kept scripts (or that do not exist) map to 0.
+        """
+        counts: Dict[int, int] = {kept_id: 0 for kept_id in kept_briefing_ids}
+        if not kept_briefing_ids:
+            return counts
+        placeholders = ",".join(["?"] * len(kept_briefing_ids))
+        cursor = self.execute_query(
+            f"SELECT kept_briefing_id, COUNT(*) AS cnt FROM kept_scripts "
+            f"WHERE kept_briefing_id IN ({placeholders}) "
+            f"GROUP BY kept_briefing_id",
+            tuple(kept_briefing_ids),
+        )
+        for row in cursor.fetchall():
+            counts[int(row["kept_briefing_id"])] = int(row["cnt"] or 0)
+        return counts
 
     def kept_script_source_ids(self, kept_briefing_id: int) -> set[int]:
         """Return the non-NULL source script ids kept under a briefing.

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -13211,6 +13211,32 @@ UPDATE db_schema_version
                 f"Failed to create kept script: {exc}"
             ) from exc
 
+    def get_kept_script_by_source(
+        self, source_script_id: int
+    ) -> Optional[Dict[str, Any]]:
+        """Return the kept script for a source script id, if any.
+
+        Mirrors `get_kept_briefing_by_source`. `source_script_id` is a
+        table-wide `UNIQUE` column (not scoped per `kept_briefing_id`), so a
+        non-NULL source script id identifies at most one kept row anywhere
+        in this database -- used by the chatbook importer (task-1870) to
+        classify a `ConflictError` on `create_kept_script` as either an
+        already-present-identical script or a genuine content conflict.
+
+        Args:
+            source_script_id: The originating Subscriptions_DB
+                `briefing_scripts.id`.
+
+        Returns:
+            The kept script row as a dict, or None if it was never kept.
+        """
+        cursor = self.execute_query(
+            "SELECT * FROM kept_scripts WHERE source_script_id = ?",
+            (source_script_id,),
+        )
+        row = cursor.fetchone()
+        return dict(row) if row is not None else None
+
     def list_kept_scripts(
         self, kept_briefing_id: int, *, limit: int = 200, offset: int = 0
     ) -> List[Dict[str, Any]]:

--- a/tldw_chatbook/UI/ChatbookCreationWindow.py
+++ b/tldw_chatbook/UI/ChatbookCreationWindow.py
@@ -242,9 +242,17 @@ class ChatbookCreationWindow(ModalScreen):
             # many will come along.
             kept_node = tree.root.add("📰 Kept Briefings", expand=False)
             kept_briefings = db.list_kept_briefings(limit=200)
+            # A grouped COUNT, not a per-briefing len(list_kept_scripts(...))
+            # -- the latter materialized every kept script's full
+            # turns_json/roster_snapshot_json (a complete cast transcript) on
+            # the UI thread purely to discard it and keep the length
+            # (task-1870 fix-wave F3).
+            kept_script_counts = db.kept_script_counts(
+                [kept["id"] for kept in kept_briefings]
+            )
 
             for kept in kept_briefings:
-                script_count = len(db.list_kept_scripts(kept["id"], limit=1000))
+                script_count = kept_script_counts.get(kept["id"], 0)
                 label = kept.get("watchlist_name") or f"Kept briefing {kept['id']}"
                 if script_count:
                     label += f" ({script_count} script{'s' if script_count != 1 else ''})"

--- a/tldw_chatbook/UI/ChatbookCreationWindow.py
+++ b/tldw_chatbook/UI/ChatbookCreationWindow.py
@@ -117,6 +117,7 @@ class ChatbookCreationWindow(ModalScreen):
             ContentType.CHARACTER: set(),
             ContentType.PROMPT: set(),
             ContentType.MEDIA: set(),
+            ContentType.KEPT_BRIEFING: set(),
         }
 
         chatbook_db_paths = get_chatbook_database_paths()
@@ -235,6 +236,24 @@ class ChatbookCreationWindow(ModalScreen):
                 )
                 node.allow_expand = False
 
+            # Add kept briefings node. Kept scripts are not independently
+            # selectable -- they ride along with their parent briefing (see
+            # ContentType.KEPT_BRIEFING) -- so the subtitle just reports how
+            # many will come along.
+            kept_node = tree.root.add("📰 Kept Briefings", expand=False)
+            kept_briefings = db.list_kept_briefings(limit=200)
+
+            for kept in kept_briefings:
+                script_count = len(db.list_kept_scripts(kept["id"], limit=1000))
+                label = kept.get("watchlist_name") or f"Kept briefing {kept['id']}"
+                if script_count:
+                    label += f" ({script_count} script{'s' if script_count != 1 else ''})"
+                node = kept_node.add(
+                    label,
+                    data={"type": ContentType.KEPT_BRIEFING, "id": str(kept["id"])},
+                )
+                node.allow_expand = False
+
         # Load prompts
         if self.db_paths["prompts"].exists():
             db = PromptsDatabase(str(self.db_paths["prompts"]), "chatbook_ui")
@@ -283,6 +302,7 @@ class ChatbookCreationWindow(ModalScreen):
             + note_count
             + char_count
             + len(self.selected_content[ContentType.PROMPT])
+            + len(self.selected_content[ContentType.KEPT_BRIEFING])
         )
 
         self.query_one("#stat-conversations", Static).update(str(conv_count))

--- a/tldw_chatbook/UI/Widgets/SmartContentTree.py
+++ b/tldw_chatbook/UI/Widgets/SmartContentTree.py
@@ -135,6 +135,12 @@ class SmartContentTree(Container):
                 yield Checkbox(
                     "Prompts", True, id="filter-prompts", classes="category-checkbox"
                 )
+                yield Checkbox(
+                    "Kept Briefings",
+                    True,
+                    id="filter-kept-briefings",
+                    classes="category-checkbox",
+                )
 
             # Selection controls
             with Horizontal(classes="selection-controls"):
@@ -195,6 +201,9 @@ class SmartContentTree(Container):
                 ContentType.CHARACTER: root.add("👤 Characters", expand=True),
                 ContentType.MEDIA: root.add("🎬 Media", expand=False),
                 ContentType.PROMPT: root.add("💡 Prompts", expand=False),
+                ContentType.KEPT_BRIEFING: root.add(
+                    "📰 Kept Briefings", expand=False
+                ),
             }
 
             # Add content nodes
@@ -282,6 +291,7 @@ class SmartContentTree(Container):
             "filter-characters": ContentType.CHARACTER,
             "filter-media": ContentType.MEDIA,
             "filter-prompts": ContentType.PROMPT,
+            "filter-kept-briefings": ContentType.KEPT_BRIEFING,
         }
 
         content_type = type_map.get(checkbox_id)

--- a/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
@@ -185,7 +185,8 @@ class ContentSelectionStep(WizardStep):
         """Compose the content selection UI."""
         with Container(classes="selection-header"):
             yield Static(
-                "Select the conversations, notes, characters, media, and prompts to include in your chatbook."
+                "Select the conversations, notes, characters, media, prompts, and "
+                "kept briefings to include in your chatbook."
             )
 
         # Smart content tree
@@ -202,6 +203,7 @@ class ContentSelectionStep(WizardStep):
             ContentType.CHARACTER: [],
             ContentType.MEDIA: [],
             ContentType.PROMPT: [],
+            ContentType.KEPT_BRIEFING: [],
         }
 
         try:
@@ -291,6 +293,36 @@ class ContentSelectionStep(WizardStep):
                                 subtitle=description[:50] + "..."
                                 if description and len(description) > 50
                                 else description,
+                            )
+                        )
+
+                    # Kept briefings (task-1870). Kept scripts are not
+                    # independently selectable -- they ride along nested
+                    # inside their parent briefing's export payload -- so
+                    # the subtitle just reports how many come along.
+                    kept_briefings = main_db.list_kept_briefings(limit=200)
+                    logger.debug(
+                        f"Found {len(kept_briefings) if kept_briefings else 0} kept briefings"
+                    )
+
+                    for kept in kept_briefings:
+                        kept_id = kept.get("id")
+                        script_count = len(
+                            main_db.list_kept_scripts(kept_id, limit=1000)
+                        )
+                        title = kept.get("watchlist_name") or (
+                            f"Kept briefing {kept_id}"
+                        )
+
+                        content_data[ContentType.KEPT_BRIEFING].append(
+                            ContentNodeData(
+                                type=ContentType.KEPT_BRIEFING,
+                                id=str(kept_id),
+                                title=title,
+                                subtitle=f"{script_count} script"
+                                f"{'s' if script_count != 1 else ''}"
+                                if script_count
+                                else "no scripts",
                             )
                         )
 

--- a/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookCreationWizard.py
@@ -304,12 +304,18 @@ class ContentSelectionStep(WizardStep):
                     logger.debug(
                         f"Found {len(kept_briefings) if kept_briefings else 0} kept briefings"
                     )
+                    # A grouped COUNT, not a per-briefing
+                    # len(list_kept_scripts(...)) -- the latter materialized
+                    # every kept script's full turns_json/roster_snapshot_json
+                    # (a complete cast transcript) on the UI thread purely to
+                    # discard it and keep the length (task-1870 fix-wave F3).
+                    kept_script_counts = main_db.kept_script_counts(
+                        [kept.get("id") for kept in kept_briefings]
+                    )
 
                     for kept in kept_briefings:
                         kept_id = kept.get("id")
-                        script_count = len(
-                            main_db.list_kept_scripts(kept_id, limit=1000)
-                        )
+                        script_count = kept_script_counts.get(kept_id, 0)
                         title = kept.get("watchlist_name") or (
                             f"Kept briefing {kept_id}"
                         )

--- a/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
@@ -290,6 +290,28 @@ class PreviewValidationStep(WizardStep):
                 f"📰 Kept Briefings ({type_counts[ContentType.KEPT_BRIEFING]})"
             )
 
+    @staticmethod
+    def _expected_content_total(manifest: ChatbookManifest) -> int:
+        """Sum of the manifest's per-type statistics.
+
+        Compared against `len(manifest.content_items)` in `_run_validation`
+        to flag a stats/content-items mismatch. Every content type the
+        manifest tracks a total for must be included here -- a chatbook
+        containing only kept briefings (task-1870's own happy path) used
+        to sum to 0 while `content_items` held 1, producing a false
+        "Statistics mismatch" warning (task-1870 fix-wave F2). Pulled out
+        as its own method so this arithmetic can be tested without
+        mounting the wizard step.
+        """
+        return (
+            manifest.total_conversations
+            + manifest.total_notes
+            + manifest.total_characters
+            + manifest.total_media_items
+            + manifest.total_prompts
+            + manifest.total_kept_briefings
+        )
+
     def _run_validation(self) -> None:
         """Run validation checks."""
         validation_list = self.query_one("#validation-list", Container)
@@ -323,12 +345,7 @@ class PreviewValidationStep(WizardStep):
             warnings.append("⚠️ No content items found in chatbook")
 
         # Check statistics match
-        expected_total = (
-            self.manifest.total_conversations
-            + self.manifest.total_notes
-            + self.manifest.total_characters
-            + self.manifest.total_media_items
-        )
+        expected_total = self._expected_content_total(self.manifest)
         actual_total = len(self.manifest.content_items)
 
         if expected_total == actual_total:

--- a/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
@@ -285,6 +285,11 @@ class PreviewValidationStep(WizardStep):
         if type_counts.get(ContentType.PROMPT):
             root.add(f"💡 Prompts ({type_counts[ContentType.PROMPT]})")
 
+        if type_counts.get(ContentType.KEPT_BRIEFING):
+            root.add(
+                f"📰 Kept Briefings ({type_counts[ContentType.KEPT_BRIEFING]})"
+            )
+
     def _run_validation(self) -> None:
         """Run validation checks."""
         validation_list = self.query_one("#validation-list", Container)


### PR DESCRIPTION
## Why

Task-1780's kept briefings/scripts were invisible to both systems users rely on for taking data with them: chatbook export had no awareness of the tables, and sync exclusion — a deliberate v1 ruling — was recorded only in the design spec's schema section. Task-1870's mandate: make the gap stop being silent, on both sides.

## What

- **Chatbook export (AC #1, implemented):** new `ContentType.KEPT_BRIEFING`; the creator walks selected kept briefings with each briefing's scripts nested in its payload (children, not independently selectable) plus a human-readable companion markdown file per briefing; real checkboxes in both creation surfaces; server-mode export refuses cleanly via the existing positive allowlist.
- **Chatbook import:** import-when-free on the UNIQUE `source_briefing_id` — byte-identical incoming rows skip silently (the re-keep ethos), differing content on the same source id is a named conflict where the whole incoming item (parent **and** scripts) is refused untouched, re-import is idempotent, and NULL-source scripts dedup by content multiset. The house conflict-resolver machinery was deliberately not extended: its rename/ask semantics fit display-name-keyed entities, not id-keyed idempotent artifacts (rationale in the report). Bundles predating the type import clean.
- **Sync (AC #2, recorded exclusion):** extends the owner's task-1780 "no sync columns" ruling; the dated decision block is appended to the design spec and reflected in the chatbooks guide (AC #3).
- **Whole-branch review fix wave (1 High + 4):** the conflict branch was grafting the incoming bundle's scripts onto the unrelated local briefing while the summary claimed "not modified" — probe-proven, now refused as a unit; the import wizard's stats check omitted `total_kept_briefings` (and `total_prompts`, a pre-existing live false-mismatch verified against the creator's `content_items` walk); per-briefing script counts now come from one grouped-COUNT seam instead of materializing transcripts on the UI thread; `kept_at` round-trips faithfully via an optional CRUD param (no schema change) instead of being silently re-stamped; a mid-scripts failure no longer falsifies the briefing counter.

## Testing

Round-trip into a fresh ChaChaNotes (all provenance columns, tz-faithful datetimes, `kept_at` seeded >1s in the past so equality cannot false-pass), re-import idempotency, conflict-refuses-parent-and-scripts, scripts-follow-parent, backward-compat bundle import, kept-only wizard validation. **324 passed, 1 pre-existing skip** at re-review; mutations REDded per fix (the F1 mutation reproduced the reviewer's exact probe output). Opus whole-branch review → fix wave → scoped re-review APPROVED with zero new defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds chatbook export/import for kept briefings with their scripts via `ContentType.KEPT_BRIEFING`, so kept content is portable and round-trips cleanly. Records that `kept_briefings`/`kept_scripts` remain excluded from `ChaChaNotes` sync per task-1870.

- **New Features**
  - Export kept briefings as JSON plus Markdown; scripts travel nested inside the briefing.
  - Selection UI adds a “Kept Briefings” category with checkboxes.
  - Import is idempotent on `source_briefing_id`: identical rows skip; conflicting content refuses the briefing and its scripts; NULL-source scripts dedup by content.
  - Manifest, guide, and spec updated; backward compat when `total_kept_briefings` is missing.

- **Bug Fixes**
  - Export pages kept-script collection so large briefings don’t truncate scripts.
  - Honest stats and counters: wizard sums include kept briefings and prompts; creation UI uses grouped COUNT; per-briefing counters stay correct on partial failures.
  - `kept_at` preserves the originating device’s timestamp and is excluded from conflict matching; static, parameterized INSERTs set `kept_at` via `COALESCE(?, CURRENT_TIMESTAMP)`.

<sup>Written for commit c0a9eaf6d795d8bbe339e670133e4945a0cda7bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

