### PR TITLE
test: cap the four offset-walk pagination loops (task-1761)

### DIFF
--- a/Tests/Subscriptions/test_briefing_audio_db.py
+++ b/Tests/Subscriptions/test_briefing_audio_db.py
@@ -209,10 +209,11 @@ def test_list_briefing_audio_offset_pages_through_every_row_without_gaps_or_repe
 
     limit = 3
     seen: list[int] = []
-    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
-    # an offset-ignoring regression fails fast instead of spinning to the
-    # global timeout (task-1761).
-    max_pages = 10
+    # Pages of seeded data + the empty terminator, derived from the data so
+    # the cap can never lag a future reseeding; exceeding it means offset is
+    # genuinely not advancing, and the walk fails fast instead of spinning
+    # to the global timeout (task-1761).
+    max_pages = len(expected_newest_first) // limit + 2
     for page_number in range(max_pages):
         page = db.list_briefing_audio(
             script_id, limit=limit, offset=page_number * limit

--- a/Tests/Subscriptions/test_briefing_audio_db.py
+++ b/Tests/Subscriptions/test_briefing_audio_db.py
@@ -209,12 +209,21 @@ def test_list_briefing_audio_offset_pages_through_every_row_without_gaps_or_repe
 
     limit = 3
     seen: list[int] = []
-    offset = 0
-    while True:
-        page = db.list_briefing_audio(script_id, limit=limit, offset=offset)
+    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
+    # an offset-ignoring regression fails fast instead of spinning to the
+    # global timeout (task-1761).
+    max_pages = 10
+    for page_number in range(max_pages):
+        page = db.list_briefing_audio(
+            script_id, limit=limit, offset=page_number * limit
+        )
         if not page:
             break
         seen.extend(row["id"] for row in page)
-        offset += limit
+    else:
+        pytest.fail(
+            "list_briefing_audio never returned an empty page within "
+            f"{max_pages} pages -- offset is likely being ignored"
+        )
 
     assert seen == expected_newest_first

--- a/Tests/Subscriptions/test_briefing_feed_query.py
+++ b/Tests/Subscriptions/test_briefing_feed_query.py
@@ -258,10 +258,11 @@ def test_offset_pages_through_every_row_without_gaps_or_repeats():
 
     limit = 3
     seen: list[int] = []
-    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
-    # an offset-ignoring regression fails fast instead of spinning to the
-    # global timeout (task-1761).
-    max_pages = 10
+    # Pages of seeded data + the empty terminator, derived from the data so
+    # the cap can never lag a future reseeding; exceeding it means offset is
+    # genuinely not advancing, and the walk fails fast instead of spinning
+    # to the global timeout (task-1761).
+    max_pages = len(expected_newest_first) // limit + 2
     for page_number in range(max_pages):
         page = db.list_watchlist_audio_episodes(
             watchlist_id, limit=limit, offset=page_number * limit

--- a/Tests/Subscriptions/test_briefing_feed_query.py
+++ b/Tests/Subscriptions/test_briefing_feed_query.py
@@ -258,13 +258,22 @@ def test_offset_pages_through_every_row_without_gaps_or_repeats():
 
     limit = 3
     seen: list[int] = []
-    offset = 0
-    while True:
-        page = db.list_watchlist_audio_episodes(watchlist_id, limit=limit, offset=offset)
+    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
+    # an offset-ignoring regression fails fast instead of spinning to the
+    # global timeout (task-1761).
+    max_pages = 10
+    for page_number in range(max_pages):
+        page = db.list_watchlist_audio_episodes(
+            watchlist_id, limit=limit, offset=page_number * limit
+        )
         if not page:
             break
         seen.extend(row["audio_id"] for row in page)
-        offset += limit
+    else:
+        pytest.fail(
+            "list_watchlist_audio_episodes never returned an empty page within "
+            f"{max_pages} pages -- offset is likely being ignored"
+        )
 
     assert seen == expected_newest_first
 

--- a/Tests/Subscriptions/test_briefing_presets_db.py
+++ b/Tests/Subscriptions/test_briefing_presets_db.py
@@ -129,13 +129,20 @@ def test_list_briefing_presets_offset_pages_through_every_row_without_gaps_or_re
 
     limit = 3
     seen: list[str] = []
-    offset = 0
-    while True:
-        page = db.list_briefing_presets(limit=limit, offset=offset)
+    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
+    # an offset-ignoring regression fails fast instead of spinning to the
+    # global timeout (task-1761).
+    max_pages = 10
+    for page_number in range(max_pages):
+        page = db.list_briefing_presets(limit=limit, offset=page_number * limit)
         if not page:
             break
         seen.extend(row["name"] for row in page)
-        offset += limit
+    else:
+        pytest.fail(
+            "list_briefing_presets never returned an empty page within "
+            f"{max_pages} pages -- offset is likely being ignored"
+        )
 
     assert seen == names
 
@@ -307,13 +314,22 @@ def test_list_briefing_scripts_offset_pages_through_every_row_without_gaps_or_re
 
     limit = 3
     seen: list[int] = []
-    offset = 0
-    while True:
-        page = db.list_briefing_scripts(briefing_id, limit=limit, offset=offset)
+    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
+    # an offset-ignoring regression fails fast instead of spinning to the
+    # global timeout (task-1761).
+    max_pages = 10
+    for page_number in range(max_pages):
+        page = db.list_briefing_scripts(
+            briefing_id, limit=limit, offset=page_number * limit
+        )
         if not page:
             break
         seen.extend(row["id"] for row in page)
-        offset += limit
+    else:
+        pytest.fail(
+            "list_briefing_scripts never returned an empty page within "
+            f"{max_pages} pages -- offset is likely being ignored"
+        )
 
     assert seen == expected_newest_first
 

--- a/Tests/Subscriptions/test_briefing_presets_db.py
+++ b/Tests/Subscriptions/test_briefing_presets_db.py
@@ -129,10 +129,11 @@ def test_list_briefing_presets_offset_pages_through_every_row_without_gaps_or_re
 
     limit = 3
     seen: list[str] = []
-    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
-    # an offset-ignoring regression fails fast instead of spinning to the
-    # global timeout (task-1761).
-    max_pages = 10
+    # Pages of seeded data + the empty terminator, derived from the data so
+    # the cap can never lag a future reseeding; exceeding it means offset is
+    # genuinely not advancing, and the walk fails fast instead of spinning
+    # to the global timeout (task-1761).
+    max_pages = len(names) // limit + 2
     for page_number in range(max_pages):
         page = db.list_briefing_presets(limit=limit, offset=page_number * limit)
         if not page:
@@ -314,10 +315,11 @@ def test_list_briefing_scripts_offset_pages_through_every_row_without_gaps_or_re
 
     limit = 3
     seen: list[int] = []
-    # 7 rows / limit 3 -> 3 pages + the empty terminator; cap far above so
-    # an offset-ignoring regression fails fast instead of spinning to the
-    # global timeout (task-1761).
-    max_pages = 10
+    # Pages of seeded data + the empty terminator, derived from the data so
+    # the cap can never lag a future reseeding; exceeding it means offset is
+    # genuinely not advancing, and the walk fails fast instead of spinning
+    # to the global timeout (task-1761).
+    max_pages = len(expected_newest_first) // limit + 2
     for page_number in range(max_pages):
         page = db.list_briefing_scripts(
             briefing_id, limit=limit, offset=page_number * limit

--- a/backlog/tasks/task-1761 - Cap-the-unbounded-offset-walk-loops-in-pagination-tests.md
+++ b/backlog/tasks/task-1761 - Cap-the-unbounded-offset-walk-loops-in-pagination-tests.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1761
 title: 'Cap the unbounded offset-walk loops in pagination tests'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-01 20:05'
 labels:
@@ -51,8 +51,21 @@ regresses.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each of the four `while True` offset-walk loops has a local iteration cap
-- [ ] #2 Exceeding the cap fails the test immediately with a clear, specific message (naming which
+- [x] #1 Each of the four `while True` offset-walk loops has a local iteration cap
+- [x] #2 Exceeding the cap fails the test immediately with a clear, specific message (naming which
       query/test hit it) rather than spinning to pytest's global timeout
-- [ ] #3 All four tests still pass unchanged under normal (non-regressed) behavior
+- [x] #3 All four tests still pass unchanged under normal (non-regressed) behavior
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+All four `while True` walks replaced with a bounded `for page_number in range(max_pages)` +
+`for/else` -> `pytest.fail` naming the query ("<query> never returned an empty page within N
+pages -- offset is likely being ignored"). max_pages=10 against 3 real pages, commented at each
+site with a task-1761 pointer. Verified by mutation: forcing `offset=0` in one walk fails in
+0.29s with the named message (vs. spinning to the 300s global timeout before); restored, all 48
+tests in the three files green. Scanned Tests/Subscriptions/ for new siblings of the shape --
+none beyond the four named (the pagination tests added by tasks 1812/1890/1870 are all bounded
+by construction). Done inline by the controller; no production code touched.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Why

Four briefings pagination tests walked offset pages with an uncapped `while True` whose only exit is an empty page. If a query regressed to ignoring `offset`, the same non-empty page would return forever and the test would spin to pytest's 300-second global timeout instead of failing fast with a message pointing at the bug (task-1761, filed at the phase-3 close-out).

## What

Each walk is now a bounded `for page_number in range(max_pages)` with a `for/else` that `pytest.fail`s naming the query: "`<query>` never returned an empty page within 10 pages — offset is likely being ignored". Cap is 10 pages against 3 real ones, commented at each site. Test-only; no production code touched. Scanned `Tests/Subscriptions/` for new siblings of the shape — none beyond the four named (later pagination tests from tasks 1812/1890/1870 are bounded by construction).

## Testing

All 48 tests in the three files green. Mutation-verified: forcing `offset=0` in one walk fails in **0.29s** with the named message (previously that same regression spun to the 300s timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capped the four offset-walk loops in briefing pagination tests to fail fast if `offset` is ignored, replacing `while True` with bounded `for/else` and a named `pytest.fail`.
The cap is now derived from seeded data (pages of seeded rows + the empty terminator) instead of a fixed 10 pages, keeping tests in sync with reseeds; test-only change with normal behavior unchanged. Addresses Linear task-1761.

<sup>Written for commit b59ba95c7446513be4227ffca872d6ddb6668fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

