### PR TITLE
Console tests: make the browser-row flake self-describing (TASK-1900, partial)

### DIFF
--- a/Tests/UI/test_console_browser_search_echo.py
+++ b/Tests/UI/test_console_browser_search_echo.py
@@ -1,0 +1,153 @@
+"""TASK-1900: the browser search input's mount echo must not exist.
+
+`ConsoleWorkspaceContextTray.sync_state` recomposes unconditionally, so every
+sync re-mounts a fresh search `Input`. Textual's `Input._watch_value` posts
+`Changed` for a constructor-set value unconditionally (the `_initial_value`
+flag only positions the cursor), and that echo travels the message pump --
+on a busy machine it lands AFTER the user typed a newer query. The screen's
+`Changed` handler cannot tell the echo from typing, so it overwrote the
+newer query with the older one and bumped the search token, discarding the
+in-flight fresh search. A user typing quickly on a loaded machine had their
+search silently revert.
+
+That echo is also what made
+`test_console_conversation_browser_search_ignores_stale_results` fail ~1 run
+in 5 (3/3 with CPU burners alongside): the "stale result" the failure showed
+was the echo re-arming the stale QUERY, not the stale search's rows winning.
+"""
+from __future__ import annotations
+
+import pytest
+from textual import on
+from textual.app import App, ComposeResult
+from textual.widgets import Input
+
+from tldw_chatbook.Widgets.Console.console_workspace_context import (
+    ConsoleBrowserSearchInput,
+)
+
+
+class _EchoRecorder(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.changed_values: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleBrowserSearchInput(
+            initial_value="alpha",
+            id="probe-search",
+        )
+
+    @on(Input.Changed)
+    def _record(self, event: Input.Changed) -> None:
+        self.changed_values.append(str(event.value))
+
+
+@pytest.mark.asyncio
+async def test_a_constructor_value_posts_no_changed_echo():
+    """Mounting with a value is display restoration, not a user edit."""
+    app = _EchoRecorder()
+    async with app.run_test() as pilot:
+        for _ in range(6):
+            await pilot.pause()
+
+        probe = app.query_one("#probe-search", Input)
+        assert probe.value == "alpha", "the initial value must still display"
+        assert app.changed_values == [], (
+            "the mount echo is back: a recomposed tray would re-arm a stale "
+            f"query as if the user typed it: {app.changed_values}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_typing_still_posts_changed():
+    """Suppressing the echo must not eat genuine edits."""
+    app = _EchoRecorder()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#probe-search", Input).focus()
+        await pilot.pause()
+        await pilot.press("x")
+        await pilot.pause()
+
+        assert app.changed_values, "a real keystroke no longer posts Changed"
+        # Textual 8's `select_on_focus` selects the restored text, so the
+        # keystroke replaces it -- "x", not "alphax". The claim under test is
+        # that the edit POSTS, not what the edit does to the selection.
+        assert app.changed_values[-1] == "x"
+
+
+@pytest.mark.asyncio
+async def test_the_tray_mounts_the_echo_free_input():
+    """The fix only holds if the TRAY constructs the subclass.
+
+    The two tests above exercise `ConsoleBrowserSearchInput` directly, so a
+    regression that swaps the tray's compose back to a plain
+    `Input(value=...)` would leave them green while the echo returns. This
+    drives the real tray through a sync carrying a query and listens for the
+    echo at the app, exactly where the screen's handler sits.
+    """
+    from tldw_chatbook.Workspaces.conversation_browser_state import (
+        build_console_conversation_browser_state,
+    )
+    from tldw_chatbook.Widgets.Console.console_workspace_context import (
+        ConsoleWorkspaceContextTray,
+    )
+    from tldw_chatbook.Workspaces.display_state import (
+        ConsoleWorkspaceContextState,
+    )
+
+    browser = build_console_conversation_browser_state(
+        rows=(),
+        active_workspace_id=None,
+        group_collapse_preferences={},
+        query="alpha",
+        marks_available=False,
+        error_copy="",
+        result_total_count=None,
+    )
+    state = ConsoleWorkspaceContextState(
+        heading="Workspace",
+        workspace_label="Default",
+        authority_label="",
+        sync_label="",
+        runtime_label="",
+        conversation_rows=(),
+        conversation_empty_copy="",
+        conversation_browser=browser,
+        change_workspace_enabled=False,
+        change_workspace_recovery="",
+        new_conversation_enabled=False,
+        new_conversation_recovery="",
+        recovery_copy="",
+    )
+
+    class _TrayHarness(App[None]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.changed_values: list[str] = []
+
+        def compose(self) -> ComposeResult:
+            yield ConsoleWorkspaceContextTray(state, id="console-workspace-context")
+
+        @on(Input.Changed, "#console-workspace-conversation-search")
+        def _record(self, event: Input.Changed) -> None:
+            self.changed_values.append(str(event.value))
+
+    app = _TrayHarness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tray = app.query_one(ConsoleWorkspaceContextTray)
+        # Sync AGAIN with the same query: the recompose this schedules is the
+        # production-shaped echo source (`sync_state` recomposes on every
+        # sync, and the flake's trigger was a recompose, not first mount).
+        tray.sync_state(state)
+        for _ in range(8):
+            await pilot.pause()
+
+        search = app.query_one("#console-workspace-conversation-search", Input)
+        assert search.value == "alpha", "the query text must still display"
+        assert app.changed_values == [], (
+            "the recomposed tray's search input echoed its restored query as "
+            f"a user edit: {app.changed_values}"
+        )

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from copy import deepcopy
 import inspect
 import json
@@ -5328,8 +5329,37 @@ def _browser_star_button(console, conversation_id: str) -> Button:
     )
 
 
+#: Wall-clock budget for browser-row renders (TASK-1900). Deliberately
+#: generous: this waits on a RENDER, and render latency scales with machine
+#: load in a way an iteration count cannot express.
+_BROWSER_ROW_RENDER_TIMEOUT = 15.0
+
+
 async def _wait_for_browser_conversation_row(console, pilot, conversation_id: str):
-    for _ in range(80):
+    """Wait for a browser row to render, on a wall-clock deadline.
+
+    TASK-1900. This used to spin a fixed `for _ in range(80)` over
+    `pilot.pause(0.05)` and call it four seconds. It is not four seconds: on
+    a busy machine each pause overruns AND the render itself takes longer,
+    so the budget shrinks exactly when it needs to grow. That made
+    `test_console_conversation_browser_search_ignores_stale_results` fail
+    about one run in five, and 3/3 with four CPU burners alongside -- while
+    the screen's `_console_conversation_browser_rows` state was already
+    correct. The test was right, the clock was wrong.
+
+    Args:
+        console: The mounted Console screen.
+        pilot: Its `Pilot`, used to let the event loop settle between polls.
+        conversation_id: Row to wait for.
+
+    Returns:
+        The rendered row widget.
+
+    Raises:
+        AssertionError: If the row has not rendered within the deadline.
+    """
+    deadline = time.monotonic() + _BROWSER_ROW_RENDER_TIMEOUT
+    while time.monotonic() < deadline:
         for row in console.query(".console-workspace-conversation-row"):
             if getattr(row, "conversation_id", None) == conversation_id:
                 return row
@@ -6071,6 +6101,18 @@ async def test_console_conversation_browser_search_ignores_stale_results():
         console._console_conversation_browser_search_token += 1
         fresh_token = console._console_conversation_browser_search_token
         await console._refresh_console_conversation_browser_search("beta", fresh_token)
+
+        # TASK-1900: assert the CLAIM first, on state that is correct
+        # synchronously once the refresh returns. The widget check below waits
+        # on a render, so when it was the only assertion a slow machine looked
+        # exactly like a stale result winning -- the failure said "row not
+        # found. Rows: [stale-alpha]" while the state already held only
+        # fresh-beta. Now a real regression fails here and names itself, and a
+        # render that is merely late fails below saying so.
+        assert [row.conversation_id for row in console._console_conversation_browser_rows] == [
+            "fresh-beta"
+        ], "the stale search result overwrote the fresh one"
+
         await _wait_for_browser_conversation_row(console, pilot, "fresh-beta")
         row_texts = _console_workspace_conversation_texts(console)
         assert all("Stale Alpha" not in text for text in row_texts)

--- a/backlog/tasks/task-1900 - Console UI suites fail under random ordering.md
+++ b/backlog/tasks/task-1900 - Console UI suites fail under random ordering.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1900
 title: 'Console UI suites: one test fails per full-sweep run under random ordering'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-02 08:00'
 labels:
@@ -33,10 +33,11 @@ Cost: a full sweep is not currently a reliable signal — a single red test that
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The polluting test (or shared-state seam) is identified by name, not guessed at
-- [ ] #2 The sweep passes repeatedly under several different random seeds
-- [ ] #3 The shared state involved is reset per test rather than the victim test being made tolerant of dirt
-- [ ] #4 A regression test fails if that shared state leaks between tests again
+- [x] #1 REWRITTEN -- the premise was wrong. It is not pollution: the test fails ALONE. Cause characterised below.
+- [ ] #2 `test_console_conversation_browser_search_ignores_stale_results` passes 20 consecutive runs alone
+- [ ] #3 It also passes with four CPU burners alongside, which reproduces it 3/3 today
+- [ ] #4 The root cause is named -- why the rendered row list does not converge to a state that is provably already correct
+- [ ] #5 Whether this is reachable by a real user (a search whose results never repaint) is answered yes or no, with evidence
 <!-- AC:END -->
 
 ## Update: at least one test is intrinsically flaky, not order-dependent
@@ -50,6 +51,18 @@ run 1: 1 failed   run 2: 1 passed   run 3: 1 passed   run 4: 1 passed   run 5: 1
 Failure is always `Browser row 'fresh-beta' not found. Rows: [('stale-alpha', ...)]` -- the search result arrives after the assertion, so it is a missing await/settle, not pollution.
 
 This cost real time: it failed on a feature branch, passed on that branch's base in the same environment, and the obvious conclusion ("my change broke it") was wrong. Bisecting a diff against a coin-flip test is unfalsifiable -- **run a suspect test 5x before attributing a failure to a change.**
+
+## Investigation (2026-08-02): three hypotheses killed
+
+**Not pollution.** Fails run entirely alone, `-p no:randomly`, ~1 in 5.
+
+**Not a product race in the search guard.** `_refresh_console_conversation_browser_search` re-checks both the token and the query AFTER its await, before mutating. Verified by instrumenting the failing run: at the moment of failure `_console_conversation_browser_rows` holds exactly `['fresh-beta']` -- the correct, fresh result. The stale result does NOT win.
+
+**Not the wait budget.** The helper spun a fixed `for _ in range(80)` over `pilot.pause(0.05)` -- "four seconds" that shrinks precisely when the machine is busy. Replacing it with a 15-SECOND WALL-CLOCK deadline did not help: still fails, and the rendered list still shows only `stale-alpha` after the full 15s. An explicit `_sync_console_workspace_context()` + pause before the wait fixed it only 1 run in 3.
+
+**What is left, and it is the interesting part:** the screen's row STATE is correct and the RENDERED row list never converges to it, given 15 seconds. That is either a missed refresh/recompose trigger on the browser row list, or something in the harness that stops pumping -- not yet distinguished, which is AC#4. AC#5 matters because if it is the former, a real user's conversation search can show stale rows indefinitely.
+
+Reproducer: run the test with four busy-loop processes alongside -- 3/3 failures. Alone, ~1 in 5.
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-1900 - Console UI suites fail under random ordering.md
+++ b/backlog/tasks/task-1900 - Console UI suites fail under random ordering.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1900
 title: 'Console UI suites: one test fails per full-sweep run under random ordering'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-02 08:00'
 labels:
@@ -34,10 +34,10 @@ Cost: a full sweep is not currently a reliable signal — a single red test that
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 REWRITTEN -- the premise was wrong. It is not pollution: the test fails ALONE. Cause characterised below.
-- [ ] #2 `test_console_conversation_browser_search_ignores_stale_results` passes 20 consecutive runs alone
-- [ ] #3 It also passes with four CPU burners alongside, which reproduces it 3/3 today
-- [ ] #4 The root cause is named -- why the rendered row list does not converge to a state that is provably already correct
-- [ ] #5 Whether this is reachable by a real user (a search whose results never repaint) is answered yes or no, with evidence
+- [x] #2 `test_console_conversation_browser_search_ignores_stale_results` passes 20 consecutive runs alone
+- [x] #3 It also passes with four CPU burners alongside, which reproduces it 3/3 today
+- [x] #4 The root cause is named -- why the rendered row list does not converge to a state that is provably already correct
+- [x] #5 Whether this is reachable by a real user (a search whose results never repaint) is answered yes or no, with evidence
 <!-- AC:END -->
 
 ## Update: at least one test is intrinsically flaky, not order-dependent
@@ -63,6 +63,25 @@ This cost real time: it failed on a feature branch, passed on that branch's base
 **What is left, and it is the interesting part:** the screen's row STATE is correct and the RENDERED row list never converges to it, given 15 seconds. That is either a missed refresh/recompose trigger on the browser row list, or something in the harness that stops pumping -- not yet distinguished, which is AC#4. AC#5 matters because if it is the former, a real user's conversation search can show stale rows indefinitely.
 
 Reproducer: run the test with four busy-loop processes alongside -- 3/3 failures. Alone, ~1 in 5.
+
+## Root cause (found by instrumenting the state PASSED to sync, not the state held)
+
+The failing run's tail showed the smoking gun: `sync_state q='beta'` ... then `q='alpha'` three times, LATE. The stale query comes BACK.
+
+The loop:
+
+1. `ConsoleWorkspaceContextTray.sync_state` recomposes unconditionally (correct -- its docstring documents why an equality guard is unsafe), so every sync re-mounts a fresh search `Input(value=browser.query)`.
+2. Textual 8's `Input._watch_value` posts `Changed` for a constructor-set value unconditionally -- verified in the installed source; its `_initial_value` flag only positions the cursor.
+3. That echo travels the message pump. On a busy machine it lands AFTER the user typed a newer query.
+4. `on_console_workspace_conversation_search_changed` cannot tell an echo from typing: `'alpha' != 'beta'` looks like an edit, so it overwrites the query, BUMPS THE TOKEN (discarding the fresh in-flight search via the refresh's own token guard), rebuilds rows for the stale query, and re-arms the debounce.
+
+**AC#5: yes, user-reachable.** Type "alpha", results arrive slowly, type "beta" -- on a loaded machine the search reverts to "alpha" and beta's results are silently discarded. Same defect family as the Theme whole-app freeze (init/load echo feeding a recompose reactive).
+
+Why the earlier diagnosis said "state right, render wrong": the state was sampled immediately after the fresh refresh returned, BEFORE the echo landed and flipped it back. Both observations were true at their instants; the flip happened between them.
+
+Fix at the source: `ConsoleBrowserSearchInput` applies its initial value in `on_mount` inside `self.prevent(Input.Changed)` -- Textual's documented mechanism for a programmatic set without a message. The handler's invariant ("every Changed from this box is a real edit") becomes true instead of being guessed at. Mutation-verified at the TRAY level, where the mutation reproduces the exact `['alpha', 'alpha', 'alpha']` echo train from the failing diagnostic.
+
+Evidence: previously 3/3 failing under four CPU burners -> 6/6 passing under the same load; 20/20 consecutive unloaded runs.
 
 ## Implementation Notes
 

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -33,6 +33,47 @@ from tldw_chatbook.Workspaces.display_state import (
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 
+class ConsoleBrowserSearchInput(Input):
+    """Search input whose initial value never echoes as a user edit.
+
+    TASK-1900. `ConsoleWorkspaceContextTray.sync_state` recomposes
+    unconditionally (see its own docstring for why an equality guard is
+    unsafe), so every sync re-mounts a fresh search input. Textual's
+    `Input._watch_value` posts `Changed` for a constructor-set value
+    unconditionally -- its `_initial_value` flag only positions the cursor --
+    and that echo travels the message pump, so on a busy machine it lands
+    AFTER the user typed a newer query. The screen's `Changed` handler
+    cannot tell an echo from typing: it overwrote the newer query with the
+    older one and bumped the search token, silently discarding the fresh
+    in-flight search. Symptom at user level: type "alpha", then quickly
+    "beta" -- the search reverts to "alpha".
+
+    The fix removes the echo at the source instead of teaching the handler
+    to guess: the value is applied in `on_mount` inside
+    `self.prevent(Input.Changed)`, Textual's documented mechanism for a
+    programmatic set without a message. The invariant the handler relies on
+    -- every `Changed` from this box is a real edit -- becomes true.
+    """
+
+    def __init__(self, *args: object, initial_value: str = "", **kwargs: object) -> None:
+        """Store the display value without arming the reactive.
+
+        Args:
+            *args: Forwarded to `Input` unchanged.
+            initial_value: Query text to display once mounted. Deliberately
+                NOT passed to `Input(value=...)` -- that is the echo path.
+            **kwargs: Forwarded to `Input` unchanged.
+        """
+        super().__init__(*args, **kwargs)
+        self._initial_display_value = initial_value
+
+    def on_mount(self) -> None:
+        """Apply the initial value silently, then behave like any Input."""
+        if self._initial_display_value:
+            with self.prevent(Input.Changed):
+                self.value = self._initial_display_value
+
+
 # One vocabulary for persisted-but-not-archived chats across surfaces:
 # "saved chat". Rows reach this map with either a workspace-membership role
 # ("workspace-thread"/"workspace") or a persisted conversation state
@@ -1025,8 +1066,8 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             id="console-workspace-conversation-search-row",
             classes="console-workspace-conversation-search-row",
         ):
-            search_input = Input(
-                value=browser.query,
+            search_input = ConsoleBrowserSearchInput(
+                initial_value=browser.query,
                 placeholder="Search conversations",
                 id="console-workspace-conversation-search",
                 classes="console-workspace-conversation-search",


### PR DESCRIPTION
**Root cause found and fixed.** The first commit's honest framing ("this is not a fix") stands as history; this PR now closes TASK-1900, and what looked like a flaky test was a **real, user-reachable bug**: type "alpha", results arrive slowly, type "beta" — on a busy machine the search silently reverts to "alpha" and beta's in-flight results are discarded.

## The loop, each link verified

1. `ConsoleWorkspaceContextTray.sync_state` recomposes unconditionally (correct — its docstring documents why an equality guard is unsafe), so every sync re-mounts a fresh search `Input(value=browser.query)`.
2. Textual 8's `Input._watch_value` posts `Changed` for a constructor-set value unconditionally — verified in the installed source; its `_initial_value` flag only positions the cursor.
3. The echo travels the message pump, so under load it lands **after** the user typed a newer query.
4. The screen's `Changed` handler cannot tell an echo from typing: `'alpha' != 'beta'` looks like an edit, so it overwrites the query, **bumps the token** — the refresh's own guard then discards the fresh result — and repaints the stale rows.

The decisive instrument was printing the query on the state **passed to** `sync_state`: the failing tail read `q='beta'` … then `q='alpha'` three times, late. The first commit's "state right, render wrong" was a sampling artifact — both readings were true at their instants; the echo flipped the state between them.

## The fix

`ConsoleBrowserSearchInput` applies its initial value in `on_mount` inside `self.prevent(Input.Changed)` — Textual's documented mechanism for a message-free programmatic set. The handler's invariant (*every Changed from this box is a real edit*) becomes true instead of being guessed at.

**Mutation-verified at the tray level**: swapping the tray back to `Input(value=...)` fails the new test with `['alpha', 'alpha', 'alpha']` — the exact echo train from the failing diagnostic. The unit tests alone would *not* catch that mutation (they drive the subclass directly), which is why the tray-level test exists.

## Evidence

| condition | before | after |
|---|---|---|
| four CPU burners alongside | 3/3 **failed** | 6/6 passed |
| unloaded, consecutive | ~1 in 5 failed | 20/20 passed |

The earlier commit's state assertion stays: a real stale-result regression now fails naming itself, instead of masquerading as slowness.

499 passed across the tray, workspace and native-chat-flow suites. One unrelated geometry test flaked once in a combined run that executed concurrently with the 20-run soak (load again); 5/5 isolated, full rail file green on re-run.
