### PR TITLE
Console: keep a tool call's destination visible in the approval row (TASK-695)

### DIFF
--- a/Tests/UI/test_approval_argument_budget.py
+++ b/Tests/UI/test_approval_argument_budget.py
@@ -67,9 +67,9 @@ def test_short_arguments_are_still_rendered_verbatim():
 def test_secret_redaction_still_applies_after_reordering():
     """Redaction parity must survive the new ordering (TASK-1845)."""
     rendered = _summarize_arguments(
-        {"api_key": "sk-super-secret-value", "path": "~/a.md"}
+        {"api_key": "NOT-A-REAL-KEY-placeholder", "path": "~/a.md"}
     )
-    assert "sk-super-secret-value" not in rendered
+    assert "NOT-A-REAL-KEY-placeholder" not in rendered
     assert "***" in rendered
 
 
@@ -137,3 +137,20 @@ def test_the_destination_survives_when_it_is_the_last_of_many_arguments():
         f"the destination was clipped off the end of a long argument list: "
         f"{rendered!r}"
     )
+
+
+@pytest.mark.unit
+def test_a_non_string_argument_key_never_crashes_rendering():
+    """`_summarize_arguments` must survive any payload the model emits.
+
+    The old implementation put everything inside one guarded `json.dumps`.
+    Hoisting moved key inspection OUT of that guard, and `_snake_case`'s
+    `re.sub` raises TypeError on a non-string key -- so a malformed payload
+    took down the approval row instead of rendering it. An approval card
+    that crashes is an approval the user cannot answer, and the run blocks
+    until the auto-deny fires.
+    """
+    rendered = _summarize_arguments({1: "a", "path": "/x", None: "b"})
+
+    assert "/x" in rendered, rendered
+    assert isinstance(rendered, str)

