### PR TITLE
fix: watchlists item-status writes leave the event loop, cancellation-coherent (task-1541)

### DIFF
--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -1300,6 +1300,7 @@ async def test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_ges
 
     from Tests.UI.test_destination_shells import DestinationHarness
     from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.full_app_destination_context import wait_for_selector
     from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
     from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import IngestRequested
 
@@ -1330,6 +1331,15 @@ async def test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_ges
             row["id"] for row in db.get_new_items(status="ingested", limit=10)
         }, "the precondition: the real Ingest gesture really did write `ingested`"
 
+        # Ingest's `refresh=True` tail sets `overview_data`
+        # (`reactive({}, recompose=True)`), which unmounts and remounts the
+        # whole screen; querying immediately after the DB write races that
+        # recompose. Wait for the pane to resettle before querying it -- the
+        # sibling test at :1631 does the same for the identical reason.
+        await wait_for_selector(
+            screen, pilot, "#watchlists-content-pane", timeout=4.0
+        )
+
         # The staleness this fix exists for -- assert it, do not assume it.
         content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
         assert str(content_pane.item.get("status")).lower() != "ingested", (
@@ -1338,6 +1348,9 @@ async def test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_ges
         )
 
         # 3. Press the real button.
+        await wait_for_selector(
+            screen, pilot, "#content-mark-unread-button", timeout=4.0
+        )
         screen.query_one("#content-mark-unread-button", Button).press()
         await pilot.pause(0.8)
 

--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -1498,6 +1498,77 @@ async def test_the_queue_write_runs_off_the_event_loop_thread():
 
 
 @pytest.mark.asyncio
+async def test_the_item_status_write_runs_off_the_event_loop_thread():
+    """TASK-1541: pin the load-bearing part of moving `_update_item_status`'s
+    write off the UI thread.
+
+    Same shape as `test_the_queue_write_runs_off_the_event_loop_thread`
+    directly above: `run_worker` alone only *schedules* a coroutine back onto
+    the SAME event loop, and `WatchlistsBackendController._maybe_await` only
+    awaits an argument that is already awaitable -- it never puts a plain
+    synchronous call on a thread. `_update_item_status_off_loop` is the
+    `asyncio.to_thread` boundary that actually gets `SubscriptionsDB.
+    mark_item_status` off it. A mutation that drops that boundary and awaits
+    the controller directly on the loop passes every other item-action test
+    unchanged (the end state -- status written, cell repainted -- is
+    identical either way); only watching WHICH thread runs the call can tell
+    the two apart.
+
+    Pressing the Inspector's `Ingest` button drives the SAME shared
+    `_update_item_status` every one of Ingest/Ignore/the unread toggle/
+    mark-read-on-open funnels through, so exercising it here pins the fix for
+    all four.
+    """
+    app = _build_test_app()
+    db, _source_id, item_id = _seed_new_item(app, content_hash="status-thread-ident")
+
+    loop_thread_id = threading.get_ident()
+    write_thread_ids: list[int] = []
+    real_write = db.mark_item_status
+
+    def _spy(item_id_arg, status_arg):
+        write_thread_ids.append(threading.get_ident())
+        return real_write(item_id_arg, status_arg)
+
+    db.mark_item_status = _spy
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        pane, table = await _open_items_with_seeded_item(pilot, screen, app, db)
+        row_key = str(pane.items[0]["id"])
+
+        # `LocalWatchlistsService._db()` builds a brand-new `SubscriptionsDB`
+        # on every call (`app.py`'s `_wire_watchlists_and_notifications_
+        # services`), so the instance-level spy above -- on THIS `db` object
+        # -- is invisible to the real write path unless `db_factory` is
+        # repointed at this exact object. Same reasoning as
+        # `_open_items_with_seeded_item`'s `watchlist_bundle_service._db`
+        # reassignment just above, done here only after the initial mount's
+        # background loads have settled, for the identical race reason.
+        app.local_watchlists_service.db_factory = lambda: db
+
+        pane.select_item_by_id(row_key)
+        for _ in range(20):
+            await pilot.pause()
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+        button = inspector.query_one("#inspector-ingest-button", Button)
+        button.press()
+        for _ in range(40):
+            await pilot.pause()
+            if write_thread_ids:
+                break
+
+        assert write_thread_ids, "the write must have run at all"
+        assert write_thread_ids[0] != loop_thread_id, (
+            "SubscriptionsDB.mark_item_status must run off the event-loop "
+            "thread (asyncio.to_thread), not synchronously inside the "
+            "worker on the same thread that runs the event loop"
+        )
+
+
+@pytest.mark.asyncio
 async def test_pressing_queue_for_briefing_again_unqueues_and_relabels():
     """Step 1's other half: toggling back clears the flag, the indicator,
     and restores the button's original label -- not a one-way ratchet."""

--- a/Tests/UI/test_watchlists_item_actions.py
+++ b/Tests/UI/test_watchlists_item_actions.py
@@ -189,3 +189,56 @@ def test_item_is_typed_from_its_kind_not_its_shape():
 # covered by `test_opening_an_item_marks_it_read` in
 # `Tests/UI/test_watchlists_read_status.py`, exercising the path that
 # actually writes that status today.
+
+
+@pytest.mark.asyncio
+async def test_ingest_and_ignore_never_dispatch_a_write_for_an_id_less_entity():
+    """Fix wave, F3 (Minor).
+
+    `handle_ingest_requested`/`handle_ignore_requested` derive their per-item
+    worker group as `f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}{item_id}"`
+    from `entity.get("id")`. An entity with no "id" at all would derive the
+    literal group `"...:None"`, shared by every OTHER id-less dispatch --
+    collapsing exactly the per-item isolation TASK-1541 introduced this group
+    for. Believed unreachable through the real item pipeline:
+    `normalize_watchlist_item` (see `REAL_ITEM` above) unconditionally sets
+    "id" via `build_watchlist_item_id(source, "watchlist_item", row["id"])`,
+    backed by the `subscription_items` table's own `INTEGER PRIMARY KEY`
+    column, which SQLite never lets be NULL. So this drives the handlers
+    directly with a synthetic id-less entity -- pinning the guard itself
+    rather than trying to construct an unreachable real one.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
+        IngestRequested,
+        IgnoreRequested,
+    )
+
+    app = _build_test_app()
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+
+        no_id_entity = {"entity_kind": "watchlist_item", "item_id": 999, "status": "new"}
+        assert "id" not in no_id_entity, "the fixture must actually lack the key under test"
+
+        calls: list[tuple[object, str]] = []
+        real_update_item_status = screen._update_item_status
+
+        async def _spy_update_item_status(item_id, status, **kwargs):
+            calls.append((item_id, status))
+            return await real_update_item_status(item_id, status, **kwargs)
+
+        screen._update_item_status = _spy_update_item_status
+
+        screen.post_message(IngestRequested(no_id_entity))
+        screen.post_message(IgnoreRequested(no_id_entity))
+        for _ in range(20):
+            await pilot.pause()
+
+        assert calls == [], (
+            "an id-less entity must never reach _update_item_status at all -- "
+            "the None guard must refuse the dispatch before the worker group "
+            "is even derived"
+        )

--- a/Tests/UI/test_watchlists_item_actions.py
+++ b/Tests/UI/test_watchlists_item_actions.py
@@ -193,14 +193,16 @@ def test_item_is_typed_from_its_kind_not_its_shape():
 
 @pytest.mark.asyncio
 async def test_ingest_and_ignore_never_dispatch_a_write_for_an_id_less_entity():
-    """Fix wave, F3 (Minor).
+    """Fix wave, F3 (Minor); guard still applies unchanged after task-1541's
+    later Qodo redesign (desired-status coalescing).
 
-    `handle_ingest_requested`/`handle_ignore_requested` derive their per-item
-    worker group as `f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}{item_id}"`
-    from `entity.get("id")`. An entity with no "id" at all would derive the
+    `handle_ingest_requested`/`handle_ignore_requested` dispatch through
+    `_dispatch_item_status`, which derives the per-item drainer's worker
+    group as `f"{_ITEM_STATUS_DRAIN_GROUP_PREFIX}{item_id}"` from
+    `entity.get("id")`. An entity with no "id" at all would derive the
     literal group `"...:None"`, shared by every OTHER id-less dispatch --
-    collapsing exactly the per-item isolation TASK-1541 introduced this group
-    for. Believed unreachable through the real item pipeline:
+    collapsing exactly the per-item isolation this group exists for.
+    Believed unreachable through the real item pipeline:
     `normalize_watchlist_item` (see `REAL_ITEM` above) unconditionally sets
     "id" via `build_watchlist_item_id(source, "watchlist_item", row["id"])`,
     backed by the `subscription_items` table's own `INTEGER PRIMARY KEY`

--- a/Tests/UI/test_watchlists_read_status.py
+++ b/Tests/UI/test_watchlists_read_status.py
@@ -349,46 +349,53 @@ async def test_selecting_an_item_does_not_break_keyboard_navigation():
 
 @pytest.mark.asyncio
 async def test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent():
-    """Fix wave, F2a (whole-branch review, Important).
+    """TASK-1541, Qodo redesign -- desired-status coalescing, not cancellation.
 
-    `_ITEM_STATUS_WORKER_GROUP` deliberately lets a repeat mark-read-on-open
-    supersede its own in-flight sibling, so a fast `j`/`k` run does not queue
-    one write per keystroke. Once TASK-1541 moved the write onto a genuine
-    `asyncio.to_thread` suspension point, that same supersede became able to
-    actually deliver `CancelledError` to a DIFFERENT item's write in flight
-    -- but the OS thread underneath `asyncio.to_thread` is not itself
-    cancellable, so item A's write still lands in the database regardless.
+    An earlier fix wave gave the read/unread pair a cross-item
+    `exclusive=True` "supersede" worker group so a fast `j`/`k` run would not
+    queue one write per keystroke, and patched a `CancelledError` handler to
+    keep the cache coherent when that supersede cancelled an in-flight
+    write. A later whole-branch re-review found that model unsound two
+    independent ways once the write got a genuine `asyncio.to_thread`
+    suspension point: (1) the superseded write's OS thread is not itself
+    cancellable and keeps running, so it can commit AFTER its replacement --
+    rapid opposing actions on ONE item could leave the DATABASE on the FIRST
+    action while the UI showed the second; (2) `asyncio.to_thread` CAN be
+    cancelled before the executor picks the work up at all, so the old
+    handler's "cancelled implies durable" assumption could patch the cache
+    to a status the database never reached.
 
-    Reproduces that directly: item A's write is slowed (monkeypatched
-    `WatchlistsBackendController.update_item_status`, mirroring how the
-    reviewer's scaffold widened a contended SQLite lock), A is opened
-    (dispatching its mark-read-on-open worker), and -- before that slow
-    write can possibly finish -- B is opened too, in the SAME worker group,
-    simulating the fast `j`/`k` cross-item supersede. A's write is left to
-    land, then the cached dict for A must read "reviewed", not the stale
-    "new" that would leak through if `_update_item_status`'s continuation
-    only patched the cache on the (never-reached, here) non-cancelled path.
+    Desired-status coalescing (`_dispatch_item_status`/`_drain_item_status`)
+    replaces cancellation entirely: nothing here is ever cancelled. A second
+    dispatch for an item that already has one queued just overwrites the
+    desired dict entry, and the per-item drainer always `await`s a write to
+    genuine completion before looking at that entry again -- so the database
+    (and, once a `refresh=True` write reloads it, the screen's own cache)
+    always settles on whichever action was dispatched LAST, deterministically.
 
-    Mutation: removing the `except asyncio.CancelledError` patch block in
-    `_update_item_status` reds this on the final assertion -- the database
-    reaches "reviewed" but the cached dict stays stranded at "new".
+    Reproduces exactly that: Ingest, then -- before the (slowed) write can
+    possibly land -- Ignore, both against the SAME item, mirroring the
+    Inspector's own `IngestRequested`/`IgnoreRequested` gestures. The
+    underlying write is slowed and counted via a spy on
+    `WatchlistsBackendController.update_item_status`, so the coalescing bound
+    (at most one queued write plus at most one in flight, however many
+    actions were dispatched) is directly observable, not just inferred from
+    the end state.
+
+    Mutation: removing the "loop again if a newer desired entry appeared"
+    re-check in `_drain_item_status` (i.e. exiting after the first write
+    instead of re-popping the dict) reds the final DB-status assertion --
+    the queued Ignore would simply never be drained, and the database would
+    incorrectly settle on "ingested".
     """
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
+        IngestRequested,
+        IgnoreRequested,
+    )
+
     app = _build_test_app()
     db = app.local_watchlists_service._db()
-    source_id, item_a_id = _seed_one_new_item(db, content_hash="hash-cancel-coherence-a")
-    with db.transaction() as conn:
-        item_b_id = persist_subscription_item(
-            conn,
-            source_id,
-            {
-                "url": "https://summitroute.com/blog/2024/cancel-coherence-b/",
-                "title": "Item B",
-                "content_hash": "hash-cancel-coherence-b",
-                "status": "new",
-            },
-            run_id=None,
-            now="2026-07-28T09:00:01+00:00",
-        )
+    _source_id, item_id = _seed_one_new_item(db, content_hash="hash-opposing-actions")
 
     host = DestinationHarness(app, "watchlists_collections")
     async with host.run_test(size=(180, 50)) as pilot:
@@ -400,77 +407,95 @@ async def test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent():
         pane = screen.query_one("#watchlists-items-pane", ItemsPane)
         for _ in range(40):
             await pilot.pause()
-            if len(pane.items) >= 2:
+            if pane.items:
                 break
-        assert len(pane.items) == 2, "both seeded items must reach the Items pane"
+        assert pane.items, "the seeded item must reach the Items pane"
+        entity = dict(pane.items[0])
+        assert entity["item_id"] == item_id
 
-        item_a = next(item for item in pane.items if item["item_id"] == item_a_id)
-        item_b = next(item for item in pane.items if item["item_id"] == item_b_id)
-
+        write_calls: list[str] = []
         real_update_item_status = screen._controller.update_item_status
 
-        async def _slow_for_a(*, runtime_backend=None, item_id, status):
-            if item_id == item_a["id"]:
-                await asyncio.sleep(0.4)
+        async def _slow_and_counted(*, runtime_backend=None, item_id, status):
+            write_calls.append(status)
+            await asyncio.sleep(0.2)
             return await real_update_item_status(
                 runtime_backend=runtime_backend, item_id=item_id, status=status
             )
 
