### PR TITLE
docs(evals): character probe phases 3a, 3b, and 4 implementation plans

### DIFF
--- a/Docs/superpowers/plans/2026-08-02-character-probe-phase3a-tag-vocabulary.md
+++ b/Docs/superpowers/plans/2026-08-02-character-probe-phase3a-tag-vocabulary.md
@@ -1,0 +1,1101 @@
+# Character Probe Evals — Phase 3a (Tag Vocabulary) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the character-probe eval a real tag vocabulary — built-in defaults, kinds that stop the summary implying "fewer tags is better", per-bench extension that cannot omit a kind — and make deleting a bench take its annotations with it.
+
+**Architecture:** Engine-only, no UI. A new `character_probe/tags.py` owns the vocabulary; `CharacterProbeConfig.extra_tags` stops being an untyped `tuple[dict, ...]` placeholder and becomes validated `Tag` objects; `annotate_turn` validates against **the vocabulary the run captured**, not today's. Phase 3b consumes all of it.
+
+**Tech Stack:** Python ≥3.11, pytest. No Textual in this phase.
+
+## Global Constraints
+
+Copied from `Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md` and phases 1-2's established conventions. Every task's requirements implicitly include this section.
+
+- **Every tag carries a kind** — `failure`, `notable`, or `positive` — "so the summary cannot imply 'fewer tags is better'".
+- **Creating a tag requires choosing its kind; there is no default.** The spec is explicit that `notable` is *not* a safe fallback: "it would make genuine failures invisible in exactly the view meant to surface them." A missing kind is an error, never a guess.
+- **Tags are stored as canonical slugs.** The UI offering existing tags before new ones is Phase 3b's job; this phase makes the canonical form unambiguous so that offer is possible.
+- **Annotations attach to a specific run's answers.** "A re-run produces new answers to annotate rather than silently inheriting old judgments. Deleting a run group cascades both, since they describe those answers and mean nothing without them."
+- **No logprobs / top-K / normalizer / canary vocabulary** anywhere in character-probe code. That vocabulary judges distributions; this eval reads generated text.
+- **No composite score, anywhere.** "No view anywhere sums tags into a number." This phase must not add a helper that would make one easy.
+- **Fail loudly, never silently default** — a corrupt row or missing record raises a named error identifying it; a write affecting no rows raises rather than reporting success.
+- **`character_ids` are ints** (`character_cards.id`); every eval id is a str. Do not normalise them.
+- **Back-compatibility is required.** `extra_tags` already round-trips as raw dicts through `save_character_bench` (storage.py:279) and `load_character_bench` (storage.py:480), and is already embedded in every existing run snapshot (storage.py:556). A bench or snapshot written before this phase must still load.
+- Google-style docstrings (Args/Returns/Raises) on public callables; parameterized SQL only.
+- Run tests foreground: `/private/tmp/tldw-venv/bin/python -m pytest <paths> -p no:randomly` from the clone root. Never `-q`. **Pass `timeout: 600000` on the Bash call** — the harness auto-backgrounds anything past 120s and a backgrounded pytest has stalled this workflow.
+
+## What already exists (verified against the merged code — do not rebuild it)
+
+- `eval_probe_turn_annotations` and `eval_probe_review_state` tables (`DB/Evals_DB.py:316,333`), with `tags` as a JSON list of slugs.
+- `EvalsDB.upsert_probe_turn_annotation` / `list_probe_turn_annotations` / `upsert_probe_review_state` / `list_probe_review_state` (`Evals_DB.py:1816-1935`).
+- `character_probe/storage.py`: `annotate_turn` (:921), `load_turn_annotations` (:964), `mark_conversation_reviewed` (:990), `load_review_state` (:1028).
+- `CharacterProbeConfig.extra_tags: tuple[dict, ...] = ()` (`models.py:119`) — an untyped placeholder with **no validation and no built-in defaults anywhere in the repo**.
+- `_probe_run_snapshot` already writes `"extra_tags": list(config.extra_tags)` (`storage.py:556`), and `load_probe_run_snapshot` (:644) reads the snapshot back. **This is the seam Task 4 uses** — it means a run's vocabulary is already captured, matching the spec's snapshot-provenance rule.
+
+## File Structure
+
+- `tldw_chatbook/Evals/character_probe/tags.py` (new) — the `Tag` model, `TAG_KINDS`, `BUILTIN_TAGS`, `canonical_slug`, `resolve_vocabulary`, `tag_by_slug`. Its own file because Phase 3b's UI, Phase 4's summary, and `storage.py` all import it, and it must pull no DB and no UI.
+- `tldw_chatbook/Evals/character_probe/models.py` — `extra_tags` becomes `tuple[Tag, ...]`, validated at construction.
+- `tldw_chatbook/Evals/character_probe/storage.py` — serialise/deserialise `Tag`; add `run_group_vocabulary`; validate in `annotate_turn`; cascade on delete.
+- `tldw_chatbook/DB/Evals_DB.py` — the cascade delete.
+- Tests mirror each under `Tests/Evals/character_probe/`.
+
+---
+
+### Task 1: The tag model and the built-in vocabulary
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/tags.py`
+- Test: `Tests/Evals/character_probe/test_tags.py`
+
+**Interfaces:**
+- Consumes: nothing (stdlib only — this module must stay importable without a DB).
+- Produces: `TAG_KINDS: tuple[str, str, str]`; `Tag(slug: str, label: str, kind: str)` frozen dataclass validating both fields at construction; `BUILTIN_TAGS: tuple[Tag, ...]` — exactly the ten tags below.
+
+The ten built-ins are an owner decision recorded in the spec's Tags section. Copy the slugs, labels, and kinds **verbatim** — a reviewer's muscle memory and Phase 4's grouping both depend on them being stable.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.tags import (
+    BUILTIN_TAGS,
+    TAG_KINDS,
+    Tag,
+)
+
+
+def test_the_three_kinds_are_exactly_the_specs_three():
+    assert TAG_KINDS == ("failure", "notable", "positive")
+
+
+def test_the_builtin_vocabulary_is_the_ten_the_spec_names():
+    assert {t.slug for t in BUILTIN_TAGS} == {
+        "broke-character",
+        "refused",
+        "leaked-prompt",
+        "generic-assistant-voice",
+        "contradicted-card",
+        "ignored-the-question",
+        "notable",
+        "surprising",
+        "in-character",
+        "handled-well",
+    }
+
+
+def test_each_builtin_carries_the_kind_the_spec_assigns_it():
+    by_slug = {t.slug: t.kind for t in BUILTIN_TAGS}
+    assert by_slug["broke-character"] == "failure"
+    assert by_slug["refused"] == "failure"
+    assert by_slug["leaked-prompt"] == "failure"
+    assert by_slug["generic-assistant-voice"] == "failure"
+    assert by_slug["contradicted-card"] == "failure"
+    assert by_slug["ignored-the-question"] == "failure"
+    assert by_slug["notable"] == "notable"
+    assert by_slug["surprising"] == "notable"
+    assert by_slug["in-character"] == "positive"
+    assert by_slug["handled-well"] == "positive"
+
+
+def test_builtin_slugs_are_unique():
+    slugs = [t.slug for t in BUILTIN_TAGS]
+    assert len(slugs) == len(set(slugs))
+
+
+def test_a_tag_without_a_valid_kind_is_rejected_naming_the_kind():
+    with pytest.raises(ValueError) as exc:
+        Tag(slug="whatever", label="Whatever", kind="bad")
+    assert "bad" in str(exc.value)
+    assert "failure" in str(exc.value)
+
+
+def test_a_tag_with_an_empty_kind_is_rejected_rather_than_defaulted():
+    """The spec: a guessed kind mis-groups observations; `notable` is not safe."""
+    with pytest.raises(ValueError):
+        Tag(slug="whatever", label="Whatever", kind="")
+
+
+def test_a_tag_with_a_non_canonical_slug_is_rejected_naming_the_slug():
+    with pytest.raises(ValueError) as exc:
+        Tag(slug="Broke Character", label="Broke character", kind="failure")
+    assert "Broke Character" in str(exc.value)
+
+
+def test_a_tag_with_an_empty_label_is_rejected():
+    with pytest.raises(ValueError):
+        Tag(slug="broke-character", label="", kind="failure")
+
+
+def test_a_tag_is_frozen():
+    tag = BUILTIN_TAGS[0]
+    with pytest.raises(Exception):
+        tag.slug = "mutated"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_tags.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Evals.character_probe.tags'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`tldw_chatbook/Evals/character_probe/tags.py`:
+
+```python
+"""The character-probe review vocabulary.
+
+Every tag carries a kind so no view can imply "fewer tags is better": a
+``positive`` tag and a ``failure`` tag are both observations, and the summary
+groups by kind rather than counting them together. Creating a tag therefore
+REQUIRES a kind -- the design spec rules out guessing one, and rules out
+``notable`` as a fallback specifically because it would hide genuine failures
+in the view meant to surface them.
+
+Stdlib only, deliberately: this module is imported by the engine, the review
+UI, and the summary, and must never drag a database or Textual behind it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+#: The only kinds a tag may carry. Order is display order, worst first.
+TAG_KINDS: tuple[str, str, str] = ("failure", "notable", "positive")
+
+#: A canonical slug: lowercase, digits, and single interior hyphens.
+_SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+@dataclass(frozen=True)
+class Tag:
+    """One review tag.
+
+    Args:
+        slug: The canonical stored form (see ``canonical_slug``).
+        label: What a reviewer reads. Never empty.
+        kind: One of ``TAG_KINDS``.
+
+    Raises:
+        ValueError: If the slug is not canonical, the label is blank, or the
+            kind is not one of ``TAG_KINDS`` -- naming the offending value.
+    """
+
+    slug: str
+    label: str
+    kind: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.slug, str) or not _SLUG_RE.match(self.slug):
+            raise ValueError(
+                f"Tag slug must be lowercase-hyphenated, got {self.slug!r}."
+            )
+        if not isinstance(self.label, str) or not self.label.strip():
+            raise ValueError(f"Tag {self.slug!r} needs a non-empty label.")
+        if self.kind not in TAG_KINDS:
+            raise ValueError(
+                f"Tag {self.slug!r} has kind {self.kind!r}; must be one of "
+                f"{', '.join(TAG_KINDS)}. A kind is never guessed -- the wrong "
+                f"one mis-groups the observation in the summary."
+            )
+
+
+#: The vocabulary every bench starts with (spec, Tags section). A bench
+#: extends this through ``CharacterProbeConfig.extra_tags``; it never
+#: replaces it.
+BUILTIN_TAGS: tuple[Tag, ...] = (
+    Tag("broke-character", "Broke character", "failure"),
+    Tag("refused", "Refused", "failure"),
+    Tag("leaked-prompt", "Leaked the card's prompt", "failure"),
+    Tag("generic-assistant-voice", "Generic assistant voice", "failure"),
+    Tag("contradicted-card", "Contradicted the card", "failure"),
+    Tag("ignored-the-question", "Ignored the question", "failure"),
+    Tag("notable", "Notable", "notable"),
+    Tag("surprising", "Surprising", "notable"),
+    Tag("in-character", "In character", "positive"),
+    Tag("handled-well", "Handled well", "positive"),
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_tags.py -p no:randomly`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/tags.py Tests/Evals/character_probe/test_tags.py
+git commit -m "feat(evals): the character-probe tag vocabulary and its kinds (task-1691 phase 3a)"
+```
+
+---
+
+### Task 2: Canonical slugs and per-bench extension
+
+**Files:**
+- Modify: `tldw_chatbook/Evals/character_probe/tags.py`
+- Test: `Tests/Evals/character_probe/test_tags.py`
+
+**Interfaces:**
+- Consumes: `Tag`, `BUILTIN_TAGS`, `TAG_KINDS` (Task 1).
+- Produces: `canonical_slug(text: str) -> str`; `resolve_vocabulary(extra_tags: Sequence[Mapping[str, Any]] | Sequence[Tag] = ()) -> tuple[Tag, ...]`; `tag_by_slug(vocabulary: Sequence[Tag], slug: str) -> Tag` raising `KeyError` naming the slug and listing the vocabulary.
+
+`canonical_slug` is what limits the `broke-character` / `OOC` / `out-of-character` fragmentation the spec warns about: the UI will offer existing tags first, but only a single canonical form makes "existing" a decidable question.
+
+An extra tag whose slug matches a built-in **overrides** it — that is how a bench relabels `notable` to something domain-specific without forking the kind system. An override may not change the kind of a built-in: that would make two benches' `failure` counts mean different things in the same summary.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tldw_chatbook.Evals.character_probe.tags import (
+    BUILTIN_TAGS,
+    Tag,
+    canonical_slug,
+    resolve_vocabulary,
+    tag_by_slug,
+)
+
+
+def test_canonical_slug_lowercases_and_hyphenates():
+    assert canonical_slug("Broke Character") == "broke-character"
+    assert canonical_slug("  Out Of Character  ") == "out-of-character"
+    assert canonical_slug("OOC") == "ooc"
+
+
+def test_canonical_slug_collapses_runs_and_strips_punctuation():
+    assert canonical_slug("broke   character!!") == "broke-character"
+    assert canonical_slug("re-broke  --  character") == "re-broke-character"
+
+
+def test_canonical_slug_rejects_text_with_no_usable_characters():
+    import pytest
+    with pytest.raises(ValueError):
+        canonical_slug("   !!!   ")
+
+
+def test_resolve_vocabulary_with_no_extras_is_exactly_the_builtins():
+    assert resolve_vocabulary(()) == BUILTIN_TAGS
+
+
+def test_resolve_vocabulary_appends_an_extra_tag():
+    vocab = resolve_vocabulary(
+        [{"slug": "meta-commentary", "label": "Meta commentary", "kind": "failure"}]
+    )
+    assert len(vocab) == len(BUILTIN_TAGS) + 1
+    assert vocab[-1] == Tag("meta-commentary", "Meta commentary", "failure")
+
+
+def test_an_extra_tag_may_relabel_a_builtin_in_place():
+    vocab = resolve_vocabulary(
+        [{"slug": "notable", "label": "Worth a second look", "kind": "notable"}]
+    )
+    assert len(vocab) == len(BUILTIN_TAGS)
+    assert tag_by_slug(vocab, "notable").label == "Worth a second look"
+
+
+def test_an_extra_tag_may_not_change_a_builtins_kind():
+    import pytest
+    with pytest.raises(ValueError) as exc:
+        resolve_vocabulary(
+            [{"slug": "refused", "label": "Refused", "kind": "positive"}]
+        )
+    assert "refused" in str(exc.value)
+
+
+def test_an_extra_tag_without_a_kind_is_rejected_naming_the_slug():
+    import pytest
+    with pytest.raises(ValueError) as exc:
+        resolve_vocabulary([{"slug": "meta-commentary", "label": "Meta"}])
+    assert "meta-commentary" in str(exc.value)
+
+
+def test_an_extra_tags_slug_is_canonicalised_rather_than_rejected():
+    """A bench author types a label; the stored slug is canonical."""
+    vocab = resolve_vocabulary(
+        [{"slug": "Meta Commentary", "label": "Meta commentary", "kind": "notable"}]
+    )
+    assert tag_by_slug(vocab, "meta-commentary").label == "Meta commentary"
+
+
+def test_an_extra_tag_missing_a_label_falls_back_to_its_slug():
+    vocab = resolve_vocabulary([{"slug": "meta-commentary", "kind": "notable"}])
+    assert tag_by_slug(vocab, "meta-commentary").label == "meta-commentary"
+
+
+def test_resolve_vocabulary_accepts_tag_objects_as_well_as_mappings():
+    vocab = resolve_vocabulary([Tag("meta-commentary", "Meta", "notable")])
+    assert tag_by_slug(vocab, "meta-commentary").kind == "notable"
+
+
+def test_two_extras_with_the_same_slug_keep_the_last():
+    vocab = resolve_vocabulary([
+        {"slug": "meta", "label": "First", "kind": "notable"},
+        {"slug": "meta", "label": "Second", "kind": "notable"},
+    ])
+    assert tag_by_slug(vocab, "meta").label == "Second"
+
+
+def test_tag_by_slug_raises_naming_the_slug_and_the_vocabulary():
+    import pytest
+    with pytest.raises(KeyError) as exc:
+        tag_by_slug(BUILTIN_TAGS, "no-such-tag")
+    assert "no-such-tag" in str(exc.value)
+    assert "broke-character" in str(exc.value)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_tags.py -p no:randomly`
+Expected: FAIL — `ImportError: cannot import name 'canonical_slug'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `tags.py`:
+
+```python
+_NON_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def canonical_slug(text: str) -> str:
+    """The single stored form of a tag name.
+
+    One canonical form is what makes "does this tag already exist?" a
+    decidable question, which is what limits the ``broke-character`` /
+    ``OOC`` / ``out-of-character`` fragmentation per-bench extension invites.
+
+    Args:
+        text: A human-typed tag name.
+
+    Returns:
+        str: Lowercase, with every run of non-alphanumerics collapsed to a
+        single hyphen and leading/trailing hyphens removed.
+
+    Raises:
+        ValueError: If nothing usable survives -- an empty slug would collide
+            with every other empty slug and silently merge unrelated tags.
+    """
+    slug = _NON_SLUG_RE.sub("-", str(text).strip().lower()).strip("-")
+    if not slug:
+        raise ValueError(f"{text!r} has no characters usable in a tag slug.")
+    return slug
+
+
+def _coerce_tag(raw: Any) -> Tag:
+    """One extra-tag entry as a validated ``Tag``.
+
+    Args:
+        raw: A ``Tag``, or a mapping with ``slug`` and ``kind`` and an
+            optional ``label``.
+
+    Returns:
+        Tag: The validated tag, its slug canonicalised.
+
+    Raises:
+        ValueError: If the entry is not a mapping, has no slug, or omits the
+            kind -- naming the slug, since a guessed kind mis-groups the
+            observation in the summary.
+    """
+    if isinstance(raw, Tag):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"An extra tag must be a mapping or Tag, got {raw!r}.")
+    raw_slug = raw.get("slug")
+    if not raw_slug:
+        raise ValueError(f"An extra tag needs a slug: {dict(raw)!r}.")
+    slug = canonical_slug(str(raw_slug))
+    kind = raw.get("kind")
+    if not kind:
+        raise ValueError(
+            f"Extra tag {slug!r} has no kind. Every tag states one of "
+            f"{', '.join(TAG_KINDS)} -- it is never guessed."
+        )
+    label = str(raw.get("label") or slug)
+    return Tag(slug=slug, label=label, kind=str(kind))
+
+
+def resolve_vocabulary(extra_tags: Sequence[Any] = ()) -> tuple[Tag, ...]:
+    """The full tag vocabulary for one bench: built-ins plus its extras.
+
+    An extra whose slug matches a built-in relabels it in place rather than
+    appending a duplicate. It may NOT change a built-in's kind: two benches
+    whose ``failure`` sets mean different things cannot be read in one
+    summary.
+
+    Args:
+        extra_tags: The bench's ``extra_tags``, as ``Tag`` objects or as the
+            raw mappings older rows and run snapshots store.
+
+    Returns:
+        tuple[Tag, ...]: Built-ins in their declared order, with overrides
+        applied in place, then each new extra in the order supplied.
+
+    Raises:
+        ValueError: If an extra is malformed, omits its kind, or tries to
+            change a built-in's kind -- naming the slug in every case.
+    """
+    builtin_kinds = {tag.slug: tag.kind for tag in BUILTIN_TAGS}
+    resolved: dict[str, Tag] = {tag.slug: tag for tag in BUILTIN_TAGS}
+    for raw in extra_tags or ():
+        tag = _coerce_tag(raw)
+        builtin_kind = builtin_kinds.get(tag.slug)
+        if builtin_kind is not None and tag.kind != builtin_kind:
+            raise ValueError(
+                f"Extra tag {tag.slug!r} would change the built-in kind "
+                f"{builtin_kind!r} to {tag.kind!r}. Built-in kinds are fixed "
+                f"so one summary can read every bench."
+            )
+        resolved[tag.slug] = tag
+    return tuple(resolved.values())
+
+
+def tag_by_slug(vocabulary: Sequence[Tag], slug: str) -> Tag:
+    """One tag from a vocabulary.
+
+    Args:
+        vocabulary: The bench's resolved vocabulary.
+        slug: The canonical slug to find.
+
+    Returns:
+        Tag: The matching tag.
+
+    Raises:
+        KeyError: If no tag matches -- naming the slug and the vocabulary, so
+            a stored annotation referencing a retired tag says which one.
+    """
+    for tag in vocabulary:
+        if tag.slug == slug:
+            return tag
+    known = ", ".join(t.slug for t in vocabulary)
+    raise KeyError(f"No tag {slug!r} in this bench's vocabulary ({known}).")
+```
+
+Add `from typing import Any, Mapping, Sequence` to the module's imports.
+
+Note that `resolved` is a dict keyed by slug and built from `BUILTIN_TAGS` first, so Python's insertion order gives built-ins-then-extras for free and an override lands in the built-in's original position — which is what `test_an_extra_tag_may_relabel_a_builtin_in_place` pins.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_tags.py -p no:randomly`
+Expected: PASS (22 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/tags.py Tests/Evals/character_probe/test_tags.py
+git commit -m "feat(evals): canonical tag slugs and per-bench vocabulary extension (task-1691 phase 3a)"
+```
+
+---
+
+### Task 3: `extra_tags` becomes validated, and keeps loading old rows
+
+**Files:**
+- Modify: `tldw_chatbook/Evals/character_probe/models.py`
+- Modify: `tldw_chatbook/Evals/character_probe/storage.py`
+- Test: `Tests/Evals/character_probe/test_bench_storage.py`
+
+**Interfaces:**
+- Consumes: `resolve_vocabulary`, `Tag` (Task 2).
+- Produces: `CharacterProbeConfig.extra_tags: tuple[Tag, ...]`, validated in `__post_init__` regardless of the `strict` flag; `storage._tags_to_json(tags)` / `storage._tags_from_json(raw)` used by both `save_character_bench` and `_probe_run_snapshot`.
+
+`extra_tags` currently accepts anything and stores it verbatim (`models.py:119`, `storage.py:279/480/556`). Validation belongs at construction so a malformed tag cannot reach the database at all.
+
+**`strict` does NOT gate this.** `strict=False` exists so a *draft* bench with no characters and no targets can be created and reloaded (Phase 2, task 5). A malformed tag is not a draft state — it is corrupt data, and the spec's "fail loudly" rule applies to it in every mode.
+
+**Back-compat matters here.** Existing `eval_tasks` rows and every existing run snapshot hold `extra_tags` as raw dicts. `_tags_from_json` must accept those. A row whose tags are corrupt raises naming the bench, per fail-loudly — it does not silently drop them.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.models import CharacterProbeConfig
+from tldw_chatbook.Evals.character_probe.storage import (
+    load_character_bench,
+    save_character_bench,
+)
+from tldw_chatbook.Evals.character_probe.tags import Tag
+
+
+def _config(**kwargs):
+    base = dict(
+        name="villain probes",
+        probe_set_id="ps-1",
+        character_ids=(1,),
+        target_ids=("t-1",),
+    )
+    base.update(kwargs)
+    return CharacterProbeConfig(**base)
+
+
+def test_extra_tags_round_trip_as_tag_objects(db):
+    bench_id = save_character_bench(
+        db,
+        _config(extra_tags=(Tag("meta-commentary", "Meta commentary", "failure"),)),
+    )
+    loaded = load_character_bench(db, bench_id)
+    assert loaded.extra_tags == (Tag("meta-commentary", "Meta commentary", "failure"),)
+
+
+def test_extra_tags_supplied_as_mappings_are_validated_and_coerced(db):
+    bench_id = save_character_bench(
+        db,
+        _config(extra_tags=({"slug": "Meta Commentary", "kind": "notable"},)),
+    )
+    loaded = load_character_bench(db, bench_id)
+    assert loaded.extra_tags[0].slug == "meta-commentary"
+    assert loaded.extra_tags[0].kind == "notable"
+
+
+def test_an_extra_tag_without_a_kind_is_rejected_at_construction():
+    with pytest.raises(ValueError) as exc:
+        _config(extra_tags=({"slug": "meta-commentary"},))
+    assert "meta-commentary" in str(exc.value)
+
+
+def test_a_malformed_extra_tag_is_rejected_even_when_not_strict():
+    """strict=False is for DRAFT benches, not for corrupt tags."""
+    with pytest.raises(ValueError):
+        CharacterProbeConfig(
+            name="draft",
+            probe_set_id="ps-1",
+            character_ids=(),
+            target_ids=(),
+            extra_tags=({"slug": "meta", "kind": "not-a-kind"},),
+            strict=False,
+        )
+
+
+def test_a_bench_row_written_before_this_phase_still_loads(db):
+    """extra_tags shipped as raw dicts; existing rows must not break."""
+    bench_id = save_character_bench(db, _config())
+    row = db.get_task(bench_id)
+    config_data = dict(row["config_data"])
+    config_data["extra_tags"] = [
+        {"slug": "meta-commentary", "label": "Meta commentary", "kind": "failure"}
+    ]
+    db.update_task(bench_id, {"config_data": config_data})
+
+    loaded = load_character_bench(db, bench_id)
+    assert loaded.extra_tags == (Tag("meta-commentary", "Meta commentary", "failure"),)
+
+
+def test_a_bench_row_with_corrupt_tags_raises_naming_the_bench(db):
+    bench_id = save_character_bench(db, _config())
+    row = db.get_task(bench_id)
+    config_data = dict(row["config_data"])
+    config_data["extra_tags"] = ["not-a-mapping"]
+    db.update_task(bench_id, {"config_data": config_data})
+
+    with pytest.raises(ValueError) as exc:
+        load_character_bench(db, bench_id)
+    assert bench_id in str(exc.value)
+
+
+def test_a_bench_with_no_extra_tags_still_loads_as_empty(db):
+    bench_id = save_character_bench(db, _config())
+    assert load_character_bench(db, bench_id).extra_tags == ()
+```
+
+Use the file's existing fixtures and helpers rather than inventing new ones. Verified for you against the real file:
+
+- The database fixture is **`db`** (`test_bench_storage.py:14`), not `evals_db`.
+- There is already a **`config` fixture** (`:19`) returning a ready `CharacterProbeConfig`. Prefer it over the `_config()` helper sketched above, passing only the field under test.
+- **`_corrupt_config_field(db, task_id, key, raw_json_value)`** (`:172`) exists for exactly the "write a bad value into a stored row" job. Use it for the back-compat and corrupt-row tests instead of hand-rolling row mutation — `get_task`/`update_task` do exist (`Evals_DB.py:873,786`), but the helper is what this file's own tests use.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_bench_storage.py -k tag -p no:randomly`
+Expected: FAIL — `extra_tags` round-trips as plain dicts, so the `Tag` equality assertions fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+First, in `tags.py`, rename `_coerce_tag` to `coerce_tag` (Task 2 defined it module-private) and update its internal caller — importing an underscore name across modules is worse than exporting it.
+
+`CharacterProbeConfig` is `@dataclass(frozen=True)` (verified at `models.py:39`), so `__post_init__` cannot assign to a field directly; it must go through `object.__setattr__`, which is the same mechanism the existing `strict` handling already lives alongside.
+
+In `models.py`, widen the field's declared type so a caller may pass mappings:
+
+```python
+    extra_tags: tuple[Any, ...] = ()
+```
+
+and in `__post_init__`, after the existing `character_ids` type checks:
+
+```python
+        # Validate and canonicalise the bench's tag extensions. NOT gated on
+        # `strict`: that flag exists so a DRAFT bench with no characters and
+        # no targets can be created and reloaded (phase 2), and a malformed
+        # tag is corrupt data rather than a draft state.
+        from .tags import coerce_tag, resolve_vocabulary
+
+        coerced = tuple(coerce_tag(raw) for raw in self.extra_tags or ())
+        object.__setattr__(self, "extra_tags", coerced)
+        resolve_vocabulary(coerced)  # rejects a kind change to a built-in
+```
+
+The import is function-local because `tags.py` is stdlib-only and `models.py` is imported by it in neither direction today — keeping the import inside `__post_init__` avoids creating a module-level cycle if `tags.py` ever needs a model. If you confirm no cycle exists, a module-level import is cleaner; say which you chose and why in your report.
+
+In `storage.py`, replace the three raw round-trip sites with a pair of helpers:
+
+```python
+def _tags_to_json(tags: Sequence[Any]) -> list[dict[str, str]]:
+    """The stored form of a bench's extra tags.
+
+    Args:
+        tags: Validated ``Tag`` objects.
+
+    Returns:
+        list[dict[str, str]]: One JSON-safe mapping per tag.
+    """
+    return [{"slug": t.slug, "label": t.label, "kind": t.kind} for t in tags]
+
+
+def _tags_from_json(raw: Any, owner_id: str) -> tuple[Tag, ...]:
+    """Extra tags read back from a stored row or run snapshot.
+
+    Accepts the raw mappings written before the vocabulary existed, so rows
+    predating this phase still load.
+
+    Args:
+        raw: The stored ``extra_tags`` value, or None.
+        owner_id: The bench or run-group id, named in any error.
+
+    Returns:
+        tuple[Tag, ...]: Validated tags, empty when none were stored.
+
+    Raises:
+        ValueError: If a stored entry is malformed -- naming ``owner_id``, so
+            a corrupt row identifies itself rather than failing anonymously.
+    """
+    try:
+        return tuple(coerce_tag(entry) for entry in raw or ())
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"{owner_id} has a corrupt extra_tags entry: {exc}") from exc
+```
+
+Use `_tags_to_json` at storage.py:279 and :556, and `_tags_from_json` at :480 — pass the bench id at :480 and the run-group id wherever the snapshot is read.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe -p no:randomly`
+Expected: PASS — the new tag tests plus every existing character_probe test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/models.py tldw_chatbook/Evals/character_probe/storage.py tldw_chatbook/Evals/character_probe/tags.py Tests/Evals/character_probe/test_bench_storage.py
+git commit -m "feat(evals): validate a bench's extra tags at construction (task-1691 phase 3a)"
+```
+
+---
+
+### Task 4: The vocabulary a run captured
+
+**Files:**
+- Modify: `tldw_chatbook/Evals/character_probe/storage.py`
+- Test: `Tests/Evals/character_probe/test_conversation_storage.py`
+
+**Interfaces:**
+- Consumes: `resolve_vocabulary` (Task 2), `_tags_from_json` (Task 3), `load_probe_run_snapshot` (storage.py:644, already shipped).
+- Produces: `run_group_vocabulary(db: EvalsDB, run_group_id: str) -> tuple[Tag, ...]`.
+
+A reviewer annotates a run's answers, so the vocabulary that applies is **the one the run captured**, not the bench's current one. `_probe_run_snapshot` already writes `extra_tags` into the snapshot (storage.py:556) — this task reads it back. The spec's snapshot-provenance rule ("a card edited or deleted after the run does not change what the run shows") applies to tags for the same reason: a tag removed from the bench today must not orphan an annotation recorded last week.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.storage import run_group_vocabulary
+from tldw_chatbook.Evals.character_probe.tags import BUILTIN_TAGS, Tag
+
+
+def test_a_run_with_no_extra_tags_has_exactly_the_builtins(db, probe_run_group):
+    assert run_group_vocabulary(db, probe_run_group) == BUILTIN_TAGS
+
+
+def test_a_runs_vocabulary_includes_the_benchs_extras_as_of_the_run(
+    db, probe_run_group_with_extra_tags
+):
+    vocab = run_group_vocabulary(db, probe_run_group_with_extra_tags)
+    assert Tag("meta-commentary", "Meta commentary", "failure") in vocab
+
+
+def test_editing_the_bench_after_the_run_does_not_change_the_runs_vocabulary(
+    db, probe_run_group_with_extra_tags, bench_id_of_that_run
+):
+    """Snapshot provenance: the run is annotated with what it captured."""
+    from tldw_chatbook.Evals.character_probe.storage import (
+        load_character_bench,
+        save_character_bench,
+    )
+    config = load_character_bench(db, bench_id_of_that_run)
+    save_character_bench(
+        db,
+        type(config)(
+            name=config.name,
+            probe_set_id=config.probe_set_id,
+            character_ids=config.character_ids,
+            target_ids=config.target_ids,
+            extra_tags=(),
+        ),
+        bench_id_of_that_run,
+    )
+    vocab = run_group_vocabulary(db, probe_run_group_with_extra_tags)
+    assert any(t.slug == "meta-commentary" for t in vocab)
+
+
+def test_an_unknown_run_group_raises_naming_it(db):
+    with pytest.raises(Exception) as exc:
+        run_group_vocabulary(db, "no-such-group")
+    assert "no-such-group" in str(exc.value)
+```
+
+Build `probe_run_group`, `probe_run_group_with_extra_tags`, and `bench_id_of_that_run` on what `Tests/Evals/character_probe/test_conversation_storage.py` already has — verified for you: the `db` fixture (`:26`), the `bench` fixture (`:174`), and the helpers `_seed_run(db)` (`:44`), `_conversation(...)` (`:31`), `_bench_config(**overrides)` (`:146`), `_cards()` (`:161`), and `_target_row(db, name, config)` (`:179`). Extend those rather than writing a second set of run-group construction.
+
+`save_character_bench(db, config, task_id=None)` is the real signature (`storage.py:225`) — a new bench creates a row, passing a `task_id` updates in place — so the positional form in the test above is correct.
+
+Note `_target_row`'s default name is `"steered"`: read what it actually writes into `config` before reusing it, and follow this slice's standing rule that a target row in a test is built the way the real "+ New target" form writes one, never as a hand-built dict.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_conversation_storage.py -k vocabulary -p no:randomly`
+Expected: FAIL — `ImportError: cannot import name 'run_group_vocabulary'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def run_group_vocabulary(db: EvalsDB, run_group_id: str) -> tuple[Tag, ...]:
+    """The tag vocabulary one run group was created under.
+
+    A reviewer annotates a run's answers, so the vocabulary that applies is
+    the one the run captured -- not the bench's current one. This is the same
+    provenance rule the card snapshot follows: editing the bench afterwards
+    must not change what the run shows, and must not orphan an annotation
+    already recorded against a tag the bench has since dropped.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The run group to read.
+
+    Returns:
+        tuple[Tag, ...]: Built-in tags plus whatever extras the snapshot
+        recorded, resolved through ``resolve_vocabulary``.
+
+    Raises:
+        ValueError: If the snapshot is missing or its stored tags are corrupt
+            -- naming the run group.
+    """
+    snapshot = load_probe_run_snapshot(db, run_group_id)
+    return resolve_vocabulary(
+        _tags_from_json(snapshot.get("extra_tags"), run_group_id)
+    )
+```
+
+Check what `load_probe_run_snapshot` already raises for an unknown group and let that propagate rather than adding a second error path.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/storage.py Tests/Evals/character_probe/test_conversation_storage.py
+git commit -m "feat(evals): a run group's tag vocabulary comes from its snapshot (task-1691 phase 3a)"
+```
+
+---
+
+### Task 5: An annotation cannot reference a tag the run never had
+
+**Files:**
+- Modify: `tldw_chatbook/Evals/character_probe/storage.py`
+- Test: `Tests/Evals/character_probe/test_conversation_storage.py`
+
+**Interfaces:**
+- Consumes: `run_group_vocabulary` (Task 4), `canonical_slug` (Task 2).
+- Produces: `annotate_turn` (storage.py:921) validating and canonicalising its `tags` argument; unchanged signature.
+
+Today `annotate_turn` writes whatever slugs it is handed. A typo'd slug becomes an annotation nobody can filter for and a tag Phase 4's summary cannot group, because it has no kind. Validating at the write matches the fail-loudly rule and keeps the summary's grouping total.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.storage import (
+    annotate_turn,
+    load_turn_annotations,
+)
+
+
+def test_a_known_tag_is_stored(db, probe_run_group):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["broke-character"], note="third turn",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["broke-character"]
+
+
+def test_an_unknown_tag_is_rejected_naming_it(db, probe_run_group):
+    with pytest.raises(ValueError) as exc:
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["brok-charcter"], note="",
+        )
+    assert "brok-charcter" in str(exc.value)
+
+
+def test_nothing_is_written_when_one_tag_of_several_is_unknown(
+    db, probe_run_group
+):
+    with pytest.raises(ValueError):
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["broke-character", "no-such-tag"], note="",
+        )
+    assert load_turn_annotations(db, probe_run_group) == {}
+
+
+def test_a_non_canonical_tag_is_canonicalised_rather_than_rejected(
+    db, probe_run_group
+):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["Broke Character"], note="",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["broke-character"]
+
+
+def test_duplicate_tags_are_stored_once(db, probe_run_group):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["broke-character", "broke-character"], note="",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["broke-character"]
+
+
+def test_an_annotation_with_no_tags_but_a_note_is_allowed(
+    db, probe_run_group
+):
+    """A note without a tag is a real observation, not an empty write."""
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0, tags=[], note="odd phrasing",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["note"] == "odd phrasing"
+
+
+def test_a_benchs_extra_tag_is_accepted(db, probe_run_group_with_extra_tags):
+    annotate_turn(
+        db, probe_run_group_with_extra_tags, 1, 0, 0, "t-1", 0,
+        tags=["meta-commentary"], note="",
+    )
+    stored = load_turn_annotations(db, probe_run_group_with_extra_tags)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["meta-commentary"]
+```
+
+Reuse the fixtures Task 4 extended. `test_conversation_storage.py` already holds this slice's annotation tests (`test_a_turn_annotation_persists_with_its_tags_and_note`, `test_a_conversation_can_be_reviewed_with_no_annotations`, `test_review_state_is_scoped_to_its_run_group`) — add these beside them rather than starting a new file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_conversation_storage.py -p no:randomly`
+Expected: FAIL — an unknown slug is written rather than rejected, so the `pytest.raises` tests fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `annotate_turn`, before the `db.upsert_probe_turn_annotation(...)` call:
+
+```python
+    vocabulary = run_group_vocabulary(db, run_group_id)
+    known = {tag.slug for tag in vocabulary}
+    canonical: list[str] = []
+    for raw in tags or ():
+        slug = canonical_slug(str(raw))
+        if slug not in known:
+            raise ValueError(
+                f"{slug!r} is not a tag in this run's vocabulary "
+                f"({', '.join(sorted(known))}). Annotations are grouped by tag "
+                f"kind, so an unknown tag would have no kind to group under."
+            )
+        if slug not in canonical:
+            canonical.append(slug)
+```
+
+then pass `canonical` where `tags` was passed. Update the docstring's Raises section to name the new `ValueError`.
+
+Validation happens before the write, so a rejected annotation leaves nothing behind — which is what `test_nothing_is_written_when_one_tag_of_several_is_unknown` pins.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/storage.py Tests/Evals/character_probe/test_conversation_storage.py
+git commit -m "feat(evals): reject an annotation tag outside the run's vocabulary (task-1691 phase 3a)"
+```
+
+---
+
+### Task 6: Deleting a bench takes its annotations with it
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Evals_DB.py`
+- Test: `Tests/Evals/character_probe/test_conversation_storage.py`
+
+**Interfaces:**
+- Consumes: `EvalsDB.delete_task` (Evals_DB.py:850), the two annotation tables (Evals_DB.py:316,333).
+- Produces: `EvalsDB.delete_probe_annotations_for_run_groups(run_group_ids: Sequence[str]) -> int` returning rows removed; `delete_task` calling it for the task's run groups.
+
+The spec: "Deleting a run group cascades both, since they describe those answers and mean nothing without them." Neither table has a foreign key or an `ON DELETE CASCADE` today, and `delete_task` (the only delete path — there is no `delete_run_group`) does not touch them. Phase 2 made a character bench deletable from the UI, so orphaned annotation rows are reachable now, not hypothetically.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_deleting_a_bench_removes_its_turn_annotations(
+    db, probe_run_group, bench_id_of_that_run
+):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["broke-character"], note="",
+    )
+    assert load_turn_annotations(db, probe_run_group)
+
+    db.delete_task(bench_id_of_that_run)
+
+    assert db.list_probe_turn_annotations(probe_run_group) == []
+
+
+def test_deleting_a_bench_removes_its_review_state(
+    db, probe_run_group, bench_id_of_that_run
+):
+    from tldw_chatbook.Evals.character_probe.storage import mark_conversation_reviewed
+
+    mark_conversation_reviewed(db, probe_run_group, 1, 0, 0, "t-1", note="fine")
+    assert db.list_probe_review_state(probe_run_group)
+
+    db.delete_task(bench_id_of_that_run)
+
+    assert db.list_probe_review_state(probe_run_group) == []
+
+
+def test_deleting_a_bench_leaves_another_benchs_annotations_alone(
+    db, probe_run_group, bench_id_of_that_run, second_probe_run_group
+):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0, tags=["refused"], note="",
+    )
+    annotate_turn(
+        db, second_probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["refused"], note="",
+    )
+
+    db.delete_task(bench_id_of_that_run)
+
+    assert db.list_probe_turn_annotations(second_probe_run_group)
+
+
+def test_deleting_a_word_bench_touches_no_probe_annotation_rows(
+    db, probe_run_group, seeded_word_bench_id
+):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0, tags=["refused"], note="",
+    )
+    db.delete_task(seeded_word_bench_id)
+    assert db.list_probe_turn_annotations(probe_run_group)
+```
+
+`second_probe_run_group` needs a run group under a **different** bench — extend the fixture module accordingly. `seeded_word_bench_id` should come from the word-bench helpers the Evals tests already use; grep for them rather than writing a new one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_conversation_storage.py -k deleting -p no:randomly`
+Expected: FAIL — the annotation rows survive `delete_task`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Evals_DB.py`:
+
+```python
+    def delete_probe_annotations_for_run_groups(
+        self, run_group_ids: Sequence[str]
+    ) -> int:
+        """Remove every character-probe annotation for these run groups.
+
+        Annotations and review state describe one run's answers and mean
+        nothing without them, so they are removed with the run rather than
+        left orphaned.
+
+        Args:
+            run_group_ids: The run groups whose annotations to remove.
+
+        Returns:
+            int: Rows removed across both tables. Zero is a normal result --
+            a run nobody reviewed has no annotations.
+        """
+        ids = [str(rg) for rg in run_group_ids if rg]
+        if not ids:
+            return 0
+        placeholders = ",".join("?" for _ in ids)
+        removed = 0
+        conn = self._get_connection()
+        with conn:
+            for table in (
+                "eval_probe_turn_annotations",
+                "eval_probe_review_state",
+            ):
+                cursor = conn.execute(
+                    f"DELETE FROM {table} WHERE run_group_id IN ({placeholders})",
+                    ids,
+                )
+                removed += cursor.rowcount
+        return removed
+```
+
+The table names are interpolated from a two-element literal tuple in this function's own body, never from a caller — the `run_group_id` values stay parameterized.
+
+**`EvalsDB` has no `transaction()` context manager** — verified. The `conn = self._get_connection()` / `with conn:` form above is what `delete_task` (Evals_DB.py:850-858) and its neighbours actually use; follow it. (The repo's CLAUDE.md shows a `db.transaction()` idiom, and an automated reviewer has previously flagged this class for not using it — that convention belongs to a different DB class in this codebase. Match the file, not the doc.)
+
+In `delete_task`, after the task's own soft-delete succeeds, collect the task's run group ids and call the new method. Find how run groups are associated with a task (`eval_runs.run_group_id` scoped by `task_id`) and read them before the delete, since a soft-deleted task may no longer resolve them.
+
+Note the asymmetry to preserve: `delete_task` is a **soft** delete for the task itself; the annotation rows are **hard**-deleted, because they carry no `deleted_at` column and nothing reads them for an undeleted view. Say so in a comment so a later reader does not "fix" it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe Tests/DB -p no:randomly`
+Expected: PASS — the new cascade tests plus every existing DB test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/DB/Evals_DB.py Tests/Evals/character_probe/test_conversation_storage.py
+git commit -m "feat(evals): deleting a bench cascades its probe annotations (task-1691 phase 3a)"
+```
+
+---
+
+## Phase 3a exit criteria
+
+- Every tag in the system carries one of exactly three kinds, and nothing can create one without stating its kind.
+- The ten built-in tags exist with the slugs and kinds the spec names.
+- A bench's `extra_tags` are validated at construction, canonicalised, and cannot change a built-in's kind.
+- A run group's vocabulary comes from its own snapshot, so editing the bench afterwards does not change or orphan what the run captured.
+- An annotation cannot reference a tag outside its run's vocabulary, and a rejected annotation writes nothing.
+- Deleting a bench removes its annotations and review state, and no other bench's.
+- `Tests/Evals/character_probe` and `Tests/Evals` remain green; nothing in `Tests/UI` needed to change, because this phase ships no UI.
+
+## Not in Phase 3a (deliberate)
+
+The conversation view, the queue, keyboard navigation, the tag-application UI, the create-a-tag flow, and ordering hints are Phase 3b — this phase gives that UI a vocabulary to render and a validated place to write. The summary is Phase 4. No view that sums tags into a number is ever in scope.

--- a/Docs/superpowers/plans/2026-08-02-character-probe-phase3b-review-queue.md
+++ b/Docs/superpowers/plans/2026-08-02-character-probe-phase3b-review-queue.md
@@ -1,0 +1,1165 @@
+# Character Probe Evals — Phase 3b (Review Queue) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a completed character-probe run readable — an ordered, filterable queue of conversations, a full transcript view, tags applied by keystroke, and an explicit "reviewed" verdict that survives closing the app.
+
+**Architecture:** The queue replaces the neutral placeholder Phase 2 mounts for a character-probe run group (`evals_screen.py:1993`). Ordering, filtering, and hint computation are pure functions in the engine, so they are testable without Textual and cannot accidentally run during a bench run. The UI is a queue list plus a conversation view, both keyboard-first.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest. Engine from phases 1 and 3a; UI alongside Phase 2's `character_bench_editor.py`.
+
+## Global Constraints
+
+Copied from `Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md` and phases 1-3a's conventions. Every task's requirements implicitly include this section.
+
+- **The two bench types never share a detail surface.** The queue renders in the slot the word-bench `ResultsGrid` occupies, and neither leaks into the other's pane.
+- **No logprobs / top-K / normalizer / canary vocabulary** anywhere in character-probe UI. A degenerate-canary warning must never appear on this bench type.
+- **Review is a queue, not a grid.** "A 3D grid of conversations has no good 2D rendering and the reader's task is sequential anyway."
+- **Keyboard-first.** "Reviewing dozens of conversations by mouse in a terminal app is untenable; moving between turns and conversations and applying tags must be a few keystrokes."
+- **"Reviewed" is explicit, and "nothing notable" is a real verdict.** A conversation is done when the reviewer says so, not when it happens to carry a tag — otherwise "a clean, in-character, well-handled exchange is indistinguishable from one nobody has opened, and the progress count lies."
+- **Ordering hints, never verdicts.** Hints reorder the queue; they are "never tags and never scores — if they become the judgment, the tool has quietly invented the metric it claims not to have."
+- **Hints are computed at review time, on demand, never during the run.** "Nothing about a run's cost or duration may depend on hinting."
+- **No composite score, anywhere.** "No view anywhere sums tags into a number."
+- **User-authored text is a markup hazard.** Any Static carrying a card name, probe text, or model output takes `markup=False`; any Button label or tooltip interpolating it uses `escape_markup`. Whitespace shown with `␣` via `snippet_editor.render_snippet_cell`; newlines guarded to one line with `guard_single_line`'s `⏎` where a value must stay on one row.
+- **Fail loudly, never silently default** — a corrupt row or missing record raises a named error identifying it; a write affecting no rows raises rather than reporting success.
+- **`character_ids` are ints**; every eval id is a str. Do not normalise them. Note that `composed_system_prompts` in the run snapshot is keyed by **`str(card_id)`** (storage.py:570-573) — a reader keying by card id must `str()` it.
+- **Tests must drive real widgets.** "The review UI's tests must drive real clicks and keypresses and assert the annotation persisted. Programmatically setting a widget's value passes while the feature is unusable." Every behavioural UI test presses or types through `pilot`, and asserts what is in the database afterwards.
+- **Painted geometry is the arbiter.** This pane has pushed a control out of reach three times. Any task adding rows asserts the controls below it stay hit-testable — `screen.get_widget_at(*control.region.center)` resolves to the control — at 160x45 AND 235x52.
+- Google-style docstrings (Args/Returns/Raises) on public callables; parameterized SQL only; CSS in `css/features/_evals.tcss` regenerated via `build_css.py`, never hand-edited.
+- Run tests foreground: `/private/tmp/tldw-venv/bin/python -m pytest <paths> -p no:randomly` from the clone root. Never `-q`. **Pass `timeout: 600000` on the Bash call** — the harness auto-backgrounds anything past 120s and a backgrounded pytest has stalled this workflow twice.
+
+## What already exists (verified — do not rebuild it)
+
+- `Conversation(card_id: int, probe_index: int, sample_index: int, target_id: str, turns: tuple[ConversationTurn, ...], error: str)` and `ConversationTurn(user: str, reply: str, error: str)` (`models.py:170,197`). `turns` holds only the turns that ran; a partial conversation keeps its completed turns and records why it stopped in `Conversation.error`. **`ConversationTurn.error` is reserved and never populated today** — read `Conversation.error` for failure, never `turn.error == ""` as "this turn succeeded".
+- `ConversationTurn.reply` may legitimately be `""` — "the model said nothing" is a real observation this eval exists to surface, not a malformed row.
+- `CardSnapshot(id, name, description, system_prompt, personality, scenario, first_message, post_history_instructions, message_example)` (`models.py:158-166`). `first_message` is the card's opening message the conversation view must render.
+- `load_conversations(db, run_group_id)` (`storage.py:880`), `load_probe_run_snapshot(db, run_group_id)` (:644). The snapshot holds `cards`, `probes`, `targets`, `sampler`, `extra_tags`, and `composed_system_prompts`.
+- `annotate_turn` (:921), `load_turn_annotations` (:964), `mark_conversation_reviewed` (:990), `load_review_state` (:1028).
+- **Phase 3a** ships `tags.py` with `Tag`, `TAG_KINDS`, `BUILTIN_TAGS`, `canonical_slug`, `coerce_tag`, `resolve_vocabulary`, `tag_by_slug`, and `storage.run_group_vocabulary(db, run_group_id)`. `annotate_turn` already rejects a slug outside the run's vocabulary.
+- `EvalsScreen._character_run_group(group)` (`evals_screen.py:490`) is the existing predicate that keeps `ResultsGrid`/`EvalsCellInspector` away from a character-probe run group; the placeholder it guards is `#evals-detail-character-run-placeholder` (:1993).
+- `snippet_editor.render_snippet_cell` (`snippet_editor.py:145`) and `snippet_editor.guard_single_line` (extracted in Phase 2) are the whitespace and single-line conventions.
+
+## File Structure
+
+- `tldw_chatbook/Evals/character_probe/hints.py` (new) — the four ordering hints as pure functions over already-loaded conversations plus the run snapshot. No DB, no UI, so "never during the run" is structural rather than a convention.
+- `tldw_chatbook/Evals/character_probe/review_queue.py` (new) — pure ordering, filtering, and progress over `(conversations, review_state, hints)`. Its own file so the queue's rules are testable without mounting anything.
+- `tldw_chatbook/UI/Evals/conversation_view.py` (new) — the transcript widget.
+- `tldw_chatbook/UI/Evals/review_pane.py` (new) — the queue list, filters, progress, and the mark-reviewed affordance; replaces Phase 2's placeholder.
+- `tldw_chatbook/UI/Evals/tag_picker.py` (new) — applying tags to a turn and creating a bench tag. Its own file because both the turn affordance and the create flow live in it and it is the one place `TAG_KINDS` reaches the UI.
+- `tldw_chatbook/UI/Screens/evals_screen.py` — mount the review pane where the placeholder was; own the keyboard bindings that belong to the screen.
+- Tests mirror each under `Tests/Evals/character_probe/` and `Tests/UI/`.
+
+---
+
+### Task 1: Ordering hints
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/hints.py`
+- Test: `Tests/Evals/character_probe/test_hints.py`
+
+**Interfaces:**
+- Consumes: `Conversation`, `ConversationTurn`, `CardSnapshot` (`models.py`); the run snapshot's `composed_system_prompts` mapping.
+- Produces: `HINT_KINDS: tuple[str, ...]`; `Hint(kind: str, turn_index: int, detail: str)` frozen dataclass; `compute_hints(conversations: Sequence[Conversation], snapshot: Mapping[str, Any]) -> dict[tuple[int, int, int, str], tuple[Hint, ...]]` keyed by `(card_id, probe_index, sample_index, target_id)`.
+
+Four hints, all from the spec: **empty or very short replies**, **replies containing text from the card's own system prompt (a leak)**, **refusal-shaped openings**, and **replies near-identical across targets**. They are hints, never tags and never scores — nothing here returns a number a caller could rank by, and `Hint` deliberately carries no severity or weight.
+
+The near-identical check compares replies **across cells**, which is exactly why this runs on demand at review time rather than at write time: computing it during a run would add a cross-cell pass to every run for a signal only the reviewer uses.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.hints import HINT_KINDS, Hint, compute_hints
+from tldw_chatbook.Evals.character_probe.models import Conversation, ConversationTurn
+
+
+def _conv(card_id=1, probe=0, sample=0, target="t-1", replies=("a reply",)):
+    return Conversation(
+        card_id=card_id,
+        probe_index=probe,
+        sample_index=sample,
+        target_id=target,
+        turns=tuple(ConversationTurn(user="q", reply=r) for r in replies),
+    )
+
+
+SNAPSHOT = {
+    "composed_system_prompts": {"1": {"t-1": "You are Vex, a rooftop thief."}},
+}
+
+
+def test_the_hint_kinds_are_the_four_the_spec_names():
+    assert set(HINT_KINDS) == {
+        "empty-or-short",
+        "prompt-leak",
+        "refusal-shaped",
+        "near-identical",
+    }
+
+
+def test_an_empty_reply_is_hinted():
+    hints = compute_hints([_conv(replies=("",))], SNAPSHOT)
+    kinds = [h.kind for h in hints[(1, 0, 0, "t-1")]]
+    assert "empty-or-short" in kinds
+
+
+def test_a_very_short_reply_is_hinted():
+    hints = compute_hints([_conv(replies=("ok",))], SNAPSHOT)
+    assert any(h.kind == "empty-or-short" for h in hints[(1, 0, 0, "t-1")])
+
+
+def test_an_ordinary_reply_is_not_hinted_as_short():
+    hints = compute_hints(
+        [_conv(replies=("Vex leans back against the chimney and grins at you.",))],
+        SNAPSHOT,
+    )
+    assert not any(
+        h.kind == "empty-or-short" for h in hints.get((1, 0, 0, "t-1"), ())
+    )
+
+
+def test_a_reply_quoting_the_cards_system_prompt_is_hinted_as_a_leak():
+    hints = compute_hints(
+        [_conv(replies=("You are Vex, a rooftop thief. How can I help?",))],
+        SNAPSHOT,
+    )
+    assert any(h.kind == "prompt-leak" for h in hints[(1, 0, 0, "t-1")])
+
+
+def test_a_reply_merely_naming_the_character_is_not_a_leak():
+    """Saying its own name is in character, not a prompt leak."""
+    hints = compute_hints(
+        [_conv(replies=("Vex is not someone you want to cross, friend.",))],
+        SNAPSHOT,
+    )
+    assert not any(
+        h.kind == "prompt-leak" for h in hints.get((1, 0, 0, "t-1"), ())
+    )
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "I'm sorry, but I can't help with that.",
+        "I cannot assist with this request.",
+        "As an AI language model, I am unable to do that.",
+    ],
+)
+def test_a_refusal_shaped_opening_is_hinted(reply):
+    hints = compute_hints([_conv(replies=(reply,))], SNAPSHOT)
+    assert any(h.kind == "refusal-shaped" for h in hints[(1, 0, 0, "t-1")])
+
+
+def test_a_refusal_later_in_a_long_reply_is_not_hinted_as_an_opening():
+    reply = (
+        "Vex laughs at the suggestion and paces the rooftop for a while, "
+        "turning it over. Eventually he says he cannot help with that."
+    )
+    hints = compute_hints([_conv(replies=(reply,))], SNAPSHOT)
+    assert not any(
+        h.kind == "refusal-shaped" for h in hints.get((1, 0, 0, "t-1"), ())
+    )
+
+
+def test_near_identical_replies_across_targets_are_hinted_on_both():
+    shared = "The night is cold and the tiles are slick underfoot tonight."
+    hints = compute_hints(
+        [
+            _conv(target="t-1", replies=(shared,)),
+            _conv(target="t-2", replies=(shared,)),
+        ],
+        {"composed_system_prompts": {"1": {"t-1": "p", "t-2": "p"}}},
+    )
+    assert any(h.kind == "near-identical" for h in hints[(1, 0, 0, "t-1")])
+    assert any(h.kind == "near-identical" for h in hints[(1, 0, 0, "t-2")])
+
+
+def test_the_same_reply_from_one_target_alone_is_not_near_identical():
+    hints = compute_hints(
+        [_conv(target="t-1", replies=("The night is cold and slick underfoot.",))],
+        SNAPSHOT,
+    )
+    assert not any(
+        h.kind == "near-identical" for h in hints.get((1, 0, 0, "t-1"), ())
+    )
+
+
+def test_different_cards_with_the_same_reply_are_not_compared():
+    """Near-identical means across TARGETS for one cell, not across cards."""
+    shared = "The night is cold and the tiles are slick underfoot tonight."
+    hints = compute_hints(
+        [
+            _conv(card_id=1, target="t-1", replies=(shared,)),
+            _conv(card_id=2, target="t-1", replies=(shared,)),
+        ],
+        {"composed_system_prompts": {"1": {"t-1": "p"}, "2": {"t-1": "p"}}},
+    )
+    assert not any(
+        h.kind == "near-identical" for h in hints.get((1, 0, 0, "t-1"), ())
+    )
+
+
+def test_a_hint_carries_the_turn_it_describes():
+    hints = compute_hints([_conv(replies=("a full and ordinary reply here", ""))], SNAPSHOT)
+    short = [h for h in hints[(1, 0, 0, "t-1")] if h.kind == "empty-or-short"]
+    assert short and short[0].turn_index == 1
+
+
+def test_a_hint_has_no_score_or_severity():
+    """Hints are never verdicts; nothing here may be ranked or summed."""
+    import dataclasses
+    fields = {f.name for f in dataclasses.fields(Hint)}
+    assert fields == {"kind", "turn_index", "detail"}
+
+
+def test_a_conversation_with_no_hints_is_absent_rather_than_empty():
+    hints = compute_hints(
+        [_conv(replies=("Vex leans back against the chimney and grins at you.",))],
+        SNAPSHOT,
+    )
+    assert (1, 0, 0, "t-1") not in hints
+
+
+def test_a_failed_conversation_with_no_turns_produces_no_hints_and_does_not_raise():
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+        turns=(), error="provider exploded",
+    )
+    assert compute_hints([conv], SNAPSHOT) == {}
+
+
+def test_a_snapshot_missing_composed_prompts_does_not_raise():
+    assert compute_hints([_conv(replies=("ok",))], {}) is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_hints.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...hints'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`hints.py`. Structure it as one function per hint plus `compute_hints` combining them, so each is independently testable and none can grow a score:
+
+```python
+"""Cheap heuristics that reorder the review queue.
+
+These are HINTS and never verdicts. Nothing here returns a number, a
+severity, or a rank: the design spec is explicit that "if they become the
+judgment, the tool has quietly invented the metric it claims not to have."
+``Hint`` therefore carries a kind, the turn it describes, and a human
+sentence -- nothing a caller could sort by magnitude.
+
+Computed on demand at review time, never during a run. The near-identical
+check compares replies ACROSS cells, so running it at write time would add a
+cross-cell pass to every run for a signal only the reviewer uses; the spec
+requires that "nothing about a run's cost or duration may depend on hinting."
+This module imports no database and no UI, which makes that structural.
+"""
+```
+
+Constants to define with a stated reason each, not bare magic numbers:
+
+- `_SHORT_REPLY_CHARS = 24` — below this a reply is flagged `empty-or-short`. An empty reply always flags.
+- `_LEAK_SHINGLE_WORDS = 6` — a run of this many consecutive words shared with the card's composed system prompt counts as a leak. Word-shingling rather than substring matching is what makes `test_a_reply_merely_naming_the_character_is_not_a_leak` pass: a single shared token is not a leak.
+- `_REFUSAL_OPENING_CHARS = 80` — refusal shapes only count within this much of the reply's start, which is what `test_a_refusal_later_in_a_long_reply_is_not_hinted_as_an_opening` pins.
+- `_REFUSAL_PATTERNS` — a tuple of lowercase regexes covering the three shapes the test parametrizes (`i'm sorry`, `i cannot/can't assist|help`, `as an ai`). Keep them as regexes over the normalised opening, not substring `in` checks, so `I am unable` and `I'm unable` both match.
+- `_NEAR_IDENTICAL_RATIO = 0.9` — `difflib.SequenceMatcher(None, a, b).ratio()` at or above this counts as near-identical. Compare per `(card_id, probe_index, sample_index, turn_index)` across differing `target_id`s only, which is what the card-isolation test pins.
+
+`compute_hints` returns a dict keyed by `(card_id, probe_index, sample_index, target_id)` containing only conversations that produced at least one hint — an absent key means "nothing stood out", which the queue renders as no hint rather than as an empty badge.
+
+Guard every snapshot read: `snapshot.get("composed_system_prompts") or {}`, and key it with `str(card_id)` (the snapshot stores string keys — storage.py:570-573).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_hints.py -p no:randomly`
+Expected: PASS (18 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/hints.py Tests/Evals/character_probe/test_hints.py
+git commit -m "feat(evals): ordering hints for the character-probe review queue (task-1691 phase 3b)"
+```
+
+---
+
+### Task 2: The queue — ordering, filtering, progress
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/review_queue.py`
+- Test: `Tests/Evals/character_probe/test_review_queue.py`
+
+**Interfaces:**
+- Consumes: `Conversation` (`models.py`); `load_review_state`'s return shape — `dict[(card_id, probe_index, sample_index, target_id), {"reviewed_at": str, "note": str}]`; `compute_hints`' return shape (Task 1).
+- Produces: `QueueEntry(key: tuple[int, int, int, str], conversation: Conversation, reviewed: bool, hints: tuple[Hint, ...])`; `QueueFilter(card_id: Optional[int], probe_index: Optional[int], target_id: Optional[str], unreviewed_only: bool)`; `build_queue(conversations, review_state, hints, queue_filter=QueueFilter()) -> tuple[QueueEntry, ...]`; `queue_progress(entries) -> tuple[int, int]` returning `(reviewed_count, total)`.
+
+The spec: the run group "presents an ordered queue, filterable by card, probe, target, or 'not yet reviewed', so a reviewer can take a deliberate slice — *'just the villain card across all three models'* — in one sitting."
+
+**Ordering:** hinted conversations first (they are "likely-interesting material"), then a stable deterministic order — `(card_id, probe_index, sample_index, target_id)` — so the queue does not reshuffle under the reviewer between sessions. Within the hinted group, the same stable key applies. **Reviewing a conversation must not move it**; the queue is stable across a review so the reviewer's position is meaningful.
+
+**Progress counts against the FILTERED queue**, and `queue_progress` returns two integers rather than a percentage — a percentage is one step from a score.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tldw_chatbook.Evals.character_probe.hints import Hint
+from tldw_chatbook.Evals.character_probe.models import Conversation, ConversationTurn
+from tldw_chatbook.Evals.character_probe.review_queue import (
+    QueueFilter,
+    build_queue,
+    queue_progress,
+)
+
+
+def _conv(card_id=1, probe=0, sample=0, target="t-1"):
+    return Conversation(
+        card_id=card_id, probe_index=probe, sample_index=sample,
+        target_id=target, turns=(ConversationTurn(user="q", reply="r"),),
+    )
+
+
+def test_an_empty_run_produces_an_empty_queue():
+    assert build_queue([], {}, {}) == ()
+
+
+def test_every_conversation_becomes_one_entry():
+    convs = [_conv(target="t-1"), _conv(target="t-2")]
+    assert len(build_queue(convs, {}, {})) == 2
+
+
+def test_entries_are_in_a_stable_deterministic_order():
+    convs = [
+        _conv(card_id=2, probe=0), _conv(card_id=1, probe=1), _conv(card_id=1, probe=0),
+    ]
+    keys = [e.key for e in build_queue(convs, {}, {})]
+    assert keys == [(1, 0, 0, "t-1"), (1, 1, 0, "t-1"), (2, 0, 0, "t-1")]
+
+
+def test_hinted_conversations_sort_ahead_of_unhinted_ones():
+    convs = [_conv(card_id=1), _conv(card_id=2)]
+    hints = {(2, 0, 0, "t-1"): (Hint("empty-or-short", 0, "empty reply"),)}
+    keys = [e.key for e in build_queue(convs, {}, hints)]
+    assert keys[0] == (2, 0, 0, "t-1")
+
+
+def test_hinted_conversations_keep_a_stable_order_among_themselves():
+    convs = [_conv(card_id=2), _conv(card_id=1)]
+    hints = {
+        (1, 0, 0, "t-1"): (Hint("refusal-shaped", 0, "x"),),
+        (2, 0, 0, "t-1"): (Hint("empty-or-short", 0, "y"),),
+    }
+    keys = [e.key for e in build_queue(convs, {}, hints)]
+    assert keys == [(1, 0, 0, "t-1"), (2, 0, 0, "t-1")]
+
+
+def test_reviewing_a_conversation_does_not_move_it():
+    convs = [_conv(card_id=1), _conv(card_id=2)]
+    before = [e.key for e in build_queue(convs, {}, {})]
+    state = {(1, 0, 0, "t-1"): {"reviewed_at": "now", "note": ""}}
+    after = [e.key for e in build_queue(convs, state, {})]
+    assert before == after
+
+
+def test_an_entry_knows_it_was_reviewed():
+    convs = [_conv()]
+    state = {(1, 0, 0, "t-1"): {"reviewed_at": "now", "note": "fine"}}
+    assert build_queue(convs, state, {})[0].reviewed is True
+
+
+def test_an_entry_with_no_review_state_is_not_reviewed():
+    assert build_queue([_conv()], {}, {})[0].reviewed is False
+
+
+def test_filtering_by_card():
+    convs = [_conv(card_id=1), _conv(card_id=2)]
+    entries = build_queue(convs, {}, {}, QueueFilter(card_id=2))
+    assert [e.key[0] for e in entries] == [2]
+
+
+def test_filtering_by_probe():
+    convs = [_conv(probe=0), _conv(probe=1)]
+    entries = build_queue(convs, {}, {}, QueueFilter(probe_index=1))
+    assert [e.key[1] for e in entries] == [1]
+
+
+def test_filtering_by_target():
+    convs = [_conv(target="t-1"), _conv(target="t-2")]
+    entries = build_queue(convs, {}, {}, QueueFilter(target_id="t-2"))
+    assert [e.key[3] for e in entries] == ["t-2"]
+
+
+def test_filtering_to_unreviewed_only():
+    convs = [_conv(card_id=1), _conv(card_id=2)]
+    state = {(1, 0, 0, "t-1"): {"reviewed_at": "now", "note": ""}}
+    entries = build_queue(convs, state, {}, QueueFilter(unreviewed_only=True))
+    assert [e.key[0] for e in entries] == [2]
+
+
+def test_filters_combine():
+    convs = [
+        _conv(card_id=1, target="t-1"), _conv(card_id=1, target="t-2"),
+        _conv(card_id=2, target="t-1"),
+    ]
+    entries = build_queue(convs, {}, {}, QueueFilter(card_id=1, target_id="t-2"))
+    assert [e.key for e in entries] == [(1, 0, 0, "t-2")]
+
+
+def test_a_filter_matching_nothing_yields_an_empty_queue():
+    entries = build_queue([_conv()], {}, {}, QueueFilter(card_id=99))
+    assert entries == ()
+
+
+def test_progress_counts_reviewed_against_total():
+    convs = [_conv(card_id=1), _conv(card_id=2)]
+    state = {(1, 0, 0, "t-1"): {"reviewed_at": "now", "note": ""}}
+    assert queue_progress(build_queue(convs, state, {})) == (1, 2)
+
+
+def test_progress_counts_against_the_filtered_queue_not_the_whole_run():
+    convs = [_conv(card_id=1), _conv(card_id=2)]
+    state = {(1, 0, 0, "t-1"): {"reviewed_at": "now", "note": ""}}
+    entries = build_queue(convs, state, {}, QueueFilter(card_id=2))
+    assert queue_progress(entries) == (0, 1)
+
+
+def test_progress_of_an_empty_queue_is_zero_of_zero():
+    assert queue_progress(()) == (0, 0)
+
+
+def test_a_failed_conversation_is_still_queued():
+    """A partial or failed conversation is still evidence and stays reviewable."""
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+        turns=(), error="provider exploded",
+    )
+    assert len(build_queue([conv], {}, {})) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_review_queue.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...review_queue'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Two frozen dataclasses and two functions. `QueueFilter`'s fields all default to `None`/`False` so `QueueFilter()` means "everything". Sort with a two-part key — `(0 if hinted else 1, card_id, probe_index, sample_index, target_id)` — which gives hinted-first plus a stable tie-break in one pass, and note in a comment that the reviewed flag is deliberately absent from the sort key so reviewing does not reshuffle the queue under the reviewer.
+
+`queue_progress` returns a `(reviewed, total)` tuple, not a ratio: a percentage is one refactor away from the composite score this design forbids. Say so in its docstring.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/review_queue.py Tests/Evals/character_probe/test_review_queue.py
+git commit -m "feat(evals): the character-probe review queue's ordering and filters (task-1691 phase 3b)"
+```
+
+---
+
+### Task 3: The conversation view
+
+**Files:**
+- Create: `tldw_chatbook/UI/Evals/conversation_view.py`
+- Modify: `tldw_chatbook/css/features/_evals.tcss` (+ regenerate the bundle)
+- Test: `Tests/UI/test_evals_conversation_view.py`
+
+**Interfaces:**
+- Consumes: `Conversation`, `ConversationTurn`, `CardSnapshot`; `Hint` (Task 1); `snippet_editor.render_snippet_cell`.
+- Produces: `ConversationView(conversation, card, hints=(), annotations=None, id=...)` — a `Vertical` with `#evals-cv-opening` (the card's first message), one `#evals-cv-turn-{index}` block per turn containing `.evals-cv-user` and `.evals-cv-reply`, and `#evals-cv-error` when the conversation failed; `ConversationView.turn_count() -> int`; `ConversationView.focus_turn(index) -> None`.
+
+The spec: it "renders the full exchange as turns, with the card's opening message and each scripted user turn in place, and a tag affordance on every model turn." The tag affordance itself is Task 5 — this task renders the transcript and leaves a per-turn anchor for it.
+
+**Every string here is model output or user-authored card text**, so every `Static` takes `markup=False`. A reply is multi-line prose and is NOT collapsed to one line — `guard_single_line` is for row labels, not for the transcript. Leading and trailing whitespace still renders through `render_snippet_cell` so "the model replied with three spaces" is visible rather than looking empty.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Evals.character_probe.hints import Hint
+from tldw_chatbook.Evals.character_probe.models import (
+    CardSnapshot, Conversation, ConversationTurn,
+)
+from tldw_chatbook.UI.Evals.conversation_view import ConversationView
+
+CARD = CardSnapshot(id=1, name="Vex", first_message="You find me on the roof.")
+CONV = Conversation(
+    card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+    turns=(
+        ConversationTurn(user="What do you think about lying?", reply="Everyone lies."),
+        ConversationTurn(user="And to protect someone?", reply="Then it's mercy."),
+    ),
+)
+
+
+class _Host(App):
+    def __init__(self, conversation=CONV, card=CARD, hints=(), annotations=None):
+        super().__init__()
+        self._args = (conversation, card, hints, annotations)
+
+    def compose(self) -> ComposeResult:
+        conversation, card, hints, annotations = self._args
+        yield ConversationView(
+            conversation, card, hints=hints, annotations=annotations, id="cv"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_cards_opening_message_is_rendered():
+    async with _Host().run_test() as pilot:
+        opening = pilot.app.query_one("#evals-cv-opening")
+        assert "You find me on the roof." in opening.render_str_or_text()
+
+
+@pytest.mark.asyncio
+async def test_every_turn_renders_its_user_prompt_and_reply():
+    async with _Host().run_test() as pilot:
+        view = pilot.app.query_one(ConversationView)
+        assert view.turn_count() == 2
+        assert len(view.query(".evals-cv-user")) == 2
+        assert len(view.query(".evals-cv-reply")) == 2
+
+
+@pytest.mark.asyncio
+async def test_turns_render_in_order():
+    async with _Host().run_test() as pilot:
+        view = pilot.app.query_one(ConversationView)
+        users = [w.render_str_or_text() for w in view.query(".evals-cv-user")]
+        assert "lying" in users[0]
+        assert "protect someone" in users[1]
+
+
+@pytest.mark.asyncio
+async def test_an_empty_reply_renders_visibly_rather_than_as_nothing():
+    """An empty reply is a real observation, not a blank row."""
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+        turns=(ConversationTurn(user="q", reply=""),),
+    )
+    async with _Host(conversation=conv).run_test() as pilot:
+        reply = pilot.app.query_one(".evals-cv-reply")
+        assert reply.render_str_or_text().strip() != ""
+
+
+@pytest.mark.asyncio
+async def test_a_whitespace_only_reply_shows_the_whitespace_marker():
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+        turns=(ConversationTurn(user="q", reply="   "),),
+    )
+    async with _Host(conversation=conv).run_test() as pilot:
+        assert "␣" in pilot.app.query_one(".evals-cv-reply").render_str_or_text()
+
+
+@pytest.mark.asyncio
+async def test_a_reply_containing_markup_renders_literally():
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+        turns=(ConversationTurn(user="q", reply="[bold]not bold[/]"),),
+    )
+    async with _Host(conversation=conv).run_test() as pilot:
+        assert "[bold]" in pilot.app.query_one(".evals-cv-reply").render_str_or_text()
+
+
+@pytest.mark.asyncio
+async def test_a_card_name_containing_markup_renders_literally():
+    card = CardSnapshot(id=1, name="Vex[/]v2", first_message="hi")
+    async with _Host(card=card).run_test() as pilot:
+        text = pilot.app.query_one(ConversationView).render_str_or_text()
+        assert "[/]" in text
+
+
+@pytest.mark.asyncio
+async def test_a_failed_conversation_shows_its_error_and_keeps_its_turns():
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+        turns=(ConversationTurn(user="q", reply="a reply"),),
+        error="provider exploded",
+    )
+    async with _Host(conversation=conv).run_test() as pilot:
+        assert "provider exploded" in (
+            pilot.app.query_one("#evals-cv-error").render_str_or_text()
+        )
+        assert len(pilot.app.query(".evals-cv-reply")) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_conversation_that_never_ran_a_turn_still_renders_its_error():
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1",
+        turns=(), error="cancelled before the first call",
+    )
+    async with _Host(conversation=conv).run_test() as pilot:
+        assert pilot.app.query_one("#evals-cv-error")
+        assert pilot.app.query_one(ConversationView).turn_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_a_successful_conversation_shows_no_error_block():
+    async with _Host().run_test() as pilot:
+        assert not pilot.app.query("#evals-cv-error")
+
+
+@pytest.mark.asyncio
+async def test_a_hint_renders_on_the_turn_it_describes():
+    hints = (Hint("empty-or-short", 1, "the reply was two characters"),)
+    async with _Host(hints=hints).run_test() as pilot:
+        turn = pilot.app.query_one("#evals-cv-turn-1")
+        assert "empty-or-short" in turn.render_str_or_text() or "short" in (
+            turn.render_str_or_text()
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_hint_never_renders_as_a_tag_or_a_score():
+    """Hints are never verdicts. No number, no applied-tag styling.
+
+    `.evals-cv-applied-tag` is the class an APPLIED tag chip carries (Task 5).
+    A hint must never wear it -- the two must stay visually distinguishable,
+    because a hint that reads as a tag has become the verdict the spec
+    forbids. Deliberately NOT `.evals-cv-tag`, which is Task 5's per-turn tag
+    BUTTON and will exist on every turn.
+    """
+    hints = (Hint("refusal-shaped", 0, "opens with a refusal"),)
+    async with _Host(hints=hints).run_test() as pilot:
+        turn = pilot.app.query_one("#evals-cv-turn-0")
+        assert turn.query(".evals-cv-hint")
+        assert not turn.query(".evals-cv-applied-tag")
+
+
+@pytest.mark.asyncio
+async def test_no_logprob_or_canary_vocabulary_appears():
+    async with _Host().run_test() as pilot:
+        text = pilot.app.query_one(ConversationView).render_str_or_text().lower()
+        for forbidden in ("logprob", "top-k", "top_k", "canary", "normalizer"):
+            assert forbidden not in text
+
+
+@pytest.mark.asyncio
+async def test_an_existing_annotation_renders_on_its_turn():
+    annotations = {1: {"tags": ["broke-character"], "note": "slipped here"}}
+    async with _Host(annotations=annotations).run_test() as pilot:
+        turn = pilot.app.query_one("#evals-cv-turn-1")
+        assert "broke-character" in turn.render_str_or_text()
+        assert "slipped here" in turn.render_str_or_text()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(160, 45), (235, 52)])
+async def test_the_last_turn_is_reachable_at_realistic_sizes(size):
+    turns = tuple(
+        ConversationTurn(user=f"question {i}", reply="a reply " * 20) for i in range(12)
+    )
+    conv = Conversation(
+        card_id=1, probe_index=0, sample_index=0, target_id="t-1", turns=turns,
+    )
+    async with _Host(conversation=conv).run_test(size=size) as pilot:
+        view = pilot.app.query_one(ConversationView)
+        view.scroll_end(animate=False)
+        await pilot.pause()
+        last = pilot.app.query_one("#evals-cv-turn-11")
+        hit = pilot.app.screen.get_widget_at(*last.region.center)[0]
+        assert hit is last or last in hit.ancestors
+```
+
+`render_str_or_text()` is a placeholder for however this repo's existing tests read a widget's painted text — **grep `Tests/UI/test_evals_character_bench_editor.py` and `test_evals_snippet_editor.py` for the real helper and use it verbatim**. Do not add a new one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_conversation_view.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...conversation_view'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+A `Vertical` whose `compose()` yields: the card's opening message (`#evals-cv-opening`, `markup=False`), then per turn a `Vertical(id=f"evals-cv-turn-{index}")` containing the scripted user prompt (`.evals-cv-user`) and the reply (`.evals-cv-reply`), each a `Static(markup=False)` rendering through `render_snippet_cell` so whitespace stays visible; then any hints for that turn as a plain line (`.evals-cv-hint`) and any existing annotation, whose applied tags carry `.evals-cv-applied-tag` (`.evals-cv-annotation` on the block); then `#evals-cv-error` **only when `conversation.error`** is non-empty.
+
+Keep `.evals-cv-hint` and `.evals-cv-applied-tag` visually distinct and never share a class between them. Task 5 adds a per-turn tag *button* with id `#evals-cv-tag-{turn_index}` inside this same block — that is a third thing again, and none of the three may be styled as another.
+
+`focus_turn(index)` scrolls the turn block into view and focuses it — Task 7's keyboard navigation calls it, and Task 5 mounts the tag affordance inside the same block.
+
+Style hints and annotations differently and give hints no tag-like class: `test_a_hint_never_renders_as_a_tag_or_a_score` pins that a hint is not mistakable for an applied tag.
+
+CSS: `#evals-conversation-view` gets `height: 1fr; overflow-y: auto;`. Note the difference from Phase 2's editor, which took `overflow-y: auto` with no height because `#evals-detail-pane` bounds it — here the view is one of two siblings in a split pane and must take its share explicitly. Verify the real parent before choosing, and regenerate the bundle with `/private/tmp/tldw-venv/bin/python tldw_chatbook/css/build_css.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_conversation_view.py -p no:randomly`
+Expected: PASS (15 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Evals/conversation_view.py tldw_chatbook/css Tests/UI/test_evals_conversation_view.py
+git commit -m "feat(evals): the character-probe conversation view (task-1691 phase 3b)"
+```
+
+---
+
+### Task 4: The review pane replaces the placeholder
+
+**Files:**
+- Create: `tldw_chatbook/UI/Evals/review_pane.py`
+- Modify: `tldw_chatbook/UI/Screens/evals_screen.py`
+- Modify: `tldw_chatbook/css/features/_evals.tcss` (+ regenerate the bundle)
+- Test: `Tests/UI/test_evals_review_pane.py`
+
+**Interfaces:**
+- Consumes: `build_queue`, `queue_progress`, `QueueFilter` (Task 2); `compute_hints` (Task 1); `ConversationView` (Task 3); `load_conversations`, `load_probe_run_snapshot`, `load_review_state`, `load_turn_annotations`, `mark_conversation_reviewed` (storage).
+- Produces: `ReviewPane(view_model, run_group_id, id="evals-review-pane")` with `#evals-review-list` (one `#evals-review-row-{index}` per queued conversation), `#evals-review-progress`, the filter controls `#evals-review-filter-card` / `-probe` / `-target` / `-unreviewed`, and `#evals-review-mark-reviewed`; message `ReviewPane.ConversationSelected(key)`.
+
+This replaces the neutral placeholder Phase 2 mounts at `evals_screen.py:1993` (`#evals-detail-character-run-placeholder`). Keep `_character_run_group` (`evals_screen.py:490`) as the predicate — it already keeps `ResultsGrid`/`EvalsCellInspector` away from this bench type; this task changes only what mounts in the true branch.
+
+**"Reviewed" is explicit.** `#evals-review-mark-reviewed` writes review state via `mark_conversation_reviewed` even when the conversation carries no annotations at all — "nothing notable" is a real verdict and the progress count depends on it.
+
+**Hints are computed here, on demand**, when the pane loads a run group — never in the run worker.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_selecting_a_character_run_group_renders_the_review_pane(
+    evals_app, reviewable_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        assert pilot.app.screen.query("#evals-review-pane")
+        assert not pilot.app.screen.query("#evals-detail-character-run-placeholder")
+
+
+@pytest.mark.asyncio
+async def test_a_word_bench_run_group_still_renders_its_results_grid(
+    evals_app, word_bench_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=word_bench_run_group)
+        await pilot.pause()
+        assert not pilot.app.screen.query("#evals-review-pane")
+
+
+@pytest.mark.asyncio
+async def test_every_conversation_gets_a_queue_row(evals_app, reviewable_run_group):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        assert len(pilot.app.screen.query(".evals-review-row")) == 4
+
+
+@pytest.mark.asyncio
+async def test_clicking_a_queue_row_shows_that_conversation(
+    evals_app, reviewable_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-1")
+        await pilot.pause()
+        assert pilot.app.screen.query_one("#evals-conversation-view")
+
+
+@pytest.mark.asyncio
+async def test_progress_starts_at_zero_of_the_queue_length(
+    evals_app, reviewable_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        text = pilot.app.screen.query_one("#evals-review-progress").render_str_or_text()
+        assert "0" in text and "4" in text
+
+
+@pytest.mark.asyncio
+async def test_marking_reviewed_persists_and_advances_progress(
+    evals_app, reviewable_run_group, evals_db
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.click("#evals-review-mark-reviewed")
+        await pilot.pause()
+
+        from tldw_chatbook.Evals.character_probe.storage import load_review_state
+        assert len(load_review_state(evals_db, reviewable_run_group)) == 1
+        text = pilot.app.screen.query_one("#evals-review-progress").render_str_or_text()
+        assert "1" in text
+
+
+@pytest.mark.asyncio
+async def test_a_conversation_with_no_annotations_can_be_marked_reviewed(
+    evals_app, reviewable_run_group, evals_db
+):
+    """Reading a conversation and finding nothing notable is a real verdict."""
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.click("#evals-review-mark-reviewed")
+        await pilot.pause()
+
+        from tldw_chatbook.Evals.character_probe.storage import load_turn_annotations
+        assert load_turn_annotations(evals_db, reviewable_run_group) == {}
+        from tldw_chatbook.Evals.character_probe.storage import load_review_state
+        assert load_review_state(evals_db, reviewable_run_group)
+
+
+@pytest.mark.asyncio
+async def test_review_state_survives_reopening_the_run_group(
+    evals_app, reviewable_run_group
+):
+    """The queue is resumable across sessions, which annotation work requires."""
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.click("#evals-review-mark-reviewed")
+        await pilot.pause()
+
+        # Navigate away and back, so the pane is rebuilt from the database
+        # rather than from whatever it still holds in memory.
+        pilot.app.screen.select(kind="bench", id=bench_id_of_that_run)
+        await pilot.pause()
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        text = pilot.app.screen.query_one("#evals-review-progress").render_str_or_text()
+        assert "1" in text
+
+
+@pytest.mark.asyncio
+async def test_filtering_to_unreviewed_only_hides_a_reviewed_conversation(
+    evals_app, reviewable_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.click("#evals-review-mark-reviewed")
+        await pilot.click("#evals-review-filter-unreviewed")
+        await pilot.pause()
+        assert len(pilot.app.screen.query(".evals-review-row")) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_card_name_with_markup_renders_literally_in_a_queue_row(
+    evals_app, run_group_with_markup_card_name
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=run_group_with_markup_card_name)
+        await pilot.pause()
+        row = pilot.app.screen.query_one("#evals-review-row-0")
+        assert "[/]" in row.render_str_or_text()
+
+
+@pytest.mark.asyncio
+async def test_no_logprob_or_canary_vocabulary_appears_in_the_pane(
+    evals_app, reviewable_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        text = pilot.app.screen.query_one("#evals-review-pane").render_str_or_text().lower()
+        for forbidden in ("logprob", "top-k", "top_k", "canary", "normalizer"):
+            assert forbidden not in text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(160, 45), (235, 52)])
+async def test_mark_reviewed_stays_hit_testable_at_realistic_sizes(
+    evals_app, reviewable_run_group, size
+):
+    async with evals_app.run_test(size=size) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        button = pilot.app.screen.query_one("#evals-review-mark-reviewed")
+        hit = pilot.app.screen.get_widget_at(*button.region.center)[0]
+        assert hit is button or button in hit.ancestors
+```
+
+The reopen test needs `bench_id_of_that_run` alongside the run-group fixture — add it if the fixture module does not already expose one. Build `reviewable_run_group` (2 cards × 2 probes × 1 target × 1 sample = 4 conversations), `word_bench_run_group`, and `run_group_with_markup_card_name` on `Tests/UI/test_evals_character_run_e2e.py`'s existing fixtures — **import them rather than writing new run-group construction**, and remember that fixture's own lesson: build target rows the way the real "+ New target" form writes them, never as hand-built dicts.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_review_pane.py -p no:randomly`
+Expected: FAIL — the placeholder still mounts; `#evals-review-pane` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`ReviewPane` is a `Horizontal` split: the queue list on the left (`#evals-review-list`, one `Button` per entry with the card name, probe index, target name, a reviewed marker, and a hint marker), the conversation on the right. Above the list, the four filter controls; below it, `#evals-review-progress` rendering `f"{reviewed} of {total} reviewed"` — two integers, never a percentage.
+
+On mount, load once: `load_conversations`, `load_probe_run_snapshot`, `load_review_state`, `load_turn_annotations`, then `compute_hints`. Rebuild only the list when a filter changes; rebuild only the right-hand side when the selection changes — recomposing the whole pane on every keystroke is what made Phase 2's card picker drop focus.
+
+In `evals_screen.py`, replace the placeholder mount (`:1993`) with `ReviewPane(...)`. Leave `_character_run_group` and the `ResultsGrid` guards exactly as they are — they already encode "never the word-bench surface for this bench type", and Task 4 must not weaken that.
+
+CSS: give the list a bounded width and the conversation side `1fr`. Regenerate the bundle.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_review_pane.py Tests/UI/test_evals_screen.py Tests/UI/test_evals_character_run_e2e.py -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Evals/review_pane.py tldw_chatbook/UI/Screens/evals_screen.py tldw_chatbook/css Tests/UI/test_evals_review_pane.py
+git commit -m "feat(evals): the character-probe review queue pane (task-1691 phase 3b)"
+```
+
+---
+
+### Task 5: Applying a tag to a turn
+
+**Files:**
+- Create: `tldw_chatbook/UI/Evals/tag_picker.py`
+- Modify: `tldw_chatbook/UI/Evals/conversation_view.py`
+- Test: `Tests/UI/test_evals_tag_picker.py`
+
+**Interfaces:**
+- Consumes: `run_group_vocabulary` (Phase 3a), `annotate_turn`, `Tag`, `TAG_KINDS`.
+- Produces: `TagPicker(vocabulary, selected_slugs, note, id=...)` with `#evals-tag-search`, one `#evals-tag-row-{index}` per matching tag grouped under a heading per kind, `#evals-tag-note`, `#evals-tag-apply`; message `TagPicker.Applied(slugs: tuple[str, ...], note: str)`. `ConversationView` gains `#evals-cv-tag-{turn_index}` — the per-turn affordance that opens it.
+
+The spec: "the UI offers existing tags before creating new ones, to limit the `broke-character` / `OOC` / `out-of-character` fragmentation that per-bench extension invites." So the picker leads with the run's vocabulary and search filters it; creating a new one is Task 6 and sits **after** the existing list, never before it.
+
+Tags are grouped by kind with the kind named, because a reviewer choosing between `notable` and `broke-character` is choosing a kind as much as a label.
+
+- [ ] **Step 1: Write the failing test**
+
+Cover, driving everything through `pilot`: every vocabulary tag renders a row; rows are grouped under their kind's heading; clicking a row selects it and clicking again deselects; search filters case-insensitively and does not drop a selection filtered out of view; a tag label containing markup renders literally; applying posts `Applied` with the selected slugs and the typed note; applying with **no** tags but a typed note still posts (a note alone is a real observation); and the geometry assertion that `#evals-tag-apply` stays hit-testable at 160x45 and 235x52 with a full ten-tag vocabulary.
+
+Then the integration test that matters most, driving the real widget chain and asserting the **database**:
+
+```python
+@pytest.mark.asyncio
+async def test_applying_a_tag_from_the_conversation_view_persists_it(
+    evals_app, reviewable_run_group, evals_db
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.pause()
+        await pilot.click("#evals-cv-tag-0")
+        await pilot.pause()
+        await pilot.click("#evals-tag-row-0")
+        await pilot.click("#evals-tag-apply")
+        await pilot.pause()
+
+        from tldw_chatbook.Evals.character_probe.storage import load_turn_annotations
+        stored = load_turn_annotations(evals_db, reviewable_run_group)
+        assert stored, "no annotation was written"
+        (key, value), = stored.items()
+        assert key[4] == 0  # turn_index
+        assert value["tags"]
+```
+
+and its converse, which is the one that catches an unusable affordance:
+
+```python
+@pytest.mark.asyncio
+async def test_the_applied_tag_renders_on_the_turn_without_reopening_the_run(
+    evals_app, reviewable_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.click("#evals-cv-tag-0")
+        await pilot.pause()
+        await pilot.click("#evals-tag-row-0")
+        await pilot.click("#evals-tag-apply")
+        await pilot.pause()
+        turn = pilot.app.screen.query_one("#evals-cv-turn-0")
+        assert "broke-character" in turn.render_str_or_text()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_tag_picker.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...tag_picker'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Model `TagPicker` on Phase 2's `CardPicker` (`card_picker.py`) — it solved the same problems and its traps are already paid for: rows live in their own `#evals-tag-picker-rows` container so filtering never rebuilds the search `Input` and drops focus, and selection is tracked by slug so a tag filtered out of view stays selected. **Row ids are positional over the filtered list**, exactly as `CardPicker`'s are; do not use a row id to mean a specific tag after a search.
+
+Every tag label is user-authored (a bench may relabel a built-in), so labels go through `escape_markup` in `Button` labels and `markup=False` in any `Static`.
+
+`ConversationView` gains a tag button per turn, mounted inside that turn's block, opening the picker seeded with the turn's existing tags and note. On `Applied`, the pane calls `annotate_turn` and refreshes just that turn's annotation line — not the whole view.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_tag_picker.py Tests/UI/test_evals_conversation_view.py Tests/UI/test_evals_review_pane.py -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Evals/tag_picker.py tldw_chatbook/UI/Evals/conversation_view.py Tests/UI/test_evals_tag_picker.py
+git commit -m "feat(evals): apply review tags to a conversation turn (task-1691 phase 3b)"
+```
+
+---
+
+### Task 6: Creating a bench tag, kind required
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Evals/tag_picker.py`
+- Modify: `tldw_chatbook/UI/Evals/review_pane.py`
+- Test: `Tests/UI/test_evals_tag_picker.py`
+
+**Interfaces:**
+- Consumes: `canonical_slug`, `TAG_KINDS`, `coerce_tag` (Phase 3a); `save_character_bench`, `load_character_bench`.
+- Produces: `#evals-tag-new-name`, `#evals-tag-new-kind` (one control per kind, no pre-selection), `#evals-tag-new-create`, `#evals-tag-new-error`; message `TagPicker.TagCreated(tag: Tag)`.
+
+The spec is unusually firm here: "**Creating a tag requires choosing its kind** — the extension flow asks, with no default. A kind guessed on the user's behalf would quietly mis-group observations in the summary, and `notable` is not a safe fallback: it would make genuine failures invisible in exactly the view meant to surface them."
+
+So: **no kind is pre-selected**, and Create is refused with a visible reason until one is chosen. Do not make `notable` the default "to be helpful".
+
+A created tag is added to the **bench's** `extra_tags` — it outlives this run. But the run being reviewed keeps the vocabulary its snapshot captured (Phase 3a, task 4), so a newly created tag is usable in **this** review only if the pane also adds it to its in-memory vocabulary. Decide and state which you implement:
+- **Recommended:** add it to the bench AND to the pane's live vocabulary for this session, so the reviewer can use the tag they just created. Note in the code that `run_group_vocabulary` will not return it on a later reopen of this older run, and why that is the correct provenance trade-off.
+- The alternative — refusing to use a new tag until the bench is re-run — is defensible but frustrating; if you pick it, say so and make the UI state it plainly rather than silently failing the next apply.
+
+- [ ] **Step 1: Write the failing test**
+
+Cover, all through `pilot`: creating a tag with a name and a kind adds it to the bench's `extra_tags` **in the database**; Create with a name but **no kind** is refused with a visible error naming the missing kind, and writes nothing; no kind control is selected when the picker opens; a name that canonicalises to an existing slug relabels rather than duplicating; a name with no usable characters is refused with a visible error; the created tag is immediately selectable in this picker and, when applied, persists through `annotate_turn`; and the geometry assertion that `#evals-tag-new-create` stays hit-testable at both sizes with a full vocabulary above it.
+
+The load-bearing one:
+
+```python
+@pytest.mark.asyncio
+async def test_creating_a_tag_without_choosing_a_kind_is_refused_and_writes_nothing(
+    evals_app, reviewable_run_group, evals_db, bench_id_of_that_run
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.click("#evals-cv-tag-0")
+        await pilot.pause()
+        await pilot.click("#evals-tag-new-name")
+        await pilot.press(*"meta commentary")
+        await pilot.click("#evals-tag-new-create")
+        await pilot.pause()
+
+        assert pilot.app.screen.query_one("#evals-tag-new-error").visible
+        from tldw_chatbook.Evals.character_probe.storage import load_character_bench
+        assert load_character_bench(evals_db, bench_id_of_that_run).extra_tags == ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_tag_picker.py -k new -p no:randomly`
+Expected: FAIL — `NoMatches: #evals-tag-new-name`
+
+- [ ] **Step 3: Write minimal implementation**
+
+The create form sits **below** the existing-tag list, so the spec's "offers existing tags before creating new ones" is true of the layout and not only of the code. One control per kind (`RadioSet` or three toggle Buttons — follow whatever this slice already uses for a small exclusive choice; grep `bench_editor.py` before inventing one), with **nothing selected initially**.
+
+On Create: canonicalise the name; if it yields nothing, or no kind is selected, render the reason in `#evals-tag-new-error` and return without writing. Otherwise build the `Tag`, append it to the bench's `extra_tags` via `save_character_bench`, add it to the picker's live vocabulary, and post `TagCreated`.
+
+`#evals-tag-new-error` is a `Static(markup=False)` carrying a user-typed name — same convention as Phase 2's `#evals-cb-form-error`, including that a failed create does **not** recompose, so the typed name survives.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_tag_picker.py Tests/Evals/character_probe -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Evals/tag_picker.py tldw_chatbook/UI/Evals/review_pane.py Tests/UI/test_evals_tag_picker.py
+git commit -m "feat(evals): create a bench tag, kind required (task-1691 phase 3b)"
+```
+
+---
+
+### Task 7: Keyboard-first review
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Evals/review_pane.py`
+- Modify: `tldw_chatbook/UI/Evals/conversation_view.py`
+- Test: `Tests/UI/test_evals_review_keyboard.py`
+
+**Interfaces:**
+- Consumes: `ReviewPane`, `ConversationView`, `TagPicker` (Tasks 3-6).
+- Produces: `ReviewPane.BINDINGS` — `j`/`k` next/previous conversation, `n`/`p` next/previous turn, `t` open the tag picker on the focused turn, `r` mark the current conversation reviewed, `u` toggle the unreviewed-only filter.
+
+The spec: "Reviewing dozens of conversations by mouse in a terminal app is untenable; moving between turns and conversations and applying tags must be a few keystrokes."
+
+**Every test here presses real keys through `pilot` and asserts the persisted result or the moved focus** — never calls the action method directly. An action method that works while its binding is unreachable is exactly the defect family this project has shipped four times.
+
+Check for conflicts before choosing: `EvalsScreen` and the app shell already own bindings, and a single-letter binding that collides with an existing one, or that fires while an `Input` has focus, is worse than no binding. **Confirm the pane's bindings do not fire while the reviewer is typing in `#evals-tag-note`, `#evals-tag-search`, or `#evals-tag-new-name`** — that is a test, not an assumption.
+
+- [ ] **Step 1: Write the failing test**
+
+Cover: `j` moves the selection to the next conversation and the conversation view follows; `k` moves back; `j` at the end of the queue does not wrap or crash; `n`/`p` move the focused turn within a conversation and the focus is really on the turn block; `t` opens the tag picker for the focused turn (assert the picker is mounted and seeded with **that** turn's existing tags); `r` writes review state to the database and advances the progress line; `u` toggles the unreviewed-only filter and the row count changes; and — the one that catches a binding that silently steals keystrokes:
+
+```python
+@pytest.mark.asyncio
+async def test_typing_a_note_does_not_trigger_the_review_bindings(
+    evals_app, reviewable_run_group, evals_db
+):
+    """`r`, `j`, `t`, `u` are letters. A reviewer must be able to type them."""
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewable_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-row-0")
+        await pilot.click("#evals-cv-tag-0")
+        await pilot.pause()
+        await pilot.click("#evals-tag-note")
+        await pilot.press(*"jerky turn, refused up front")
+        await pilot.pause()
+
+        note = pilot.app.screen.query_one("#evals-tag-note")
+        assert note.value == "jerky turn, refused up front"
+        from tldw_chatbook.Evals.character_probe.storage import load_review_state
+        assert load_review_state(evals_db, reviewable_run_group) == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_review_keyboard.py -p no:randomly`
+Expected: FAIL — no bindings exist, so `j` moves nothing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `BINDINGS` to `ReviewPane` with `show=False` for the ones that would crowd the footer, and a short footer hint for `r` and `t` — the two a first-time reviewer will not guess. Actions operate on the pane's current selection and focused turn, both of which the pane already tracks from Tasks 4 and 5.
+
+Textual routes a key to the focused widget first, so a binding on the pane will not fire while an `Input` inside it has focus — but **verify that against the real widget tree rather than trusting it**, because the picker may be mounted as a modal whose focus behaviour differs. If a collision does occur, gate the actions on `isinstance(self.app.focused, Input)` rather than removing the binding.
+
+Document each binding's choice in a comment where it is defined: `j`/`k` and `n`/`p` are chosen for one-hand navigation without a modifier, `r` and `t` for their initials.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_review_keyboard.py Tests/UI/test_evals_review_pane.py Tests/UI/test_evals_tag_picker.py -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Evals/review_pane.py tldw_chatbook/UI/Evals/conversation_view.py Tests/UI/test_evals_review_keyboard.py
+git commit -m "feat(evals): keyboard-first character-probe review (task-1691 phase 3b)"
+```
+
+---
+
+## Phase 3b exit criteria
+
+- Selecting a character-probe run group renders the review queue, not the placeholder and never the word-bench results grid.
+- The queue is ordered with hinted conversations first, is filterable by card, probe, target, and not-yet-reviewed, and does not reshuffle when a conversation is reviewed.
+- The conversation view shows the card's opening message and every turn, with empty and whitespace-only replies visible rather than blank.
+- A tag can be applied to a specific turn by keystroke and is in the database afterwards.
+- A tag can be created only with an explicitly chosen kind; a create without one is refused visibly and writes nothing.
+- "Reviewed" can be recorded with zero annotations, the progress count reflects it, and it survives reopening the run group.
+- Hints render as hints — never as tags, never as a number, never in the run path.
+- Every new control is hit-testable at 160x45 and 235x52.
+- `Tests/Evals` and the word-bench UI suites remain green and behaviourally untouched.
+
+## Not in Phase 3b (deliberate)
+
+The summary — per-tag counts across cards, probes, and targets — is Phase 4. Cross-run comparison is out of scope entirely (the spec: annotations are per run group, and non-determinism makes comparison unsound without seeds). A rich probe editor stays a follow-up. And no view here sums tags into a number.

--- a/Docs/superpowers/plans/2026-08-02-character-probe-phase4-summary.md
+++ b/Docs/superpowers/plans/2026-08-02-character-probe-phase4-summary.md
@@ -1,0 +1,372 @@
+# Character Probe Evals — Phase 4 (Summary) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Answer the question the eval was built for — which model broke character most, which card was hardest, which probe broke things regardless of model — as per-tag counts, and never as a score.
+
+**Architecture:** Aggregation is a pure function over the annotations Phase 3b records; the UI is one more surface inside the review pane. Small by design: the hard constraint here is what the summary must *refuse* to do.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest. Engine from phases 1 and 3a; UI alongside Phase 3b's review pane.
+
+## Global Constraints
+
+Copied from `Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md`. Every task's requirements implicitly include this section.
+
+- **The summary reports per-tag counts and never a composite score.** The spec, verbatim: "Ranking models by 'fewest bad tags' would invent the objective metric this eval exists precisely because we lack — and would be wrong anyway, since `notable` and `positive` tags are not penalties. **No view anywhere sums tags into a number.**"
+- **Every tag carries a kind** (`failure`, `notable`, `positive`), and the summary groups by kind so it cannot imply "fewer tags is better".
+- **No logprobs / top-K / normalizer / canary vocabulary** anywhere in character-probe UI.
+- **The three questions the summary answers**, from the spec: which model broke character most, which card was hardest, which probe broke things regardless of model. Those are the three groupings — by target, by card, by probe.
+- User-authored text is a markup hazard: `markup=False` on any Static carrying a card name, probe text, or tag label; `escape_markup` in Button labels and tooltips.
+- Fail loudly, never silently default.
+- `character_ids` are ints; every eval id is a str. Do not normalise them.
+- Tests must drive real widgets — press or type through `pilot`, assert what is in the database or on the screen, not what a helper returned.
+- Painted geometry is the arbiter — new controls stay hit-testable at 160x45 AND 235x52.
+- Google-style docstrings; CSS in `css/features/_evals.tcss` regenerated via `build_css.py`, never hand-edited.
+- Run tests foreground: `/private/tmp/tldw-venv/bin/python -m pytest <paths> -p no:randomly`. Never `-q`. **Pass `timeout: 600000` on the Bash call.**
+
+## What already exists (assumed from phases 3a and 3b — verify before use)
+
+- `tags.py`: `Tag`, `TAG_KINDS`, `BUILTIN_TAGS`, `tag_by_slug`, `resolve_vocabulary`.
+- `storage.run_group_vocabulary(db, run_group_id)`, `load_turn_annotations(db, run_group_id)` returning `dict[(card_id, probe_index, sample_index, target_id, turn_index), {"tags": [...], "note": str}]`, `load_review_state`, `load_probe_run_snapshot`.
+- `review_queue.queue_progress(entries) -> (reviewed, total)`.
+- `ReviewPane` (`UI/Evals/review_pane.py`) with its queue list and conversation side.
+
+## File Structure
+
+- `tldw_chatbook/Evals/character_probe/summary.py` (new) — pure aggregation over loaded annotations plus the run snapshot. No DB, no UI, no ranking.
+- `tldw_chatbook/UI/Evals/summary_view.py` (new) — the three grouped tables and the coverage line.
+- `tldw_chatbook/UI/Evals/review_pane.py` — a way to reach the summary from the queue.
+- Tests mirror each under `Tests/Evals/character_probe/` and `Tests/UI/`.
+
+---
+
+### Task 1: Aggregating tag counts
+
+**Files:**
+- Create: `tldw_chatbook/Evals/character_probe/summary.py`
+- Test: `Tests/Evals/character_probe/test_summary.py`
+
+**Interfaces:**
+- Consumes: `load_turn_annotations`' return shape; the run snapshot's `cards`, `probes`, `targets`; `Tag` and `tag_by_slug` (Phase 3a).
+- Produces: `TagCount(slug: str, label: str, kind: str, count: int)`; `GroupedCounts(group_key: str | int, group_label: str, counts: tuple[TagCount, ...])`; `summarise(annotations, snapshot, vocabulary) -> dict[str, tuple[GroupedCounts, ...]]` keyed by exactly `"by_target"`, `"by_card"`, `"by_probe"`.
+
+`count` is the number of **annotations carrying that tag** within the group — a count of observations, which is a fact. It is not a score, and nothing in this module combines counts across kinds. `summarise` returns counts grouped by kind-ordered tag; it must not return a total, a ratio, a rank, or a sort by "worst".
+
+**The three groupings are the three questions**, no more: by target ("which model broke character most"), by card ("which card was hardest"), by probe ("which probe broke things regardless of model").
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from tldw_chatbook.Evals.character_probe.summary import summarise
+from tldw_chatbook.Evals.character_probe.tags import BUILTIN_TAGS
+
+SNAPSHOT = {
+    "cards": [{"id": 1, "name": "Vex"}, {"id": 2, "name": "Marlow"}],
+    "probes": [{"turns": ["q1"]}, {"turns": ["q2"]}],
+    "targets": [{"id": "t-1", "name": "llama-8b"}, {"id": "t-2", "name": "llama-70b"}],
+}
+
+
+def _annotations(*entries):
+    """entries: (card_id, probe, sample, target, turn, [slugs])"""
+    return {
+        (c, p, s, t, turn): {"tags": list(slugs), "note": ""}
+        for c, p, s, t, turn, slugs in entries
+    }
+
+
+def test_an_empty_run_summarises_to_empty_groups():
+    result = summarise({}, SNAPSHOT, BUILTIN_TAGS)
+    assert set(result) == {"by_target", "by_card", "by_probe"}
+    assert all(
+        all(not g.counts for g in groups) for groups in result.values()
+    )
+
+
+def test_a_tag_is_counted_under_its_target():
+    annotations = _annotations((1, 0, 0, "t-1", 0, ["broke-character"]))
+    groups = summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_target"]
+    by_key = {g.group_key: g for g in groups}
+    counts = {c.slug: c.count for c in by_key["t-1"].counts}
+    assert counts["broke-character"] == 1
+    assert not by_key["t-2"].counts
+
+
+def test_a_tag_is_counted_under_its_card():
+    annotations = _annotations((2, 0, 0, "t-1", 0, ["refused"]))
+    groups = summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_card"]
+    by_key = {g.group_key: g for g in groups}
+    assert {c.slug: c.count for c in by_key[2].counts}["refused"] == 1
+
+
+def test_a_tag_is_counted_under_its_probe():
+    annotations = _annotations((1, 1, 0, "t-1", 0, ["refused"]))
+    groups = summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_probe"]
+    by_key = {g.group_key: g for g in groups}
+    assert {c.slug: c.count for c in by_key[1].counts}["refused"] == 1
+
+
+def test_one_annotation_with_two_tags_counts_once_for_each():
+    annotations = _annotations((1, 0, 0, "t-1", 0, ["refused", "broke-character"]))
+    groups = {g.group_key: g for g in summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_target"]}
+    counts = {c.slug: c.count for c in groups["t-1"].counts}
+    assert counts["refused"] == 1
+    assert counts["broke-character"] == 1
+
+
+def test_the_same_tag_on_two_turns_counts_twice():
+    annotations = _annotations(
+        (1, 0, 0, "t-1", 0, ["broke-character"]),
+        (1, 0, 0, "t-1", 1, ["broke-character"]),
+    )
+    groups = {g.group_key: g for g in summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_target"]}
+    assert {c.slug: c.count for c in groups["t-1"].counts}["broke-character"] == 2
+
+
+def test_a_group_carries_its_human_label():
+    annotations = _annotations((1, 0, 0, "t-1", 0, ["refused"]))
+    groups = {g.group_key: g for g in summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_card"]}
+    assert groups[1].group_label == "Vex"
+
+
+def test_every_group_from_the_snapshot_appears_even_with_no_annotations():
+    """A model nobody tagged is a result, not an absence."""
+    annotations = _annotations((1, 0, 0, "t-1", 0, ["refused"]))
+    groups = summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_target"]
+    assert {g.group_key for g in groups} == {"t-1", "t-2"}
+
+
+def test_counts_are_ordered_by_tag_kind_not_by_magnitude():
+    """Ordering by count would be a ranking; kind order is the spec's order."""
+    annotations = _annotations(
+        (1, 0, 0, "t-1", 0, ["in-character"]),
+        (1, 0, 0, "t-1", 1, ["in-character"]),
+        (1, 0, 0, "t-1", 2, ["broke-character"]),
+    )
+    groups = {g.group_key: g for g in summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_target"]}
+    kinds = [c.kind for c in groups["t-1"].counts]
+    assert kinds == sorted(kinds, key=lambda k: ("failure", "notable", "positive").index(k))
+    assert kinds[0] == "failure"
+
+
+def test_a_tag_count_carries_its_kind_and_label():
+    annotations = _annotations((1, 0, 0, "t-1", 0, ["broke-character"]))
+    groups = {g.group_key: g for g in summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_target"]}
+    count = groups["t-1"].counts[0]
+    assert count.kind == "failure"
+    assert count.label == "Broke character"
+
+
+def test_a_tag_outside_the_vocabulary_raises_naming_it():
+    """Phase 3a rejects these at write time; a corrupt row must not be silent."""
+    annotations = _annotations((1, 0, 0, "t-1", 0, ["no-such-tag"]))
+    with pytest.raises(KeyError) as exc:
+        summarise(annotations, SNAPSHOT, BUILTIN_TAGS)
+    assert "no-such-tag" in str(exc.value)
+
+
+def test_an_annotation_with_only_a_note_contributes_no_counts():
+    annotations = _annotations((1, 0, 0, "t-1", 0, []))
+    groups = {g.group_key: g for g in summarise(annotations, SNAPSHOT, BUILTIN_TAGS)["by_target"]}
+    assert not groups["t-1"].counts
+
+
+def test_the_summary_exposes_no_total_ratio_or_rank():
+    """The one constraint this whole phase exists to hold."""
+    import dataclasses
+    from tldw_chatbook.Evals.character_probe.summary import GroupedCounts, TagCount
+
+    assert {f.name for f in dataclasses.fields(TagCount)} == {
+        "slug", "label", "kind", "count",
+    }
+    assert {f.name for f in dataclasses.fields(GroupedCounts)} == {
+        "group_key", "group_label", "counts",
+    }
+    import tldw_chatbook.Evals.character_probe.summary as mod
+    exported = {n for n in dir(mod) if not n.startswith("_")}
+    for forbidden in ("rank", "score", "total", "ratio", "best", "worst"):
+        assert not any(forbidden in name.lower() for name in exported)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe/test_summary.py -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named '...summary'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Two frozen dataclasses and one function, with the module docstring carrying the constraint so nobody adds a total later:
+
+```python
+"""Per-tag counts across a character-probe run.
+
+This module deliberately produces NO composite score, total, ratio, or rank.
+The design spec: "Ranking models by 'fewest bad tags' would invent the
+objective metric this eval exists precisely because we lack -- and would be
+wrong anyway, since `notable` and `positive` tags are not penalties. No view
+anywhere sums tags into a number."
+
+A count of how many times a tag was applied within a group is a fact about
+what a reader observed. The moment counts of different kinds are combined,
+it stops being a fact and becomes the metric this eval refuses to invent.
+``TagCount`` and ``GroupedCounts`` therefore carry no field a caller could
+sort by across kinds, and this module exports no such helper.
+"""
+```
+
+`summarise` walks the annotations once, resolving each slug through `tag_by_slug` (which raises naming the slug for anything outside the vocabulary — that is the fail-loudly path the test pins), and accumulates into three `dict[group_key, Counter]`. Then it materialises every group present in the snapshot — including groups with no annotations, so "nobody tagged this model" reads as a result rather than a missing row — ordering each group's counts by `TAG_KINDS.index(kind)` then by slug, never by count.
+
+Read groups from the snapshot: targets from `snapshot["targets"]` (`id`, `name`), cards from `snapshot["cards"]` (`id`, `name`), probes from `snapshot["probes"]` by index with a label like `f"Probe {index + 1}"`. Guard each read with `or []`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/Evals/character_probe -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Evals/character_probe/summary.py Tests/Evals/character_probe/test_summary.py
+git commit -m "feat(evals): per-tag count aggregation for a character-probe run (task-1691 phase 4)"
+```
+
+---
+
+### Task 2: The summary view
+
+**Files:**
+- Create: `tldw_chatbook/UI/Evals/summary_view.py`
+- Modify: `tldw_chatbook/UI/Evals/review_pane.py`
+- Modify: `tldw_chatbook/css/features/_evals.tcss` (+ regenerate the bundle)
+- Test: `Tests/UI/test_evals_summary_view.py`
+
+**Interfaces:**
+- Consumes: `summarise`, `GroupedCounts`, `TagCount` (Task 1); `queue_progress` (Phase 3b); `TAG_KINDS`.
+- Produces: `SummaryView(grouped, coverage, id="evals-summary-view")` with `#evals-summary-by-target`, `#evals-summary-by-card`, `#evals-summary-by-probe`, and `#evals-summary-coverage`; `#evals-review-summary` in `ReviewPane` to reach it, and `#evals-review-back-to-queue` to return.
+
+**The coverage line is what keeps the summary honest.** It states how much of the run has actually been reviewed — `queue_progress`' two integers — because counts over a half-read run mean something different from counts over a finished one, and a reader who cannot see that will over-read the table. It is not a score and is never rendered as a percentage.
+
+Each grouping renders as a small table: one row per group, one column per tag that has a non-zero count anywhere in that grouping, with the tag's **kind shown in the header**. A group with no counts renders its row with zeros rather than being dropped.
+
+- [ ] **Step 1: Write the failing test**
+
+Cover, driving through `pilot`: the three groupings each render with a row per group; a group with no annotations still renders a row; the tag columns show each tag's kind; a card name containing markup renders literally; a bench-relabelled tag shows its label rather than its slug; the coverage line shows reviewed-of-total as two integers; the summary is reachable from the queue by clicking `#evals-review-summary` and returns by `#evals-review-back-to-queue`; no logprob/top-K/canary/normalizer vocabulary appears; and the geometry assertion at both sizes.
+
+Plus the two that hold the phase's one hard line:
+
+```python
+@pytest.mark.asyncio
+async def test_the_summary_shows_no_percentage_and_no_composite_number(
+    evals_app, reviewed_run_group
+):
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=reviewed_run_group)
+        await pilot.pause()
+        await pilot.click("#evals-review-summary")
+        await pilot.pause()
+        text = pilot.app.screen.query_one("#evals-summary-view").render_str_or_text()
+        assert "%" not in text
+        for forbidden in ("score", "rank", "overall", "total"):
+            assert forbidden not in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_groups_are_not_ordered_by_how_many_failure_tags_they_carry(
+    evals_app, run_group_with_lopsided_tags
+):
+    """Sorting by failure count IS a ranking, however it is rendered."""
+    async with evals_app.run_test(size=(160, 45)) as pilot:
+        pilot.app.screen.select(kind="run_group", id=run_group_with_lopsided_tags)
+        await pilot.pause()
+        await pilot.click("#evals-review-summary")
+        await pilot.pause()
+        rows = pilot.app.screen.query(".evals-summary-target-row")
+        labels = [r.render_str_or_text() for r in rows]
+        # The heavily-tagged target is t-2; a ranking would float it first.
+        assert "llama-8b" in labels[0]
+```
+
+`render_str_or_text()` above stands in for however this repo's tests actually read a widget's painted text — **grep `Tests/UI/test_evals_character_bench_editor.py` for the real helper and use it verbatim**, as Phase 3b's tasks do. Do not add a new one.
+
+Build `reviewed_run_group` and `run_group_with_lopsided_tags` on Phase 3b's review fixtures — import them rather than constructing run groups again, and keep that lineage's rule: target rows built the way the real "+ New target" form writes them, never hand-built dicts.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_summary_view.py -p no:randomly`
+Expected: FAIL — `NoMatches: #evals-review-summary`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`SummaryView` is a `Vertical` yielding the coverage line first — it frames everything below it — then the three grouped tables under plain headings naming the question each answers ("By model", "By character", "By probe"). Every cell carrying a name or label is a `Static(markup=False)`; tag labels in headers go through `escape_markup` if they land in a `Button`.
+
+In `ReviewPane`, add `#evals-review-summary` beside the progress line and swap the right-hand side between the conversation view and the summary, with `#evals-review-back-to-queue` to return. Recompute `summarise` when entering the summary, not on every annotation — the counts are a read of the database, and a reviewer tagging turns does not need the table rebuilt under them mid-keystroke.
+
+Order the rows by the snapshot's own order (targets as configured, cards as configured, probes by index). That is deliberate and is what `test_groups_are_not_ordered_by_how_many_failure_tags_they_carry` pins: any count-derived ordering is a ranking wearing a different hat.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_evals_summary_view.py Tests/UI/test_evals_review_pane.py Tests/UI/test_evals_review_keyboard.py -p no:randomly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Evals/summary_view.py tldw_chatbook/UI/Evals/review_pane.py tldw_chatbook/css Tests/UI/test_evals_summary_view.py
+git commit -m "feat(evals): the character-probe run summary (task-1691 phase 4)"
+```
+
+---
+
+### Task 3: The live pass
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md` (record the result)
+- Test: manual, recorded
+
+**Interfaces:**
+- Consumes: everything phases 1-4 built.
+- Produces: a recorded live-verification note.
+
+The spec closes with a requirement no automated test satisfies: "**A live pass against a real llama.cpp instance with real character cards is required before this is called done.**" This project has shipped four features whose tests were green and which no user could operate — a dead Run button, an untoggleable checkbox, steering that never reached the model, and a target resolution that silently reused a steered row. Every one was found by driving the real app, not by a suite.
+
+- [ ] **Step 1: Prepare the run**
+
+Start the llama.cpp instance the earlier phases used (`127.0.0.1:9099`), and make sure the profile has at least two real character cards with distinct voices and a probe file with at least one multi-turn probe and one single-turn probe.
+
+- [ ] **Step 2: Drive the whole journey by hand**
+
+In a real terminal at 160x45, then again at 235x52: import the probe set, create a character bench, pick both cards, save, check the estimate matches cards × probes × targets × samples × turns, run it, and watch the run reach a terminal state.
+
+- [ ] **Step 3: Review by keyboard only**
+
+With hands off the mouse: move through the queue with `j`/`k`, move through turns with `n`/`p`, apply a tag with `t`, mark a conversation reviewed with `r`, and filter to unreviewed with `u`. Type a note containing the letters `j`, `r`, `t`, and `u` and confirm none of them triggers a binding.
+
+- [ ] **Step 4: Confirm what the tests cannot**
+
+Check by eye: replies render readably at both sizes; an empty reply is visibly empty rather than a blank gap; hints read as hints and not as verdicts; the summary's coverage line matches what you actually reviewed; and closing and reopening the app preserves every annotation and the reviewed count.
+
+- [ ] **Step 5: Record the result and commit**
+
+Append a short "Live verification" section to the design spec: the date, the llama.cpp model, the terminal sizes, what worked, and every defect found. **A defect found here is a task, not a footnote** — file it before closing the phase.
+
+```bash
+git add Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
+git commit -m "docs(evals): record the character-probe live verification pass (task-1691 phase 4)"
+```
+
+---
+
+## Phase 4 exit criteria
+
+- The summary answers the three questions the spec names, grouped by target, card, and probe.
+- Counts are grouped by tag kind, and no view anywhere sums them into a number, a ratio, a rank, or a percentage.
+- Group ordering comes from the run's own configuration, never from counts.
+- The coverage line states how much of the run has actually been reviewed, as two integers.
+- A tag outside the run's vocabulary raises naming it rather than being silently dropped.
+- The live pass is done, recorded in the spec, and every defect it found is filed.
+
+## Not in Phase 4 (deliberate)
+
+Cross-run comparison stays out of scope — annotations are per run group, and non-determinism makes comparison unsound without seeds. Export of any kind is a follow-up. And there is still no composite score.

--- a/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
+++ b/Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md
@@ -174,6 +174,23 @@ guessed on the user's behalf would quietly mis-group observations in the summary
 not a safe fallback: it would make genuine failures invisible in exactly the view meant to surface
 them.
 
+**The built-in vocabulary** (owner decision, 2026-08-02). Ten tags, chosen so the common verdicts
+are one keystroke away and per-bench extension is the exception rather than the rule — the
+fragmentation this section warns about is driven by people inventing a tag because none of the
+built-ins fit:
+
+| Kind | Slugs |
+|---|---|
+| `failure` | `broke-character`, `refused`, `leaked-prompt`, `generic-assistant-voice`, `contradicted-card`, `ignored-the-question` |
+| `notable` | `notable`, `surprising` |
+| `positive` | `in-character`, `handled-well` |
+
+`leaked-prompt` means the card's own system prompt surfaced in the reply. `notable` is the
+deliberate catch-all — "worth another look" without claiming the reply was good or bad.
+
+These are the defaults, not a closed set: a bench extends them through `extra_tags`, and every
+extension states its kind.
+
 ## Execution
 
 Calls go through the app's normal chat path (`chat_api_call`), not the word-bench capture client:


### PR DESCRIPTION
Docs only — no production code. Plans for the rest of the character-probe eval, following the merged phases 1 (#1176) and 2 (#1204).

Spec: `Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md`.

## Why phase 3 is split

The spec's Review section is larger than phase 1 or phase 2 were, and about half of it is engine work with no UI at all. Splitting it means the substrate lands and is reviewable on its own, and the UI plan can consume a vocabulary that already exists rather than inventing one mid-branch.

| Plan | Tasks | What it delivers |
|---|---|---|
| **3a — tag vocabulary** | 6 | Engine only. Ten built-in tags with kinds, canonical slugs, per-bench extension that cannot omit a kind, a run's vocabulary read from its own snapshot, annotation writes validated against it, and deleting a bench cascading its annotations. |
| **3b — review queue** | 7 | Ordering hints, the queue's ordering and filters, the conversation view, the pane replacing phase 2's placeholder, tag application, creating a tag, keyboard-first review. |
| **4 — summary** | 3 | Per-tag counts grouped by target, card, and probe; plus the live pass against real llama.cpp the spec requires before this is called done. |

## What phase 1 already shipped, which these plans do *not* rebuild

Worth stating because it materially shrank phase 3: `annotate_turn`, `load_turn_annotations`, `mark_conversation_reviewed`, `load_review_state`, and both `eval_probe_turn_annotations` / `eval_probe_review_state` tables already exist and are merged.

What was genuinely missing:

- **Tag kinds.** `CharacterProbeConfig.extra_tags` shipped as an untyped `tuple[dict, ...]` with no validation, and there are no built-in tag defaults anywhere in the repo — so the spec's "every tag carries a kind" was unenforceable and its "built-in defaults" did not exist.
- **The delete cascade.** Neither annotation table has a foreign key, and `delete_task` does not touch them. Phase 2 made a character bench deletable from the UI, so orphaned annotation rows are reachable today.
- **All of the review UI.**

## The built-in vocabulary

The spec called for "built-in defaults, extendable per bench" but never listed them. Now recorded (owner decision), ten tags:

| Kind | Slugs |
|---|---|
| `failure` | `broke-character`, `refused`, `leaked-prompt`, `generic-assistant-voice`, `contradicted-card`, `ignored-the-question` |
| `notable` | `notable`, `surprising` |
| `positive` | `in-character`, `handled-well` |

## Two design points worth review before implementation starts

**A run's tag vocabulary comes from its own snapshot, not the bench's current one.** `_probe_run_snapshot` already writes `extra_tags`, so this is a read of existing data. It means a tag dropped from the bench today cannot orphan an annotation recorded last week — the same provenance rule the card snapshot already follows. It also means a tag created *during* a review is usable in that session but will not reappear on a later reopen of that older run; 3b task 6 calls that trade-off out and asks the implementer to state which behaviour they shipped.

**Nothing anywhere sums tags into a number.** The spec is unusually firm and these plans hold the line structurally rather than by convention: `Hint` carries no severity or weight, `queue_progress` returns two integers rather than a percentage, summary rows are ordered by the run's own configuration rather than by count, and phase 4 task 1 has a test asserting the module exports no name containing `rank` / `score` / `total` / `ratio` / `best` / `worst`.

## Plan hygiene

16 tasks and 80 steps across the three plans. Self-reviewed for spec coverage, placeholders (zero), and cross-plan identifier drift — every symbol is defined in the phase that produces it and referenced in the phases that consume it. One real collision was caught and fixed: a hint, an applied-tag chip, and the per-turn tag button are three different things in the same block, and 3b task 3's test originally asserted against the class 3b task 5 would have used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds implementation plans for character‑probe eval phases 3a (tag vocabulary), 3b (review queue), and 4 (summary), and records the built‑in tag defaults in the spec. Phase 3 is split to land engine substrate first and keep review and summary score‑free.

- **New Features**
  - 3a — tag vocabulary: engine-only; 10 built‑in tags with kinds and canonical slugs; per‑bench extension (kind required); runs read vocab from their snapshot; validate annotation writes; bench delete cascades annotations.
  - 3b — review queue: pure engine functions for ordering/filtering/hints; queue + full transcript view; keyboard-first tag apply/create; replaces phase 2’s placeholder pane.
  - 4 — summary: per‑tag counts by target/card/probe; no scores; includes a live pass against `llama.cpp`.
  - Spec: lists the 10 built‑in tags grouped by kind with notes for `leaked-prompt` and `notable`; defaults, extendable per bench.

<sup>Written for commit b2e6d37f83c5823ecfd375fe5f532a1886b8da9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