--- a/Tests/UI/test_approval_argument_budget.py
+++ b/Tests/UI/test_approval_argument_budget.py
@@ -1,0 +1,139 @@
+"""TASK-695: a tool call's target must survive argument truncation.
+
+`_summarize_arguments` capped the WHOLE JSON blob at 80 characters, and
+`json.dumps` preserves the model's key order. A `write_file` that emits
+`content` before `file_path` therefore rendered 67 characters of file body
+and truncated the destination out of view -- the card asked "may I write
+this?" without showing where.
+
+TASK-1846 gave arguments the full row width but not this: the cap is a text
+budget, not a layout one, so the extra cells went unused while the path
+stayed hidden.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import (
+    _collapse_pending_calls,
+    _summarize_arguments,
+    _summarize_row_arguments,
+)
+
+
+@pytest.mark.unit
+def test_the_destination_survives_a_huge_leading_content_argument():
+    """The reported case: `write_file` with content serialised first."""
+    rendered = _summarize_arguments(
+        {"content": "x" * 400, "file_path": "~/notes/IMPORTANT.md"}
+    )
+    assert "IMPORTANT.md" in rendered, (
+        "the write destination is truncated out of view; the card asks 'may "
+        f"I write this?' without showing where: {rendered!r}"
+    )
+
+
+@pytest.mark.unit
+def test_it_holds_through_the_row_renderer_too():
+    """The production path is the row renderer, not the helper."""
+    entry = _collapse_pending_calls(
+        [
+            {
+                "llm_name": "write_file",
+                "arguments": {"content": "y" * 500, "file_path": "/tmp/target.md"},
+            }
+        ]
+    )[0]
+    assert "target.md" in _summarize_row_arguments(entry)
+
+
+@pytest.mark.unit
+def test_no_single_argument_may_consume_the_whole_budget():
+    """One huge value must not starve every other argument off the line."""
+    rendered = _summarize_arguments(
+        {"blob": "z" * 1000, "mode": "overwrite", "path": "/etc/hosts"}
+    )
+    assert "/etc/hosts" in rendered, rendered
+    assert "overwrite" in rendered, rendered
+
+
+@pytest.mark.unit
+def test_short_arguments_are_still_rendered_verbatim():
+    """The common case must not gain ellipses or reordering noise."""
+    assert _summarize_arguments({"path": "~/a.md"}) == '{"path":"~/a.md"}'
+
+
+@pytest.mark.unit
+def test_secret_redaction_still_applies_after_reordering():
+    """Redaction parity must survive the new ordering (TASK-1845)."""
+    rendered = _summarize_arguments(
+        {"api_key": "sk-super-secret-value", "path": "~/a.md"}
+    )
+    assert "sk-super-secret-value" not in rendered
+    assert "***" in rendered
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "key",
+    ["path", "file_path", "filePath", "dest", "destination", "src", "source",
+     "output_dir", "url", "uri", "command", "target", "filename", "host"],
+)
+def test_destination_like_keys_are_recognised(key: str):
+    """Args:
+        key: An argument name that names WHERE a call acts.
+    """
+    from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import (
+        _is_destination_key,
+    )
+
+    assert _is_destination_key(key), key
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("key", ["profile", "filter", "compiled", "urinal", "hostility"])
+def test_ordinary_keys_are_not_mistaken_for_destinations(key: str):
+    """Substring matching treats `profile` as a file and `urinal` as a URL.
+
+    A false positive is only a reordering, not a leak -- but it pushes the
+    REAL destination later in a line that is budget-limited, which is the
+    defect this task exists to fix.
+
+    Args:
+        key: An argument name that merely contains a destination word.
+    """
+    from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import (
+        _is_destination_key,
+    )
+
+    assert not _is_destination_key(key), key
+
+
+@pytest.mark.unit
+def test_a_source_path_is_not_reordered_behind_its_destination():
+    """`src`/`dest` are both destinations; the call's own order is kept."""
+    rendered = _summarize_arguments({"src": "/a/one.md", "dest": "/b/two.md"})
+    assert rendered.index('"src"') < rendered.index('"dest"'), rendered
+
+
+@pytest.mark.unit
+def test_the_destination_survives_when_it_is_the_last_of_many_arguments():
+    """Hoisting, not just per-value budgets, is what saves this case.
+
+    With a handful of arguments the per-value budget alone keeps the
+    destination on screen wherever it sits. With MANY, the shared budget
+    shrinks but the total still reaches the line cap, and whatever sits last
+    is clipped -- so a call whose path is emitted last loses it again.
+
+    Mutation-checked: removing the hoisting leaves every other test in this
+    file green and fails only this one.
+    """
+    arguments = {f"opt_{n}": f"value-{n}" * 3 for n in range(8)}
+    arguments["file_path"] = "~/notes/IMPORTANT.md"
+
+    rendered = _summarize_arguments(arguments)
+
+    assert "IMPORTANT.md" in rendered, (
+        f"the destination was clipped off the end of a long argument list: "
+        f"{rendered!r}"
+    )

--- a/backlog/tasks/task-570 - Console-branching-agent-inline-TOOL-markers-vanish-each-turn.md
+++ b/backlog/tasks/task-570 - Console-branching-agent-inline-TOOL-markers-vanish-each-turn.md
@@ -3,7 +3,7 @@ id: TASK-570
 title: >-
   Console branching: agent inline TOOL markers vanish each turn on active-path
   recompute
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-25'
 labels:
@@ -26,7 +26,17 @@ Post-Phase-C re-triage (2026-07-25): Phase C (PR #827) landed durable id-anchori
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Inline agent TOOL markers persist in the Console transcript across subsequent turns/swipes for a conversation that used the agent runtime (or the limitation is documented honestly where users see it)
-- [ ] #2 Marker persistence does not reintroduce TOOL rows into the conversation tree (they must stay display-only, never parents)
-- [ ] #3 Behavior verified in the live TUI with an agent-runtime conversation
+- [x] #1 Inline agent TOOL markers persist in the Console transcript across subsequent turns/swipes for a conversation that used the agent runtime (or the limitation is documented honestly where users see it)
+- [x] #2 Marker persistence does not reintroduce TOOL rows into the conversation tree (they must stay display-only, never parents)
+- [x] #3 Behavior verified in the live TUI with an agent-runtime conversation
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Closed as already fixed, by TASK-1842 (PR #1192).** This task's own prescription -- "re-derive/re-overlay the markers after each recompute" -- is what shipped: markers are anchored to the node they followed and spliced back by `_with_tool_markers` on every `_recompute_active_path`, while still never becoming tree nodes. The resume door (`restore_state`, which writes the view directly) was closed in the same change, and `_purge_tool_markers` was added afterwards so markers do not outlive their anchor or their session.
+
+Kept rather than deleted because the diagnosis here is the better-written one, and it records the Phase A/Phase C history that explains WHY the markers were transient by design.
+
+**Filed twice.** TASK-1842 was written from a user report without first searching the backlog for an existing task describing the same defect. Search before filing.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-695 - Approval-card-can-truncate-a-tool-calls-target-path-out-of-view.md
+++ b/backlog/tasks/task-695 - Approval-card-can-truncate-a-tool-calls-target-path-out-of-view.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-695
 title: Approval card can truncate a tool call's target path out of view
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 06:45'
 labels:
@@ -28,8 +28,23 @@ Fix should ensure security-relevant arguments (paths, destinations) survive trun
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] A `write_file` approval row shows the target path regardless of the model's argument key order and regardless of `content` length
-- [ ] Long argument values are still bounded so one call cannot dominate the card
-- [ ] A test drives an approval row for a call whose `content` precedes `file_path` and exceeds the cap, asserting the path is visible in the rendered summary
-- [ ] MCP approval rows keep their existing summary behavior, or the change is applied deliberately to both with the shared behavior tested
+- [x] A `write_file` approval row shows the target path regardless of the model's argument key order and regardless of `content` length
+- [x] Long argument values are still bounded so one call cannot dominate the card
+- [x] A test drives an approval row for a call whose `content` precedes `file_path` and exceeds the cap, asserting the path is visible in the rendered summary
+- [x] MCP approval rows keep their existing summary behavior, or the change is applied deliberately to both with the shared behavior tested
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two changes in `_summarize_arguments`, neither of which raises the global cap (raising it only moves the cliff):
+
+1. **Destination keys are hoisted.** `_is_destination_key` matches whole TOKENS, not substrings -- `profile` contains "file" and `urinal` contains "uri", and a false positive pushes the real destination later in a budget-limited line, which is the defect this exists to fix. camelCase is split, so `filePath` matches.
+2. **Every value gets its own budget.** Destinations render at the full per-value limit; what they leave is split evenly among the remaining arguments, with a floor so a value never renders as pure ellipsis. Without the split, the SECOND bulk argument still starves everything after it -- a fixed per-value cap just moves the cliff along by one key.
+
+Redaction runs BEFORE reordering and clipping, so neither can expose a secret (pinned by a test).
+
+AC#4: this is the shared summariser, so MCP and built-in rows change together -- deliberate, and the whole point is that it is the one place a target can be hidden.
+
+**Both halves are mutation-verified, and the first attempt to verify hoisting failed to.** Removing the hoisting left all 25 tests green, because with a handful of arguments the per-value budget alone keeps the destination on screen wherever it sits. Hoisting only becomes load-bearing when the destination is last among MANY arguments -- the shared budget shrinks, the total still reaches the line cap, and the tail is clipped. That case now has its own test, and removing the hoisting fails only that one.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
@@ -241,12 +241,25 @@ _DESTINATION_TOKENS: frozenset[str] = frozenset(
 )
 
 
-def _snake_case(key: str) -> str:
-    """Return ``key`` lowercased with camelCase split into ``_`` tokens."""
-    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key).lower()
+def _snake_case(key: Any) -> str:
+    """Return ``key`` lowercased with camelCase split into ``_`` tokens.
+
+    Takes ``Any``, not ``str``: these keys come straight from model output,
+    where a malformed payload can carry a non-string key. `re.sub` raises
+    TypeError on one, which used to take down the whole approval row -- an
+    approval the user cannot answer, blocking the run until the auto-deny
+    fires. Coerced here, at the boundary.
+
+    Args:
+        key: One argument name from a tool call, of any type.
+
+    Returns:
+        The key as a lowercase, ``_``-separated string.
+    """
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", str(key)).lower()
 
 
-def _is_destination_key(key: str) -> bool:
+def _is_destination_key(key: Any) -> bool:
     """Whether ``key`` names WHERE a call acts, rather than what it carries.
 
     TASK-695: these are the arguments an approval decision actually turns
@@ -255,7 +268,8 @@ def _is_destination_key(key: str) -> bool:
     never push the destination off the end of the summary.
 
     Args:
-        key: One argument name from the model's tool call.
+        key: One argument name from the model's tool call. Any type -- see
+            `_snake_case` for why this is not narrowed to ``str``.
 
     Returns:
         True when the name looks like a destination/target.
@@ -318,7 +332,7 @@ def _summarize_arguments(arguments: Mapping[str, Any] | None) -> str:
     # a fixed per-value cap only moves the cliff along by one key.
     destinations = [kv for kv in ordered if _is_destination_key(kv[0])]
     payloads = [kv for kv in ordered if not _is_destination_key(kv[0])]
-    overhead = sum(len(json.dumps(key)) + 2 for key, _ in ordered) + 2
+    overhead = sum(len(json.dumps(str(key))) + 2 for key, _ in ordered) + 2
     spent = sum(len(_render(v, _ARGS_VALUE_LIMIT)) for _, v in destinations)
     share = _ARGS_VALUE_LIMIT
     if payloads:
@@ -326,7 +340,7 @@ def _summarize_arguments(arguments: Mapping[str, Any] | None) -> str:
         share = max(_ARGS_MIN_VALUE_LIMIT, min(_ARGS_VALUE_LIMIT, remaining // len(payloads)))
 
     parts = [
-        f"{json.dumps(key)}:"
+        f"{json.dumps(str(key))}:"
         f"{_render(value, _ARGS_VALUE_LIMIT if _is_destination_key(key) else share)}"
         for key, value in ordered
     ]

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
@@ -29,6 +29,7 @@ and_resume.py``) without also removing the now-orphaned widget code;
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Mapping, Sequence
 
 from textual import on
@@ -112,6 +113,18 @@ def _row_header_tooltip(entry: Mapping[str, Any]) -> str:
 _PATH_PRECHECK_SUFFIX = " -- path outside allowed folders; will fail even if approved"
 
 _ARGS_SUMMARY_LIMIT = 80
+
+#: TASK-695: per-VALUE budget inside the summary above. Without it a single
+#: bulk argument (a `write_file` body, a pasted document) consumes the whole
+#: line and every other argument -- including the destination the decision
+#: turns on -- is clipped away. Sized so a typical path survives intact
+#: while a payload is obviously abbreviated.
+_ARGS_VALUE_LIMIT = 34
+
+#: Floor for a shared value budget: below this a value is all ellipsis and
+#: tells the reader nothing, so it is better to overflow the line cap (which
+#: clips the tail) than to render every argument as noise.
+_ARGS_MIN_VALUE_LIMIT = 10
 
 #: TASK-1845: needs-decision was a border + 10% tint with no text change, so
 #: the state vanished in monochrome. PRODUCT.md: "colour must never be the
@@ -213,23 +226,111 @@ def _format_row_header(entry: Mapping[str, Any]) -> str:
     return header
 
 
+#: TASK-695: argument names that say WHERE a call acts. Matched as whole
+#: tokens (see `_is_destination_key`), so `profile` is not a file and
+#: `urinal` is not a URL.
+_DESTINATION_TOKENS: frozenset[str] = frozenset(
+    {
+        "path", "paths", "filepath", "file", "files", "filename",
+        "dir", "dirs", "directory", "folder",
+        "dest", "destination", "target", "output", "out",
+        "src", "source", "input",
+        "url", "uri", "endpoint", "host", "hostname",
+        "cmd", "command", "script",
+    }
+)
+
+
+def _snake_case(key: str) -> str:
+    """Return ``key`` lowercased with camelCase split into ``_`` tokens."""
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key).lower()
+
+
+def _is_destination_key(key: str) -> bool:
+    """Whether ``key`` names WHERE a call acts, rather than what it carries.
+
+    TASK-695: these are the arguments an approval decision actually turns
+    on -- the file being written, the URL being fetched, the command being
+    run. They are hoisted ahead of bulk payloads so a large ``content`` can
+    never push the destination off the end of the summary.
+
+    Args:
+        key: One argument name from the model's tool call.
+
+    Returns:
+        True when the name looks like a destination/target.
+    """
+    # Matched on TOKENS, not substrings: `profile` contains "file" and
+    # `urinal` contains "uri", and a false positive reorders the line so the
+    # real destination lands later in a budget-limited summary -- the exact
+    # failure this hoisting exists to prevent.
+    tokens = {
+        token
+        for token in re.split(r"[^a-z0-9]+|(?<=[a-z])(?=[0-9])", _snake_case(key))
+        if token
+    }
+    return bool(tokens & _DESTINATION_TOKENS)
+
+
 def _summarize_arguments(arguments: Mapping[str, Any] | None) -> str:
     """Return ONE payload as a compact, ``markup=False``-safe summary.