-        screen._controller.update_item_status = _slow_for_a
+        screen._controller.update_item_status = _slow_and_counted
 
-        # Dispatch A's mark-read-on-open. Its write is now slowed to 0.4s, so
-        # it is still suspended on the genuine `await asyncio.to_thread(...)`
-        # boundary well past the couple of pauses below.
-        screen._mark_item_read_on_open(item_a)
+        # Rapid opposing actions on the SAME item: Ingest, then -- while that
+        # slowed write is still draining -- Ignore. Exactly the Inspector's
+        # own gestures, fired back to back.
+        screen.post_message(IngestRequested(entity))
         await pilot.pause(0.05)
         await pilot.pause(0.05)
+        screen.post_message(IgnoreRequested(entity))
 
-        # Simulate the fast `j`/`k` cross-item supersede: B's dispatch lands
-        # in the SAME `_ITEM_STATUS_WORKER_GROUP`, `exclusive=True`, so it
-        # cancels A's still-suspended worker.
-        screen._mark_item_read_on_open(item_b)
-
-        # Let A's slowed write actually land -- the OS thread cannot be
-        # cancelled, so this must eventually succeed regardless of the
-        # supersede above.
-        for _ in range(60):
+        for _ in range(80):
             await pilot.pause(0.05)
-            if db.get_item_status(item_a_id) == "reviewed":
+            if db.get_item_status(item_id) == "ignored":
                 break
-        assert db.get_item_status(item_a_id) == "reviewed", (
-            "the OS thread under asyncio.to_thread is not cancellable -- A's "
-            "write must complete in the database even though its coroutine "
-            "was cancelled by B's supersede"
+        assert db.get_item_status(item_id) == "ignored", (
+            "the LAST dispatched action (Ignore) must be what the database "
+            "settles on, deterministically -- not whichever write's OS "
+            "thread happened to finish last"
+        )
+        assert len(write_calls) <= 2, (
+            "coalescing must bound this item to at most one queued write "
+            "plus at most one in-flight write, however many actions were "
+            f"dispatched -- observed writes: {write_calls!r}"
         )
 
+        # And the screen's own cache, reloaded by Ignore's `refresh=True`
+        # tail, must end up coherent with that same final database state.
+        # `_load_items()` always queries `status=None`, which
+        # `LocalWatchlistsService.list_items` collapses to `status="new"` --
+        # so an item that is no longer "new" (whether "ingested" or
+        # "ignored") is simply ABSENT from `_loaded_items`, not present with
+        # some other status string. Coherence here means the reload has
+        # genuinely happened and agrees the item is no longer new -- not
+        # that it is still sitting in the cache believing itself "new" (the
+        # pre-write value) or "ingested" (the superseded write's value).
         for _ in range(40):
             await pilot.pause(0.05)
-            if item_a.get("status") == "reviewed":
+            if not any(row.get("item_id") == item_id for row in screen._loaded_items):
                 break
-        assert item_a.get("status") == "reviewed", (
-            "the cached dict must be patched to match the database even "
-            "though A's coroutine was cancelled mid-flight -- otherwise it "
-            "is left reading a stale 'new' forever, diverged from a "
-            "database the app itself just wrote"
+        assert not any(row.get("item_id") == item_id for row in screen._loaded_items), (
+            "the reloaded Items cache must agree the item is no longer "
+            "'new' -- coherent with the database's final ('ignored') "
+            "status, not stuck on the superseded Ingest's write or the "
+            "original pre-write 'new'"
         )
 
 
 @pytest.mark.asyncio
 async def test_mark_read_on_open_does_not_overwrite_an_item_ingested_behind_the_cache():
-    """Fix wave, F2b (whole-branch review, Important) -- the other half of F2.
+    """TASK-1541, Qodo redesign -- the inside-drain gate re-check.
 
-    `_mark_item_read_on_open` only ever declines its write when the CACHED
-    dict already disagrees with "new" -- and nothing patches that cache when
-    an item is ingested through the Inspector's `Ingest` button (no
-    `patch_item=` there, by design -- see `handle_ingest_requested`). So a
-    cache that goes stale for ANY reason (this test moves the database
-    directly, "behind the cache's back", rather than reproducing the F2a
-    cancellation race) must not let a subsequent open of that same item
-    overwrite the real, backend-held status.
+    `_mark_item_read_on_open`'s cheap pre-filter only ever declines against
+    the CACHED dict ("new") -- and nothing patches that cache when an item
+    is ingested through the Inspector's `Ingest` button (no `patch_item=`
+    there, by design -- see `handle_ingest_requested`). So the real guard
+    against overwriting an ingest has to be the backend re-check
+    `_item_status_write_allowed` performs immediately before the write,
+    INSIDE `_drain_item_status`'s loop -- not the pre-filter, and not a check
+    done once at dispatch time.
 
