### PR TITLE
chore: mark task-1870 Done (PR #1205 merged)

### DIFF
--- a/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
+++ b/backlog/tasks/task-1870 - Kept-briefings-sync-chatbook-export-coverage.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1870
 title: 'Kept briefings: sync/chatbook-export coverage'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-02 00:16'
 updated_date: '2026-08-02 13:34'


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark `TASK-1870` (“Kept briefings: sync/chatbook-export coverage”) as Done in the backlog. Updated the task status from In Progress to Done.

<sup>Written for commit 9d5dbc88d176ec3d2f50d1b182417cf26633c3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

