### PR TITLE
chore: mark task-1761 Done (PR #1207 merged)

### DIFF
--- a/backlog/tasks/task-1761 - Cap-the-unbounded-offset-walk-loops-in-pagination-tests.md
+++ b/backlog/tasks/task-1761 - Cap-the-unbounded-offset-walk-loops-in-pagination-tests.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1761
 title: 'Cap the unbounded offset-walk loops in pagination tests'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-01 20:05'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked TASK-1761 “Cap the unbounded offset-walk loops in pagination tests” as Done, reflecting that the fix shipped in PR #1207. Backlog-only change; no product code modified.

<sup>Written for commit f6572cda9e75837dc9068d503271a6571d78bd47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