-    Mutation: removing the `_blocking_status_for` backend gate in
-    `_confirm_new_then_mark_item_read_on_open` (falling back to trusting the
-    cached "new" alone, as `_mark_item_read_on_open` did before this fix)
+    Reproduces the window directly: `_mark_item_read_on_open` is called
+    first, which queues the desired "reviewed" entry and schedules (but does
+    not run a single line of) the drainer worker -- it is a plain
+    synchronous call, and `run_worker` only SCHEDULES a coroutine. The item
+    is THEN ingested directly against the database, still with no `await` in
+    between -- i.e. the item gets ingested WHILE the mark-read desired entry
+    sits queued, waiting for its drainer to actually start. Only once the
+    test yields to the event loop does the drainer run, re-ask the backend,
+    and see "ingested" -- the gate must refuse the write then, not the
+    cached "new" the pre-filter already let through.
+
+    Mutation: removing the inside-drain gate re-check (the `intent.gate`
+    branch in `_drain_item_status`, or `_item_status_write_allowed` itself)
     reds this on the final assertion -- the ingest gets overwritten with
     "reviewed".
     """
@@ -496,24 +521,83 @@ async def test_mark_read_on_open_does_not_overwrite_an_item_ingested_behind_the_
         assert item["item_id"] == item_id
         assert item.get("status") == "new", "precondition: the cached dict starts at 'new'"
 
-        # Ingest it directly through the database -- "behind the cache's
-        # back" -- exactly what the real Ingest gesture also does, since
-        # `handle_ingest_requested` passes no `patch_item=`. The cached
-        # dict above is a separate object and is NOT touched by this.
+        # Dispatch mark-read-on-open first: queues the desired "reviewed"
+        # entry and schedules the per-item drainer without running any of it
+        # yet (no `await` has happened in this test).
+        screen._mark_item_read_on_open(item)
+
+        # Ingest it directly through the database -- still with no `await`
+        # in between -- "while the desired entry waits", exactly as the
+        # docstring above describes. The cached dict is a separate object
+        # and is NOT touched by this.
         db.mark_item_status(item_id, "ingested")
         assert item.get("status") == "new", (
             "the cached dict must still read stale 'new' -- otherwise this "
             "test is not exercising a stale cache at all"
         )
 
-        # Re-open the item: the cache still says "new", so without the
-        # backend gate this fires the write unconditionally.
-        screen._mark_item_read_on_open(item)
+        # Only now does control return to the event loop, letting the
+        # drainer actually run its gate re-check.
         for _ in range(40):
             await pilot.pause(0.05)
 
         assert db.get_item_status(item_id) == "ingested", (
-            "opening an item whose cache is stale must not overwrite a real "
-            "backend status the cache does not know about -- the ingest "
-            "must survive"
+            "the item was ingested while the mark-read desired entry sat "
+            "queued -- the inside-drain gate re-check must refuse the "
+            "'reviewed' write when it finally runs, not overwrite the ingest"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_item_status_write_toasts_an_error_and_leaves_the_cache_untouched():
+    """TASK-1541, Qodo redesign.
+
+    `_drain_item_status` calls `_update_item_status` for each popped
+    intent, and that method's `except Exception` branch is the only thing
+    standing between a genuine DB failure and a cache silently claiming a
+    status the write never reached. Pinned directly: a failed write (a
+    deliberate Ingest, so `notify_toast=True`) must surface an error toast
+    and must not move the item's status at all.
+    """
+    from unittest.mock import Mock
+
+    from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import IngestRequested
+
+    app = _build_test_app()
+    db = app.local_watchlists_service._db()
+    _source_id, item_id = _seed_one_new_item(db, content_hash="hash-failed-write")
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "items"
+        await pilot.pause(0.3)
+
+        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        for _ in range(40):
+            await pilot.pause()
+            if pane.items:
+                break
+        assert pane.items, "the seeded item must reach the Items pane"
+        entity = dict(pane.items[0])
+        assert entity["item_id"] == item_id
+
+        async def _raise(*, runtime_backend=None, item_id, status):
+            raise RuntimeError("simulated DB failure")
+
+        screen._controller.update_item_status = _raise
+        app.notify = Mock()
+
+        screen.post_message(IngestRequested(entity))
+        for _ in range(40):
+            await pilot.pause(0.05)
+
+        assert db.get_item_status(item_id) == "new", (
+            "a failed write must leave the item's status exactly as it was"
+        )
+        assert app.notify.called, (
+            "a failed write must surface an error toast, not fail silently"
+        )
+        _args, kwargs = app.notify.call_args
+        assert kwargs.get("severity") == "error"

--- a/Tests/UI/test_watchlists_read_status.py
+++ b/Tests/UI/test_watchlists_read_status.py
@@ -28,6 +28,8 @@ reloading and recomposing.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from textual.widgets import Button, DataTable
 
@@ -343,3 +345,175 @@ async def test_selecting_an_item_does_not_break_keyboard_navigation():
         )
         assert pane.selected_item is not None
         assert pane.selected_item.get("title") == "Item 2"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent():
+    """Fix wave, F2a (whole-branch review, Important).
+
+    `_ITEM_STATUS_WORKER_GROUP` deliberately lets a repeat mark-read-on-open
+    supersede its own in-flight sibling, so a fast `j`/`k` run does not queue
+    one write per keystroke. Once TASK-1541 moved the write onto a genuine
+    `asyncio.to_thread` suspension point, that same supersede became able to
+    actually deliver `CancelledError` to a DIFFERENT item's write in flight
+    -- but the OS thread underneath `asyncio.to_thread` is not itself
+    cancellable, so item A's write still lands in the database regardless.
+
+    Reproduces that directly: item A's write is slowed (monkeypatched
+    `WatchlistsBackendController.update_item_status`, mirroring how the
+    reviewer's scaffold widened a contended SQLite lock), A is opened
+    (dispatching its mark-read-on-open worker), and -- before that slow
+    write can possibly finish -- B is opened too, in the SAME worker group,
+    simulating the fast `j`/`k` cross-item supersede. A's write is left to
+    land, then the cached dict for A must read "reviewed", not the stale
+    "new" that would leak through if `_update_item_status`'s continuation
+    only patched the cache on the (never-reached, here) non-cancelled path.
+
+    Mutation: removing the `except asyncio.CancelledError` patch block in
+    `_update_item_status` reds this on the final assertion -- the database
+    reaches "reviewed" but the cached dict stays stranded at "new".
+    """
+    app = _build_test_app()
+    db = app.local_watchlists_service._db()
+    source_id, item_a_id = _seed_one_new_item(db, content_hash="hash-cancel-coherence-a")
+    with db.transaction() as conn:
+        item_b_id = persist_subscription_item(
+            conn,
+            source_id,
+            {
+                "url": "https://summitroute.com/blog/2024/cancel-coherence-b/",
+                "title": "Item B",
+                "content_hash": "hash-cancel-coherence-b",
+                "status": "new",
+            },
+            run_id=None,
+            now="2026-07-28T09:00:01+00:00",
+        )
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "items"
+        await pilot.pause(0.3)
+
+        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        for _ in range(40):
+            await pilot.pause()
+            if len(pane.items) >= 2:
+                break
+        assert len(pane.items) == 2, "both seeded items must reach the Items pane"
+
+        item_a = next(item for item in pane.items if item["item_id"] == item_a_id)
+        item_b = next(item for item in pane.items if item["item_id"] == item_b_id)
+
+        real_update_item_status = screen._controller.update_item_status
+
+        async def _slow_for_a(*, runtime_backend=None, item_id, status):
+            if item_id == item_a["id"]:
+                await asyncio.sleep(0.4)
+            return await real_update_item_status(
+                runtime_backend=runtime_backend, item_id=item_id, status=status
+            )
+
+        screen._controller.update_item_status = _slow_for_a
+
+        # Dispatch A's mark-read-on-open. Its write is now slowed to 0.4s, so
+        # it is still suspended on the genuine `await asyncio.to_thread(...)`
+        # boundary well past the couple of pauses below.
+        screen._mark_item_read_on_open(item_a)
+        await pilot.pause(0.05)
+        await pilot.pause(0.05)
+
+        # Simulate the fast `j`/`k` cross-item supersede: B's dispatch lands
+        # in the SAME `_ITEM_STATUS_WORKER_GROUP`, `exclusive=True`, so it
+        # cancels A's still-suspended worker.
+        screen._mark_item_read_on_open(item_b)
+
+        # Let A's slowed write actually land -- the OS thread cannot be
+        # cancelled, so this must eventually succeed regardless of the
+        # supersede above.
+        for _ in range(60):
+            await pilot.pause(0.05)
+            if db.get_item_status(item_a_id) == "reviewed":
+                break
+        assert db.get_item_status(item_a_id) == "reviewed", (
+            "the OS thread under asyncio.to_thread is not cancellable -- A's "
+            "write must complete in the database even though its coroutine "
+            "was cancelled by B's supersede"
+        )
+
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if item_a.get("status") == "reviewed":
+                break
+        assert item_a.get("status") == "reviewed", (
+            "the cached dict must be patched to match the database even "
+            "though A's coroutine was cancelled mid-flight -- otherwise it "
+            "is left reading a stale 'new' forever, diverged from a "
+            "database the app itself just wrote"
+        )
+
+
+@pytest.mark.asyncio
+async def test_mark_read_on_open_does_not_overwrite_an_item_ingested_behind_the_cache():
+    """Fix wave, F2b (whole-branch review, Important) -- the other half of F2.
+
+    `_mark_item_read_on_open` only ever declines its write when the CACHED
+    dict already disagrees with "new" -- and nothing patches that cache when
+    an item is ingested through the Inspector's `Ingest` button (no
+    `patch_item=` there, by design -- see `handle_ingest_requested`). So a
+    cache that goes stale for ANY reason (this test moves the database
+    directly, "behind the cache's back", rather than reproducing the F2a
+    cancellation race) must not let a subsequent open of that same item
+    overwrite the real, backend-held status.
+
+    Mutation: removing the `_blocking_status_for` backend gate in
+    `_confirm_new_then_mark_item_read_on_open` (falling back to trusting the
+    cached "new" alone, as `_mark_item_read_on_open` did before this fix)
+    reds this on the final assertion -- the ingest gets overwritten with
+    "reviewed".
+    """
+    app = _build_test_app()
+    db = app.local_watchlists_service._db()
+    _source_id, item_id = _seed_one_new_item(db, content_hash="hash-stale-cache-overwrite")
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "items"
+        await pilot.pause(0.3)
+
+        pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        for _ in range(40):
+            await pilot.pause()
+            if pane.items:
+                break
+        assert pane.items, "the seeded item must reach the Items pane"
+
+        item = pane.items[0]
+        assert item["item_id"] == item_id
+        assert item.get("status") == "new", "precondition: the cached dict starts at 'new'"
+
+        # Ingest it directly through the database -- "behind the cache's
+        # back" -- exactly what the real Ingest gesture also does, since
+        # `handle_ingest_requested` passes no `patch_item=`. The cached
+        # dict above is a separate object and is NOT touched by this.
+        db.mark_item_status(item_id, "ingested")
+        assert item.get("status") == "new", (
+            "the cached dict must still read stale 'new' -- otherwise this "
+            "test is not exercising a stale cache at all"
+        )
+
+        # Re-open the item: the cache still says "new", so without the
+        # backend gate this fires the write unconditionally.
+        screen._mark_item_read_on_open(item)
+        for _ in range(40):
+            await pilot.pause(0.05)
+
+        assert db.get_item_status(item_id) == "ingested", (
+            "opening an item whose cache is stale must not overwrite a real "
+            "backend status the cache does not know about -- the ingest "
+            "must survive"
+        )

--- a/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
+++ b/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
@@ -36,9 +36,9 @@ screen-wide version of the same bug across every other item-status write path.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `_update_item_status`'s DB write runs off the event loop thread, verified by a thread-identity test following the shape of `test_the_queue_write_runs_off_the_event_loop_thread` (`Tests/UI/test_watchlists_inspector.py`)
-- [ ] #2 The fix does not add `exclusive=True` cancellation that would abort one in-flight item-status write because another item's write started
-- [ ] #3 Existing Ingest/Ignore/unread-toggle/mark-read-on-open item-action tests still pass unchanged
+- [x] #1 `_update_item_status`'s DB write runs off the event loop thread, verified by a thread-identity test following the shape of `test_the_queue_write_runs_off_the_event_loop_thread` (`Tests/UI/test_watchlists_inspector.py`)
+- [x] #2 The fix does not add `exclusive=True` cancellation that would abort one in-flight item-status write because another item's write started
+- [ ] #3 Existing Ingest/Ignore/unread-toggle/mark-read-on-open item-action tests still pass unchanged -- see Implementation Notes: one pre-existing test is now measurably flakier, root-caused to an adjacent, out-of-scope hazard, left unchecked pending a decision on the follow-up
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,3 +48,75 @@ screen-wide version of the same bug across every other item-status write path.
 2. Thread-identity test following `test_the_queue_write_runs_off_the_event_loop_thread`; run the existing Ingest/Ignore/unread/mark-read tests unchanged (AC #3).
 3. Mutation: revert the to_thread wrap → thread-identity test REDs.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Added `WatchlistsCollectionsScreen._update_item_status_off_loop` (`watchlists_collections_screen.py:6663`):
+`_update_item_status` now awaits this instead of `self._controller.update_item_status(...)` directly.
+The whole chain underneath (`controller.update_item_status` -> `WatchlistScopeService.update_item` ->
+`LocalWatchlistsService.update_item` -> `SubscriptionsDB.mark_item_status`) is `async def` all the way
+down with no genuine `await` anywhere in it, so a plain `await` -- even from inside a `run_worker`
+coroutine -- ran the transactional `UPDATE` synchronously on the event-loop thread. The new helper
+captures `runtime_backend` on the calling (loop) thread, then drives the controller coroutine to
+completion inside `asyncio.to_thread`, using a throwaway `asyncio.run()` in the worker thread (the
+thread has no event loop of its own). This mirrors the ALREADY-established codebase idiom for this
+exact shape -- `library_screen.py`'s `_run_library_service_call(..., isolate_in_worker=True)` -- rather
+than inventing a new one, and keeps going through the controller/scope-service/local-service layers
+(so status validation, id normalization and policy enforcement all still run) instead of reaching past
+them to call `SubscriptionsDB.mark_item_status` directly the way `_toggle_briefing_queue` does for its
+simpler, controller-free write.
+
+**`exclusive=` decision (AC #2).** Audited all four `run_worker` dispatch sites for `_update_item_status`:
+- **Ingest/Ignore** (`handle_ingest_requested`/`handle_ignore_requested`) previously had `exclusive=True`
+  with no `group=`, landing in the plain `"default"` group shared by ~25 other call sites (`_check_now_
+  source`, `_load_items`, etc.). Before this fix that was inert for cancellation purposes -- the write
+  had no real suspension point, so by the time any other worker could start, this one had already run to
+  completion (asyncio only delivers a cancellation at a genuine `await` boundary). Once the write gets a
+  real `asyncio.to_thread` boundary, that same `exclusive=True` would newly be able to cancel an
+  in-flight write for a DIFFERENT item (or any unrelated default-group action) mid-flight -- exactly what
+  AC #2 forbids, and exactly the "zombie work" `_toggle_briefing_queue`'s own docstring warns about
+  (`asyncio.to_thread`'s underlying thread keeps running after the awaiting Task is cancelled). Fixed by
+  giving Ingest/Ignore a **per-item** group (`_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX + item_id`),
+  keeping `exclusive=True`: a second Ingest/Ignore on the SAME item still supersedes its own earlier
+  write (deterministic "last press wins", same trade-off `_toggle_briefing_queue` already accepts for the
+  briefing-queue flag), but two DIFFERENT items' writes -- or an unrelated default-group action -- can
+  never cancel each other. This matters concretely because `SubscriptionsDB` sets no `busy_timeout`
+  pragma, so a contended write is exactly the scenario (from this task's own description) where a write
+  for item A could sit in flight for seconds while the user moves on and acts on item B.
+- **Unread toggle / mark-read-on-open** (`_mark_item_unread` / `_mark_item_read_on_open`) already share a
+  DEDICATED group (`_ITEM_STATUS_WORKER_GROUP`) with `exclusive=True`, added by Task 5 specifically so a
+  fast `j`/`k` run supersedes its own earlier (possibly different-item) write rather than piling one up
+  per keystroke, while never touching unrelated default-group work. This is pre-existing, documented,
+  intentional cross-item-supersede design, not something this task adds -- left completely unchanged.
+
+**AC #3 -- one existing test is now measurably flakier; documented rather than silently patched around.**
+Full targeted suite (`test_watchlists_inspector.py`, `test_watchlists_item_actions.py`,
+`test_watchlists_read_status.py`, `test_watchlists_content_pane.py`, `test_watchlists_check_now_
+failure.py`, `Tests/Watchlists/` -- 470 tests) passes green. Under repeated isolated runs, though,
+`test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_gesture`
+(`Tests/UI/test_watchlists_content_pane.py`) went from ~8% flaky on unmodified `dev` to ~35-40% flaky
+with this fix applied (interleaved A/B sampling, n=24 each). Root-caused with temporary instrumentation
+(not committed): the failure is a `NoMatches` on a widget the test queries immediately after its own
+DB-polling loop observes the new status -- i.e. `Ingest`'s `refresh=True` path calls
+`_refresh_overview_data()`, which sets `overview_data` (`reactive(..., recompose=True)`), forcing a full
+screen recompose. Before this fix, the write and the recompose dispatch were atomically coupled (no real
+suspension point), so the test's DB-polling loop could never observe the new status before the recompose
+had *also* been dispatched. After this fix, the write's visibility (a commit inside the worker thread)
+and the screen's own continuation resuming on the loop are genuinely decoupled by the `asyncio.to_thread`
+handoff, so the test can race ahead and query a widget while the recompose is transiently mid-flight.
+Tried a lighter-weight variant (driving the coroutine manually via `.send(None)` instead of
+`asyncio.run()`, to test whether call overhead was the driver) -- it did not help (measured *worse*,
+~60% in n=15), which rules out "make the thread hop cheaper" as a fix and confirms this is inherent to
+having a genuine off-thread yield at all, not to this implementation's specific shape. `_toggle_briefing_
+queue` and mark-read-on-open both avoid this because their post-write UI update is a targeted patch
+(`_patch_item_queued_flag` / `patch_item=`), never a full recompose; Ingest/Ignore/unread-toggle still
+use `_update_item_status`'s `refresh=True` default, which does recompose. Fixing that (giving Ingest/
+Ignore/unread-toggle the same non-recomposing post-write update already proven for the other two paths)
+would close this properly, but is a materially larger, user-visible behavior change outside this task's
+ACs, so it is left unimplemented and unrecommended-into-code here -- AC #3's checkbox is left unchecked
+and status stays In Progress pending a decision on that follow-up, rather than silently declared done.
+
+**Files changed:** `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` (new
+`_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX` constant, `_update_item_status_off_loop`, Ingest/Ignore
+dispatch groups); `Tests/UI/test_watchlists_inspector.py` (new
+`test_the_item_status_write_runs_off_the_event_loop_thread`, mirroring the queue-write precedent).

--- a/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
+++ b/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
@@ -215,3 +215,93 @@ of Textual widget-mount race the verdict separately noted as a "bonus datum" tea
 elsewhere in this review. Not investigated further as out of scope for task-1541.
 `test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_gesture` (F1's target): 20/20
 sequential (`-p no:randomly`), confirming the flake is closed.
+
+---
+
+## Qodo redesign (desired-status coalescing replaces cancellation)
+
+A later Qodo review of the fix wave found the cross-item/per-item `exclusive=True` "supersede"
+worker-group model itself unsound for a durable write, two independent ways, once the write got a
+genuine `asyncio.to_thread` suspension point:
+
+1. The superseded write's OS thread is NOT itself cancellable once started and keeps running, so it
+   can commit AFTER its replacement's write. Rapid opposing actions on one item (e.g. Ingest then
+   Ignore) could leave the DATABASE on the FIRST action while the UI/cache showed the second.
+2. The opposite failure: `asyncio.to_thread` CAN be cancelled before the executor picks the work up
+   at all (reachable under a saturated default executor, no exotic timing required), in which case
+   the write never runs at all. The F2a `except asyncio.CancelledError` handler assumed "cancelled
+   implies the write is durable" and patched the cache to the target status regardless -- false in
+   this case, so the cache could claim a status the database never reached.
+
+Both holes share one root cause: supersede-by-cancellation is the wrong mechanism for a write that
+must be durable. This redesign replaces it with desired-status coalescing and deletes the
+cancellation machinery entirely, rather than patching either hole:
+
+- `_ItemStatusIntent` (frozen dataclass) captures everything a write's completion needs (`status`,
+  `notify_toast`, `refresh`, `patch_item`, `gate`) -- exactly what the four dispatch paths (Ingest,
+  Ignore, the unread toggle, mark-read-on-open) used to pass directly to `_update_item_status`.
+- `_dispatch_item_status` stores at most one such intent per item id in the screen-level
+  `_item_status_desired` dict -- a second dispatch for the same item simply OVERWRITES the entry --
+  and starts a per-item drainer worker (`wl-item-status-drain:{item_id}`, `exclusive=False`) only if
+  one is not already running for that item (`_item_status_draining`). A drainer already running is
+  NEVER cancelled and NEVER told to stop; it just picks the new entry up itself.
+- `_drain_item_status` is the one worker body that ever writes an item's status now: it pops the
+  item's desired entry, re-checks the backend terminal-status gate right before writing when
+  `intent.gate` is set (`_item_status_write_allowed`, folding what used to be duplicated between
+  `_mark_item_unread` and `_confirm_new_then_mark_item_read_on_open`), `await`s the write to GENUINE
+  completion (never a cancellation, since nothing here is ever cancelled), then loops back to check
+  the dict again before exiting. This gives a real, database-level "last dispatched action wins"
+  guarantee per item, and bounds each item to at most one queued write plus at most one in-flight
+  write, matching the old design's queue-depth bound without its unsoundness.
+- `_update_item_status`'s `except asyncio.CancelledError` handler is deleted outright (not patched):
+  nothing that calls it is ever cancelled by this screen's own logic any more, so the premise for
+  that handler no longer exists. `_confirm_new_then_mark_item_read_on_open` and `_mark_item_unread`
+  are both deleted too, folded into `_item_status_write_allowed` + `_drain_item_status`.
+  `_ITEM_STATUS_WORKER_GROUP` and `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX` are removed, replaced by
+  one `_ITEM_STATUS_DRAIN_GROUP_PREFIX`.
+- `_update_item_status_off_loop`'s F4 docstring caveat ("last press wins is not guaranteed at the
+  database") is corrected rather than carried forward: because the drainer now always awaits a write
+  to completion before popping this SAME item's next entry, at most one such OS thread is ever alive
+  per item at a time, so the old zombie-race between two unordered writes to the same row cannot
+  happen any more.
+
+**Tests (`Tests/UI/test_watchlists_read_status.py`).** The F2 pair is reworked to pin behavior under
+the new mechanism (same test names, new scenarios/docstrings):
+- `test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent` now drives rapid opposing
+  Ingest/Ignore actions on ONE item (matching the Inspector's real `IngestRequested`/
+  `IgnoreRequested` gestures) with the underlying write slowed and spy-counted. Asserts the database
+  settles on the LAST dispatched action deterministically, that coalescing bounds the actual writes
+  to `<= 2` (spy-observed), and that the screen's reloaded `_loaded_items` cache ends up coherent
+  with that final state (absent, since `list_items(status=None)` collapses to `"new"` and the item is
+  no longer new).
+- `test_mark_read_on_open_does_not_overwrite_an_item_ingested_behind_the_cache` now dispatches
+  mark-read-on-open FIRST (queuing the desired entry and scheduling, but not yet running, the
+  drainer) and only THEN ingests the item directly against the database, still with no `await` in
+  between -- i.e. the item is ingested WHILE the mark-read desired entry sits queued. This pins the
+  INSIDE-drain gate re-check specifically, not just "gate exists somewhere."
+- New: `test_a_failed_item_status_write_toasts_an_error_and_leaves_the_cache_untouched` -- a failed
+  write (stubbed `WatchlistsBackendController.update_item_status` raising) surfaces an error toast
+  and leaves the item's status untouched.
+
+Mutation-verified (Edit/Edit-revert, clean `git status --short` between each): removing the
+"loop again if a newer desired entry appeared" re-check in `_drain_item_status` reds the rapid-
+opposing-actions test (the queued Ignore is never drained, database incorrectly settles on
+"ingested"); removing the inside-drain gate re-check (`intent.gate` branch) reds ONLY the
+mark-read-on-open-behind-the-cache test, confirmed by running the full file (6/7 pass, only that one
+fails) -- both restored and reverified green.
+
+`test_the_item_status_write_runs_off_the_event_loop_thread` (`Tests/UI/test_watchlists_inspector.py`)
+and `test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_gesture`
+(`Tests/UI/test_watchlists_content_pane.py`, F1's former flake target) both re-verified green --
+the latter 10/10 sequential (`-p no:randomly`).
+
+**Files changed (Qodo redesign):** `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+(`_ItemStatusIntent`, `_ITEM_STATUS_DRAIN_GROUP_PREFIX`, `_dispatch_item_status`,
+`_drain_item_status`, `_item_status_write_allowed`; rewrote `_mark_item_read_on_open`,
+`handle_unread_toggle_requested`, `handle_ingest_requested`, `handle_ignore_requested`,
+`_update_item_status`, `_update_item_status_off_loop`'s docstring; deleted
+`_confirm_new_then_mark_item_read_on_open`, `_mark_item_unread`,
+`_ITEM_STATUS_WORKER_GROUP`, `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX`);
+`Tests/UI/test_watchlists_read_status.py` (F2 pair reworked, one new test).
+`_toggle_briefing_queue` and every other screen write keep their own pre-existing groups untouched --
+this redesign is scoped strictly to the four item-status paths.

--- a/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
+++ b/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1541
 title: 'Watchlists screen: item-status writes never leave the event loop'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-30 15:53'
 labels:
@@ -40,3 +40,11 @@ screen-wide version of the same bug across every other item-status write path.
 - [ ] #2 The fix does not add `exclusive=True` cancellation that would abort one in-flight item-status write because another item's write started
 - [ ] #3 Existing Ingest/Ignore/unread-toggle/mark-read-on-open item-action tests still pass unchanged
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Mirror `_toggle_briefing_queue`'s (`c43f0f840`) `asyncio.to_thread` shape in `_update_item_status`: the controller call wrapped so the transactional write leaves the event loop; keep `run_worker` dispatch but audit its `exclusive=True` per AC #2 (per-item writes must not cancel each other).
+2. Thread-identity test following `test_the_queue_write_runs_off_the_event_loop_thread`; run the existing Ingest/Ignore/unread/mark-read tests unchanged (AC #3).
+3. Mutation: revert the to_thread wrap → thread-identity test REDs.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
+++ b/backlog/tasks/task-1541 - Watchlists-screen-item-status-writes-never-leave-the-event-loop.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1541
 title: 'Watchlists screen: item-status writes never leave the event loop'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 15:53'
 labels:
@@ -38,7 +38,7 @@ screen-wide version of the same bug across every other item-status write path.
 <!-- AC:BEGIN -->
 - [x] #1 `_update_item_status`'s DB write runs off the event loop thread, verified by a thread-identity test following the shape of `test_the_queue_write_runs_off_the_event_loop_thread` (`Tests/UI/test_watchlists_inspector.py`)
 - [x] #2 The fix does not add `exclusive=True` cancellation that would abort one in-flight item-status write because another item's write started
-- [ ] #3 Existing Ingest/Ignore/unread-toggle/mark-read-on-open item-action tests still pass unchanged -- see Implementation Notes: one pre-existing test is now measurably flakier, root-caused to an adjacent, out-of-scope hazard, left unchecked pending a decision on the follow-up
+- [x] #3 Existing Ingest/Ignore/unread-toggle/mark-read-on-open item-action tests still pass unchanged -- see Implementation Notes: closed by a test-side determinism fix (added waits, zero assertions weakened) rather than by touching the production recompose
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -120,3 +120,98 @@ and status stays In Progress pending a decision on that follow-up, rather than s
 `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX` constant, `_update_item_status_off_loop`, Ingest/Ignore
 dispatch groups); `Tests/UI/test_watchlists_inspector.py` (new
 `test_the_item_status_write_runs_off_the_event_loop_thread`, mirroring the queue-write precedent).
+
+---
+
+## Fix wave (whole-branch review, `.superpowers/sdd/briefings-residuals/task-1541-verdict.md`)
+
+A whole-branch review found the flake above was test-side (not inherent, contra the note above) and,
+separately, that this task's own change newly enabled a reachable data-loss path on the
+mark-read-on-open route. Both are fixed here; AC #3 is now genuinely satisfiable rather than
+worked around, and its checkbox above reflects that -- **no assertion in any existing test was
+weakened or removed**, only waits were added.
+
+**F1 -- the flake, closed test-side (AC #3).** The implementer's ~8%→~35-40% flakiness measurement
+was right about direction and wrong about "inherent to any off-thread yield": the repo's own sibling
+test 60 lines below the flaky one already drives the identical `IngestRequested` → `refresh=True`
+recompose and waits it out with `wait_for_selector`; the flaky test simply polled the DB and queried a
+widget with no intervening await. Fix:
+`test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_gesture`
+(`Tests/UI/test_watchlists_content_pane.py`) now imports and calls the same
+`wait_for_selector(screen, pilot, ..., timeout=4.0)` helper at the two race sites (after the Ingest
+precondition, before the Mark-unread button press) -- every existing assertion, including the
+load-bearing staleness check, is byte-identical. Measured 20/20 sequential (`-p no:randomly`) after
+the fix, versus the pre-fix flake.
+
+**F2 -- cross-item-supersede cancellation newly reaches a write with no backend guard (Important,
+data loss).** The per-item `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX` reasoning applied to Ingest/Ignore
+above is correct but incomplete: `_ITEM_STATUS_WORKER_GROUP` (the read/unread pair, including
+mark-read-on-open) is cross-item *by design*, and that design was safe only because the write it
+guarded was inert for cancellation before this task. Once the write got a genuine
+`asyncio.to_thread` suspension point, a fast `j`/`k` run's cross-item supersede became able to
+actually cancel item A's in-flight mark-read-on-open write while item B's fires -- and because
+`asyncio.to_thread`'s underlying OS thread is not itself cancellable, A's write still completes in
+the database while A's continuation (the `patch_item`/cache-repaint step) never runs, leaving the
+cached dict stale. If A is then Ingested (no `patch_item=` there either) and re-opened,
+`_mark_item_read_on_open` previously gated ONLY on that stale cached dict -- "new" -- and would
+write "reviewed" straight over the ingest. Fixed two ways, both required:
+- `_update_item_status` now catches `asyncio.CancelledError` around the write and applies the same
+  `patch_item`/repaint the normal continuation would have, synchronously, before re-raising --
+  because the write is durable regardless of the cancellation, the cache must not be allowed to
+  diverge from it.
+- `_mark_item_read_on_open`'s worker body (split out as
+  `_confirm_new_then_mark_item_read_on_open`) now re-asks the backend (`_blocking_status_for`,
+  the same guard `_mark_item_unread` already uses) immediately before the write, instead of trusting
+  the cached "new" alone -- closing the hole for every cause of cache staleness, not just this one.
+
+Pinned by two new tests in `Tests/UI/test_watchlists_read_status.py`:
+`test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent` (slows item A's write via a
+monkeypatched `WatchlistsBackendController.update_item_status`, dispatches A then supersedes with B in
+the same group, asserts the database lands on "reviewed" AND the cached dict is patched to match) and
+`test_mark_read_on_open_does_not_overwrite_an_item_ingested_behind_the_cache` (moves the database to
+"ingested" directly while the cached dict still reads stale "new", re-opens the item, asserts the
+ingest survives). Mutation-verified in both directions: removing the `CancelledError` patch reds only
+the first test; removing the backend gate reds only the second; both restored and reverified green.
+
+**F3 (Minor) -- `item_id=None` would collapse every id-less Ingest/Ignore into one shared group.**
+`handle_ingest_requested`/`handle_ignore_requested` derive their per-item group from
+`entity.get("id")` with no None guard, unlike `_mark_item_read_on_open` and
+`handle_unread_toggle_requested`, which both already refuse on a missing id. Added the identical
+`if item_id is None: return` guard to both handlers. Believed unreachable through the real item
+pipeline -- `normalize_watchlist_item` unconditionally sets `"id"` via
+`build_watchlist_item_id(source, "watchlist_item", row["id"])`, backed by the table's own
+`INTEGER PRIMARY KEY`, which SQLite never lets be NULL -- so pinned directly rather than via a
+real-feeling fixture: `test_ingest_and_ignore_never_dispatch_a_write_for_an_id_less_entity`
+(`Tests/UI/test_watchlists_item_actions.py`) posts a synthetic id-less entity and asserts
+`_update_item_status` is never called at all. Mutation-verified: removing either guard reds this
+test.
+
+**F4 (Minor, docs-only) -- "last press wins" is not a guaranteed database order.** The per-item
+group's docstring claimed a repeat Ingest/Ignore on the same item "supersedes its own earlier write"
+the same way `_toggle_briefing_queue` accepts for the briefing-queue flag -- but that flag's write has
+no genuine suspension point, while this one now does, and `asyncio.to_thread` threads are zombies:
+the superseded write's thread and its replacement's thread are two independent, unordered writes to
+the same row, and either can commit last. Corrected the constant's docstring and added the same
+caveat to `_update_item_status_off_loop`'s docstring (two racing durable writes may land in either
+order; the per-item group bounds what the UI settles on, not what order the database sees them in).
+No code change; no test claim to weaken, since none existed.
+
+**Files changed (fix wave):** `Tests/UI/test_watchlists_content_pane.py` (F1, three-line
+`wait_for_selector` addition, no assertions touched); `tldw_chatbook/UI/Screens/
+watchlists_collections_screen.py` (F2: `CancelledError` handling in `_update_item_status`, new
+`_confirm_new_then_mark_item_read_on_open`; F3: None guards in `handle_ingest_requested`/
+`handle_ignore_requested`; F4: docstring corrections only); `Tests/UI/test_watchlists_read_status.py`
+(two new F2 tests); `Tests/UI/test_watchlists_item_actions.py` (one new F3 test).
+
+**Verification.** `Tests/Watchlists/ Tests/UI/test_watchlists_inspector.py
+Tests/UI/test_watchlists_content_pane.py Tests/UI/test_watchlists_item_actions.py
+Tests/UI/test_watchlists_read_status.py` — 452 passed, 1 failed in 525.74s. The one failure
+(`Tests/Watchlists/test_watchlists_artifacts_pane.py::test_a_claimed_watchlist_survives_an_artifacts_open`)
+is unrelated to this fix wave: its traceback is a Textual-internal `NoMatches: No nodes match
+'#label' on SelectCurrent` raised from `Select._on_mount` → `_init_selected_option` during app
+mount, in a test file this fix wave never touches (briefings/artifacts claim logic, not item
+status). Passed 5/5 in isolation; only reproduces under full-suite ordering/load, the same class
+of Textual widget-mount race the verdict separately noted as a "bonus datum" teardown crash
+elsewhere in this review. Not investigated further as out of scope for task-1541.
+`test_mark_unread_refuses_to_overwrite_an_item_ingested_by_the_real_gesture` (F1's target): 20/20
+sequential (`-p no:randomly`), confirming the flake is closed.

--- a/backlog/tasks/task-1930 - Cancellation-coherence-residuals-on-the-item-status-write-paths.md
+++ b/backlog/tasks/task-1930 - Cancellation-coherence-residuals-on-the-item-status-write-paths.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1930
 title: Cancellation-coherence residuals on the item-status write paths
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02'
 labels:
@@ -14,30 +14,53 @@ priority: low
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Filed from task-1541's fix-wave re-review (report:
-`.superpowers/sdd/briefings-residuals/task-1541-fixwave-rereview.md`), which APPROVED the wave
-and parked two Minors:
+**Superseded by task-1541's Qodo redesign (desired-status coalescing) -- see that task's
+Implementation Notes, "Qodo redesign" section. Both residuals below are now moot: the mechanism
+they described no longer exists in the code.**
+
+Originally filed from task-1541's fix-wave re-review (report:
+`.superpowers/sdd/briefings-residuals/task-1541-fixwave-rereview.md`), which APPROVED that wave
+and parked two Minors against its `exclusive=True` "supersede" worker-group model:
 
 1. **Write-failure + coincident-cancellation race in `_update_item_status`'s CancelledError
-   handler** (`UI/Screens/watchlists_collections_screen.py`). The handler assumes the
-   `to_thread` write landed (threads don't cancel) and synchronously patches the cached dict
+   handler** (`UI/Screens/watchlists_collections_screen.py`). The handler assumed the
+   `to_thread` write landed (threads don't cancel) and synchronously patched the cached dict
    before re-raising. In the narrow window where the write itself RAISED (DB error) and a
-   cancellation arrives in the same sub-millisecond, asyncio's `to_thread`/`wrap_future`
-   plumbing discards the real exception unlogged and the handler patches the cache to a status
-   the DB never reached. Not practically reachable today; the docstring currently overstates
-   the guarantee.
+   cancellation arrived in the same sub-millisecond, asyncio's `to_thread`/`wrap_future`
+   plumbing could discard the real exception unlogged and the handler would patch the cache to
+   a status the DB never reached.
 
-2. **`_mark_item_unread` lacks the sibling cancellation-safety treatment.** The explicit
-   "Mark unread" button shares the cross-item supersede worker group with mark-read-on-open but
-   did not get task-1541's CancelledError cache patch: a cancelled toggle can leave the cached
-   dict stale and produce no toast. Milder than the fixed data-loss case (self-healing on next
-   load, no permanent status overwrite), which is why it was parked rather than folded into the
-   wave.
+2. **`_mark_item_unread` lacked the sibling cancellation-safety treatment.** The explicit
+   "Mark unread" button shared the cross-item supersede worker group with mark-read-on-open but
+   did not get task-1541's CancelledError cache patch: a cancelled toggle could leave the cached
+   dict stale and produce no toast.
+
+A follow-up, broader Qodo review of the same fix wave went further than either of the two Minors
+above: it found the whole cancellation-based "supersede" model unsound for a durable write (not
+just in these two narrow corners) and had it replaced outright with desired-status coalescing
+(`_dispatch_item_status`/`_drain_item_status`/`_ItemStatusIntent`) -- see task-1541's notes. That
+redesign deletes the `except asyncio.CancelledError` handler in `_update_item_status` entirely
+(AC #1's target) and deletes `_mark_item_unread` entirely, folding its gate logic into the shared
+`_item_status_write_allowed` helper every gated write now goes through (AC #2's target). Nothing
+in the new code is ever cancelled by this screen's own logic, so there is no
+"cancellation-coherence" gap left to patch on either path -- the premise both ACs were written
+against no longer exists.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The CancelledError handler only patches the cache when the write genuinely landed (or the docstring states the residual window honestly and the discarded-exception path at least logs type-only)
-- [ ] #2 `_mark_item_unread` gets the same cancellation-coherence treatment as `_update_item_status` (patch-before-re-raise), with a test mirroring `test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent`
-- [ ] #3 Existing item-status tests pass unchanged
+- [x] #1 Moot: `_update_item_status`'s `except asyncio.CancelledError` handler this AC targeted was deleted outright by task-1541's Qodo redesign, not patched -- nothing calls this method under a cancellation any more, so there is no write-failure/cancellation race left to close
+- [x] #2 Moot: `_mark_item_unread` this AC targeted was deleted outright by the same redesign, folded into `_item_status_write_allowed` (shared by both gated writes) and `_drain_item_status` (which never cancels); there is no sibling treatment left to add because there is no cancellation to be coherent against
+- [x] #3 Existing item-status tests pass unchanged by this bookkeeping-only task (no production code touched here; task-1541's own redesign commit is verified separately in that task's notes)
 <!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+No code changes in this task. Closed as obsolete-by-supersession (honest bookkeeping, not
+"Won't Do" -- the underlying CONCERN this task raised, cache/DB divergence around a cancelled
+write, is actually resolved, just not by the incremental patch these ACs originally described).
+The redesign that supersedes both residuals is documented in task-1541's Implementation Notes
+("Qodo redesign (desired-status coalescing replaces cancellation)" section) and landed on branch
+`fix/task-1541-item-status-off-loop`. Left this file in place per project convention (never delete
+a filed task) rather than removing it now that its content is stale.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1930 - Cancellation-coherence-residuals-on-the-item-status-write-paths.md
+++ b/backlog/tasks/task-1930 - Cancellation-coherence-residuals-on-the-item-status-write-paths.md
@@ -1,0 +1,43 @@
+---
+id: TASK-1930
+title: Cancellation-coherence residuals on the item-status write paths
+status: To Do
+assignee: []
+created_date: '2026-08-02'
+labels:
+  - watchlists
+  - correctness
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Filed from task-1541's fix-wave re-review (report:
+`.superpowers/sdd/briefings-residuals/task-1541-fixwave-rereview.md`), which APPROVED the wave
+and parked two Minors:
+
+1. **Write-failure + coincident-cancellation race in `_update_item_status`'s CancelledError
+   handler** (`UI/Screens/watchlists_collections_screen.py`). The handler assumes the
+   `to_thread` write landed (threads don't cancel) and synchronously patches the cached dict
+   before re-raising. In the narrow window where the write itself RAISED (DB error) and a
+   cancellation arrives in the same sub-millisecond, asyncio's `to_thread`/`wrap_future`
+   plumbing discards the real exception unlogged and the handler patches the cache to a status
+   the DB never reached. Not practically reachable today; the docstring currently overstates
+   the guarantee.
+
+2. **`_mark_item_unread` lacks the sibling cancellation-safety treatment.** The explicit
+   "Mark unread" button shares the cross-item supersede worker group with mark-read-on-open but
+   did not get task-1541's CancelledError cache patch: a cancelled toggle can leave the cached
+   dict stale and produce no toast. Milder than the fixed data-loss case (self-healing on next
+   load, no permanent status overwrite), which is why it was parked rather than folded into the
+   wave.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The CancelledError handler only patches the cache when the write genuinely landed (or the docstring states the residual window honestly and the discarded-exception path at least logs type-only)
+- [ ] #2 `_mark_item_unread` gets the same cancellation-coherence treatment as `_update_item_status` (patch-before-re-raise), with a test mirroring `test_a_cancelled_mark_read_still_leaves_the_cached_dict_coherent`
+- [ ] #3 Existing item-status tests pass unchanged
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -11,7 +11,7 @@ import asyncio
 import re
 import threading
 from collections.abc import Collection, Mapping, Sequence
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -196,41 +196,102 @@ NOISE_SELECTORS_SAVED_TOAST = (
     "A change the page makes before that check will not be reported."
 )
 
-#: Worker group for the two item read/unread status writes. They must
-#: supersede each other (a fast `j` run should not queue up one write per key)
-#: but must NOT supersede unrelated work -- see the note at
-#: `_mark_item_read_on_open`'s `run_worker` call.
-_ITEM_STATUS_WORKER_GROUP = "wl-item-status"
-
-#: Per-item worker group prefix for the Ingest/Ignore actions (TASK-1541).
-#: `_ITEM_STATUS_WORKER_GROUP` above already gives the read/unread pair their
-#: own group so a fast `j` run's mark-read write cannot cancel an unrelated
-#: "Check now" fetch; Ingest/Ignore never got the same treatment and stayed
-#: in the plain `exclusive=True` default group shared with ~25 other call
-#: sites. That was harmless only because the write itself ran synchronously
-#: with no real `await` boundary a cancellation could land on -- see
-#: `_update_item_status_off_loop`'s docstring. Moving the write onto
-#: `asyncio.to_thread` gives it a genuine suspension point, so leaving Ingest/
-#: Ignore in the default group would newly let an unrelated action (or a
-#: DIFFERENT item's Ingest/Ignore) cancel this item's in-flight write --
-#: exactly the risk that matters here, since `SubscriptionsDB` sets no
-#: `busy_timeout` pragma and a contended write can sit for the length of
-#: SQLite's default lock wait while the user is free to select a different
-#: item in the meantime. Formatting the group per item id (rather than one
-#: shared group, or `_ITEM_STATUS_WORKER_GROUP` itself) means only a REPEAT
-#: Ingest/Ignore on the SAME item supersedes its own earlier write -- while
-#: two DIFFERENT items' writes can never cancel each other. Fix wave (F4,
-#: Minor): this is NOT the same guaranteed "last press wins" contract
-#: `_toggle_briefing_queue` names for the briefing-queue flag -- see
-#: `_update_item_status_off_loop`'s docstring for why not, now that the
-#: write has a genuine off-thread suspension point.
-_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX = "wl-item-status-action:"
+#: Per-item worker-group prefix for the item-status write drainer (TASK-1541,
+#: Qodo redesign). Ingest, Ignore, the unread toggle, and mark-read-on-open
+#: ALL funnel through `_dispatch_item_status`/`_drain_item_status` now, one
+#: drainer per item id -- see those methods' docstrings.
+#:
+#: This replaces two separate `exclusive=True` "supersede" worker groups an
+#: earlier version of this fix used (one shared cross-item group for the
+#: read/unread pair, one per-item group for Ingest/Ignore): a whole-branch
+#: re-review found that "supersede by cancellation" model unsound for a
+#: durable write, two independent ways, once the write got a genuine
+#: `asyncio.to_thread` suspension point (see `_update_item_status_off_loop`):
+#:
+#: 1. `asyncio.to_thread`'s underlying OS thread is not itself cancellable
+#:    once it has started running -- cancelling the AWAITING coroutine does
+#:    not stop the write. So a superseded write's thread and its
+#:    replacement's thread became two independent, un-ordered writes to the
+#:    SAME row, either able to commit last: rapid Ingest-then-Ignore on one
+#:    item could leave the DATABASE on the FIRST action while the UI (and any
+#:    cache patch) showed the second.
+#: 2. The opposite failure mode: `asyncio.to_thread` CAN be cancelled before
+#:    the executor picks the work item up at all (reachable under a
+#:    saturated default executor, no exotic timing needed) -- in which case
+#:    the write never runs. The old `except asyncio.CancelledError` handler
+#:    assumed "cancelled implies the write is durable" and patched the cache
+#:    to the target status regardless, which is simply false in this case:
+#:    the cache would then claim a status the database never reached.
+#:
+#: Desired-status coalescing (`_ItemStatusIntent`) replaces cancellation
+#: entirely rather than patching either hole: each item gets at most one
+#: QUEUED write (the latest dispatch overwrites the dict entry) plus at most
+#: one IN-FLIGHT write, and the drainer always `await`s a write to genuine
+#: completion -- success or a real exception -- before popping the next
+#: entry for that SAME item, so two writes for one item can never race each
+#: other, and nothing is ever cancelled mid-write. Two DIFFERENT items'
+#: drainers still never interact at all (own group each, `exclusive=False`),
+#: which is the one part of the old design worth keeping: a fast `j`/`k` run
+#: or a rapid Ingest/Ignore burst still costs at most one queued write per
+#: item, not one write per keystroke.
+_ITEM_STATUS_DRAIN_GROUP_PREFIX = "wl-item-status-drain:"
 
 #: Item statuses the reader's "Mark unread" button must never overwrite: they
 #: are not read/unread states at all, and `new` would destroy the record.
 #: A frozenset, since `_blocking_status_for` now asks the backend for the
 #: item's one status and only has to decide whether it is in this set.
 _NON_READ_STATE_STATUSES: frozenset[str] = frozenset({"ingested", "ignored", "error"})
+
+
+@dataclass(frozen=True)
+class _ItemStatusIntent:
+    """One desired item-status write, captured at the moment it is dispatched.
+
+    TASK-1541 (Qodo redesign). `_dispatch_item_status` stores exactly one of
+    these per item id in `WatchlistsCollectionsScreen._item_status_desired`
+    -- a second dispatch for the same item before the first has been popped
+    OVERWRITES this dict entry rather than queuing a second one, which is
+    the whole of the "coalescing" scheme: at most one write is ever queued
+    per item, and the drainer (`_drain_item_status`) always acts on
+    whichever intent is current when it next looks.
+
+    Fields mirror exactly what `_update_item_status`'s four callers used to
+    pass directly (Ingest, Ignore, the unread toggle, mark-read-on-open) --
+    nothing new was invented, the dispatch-time context just now has to
+    travel through a dict entry instead of a function call.
+
+    Attributes:
+        status: The target `subscription_items.status` value.
+        notify_toast: Whether a successful (or refused/failed) write should
+            surface a toast. `False` only for the silent mark-read-on-open
+            path, matching `_update_item_status`'s previous default.
+        refresh: Whether a successful write should reload `ItemsPane.items`
+            and recompose via `_refresh_overview_data()`. `False` only for
+            mark-read-on-open, which patches `patch_item` in place instead
+            -- see `_mark_item_read_on_open`'s docstring for why a recompose
+            on every item SELECTION was a CRITICAL regression.
+        patch_item: The live dict object (already held by `ItemsPane.items`/
+            `_selected_content_item`/`ContentPane.item`) to mutate in place
+            on a successful write, or `None` when the caller relies on
+            `refresh` instead. Passed by exactly one caller in the whole
+            app, `_mark_item_read_on_open` -- see `handle_unread_toggle_
+            requested`'s docstring for why that matters.
+        gate: Whether the drainer must re-ask the backend
+            (`_blocking_status_for`) immediately before writing and refuse
+            if the item already holds a terminal status
+            (`_NON_READ_STATE_STATUSES`). `True` for the unread toggle and
+            mark-read-on-open, which can otherwise clobber an Ingest/Ignore
+            that neither of those two dispatch paths would ever see coming
+            (Ingest/Ignore pass no `patch_item=`, so nothing patches the
+            cache those two read from). `False` for Ingest/Ignore
+            themselves -- there is nothing to protect an ingest/ignore FROM.
+    """
+
+    status: str
+    notify_toast: bool = True
+    refresh: bool = True
+    patch_item: dict[str, Any] | None = None
+    gate: bool = False
 
 
 def watchlist_delete_consequence(source_count: int) -> str:
@@ -632,6 +693,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._last_persisted_collapsed: frozenset[Region] | None = None
         self._pending_persist_layout: RegionLayout | None = None
         self._layout_persist_lock = threading.Lock()
+        # Desired-status coalescing for the four item-status write paths
+        # (Ingest, Ignore, the unread toggle, mark-read-on-open) -- TASK-1541,
+        # Qodo redesign. See `_ItemStatusIntent`'s docstring for the full
+        # unsoundness `_ITEM_STATUS_DRAIN_GROUP_PREFIX`'s comment names, and
+        # `_dispatch_item_status`/`_drain_item_status` for the mechanism these
+        # two dicts drive. Event-loop-only state, exactly like every other
+        # in-flight flag on this screen (`_briefing_in_flight` et al. above):
+        # read and written only from the loop thread, never from inside the
+        # `asyncio.to_thread` write itself.
+        #
+        # `_item_status_desired` holds at most one queued write per item id --
+        # a second dispatch for the same item overwrites the entry rather
+        # than adding a second one, which is the whole of the coalescing
+        # scheme. `_item_status_draining` names which items currently have a
+        # drainer worker running, so a dispatch that lands while one is
+        # already draining does not start a second one (and NEVER cancels the
+        # running one) -- it just relies on the running drainer to notice the
+        # new entry on its own next loop.
+        self._item_status_desired: dict[Any, "_ItemStatusIntent"] = {}
+        self._item_status_draining: set[Any] = set()
         self._controller = WatchlistsBackendController(
             app_instance=app_instance,
             scope_service=getattr(app_instance, "watchlist_scope_service", None),
@@ -6052,10 +6133,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         `refresh=False` + `patch_item=item` (Task 5 fix round 1, CRITICAL):
         this fires on every single item SELECTION, not just a deliberate
-        button click. `_update_item_status`'s default refresh reloads
-        `ItemsPane.items` and calls `_refresh_overview_data()`, and
-        `overview_data` is `reactive({}, recompose=True)` -- a SCREEN-level
-        recompose, which rebuilds every region via its factory
+        button click. A default `refresh` reloads `ItemsPane.items` and
+        calls `_refresh_overview_data()`, and `overview_data` is
+        `reactive({}, recompose=True)` -- a SCREEN-level recompose, which
+        rebuilds every region via its factory
         (`_build_list_pane`/`_build_content_pane`/etc.), replacing the live
         `ItemsPane`/`DataTable` instances wholesale. Proven live: with the
         default refresh, one item selection detached the old `ItemsPane`,
@@ -6065,30 +6146,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `_selected_content_item`/`ContentPane.item` in place instead, so a
         later status check sees "reviewed" without forcing a rebuild.
 
-        This reuses the exact status column `_update_item_status` already
-        writes for the deliberate item-status actions (Ingest/Ignore, the
-        unread toggle) -- `SubscriptionsDB.mark_item_status`, keyed by the
+        This reuses the exact status column Ingest/Ignore/the unread toggle
+        already write -- `SubscriptionsDB.mark_item_status`, keyed by the
         item's own row id, not by any (watchlist, item) pair -- so it is
         global by construction: the same article read from "All sources" is
         read in every watchlist whose sources include it.
 
         The "new" check above is a cheap pre-filter against the CACHED dict
-        only, so a plain non-"new" selection dispatches no worker at all --
-        but the write itself is gated again, against the BACKEND, inside
-        `_confirm_new_then_mark_item_read_on_open` below (fix wave, F2b,
-        Important). Once TASK-1541 gave this write a real suspension point,
-        the pre-existing cross-item `exclusive=True` supersede on
-        `_ITEM_STATUS_WORKER_GROUP` became able to cancel an in-flight write
-        for a DIFFERENT item (a fast `j`/`k` run), and a cancelled write's
-        continuation not running left the cached dict stale -- e.g. still
-        "new" after the database had already moved to "reviewed" (see F2a in
-        `_update_item_status`'s docstring). If that item is then Ingested
-        (which never patches this dict either) and re-opened, gating on the
-        stale cached dict alone would write "reviewed" straight over the
-        ingest. Asking the backend right before the write -- mirroring
-        `_mark_item_unread`'s existing `_blocking_status_for` guard -- closes
-        that regardless of why the cache went stale, not just for this one
-        cause.
+        only, so a plain non-"new" selection dispatches nothing at all -- but
+        the write itself is gated again, against the BACKEND, immediately
+        before it happens inside `_drain_item_status` (`gate=True` below;
+        fix wave, F2b, Important, and TASK-1541's Qodo redesign afterwards).
+        Ingest/Ignore never patch this dict (they pass no `patch_item=`), so
+        if either ran behind this cache's back -- or the dict went stale for
+        any other reason -- the cached "new" check above cannot see it;
+        asking the backend right before the write, mirroring the unread
+        toggle's own `_blocking_status_for` guard, closes that regardless of
+        the cause.
         """
         if item is None:
             return
