### PR TITLE
Move curated install workers to LLMScreen so a recompose cannot orphan a download (TASK-1803)

### DIFF
--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -151,12 +151,18 @@ async def test_the_status_row_reports_running_servers():
 
 @pytest.mark.asyncio
 async def test_model_install_progress_survives_switch_to_installed():
-    """Curated progress remains visible in Installed and in the Lab status row."""
+    """Curated progress remains visible in Installed and in the Lab status row.
+
+    Delivers through ``LLMScreen._deliver_curated`` -- the screen's own
+    entry point for a curated-install tick (TASK-1803: the screen owns the
+    worker that would call this in production; ``CuratedView`` no longer
+    posts ``InstallProgressed``/``InstallStatusChanged`` itself) -- rather
+    than posting directly on ``CuratedView``, which nothing does any more.
+    """
     from unittest.mock import MagicMock
 
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
     from tldw_chatbook.Model_Artifacts.service import ArtifactRef
-    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
     from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
     from tldw_chatbook.Widgets.ModelArtifacts import (
         InstallProgressed,
@@ -169,7 +175,6 @@ async def test_model_install_progress_survives_switch_to_installed():
         await pilot.pause()
         await pilot.pause()
         window = screen.query_one(LLMManagementWindow)
-        curated = window.query_one(CuratedView)
         installed = window.query_one(InstalledView)
         installed.ensure_loaded = MagicMock()
         reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
@@ -181,8 +186,8 @@ async def test_model_install_progress_survives_switch_to_installed():
             1024,
         )
 