+
+    TASK-695: the summary used to be one ``json.dumps`` blob clipped at
+    ``_ARGS_SUMMARY_LIMIT``, and ``json.dumps`` preserves the model's key
+    order -- so a ``write_file`` emitting ``content`` before ``file_path``
+    showed 67 characters of file body and truncated the destination out of
+    view. The card asked "may I write this?" without showing where.
+
+    Two changes fix that without raising the global cap (which would only
+    move the cliff): destination-like keys are rendered FIRST, and every
+    value gets its own budget so one bulk payload cannot consume the line.
 
     Secret-looking values (``api_key``, ``token``, ``password``, ...) are
     redacted before rendering -- redaction parity with every other MCP
     display/log boundary (see ``tldw_chatbook.MCP.redaction``'s module
     docstring); the approval card is the one place a raw secret argument
-    was still reaching the screen unredacted.
+    was still reaching the screen unredacted. Redaction runs BEFORE the
+    reordering and clipping below, so neither can expose a secret.
     """
     try:
-        text = json.dumps(
-            redact_mapping(dict(arguments or {})),
-            default=str,
-            separators=(",", ":"),
-        )
+        redacted = redact_mapping(dict(arguments or {}))
     except Exception:  # noqa: BLE001 -- a bad arg must never crash rendering
-        text = str(arguments or {})
+        return str(arguments or {})[: _ARGS_SUMMARY_LIMIT]
+    if not redacted:
+        return "{}"
+
+    # Destinations first, each group keeping the model's own order so a call
+    # with several paths still reads in the order it was made.
+    ordered = sorted(redacted.items(), key=lambda kv: not _is_destination_key(kv[0]))
+
+    def _render(value: Any, budget: int) -> str:
+        try:
+            text = json.dumps(value, default=str, separators=(",", ":"))
+        except Exception:  # noqa: BLE001
+            text = json.dumps(str(value))
+        if len(text) > budget:
+            return text[: max(1, budget - 1)] + "…"
+        return text
+
+    # Destinations are rendered first and at the full per-value budget; what
+    # they leave is split evenly among the remaining arguments. Without the
+    # split, the second bulk argument still starves everything after it --
+    # a fixed per-value cap only moves the cliff along by one key.
+    destinations = [kv for kv in ordered if _is_destination_key(kv[0])]
+    payloads = [kv for kv in ordered if not _is_destination_key(kv[0])]
+    overhead = sum(len(json.dumps(key)) + 2 for key, _ in ordered) + 2
+    spent = sum(len(_render(v, _ARGS_VALUE_LIMIT)) for _, v in destinations)
+    share = _ARGS_VALUE_LIMIT
+    if payloads:
+        remaining = _ARGS_SUMMARY_LIMIT - overhead - spent
+        share = max(_ARGS_MIN_VALUE_LIMIT, min(_ARGS_VALUE_LIMIT, remaining // len(payloads)))
+
+    parts = [
+        f"{json.dumps(key)}:"
+        f"{_render(value, _ARGS_VALUE_LIMIT if _is_destination_key(key) else share)}"
+        for key, value in ordered
+    ]
+    text = "{" + ",".join(parts) + "}"
     if len(text) > _ARGS_SUMMARY_LIMIT:
         return text[: _ARGS_SUMMARY_LIMIT - 1] + "…"
     return text


### PR DESCRIPTION
`_summarize_arguments` clipped one `json.dumps` blob at 80 characters, and `json.dumps` preserves the model's key order. A `write_file` emitting `content` before `file_path` therefore rendered 67 characters of file body and truncated the destination out of view:

```
{"content":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…
path visible? False
```

The card asked **"may I write this?" without showing where.** Verified reproducing on `dev` before starting.

TASK-1846 gave the row full width but not this — the cap is a *text* budget, not a layout one, so the extra cells went unused while the path stayed hidden.

## Two changes, neither raising the global cap

Raising the cap only moves the cliff, so instead:

**Destination keys are hoisted.** `_is_destination_key` matches whole **tokens**, not substrings — `profile` contains "file" and `urinal` contains "uri", and a false positive pushes the real destination *later* in a budget-limited line, which is the defect this exists to fix. camelCase is split, so `filePath` matches.

**Every value gets its own budget.** Destinations render at the full per-value limit; what they leave is split evenly among the rest, with a floor so a value never renders as pure ellipsis. Without the split, the *second* bulk argument still starves everything after it.

Redaction runs **before** reordering and clipping, so neither can expose a secret — pinned by a test.

Result:
```
{"file_path":"~/notes/IMPORTANT.md","content":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…}
{"path":"/etc/hosts","blob":"zzzzzzzzzzzzzzzzzzz…,"mode":"overwrite"}
{"path":"~/a.md"}                                    ← short args unchanged
```

## My first attempt to mutation-verify the hoisting failed to

Removing the hoisting left **all 25 tests green**. With a handful of arguments the per-value budget alone keeps the destination on screen wherever it sits — hoisting only becomes load-bearing when the destination is last among *many* arguments, where the shared budget shrinks but the total still reaches the line cap and the tail is clipped. That case now has its own test, and removing the hoisting fails only that one.

AC#4 note: this is the shared summariser, so MCP and built-in rows change together. Deliberate — the whole point is that it is the one place a target can be hidden.

250 passed across the approval and controller suites.

## Also closes TASK-570 as already fixed

"Console branching: agent inline TOOL markers vanish each turn" is the same defect as TASK-1842, fixed in #1192 — its own prescription (*"re-derive/re-overlay the markers after each recompute"*) is exactly what shipped. I filed 1842 from a user report without searching the backlog first, so the same defect was tracked twice. Kept rather than deleted: its diagnosis is the better-written one and records the Phase A/C history explaining why markers were transient by design.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps a tool call’s destination (path/URL/command) visible in the approval row and hardens the summarizer to avoid crashes. Satisfies TASK-695 and confirms TASK-570 as already fixed.

- **Bug Fixes**
  - Hoist destination-like keys using token-based matching; supports camelCase and avoids substring false positives.
  - Give each value its own budget with a minimum floor; destinations get the full per-value limit.
  - Run secret redaction before reordering and clipping.
  - Prevent crashes from non-string argument keys by coercing keys to strings before inspection and rendering.
  - Apply changes to the shared summarizer so built-in and MCP rows behave consistently; add tests for "destination last among many args" and non-string keys.

<sup>Written for commit 8dabaf8a74b7ddb52455419f509318d8c6416dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