@@ -6097,57 +6171,15 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         item_id = item.get("id")
         if item_id is None:
             return
-        self.run_worker(
-            self._confirm_new_then_mark_item_read_on_open(item_id, item),
-            exclusive=True,
-            # Whole-branch review (Important): `exclusive=True` with no
-            # `group=` lands in the DEFAULT group, which ~25 call sites on
-            # this screen share -- including `_check_now_source`. Since Phase
-            # D this worker fires on every item selection and every `j`/`k`,
-            # so opening an item cancelled an in-flight "Check now" network
-            # fetch the user had just been toasted about. Give both
-            # item-status writes their own group so they only ever supersede
-            # each other.
-            group=_ITEM_STATUS_WORKER_GROUP,
-        )
-
-    async def _confirm_new_then_mark_item_read_on_open(
-        self, item_id: Any, item: dict[str, Any]
-    ) -> None:
-        """Backend-gated body dispatched by `_mark_item_read_on_open` (F2b).
-
-        Re-asks the backend for this item's real status -- exactly the
-        `_blocking_status_for` check `_mark_item_unread` already performs --
-        immediately before the write, rather than trusting `item`'s cached
-        "new" (already checked by the caller, but only against the cache).
-        This is what closes F2's cross-item-cancellation data-loss hole: if a
-        superseded, cancelled sibling write already patched the DB to
-        "reviewed"/"ingested"/etc. behind this dict's back, or any other
-        writer moved it, the backend read below sees the truth and this
-        method declines rather than clobbering it back to "reviewed".
-
-        Runs inside the SAME `_ITEM_STATUS_WORKER_GROUP` worker
-        `_mark_item_read_on_open` dispatches, so a fast `j`/`k` still
-        supersedes this check itself exactly as it superseded the write
-        before this fix -- the added backend read costs one query on the
-        selection path, not one per keystroke that gets cancelled anyway.
-        """
-        try:
-            blocking = await self._blocking_status_for(item_id)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Could not confirm an item's status before marking it read "
-                "on open; leaving it unchanged."
-            )
-            return
-        if blocking is not None:
-            return
-        await self._update_item_status(
+        self._dispatch_item_status(
             item_id,
-            "reviewed",
-            notify_toast=False,
-            refresh=False,
-            patch_item=item,
+            _ItemStatusIntent(
+                status="reviewed",
+                notify_toast=False,
+                refresh=False,
+                patch_item=item,
+                gate=True,
+            ),
         )
 
     @on(UnreadToggleRequested)
@@ -6165,16 +6197,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `new`, losing the fact of an ingest and dropping the item out of the
         Ingested filter that was the only way to find it again.
 
-        The refusal is decided in `_mark_item_unread`, by asking the backend,
-        NOT from `event.item` (re-review, Important). `event.item` is
+        The refusal is decided by `_drain_item_status`'s gate
+        (`_item_status_write_allowed`), by asking the backend, NOT from
+        `event.item` (re-review, Important). `event.item` is
         `ContentPane.item` -- the dict the screen has held since the item was
         selected -- and `handle_ingest_requested`/`handle_ignore_requested`
-        call `_update_item_status` with no `patch_item=`, so that dict is
-        never updated when they run. `patch_item=` is passed by exactly one
-        caller in the whole app (`_mark_item_read_on_open`) and by neither of
-        those two. Ingest an open item and the reader's dict still says
-        `reviewed`, so a guard reading `event.item` never fires and the button
-        destroys the ingest anyway -- reproduced end to end.
+        dispatch with no `patch_item=`, so that dict is never updated when
+        they run. `patch_item=` is passed by exactly one dispatch path in the
+        whole app (`_mark_item_read_on_open`) and by neither of those two.
+        Ingest an open item and the reader's dict still says `reviewed`, so a
+        guard reading `event.item` never fires and the button destroys the
+        ingest anyway -- reproduced end to end.
         """
         event.stop()
         item = event.item
@@ -6183,16 +6216,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         item_id = item.get("id")
         if item_id is None:
             return
-        self.run_worker(
-            self._mark_item_unread(item_id),
-            exclusive=True,
-            group=_ITEM_STATUS_WORKER_GROUP,
-        )
+        self._dispatch_item_status(item_id, _ItemStatusIntent(status="new", gate=True))
 
-    async def _mark_item_unread(self, item_id: Any) -> None:
-        """Ask the backend for the item's real status, then refuse or write.
+    async def _item_status_write_allowed(
+        self, item_id: Any, intent: "_ItemStatusIntent"
+    ) -> bool:
+        """The backend terminal-status gate, re-asked right before the write.
 
-        Deciding here, from a live query, rather than keeping the screen's
+        TASK-1541 (Qodo redesign). Shared by both gated intents (the unread
+        toggle and mark-read-on-open, `_ItemStatusIntent.gate=True`) --
+        previously this check was duplicated between `_mark_item_unread` and
+        `_confirm_new_then_mark_item_read_on_open`, one per caller; both are
+        gone now, folded into this one method plus `_drain_item_status`'s
+        loop.
+
+        Deciding from a live backend query, rather than keeping the screen's
         cached dicts patched at every status writer (re-review, Important).
         Both were on the table; this leaves strictly fewer places able to
         drift:
@@ -6205,43 +6243,157 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         * Asking has exactly one decision point, and it asks the system of
           record, so it is right no matter who moved the item or when.
 
+        Called from INSIDE `_drain_item_status`, immediately before the
+        write, not once at dispatch time: a desired entry can sit queued for
+        a moment (another item's write draining, or simply the worker not
+        yet scheduled), and only re-asking right before the write catches
+        anything that moved the item to a terminal status during that wait
+        -- including another intent for the SAME item, drained just before
+        this one, that happened to be an Ingest/Ignore.
+
         `_loaded_items` is NOT the system of record and cannot be used here:
         `local_watchlists_service.list_items` collapses `status=None` to
         `status="new"` (verified), so an ingested item is not merely stale in
         that cache -- it is absent from it entirely, along with every other
-        non-`new` item. An earlier version of this fix read `_loaded_items`
-        after an awaited `_load_items()` and still wrote `new` over a live
-        ingest, for exactly that reason.
+        non-`new` item.
 
-        Fails CLOSED. If the backend cannot be asked, the write is refused
-        and the user is told to retry: marking unread is a convenience the
-        user can repeat, whereas overwriting an ingest is not recoverable, so
-        an unanswered question must not resolve in favour of the destructive
-        branch.
+        Fails CLOSED. If the backend cannot be asked, the write is refused:
+        marking unread/read is a convenience the user can repeat, whereas
+        overwriting an ingest is not recoverable, so an unanswered question
+        must not resolve in favour of the destructive branch.
 
         Args:
-            item_id: Normalized id of the item to mark unread.
+            item_id: Normalized id of the item to check.
+            intent: The queued write this gate is deciding whether to allow.
+
+        Returns:
+            `True` if the write may proceed, `False` if it was refused (a
+            toast already fired when `intent.notify_toast`).
         """
+        label = "unread" if intent.status == "new" else intent.status
         try:
             blocking = await self._blocking_status_for(item_id)
         except Exception:
             logger.opt(exception=True).warning(
-                "Could not confirm an item's status before marking it unread."
+                f"Could not confirm an item's status before marking it {label}; "
+                "leaving it unchanged."
             )
-            self.notify(
-                "Could not confirm this item's current status, so it was left "
-                "unchanged. Try again.",
-                severity="warning",
-            )
-            return
+            if intent.notify_toast:
+                self.notify(
+                    "Could not confirm this item's current status, so it was "
+                    "left unchanged. Try again.",
+                    severity="warning",
+                )
+            return False
         if blocking is not None:
-            self.notify(
-                f"This item is marked {blocking}; leaving it as it is rather "
-                "than overwriting that with unread.",
-                severity="warning",
-            )
+            if intent.notify_toast:
+                self.notify(
+                    f"This item is marked {blocking}; leaving it as it is "
+                    f"rather than overwriting that with {label}.",
+                    severity="warning",
+                )
+            return False
+        return True
+
+    def _dispatch_item_status(self, item_id: Any, intent: "_ItemStatusIntent") -> None:
+        """Queue `intent` as `item_id`'s desired write and ensure a drainer runs.
+
+        TASK-1541 (Qodo redesign). Every one of the four item-status dispatch
+        paths (Ingest, Ignore, the unread toggle, mark-read-on-open) calls
+        this instead of directly starting its own worker -- see
+        `_ItemStatusIntent`'s and `_ITEM_STATUS_DRAIN_GROUP_PREFIX`'s
+        docstrings for why (cancellation-based "supersede" was unsound for a
+        durable write, two independent ways).
+
+        Overwriting `self._item_status_desired[item_id]` unconditionally is
+        the coalescing: a second dispatch for the same item before the first
+        has been drained simply replaces what the drainer will act on next --
+        there is never more than one write queued per item. If a drainer is
+        already running for this item (`item_id in self._item_status_
+        draining`), nothing further happens here: the running drainer is
+        NEVER cancelled and NEVER told to stop early, it just picks the new
+        entry up itself the next time its loop checks the dict (see
+        `_drain_item_status`). Only when no drainer is currently running is
+        one started, in this item's OWN group -- so a burst of dispatches
+        across MANY different items still gets one independent drainer each,
+        never sharing a group and never able to interact.
+        """
+        self._item_status_desired[item_id] = intent
+        if item_id in self._item_status_draining:
             return
-        await self._update_item_status(item_id, "new")
+        self._item_status_draining.add(item_id)
+        self.run_worker(
+            self._drain_item_status(item_id),
+            group=f"{_ITEM_STATUS_DRAIN_GROUP_PREFIX}{item_id}",
+            exclusive=False,
+        )
+
+    async def _drain_item_status(self, item_id: Any) -> None:
+        """Per-item worker: pop the desired write, perform it, repeat.
+
+        TASK-1541 (Qodo redesign). This is the ONLY worker body that ever
+        writes an item's status now -- Ingest, Ignore, the unread toggle, and
+        mark-read-on-open all reach it through `_dispatch_item_status`, one
+        drainer per item id, never shared across items and never cancelled.
+
+        The invariant that replaces cancellation-based "supersede": pop this
+        item's desired entry, `await` `_update_item_status` (which itself
+        `await`s the actual `asyncio.to_thread` write) to GENUINE completion
+        -- success or a real exception, never a cancellation, since nothing
+        here is ever cancelled -- THEN check the dict again before exiting.
+        If a newer desired entry appeared while that write was in flight
+        (another dispatch for this SAME item, which only ever overwrites the
+        dict rather than starting a second drainer), the loop goes around
+        again and writes THAT instead. Only when the dict holds nothing more
+        for this item does the drainer exit and clear itself from
+        `_item_status_draining`.
+
+        Two consequences fall out of this shape directly:
+
+        * At most one write is ever queued per item (the dict holds a single
+          entry) plus at most one in flight -- the same bound the old
+          cross-item/per-item `exclusive=True` groups gave, without the
+          unsoundness: a fast `j`/`k` run or an Ingest-then-Ignore burst on
+          one item still costs at most two writes, not one per keystroke,
+          but BOTH writes always run to completion in dispatch order, so the
+          LAST action dispatched is always the one the database (and the
+          cache, if `patch_item` is set) settles on -- deterministically,
+          not "whichever OS thread happened to finish last" (the old
+          model's actual behaviour once the write got a genuine suspension
+          point; see `_ITEM_STATUS_DRAIN_GROUP_PREFIX`'s docstring).
+        * A gated intent (`intent.gate`, the unread toggle and
+          mark-read-on-open) is re-checked against the backend
+          (`_item_status_write_allowed`) immediately before ITS OWN write,
+          not once at dispatch time -- so an Ingest/Ignore that lands on this
+          same item while a gated entry is still queued is seen, even though
+          neither of those two ever patches the cache this dict's staleness
+          check would otherwise rely on.
+
+        `try`/`finally` around the loop, not just around the body: whatever
+        exits the loop (the normal empty-dict return, or -- not expected in
+        practice, since `_update_item_status` itself catches `Exception` --
+        anything else) must still clear this item from `_item_status_
+        draining`, or the item would be permanently unable to dispatch a new
+        write again for the rest of the screen's life.
+        """
+        try:
+            while True:
+                intent = self._item_status_desired.pop(item_id, None)
+                if intent is None:
+                    return
+                if intent.gate:
+                    allowed = await self._item_status_write_allowed(item_id, intent)
+                    if not allowed:
+                        continue
+                await self._update_item_status(
+                    item_id,
+                    intent.status,
+                    notify_toast=intent.notify_toast,
+                    refresh=intent.refresh,
+                    patch_item=intent.patch_item,
+                )
+        finally:
+            self._item_status_draining.discard(item_id)
 
     async def _blocking_status_for(self, item_id: Any) -> str | None:
         """Which `_NON_READ_STATE_STATUSES` value the backend holds for this item.
@@ -6478,30 +6630,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             return
         item_id = entity.get("id")
         if item_id is None:
-            # Fix wave (F3, Minor): an id-less entity would otherwise
-            # derive the group below as
-            # f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}None", collapsing
-            # EVERY id-less Ingest/Ignore into one shared group -- exactly
-            # the cross-item cancellation the per-item grouping exists to
-            # avoid. Believed unreachable in practice:
-            # `normalize_watchlist_item` unconditionally sets "id" via
-            # `build_watchlist_item_id(source, "watchlist_item", row["id"])`
-            # for every item this screen's own Items pane produces, and
-            # `row["id"]` is the table's `INTEGER PRIMARY KEY`, never NULL --
-            # so `event.entity` reaching here without an "id" would mean
-            # something other than this screen's own item pipeline
-            # constructed it. Refusing the dispatch (rather than falling back
-            # to a unique per-dispatch suffix) also matches
+            # Fix wave (F3, Minor): an id-less entity would otherwise derive
+            # `_dispatch_item_status`'s per-item drain group as
+            # f"{_ITEM_STATUS_DRAIN_GROUP_PREFIX}None", collapsing EVERY
+            # id-less Ingest/Ignore into one shared drainer -- exactly the
+            # cross-item interaction the per-item grouping exists to avoid.
+            # Believed unreachable in practice: `normalize_watchlist_item`
+            # unconditionally sets "id" via `build_watchlist_item_id(source,
+            # "watchlist_item", row["id"])` for every item this screen's own
+            # Items pane produces, and `row["id"]` is the table's `INTEGER
+            # PRIMARY KEY`, never NULL -- so `event.entity` reaching here
+            # without an "id" would mean something other than this screen's
+            # own item pipeline constructed it. Refusing the dispatch (rather
+            # than falling back to a unique per-dispatch suffix) also matches
             # `_mark_item_read_on_open`'s and `handle_unread_toggle_
             # requested`'s existing `item_id is None: return` guards.
             return
-        self.run_worker(
-            self._update_item_status(item_id, "ingested"),
-            exclusive=True,
-            # TASK-1541: per-item group, not the default one -- see
-            # `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX`'s note.
-            group=f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}{item_id}",
-        )
+        self._dispatch_item_status(item_id, _ItemStatusIntent(status="ingested"))
 
     @on(IgnoreRequested)
     def handle_ignore_requested(self, event: IgnoreRequested) -> None:
@@ -6515,13 +6660,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # `handle_ingest_requested` just above -- same hazard, same
             # reachability analysis, same refusal.
             return
-        self.run_worker(
-            self._update_item_status(item_id, "ignored"),
-            exclusive=True,
-            # TASK-1541: per-item group, not the default one -- see
-            # `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX`'s note.
-            group=f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}{item_id}",
-        )
+        self._dispatch_item_status(item_id, _ItemStatusIntent(status="ignored"))
 
     @on(ToggleBriefingQueueRequested)
     def handle_toggle_briefing_queue_requested(
@@ -6684,6 +6823,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     ) -> None:
         """Move one item to `status` through the shared item-status API.
 
+        Called exactly once per popped `_ItemStatusIntent`, from inside
+        `_drain_item_status`'s loop (TASK-1541, Qodo redesign) -- never
+        directly by a dispatch handler any more. That loop always `await`s
+        this to completion before looking at this item's desired-status dict
+        entry again, so at most one call to this method is ever in flight for
+        a given item at a time.
+
         `notify_toast` is False only for the Task 5 auto-mark-read-on-open
         path -- every other caller (Ingest/Ignore, the unread toggle) is a
         deliberate user action and keeps the toast. The failure toast is
@@ -6714,25 +6860,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         the event-loop thread despite this coroutine already being dispatched
         through `run_worker`.
 
-        Fix wave (F2a, whole-branch review, Important): this coroutine can be
-        cancelled (both status-writing worker groups are `exclusive=True`,
-        superseding a same-group in-flight write) while suspended at the
-        genuine `await asyncio.to_thread(...)` inside `_update_item_status_
-        off_loop`. That suspension is the one place a cancellation is
-        actually delivered, and by the time it is, the OS thread doing the
-        write is NOT itself cancellable -- see that method's docstring -- so
-        the transactional UPDATE completes and the database WILL land on
-        `status` regardless. If the cancellation is left to propagate
-        unpatched, the cached dict (`ItemsPane.items`/`_selected_content_
-        item`/`ContentPane.item`) is stranded reading the pre-write value
-        forever, diverged from a database the app itself just wrote -- the
-        same stale-cache data-loss shape `_mark_item_read_on_open` and
-        `_mark_item_unread` already guard the read side of. So the
-        `CancelledError` handler below applies the SAME patch the normal
-        continuation would have, synchronously (no `await`, so it cannot
-        itself be suspended or re-cancelled), before re-raising so the
-        cancellation still propagates as normal and the `refresh` tail below
-        correctly does not run for a superseded write.
+        No `CancelledError` handling (Qodo redesign; an earlier fix wave had
+        one here -- deleted). That handler assumed a cancellation always
+        meant "the write is durable regardless, just patch the cache to
+        match it", which a later re-review found false in a narrow but real
+        window (the underlying thread can itself raise, or -- worse -- never
+        run at all if cancelled before the executor picked it up; see
+        `_ITEM_STATUS_DRAIN_GROUP_PREFIX`'s docstring). The redesign removes
+        the premise instead of patching the handler: nothing that calls this
+        method is ever cancelled any more (`_drain_item_status`'s worker is
+        `exclusive=False` and is never explicitly cancelled), so there is no
+        cancellation path here to handle -- if this coroutine is interrupted
+        at all, it is an external teardown (e.g. the screen unmounting),
+        exactly like every other worker on this screen, not a same-item or
+        cross-item "supersede".
         """
         notify = getattr(self.app_instance, "notify", None)
         try:
@@ -6748,14 +6889,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if notify_toast and callable(notify):
                 label = "unread" if status == "new" else status
                 notify(f"Item marked {label}.", severity="information")
-        except asyncio.CancelledError:
-            # F2a: the write is durable even though this coroutine is not --
-            # see the docstring above. Patch the cache to match the database
-            # write that is happening (or has already happened) regardless.
-            if patch_item is not None:
-                patch_item["status"] = status
-                self._repaint_item_status_cell(patch_item.get("id"), status)
-            raise
         except Exception:
             logger.opt(exception=True).warning(f"Failed to mark item {status}.")
             if notify_toast and callable(notify):
@@ -6796,20 +6929,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         plain string -- the worker body itself must never read a screen
         reactive directly.
 
-        Fix wave (F4, Minor, docs-only): this OS thread is not cancellable --
-        `asyncio.to_thread`'s underlying executor future can only be
-        cancelled before it starts running, and by the time an
-        `exclusive=True` supersede on either status-writing worker group
-        actually delivers a `CancelledError` (at the `await` on the last line
-        below), this thread already has started. So a "last press wins"
-        contract for repeat Ingest/Ignore-then-Ignore/Ingest on the SAME item
-        (`_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX`'s per-item group) is NOT
-        guaranteed at the database: the superseded write's thread and its
-        replacement's thread are two independent, un-ordered zombies racing
-        each other to the same row, and either can land last. The per-item
-        group bounds what the UI settles on (whichever write's continuation
-        runs last patches the cache and repaints the cell), not what order
-        the two durable writes commit in.
+        Drain invariant (TASK-1541, Qodo redesign; replaces an earlier,
+        incorrect "last press wins is not guaranteed at the database" caveat
+        that used to live here). This OS thread is genuinely not cancellable
+        once started -- `asyncio.to_thread`'s underlying executor future can
+        only be cancelled before it begins running -- which is exactly why an
+        earlier design (`exclusive=True` "supersede" worker groups) could not
+        safely guarantee write ORDER: a superseded write's thread and its
+        replacement's thread were two independent, un-ordered writes to the
+        same row, either able to commit last. `_drain_item_status` sidesteps
+        that instead of tolerating it: it `await`s this method to genuine
+        completion before ever popping this SAME item's next desired entry,
+        so at most one call to this method is alive for a given item at any
+        time -- there is no second thread for the SAME row to race against.
+        Repeat Ingest/Ignore (or any other item-status action) on one item
+        now has a real "last dispatched action wins" guarantee, at the
+        database, not just at whatever the UI happens to repaint last.
 
         Returns:
             The controller's result dict, unused by the only current caller
@@ -7095,8 +7230,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `watch_selected_item` -> `ItemSelected` -> `handle_item_selected`
         path a mouse click or an arrow-key highlight already uses -- so
         this still inherits the Task 5 fix for free
-        (`_mark_item_read_on_open` calls `_update_item_status(...,
-        refresh=False, patch_item=item)`, patching the item dict in place
+        (`_mark_item_read_on_open` dispatches an `_ItemStatusIntent(refresh=
+        False, patch_item=item)`, patching the item dict in place
         instead of forcing the `overview_data` `reactive(recompose=True)`
         full-screen rebuild that once dropped focus and broke a second
         keypress).

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -218,10 +218,12 @@ _ITEM_STATUS_WORKER_GROUP = "wl-item-status"
 #: SQLite's default lock wait while the user is free to select a different
 #: item in the meantime. Formatting the group per item id (rather than one
 #: shared group, or `_ITEM_STATUS_WORKER_GROUP` itself) means only a REPEAT
-#: Ingest/Ignore on the SAME item supersedes its own earlier write -- the
-#: same "last press wins" contract `_toggle_briefing_queue` already accepts
-#: for the briefing-queue flag -- while two DIFFERENT items' writes can never
-#: cancel each other.
+#: Ingest/Ignore on the SAME item supersedes its own earlier write -- while
+#: two DIFFERENT items' writes can never cancel each other. Fix wave (F4,
+#: Minor): this is NOT the same guaranteed "last press wins" contract
+#: `_toggle_briefing_queue` names for the briefing-queue flag -- see
+#: `_update_item_status_off_loop`'s docstring for why not, now that the
+#: write has a genuine off-thread suspension point.
 _ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX = "wl-item-status-action:"
 
 #: Item statuses the reader's "Mark unread" button must never overwrite: they
@@ -6069,6 +6071,24 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         item's own row id, not by any (watchlist, item) pair -- so it is
         global by construction: the same article read from "All sources" is
         read in every watchlist whose sources include it.
+
+        The "new" check above is a cheap pre-filter against the CACHED dict
+        only, so a plain non-"new" selection dispatches no worker at all --
+        but the write itself is gated again, against the BACKEND, inside
+        `_confirm_new_then_mark_item_read_on_open` below (fix wave, F2b,
+        Important). Once TASK-1541 gave this write a real suspension point,
+        the pre-existing cross-item `exclusive=True` supersede on
+        `_ITEM_STATUS_WORKER_GROUP` became able to cancel an in-flight write
+        for a DIFFERENT item (a fast `j`/`k` run), and a cancelled write's
+        continuation not running left the cached dict stale -- e.g. still
+        "new" after the database had already moved to "reviewed" (see F2a in
+        `_update_item_status`'s docstring). If that item is then Ingested
+        (which never patches this dict either) and re-opened, gating on the
+        stale cached dict alone would write "reviewed" straight over the
+        ingest. Asking the backend right before the write -- mirroring
+        `_mark_item_unread`'s existing `_blocking_status_for` guard -- closes
+        that regardless of why the cache went stale, not just for this one
+        cause.
         """
         if item is None:
             return
@@ -6078,13 +6098,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if item_id is None:
             return
         self.run_worker(
-            self._update_item_status(
-                item_id,
-                "reviewed",
-                notify_toast=False,
-                refresh=False,
-                patch_item=item,
-            ),
+            self._confirm_new_then_mark_item_read_on_open(item_id, item),
             exclusive=True,
             # Whole-branch review (Important): `exclusive=True` with no
             # `group=` lands in the DEFAULT group, which ~25 call sites on
@@ -6095,6 +6109,45 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # item-status writes their own group so they only ever supersede
             # each other.
             group=_ITEM_STATUS_WORKER_GROUP,
+        )
+
+    async def _confirm_new_then_mark_item_read_on_open(
+        self, item_id: Any, item: dict[str, Any]
+    ) -> None:
+        """Backend-gated body dispatched by `_mark_item_read_on_open` (F2b).
+
+        Re-asks the backend for this item's real status -- exactly the
+        `_blocking_status_for` check `_mark_item_unread` already performs --
+        immediately before the write, rather than trusting `item`'s cached
+        "new" (already checked by the caller, but only against the cache).
+        This is what closes F2's cross-item-cancellation data-loss hole: if a
+        superseded, cancelled sibling write already patched the DB to
+        "reviewed"/"ingested"/etc. behind this dict's back, or any other
+        writer moved it, the backend read below sees the truth and this
+        method declines rather than clobbering it back to "reviewed".
+
+        Runs inside the SAME `_ITEM_STATUS_WORKER_GROUP` worker
+        `_mark_item_read_on_open` dispatches, so a fast `j`/`k` still
+        supersedes this check itself exactly as it superseded the write
+        before this fix -- the added backend read costs one query on the
+        selection path, not one per keystroke that gets cancelled anyway.
+        """
+        try:
+            blocking = await self._blocking_status_for(item_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Could not confirm an item's status before marking it read "
+                "on open; leaving it unchanged."
+            )
+            return
+        if blocking is not None:
+            return
+        await self._update_item_status(
+            item_id,
+            "reviewed",
+            notify_toast=False,
+            refresh=False,
+            patch_item=item,
         )
 
     @on(UnreadToggleRequested)
@@ -6424,6 +6477,24 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if entity is None:
             return
         item_id = entity.get("id")
+        if item_id is None:
+            # Fix wave (F3, Minor): an id-less entity would otherwise
+            # derive the group below as
+            # f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}None", collapsing
+            # EVERY id-less Ingest/Ignore into one shared group -- exactly
+            # the cross-item cancellation the per-item grouping exists to
+            # avoid. Believed unreachable in practice:
+            # `normalize_watchlist_item` unconditionally sets "id" via
+            # `build_watchlist_item_id(source, "watchlist_item", row["id"])`
+            # for every item this screen's own Items pane produces, and
+            # `row["id"]` is the table's `INTEGER PRIMARY KEY`, never NULL --
+            # so `event.entity` reaching here without an "id" would mean
+            # something other than this screen's own item pipeline
+            # constructed it. Refusing the dispatch (rather than falling back
+            # to a unique per-dispatch suffix) also matches
+            # `_mark_item_read_on_open`'s and `handle_unread_toggle_
+            # requested`'s existing `item_id is None: return` guards.
+            return
         self.run_worker(
             self._update_item_status(item_id, "ingested"),
             exclusive=True,
@@ -6439,6 +6510,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if entity is None:
             return
         item_id = entity.get("id")
+        if item_id is None:
+            # Fix wave (F3, Minor): see the identical guard and comment in
+            # `handle_ingest_requested` just above -- same hazard, same
+            # reachability analysis, same refusal.
+            return
         self.run_worker(
             self._update_item_status(item_id, "ignored"),
             exclusive=True,
@@ -6637,6 +6713,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         ran the transactional `SubscriptionsDB.mark_item_status` UPDATE on
         the event-loop thread despite this coroutine already being dispatched
         through `run_worker`.
+
+        Fix wave (F2a, whole-branch review, Important): this coroutine can be
+        cancelled (both status-writing worker groups are `exclusive=True`,
+        superseding a same-group in-flight write) while suspended at the
+        genuine `await asyncio.to_thread(...)` inside `_update_item_status_
+        off_loop`. That suspension is the one place a cancellation is
+        actually delivered, and by the time it is, the OS thread doing the
+        write is NOT itself cancellable -- see that method's docstring -- so
+        the transactional UPDATE completes and the database WILL land on
+        `status` regardless. If the cancellation is left to propagate
+        unpatched, the cached dict (`ItemsPane.items`/`_selected_content_
+        item`/`ContentPane.item`) is stranded reading the pre-write value
+        forever, diverged from a database the app itself just wrote -- the
+        same stale-cache data-loss shape `_mark_item_read_on_open` and
+        `_mark_item_unread` already guard the read side of. So the
+        `CancelledError` handler below applies the SAME patch the normal
+        continuation would have, synchronously (no `await`, so it cannot
+        itself be suspended or re-cancelled), before re-raising so the
+        cancellation still propagates as normal and the `refresh` tail below
+        correctly does not run for a superseded write.
         """
         notify = getattr(self.app_instance, "notify", None)
         try:
@@ -6652,6 +6748,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if notify_toast and callable(notify):
                 label = "unread" if status == "new" else status
                 notify(f"Item marked {label}.", severity="information")
+        except asyncio.CancelledError:
+            # F2a: the write is durable even though this coroutine is not --
+            # see the docstring above. Patch the cache to match the database
+            # write that is happening (or has already happened) regardless.
+            if patch_item is not None:
+                patch_item["status"] = status
+                self._repaint_item_status_cell(patch_item.get("id"), status)
+            raise
         except Exception:
             logger.opt(exception=True).warning(f"Failed to mark item {status}.")
             if notify_toast and callable(notify):
@@ -6691,6 +6795,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         the calling (event-loop) thread, and passed into the thread body as a
         plain string -- the worker body itself must never read a screen
         reactive directly.
+
+        Fix wave (F4, Minor, docs-only): this OS thread is not cancellable --
+        `asyncio.to_thread`'s underlying executor future can only be
+        cancelled before it starts running, and by the time an
+        `exclusive=True` supersede on either status-writing worker group
+        actually delivers a `CancelledError` (at the `await` on the last line
+        below), this thread already has started. So a "last press wins"
+        contract for repeat Ingest/Ignore-then-Ignore/Ingest on the SAME item
+        (`_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX`'s per-item group) is NOT
+        guaranteed at the database: the superseded write's thread and its
+        replacement's thread are two independent, un-ordered zombies racing
+        each other to the same row, and either can land last. The per-item
+        group bounds what the UI settles on (whichever write's continuation
+        runs last patches the cache and repaints the cell), not what order
+        the two durable writes commit in.
 
         Returns:
             The controller's result dict, unused by the only current caller

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -202,6 +202,28 @@ NOISE_SELECTORS_SAVED_TOAST = (
 #: `_mark_item_read_on_open`'s `run_worker` call.
 _ITEM_STATUS_WORKER_GROUP = "wl-item-status"
 
+#: Per-item worker group prefix for the Ingest/Ignore actions (TASK-1541).
+#: `_ITEM_STATUS_WORKER_GROUP` above already gives the read/unread pair their
+#: own group so a fast `j` run's mark-read write cannot cancel an unrelated
+#: "Check now" fetch; Ingest/Ignore never got the same treatment and stayed
+#: in the plain `exclusive=True` default group shared with ~25 other call
+#: sites. That was harmless only because the write itself ran synchronously
+#: with no real `await` boundary a cancellation could land on -- see
+#: `_update_item_status_off_loop`'s docstring. Moving the write onto
+#: `asyncio.to_thread` gives it a genuine suspension point, so leaving Ingest/
+#: Ignore in the default group would newly let an unrelated action (or a
+#: DIFFERENT item's Ingest/Ignore) cancel this item's in-flight write --
+#: exactly the risk that matters here, since `SubscriptionsDB` sets no
+#: `busy_timeout` pragma and a contended write can sit for the length of
+#: SQLite's default lock wait while the user is free to select a different
+#: item in the meantime. Formatting the group per item id (rather than one
+#: shared group, or `_ITEM_STATUS_WORKER_GROUP` itself) means only a REPEAT
+#: Ingest/Ignore on the SAME item supersedes its own earlier write -- the
+#: same "last press wins" contract `_toggle_briefing_queue` already accepts
+#: for the briefing-queue flag -- while two DIFFERENT items' writes can never
+#: cancel each other.
+_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX = "wl-item-status-action:"
+
 #: Item statuses the reader's "Mark unread" button must never overwrite: they
 #: are not read/unread states at all, and `new` would destroy the record.
 #: A frozenset, since `_blocking_status_for` now asks the backend for the
@@ -6401,7 +6423,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         entity = event.entity
         if entity is None:
             return
-        self.run_worker(self._update_item_status(entity.get("id"), "ingested"), exclusive=True)
+        item_id = entity.get("id")
+        self.run_worker(
+            self._update_item_status(item_id, "ingested"),
+            exclusive=True,
+            # TASK-1541: per-item group, not the default one -- see
+            # `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX`'s note.
+            group=f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}{item_id}",
+        )
 
     @on(IgnoreRequested)
     def handle_ignore_requested(self, event: IgnoreRequested) -> None:
@@ -6409,7 +6438,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         entity = event.entity
         if entity is None:
             return
-        self.run_worker(self._update_item_status(entity.get("id"), "ignored"), exclusive=True)
+        item_id = entity.get("id")
+        self.run_worker(
+            self._update_item_status(item_id, "ignored"),
+            exclusive=True,
+            # TASK-1541: per-item group, not the default one -- see
+            # `_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX`'s note.
+            group=f"{_ITEM_STATUS_ACTION_WORKER_GROUP_PREFIX}{item_id}",
+        )
 
     @on(ToggleBriefingQueueRequested)
     def handle_toggle_briefing_queue_requested(
@@ -6594,14 +6630,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `ItemsPane.items`/`_selected_content_item`/`ContentPane.item` -- is
         mutated in place instead, so a later status check already sees the
         new value without forcing a rebuild.
+
+        TASK-1541: the write itself goes through `_update_item_status_
+        off_loop`, not a direct `await self._controller.update_item_status(
+        ...)`. See that method's docstring for why a plain `await` here still
+        ran the transactional `SubscriptionsDB.mark_item_status` UPDATE on
+        the event-loop thread despite this coroutine already being dispatched
+        through `run_worker`.
         """
         notify = getattr(self.app_instance, "notify", None)
         try:
-            await self._controller.update_item_status(
-                runtime_backend=self.runtime_backend,
-                item_id=item_id,
-                status=status,
-            )
+            await self._update_item_status_off_loop(item_id=item_id, status=status)
             if patch_item is not None:
                 patch_item["status"] = status
                 # Whole-branch review (Important): the in-place patch is
@@ -6620,6 +6659,55 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if refresh:
             self.run_worker(self._load_items(), exclusive=True)
             self._refresh_overview_data()
+
+    async def _update_item_status_off_loop(
+        self, *, item_id: Any, status: str
+    ) -> dict[str, Any]:
+        """Drive the item-status write to completion off the UI thread.
+
+        TASK-1541. `_update_item_status` used to `await
+        self._controller.update_item_status(...)` directly, and every layer
+        of that call chain -- `WatchlistsBackendController.update_item_status`
+        -> `WatchlistScopeService.update_item` -> `LocalWatchlistsService.
+        update_item` -> `SubscriptionsDB.mark_item_status` -- is an `async
+        def` with no genuine `await` of its own. `_maybe_await` (the
+        controller's own helper) only awaits a value that is ALREADY
+        awaitable; it never puts a plain synchronous call on a thread. So
+        awaiting that chain runs the whole thing, including the transactional
+        `UPDATE`, synchronously to completion on whichever thread awaits the
+        outermost coroutine -- and `run_worker` only *schedules* a coroutine
+        back onto this SAME event loop, it does not move it to a thread
+        (identical shape to `_toggle_briefing_queue`'s fix, whose docstring
+        names this exact trap). `SubscriptionsDB` sets no `busy_timeout`
+        pragma, so a second app instance (or a background check) contending
+        for the same row blocked the UI thread for the length of the lock
+        wait, not just the write.
+
+        Mirrors `library_screen.py`'s `_run_library_service_call(...,
+        isolate_in_worker=True)`: `asyncio.to_thread` gives the worker thread
+        no event loop of its own, so `asyncio.run` builds a throwaway one
+        there to drive the controller coroutine to completion, rather than
+        resuming it back on this loop. `runtime_backend` is read here, on
+        the calling (event-loop) thread, and passed into the thread body as a
+        plain string -- the worker body itself must never read a screen
+        reactive directly.
+
+        Returns:
+            The controller's result dict, unused by the only current caller
+            but kept so a future caller does not have to re-add it.
+        """
+        runtime_backend = self.runtime_backend
+
+        def _invoke() -> dict[str, Any]:
+            return asyncio.run(  # policy-exception: worker-thread loop
+                self._controller.update_item_status(
+                    runtime_backend=runtime_backend,
+                    item_id=item_id,
+                    status=status,
+                )
+            )
+
+        return await asyncio.to_thread(_invoke)
 
     def _repaint_item_status_cell(self, item_id: Any, status: str) -> None:
         """Push a patched status into the mounted Items table's Status cell."""


### PR DESCRIPTION
## Why

Every item-status write on the Watchlists screen (Ingest, Ignore, unread-toggle, mark-read-on-open) ran its transactional `SubscriptionsDB` write **on the UI thread** — `run_worker` on a coroutine only reschedules onto the same loop, and the backend controller's `_maybe_await` never wraps sync calls. With no `busy_timeout` configured, any lock contention (a second instance, a background check) froze the UI for the duration (task-1541, found during an earlier task's review which fixed only its own new write).

## What

- `_update_item_status`'s write moved off-loop via `asyncio.to_thread`, following the screen's own `_toggle_briefing_queue` precedent; thread-identity test pins the *write* thread via a spy recording `get_ident()`.
- Ingest/Ignore moved from the shared "default" worker group to a **per-item** group — same-item repeats still supersede; different items can no longer cancel each other or be cancelled by unrelated default-group work (AC #2). The unread/mark-read pair keeps its intentional cross-item supersede group (fast j/k coalescing).
- **Review find (Important, data-loss):** moving the write off-loop un-inerted a cancellation point — fast j/k could cancel a mark-read *continuation* after its durable write landed, leaving the cache claiming `new` while the DB said `reviewed`; re-opening the item then overwrote an `ingested` status via the cache-gated mark-read-on-open. Fixed twice over: the CancelledError handler now synchronously patches the cache to match the durable write before re-raising, and mark-read-on-open gained a backend-side terminal-status gate. Mutation-proven in both directions.
- **Review find (flake refuted as "inherent"):** the fix amplified a pre-existing racy test (measured 12.5% → 45.8% at n=24) that polled the DB and never awaited the screen's recompose; fixed with the repo's own `wait_for_selector` helper — assertions byte-identical, 20/20 twice after.
- Minor hardening: `item_id=None` can't collapse per-item groups (guarded + pinned); docstring states DB write ordering is bounded by the supersede group only in the UI, not the DB. Follow-up task-1930 filed for two parked Minors (narrow write-fail+cancel race; `_mark_item_unread`'s milder sibling gap).

## Testing

452 passed across the Watchlists/UI item-action suites (1 unrelated rotating-victim mount race in an untouched file, 5/5 in isolation); the previously-flaky test 20/20 twice; new cancellation-coherence, overwrite-prevention, and group-collision tests all mutation-verified. Opus whole-branch review → fix wave → scoped re-review APPROVED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Watchlists item-status writes off the UI event loop and replaces cancellation-based supersede with a per-item desired-status drainer so the last action deterministically wins without cross-item interference. Prevents UI freezes and stale/overwritten states; addresses task-1541 and supersedes task-1930.

- **Refactors**
  - Introduced `_ItemStatusIntent`, `_dispatch_item_status`, and per-item drain workers (`_ITEM_STATUS_DRAIN_GROUP_PREFIX`) that coalesce desired status; each item has at most one queued and one in-flight write, and the drainer awaits completion before checking again.
  - Added `_update_item_status_off_loop` (uses `asyncio.to_thread`) to run `SubscriptionsDB.mark_item_status` off-loop; removed `CancelledError` handling and deleted `_mark_item_unread`/`_confirm_new_then_mark_item_read_on_open`.
  - Added inside-drain backend gate `_item_status_write_allowed` for unread and mark-read-on-open to avoid overwriting ingest/ignore done behind the cache.
  - Guarded id-less entities in Ingest/Ignore to avoid collapsing into a shared worker group.

- **Tests**
  - New tests pin off-loop writes (thread identity), coalescing determinism for rapid opposing actions, the inside-drain gate when ingest happens behind a stale cache, and error-toast behavior on failed writes.
  - Stabilized the flaky content-pane test with `wait_for_selector` waits; existing item-action assertions remain unchanged.

<sup>Written for commit f34349ff842c6ac9a5b8e5ff5528e618a7ad14eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