-        curated.post_message(InstallStatusChanged(reference, active=True))
-        curated.post_message(InstallProgressed(progress))
+        screen._deliver_curated(InstallStatusChanged(reference, active=True))
+        screen._deliver_curated(InstallProgressed(progress))
         await pilot.pause()
 
         installed_row = next(
@@ -197,7 +202,7 @@ async def test_model_install_progress_survives_switch_to_installed():
         assert "Model install: downloading" in str(chip.renderable)
 
         installed.ensure_loaded.reset_mock()
-        curated.post_message(
+        screen._deliver_curated(
             InstallStatusChanged(reference, active=False, succeeded=True)
         )
         await pilot.pause()
@@ -208,25 +213,29 @@ async def test_model_install_progress_survives_switch_to_installed():
 
 @pytest.mark.asyncio
 async def test_curated_install_progress_survives_a_screen_level_recompose(monkeypatch):
-    """TASK-596 delta port: a curated install must not go blank/stale.
+    """TASK-596 delta port / TASK-1803: a curated install must not go blank/stale.
 
     ``LabScreen.recompose()`` tears down and rebuilds the whole
     ``LLMManagementWindow`` -- ``CuratedView`` included -- which used to
     mean a curated install in progress lost its progress display for the
     rest of the run: the fresh ``CuratedView`` instance starts with no
-    memory of the install, and (since ``CuratedView`` owns its own
+    memory of the install, and (back when ``CuratedView`` owned its own
     preflight/provision worker) further progress ticks from the ORIGINAL
     instance's worker thread were posted to that now-closed instance and
     silently dropped, never reaching the fresh one either.
 
-    Exercises the real ``CuratedView._provision`` code path (not a
-    simulation of it) against a stubbed ``ArtifactAcquisitionService`` so
-    this test controls exactly when a second progress tick fires relative
-    to the recompose, then asserts both halves of the fix: the freshly
-    (re)mounted view is hydrated with the last known progress (not blank),
-    and a progress tick emitted AFTER the recompose -- delivered through
-    the pre-recompose instance's own worker, exactly as the real download
-    would -- still reaches and updates the fresh view (not stale).
+    TASK-1803 moved that worker to ``LLMScreen`` -- this screen owns the
+    ``WorkerManager`` the download actually runs under, and a screen-level
+    recompose never tears the *screen* down, only its body -- so there is
+    no orphaned poster left to compensate for. This test exercises the
+    real ``LLMScreen._provision_curated`` code path (not a simulation of
+    it) against a stubbed ``ArtifactAcquisitionService`` so it controls
+    exactly when a second progress tick fires relative to the recompose,
+    then asserts both halves of the fix: the freshly (re)mounted view is
+    hydrated with the last known progress (not blank), and a progress tick
+    emitted AFTER the recompose -- delivered through this screen's own
+    still-running worker, exactly as the real download would -- still
+    reaches and updates the fresh view (not stale).
 
     Content-only, like this test: it cannot tell one render from three.
     See test_curated_install_progress_renders_exactly_once_per_tick below
@@ -264,8 +273,8 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
         Only ``.provision`` is exercised; it delivers one progress tick,
         waits for the test to force a screen-level recompose, then
         delivers a second tick -- all through the real ``progress``
-        callback ``CuratedView._provision`` built, so ``_deliver``'s fix
-        under test runs unmodified.
+        callback ``LLMScreen._provision_curated`` built, so
+        ``_deliver_curated`` under test runs unmodified.
         """
 
         def __init__(self, _service) -> None:
@@ -285,10 +294,10 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
                 consent: The granted consent object (unused).
                 registry: The curated registry (unused).
                 sources: File source map (unused).
-                progress: The real ``deliver`` callback ``CuratedView.
-                    _provision`` built; called synchronously, twice, exactly
-                    as the real acquisition service would call it from its
-                    own await points.
+                progress: The real ``deliver`` callback ``LLMScreen.
+                    _provision_curated`` built; called synchronously,
+                    twice, exactly as the real acquisition service would
+                    call it from its own await points.
 
             Returns:
                 A sentinel standing in for the real installed-path result;
@@ -311,19 +320,20 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
         window = screen.query_one(LLMManagementWindow)
         curated = window.query_one(CuratedView)
 
-        # Mimics _confirm_install's own setup (captures the screen before
-        # the worker starts, bypasses real preflight/registry I/O) --
-        # exercising _provision itself directly, on this test's own event
-        # loop rather than a real background thread, so `resume` can pause
-        # it deterministically at an exact point.
-        curated._operation_reference = reference
-        curated._progress_screen = curated.screen
-        curated._service_for_worker = MagicMock()
-        curated._registry_for_worker = MagicMock()
-        curated._source_map = MagicMock(return_value={})
+        # Mimics _confirm_curated_install's own setup (bypasses real
+        # preflight/registry I/O) -- exercising _provision_curated itself
+        # directly, on this test's own event loop rather than a real
+        # background thread, so `resume` can pause it deterministically at
+        # an exact point. State lives on the SCREEN now (TASK-1803), not
+        # on the CuratedView instance -- it must survive the instance
+        # being torn down below.
+        screen._model_install_reference = reference
+        screen._model_install_service = MagicMock()
+        screen._model_install_registry = MagicMock()
+        screen._model_install_sources = {}
         fake_report = MagicMock(root=reference)
 
-        provision_task = asyncio.create_task(curated._provision(fake_report))
+        provision_task = asyncio.create_task(screen._provision_curated(fake_report))
         await pilot.pause()
         await pilot.pause()
 
@@ -359,14 +369,13 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
         # known progress to it via _hydrate_curated_progress.
         assert "encoder.onnx" in _progress_text(fresh_curated)
 
-        # Half 2 of the fix: still updating. This tick is delivered by the
-        # ORIGINAL (now unmounted, orphaned) curated instance's own
-        # worker -- exactly what the real download does after a
-        # mid-install recompose. self.post_message on that orphaned
-        # instance now returns False (a closed widget's post_message() is
-        # a no-op), so _deliver falls back to the captured screen; without
-        # that fallback this would be silently dropped and the fresh view
-        # would stay on "encoder.onnx".
+        # Half 2 of the fix: still updating. This tick is delivered by
+        # THIS SCREEN's own still-running worker -- exactly what the real
+        # download does after a mid-install recompose, since the worker
+        # was never owned by the CuratedView instance the recompose tore
+        # down in the first place. _deliver_curated posts at
+        # self.llm_window, read fresh -- already the NEW window by this
+        # point -- so this reaches fresh_curated with no fallback required.
         resume.set()
         await provision_task
         await pilot.pause()
@@ -379,20 +388,28 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
 async def test_curated_install_progress_after_recompose_still_mirrors_into_installed_view(
     monkeypatch,
 ):
-    """PR #1185 automated review, Important #1 (fix round 2).
+    """PR #1185 automated review, Important #1 (fix round 2); TASK-1803.
 
-    ``CuratedView._deliver``'s durable fallback used to post straight at
-    the captured Screen. Textual only ever bubbles a message UP from
-    wherever it is posted, never back down, and ``LLMManagementWindow``
-    (which owns the ``InstallProgressed``/``InstallStatusChanged``
-    handlers that mirror progress and lifecycle into ``InstalledView``,
-    see ``LLM_Management_Window.py``) sits BELOW the Screen. Posting at
-    the Screen therefore entered the tree above that mirroring node, so
-    it silently never ran after a recompose: Curated kept updating (the
-    two tests above only ever checked Curated), while Installed silently
-    stopped receiving ticks/completion. This test is the one the review
-    asked for: it checks the MIRRORING handler's own effect on
-    ``InstalledView``, not the curated side, after a real recompose.
+    ``LLMManagementWindow`` (which owns the ``InstallProgressed``/
+    ``InstallStatusChanged`` handlers that mirror progress and lifecycle
+    into ``InstalledView``, see ``LLM_Management_Window.py``) sits BELOW
+    the Screen. Before TASK-1803, ``CuratedView`` posted these messages
+    itself and needed a durable fallback for when a screen-level recompose
+    orphaned it; an earlier version of that fallback posted straight at
+    the Screen, which -- since Textual only ever bubbles a message UP from
+    wherever it is posted, never back down -- entered the tree above that
+    mirroring node and silently never ran: Curated kept updating (the
+    tests above only ever checked Curated), while Installed silently
+    stopped receiving ticks/completion.
+
+    TASK-1803 moved the worker to ``LLMScreen`` and made it always post at
+    ``self.llm_window`` (``_deliver_curated``), read fresh so it already
+    points at whichever ``LLMManagementWindow`` is currently mounted --
+    which sits BELOW this screen by construction, so this can no longer
+    regress the way the original fallback did. This test is the one the
+    original review asked for: it checks the MIRRORING handler's own
+    effect on ``InstalledView``, not the curated side, after a real
+    recompose.
 
     Args:
         monkeypatch: pytest's monkeypatch fixture, used to stub the
@@ -405,7 +422,6 @@ async def test_curated_install_progress_after_recompose_still_mirrors_into_insta
     import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
     from tldw_chatbook.Model_Artifacts.service import ArtifactRef
-    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
     from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
 
     reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
@@ -436,8 +452,8 @@ async def test_curated_install_progress_after_recompose_still_mirrors_into_insta
                 consent: The granted consent object (unused).
                 registry: The curated registry (unused).
                 sources: File source map (unused).
-                progress: The real ``deliver`` callback ``CuratedView.
-                    _provision`` built.
+                progress: The real ``deliver`` callback ``LLMScreen.
+                    _provision_curated`` built.
 
             Returns:
                 A sentinel standing in for the real installed-path result;
@@ -458,24 +474,22 @@ async def test_curated_install_progress_after_recompose_still_mirrors_into_insta
         for _ in range(5):
             await pilot.pause()
         window = screen.query_one(LLMManagementWindow)
-        curated = window.query_one(CuratedView)
         installed = window.query_one(InstalledView)
 
-        curated._operation_reference = reference
-        curated._progress_screen = curated.screen
-        curated._service_for_worker = MagicMock()
-        curated._registry_for_worker = MagicMock()
-        curated._source_map = MagicMock(return_value={})
+        screen._model_install_reference = reference
+        screen._model_install_service = MagicMock()
+        screen._model_install_registry = MagicMock()
+        screen._model_install_sources = {}
         fake_report = MagicMock(root=reference)
 
-        provision_task = asyncio.create_task(curated._provision(fake_report))
+        provision_task = asyncio.create_task(screen._provision_curated(fake_report))
         await pilot.pause()
         await pilot.pause()
 
         # Sanity check on the normal (no-recompose) path: the FIRST tick
         # already reaches InstalledView's own mirroring, via the exact
-        # bubble chain _deliver's docstring describes (CuratedView ->
-        # LLMManagementWindow -> LLMScreen).
+        # bubble chain _deliver_curated's docstring describes
+        # (LLMManagementWindow -> LLMScreen, posted at llm_window).
         assert installed._install_progress == first_progress
         assert installed._install_active is True
 
@@ -489,13 +503,13 @@ async def test_curated_install_progress_after_recompose_still_mirrors_into_insta
             "test setup bug: recompose did not actually replace InstalledView"
         )
 
-        # The tick under test: delivered by the ORIGINAL (now unmounted,
-        # orphaned) CuratedView instance's own worker, through _deliver's
-        # fallback -- exactly what the real download does after a
-        # mid-install recompose. Before this fix, _deliver posted straight
-        # at the Screen, which never reaches LLMManagementWindow's
-        # mirroring handler; fresh_installed would still show the FIRST
-        # tick's byte counts (or nothing), never the second's.
+        # The tick under test: delivered by THIS SCREEN's own
+        # still-running worker (never torn down by the recompose) --
+        # exactly what the real download does after a mid-install
+        # recompose. _deliver_curated posts at self.llm_window, read
+        # fresh -- already the NEW window by this point -- so it reaches
+        # LLMManagementWindow's mirroring handler with no fallback
+        # required.
         resume.set()
         await provision_task
         for _ in range(3):
@@ -503,30 +517,32 @@ async def test_curated_install_progress_after_recompose_still_mirrors_into_insta
 
         assert fresh_installed._install_progress == second_progress, (
             "InstalledView's mirroring handler never observed the "
-            "post-recompose tick -- _deliver's fallback bypassed "
-            "LLMManagementWindow"
+            "post-recompose tick"
         )
         assert fresh_installed._install_active is True
 
 
 @pytest.mark.asyncio
 async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatch):
-    """TASK-596 delta port, fix round 1 (Review Important #1).
+    """TASK-596 delta port, fix round 1 (Review Important #1); TASK-1803.
 
     ``InstallProgressed`` bubbles by default -- nothing in this codebase
-    ever called ``event.stop()`` on it. Posting one tick to ``CuratedView``
-    used to be handled by ``CuratedView``'s own ``_install_progressed``
-    (rendering the widget), then bubble on, unstopped, through
-    ``LLMManagementWindow`` (unrelated to this bug -- it mirrors into
-    ``InstalledView``, a different widget) up to ``LLMScreen``, whose
-    forwarding (added for the recompose fix above) rendered the SAME,
-    still-mounted ``CuratedView`` a second time via ``apply_progress``.
-    With the since-removed dual delivery (a second, independent
-    ``screen.post_message`` for the very same tick) that was three
-    renders total for one event -- confirmed live via a Pilot probe
-    before this fix. The recompose test above only ever asserted eventual
-    CONTENT, which cannot distinguish one render from three; this counts
-    the actual number of ``apply_progress`` calls instead.
+    ever calls ``event.stop()`` on it. Before TASK-1803, ``CuratedView``
+    posted this message itself, which used to be handled by its own
+    ``_install_progressed`` (rendering the widget), then bubble on,
+    unstopped, through ``LLMManagementWindow`` (unrelated to this bug --
+    it mirrors into ``InstalledView``, a different widget) up to
+    ``LLMScreen``, whose own forwarding rendered the SAME, still-mounted
+    ``CuratedView`` a second time via ``apply_progress`` -- three renders
+    total for one event with an earlier, since-removed dual-delivery
+    fallback added on top. TASK-1803 removed ``CuratedView``'s own
+    posting and self-listening entirely: ``LLMScreen`` (via
+    ``_deliver_curated``, posting at ``self.llm_window``) is now the ONLY
+    originator of this message for a curated install, and
+    ``_model_install_progressed`` is the only place that calls
+    ``apply_progress``. This counts the actual number of calls, which
+    content-only assertions (like the recompose tests above) cannot
+    distinguish from two or three.
 
     Args:
         monkeypatch: pytest's monkeypatch fixture, used to wrap
@@ -552,20 +568,16 @@ async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatc
         screen = await _models_screen(app)
         for _ in range(5):
             await pilot.pause()
-        window = screen.query_one(LLMManagementWindow)
-        curated = window.query_one(CuratedView)
 
         reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
         progress = AcquisitionProgress("fetch", reference, "encoder.onnx", 1, 2)
 
-        # Posted to the still-live, currently-mounted CuratedView -- the
-        # steady-state, no-recompose case _deliver's own docstring calls
-        # "the common case": exactly what self.post_message(message) does
-        # inside _deliver when it succeeds. Bubbles through
+        # The production entry point for a live tick (TASK-1803):
+        # LLMScreen's own worker calls exactly this. Bubbles through
         # LLMManagementWindow (mirrors into InstalledView, untouched by
-        # this fix) up to LLMScreen, whose forwarding is now the ONLY
-        # place that calls apply_progress.
-        curated.post_message(InstallProgressed(progress))
+        # this fix) up to LLMScreen, whose forwarding is the ONLY place
+        # that calls apply_progress.
+        screen._deliver_curated(InstallProgressed(progress))
         await pilot.pause()
         await pilot.pause()
         await pilot.pause()
@@ -575,6 +587,249 @@ async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatc
         f"expected exactly one apply_progress call for one progress tick, "
         f"got {len(calls)}"
     )
+
+
+@pytest.mark.asyncio
+async def test_curated_install_click_reaches_the_shared_consent_modal(monkeypatch):
+    """A real Install click -- not a direct call to an internal method --
+    posts ``CuratedView.InstallRequested``, which ``LLMScreen`` resolves
+    (through a stubbed acquisition service, so this stays network-free)
+    into the exact shared ``ModelInstallModal``.
+
+    TASK-1803: this replaces ``test_model_curated_view.py``'s
+    ``test_install_click_reaches_the_shared_consent_modal``, which used to
+    assert this against ``CuratedView`` directly (it owned the worker that
+    resolved the plan and pushed the modal itself). Now that ``LLMScreen``
+    owns that worker, the equivalent end-to-end coverage belongs here,
+    against a real, running ``LLMScreen``.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture; stubs
+            ``ArtifactAcquisitionService`` so preflight resolves without
+            real network I/O, and stubs ``push_screen`` to capture its
+            arguments without pushing a real screen.
+    """
+    from unittest.mock import MagicMock
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+    class _FakeAcquisitionService:
+        """Stands in for the real, network-capable acquisition service."""
+
+        def __init__(self, _service) -> None:
+            """Accept and discard the managed-store service the real
+            constructor takes.
+
+            Args:
+                _service: The managed-store service (unused by the fake).
+            """
+
+        async def preflight(self, ref, _registry, *, sources):
+            """Resolve a fake plan rooted at whatever reference was clicked.
+
+            Args:
+                ref: The reference LLMScreen asked to preflight.
+                _registry: The curated registry (unused).
+                sources: File source map (unused).
+
+            Returns:
+                A stand-in report whose ``.root`` is ``ref``, so
+                ``LLMScreen``'s registry lookup for the modal's label
+                resolves against the real curated registry.
+            """
+            report = MagicMock()
+            report.root = ref
+            return report
+
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
+    )
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        monkeypatch.setattr(app, "push_screen", MagicMock())
+        for _ in range(5):
+            await pilot.pause()
+
+        curated_row = next(
+            row for row in _rail_rows(screen) if row.lab_view_key == "curated"
+        )
+        curated_row.press()
+        await pilot.pause()
+
+        window = screen.query_one(LLMManagementWindow)
+        curated = window.query_one(CuratedView)
+
+        async def _loaded() -> bool:
+            return curated._loaded
+
+        for _ in range(50):
+            if await _loaded():
+                break
+            await pilot.pause()
+        assert curated._loaded, "Curated never finished its catalog load"
+
+        button = next(iter(curated.query(".curated-install").results(Button)))
+        await pilot.click(button)
+        await pilot.pause()
+        await pilot.pause()
+
+        for _ in range(20):
+            if app.push_screen.called:
+                break
+            await pilot.pause()
+        assert app.push_screen.called, "clicking Install never reached push_screen"
+
+        modal, callback = app.push_screen.call_args[0]
+        assert isinstance(modal, ModelInstallModal)
+        assert modal.report.root == button.reference
+        assert callback == screen._confirm_curated_install
+        assert screen._model_install_pending_report is modal.report
+
+
+@pytest.mark.parametrize("operation", ("preflight", "installation"))
+def test_curated_install_failures_log_exact_artifact_context(operation, monkeypatch):
+    """Worker diagnostics identify the safe immutable artifact reference.
+
+    TASK-1803: this used to run directly against ``CuratedView``'s own
+    ``_preflight_model``/``_provision_model`` (formerly in
+    ``test_model_installed_view.py``); the equivalent worker methods now
+    live on ``LLMScreen``.
+
+    Built via ``__new__`` (skipping ``__init__``) with ``app`` patched to
+    a ``MagicMock`` at the class level, exactly like the pre-existing
+    ``InstalledView``/``CuratedView`` versions of this test -- ``LLMScreen.
+    __init__`` reads the real Lab rail-collapse config through
+    ``load_rail_layout()``/``get_cli_setting()``, which this test must not
+    touch, and a mocked ``app`` lets ``call_from_thread`` be inspected
+    directly instead of raising (Textual refuses to run it from the app's
+    own thread, which this synchronous test is).
+
+    Args:
+        operation: Which worker to exercise -- ``"preflight"`` drives
+            ``_run_curated_preflight``, ``"installation"`` drives
+            ``_run_curated_provision``.
+        monkeypatch: pytest's monkeypatch fixture; patches ``LLMScreen.
+            app`` and this module's ``logger``, both reverted afterward.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    fake_app = MagicMock()
+    fake_logger = MagicMock()
+    fake_logger.opt.return_value = fake_logger
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+    monkeypatch.setattr(module, "logger", fake_logger)
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_reference = reference
+    screen._model_install_service = MagicMock()
+    screen._model_install_registry = MagicMock()
+    screen._model_install_sources = {}
+    screen._model_install_pending_report = None
+
+    if operation == "preflight":
+
+        async def fail_preflight(_reference):
+            raise RuntimeError("PRIVATE-WORKER-DETAIL")
+
+        screen._preflight_curated = fail_preflight
+        module.LLMScreen._run_curated_preflight.__wrapped__(screen)
+    else:
+        report = MagicMock()
+        report.root = reference
+        screen._model_install_pending_report = report
+
+        async def fail_provision(_report):
+            raise RuntimeError("PRIVATE-WORKER-DETAIL")
+
+        screen._provision_curated = fail_provision
+        module.LLMScreen._run_curated_provision.__wrapped__(screen)
+
+    logged = " ".join(str(value) for value in fake_logger.error.call_args.args)
+    assert reference.artifact_id in logged
+    assert reference.revision in logged
+    assert reference.variant in logged
+
+
+def test_curated_preflight_failure_notifies_and_does_not_push_a_modal(monkeypatch):
+    """The sibling success path is
+    ``test_curated_install_click_reaches_the_shared_consent_modal`` above;
+    this is its failure branch, adapted from ``test_model_curated_view.
+    py``'s former ``test_preflight_failure_notifies_and_does_not_push_a_
+    modal`` now that ``LLMScreen`` -- not ``CuratedView`` -- resolves the
+    plan (TASK-1803). Built via ``__new__``, same rationale as the test
+    above.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture; patches ``LLMScreen.
+            app`` (a read-only property with no setter, hence the
+            class-level patch rather than plain instance assignment).
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    view = MagicMock()
+    screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_worker = MagicMock()
+    screen._model_install_reference = ArtifactRef("model-a", "a" * 40, "int8")
+    screen._model_install_service = MagicMock()
+    screen._model_install_registry = MagicMock()
+    screen._model_install_sources = {}
+    screen._model_install_pending_report = None
+
+    module.LLMScreen._apply_curated_preflight_result(screen, None, "boom")
+
+    screen.notify.assert_called_once_with("boom", severity="error")
+    fake_app.push_screen.assert_not_called()
+    assert screen._model_install_worker is None
+    assert screen._model_install_reference is None
+    assert screen._model_install_service is None
+    assert screen._model_install_registry is None
+    assert screen._model_install_sources is None
+    view.cancel_pending_install.assert_called_once_with()
+
+
+def test_declining_the_consent_modal_does_not_start_the_install_worker():
+    """Adapted from ``test_model_curated_view.py``'s former test of the
+    same name -- ``LLMScreen`` now owns the decline path (TASK-1803).
+    Built via ``__new__``, same rationale as the tests above.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    view = MagicMock()
+    screen._curated_view = MagicMock(return_value=view)
+    screen._run_curated_provision = MagicMock()
+    screen._model_install_worker = None
+    screen._model_install_reference = ArtifactRef("model-a", "a" * 40, "int8")
+    screen._model_install_service = MagicMock()
+    screen._model_install_registry = MagicMock()
+    screen._model_install_sources = {}
+    screen._model_install_pending_report = object()
+
+    module.LLMScreen._confirm_curated_install(screen, False)
+
+    screen._run_curated_provision.assert_not_called()
+    assert screen._model_install_reference is None
+    assert screen._model_install_pending_report is None
+    view.cancel_pending_install.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -593,6 +593,104 @@ async def test_deliver_curated_falls_back_to_the_screen_when_llm_window_is_stale
 
 
 @pytest.mark.asyncio
+async def test_hydration_mirrors_a_tick_delivered_during_the_recompose_gap_into_installed_view():
+    """TASK-1803 review round 2 (Important): the fallback in
+    ``_deliver_curated`` keeps THIS screen's own state current when a
+    tick lands in the teardown -> remount gap (see the test above), but
+    posting on ``self`` never reaches ``LLMManagementWindow``'s mirroring
+    handlers (``_managed_install_progressed``/``_managed_install_status_
+    changed``) -- Textual only ever bubbles a message UP, never back down
+    into a sibling/descendant, and the Screen is already above that node.
+    Before this fix, ``InstalledView`` would show a stale "not
+    installing" state for however long it took the next tick to arrive
+    naturally -- this is the same mirroring gap PR #1185 fixed for
+    ``CuratedView``, recurring one level deeper.
+
+    This is the distinction the review asked to be pinned: not merely
+    that the SCREEN's own state updated (the test above), but that
+    ``InstalledView`` itself is brought up to date once the fresh window
+    actually mounts.
+
+    Reproduces the exact gap deterministically (removes the window
+    exactly as recompose's teardown does -- see the test above --
+    delivers a tick while it is closed, and confirms the OLD
+    ``InstalledView`` never saw it, proving this is a real reproduction
+    and not a no-op), then completes the deferred remount directly
+    (``_mount_lab_body``, exactly what ``call_after_refresh`` would
+    eventually call for a real recompose) and asserts the FRESH
+    ``InstalledView`` reflects the delivered tick once hydration runs.
+    """
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+    from tldw_chatbook.Widgets.ModelArtifacts import InstallProgressed
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+    progress = AcquisitionProgress("fetch", reference, "encoder.onnx", 512, 1024)
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+
+        old_window = screen.llm_window
+        assert old_window is not None
+        old_installed = old_window.query_one(InstalledView)
+
+        # The synchronous half of a screen-level recompose (see
+        # test_deliver_curated_falls_back_to_the_screen_when_llm_window_
+        # is_stale_and_closed above for why this deterministically
+        # reproduces the gap without racing a real recompose).
+        await old_window.remove()
+        await pilot.pause()
+        assert screen.llm_window is old_window, (
+            "test setup bug: something already reassigned llm_window"
+        )
+
+        # The tick under test: delivered while the window is stale and
+        # closed. Falls back to posting on self (TASK-1803 review round
+        # 1), so this screen's own state updates -- but the OLD (about to
+        # be discarded) InstalledView must NOT have received it, which is
+        # exactly what makes this a genuine reproduction of the gap the
+        # mirror needs to survive, not a no-op.
+        screen._deliver_curated(InstallProgressed(progress))
+        await pilot.pause()
+
+        assert screen._model_install_active is True
+        assert screen._model_install_last_progress == progress
+        assert old_installed._install_progress is None, (
+            "test setup bug: the OLD InstalledView must not have seen "
+            "the tick, or this isn't reproducing the gap"
+        )
+
+        # Complete the deferred remount directly -- exactly what
+        # call_after_refresh(self._mount_lab_body) would eventually call
+        # for a real recompose.
+        screen._mount_lab_body()
+        for _ in range(5):
+            await pilot.pause()
+
+        fresh_window = screen.llm_window
+        assert fresh_window is not old_window, (
+            "test setup bug: _mount_lab_body did not actually replace "
+            "the window"
+        )
+        fresh_installed = fresh_window.query_one(InstalledView)
+        assert fresh_installed is not old_installed
+
+        assert fresh_installed._install_active is True, (
+            "InstalledView was not brought up to date by hydration after "
+            "the remount -- it still shows the tick dropped in the "
+            "teardown/remount gap as though the install were not active"
+        )
+        assert fresh_installed._install_progress == progress, (
+            "InstalledView's progress was not hydrated from the tick "
+            "delivered during the recompose gap"
+        )
+
+
+@pytest.mark.asyncio
 async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatch):
     """TASK-596 delta port, fix round 1 (Review Important #1); TASK-1803.
 
@@ -963,6 +1061,226 @@ def test_curated_install_requested_refuses_a_second_concurrent_install():
     assert screen._model_install_registry is running_registry
     assert screen._model_install_sources is running_sources
     assert screen._model_install_worker is running_worker
+
+
+@pytest.mark.parametrize(
+    ("reference", "service", "registry", "sources"),
+    (
+        (None, "service", "registry", {}),
+        ("not-a-ref", "service", "registry", {}),
+        (object(), "service", "registry", {}),
+    ),
+)
+def test_curated_install_requested_refuses_an_invalid_payload_without_starting_a_worker(
+    reference, service, registry, sources
+):
+    """TASK-1803 review round 2 (Critical, Finding 1): an invalid request
+    must never be stored or acted on.
+
+    ``_run_curated_preflight`` used to assume ``self._model_install_
+    reference`` was always a valid ``ArtifactRef``: a missing or malformed
+    reference reached ``reference.artifact_id`` inside that worker's own
+    exception handler, raising a SECOND, unhandled exception that
+    pre-empted ``_apply_curated_preflight_result`` entirely and stranded
+    the retained install state with no path back to idle. The primary
+    defense is here, before anything is ever stored: an invalid
+    ``reference`` (parametrized: ``None``, a plain string, and an
+    arbitrary object -- none are ``ArtifactRef``) notifies, releases the
+    clicking view's own indicator via ``cancel_pending_install()``, clears
+    every retained field via ``_clear_curated_install_state()``, and never
+    starts a preflight worker.
+
+    Args:
+        reference: The (invalid) reference value under test.
+        service: A stand-in for ``event.service`` (a valid, non-``None``
+            placeholder here; only ``reference`` is exercised as invalid
+            in this parametrization).
+        registry: A stand-in for ``event.registry``, same rationale.
+        sources: A stand-in for ``event.sources``, same rationale.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._run_curated_preflight = MagicMock()
+    view = MagicMock()
+    screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_worker = None
+    screen._model_install_reference = None
+    screen._model_install_service = None
+    screen._model_install_registry = None
+    screen._model_install_sources = None
+    screen._model_install_pending_report = None
+
+    event = CuratedView.InstallRequested(
+        reference,
+        service=service,
+        registry=registry,
+        sources=sources,
+    )
+    event.stop = MagicMock()
+
+    module.LLMScreen._curated_install_requested(screen, event)
+
+    event.stop.assert_called_once_with()
+    screen._run_curated_preflight.assert_not_called()
+    screen.notify.assert_called_once_with(
+        "Could not start the model install: invalid request.",
+        severity="error",
+    )
+    view.cancel_pending_install.assert_called_once_with()
+    assert screen._model_install_worker is None
+    assert screen._model_install_reference is None
+    assert screen._model_install_service is None
+    assert screen._model_install_registry is None
+    assert screen._model_install_sources is None
+    assert screen._model_install_pending_report is None
+
+
+@pytest.mark.parametrize(
+    ("missing_field",),
+    (("service",), ("registry",), ("sources",)),
+)
+def test_curated_install_requested_refuses_when_service_registry_or_sources_is_none(
+    missing_field,
+):
+    """TASK-1803 review round 2 (Critical, Finding 1): the same validation
+    covers ``event.service``/``event.registry``/``event.sources`` being
+    ``None``, not only a malformed ``reference``.
+
+    Args:
+        missing_field: Which of the three payload fields to set to
+            ``None`` for this parametrization; the other two stay valid.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+
+    fields = {"service": "service", "registry": "registry", "sources": {}}
+    fields[missing_field] = None
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._run_curated_preflight = MagicMock()
+    view = MagicMock()
+    screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_worker = None
+    screen._model_install_reference = None
+    screen._model_install_service = None
+    screen._model_install_registry = None
+    screen._model_install_sources = None
+
+    event = CuratedView.InstallRequested(
+        ArtifactRef("model-a", "a" * 40, "int8"),
+        **fields,
+    )
+    event.stop = MagicMock()
+
+    module.LLMScreen._curated_install_requested(screen, event)
+
+    screen._run_curated_preflight.assert_not_called()
+    screen.notify.assert_called_once_with(
+        "Could not start the model install: invalid request.",
+        severity="error",
+    )
+    assert screen._model_install_reference is None
+
+
+def test_run_curated_preflight_schedules_apply_result_when_reference_is_none(
+    monkeypatch,
+):
+    """TASK-1803 review round 2 (Critical, Finding 1): defense-in-depth.
+
+    ``_curated_install_requested`` already refuses to store an invalid
+    reference, so this should be unreachable in practice -- but
+    ``_run_curated_preflight`` must never trust that assumption blindly.
+    If ``self._model_install_reference`` is somehow ``None`` when this
+    worker runs, it must still schedule
+    ``_apply_curated_preflight_result(None, <message>)`` directly rather
+    than reaching the ``try`` block and risking an ``AttributeError`` on
+    ``None.artifact_id`` that would pre-empt that call entirely.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture; patches ``LLMScreen.
+            app`` (a read-only property with no setter, hence the
+            class-level patch rather than plain instance assignment).
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_reference = None
+
+    module.LLMScreen._run_curated_preflight.__wrapped__(screen)
+
+    fake_app.call_from_thread.assert_called_once()
+    args = fake_app.call_from_thread.call_args[0]
+    assert args[0] == screen._apply_curated_preflight_result
+    assert args[1] is None
+    assert isinstance(args[2], str) and args[2]
+
+
+def test_run_curated_preflight_except_clause_survives_a_malformed_reference(
+    monkeypatch,
+):
+    """TASK-1803 review round 2 (Critical, Finding 1): the except clause
+    itself must never raise a second exception.
+
+    Forces ``_preflight_curated`` to fail with a malformed (non-
+    ``ArtifactRef``) ``self._model_install_reference`` already in place --
+    exactly the state a bug elsewhere could otherwise leave behind -- and
+    asserts the exception handler still schedules
+    ``_apply_curated_preflight_result(None, ...)`` exactly once, using
+    ``getattr(..., "unknown")`` formatting instead of raising its own
+    ``AttributeError`` reaching for ``.artifact_id``/``.revision``/
+    ``.variant`` on an object that has none of them.
+
+    Args:
+        monkeypatch: pytest's monkeypatch fixture; patches ``LLMScreen.
+            app`` (a read-only property with no setter) and this module's
+            ``logger``.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    fake_logger = MagicMock()
+    fake_logger.opt.return_value = fake_logger
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+    monkeypatch.setattr(module, "logger", fake_logger)
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_reference = object()  # malformed: not an ArtifactRef
+
+    async def fail_preflight(_reference):
+        raise RuntimeError("PRIVATE-WORKER-DETAIL")
+
+    screen._preflight_curated = fail_preflight
+
+    # Must not itself raise (that is exactly the regression under test).
+    module.LLMScreen._run_curated_preflight.__wrapped__(screen)
+
+    fake_logger.error.assert_called_once()
+    logged = " ".join(str(value) for value in fake_logger.error.call_args.args)
+    assert "unknown" in logged
+    assert "PRIVATE-WORKER-DETAIL" not in logged
+
+    fake_app.call_from_thread.assert_called_once_with(
+        screen._apply_curated_preflight_result,
+        None,
+        fake_app.call_from_thread.call_args[0][2],
+    )
+    assert fake_app.call_from_thread.call_args[0][1] is None
 
 
 @pytest.mark.parametrize(

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -523,6 +523,76 @@ async def test_curated_install_progress_after_recompose_still_mirrors_into_insta
 
 
 @pytest.mark.asyncio
+async def test_deliver_curated_falls_back_to_the_screen_when_llm_window_is_stale_and_closed():
+    """TASK-1803 review round 1 (Critical): ``self.llm_window`` is a plain
+    attribute, not a live query. ``LabScreen.recompose()`` (``lab_frame.
+    py``'s ``recompose()``, which calls the base ``Widget.recompose()``)
+    tears down and closes the old ``LLMManagementWindow`` SYNCHRONOUSLY,
+    but only the deferred ``_mount_lab_body`` (scheduled via
+    ``call_after_refresh``) reassigns ``self.llm_window`` to the fresh
+    instance. Between those two points, ``self.llm_window`` still refers
+    to the closed widget -- ``post_message`` on a closed target returns
+    ``False`` without raising, and the original ``_deliver_curated``
+    ignored that return value, silently dropping the message: this
+    screen's OWN ``@on(InstallProgressed)``/``@on(InstallStatusChanged)``
+    handlers never fired either, so even the Lab status chip and
+    ``_model_install_active`` got stuck -- a regression against the
+    deleted ``CuratedView._deliver``, which used a live ``try``/``except
+    NoMatches`` query specifically so a stale reference could never
+    swallow a tick this way.
+
+    Reproduces the exact gap without waiting for a real recompose to race
+    it: removes the window exactly as ``recompose()``'s teardown does,
+    confirms ``self.llm_window`` is still that same, now-closed instance
+    (pinning the reproduction itself, not just the fix), then delivers a
+    tick and asserts this screen's own state still updated -- proving the
+    fallback-on-``False`` in ``_deliver_curated`` (not a query, and not
+    the four-level chain the deleted code used) closes the gap.
+    """
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.Widgets.ModelArtifacts import InstallStatusChanged
+
+    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+
+        old_window = screen.llm_window
+        assert old_window is not None
+
+        # The synchronous half of a screen-level recompose: the old body
+        # is removed/closed immediately. Deliberately NOT followed by
+        # anything that would reassign screen.llm_window (the deferred
+        # _mount_lab_body/build_lab_body pair a real recompose schedules
+        # via call_after_refresh) -- that is exactly the gap under test.
+        await old_window.remove()
+        await pilot.pause()
+
+        assert screen.llm_window is old_window, (
+            "test setup bug: something already reassigned llm_window -- "
+            "this must still be the stale, closed reference"
+        )
+        assert old_window._closed is True
+        assert old_window.post_message(InstallStatusChanged(reference, active=True)) is False, (
+            "test setup bug: the removed window must already be closed, "
+            "i.e. post_message on it must return False, for this to be "
+            "the gap _deliver_curated needs to survive"
+        )
+
+        screen._deliver_curated(InstallStatusChanged(reference, active=True))
+        await pilot.pause()
+
+        assert screen._model_install_active is True, (
+            "_deliver_curated silently dropped the message when "
+            "self.llm_window was stale and closed -- this screen's own "
+            "state never updated"
+        )
+
+
+@pytest.mark.asyncio
 async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatch):
     """TASK-596 delta port, fix round 1 (Review Important #1); TASK-1803.
 
@@ -830,6 +900,147 @@ def test_declining_the_consent_modal_does_not_start_the_install_worker():
     assert screen._model_install_reference is None
     assert screen._model_install_pending_report is None
     view.cancel_pending_install.assert_called_once_with()
+
+
+def test_curated_install_requested_refuses_a_second_concurrent_install():
+    """TASK-1803 review round 1 (Important, gap #2): untested until now.
+
+    ``_curated_install_requested``'s worker-in-flight guard (mirroring
+    ``LibraryScreen.handle_parakeet_v2_install_requested``'s own) must
+    refuse a second request while one install is still running -- not
+    start a competing preflight worker, not touch the running install's
+    own retained reference/service/registry/sources, and not touch its
+    worker handle -- and must release only the freshly clicking
+    ``CuratedView``'s own in-flight indicator (see the method's own
+    docstring for why that view, specifically, is the one instance a
+    screen-level recompose can hand a second chance to click Install
+    while the original install is still in flight elsewhere).
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+
+    running_worker = MagicMock()
+    running_worker.is_finished = False
+    running_reference = ArtifactRef("model-a", "a" * 40, "int8")
+    running_service = MagicMock()
+    running_registry = MagicMock()
+    running_sources = {}
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._run_curated_preflight = MagicMock()
+    view = MagicMock()
+    screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_worker = running_worker
+    screen._model_install_reference = running_reference
+    screen._model_install_service = running_service
+    screen._model_install_registry = running_registry
+    screen._model_install_sources = running_sources
+
+    event = CuratedView.InstallRequested(
+        ArtifactRef("model-b", "b" * 40, "int8"),
+        service=MagicMock(),
+        registry=MagicMock(),
+        sources={},
+    )
+    event.stop = MagicMock()
+
+    module.LLMScreen._curated_install_requested(screen, event)
+
+    event.stop.assert_called_once_with()
+    screen.notify.assert_called_once_with(
+        "A curated model install is already running.",
+        severity="information",
+    )
+    view.cancel_pending_install.assert_called_once_with()
+    screen._run_curated_preflight.assert_not_called()
+    # The running install's own retained state must survive untouched.
+    assert screen._model_install_reference is running_reference
+    assert screen._model_install_service is running_service
+    assert screen._model_install_registry is running_registry
+    assert screen._model_install_sources is running_sources
+    assert screen._model_install_worker is running_worker
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_severity", "expected_message"),
+    (
+        (None, "information", "Model installed and activated."),
+        ("boom", "error", "boom"),
+    ),
+)
+def test_apply_curated_provision_result_notifies_mirrors_and_resets_state(
+    error, expected_severity, expected_message, monkeypatch
+):
+    """TASK-1803 review round 1 (Important, gap #1): untested until now.
+
+    ``_apply_curated_provision_result`` is the sole path that ends a
+    curated install, success or failure: it must notify the exact
+    outcome, deliver the terminal ``InstallStatusChanged(active=False,
+    ...)`` (so the Lab chip and ``InstalledView``'s mirror both learn the
+    install finished -- losing this message is what leaves the chip stuck
+    on "downloading" forever), reset every bit of retained install state
+    so a later install starts clean, and tell the visible ``CuratedView``
+    (if any) to reload. The deleted ``CuratedView._apply_provision_result``
+    had a direct test (``test_curated_provision_completion_tolerates_
+    recompose_gap``); its stated replacement
+    (``test_finish_install_clears_the_indicator_and_reloads_despite_a_
+    missing_progress_widget`` in ``test_model_curated_view.py``) only
+    covers ``CuratedView.finish_install()``'s render half, not this
+    method's notify/deliver/reset half.
+
+    Args:
+        error: The error string ``_run_curated_provision`` would pass on
+            failure, or ``None`` on success.
+        expected_severity: The ``notify()`` severity this error value
+            maps to.
+        expected_message: The ``notify()`` message this error value maps
+            to.
+        monkeypatch: pytest's monkeypatch fixture; patches ``LLMScreen.
+            app`` (a read-only property with no setter).
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+
+    reference = ArtifactRef("model-a", "a" * 40, "int8")
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._deliver_curated = MagicMock()
+    view = MagicMock()
+    screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_worker = MagicMock()
+    screen._model_install_reference = reference
+    screen._model_install_service = MagicMock()
+    screen._model_install_registry = MagicMock()
+    screen._model_install_sources = {}
+    screen._model_install_pending_report = object()
+
+    module.LLMScreen._apply_curated_provision_result(screen, error)
+
+    screen.notify.assert_called_once_with(expected_message, severity=expected_severity)
+    assert screen._model_install_worker is None
+    assert screen._model_install_pending_report is None
+    assert screen._model_install_reference is None
+    assert screen._model_install_service is None
+    assert screen._model_install_registry is None
+    assert screen._model_install_sources is None
+
+    screen._deliver_curated.assert_called_once()
+    delivered = screen._deliver_curated.call_args[0][0]
+    assert isinstance(delivered, module.InstallStatusChanged)
+    assert delivered.reference == reference
+    assert delivered.active is False
+    assert delivered.succeeded == (error is None)
+
+    view.finish_install.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_model_curated_view.py
+++ b/Tests/UI/test_model_curated_view.py
@@ -1,32 +1,32 @@
-"""Dedicated coverage for the Curated view (TASK-596 delta port).
+"""Dedicated coverage for the Curated view (TASK-596 delta port; TASK-1803).
 
-``CuratedView`` already has a handful of tests scattered in
-``Tests/UI/test_model_installed_view.py`` (no-I/O-at-compose, the
-preflight-result-opens-the-modal path, and two recompose-gap tolerance
-tests). This file adds the coverage that was still missing: that
-``ensure_loaded`` actually performs the load and renders rows once
-triggered (not just that it stays idle before that), that an installed
-reference is marked as such rather than offered a redundant Install, that
-no user-visible string contains "artifact", that a real Install click
-reaches the shared consent modal, and two error/decline paths
-(``_apply_preflight_result``'s failure branch and ``_confirm_install``'s
-decline branch) that were not exercised anywhere else.
+``CuratedView`` also has a handful of tests scattered in
+``Tests/UI/test_model_installed_view.py`` (no-I/O-at-compose and one
+recompose-gap tolerance test for ``apply_progress``). This file adds the
+coverage that was still missing: that ``ensure_loaded`` actually performs
+the load and renders rows once triggered (not just that it stays idle
+before that), that an installed reference is marked as such rather than
+offered a redundant Install, that no user-visible string contains
+"artifact", and that a real Install click posts the exact intent message
+the host screen needs.
 
-Adapted from the reference implementation's ``feat/model-artifact-browser``
-branch, NOT copied: that branch's ``CuratedView`` takes ``service_root=``/
-``registry=`` directly, posts an ``InstallRequested`` message, and never
-calls ``preflight()``/``provision()`` itself -- ``LLMScreen`` owns those
-workers there. dev's ``CuratedView`` (this branch) takes
-``service_factory=``/``registry_factory=`` lazy factories and owns its own
-preflight/provision workers directly, so every test here drives dev's
-actual methods (``ensure_loaded``, ``_install_pressed``, ``_preflight_model``,
-``_confirm_install``, ``_apply_preflight_result``) instead of the reference's
-``activate()``/``InstallRequested``/screen-owned-worker shape. Tests that
-only make sense against that other shape (the "no preflight/provision call
-anywhere in this module" AST check, the "only one @work method" AST check,
-and every ``LLMScreen``-owned-worker test) are dropped -- dev's module
-genuinely does call preflight/provision itself, and asserting otherwise
-would just be testing a design dev does not have.
+TASK-1803 moved this view's preflight/provision workers to ``LLMScreen``,
+mirroring how the reference implementation's ``feat/model-artifact-
+browser`` branch always shaped ``CuratedView`` (``service_root=``/
+``registry=``, posting ``InstallRequested``, never calling ``preflight()``/
+``provision()`` itself) -- except this branch keeps its established
+``service_factory=``/``registry_factory=`` lazy-factory constructor
+instead of adopting that branch's ``service_root=``/``registry=`` shape,
+since ``Tests/UI/test_model_installed_view.py`` and
+``test_llm_screen_lab_adoption.py`` already depend on it. Tests that used
+to drive this view's own ``_preflight_model``/``_confirm_install``/
+``_apply_preflight_result`` directly (the plan-resolution and consent-
+modal-push coverage, and the decline/failure paths that used to run
+against them) moved to ``test_llm_screen_lab_adoption.py``, against
+``LLMScreen``, which now owns that logic; what belongs here instead is
+``CuratedView``'s own render-only contract: it posts
+``InstallRequested`` and, once told the outcome, calls
+``cancel_pending_install()``/``finish_install()``/``apply_progress()``.
 """
 
 from __future__ import annotations
@@ -36,10 +36,11 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from textual import on
 from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
 from textual.widgets import Button, Static
 
-import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
 from tldw_chatbook.Model_Artifacts import (
     ArtifactDescriptor,
     ArtifactFile,
@@ -49,13 +50,8 @@ from tldw_chatbook.Model_Artifacts import (
     ModelArtifactService,
     ProvenanceClass,
 )
-from tldw_chatbook.Model_Artifacts.acquisition import (
-    ArtifactPreflightEntry,
-    PreflightReport,
-)
 from tldw_chatbook.Model_Artifacts.curated_registry import CuratedRegistry
 from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
-from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
 
 
 class _ViewApp(App):
@@ -114,36 +110,6 @@ def _registry_with(*descriptors: ArtifactDescriptor) -> CuratedRegistry:
             sources={file.path: f"https://example.test/{file.path}" for file in descriptor.files},
         )
     return registry
-
-
-def _report(reference: ArtifactRef, *, destination: Path) -> PreflightReport:
-    entry = ArtifactPreflightEntry(
-        ref=reference,
-        source_url=f"https://example.test/{reference.artifact_id}/model.bin",
-        repository=f"example/{reference.artifact_id}",
-        revision=reference.revision,
-        license_id="mit",
-        license_url="https://example.test/license",
-        precision=reference.variant,
-        total_bytes=100_000,
-        file_count=1,
-        already_installed=False,
-        provenance=(ProvenanceClass.CHATBOOK_CURATED,),
-    )
-    return PreflightReport(
-        root=reference,
-        closure_fingerprint="f" * 64,
-        entries=(entry,),
-        download_bytes=100_000,
-        already_staged_bytes=0,
-        staging_overhead_bytes=0,
-        retained_bytes=0,
-        destination=destination,
-        free_bytes=10**12,
-        required_bytes=200_000,
-        sufficient_space=True,
-        gating_errors=(),
-    )
 
 
 def _all_text(app: App) -> str:
@@ -273,53 +239,48 @@ async def test_no_user_visible_string_contains_artifact(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Install-request flow through to the consent modal.
+# Install-request flow: this view posts the intent and stops.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_install_click_reaches_the_shared_consent_modal(
-    tmp_path: Path, monkeypatch
+async def test_install_click_posts_install_requested_with_the_resolved_service_and_registry(
+    tmp_path: Path,
 ) -> None:
     """A real Install click -- not a direct call to an internal method --
-    resolves a plan (through a stubbed acquisition service, so this stays
-    network-free) and pushes the exact shared ``ModelInstallModal``.
+    posts ``CuratedView.InstallRequested`` carrying the exact reference,
+    service, registry, and source map the host screen needs to resolve a
+    plan itself (TASK-1803: this view no longer performs that resolution;
+    ``LLMScreen`` does). See ``test_llm_screen_lab_adoption.py``'s
+    ``test_curated_install_click_reaches_the_shared_consent_modal`` for
+    the end-to-end coverage of what happens once ``LLMScreen`` receives
+    this message.
 
     Args:
-        tmp_path: pytest fixture; the managed store root and the report's
-            destination path.
-        monkeypatch: pytest fixture; stubs ``ArtifactAcquisitionService``
-            so preflight resolves without real network I/O.
+        tmp_path: pytest fixture; the managed store root.
     """
     reference = ArtifactRef("model-a", "a" * 40, "int8")
     descriptor = _descriptor(reference)
     registry = _registry_with(descriptor)
     service = ModelArtifactService(tmp_path / "store")
-    report = _report(reference, destination=tmp_path / "dest")
-
-    class _FakeAcquisitionService:
-        def __init__(self, _service) -> None:
-            pass
-
-        async def preflight(self, ref, _registry, *, sources):
-            assert ref == reference
-            return report
-
-    monkeypatch.setattr(
-        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
-    )
 
     view = CuratedView(service_factory=lambda: service, registry_factory=lambda: registry)
 
-    app = _ViewApp(view)
-    async with app.run_test() as pilot:
-        # Patched on the real, running app instance (not the CuratedView
-        # class): this test needs the view's own `self.app` to resolve
-        # normally so the real @work threaded worker and pilot.click()
-        # both function -- only push_screen itself is stubbed, to capture
-        # its arguments without actually pushing a screen.
-        monkeypatch.setattr(app, "push_screen", MagicMock())
+    class _CapturingApp(App):
+        def __init__(self, view: CuratedView) -> None:
+            self.view = view
+            self.requests: list[CuratedView.InstallRequested] = []
+            super().__init__()
 
+        def compose(self) -> ComposeResult:
+            yield self.view
+
+        @on(CuratedView.InstallRequested)
+        def _capture(self, event: CuratedView.InstallRequested) -> None:
+            self.requests.append(event)
+
+    app = _CapturingApp(view)
+    async with app.run_test() as pilot:
         view.ensure_loaded()
         loaded = await _wait_until(lambda: view._loaded, pilot=pilot)
         assert loaded
@@ -328,61 +289,63 @@ async def test_install_click_reaches_the_shared_consent_modal(
         await pilot.click(button)
         await pilot.pause()
 
-        pushed = await _wait_until(lambda: app.push_screen.called, pilot=pilot)
-        assert pushed, "clicking Install never reached push_screen"
+        assert len(app.requests) == 1
+        event = app.requests[0]
+        assert event.reference == reference
+        assert event.service is service
+        assert event.registry is registry
+        assert event.sources == {reference: registry.sources(reference)}
 
-        modal, callback = app.push_screen.call_args[0]
-        assert isinstance(modal, ModelInstallModal)
-        assert modal.report is report
-        assert modal.model_label == descriptor.model_id
-        assert callback == view._confirm_install
-        assert view._pending_report is report
+        # The clicked row's own button re-disables immediately (the
+        # long-standing "cannot double-click Install" contract, unrelated
+        # to whether LLMScreen has even received the message yet) -- via
+        # a full recompose, so re-query rather than reuse the pre-click
+        # Button instance, which the recompose already detached.
+        refreshed_button = _install_buttons(app)[0]
+        assert refreshed_button.disabled is True
 
 
 # ---------------------------------------------------------------------------
-# Error / decline paths not otherwise exercised.
+# Render-only outcomes: cancel_pending_install() / finish_install().
+#
+# TASK-1803: the host screen (LLMScreen) is the only caller of either --
+# after a preflight failure or an explicit consent-modal decline
+# (cancel_pending_install(), no reload), or once provisioning completes,
+# successfully or not (finish_install(), always reloads). Both replace
+# this view's former _apply_preflight_result failure branch and
+# _confirm_install decline branch, now that LLMScreen owns preflight/
+# provision and only tells this view the outcome.
 # ---------------------------------------------------------------------------
 
 
-def test_preflight_failure_notifies_and_does_not_push_a_modal(monkeypatch) -> None:
-    """The sibling success path is test_curated_preflight_result_opens_the_
-    shared_modal in test_model_installed_view.py; this is its failure branch.
-
-    Args:
-        monkeypatch: pytest fixture; replaces the read-only ``app`` property
-            on the ``CuratedView`` class with a ``MagicMock`` for this bare,
-            unmounted view.
-    """
-    fake_app = MagicMock()
-    # Class-level property patch (Screen/Widget.app is read-only) -- safe
-    # here because this view is never mounted inside a real App/run_test(),
-    # unlike test_install_click_reaches_the_shared_consent_modal above.
-    monkeypatch.setattr(CuratedView, "app", property(lambda self: fake_app))
+def test_cancel_pending_install_clears_the_indicator_without_reloading() -> None:
+    """A preflight failure or a decline never started an install, so this
+    must not reload the catalog -- unlike ``finish_install()`` below."""
     view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
-    reference = ArtifactRef("model-a", "a" * 40, "int8")
-    view._operation_reference = reference
-    view.notify = MagicMock()
+    view._operation_reference = ArtifactRef("model-a", "a" * 40, "int8")
     view.refresh = MagicMock()
+    view.ensure_loaded = MagicMock()
 
-    view._apply_preflight_result(None, "boom")
+    view.cancel_pending_install()
 
     assert view._operation_reference is None
-    view.notify.assert_called_once_with("boom", severity="error")
-    fake_app.push_screen.assert_not_called()
     view.refresh.assert_called_once_with(recompose=True)
+    view.ensure_loaded.assert_not_called()
 
 
-def test_declining_the_consent_modal_does_not_start_the_install_worker() -> None:
+def test_finish_install_clears_the_indicator_and_reloads_despite_a_missing_progress_widget() -> None:
+    """``finish_install()`` always reloads (a just-installed row must stop
+    offering a redundant Install), and tolerates the progress widget being
+    momentarily unfindable mid-recompose -- the same tolerance
+    ``apply_progress`` documents for the same underlying reason."""
     view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
-    reference = ArtifactRef("model-a", "a" * 40, "int8")
-    view._operation_reference = reference
-    view._pending_report = object()
-    view._provision_model = MagicMock()
-    view.refresh = MagicMock()
+    view._operation_reference = ArtifactRef("model-a", "a" * 40, "int8")
+    view._progress = object()
+    view.query_one = MagicMock(side_effect=NoMatches)
+    view.ensure_loaded = MagicMock()
 
-    view._confirm_install(False)
+    view.finish_install()
 
-    assert view._pending_report is None
     assert view._operation_reference is None
-    view._provision_model.assert_not_called()
-    view.refresh.assert_called_once_with(recompose=True)
+    assert view._progress is None
+    view.ensure_loaded.assert_called_once_with(force=True)

--- a/Tests/UI/test_model_installed_view.py
+++ b/Tests/UI/test_model_installed_view.py
@@ -385,29 +385,6 @@ async def test_curated_view_performs_no_io_at_compose_time(tmp_path: Path) -> No
     registry_factory.assert_not_called()
 
 
-def test_curated_preflight_result_opens_the_shared_modal(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """Selection shows the exact shared consent plan before acquisition."""
-    from Tests.UI.test_model_artifact_widgets import _report
-    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
-    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
-
-    fake_app = MagicMock()
-    monkeypatch.setattr(CuratedView, "app", property(lambda self: fake_app))
-    view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
-    report = _report(tmp_path / "managed")
-    view._operation_reference = report.root
-
-    view._apply_preflight_result(report, None)
-
-    assert view._pending_report is report
-    modal, callback = fake_app.push_screen.call_args[0]
-    assert isinstance(modal, ModelInstallModal)
-    assert callback == view._confirm_install
-
-
 def test_curated_progress_tolerates_recompose_gap() -> None:
     """A progress event is retained while its widget is temporarily absent.
 
@@ -435,73 +412,6 @@ def test_curated_progress_tolerates_recompose_gap() -> None:
 
     assert view._progress is progress
     view.refresh.assert_called_once_with(recompose=True)
-
-
-def test_curated_provision_completion_tolerates_recompose_gap() -> None:
-    """Missing progress markup cannot skip install cleanup and refresh."""
-    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
-
-    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
-    view = CuratedView(service_factory=MagicMock(), registry_factory=MagicMock())
-    view._operation_reference = reference
-    view._pending_report = object()
-    view._progress = object()
-    view.query_one = MagicMock(side_effect=NoMatches)
-    view.notify = MagicMock()
-    view.post_message = MagicMock()
-    view.ensure_loaded = MagicMock()
-
-    view._apply_provision_result(None)
-
-    assert view._operation_reference is None
-    assert view._pending_report is None
-    assert view._progress is None
-    view.post_message.assert_called_once()
-    view.ensure_loaded.assert_called_once_with(force=True)
-
-
-@pytest.mark.parametrize("operation", ("preflight", "installation"))
-def test_curated_install_failures_log_exact_artifact_context(
-    operation: str,
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """Worker diagnostics identify the safe immutable artifact reference."""
-    from Tests.UI.test_model_artifact_widgets import _report
-    from tldw_chatbook.UI.Screens import model_curated_view as module
-
-    reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
-    fake_app = MagicMock()
-    fake_logger = MagicMock()
-    fake_logger.opt.return_value = fake_logger
-    monkeypatch.setattr(module.CuratedView, "app", property(lambda self: fake_app))
-    monkeypatch.setattr(module, "logger", fake_logger)
-    view = module.CuratedView(
-        service_factory=MagicMock(),
-        registry_factory=MagicMock(),
-    )
-
-    if operation == "preflight":
-        async def fail_preflight(_reference):
-            raise RuntimeError("PRIVATE-WORKER-DETAIL")
-
-        view._preflight = fail_preflight
-        module.CuratedView._preflight_model.__wrapped__(view, reference)
-    else:
-        report = _report(tmp_path / "managed")
-        view._pending_report = report
-
-        async def fail_provision(_report):
-            raise RuntimeError("PRIVATE-WORKER-DETAIL")
-
-        view._provision = fail_provision
-        module.CuratedView._provision_model.__wrapped__(view)
-        reference = report.root
-
-    logged = " ".join(str(value) for value in fake_logger.error.call_args.args)
-    assert reference.artifact_id in logged
-    assert reference.revision in logged
-    assert reference.variant in logged
 
 
 def test_models_rail_lists_curated_and_installed_and_drops_local_models() -> None:

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -463,35 +463,47 @@ class LLMScreen(LabScreen):
     def _deliver_curated(self, message: InstallProgressed | InstallStatusChanged) -> None:
         """Post one curated-install message so it bubbles through ``LLMManagementWindow``.
 
-        Always posted at ``self.llm_window`` -- read fresh on every call,
-        so it already points at whichever ``LLMManagementWindow`` instance
-        is currently mounted even after a screen-level recompose replaces
-        it (``build_lab_body`` reassigns this attribute every time it
-        runs). Posting there lets the message bubble CuratedView-less
-        straight through ``LLMManagementWindow``'s own mirroring handlers
-        (``_managed_install_progressed``/``_managed_install_status_
-        changed``, which keep ``InstalledView`` in sync) and on up to this
-        screen's own ``@on(InstallProgressed)``/``@on(InstallStatusChanged)``
-        handlers -- the exact same single bubble path ``CuratedView`` used
-        to originate (``CuratedView`` -> ``LLMManagementWindow`` ->
-        ``LLMScreen``), except this screen is now the origin, not an
-        orphanable view, so there is no "closed widget, silent no-op"
-        failure mode left to compensate for (TASK-1803; this replaces the
-        removed ``CuratedView._deliver``/``_progress_screen``).
+        Tried first at ``self.llm_window`` -- read fresh on every call, so
+        it already points at whichever ``LLMManagementWindow`` instance is
+        currently mounted once a screen-level recompose has finished
+        replacing it (``build_lab_body`` reassigns this attribute every
+        time it runs). Posting there lets the message bubble CuratedView-
+        less straight through ``LLMManagementWindow``'s own mirroring
+        handlers (``_managed_install_progressed``/``_managed_install_
+        status_changed``, which keep ``InstalledView`` in sync) and on up
+        to this screen's own ``@on(InstallProgressed)``/
+        ``@on(InstallStatusChanged)`` handlers -- the exact same single
+        bubble path ``CuratedView`` used to originate (``CuratedView`` ->
+        ``LLMManagementWindow`` -> ``LLMScreen``), except this screen is
+        now the origin, not an orphanable view.
 
-        Falls back to posting directly on ``self`` only in the narrow gap
-        where a screen-level recompose is between tearing down the old
-        ``LLMManagementWindow`` and ``build_lab_body`` mounting the new
-        one: this screen's own handlers still update the status chip and
-        retained progress even though ``LLMManagementWindow``'s mirror is
-        briefly unreachable, and the very next tick -- once the fresh
-        window exists again -- resumes the full path.
+        ``self.llm_window`` is a plain attribute, not a live query:
+        ``LabScreen.recompose()`` tears down and closes the old
+        ``LLMManagementWindow`` SYNCHRONOUSLY, but only ``_mount_lab_body``
+        -- deferred via ``call_after_refresh`` -- reassigns this attribute
+        to the fresh instance. Between those two points, ``self.llm_window``
+        still refers to the closed widget, and ``post_message`` on a closed
+        target returns ``False`` without raising (this is the exact
+        "closed widget, silent no-op" hazard the deleted ``CuratedView.
+        _deliver``/``_progress_screen`` fallback chain existed to survive --
+        moving the worker here did not eliminate it, only relocated it to
+        this one narrower window). Checking that return value and falling
+        back to posting directly on ``self`` restores the guarantee this
+        method's own callers depend on: ``self`` is the screen running
+        this method, so it is never itself the thing a recompose closes.
+        This screen's own handlers -- the status chip and retained
+        progress/lifecycle state -- always update, even when
+        ``LLMManagementWindow``'s mirror is briefly unreachable; the very
+        next tick, once the fresh window exists and this attribute is
+        reassigned, resumes the full path.
 
         Args:
             message: The event to deliver; a fresh instance per call.
         """
         target: Widget = self.llm_window if self.llm_window is not None else self
-        target.post_message(message)
+        if target.post_message(message):
+            return
+        self.post_message(message)
 
     def compose_lab_rail(self) -> ComposeResult:
         """Yield the two rail sections and their nine provider rows."""

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
-from textual import on
+from loguru import logger
+from textual import on, work
 from textual.app import ComposeResult
 from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Button, Static
+from textual.worker import Worker
 
-from ...Widgets.ModelArtifacts import InstallProgressed, InstallStatusChanged
+from ...Model_Artifacts.service import ArtifactRef, ModelArtifactService
+from ...Widgets.ModelArtifacts import (
+    InstallProgressed,
+    InstallStatusChanged,
+    ModelInstallModal,
+)
 from ..Lab_Modules.lab_server_status import (
     LabServerRow,
     read_server_rows,
@@ -22,11 +30,13 @@ from ..Lab_Modules.lab_workbench import LAB_RAIL_ROW_CLASS
 from ..LLM_Management_Window import LLMManagementWindow
 from ..Workbench.workbench_state import WorkbenchHeaderState
 from .lab_frame import LabInspectorRow, LabScreen, LabStatusChip
+from .model_browser_state import install_failure_message
 from .model_curated_view import CuratedView
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
-    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress, PreflightReport
+    from tldw_chatbook.Model_Artifacts.curated_registry import CuratedRegistry
 
 #: (section title, ((view key, label), ...)) in rail order. The view keys are
 #: exactly LLMManagementWindow.view_mapping's keys.
@@ -94,6 +104,30 @@ class LLMScreen(LabScreen):
         #: ``_parakeet_v2_install_progress``. Cleared whenever the install
         #: stops (see ``_model_install_status_changed``).
         self._model_install_last_progress: "AcquisitionProgress | None" = None
+        #: The curated-install worker currently running (preflight OR
+        #: provision -- reassigned when the second phase starts, mirroring
+        #: ``LibraryScreen``'s single ``_parakeet_v2_install_worker``
+        #: field across its own two phases). Guards
+        #: ``_curated_install_requested`` against starting a second,
+        #: concurrent install while this one is still in flight -- this
+        #: screen owns exactly one ``WorkerManager``, unlike the
+        #: view-owned workers TASK-1803 replaced, so this guard now holds
+        #: across a screen-level recompose instead of only within one
+        #: ``CuratedView`` instance's lifetime.
+        self._model_install_worker: Worker | None = None
+        #: The reference, service, registry, and source map the currently
+        #: running (or about-to-run) curated install needs -- captured
+        #: once from the posted ``CuratedView.InstallRequested`` (or, for
+        #: ``_model_install_pending_report``, once preflight resolves) and
+        #: read back by this screen's own worker methods for as long as
+        #: the operation runs, so nothing here depends on the posting
+        #: ``CuratedView`` instance still existing by the time provisioning
+        #: finishes.
+        self._model_install_reference: ArtifactRef | None = None
+        self._model_install_service: ModelArtifactService | None = None
+        self._model_install_registry: "CuratedRegistry | None" = None
+        self._model_install_sources: dict[ArtifactRef, dict[str, str]] | None = None
+        self._model_install_pending_report: "PreflightReport | None" = None
         #: Server rows snapshotted for the duration of one
         #: ``refresh_lab_status`` pass; None outside one. See
         #: :meth:`_current_server_rows`.
@@ -176,13 +210,16 @@ class LLMScreen(LabScreen):
         """Keep the Lab chip current, and re-render live progress (TASK-596).
 
         Forwards the event into whichever ``CuratedView`` is currently
-        mounted -- not only the instance that posted it. ``CuratedView``
-        delivers ``InstallProgressed`` both to itself (unchanged, for the
-        common no-recompose case) and, durably, to the screen it was
-        mounted under (see ``CuratedView._progress_screen``'s docstring),
-        so this handler keeps firing with live updates even after a
-        screen-level recompose has replaced the view that started the
-        install with a fresh instance.
+        mounted -- not only the instance mounted when the install started.
+        This screen itself is the sole poster of ``InstallProgressed`` for
+        a curated install (TASK-1803: see ``_run_curated_provision`` and
+        ``_deliver_curated``, which post at ``self.llm_window`` so the
+        message bubbles through ``LLMManagementWindow``'s own mirroring
+        handler on its way here) -- unlike before, when ``CuratedView``
+        posted it and needed a durable fallback path to survive a
+        screen-level recompose tearing it down mid-install. This screen
+        is never what a recompose tears down, so no such fallback is
+        needed any more.
         """
         self._model_install_active = True
         self._model_install_phase = event.progress.phase
@@ -218,6 +255,243 @@ class LLMScreen(LabScreen):
             return self.llm_window.query_one(CuratedView)
         except NoMatches:
             return None
+
+    # -- Curated model install: this screen owns preflight/provision -----
+    #
+    # TASK-1803: CuratedView posts CuratedView.InstallRequested and renders
+    # what it is told (apply_progress/cancel_pending_install/finish_install);
+    # every method below -- resolving the plan, showing the consent modal,
+    # and provisioning -- runs here, mirroring LibraryScreen's
+    # handle_parakeet_v2_install_requested/_run_parakeet_v2_preflight/
+    # _run_parakeet_v2_install. This screen survives the screen-level
+    # recompose that used to orphan CuratedView's own worker (see
+    # git history for CuratedView._deliver/_progress_screen, both removed
+    # now that the thing they compensated for cannot happen), so no
+    # durable-delivery fallback is needed: _deliver_curated below always
+    # has a live target.
+
+    @on(CuratedView.InstallRequested)
+    def _curated_install_requested(self, event: CuratedView.InstallRequested) -> None:
+        """Resolve an install plan for a curated model, off the Textual event loop.
+
+        Refuses a second concurrent install outright (mirroring
+        ``LibraryScreen.handle_parakeet_v2_install_requested``'s own
+        worker-in-flight guard): the requesting ``CuratedView`` already
+        disabled its own row before posting this, but only a screen-level
+        recompose can hand a *different*, freshly (re)mounted instance a
+        chance to post a second request while the first is still running
+        -- ``cancel_pending_install()`` releases only that fresh
+        instance's own indicator, leaving the still-running install's
+        retained state (below) untouched.
+        """
+        event.stop()
+        worker = self._model_install_worker
+        if worker is not None and not worker.is_finished:
+            self.notify(
+                "A curated model install is already running.",
+                severity="information",
+            )
+            view = self._curated_view()
+            if view is not None:
+                view.cancel_pending_install()
+            return
+        self._model_install_reference = event.reference
+        self._model_install_service = event.service
+        self._model_install_registry = event.registry
+        self._model_install_sources = event.sources
+        self._model_install_worker = self._run_curated_preflight()
+
+    async def _preflight_curated(self, reference: ArtifactRef):
+        """Resolve a curated acquisition plan on the worker's event loop.
+
+        Args:
+            reference: The exact curated model reference to preflight.
+
+        Returns:
+            The immutable ``PreflightReport`` describing the download.
+        """
+        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
+
+        acquisition = ArtifactAcquisitionService(self._model_install_service)
+        return await acquisition.preflight(
+            reference,
+            self._model_install_registry,
+            sources=self._model_install_sources,
+        )
+
+    @work(thread=True, group="llm_curated_preflight", exit_on_error=False)
+    def _run_curated_preflight(self) -> None:
+        """Resolve the curated install plan off the Textual event loop."""
+        reference = self._model_install_reference
+        try:
+            report = asyncio.run(  # policy-exception: worker-thread loop
+                self._preflight_curated(reference)
+            )
+        except Exception as exc:
+            logger.opt(exception=True).error(
+                "Curated model preflight failed for {}@{}/{}",
+                reference.artifact_id,
+                reference.revision,
+                reference.variant,
+            )
+            self.app.call_from_thread(
+                self._apply_curated_preflight_result,
+                None,
+                install_failure_message(exc, model_label=reference.artifact_id),
+            )
+            return
+        self.app.call_from_thread(self._apply_curated_preflight_result, report, None)
+
+    def _apply_curated_preflight_result(
+        self,
+        report: "PreflightReport | None",
+        error: str | None,
+    ) -> None:
+        """Show the shared consent modal, or a sanitized preflight failure."""
+        self._model_install_worker = None
+        if error is not None or report is None:
+            self.notify(error or "Model preflight failed.", severity="error")
+            self._clear_curated_install_state()
+            return
+        self._model_install_pending_report = report
+        descriptor = self._model_install_registry.descriptor(report.root)
+        self.app.push_screen(
+            ModelInstallModal(report, model_label=descriptor.model_id),
+            self._confirm_curated_install,
+        )
+
+    def _confirm_curated_install(self, confirmed: bool) -> None:
+        """Start provisioning only after explicit consent."""
+        if not confirmed:
+            self._clear_curated_install_state()
+            return
+        reference = self._model_install_reference
+        if reference is not None:
+            self._deliver_curated(InstallStatusChanged(reference, active=True))
+        self._model_install_worker = self._run_curated_provision()
+
+    async def _provision_curated(self, report: "PreflightReport"):
+        """Provision the consented report on the worker's event loop.
+
+        Args:
+            report: The plan ``_confirm_curated_install`` obtained consent
+                for.
+
+        Returns:
+            The root ``ArtifactRef`` provisioned and (by default) activated.
+        """
+        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
+
+        acquisition = ArtifactAcquisitionService(self._model_install_service)
+
+        def deliver(progress: "AcquisitionProgress") -> None:
+            self._deliver_curated(InstallProgressed(progress))
+
+        return await acquisition.provision(
+            report.root,
+            report.grant(),
+            self._model_install_registry,
+            sources=self._model_install_sources,
+            progress=deliver,
+        )
+
+    @work(thread=True, group="llm_curated_install", exit_on_error=False)
+    def _run_curated_provision(self) -> None:
+        """Provision the consented plan off the Textual event loop."""
+        report = self._model_install_pending_report
+        if report is None:
+            self.app.call_from_thread(
+                self._apply_curated_provision_result,
+                "No install plan is available; review the model again.",
+            )
+            return
+        try:
+            asyncio.run(self._provision_curated(report))  # policy-exception: worker-thread loop
+        except Exception as exc:
+            logger.opt(exception=True).error(
+                "Curated model installation failed for {}@{}/{}",
+                report.root.artifact_id,
+                report.root.revision,
+                report.root.variant,
+            )
+            self.app.call_from_thread(
+                self._apply_curated_provision_result,
+                install_failure_message(exc, model_label=report.root.artifact_id),
+            )
+            return
+        self.app.call_from_thread(self._apply_curated_provision_result, None)
+
+    def _apply_curated_provision_result(self, error: str | None) -> None:
+        """Finish an installation: notify, mirror lifecycle, and reset state."""
+        reference = self._model_install_reference
+        self._model_install_worker = None
+        self._model_install_pending_report = None
+        if error is not None:
+            self.notify(error, severity="error")
+        else:
+            self.notify("Model installed and activated.", severity="information")
+        if reference is not None:
+            self._deliver_curated(
+                InstallStatusChanged(reference, active=False, succeeded=error is None)
+            )
+        self._model_install_reference = None
+        self._model_install_service = None
+        self._model_install_registry = None
+        self._model_install_sources = None
+        view = self._curated_view()
+        if view is not None:
+            view.finish_install()
+
+    def _clear_curated_install_state(self) -> None:
+        """Reset this screen's own bookkeeping after a request that never
+        started provisioning (a preflight failure or an explicit decline
+        at the consent modal) -- neither ever posted
+        ``InstallStatusChanged(active=True)``, so neither mirrors into
+        ``InstalledView`` or reloads the catalog; the visible
+        ``CuratedView`` (if still mounted) only needs its own in-flight
+        indicator released.
+        """
+        self._model_install_reference = None
+        self._model_install_service = None
+        self._model_install_registry = None
+        self._model_install_sources = None
+        self._model_install_pending_report = None
+        view = self._curated_view()
+        if view is not None:
+            view.cancel_pending_install()
+
+    def _deliver_curated(self, message: InstallProgressed | InstallStatusChanged) -> None:
+        """Post one curated-install message so it bubbles through ``LLMManagementWindow``.
+
+        Always posted at ``self.llm_window`` -- read fresh on every call,
+        so it already points at whichever ``LLMManagementWindow`` instance
+        is currently mounted even after a screen-level recompose replaces
+        it (``build_lab_body`` reassigns this attribute every time it
+        runs). Posting there lets the message bubble CuratedView-less
+        straight through ``LLMManagementWindow``'s own mirroring handlers
+        (``_managed_install_progressed``/``_managed_install_status_
+        changed``, which keep ``InstalledView`` in sync) and on up to this
+        screen's own ``@on(InstallProgressed)``/``@on(InstallStatusChanged)``
+        handlers -- the exact same single bubble path ``CuratedView`` used
+        to originate (``CuratedView`` -> ``LLMManagementWindow`` ->
+        ``LLMScreen``), except this screen is now the origin, not an
+        orphanable view, so there is no "closed widget, silent no-op"
+        failure mode left to compensate for (TASK-1803; this replaces the
+        removed ``CuratedView._deliver``/``_progress_screen``).
+
+        Falls back to posting directly on ``self`` only in the narrow gap
+        where a screen-level recompose is between tearing down the old
+        ``LLMManagementWindow`` and ``build_lab_body`` mounting the new
+        one: this screen's own handlers still update the status chip and
+        retained progress even though ``LLMManagementWindow``'s mirror is
+        briefly unreachable, and the very next tick -- once the fresh
+        window exists again -- resumes the full path.
+
+        Args:
+            message: The event to deliver; a fresh instance per call.
+        """
+        target: Widget = self.llm_window if self.llm_window is not None else self
+        target.post_message(message)
 
     def compose_lab_rail(self) -> ComposeResult:
         """Yield the two rail sections and their nine provider rows."""

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -32,6 +32,7 @@ from ..Workbench.workbench_state import WorkbenchHeaderState
 from .lab_frame import LabInspectorRow, LabScreen, LabStatusChip
 from .model_browser_state import install_failure_message
 from .model_curated_view import CuratedView
+from .model_installed_view import InstalledView
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -256,6 +257,22 @@ class LLMScreen(LabScreen):
         except NoMatches:
             return None
 
+    def _installed_view(self) -> "InstalledView | None":
+        """Return the mounted ``InstalledView``, or None if it cannot be found.
+
+        Returns:
+            The view, or None when the window has not mounted yet, or a
+            screen-level recompose has torn down the previous instance and
+            the fresh one is not mounted yet either (see
+            ``LabScreen.recompose()``).
+        """
+        if self.llm_window is None:
+            return None
+        try:
+            return self.llm_window.query_one(InstalledView)
+        except NoMatches:
+            return None
+
     # -- Curated model install: this screen owns preflight/provision -----
     #
     # TASK-1803: CuratedView posts CuratedView.InstallRequested and renders
@@ -283,6 +300,20 @@ class LLMScreen(LabScreen):
         -- ``cancel_pending_install()`` releases only that fresh
         instance's own indicator, leaving the still-running install's
         retained state (below) untouched.
+
+        Also validates the event's payload before storing any of it
+        (TASK-1803 review round 2, Critical): ``CuratedView`` only ever
+        posts a well-formed request today, but nothing enforces that at
+        the type level, and ``_run_curated_preflight`` used to assume
+        ``self._model_install_reference`` was always a valid
+        ``ArtifactRef`` -- a malformed or missing reference reached
+        ``reference.artifact_id`` in that worker's own exception handler,
+        raising a SECOND exception that pre-empted
+        ``_apply_curated_preflight_result`` entirely and stranded the
+        retained install state with no path back to idle. Rejecting an
+        invalid request here, before it is ever stored, is the primary
+        defense; ``_run_curated_preflight``'s own guard and safe
+        formatting are the defense-in-depth backstop.
         """
         event.stop()
         worker = self._model_install_worker
@@ -294,6 +325,22 @@ class LLMScreen(LabScreen):
             view = self._curated_view()
             if view is not None:
                 view.cancel_pending_install()
+            return
+        if (
+            not isinstance(event.reference, ArtifactRef)
+            or event.service is None
+            or event.registry is None
+            or event.sources is None
+        ):
+            logger.error(
+                "Curated install request carried an invalid reference, "
+                "service, registry, or source map; refusing to start."
+            )
+            self.notify(
+                "Could not start the model install: invalid request.",
+                severity="error",
+            )
+            self._clear_curated_install_state()
             return
         self._model_install_reference = event.reference
         self._model_install_service = event.service
@@ -321,23 +368,46 @@ class LLMScreen(LabScreen):
 
     @work(thread=True, group="llm_curated_preflight", exit_on_error=False)
     def _run_curated_preflight(self) -> None:
-        """Resolve the curated install plan off the Textual event loop."""
+        """Resolve the curated install plan off the Textual event loop.
+
+        Defense-in-depth (TASK-1803 review round 2, Critical): ``_curated_
+        install_requested`` already refuses to store an invalid reference,
+        so ``reference`` below should always be a real ``ArtifactRef`` by
+        the time this runs -- but this method no longer trusts that. A
+        missing/malformed reference schedules
+        ``_apply_curated_preflight_result`` directly instead of ever
+        reaching the ``try`` block, and the ``except`` clause formats the
+        reference defensively (``getattr(..., default)``) rather than
+        assuming attribute access succeeds. Every path below -- the guard,
+        the exception handler, and the success path -- ends in exactly
+        one ``call_from_thread(self._apply_curated_preflight_result, ...)``,
+        so the retained install state can never be left stranded by a
+        second, unhandled exception inside the error handler itself.
+        """
         reference = self._model_install_reference
+        if reference is None:
+            self.app.call_from_thread(
+                self._apply_curated_preflight_result,
+                None,
+                "No install request is available; review the model again.",
+            )
+            return
         try:
             report = asyncio.run(  # policy-exception: worker-thread loop
                 self._preflight_curated(reference)
             )
         except Exception as exc:
+            artifact_id = getattr(reference, "artifact_id", "unknown")
             logger.opt(exception=True).error(
                 "Curated model preflight failed for {}@{}/{}",
-                reference.artifact_id,
-                reference.revision,
-                reference.variant,
+                artifact_id,
+                getattr(reference, "revision", "unknown"),
+                getattr(reference, "variant", "unknown"),
             )
             self.app.call_from_thread(
                 self._apply_curated_preflight_result,
                 None,
-                install_failure_message(exc, model_label=reference.artifact_id),
+                install_failure_message(exc, model_label=artifact_id),
             )
             return
         self.app.call_from_thread(self._apply_curated_preflight_result, report, None)
@@ -397,7 +467,15 @@ class LLMScreen(LabScreen):
 
     @work(thread=True, group="llm_curated_install", exit_on_error=False)
     def _run_curated_provision(self) -> None:
-        """Provision the consented plan off the Textual event loop."""
+        """Provision the consented plan off the Textual event loop.
+
+        Same defense-in-depth as ``_run_curated_preflight`` (TASK-1803
+        review round 2): the ``except`` clause formats ``report.root``
+        defensively rather than assuming attribute access succeeds, so a
+        malformed report can never turn one failure into a second,
+        unhandled exception that skips
+        ``_apply_curated_provision_result`` and strands install state.
+        """
         report = self._model_install_pending_report
         if report is None:
             self.app.call_from_thread(
@@ -408,15 +486,17 @@ class LLMScreen(LabScreen):
         try:
             asyncio.run(self._provision_curated(report))  # policy-exception: worker-thread loop
         except Exception as exc:
+            root = getattr(report, "root", None)
+            artifact_id = getattr(root, "artifact_id", "unknown")
             logger.opt(exception=True).error(
                 "Curated model installation failed for {}@{}/{}",
-                report.root.artifact_id,
-                report.root.revision,
-                report.root.variant,
+                artifact_id,
+                getattr(root, "revision", "unknown"),
+                getattr(root, "variant", "unknown"),
             )
             self.app.call_from_thread(
                 self._apply_curated_provision_result,
-                install_failure_message(exc, model_label=report.root.artifact_id),
+                install_failure_message(exc, model_label=artifact_id),
             )
             return
         self.app.call_from_thread(self._apply_curated_provision_result, None)
@@ -602,6 +682,27 @@ class LLMScreen(LabScreen):
         every recompose, not only first mount) -- mirroring
         ``LibraryScreen``'s own ``_hydrate_parakeet_v2_progress`` -- so the
         fresh ``CuratedView`` has actually finished mounting first.
+
+        Also mirrors the same retained state directly into the freshly
+        (re)mounted ``LLMManagementWindow``'s own ``InstalledView`` (TASK-
+        1803 review round 2, Important). ``_deliver_curated``'s fallback
+        (see its own docstring) keeps THIS screen's own state current even
+        when a tick lands in the narrow teardown -> remount gap, by
+        posting directly on ``self`` when the stale, closed
+        ``self.llm_window`` cannot receive it -- but a message posted at
+        the Screen never reaches ``LLMManagementWindow``'s mirroring
+        handlers (``_managed_install_progressed``/``_managed_install_
+        status_changed``): Textual only ever bubbles a message UP, never
+        back down into a sibling/descendant, and the Screen is already
+        above that node. Left uncorrected, a fresh ``InstalledView`` would
+        show a stale "not installing" state for however long it takes the
+        NEXT tick to arrive naturally through the fresh window's own
+        mirror -- this is the same mirroring gap PR #1185 fixed for
+        ``CuratedView``, recurring one level deeper now that ``LLMScreen``
+        owns the worker. Calling ``InstalledView.set_install_state``
+        directly here closes it by construction, deterministically, on
+        every (re)mount, rather than by trying to identify and replay
+        whichever specific message the gap happened to swallow.
         """
         if not self._model_install_active:
             return
@@ -610,6 +711,9 @@ class LLMScreen(LabScreen):
         view = self._curated_view()
         if view is not None:
             view.apply_progress(self._model_install_last_progress)
+        installed = self._installed_view()
+        if installed is not None:
+            installed.set_install_state(self._model_install_last_progress, active=True)
 
     def _sync_rail_active(self, active_view: str) -> None:
         """Move the rail highlight to the row matching the active view.

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from loguru import logger
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
-from textual.dom import NoScreen
+from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -26,20 +24,10 @@ from tldw_chatbook.Model_Artifacts.service import (
     ModelArtifactService,
 )
 from tldw_chatbook.Model_Artifacts.store import managed_service
-from tldw_chatbook.UI.Screens.model_browser_state import (
-    install_failure_message,
-    provenance_label,
-)
-from tldw_chatbook.Widgets.ModelArtifacts import (
-    InstallProgressed,
-    InstallStatusChanged,
-    ModelInstallModal,
-    ModelInstallProgress,
-)
+from tldw_chatbook.UI.Screens.model_browser_state import provenance_label
+from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallProgress
 
 if TYPE_CHECKING:
-    from textual.screen import Screen
-
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
 
 
@@ -52,7 +40,70 @@ class CuratedRow:
 
 
 class CuratedView(Widget):
-    """Browse and explicitly install models curated by the application."""
+    """Browse curated models and request their installation.
+
+    Rendering only, past the catalog load: an Install click posts
+    :class:`InstallRequested` and waits to be told what happened via
+    :meth:`apply_progress`, :meth:`cancel_pending_install`, or
+    :meth:`finish_install`. ``LLMScreen`` owns the actual preflight/
+    provision workers (mirroring ``LibraryScreen``'s Parakeet v2 flow,
+    ``library_screen.py``'s ``_run_parakeet_v2_preflight``/
+    ``_run_parakeet_v2_install``) precisely so a several-hundred-megabyte
+    download survives both the consent modal being dismissed and a
+    screen-level recompose that tears down and rebuilds this exact view
+    mid-install (TASK-1803).
+
+    Before this change, this view owned that worker directly, and a
+    screen-level recompose mid-install orphaned it: the torn-down
+    instance's own ``post_message`` became a silent no-op, so progress
+    stopped reaching the UI unless compensating durable-delivery logic
+    (a fallback chain trying this instance, then the live ``CuratedView``,
+    then ``LLMManagementWindow``, then the ``Screen``) papered over it.
+    Moving the worker to ``LLMScreen`` -- which already survives that same
+    recompose to hydrate this view's progress display, see
+    ``LLMScreen._hydrate_curated_progress`` -- removes the need for any of
+    that: ``LLMScreen`` is never the thing being torn down, so there is no
+    orphaned poster left to compensate for.
+
+    This module deliberately never imports ``ArtifactAcquisitionService``
+    nor calls ``preflight()``/``provision()`` itself; ``Model_Artifacts.
+    acquisition``/``fetch`` are only ever imported inside ``LLMScreen``'s
+    own worker methods.
+    """
+
+    class InstallRequested(Message):
+        """Posted when Install is pressed for a not-yet-installed model."""
+
+        def __init__(
+            self,
+            reference: ArtifactRef,
+            *,
+            service: ModelArtifactService,
+            registry: CuratedRegistry,
+            sources: dict[ArtifactRef, dict[str, str]],
+        ) -> None:
+            """Carry everything the host screen needs to preflight/provision.
+
+            Args:
+                reference: The exact curated model reference to install.
+                service: The managed-store service resolved by this view's
+                    own (possibly test-injected) ``service_factory`` --
+                    captured here so ``LLMScreen``'s worker uses the exact
+                    same instance a test constructed this view with,
+                    without ``LLMScreen`` needing its own factory-override
+                    constructor knobs.
+                registry: The curated registry resolved the same way, via
+                    ``registry_factory``.
+                sources: The file source map for every currently
+                    registered curated descriptor (this view's own
+                    ``_source_map()``); re-walked by ``preflight()``/
+                    ``provision()`` themselves.
+            """
+            super().__init__()
+            self.reference = reference
+            self.service = service
+            self.registry = registry
+            self.sources = sources
 
     DEFAULT_CSS = """
     CuratedView {
@@ -110,21 +161,7 @@ class CuratedView(Widget):
         self._loading = False
         self._load_error: str | None = None
         self._operation_reference: ArtifactRef | None = None
-        self._pending_report = None
-        self._progress = None
-        #: The screen this view was mounted under when its current install
-        #: started, captured by ``_confirm_install`` on the main thread
-        #: before the worker starts. Unlike this exact ``CuratedView``
-        #: instance, the screen survives a screen-level
-        #: ``LabScreen.recompose()`` that tears down and rebuilds the whole
-        #: ``LLMManagementWindow`` (this view included) mid-download, so
-        #: ``_deliver`` falls back to posting there -- once this instance
-        #: can no longer receive its own messages -- letting the host
-        #: screen re-apply live progress to whichever ``CuratedView``
-        #: instance is mounted next (see
-        #: ``LLMScreen._hydrate_curated_progress``) instead of the
-        #: download going silently unrendered for the rest of its run.
-        self._progress_screen: "Screen | None" = None
+        self._progress: "AcquisitionProgress | None" = None
         super().__init__(id=id)
 
     def compose(self) -> ComposeResult:
@@ -247,13 +284,21 @@ class CuratedView(Widget):
 
     @on(Button.Pressed, ".curated-install")
     def _install_pressed(self, event: Button.Pressed) -> None:
+        """Post an install intent; never call preflight/provision here."""
         event.stop()
         reference = getattr(event.button, "reference", None)
         if not isinstance(reference, ArtifactRef) or self._operation_reference is not None:
             return
         self._operation_reference = reference
         self.refresh(recompose=True)
-        self._preflight_model(reference)
+        self.post_message(
+            self.InstallRequested(
+                reference,
+                service=self._service_for_worker(),
+                registry=self._registry_for_worker(),
+                sources=self._source_map(),
+            )
+        )
 
     def _source_map(self) -> dict[ArtifactRef, dict[str, str]]:
         """Return sources for every descriptor in the curated registry."""
@@ -263,218 +308,27 @@ class CuratedView(Widget):
             for descriptor in registry.list()
         }
 
-    async def _preflight(self, reference: ArtifactRef):
-        """Resolve a curated acquisition plan on the worker's event loop."""
-        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
-
-        acquisition = ArtifactAcquisitionService(self._service_for_worker())
-        return await acquisition.preflight(
-            reference,
-            self._registry_for_worker(),
-            sources=self._source_map(),
-        )
-
-    @work(thread=True, group="curated_model_install", exclusive=True, exit_on_error=False)
-    def _preflight_model(self, reference: ArtifactRef) -> None:
-        """Resolve the plan off the Textual event loop."""
-        try:
-            report = asyncio.run(self._preflight(reference))
-        except Exception as exc:
-            logger.opt(exception=True).error(
-                "Curated model preflight failed for {}@{}/{}",
-                reference.artifact_id,
-                reference.revision,
-                reference.variant,
-            )
-            self.app.call_from_thread(
-                self._apply_preflight_result,
-                None,
-                install_failure_message(exc, model_label=reference.artifact_id),
-            )
-            return
-        self.app.call_from_thread(self._apply_preflight_result, report, None)
-
-    def _apply_preflight_result(self, report, error: str | None) -> None:
-        """Show the shared plan modal or a sanitized failure."""
-        if error is not None or report is None:
-            self._operation_reference = None
-            self.notify(error or "Model preflight failed.", severity="error")
-            self.refresh(recompose=True)
-            return
-        self._pending_report = report
-        descriptor = self._registry_for_worker().descriptor(report.root)
-        self.app.push_screen(
-            ModelInstallModal(report, model_label=descriptor.model_id),
-            self._confirm_install,
-        )
-
-    def _confirm_install(self, confirmed: bool) -> None:
-        """Start provisioning only after explicit consent."""
-        if not confirmed:
-            self._pending_report = None
-            self._operation_reference = None
-            self.refresh(recompose=True)
-            return
-        # See _progress_screen's own docstring: captured here, on the main
-        # thread, before the worker starts -- not inside _provision, which
-        # runs on the worker thread -- and before the InstallStatusChanged
-        # post below, so _deliver's fallback is available from the very
-        # first message this install produces.
-        try:
-            self._progress_screen = self.screen
-        except NoScreen:
-            self._progress_screen = None
-        if self._operation_reference is not None:
-            self._deliver(
-                InstallStatusChanged(self._operation_reference, active=True)
-            )
-        self._provision_model()
-
-    def _deliver(self, message: InstallProgressed | InstallStatusChanged) -> None:
-        """Post one message to whichever target can still receive it.
-
-        Tries this instance first -- ``self.post_message`` -- which
-        preserves today's exact bubble path (``CuratedView`` ->
-        ``LLMManagementWindow``, which mirrors progress into
-        ``InstalledView`` -- unrelated to this task -- -> ``LLMScreen``)
-        for the common, no-recompose case: exactly the same single message
-        this code posted before ``_progress_screen`` existed.
-        ``post_message`` returns ``False`` without raising once this
-        instance is closed (torn down by a screen-level recompose, see
-        ``_progress_screen``'s docstring) -- only THEN does this fall back.
-
-        Review Important #1 (this delta port's first round): posting to
-        both targets unconditionally, every tick, meant ``LLMScreen``'s own
-        forwarding (``_model_install_progressed``/``_hydrate_curated_
-        progress``) re-applied the SAME event to the SAME still-mounted
-        ``CuratedView`` a second (and, with ``InstallProgressed`` also
-        bubbling through this instance's own now-removed self-listening
-        handler, third) time -- confirmed live via a Pilot probe showing
-        three ``apply_progress`` calls for one tick. Exactly one message
-        is posted per tick now, so ``LLMScreen`` renders exactly once.
-
-        Review Important #2 (PR #1185 automated review, fix round 2): the
-        fallback used to post directly at the captured Screen. Textual
-        only bubbles a message UP from wherever it is posted -- never back
-        down -- and ``LLMManagementWindow`` (which owns the
-        ``InstallProgressed``/``InstallStatusChanged`` handlers that mirror
-        progress and lifecycle into ``InstalledView``) sits BELOW the
-        Screen in the tree. Posting at the Screen therefore entered the
-        tree above that mirroring node, so it silently never ran after a
-        recompose: Curated kept updating via ``LLMScreen``, but Installed
-        stopped receiving ticks/completion until some later, unrelated
-        refresh. The fallback now re-enters the tree below that node
-        instead -- at the live ``CuratedView`` if one is mounted (the
-        normal case, restoring the FULL path: mirror at
-        ``LLMManagementWindow``, then render at ``LLMScreen``, in one
-        message), or at the live ``LLMManagementWindow`` if a fresh
-        ``CuratedView`` has not finished (re)mounting yet (the same
-        nested-mount window ``apply_progress`` itself tolerates), and only
-        as a last resort -- neither found -- at the Screen itself, exactly
-        as the reviewer specified.
-
-        Args:
-            message: The event to deliver; a fresh instance per call (never
-                reused across two different posts, so no Message ever
-                needs its ``_prevent`` set merged from two different
-                targets).
-        """
-        if self.post_message(message):
-            return
-        screen = self._progress_screen
-        if screen is None:
-            return
-        # Local import: avoids a module-scope cycle with
-        # LLM_Management_Window, which itself only imports this module
-        # locally (inside its own compose()), for the same reason.
-        from tldw_chatbook.UI.LLM_Management_Window import LLMManagementWindow
-
-        try:
-            target: Widget = screen.query_one(CuratedView)
-        except NoMatches:
-            try:
-                target = screen.query_one(LLMManagementWindow)
-            except NoMatches:
-                target = screen
-        target.post_message(message)
-
-    async def _provision(self, report):
-        """Provision the consented report on the worker's event loop."""
-        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
-
-        acquisition = ArtifactAcquisitionService(self._service_for_worker())
-
-        def deliver(progress: "AcquisitionProgress") -> None:
-            self._deliver(InstallProgressed(progress))
-
-        return await acquisition.provision(
-            report.root,
-            report.grant(),
-            self._registry_for_worker(),
-            sources=self._source_map(),
-            progress=deliver,
-        )
-
-    @work(thread=True, group="curated_model_install", exclusive=True, exit_on_error=False)
-    def _provision_model(self) -> None:
-        """Provision the consented plan off the Textual event loop."""
-        report = self._pending_report
-        if report is None:
-            self.app.call_from_thread(
-                self._apply_provision_result,
-                "No install plan is available; review the model again.",
-            )
-            return
-        try:
-            asyncio.run(self._provision(report))
-        except Exception as exc:
-            logger.opt(exception=True).error(
-                "Curated model installation failed for {}@{}/{}",
-                report.root.artifact_id,
-                report.root.revision,
-                report.root.variant,
-            )
-            self.app.call_from_thread(
-                self._apply_provision_result,
-                install_failure_message(
-                    exc,
-                    model_label=report.root.artifact_id,
-                ),
-            )
-            return
-        self.app.call_from_thread(self._apply_provision_result, None)
-
     def apply_progress(self, progress: "AcquisitionProgress") -> None:
         """Render one acquisition progress event, retaining it for later.
 
         Called ONLY by the host screen (``LLMScreen``) -- via its own
         ``InstallProgressed`` handler for a live tick, and via
         ``_hydrate_curated_progress`` to re-apply the last known progress
-        to a freshly (re)mounted instance after a screen-level recompose
-        (see ``_progress_screen``'s docstring). This view deliberately has
-        no ``@on(InstallProgressed)`` handler of its own: it used to
-        (re-rendering itself on receipt of the very message it had just
-        posted to itself), which meant one tick rendered TWICE on the same
-        still-mounted widget once ``LLMScreen`` started forwarding too --
-        confirmed live via a Pilot probe showing three ``apply_progress``
-        calls for one tick (Review Important #1). ``LLMScreen`` is now the
-        sole caller, giving exactly one render per tick regardless of
-        which delivery path (self or the durable screen fallback,
-        see ``_deliver``) carried it.
+        to a freshly (re)mounted instance after a screen-level recompose.
+        This view has no ``@on(InstallProgressed)`` handler of its own and
+        never posts that message itself (TASK-1803 moved the worker that
+        used to post it to ``LLMScreen``); ``LLMScreen`` is the sole
+        caller, giving exactly one render per tick.
 
         ``self._progress`` is retained before either branch below runs, so
         a fallback ``refresh(recompose=True)`` still picks up the correct
-        value on CuratedView's next (complete) compose pass: this method
-        can run (via ``_hydrate_curated_progress``, scheduled by
-        ``call_after_refresh``) at a point where CuratedView itself has
+        value on this view's next (complete) compose pass: this method can
+        run (via ``_hydrate_curated_progress``, scheduled by
+        ``call_after_refresh``) at a point where this view itself has
         (re)mounted but its own ``ModelInstallProgress`` child has not yet
         finished composing ITS OWN children -- a widget that ``query_one``
         finds but whose own ``update_progress`` call then raises
-        ``NoMatches`` reaching into it. Unrelated to the double-render
-        issue above (that was about how many times a fully-mounted widget
-        got re-rendered; this is about a widget still mid-mount) -- kept
-        even now that delivery is single-path, tolerating the outer
-        widget lookup being temporarily absent one level deeper.
+        ``NoMatches`` reaching into it.
 
         Args:
             progress: The acquisition progress event to render.
@@ -490,16 +344,29 @@ class CuratedView(Widget):
         except NoMatches:
             self.refresh(recompose=True)
 
-    def _apply_provision_result(self, error: str | None) -> None:
-        """Finish an installation and refresh curated installed-state."""
-        reference = self._operation_reference
-        self._pending_report = None
+    def cancel_pending_install(self) -> None:
+        """Clear the in-flight indicator without reloading the catalog.
+
+        Called by the host screen (``LLMScreen``) when a request this view
+        posted did not lead to an install actually starting: a preflight
+        failure, an explicit decline at the consent modal, or a request
+        refused outright because a different install is already running
+        (in which case this is the freshly (re)mounted view that just
+        clicked Install, not the instance whose install is still in
+        flight -- see ``LLMScreen._curated_install_requested``).
+        """
+        self._operation_reference = None
+        self.refresh(recompose=True)
+
+    def finish_install(self) -> None:
+        """Clear the in-flight indicator and reload after a completed install.
+
+        Called by the host screen (``LLMScreen``) once provisioning
+        finishes, successfully or not -- reloading refreshes which rows
+        show "Installed" and re-enables Install everywhere else.
+        """
         self._operation_reference = None
         self._progress = None
-        # _progress_screen itself is cleared only after _deliver (below)
-        # has had a chance to use it as its fallback target for this
-        # exact completion message -- clearing it first would silently
-        # disable the durable path for the one message that most needs it.
         try:
             progress = self.query_one(
                 "#curated-model-install-progress",
@@ -509,21 +376,4 @@ class CuratedView(Widget):
             progress = None
         if progress is not None:
             progress.display = False
-        if error is not None:
-            self.notify(error, severity="error")
-        else:
-            self.notify("Model installed and activated.", severity="information")
-        if reference is not None:
-            # _deliver (see its own docstring): tries this instance first,
-            # falls back to the captured screen only if a screen-level
-            # recompose already orphaned it -- otherwise this completion
-            # message would never bubble anywhere (a closed widget's
-            # post_message() is a silent no-op), and the host screen would
-            # never learn the install finished, re-hydrating a stale
-            # "still active" progress display on every future recompose
-            # (see LLMScreen._hydrate_curated_progress).
-            self._deliver(
-                InstallStatusChanged(reference, active=False, succeeded=error is None)
-            )
-        self._progress_screen = None
         self.ensure_loaded(force=True)


### PR DESCRIPTION
Closes TASK-1803. Follow-up to #1185, which compensated for this defect rather than fixing it.

## The rule, and why it exists

The model browser's design says **views post intent messages; the host screen owns the `@work(thread=True)` worker.** That is not style — a model download runs for minutes, and it has to survive both the consent modal being dismissed and the screen recomposing. `InstalledView` and `LibraryScreen` follow it.

`CuratedView` did not: it drove `preflight` and `provision` itself. So when the Models screen recomposed mid-install, the view instance owning the worker was closed, its `post_message` became a silent no-op, and progress stopped reaching the UI.

#1185 papered over the symptom with a four-level delivery fallback — `self` → live `CuratedView` → `LLMManagementWindow` → `Screen`. That chain existed **only** because the worker was owned by something that does not outlive a recompose.

## What changes

`LLMScreen` now owns the curated preflight and provision workers, mirroring how `LibraryScreen` owns the Parakeet ones. `CuratedView` posts intents and renders what it is told; it no longer imports or calls `ArtifactAcquisitionService`.

**The fallback chain is deleted outright** — not shortened. That was the honest test of whether the fix was real, and it is TASK-1803's third acceptance criterion.

Catalog listing (`_load_curated`) stays on the view, matching `InstalledView._load_inventory`. It is not acquisition and carries none of the orphaning risk.

## The behaviours #1185 established still hold, and are still tested

- exactly **one** `apply_progress` call per progress tick (a test counts invocations rather than inspecting the end state — content-only assertions cannot tell one render from three);
- progress survives a real screen-level recompose mid-install;
- a tick delivered after a recompose still reaches `LLMManagementWindow`'s `@on(InstallProgressed)` / `@on(InstallStatusChanged)` handlers, which mirror into `InstalledView`. Messages bubble upward only, so anything posted above that node silently starves the Installed view.

## One Critical defect found in review, and fixed

The first cut of this change replaced the fallback with `self.llm_window` — a plain attribute. `LabScreen.recompose()` tears down and closes the old `LLMManagementWindow` **synchronously**, but only the deferred `_mount_lab_body` reassigns that attribute. In between, it points at a *closed* widget, and `post_message` on a closed target returns `False` without raising, so a tick delivered in that window vanished with no handler firing.

That was a regression against the very code being deleted: the old `_deliver` queried the live tree precisely so a stale reference could not swallow a tick. Losing the terminal `InstallStatusChanged(active=False, …)` there would strand the Lab chip on "downloading" and leave Installed never learning the install finished.

Fixed by honouring `post_message`'s boolean return and falling back to the screen itself — the same signal the deleted code relied on, without reinstating the chain. Pinned by a test that reproduces the gap exactly (`await old_window.remove()`, then deliver) and asserts the screen's own state still updates; confirmed red with the check disabled.

Review also found `_apply_curated_provision_result` and the concurrent-install guard untested; both now have direct coverage.

## Related defect, filed not fixed

`model_remote_view.py` (Phase 2, #1190) has the **same** ownership violation, imports `ArtifactAcquisitionService` at module scope, and — unlike the pre-#1185 `CuratedView` — has no compensating delivery logic at all, so a recompose mid-install loses progress with nothing to catch it. Filed as **TASK-1914** rather than expanded into this PR.

## Verification

618 passed, 1 skipped (pre-existing, unrelated) across the model browser, Lab rail, `Model_Artifacts`, and STT boundary suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves curated model install workers to LLMScreen so recomposes can’t orphan downloads, removes the multi-hop fallback, and adds delivery-gap handling and input validation so installs always finish and mirror correctly into Installed. Implements TASK-1803.

- **Refactors**
  - LLMScreen now owns preflight, consent modal, and provision; CuratedView only posts InstallRequested and renders via apply_progress/cancel_pending_install/finish_install.
  - Single delivery path posts to the current LLMManagementWindow; if stale/closed, falls back to the screen.
  - Install state (reference, service, registry, sources, pending report) is retained on LLMScreen and survives recomposes.
  - On remount, hydration mirrors retained progress into Installed via set_install_state to keep it in sync.
  - Tests updated and extended; ownership-sensitive cases moved to the LLMScreen suite.

- **Bug Fixes**
  - _deliver_curated checks post_message’s return and falls back to the screen to avoid lost ticks during the recompose teardown→remount gap.
  - Validates install requests before starting; bad input notifies, releases the view’s indicator, and clears state; guards None/malformed refs in preflight/provision and ensures one UI apply per tick.
  - Keeps progress/completion mirrored into Installed after recomposes; blocks concurrent curated installs while preserving the running state.
  - Correct notifications and full state reset on success/failure; always emits the terminal InstallStatusChanged(active=false, …).

<sup>Written for commit a527a695f19b78616a160a34438a8b446f5d25a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

