### PR TITLE
feat(evals): character probe phase 3a — the tag vocabulary

### DIFF
--- a/Tests/Evals/character_probe/test_bench_storage.py
+++ b/Tests/Evals/character_probe/test_bench_storage.py
@@ -8,6 +8,7 @@ from tldw_chatbook.Evals.character_probe.storage import (
     load_character_bench,
     save_character_bench,
 )
+from tldw_chatbook.Evals.character_probe.tags import Tag
 
 
 @pytest.fixture
@@ -260,3 +261,75 @@ def test_character_ids_must_be_integers():
         CharacterProbeConfig(
             name="n", probe_set_id="p", character_ids=("3", "7"), target_ids=("t",)
         )
+
+
+def test_extra_tags_round_trip_as_tag_objects(db, config):
+    tagged = CharacterProbeConfig(
+        **{
+            **config.__dict__,
+            "extra_tags": (Tag("meta-commentary", "Meta commentary", "failure"),),
+        }
+    )
+    bench_id = save_character_bench(db, tagged)
+    loaded = load_character_bench(db, bench_id)
+    assert loaded.extra_tags == (Tag("meta-commentary", "Meta commentary", "failure"),)
+
+
+def test_extra_tags_supplied_as_mappings_are_validated_and_coerced(db, config):
+    tagged = CharacterProbeConfig(
+        **{
+            **config.__dict__,
+            "extra_tags": ({"slug": "Meta Commentary", "kind": "notable"},),
+        }
+    )
+    bench_id = save_character_bench(db, tagged)
+    loaded = load_character_bench(db, bench_id)
+    assert loaded.extra_tags[0].slug == "meta-commentary"
+    assert loaded.extra_tags[0].kind == "notable"
+
+
+def test_an_extra_tag_without_a_kind_is_rejected_at_construction(config):
+    with pytest.raises(ValueError) as exc:
+        CharacterProbeConfig(
+            **{**config.__dict__, "extra_tags": ({"slug": "meta-commentary"},)}
+        )
+    assert "meta-commentary" in str(exc.value)
+
+
+def test_a_malformed_extra_tag_is_rejected_even_when_not_strict():
+    """strict=False is for DRAFT benches, not for corrupt tags."""
+    with pytest.raises(ValueError):
+        CharacterProbeConfig(
+            name="draft",
+            probe_set_id="ps-1",
+            character_ids=(),
+            target_ids=(),
+            extra_tags=({"slug": "meta", "kind": "not-a-kind"},),
+            strict=False,
+        )
+
+
+def test_a_bench_row_written_before_this_phase_still_loads(db, config):
+    """extra_tags shipped as raw dicts; existing rows must not break."""
+    bench_id = save_character_bench(db, config)
+    _corrupt_config_field(
+        db,
+        bench_id,
+        "extra_tags",
+        '[{"slug": "meta-commentary", "label": "Meta commentary", "kind": "failure"}]',
+    )
+    loaded = load_character_bench(db, bench_id)
+    assert loaded.extra_tags == (Tag("meta-commentary", "Meta commentary", "failure"),)
+
+
+def test_a_bench_row_with_corrupt_tags_raises_naming_the_bench(db, config):
+    bench_id = save_character_bench(db, config)
+    _corrupt_config_field(db, bench_id, "extra_tags", '["not-a-mapping"]')
+    with pytest.raises(ValueError) as exc:
+        load_character_bench(db, bench_id)
+    assert bench_id in str(exc.value)
+
+
+def test_a_bench_with_no_extra_tags_still_loads_as_empty(db, config):
+    bench_id = save_character_bench(db, config)
+    assert load_character_bench(db, bench_id).extra_tags == ()

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -672,6 +672,72 @@ def test_omitting_vocabulary_still_validates_against_the_runs_captured_vocabular
     assert load_turn_annotations(db, probe_run_group) == {}
 
 
+# --- annotate_turn's `vocabulary` param normalises its input (Qodo review
+# PR #1216, finding 4) ---------------------------------------------------
+#
+# The tests above pass `vocabulary` as `Tag` objects built from
+# `run_group_vocabulary`. A caller may instead hold the mapping/JSON form
+# stored rows and run snapshots use -- `annotate_turn` used to access
+# `tag.slug` directly and crash with an uncontrolled `AttributeError` on
+# that shape. It also never enforced kind-immutability against a supplied
+# vocabulary. Both are closed by running the supplied vocabulary through
+# `resolve_vocabulary` (which itself runs each entry through `coerce_tag`),
+# the same normalisation a stored vocabulary already gets.
+
+
+def test_an_explicit_vocabulary_given_as_mappings_is_accepted(db, probe_run_group):
+    """A caller holding a vocabulary read back from JSON -- the mapping
+    form, not `Tag` objects -- can still pass it to `vocabulary` directly."""
+    mapping_vocabulary = [
+        {"slug": tag.slug, "label": tag.label, "kind": tag.kind}
+        for tag in BUILTIN_TAGS
+    ] + [{"slug": "meta-commentary", "label": "Meta commentary", "kind": "failure"}]
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["meta-commentary"], note="",
+        vocabulary=mapping_vocabulary,
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["meta-commentary"]
+
+
+def test_a_malformed_explicit_vocabulary_entry_raises_a_named_valueerror(
+    db, probe_run_group
+):
+    """Before this fix, a mapping-shaped `vocabulary` entry with no `slug`
+    crashed with an uncontrolled `AttributeError` from `tag.slug` on a
+    plain dict. It must instead raise a named `ValueError`, matching every
+    other malformed-tag path in this module (`coerce_tag`,
+    `resolve_vocabulary`)."""
+    with pytest.raises(ValueError) as exc:
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["broke-character"], note="",
+            vocabulary=[{"label": "No slug here", "kind": "failure"}],
+        )
+    assert not isinstance(exc.value, AttributeError)
+    assert load_turn_annotations(db, probe_run_group) == {}
+
+
+def test_an_explicit_vocabulary_cannot_change_a_builtins_kind(db, probe_run_group):
+    """A caller-supplied vocabulary is validated through the same
+    kind-immutability rule `resolve_vocabulary` already enforces for a
+    bench's stored `extra_tags`: `refused` is a built-in `failure` tag, and
+    an explicit vocabulary trying to relabel it `positive` is refused
+    rather than silently accepted -- Phase 3b's live, session-extended
+    vocabulary must not be able to smuggle that past validation."""
+    tampered_vocabulary = [
+        {"slug": "refused", "label": "Refused", "kind": "positive"},
+    ]
+    with pytest.raises(ValueError, match="refused"):
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["refused"], note="",
+            vocabulary=tampered_vocabulary,
+        )
+    assert load_turn_annotations(db, probe_run_group) == {}
+
+
 # --- delete_task cascades probe annotations (whole-branch review I4, task-6) --
 #
 # `probe_run_group` is opened under the `bench` fixture's task_id (see the

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -607,3 +607,107 @@ def test_a_benchs_extra_tag_is_accepted(db, probe_run_group_with_extra_tags):
     )
     stored = load_turn_annotations(db, probe_run_group_with_extra_tags)
     assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["meta-commentary"]
+
+
+# --- delete_task cascades probe annotations (whole-branch review I4, task-6) --
+#
+# `probe_run_group` is opened under the `bench` fixture's task_id (see the
+# `probe_run_group` fixture above: it destructures `bench` for its
+# `task_id`). Requesting `bench` directly here, alongside `probe_run_group`,
+# yields that SAME cached task_id -- pytest caches a function-scoped fixture
+# once per test, however many other fixtures also depend on it -- so `bench`
+# is the right handle for "the bench `probe_run_group` runs under", not
+# `bench_id_of_that_run` (that fixture is a deliberately different bench,
+# carrying an extra tag, used by `probe_run_group_with_extra_tags`).
+
+
+@pytest.fixture
+def second_probe_run_group(db):
+    """A run group under a bench distinct from `probe_run_group`'s, so the
+    cascade-isolation test can prove deleting one bench does not touch
+    another's annotations.
+
+    Uses its own target name -- eval_models is UNIQUE on
+    (name, provider, model_id), and this fixture is deliberately combined
+    with `probe_run_group` (via `bench`) in the same test, which already
+    creates a target named "steered" (`_target_row`'s default).
+    """
+    config = _bench_config(name="a different bench")
+    task_id = save_character_bench(db, config)
+    group_id, _ = create_probe_run_group(
+        db,
+        task_id,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [_target_row(db, name="steered-2")],
+    )
+    return group_id
+
+
+@pytest.fixture
+def seeded_word_bench_id(db):
+    """A minimal word-bench `eval_tasks` row, written directly against
+    `create_task` the same way
+    `Tests/Evals/character_probe/test_bench_storage.py::
+    test_loading_a_word_bench_as_a_character_bench_raises` does. All this
+    test needs is a bench `delete_task` can target that is NOT a character
+    probe bench, to prove the cascade is scoped to that task's own run
+    groups rather than to every probe annotation row in the database."""
+    return db.create_task(
+        name="word bench",
+        description="",
+        task_type="logprob",
+        config_format="custom",
+        config_data={"bench_type": "word_bench"},
+    )
+
+
+def test_deleting_a_bench_removes_its_turn_annotations(db, probe_run_group, bench):
+    _config, task_id = bench
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["broke-character"], note="",
+    )
+    assert load_turn_annotations(db, probe_run_group)
+
+    db.delete_task(task_id)
+
+    assert db.list_probe_turn_annotations(probe_run_group) == []
+
+
+def test_deleting_a_bench_removes_its_review_state(db, probe_run_group, bench):
+    _config, task_id = bench
+    mark_conversation_reviewed(db, probe_run_group, 1, 0, 0, "t-1", note="fine")
+    assert db.list_probe_review_state(probe_run_group)
+
+    db.delete_task(task_id)
+
+    assert db.list_probe_review_state(probe_run_group) == []
+
+
+def test_deleting_a_bench_leaves_another_benchs_annotations_alone(
+    db, probe_run_group, bench, second_probe_run_group
+):
+    _config, task_id = bench
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0, tags=["refused"], note="",
+    )
+    annotate_turn(
+        db, second_probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["refused"], note="",
+    )
+
+    db.delete_task(task_id)
+
+    assert db.list_probe_turn_annotations(second_probe_run_group)
+
+
+def test_deleting_a_word_bench_touches_no_probe_annotation_rows(
+    db, probe_run_group, seeded_word_bench_id
+):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0, tags=["refused"], note="",
+    )
+    db.delete_task(seeded_word_bench_id)
+    assert db.list_probe_turn_annotations(probe_run_group)

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -93,11 +93,12 @@ def test_a_turn_annotation_persists_with_its_tags_and_note(db):
     assert stored["note"] == "drifted here"
 
 
-def test_re_annotating_the_same_turn_replaces_it(db):
-    run_id, target_id = _seed_run(db)
-    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 0, ["refused"], "")
-    annotate_turn(db, "rg-1", 1, 0, 0, target_id, 0, ["in-character"], "fine actually")
-    stored = load_turn_annotations(db, "rg-1")[(1, 0, 0, target_id, 0)]
+def test_re_annotating_the_same_turn_replaces_it(db, probe_run_group):
+    annotate_turn(db, probe_run_group, 1, 0, 0, "t-1", 0, ["refused"], "")
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0, ["in-character"], "fine actually"
+    )
+    stored = load_turn_annotations(db, probe_run_group)[(1, 0, 0, "t-1", 0)]
     assert stored["tags"] == ["in-character"]
 
 
@@ -534,3 +535,75 @@ def test_an_unknown_run_group_raises_naming_it(db):
     with pytest.raises(Exception) as exc:
         run_group_vocabulary(db, "no-such-group")
     assert "no-such-group" in str(exc.value)
+
+
+# --- annotate_turn tag validation (whole-branch review I4, task-5) -------
+
+
+def test_a_known_tag_is_stored(db, probe_run_group):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["broke-character"], note="third turn",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["broke-character"]
+
+
+def test_an_unknown_tag_is_rejected_naming_it(db, probe_run_group):
+    with pytest.raises(ValueError) as exc:
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["brok-charcter"], note="",
+        )
+    assert "brok-charcter" in str(exc.value)
+
+
+def test_nothing_is_written_when_one_tag_of_several_is_unknown(
+    db, probe_run_group
+):
+    with pytest.raises(ValueError):
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["broke-character", "no-such-tag"], note="",
+        )
+    assert load_turn_annotations(db, probe_run_group) == {}
+
+
+def test_a_non_canonical_tag_is_canonicalised_rather_than_rejected(
+    db, probe_run_group
+):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["Broke Character"], note="",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["broke-character"]
+
+
+def test_duplicate_tags_are_stored_once(db, probe_run_group):
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["broke-character", "broke-character"], note="",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["broke-character"]
+
+
+def test_an_annotation_with_no_tags_but_a_note_is_allowed(
+    db, probe_run_group
+):
+    """A note without a tag is a real observation, not an empty write."""
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0, tags=[], note="odd phrasing",
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["note"] == "odd phrasing"
+
+
+def test_a_benchs_extra_tag_is_accepted(db, probe_run_group_with_extra_tags):
+    annotate_turn(
+        db, probe_run_group_with_extra_tags, 1, 0, 0, "t-1", 0,
+        tags=["meta-commentary"], note="",
+    )
+    stored = load_turn_annotations(db, probe_run_group_with_extra_tags)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["meta-commentary"]

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -13,14 +13,17 @@ from tldw_chatbook.Evals.character_probe.storage import (
     annotate_turn,
     conversation_sample_id,
     create_probe_run_group,
+    load_character_bench,
     load_conversations,
     load_probe_run_snapshot,
     load_review_state,
     load_turn_annotations,
     mark_conversation_reviewed,
+    run_group_vocabulary,
     save_character_bench,
     save_conversations,
 )
+from tldw_chatbook.Evals.character_probe.tags import BUILTIN_TAGS, Tag
 
 
 @pytest.fixture
@@ -181,6 +184,46 @@ def _target_row(db, name="steered", config=None):
         name=name, provider="llama_cpp", model_id="m", config=config or {}
     )
     return db.get_model(row_id)
+
+
+@pytest.fixture
+def probe_run_group(db, bench):
+    """A run group opened under a bench with no extra tags."""
+    config, task_id = bench
+    group_id, _ = create_probe_run_group(
+        db,
+        task_id,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [_target_row(db)],
+    )
+    return group_id
+
+
+@pytest.fixture
+def bench_id_of_that_run(db):
+    """A bench carrying an extra tag, saved before any run group opens."""
+    config = _bench_config(
+        name="villain probes with extras",
+        extra_tags=(Tag("meta-commentary", "Meta commentary", "failure"),),
+    )
+    return save_character_bench(db, config)
+
+
+@pytest.fixture
+def probe_run_group_with_extra_tags(db, bench_id_of_that_run):
+    """A run group opened under a bench that carries an extra tag."""
+    config = load_character_bench(db, bench_id_of_that_run)
+    group_id, _ = create_probe_run_group(
+        db,
+        bench_id_of_that_run,
+        config,
+        _cards(),
+        ProbeSet(probes=(Probe(turns=("One",)),)),
+        [_target_row(db)],
+    )
+    return group_id
 
 
 def test_create_probe_run_group_returns_a_run_per_target(db, bench):
@@ -451,3 +494,43 @@ def test_character_probe_never_imports_the_word_bench_measurement_stack():
         source = module.read_text()
         for token in forbidden_tokens:
             assert token not in source, f"{module.name} mentions {token}"
+
+
+# --- run_group_vocabulary (whole-branch review I4, task-4) ---------------
+
+
+def test_a_run_with_no_extra_tags_has_exactly_the_builtins(db, probe_run_group):
+    assert run_group_vocabulary(db, probe_run_group) == BUILTIN_TAGS
+
+
+def test_a_runs_vocabulary_includes_the_benchs_extras_as_of_the_run(
+    db, probe_run_group_with_extra_tags
+):
+    vocab = run_group_vocabulary(db, probe_run_group_with_extra_tags)
+    assert Tag("meta-commentary", "Meta commentary", "failure") in vocab
+
+
+def test_editing_the_bench_after_the_run_does_not_change_the_runs_vocabulary(
+    db, probe_run_group_with_extra_tags, bench_id_of_that_run
+):
+    """Snapshot provenance: the run is annotated with what it captured."""
+    config = load_character_bench(db, bench_id_of_that_run)
+    save_character_bench(
+        db,
+        type(config)(
+            name=config.name,
+            probe_set_id=config.probe_set_id,
+            character_ids=config.character_ids,
+            target_ids=config.target_ids,
+            extra_tags=(),
+        ),
+        bench_id_of_that_run,
+    )
+    vocab = run_group_vocabulary(db, probe_run_group_with_extra_tags)
+    assert any(t.slug == "meta-commentary" for t in vocab)
+
+
+def test_an_unknown_run_group_raises_naming_it(db):
+    with pytest.raises(Exception) as exc:
+        run_group_vocabulary(db, "no-such-group")
+    assert "no-such-group" in str(exc.value)

--- a/Tests/Evals/character_probe/test_conversation_storage.py
+++ b/Tests/Evals/character_probe/test_conversation_storage.py
@@ -609,6 +609,69 @@ def test_a_benchs_extra_tag_is_accepted(db, probe_run_group_with_extra_tags):
     assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["meta-commentary"]
 
 
+# --- annotate_turn's optional `vocabulary` param (final review fix wave,
+# findings 1+2) --------------------------------------------------------
+#
+# Phase 3b's recommended flow creates a tag mid-review: written to the
+# bench's `extra_tags` and added to the review pane's live vocabulary, never
+# to the already-captured run snapshot. Without a way to pass that live
+# vocabulary in, such a tag would render as selectable and then raise
+# ValueError on `annotate_turn`, which only ever consulted
+# `run_group_vocabulary` (the snapshot-derived vocabulary). These tests
+# cover the new `vocabulary` parameter that closes that gap.
+
+
+def test_an_explicit_vocabulary_accepts_a_tag_not_in_the_runs_snapshot(
+    db, probe_run_group
+):
+    """`probe_run_group`'s snapshot carries no extra tags, so
+    `run_group_vocabulary` alone would reject `meta-commentary`. Passing it
+    explicitly -- standing in for a review pane's live, session-extended
+    vocabulary -- accepts and persists it anyway."""
+    live_vocabulary = run_group_vocabulary(db, probe_run_group) + (
+        Tag("meta-commentary", "Meta commentary", "failure"),
+    )
+    annotate_turn(
+        db, probe_run_group, 1, 0, 0, "t-1", 0,
+        tags=["meta-commentary"], note="",
+        vocabulary=live_vocabulary,
+    )
+    stored = load_turn_annotations(db, probe_run_group)
+    assert stored[(1, 0, 0, "t-1", 0)]["tags"] == ["meta-commentary"]
+
+
+def test_an_explicit_vocabulary_still_rejects_a_slug_outside_it(db, probe_run_group):
+    """An explicit vocabulary is a real allowlist, not a bypass: a slug
+    outside it is rejected exactly as the default (snapshot-derived) path
+    rejects a slug outside the run's captured vocabulary, and nothing is
+    written."""
+    live_vocabulary = run_group_vocabulary(db, probe_run_group) + (
+        Tag("meta-commentary", "Meta commentary", "failure"),
+    )
+    with pytest.raises(ValueError, match="no-such-tag"):
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["no-such-tag"], note="",
+            vocabulary=live_vocabulary,
+        )
+    assert load_turn_annotations(db, probe_run_group) == {}
+
+
+def test_omitting_vocabulary_still_validates_against_the_runs_captured_vocabulary(
+    db, probe_run_group
+):
+    """Omitting `vocabulary` must behave exactly as before this parameter
+    existed: the same `meta-commentary` slug that an explicit live
+    vocabulary accepts (see above) is still rejected here, because
+    `probe_run_group`'s own captured snapshot has no such extra tag."""
+    with pytest.raises(ValueError, match="meta-commentary"):
+        annotate_turn(
+            db, probe_run_group, 1, 0, 0, "t-1", 0,
+            tags=["meta-commentary"], note="",
+        )
+    assert load_turn_annotations(db, probe_run_group) == {}
+
+
 # --- delete_task cascades probe annotations (whole-branch review I4, task-6) --
 #
 # `probe_run_group` is opened under the `bench` fixture's task_id (see the
@@ -653,14 +716,26 @@ def seeded_word_bench_id(db):
     test_loading_a_word_bench_as_a_character_bench_raises` does. All this
     test needs is a bench `delete_task` can target that is NOT a character
     probe bench, to prove the cascade is scoped to that task's own run
-    groups rather than to every probe annotation row in the database."""
-    return db.create_task(
+    groups rather than to every probe annotation row in the database.
+
+    Carries a real run group (an `eval_runs` row stamped with
+    `run_group_id`), not just the bare task row: without one,
+    `delete_task`'s own `run_group_ids` lookup for this task always returns
+    `[]`, and `delete_probe_annotations_for_run_groups` no-ops on an empty
+    id list -- the DELETE against `eval_probe_turn_annotations`/
+    `eval_probe_review_state` is never actually executed, so a scoping bug
+    in that DELETE's `WHERE run_group_id IN (...)` would pass unnoticed."""
+    task_id = db.create_task(
         name="word bench",
         description="",
         task_type="logprob",
         config_format="custom",
         config_data={"bench_type": "word_bench"},
     )
+    model_id = db.create_model(name="word-target", provider="llama_cpp", model_id="m")
+    run_id = db.create_run(name="r", task_id=task_id, model_id=model_id)
+    db.update_run(run_id, {"run_group_id": "word-bench-rg"})
+    return task_id
 
 
 def test_deleting_a_bench_removes_its_turn_annotations(db, probe_run_group, bench):

--- a/Tests/Evals/character_probe/test_tags.py
+++ b/Tests/Evals/character_probe/test_tags.py
@@ -1,0 +1,75 @@
+import pytest
+
+from tldw_chatbook.Evals.character_probe.tags import (
+    BUILTIN_TAGS,
+    TAG_KINDS,
+    Tag,
+)
+
+
+def test_the_three_kinds_are_exactly_the_specs_three():
+    assert TAG_KINDS == ("failure", "notable", "positive")
+
+
+def test_the_builtin_vocabulary_is_the_ten_the_spec_names():
+    assert {t.slug for t in BUILTIN_TAGS} == {
+        "broke-character",
+        "refused",
+        "leaked-prompt",
+        "generic-assistant-voice",
+        "contradicted-card",
+        "ignored-the-question",
+        "notable",
+        "surprising",
+        "in-character",
+        "handled-well",
+    }
+
+
+def test_each_builtin_carries_the_kind_the_spec_assigns_it():
+    by_slug = {t.slug: t.kind for t in BUILTIN_TAGS}
+    assert by_slug["broke-character"] == "failure"
+    assert by_slug["refused"] == "failure"
+    assert by_slug["leaked-prompt"] == "failure"
+    assert by_slug["generic-assistant-voice"] == "failure"
+    assert by_slug["contradicted-card"] == "failure"
+    assert by_slug["ignored-the-question"] == "failure"
+    assert by_slug["notable"] == "notable"
+    assert by_slug["surprising"] == "notable"
+    assert by_slug["in-character"] == "positive"
+    assert by_slug["handled-well"] == "positive"
+
+
+def test_builtin_slugs_are_unique():
+    slugs = [t.slug for t in BUILTIN_TAGS]
+    assert len(slugs) == len(set(slugs))
+
+
+def test_a_tag_without_a_valid_kind_is_rejected_naming_the_kind():
+    with pytest.raises(ValueError) as exc:
+        Tag(slug="whatever", label="Whatever", kind="bad")
+    assert "bad" in str(exc.value)
+    assert "failure" in str(exc.value)
+
+
+def test_a_tag_with_an_empty_kind_is_rejected_rather_than_defaulted():
+    """The spec: a guessed kind mis-groups observations; `notable` is not safe."""
+    with pytest.raises(ValueError):
+        Tag(slug="whatever", label="Whatever", kind="")
+
+
+def test_a_tag_with_a_non_canonical_slug_is_rejected_naming_the_slug():
+    with pytest.raises(ValueError) as exc:
+        Tag(slug="Broke Character", label="Broke character", kind="failure")
+    assert "Broke Character" in str(exc.value)
+
+
+def test_a_tag_with_an_empty_label_is_rejected():
+    with pytest.raises(ValueError):
+        Tag(slug="broke-character", label="", kind="failure")
+
+
+def test_a_tag_is_frozen():
+    tag = BUILTIN_TAGS[0]
+    with pytest.raises(Exception):
+        tag.slug = "mutated"

--- a/Tests/Evals/character_probe/test_tags.py
+++ b/Tests/Evals/character_probe/test_tags.py
@@ -4,6 +4,9 @@ from tldw_chatbook.Evals.character_probe.tags import (
     BUILTIN_TAGS,
     TAG_KINDS,
     Tag,
+    canonical_slug,
+    resolve_vocabulary,
+    tag_by_slug,
 )
 
 
@@ -73,3 +76,86 @@ def test_a_tag_is_frozen():
     tag = BUILTIN_TAGS[0]
     with pytest.raises(Exception):
         tag.slug = "mutated"
+
+
+def test_canonical_slug_lowercases_and_hyphenates():
+    assert canonical_slug("Broke Character") == "broke-character"
+    assert canonical_slug("  Out Of Character  ") == "out-of-character"
+    assert canonical_slug("OOC") == "ooc"
+
+
+def test_canonical_slug_collapses_runs_and_strips_punctuation():
+    assert canonical_slug("broke   character!!") == "broke-character"
+    assert canonical_slug("re-broke  --  character") == "re-broke-character"
+
+
+def test_canonical_slug_rejects_text_with_no_usable_characters():
+    with pytest.raises(ValueError):
+        canonical_slug("   !!!   ")
+
+
+def test_resolve_vocabulary_with_no_extras_is_exactly_the_builtins():
+    assert resolve_vocabulary(()) == BUILTIN_TAGS
+
+
+def test_resolve_vocabulary_appends_an_extra_tag():
+    vocab = resolve_vocabulary(
+        [{"slug": "meta-commentary", "label": "Meta commentary", "kind": "failure"}]
+    )
+    assert len(vocab) == len(BUILTIN_TAGS) + 1
+    assert vocab[-1] == Tag("meta-commentary", "Meta commentary", "failure")
+
+
+def test_an_extra_tag_may_relabel_a_builtin_in_place():
+    vocab = resolve_vocabulary(
+        [{"slug": "notable", "label": "Worth a second look", "kind": "notable"}]
+    )
+    assert len(vocab) == len(BUILTIN_TAGS)
+    assert tag_by_slug(vocab, "notable").label == "Worth a second look"
+
+
+def test_an_extra_tag_may_not_change_a_builtins_kind():
+    with pytest.raises(ValueError) as exc:
+        resolve_vocabulary(
+            [{"slug": "refused", "label": "Refused", "kind": "positive"}]
+        )
+    assert "refused" in str(exc.value)
+
+
+def test_an_extra_tag_without_a_kind_is_rejected_naming_the_slug():
+    with pytest.raises(ValueError) as exc:
+        resolve_vocabulary([{"slug": "meta-commentary", "label": "Meta"}])
+    assert "meta-commentary" in str(exc.value)
+
+
+def test_an_extra_tags_slug_is_canonicalised_rather_than_rejected():
+    """A bench author types a label; the stored slug is canonical."""
+    vocab = resolve_vocabulary(
+        [{"slug": "Meta Commentary", "label": "Meta commentary", "kind": "notable"}]
+    )
+    assert tag_by_slug(vocab, "meta-commentary").label == "Meta commentary"
+
+
+def test_an_extra_tag_missing_a_label_falls_back_to_its_slug():
+    vocab = resolve_vocabulary([{"slug": "meta-commentary", "kind": "notable"}])
+    assert tag_by_slug(vocab, "meta-commentary").label == "meta-commentary"
+
+
+def test_resolve_vocabulary_accepts_tag_objects_as_well_as_mappings():
+    vocab = resolve_vocabulary([Tag("meta-commentary", "Meta", "notable")])
+    assert tag_by_slug(vocab, "meta-commentary").kind == "notable"
+
+
+def test_two_extras_with_the_same_slug_keep_the_last():
+    vocab = resolve_vocabulary([
+        {"slug": "meta", "label": "First", "kind": "notable"},
+        {"slug": "meta", "label": "Second", "kind": "notable"},
+    ])
+    assert tag_by_slug(vocab, "meta").label == "Second"
+
+
+def test_tag_by_slug_raises_naming_the_slug_and_the_vocabulary():
+    with pytest.raises(KeyError) as exc:
+        tag_by_slug(BUILTIN_TAGS, "no-such-tag")
+    assert "no-such-tag" in str(exc.value)
+    assert "broke-character" in str(exc.value)

--- a/Tests/Evals/test_evals_db.py
+++ b/Tests/Evals/test_evals_db.py
@@ -850,6 +850,108 @@ class TestErrorHandling:
             temp_db.delete_task(task_id)
 
 
+class TestProbeAnnotationCascadeBatching:
+    """PR #1216 Qodo review, finding 1: `delete_probe_annotations_for_run_groups`
+    used to build a single `DELETE ... WHERE run_group_id IN (?, ?, ...)`
+    with one bind parameter per run group. A bench with enough run groups
+    would exceed SQLite's own host-parameter limit (as low as 999 on some
+    builds), the DELETE would raise, and `delete_task` would leave the
+    bench undeletable. The fix batches the id list.
+    """
+
+    def test_delete_probe_annotations_for_run_groups_processes_every_batch(
+        self, in_memory_db, monkeypatch
+    ):
+        """Shrinking the batch-size constant to 3 (rather than inserting
+        thousands of rows to force a real overflow -- this machine's SQLite
+        build tolerates tens of thousands of host parameters, so no
+        practical row count here would reproduce the original crash)
+        exercises the exact same multi-batch code path deterministically
+        and fast: 7 run groups span three batches (3, 3, 1) per table.
+        Proves no id is skipped and none is double-counted.
+        """
+        import tldw_chatbook.DB.Evals_DB as evals_db_module
+
+        monkeypatch.setattr(
+            evals_db_module, "_PROBE_ANNOTATION_CASCADE_BATCH_SIZE", 3
+        )
+
+        run_group_ids = [f"rg-{i}" for i in range(7)]
+        for rg in run_group_ids:
+            in_memory_db.upsert_probe_turn_annotation(
+                run_group_id=rg,
+                card_id=1,
+                probe_index=0,
+                sample_index=0,
+                target_id="t-1",
+                turn_index=0,
+                tags=["refused"],
+                note="",
+            )
+
+        removed = in_memory_db.delete_probe_annotations_for_run_groups(
+            run_group_ids
+        )
+
+        assert removed == 7
+        for rg in run_group_ids:
+            assert in_memory_db.list_probe_turn_annotations(rg) == []
+
+    def test_deleting_a_bench_with_more_run_groups_than_one_batch_cascades_them_all(
+        self, in_memory_db
+    ):
+        """The scenario the brief asks for directly: a bench with more run
+        groups than fit in one cascade batch (default batch size 500) still
+        deletes cleanly through the real `delete_task` path, and every
+        annotation row is removed -- none silently skipped by a batch
+        boundary. 1200 run groups span three batches (500, 500, 200).
+
+        Run and annotation rows are stamped in directly via bulk `executemany`
+        against `eval_runs` / `eval_probe_turn_annotations` rather than via
+        `create_run` + `upsert_probe_turn_annotation` in a 1200-iteration
+        Python loop (each of those commits its own transaction) -- no real
+        conversations are needed, only rows the cascade should catch, per
+        the fix brief.
+        """
+        task_id = in_memory_db.create_task(
+            name="big bench",
+            description="",
+            task_type="generation",
+            config_format="custom",
+            config_data={"bench_type": "character_probe"},
+        )
+        model_id = in_memory_db.create_model(
+            name="m", provider="llama_cpp", model_id="m"
+        )
+
+        n = 1200
+        run_group_ids = [f"rg-{i}" for i in range(n)]
+
+        conn = in_memory_db.get_connection()
+        with conn:
+            conn.executemany(
+                "INSERT INTO eval_runs "
+                "(name, task_id, model_id, config_overrides, run_group_id, client_id) "
+                "VALUES (?, ?, ?, '{}', ?, 'test_client')",
+                [(f"r-{i}", task_id, model_id, rg) for i, rg in enumerate(run_group_ids)],
+            )
+            conn.executemany(
+                "INSERT INTO eval_probe_turn_annotations "
+                "(run_group_id, card_id, probe_index, sample_index, target_id, "
+                " turn_index, tags, note, client_id) "
+                "VALUES (?, 1, 0, 0, 't-1', 0, '[\"refused\"]', '', 'test_client')",
+                [(rg,) for rg in run_group_ids],
+            )
+
+        assert in_memory_db.delete_task(task_id) is True
+
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM eval_probe_turn_annotations "
+            "WHERE run_group_id LIKE 'rg-%'"
+        ).fetchone()[0]
+        assert remaining == 0
+
+
 class TestThreadSafety:
     """Test thread safety of database operations."""
 

--- a/Tests/Evals/test_evals_db.py
+++ b/Tests/Evals/test_evals_db.py
@@ -20,7 +20,7 @@ import time
 from pathlib import Path
 from loguru import logger
 
-from tldw_chatbook.DB.Evals_DB import EvalsDB, InputError
+from tldw_chatbook.DB.Evals_DB import EvalsDB, EvalsDBError, InputError
 
 
 class TestEvalsDBInitialization:
@@ -823,6 +823,31 @@ class TestErrorHandling:
         success = temp_db.update_task(task_id, description="Updated")
         # For now, this will succeed as optimistic locking is not implemented
         assert success
+
+    def test_delete_task_wraps_a_driver_error_in_evalsdberror(self, temp_db):
+        """delete_task's docstring promises EvalsDBError for "the delete
+        failed for a reason other than 'no matching row'" -- for the whole
+        method, not just the UPDATE that soft-deletes the task. The run-group
+        lookup that runs before that UPDATE (to find the task's
+        character-probe annotations to cascade) used to run outside the
+        method's own try/except, so a failure there leaked sqlite3's raw
+        driver exception instead. Dropping eval_runs simulates that lookup
+        failing; delete_task must still raise EvalsDBError, matching every
+        other failure path in this method and the docstring callers rely on.
+        """
+        task_id = temp_db.create_task(
+            name="test_task",
+            description="Test",
+            task_type="question_answer",
+            config_format="custom",
+            config_data={},
+        )
+        conn = temp_db.get_connection()
+        conn.execute("DROP TABLE eval_runs")
+        conn.commit()
+
+        with pytest.raises(EvalsDBError):
+            temp_db.delete_task(task_id)
 
 
 class TestThreadSafety:

--- a/Tests/UI/test_evals_character_bench_editor.py
+++ b/Tests/UI/test_evals_character_bench_editor.py
@@ -65,6 +65,7 @@ from tldw_chatbook.Evals.character_probe.storage import (
     save_character_bench,
     save_probe_set,
 )
+from tldw_chatbook.Evals.character_probe.tags import Tag
 from tldw_chatbook.UI.Evals.character_bench_editor import (
     MAX_TOKENS_ERROR_TEXT,
     SAMPLES_ERROR_TEXT,
@@ -417,7 +418,7 @@ async def test_saving_carries_concurrency_and_extra_tags_through_verbatim(
             character_ids=(3,),
             target_ids=(target_id,),
             concurrency=4,
-            extra_tags=({"slug": "villain"},),
+            extra_tags=({"slug": "villain", "kind": "notable"},),
         ),
     )
     async with character_app.run_test(size=_REALISTIC_SIZE) as pilot:
@@ -428,7 +429,7 @@ async def test_saving_carries_concurrency_and_extra_tags_through_verbatim(
 
         stored = load_character_bench(evals_db, bench_id)
         assert stored.concurrency == 4
-        assert stored.extra_tags == ({"slug": "villain"},)
+        assert stored.extra_tags == (Tag("villain", "villain", "notable"),)
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -35,9 +35,35 @@ if TYPE_CHECKING:
 
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
+from tldw_chatbook.DB.sql_validation import validate_identifier
 
 # Database Schema Version
 SCHEMA_VERSION = 5
+
+#: SQLite's own host-parameter limit varies by build -- as low as 999 on
+#: older versions, tens of thousands on newer ones -- so a single
+#: ``DELETE ... WHERE x IN (?, ?, ...)`` with one parameter per id can
+#: overflow it once a bench has enough run groups (TASK-1691 phase 3a
+#: finding 1). 500 stays comfortably under the lowest of those while still
+#: batching in large, efficient chunks.
+_PROBE_ANNOTATION_CASCADE_BATCH_SIZE = 500
+
+#: The two tables ``delete_probe_annotations_for_run_groups`` cascades a
+#: hard delete into. A bare table name can never be a bind parameter, so
+#: this literal, module-level tuple -- never caller-reachable -- is the
+#: identifier source; each name is still run through
+#: ``sql_validation.validate_identifier`` before being interpolated
+#: (TASK-1691 phase 3a finding 2), matching this project's "SQL identifiers
+#: through sql_validation.py" rule even though the source here is already a
+#: trusted literal. ``sql_validation.validate_table_name`` was not used
+#: instead: it whitelists against ``VALID_TABLES``, which is keyed by
+#: ``chachanotes``/``media``/``prompts`` and has no entry (or maintained
+#: test coverage, see that module's TASK-864 comment) for EvalsDB's own
+#: tables -- adding one is a larger, separate change than this fix.
+_PROBE_ANNOTATION_CASCADE_TABLES: Tuple[str, str] = (
+    "eval_probe_turn_annotations",
+    "eval_probe_review_state",
+)
 
 
 class EvalsDBError(Exception):
@@ -873,29 +899,38 @@ class EvalsDB:
         conn = self._get_connection()
 
         try:
-            # Resolve the task's run groups BEFORE the soft-delete below. This
-            # is not read-after-write squeamishness: eval_runs.task_id points
-            # at eval_tasks.id directly and does not care about
-            # eval_tasks.deleted_at, so the lookup would still work after the
-            # soft-delete too. It runs first anyway so "gather everything this
-            # task owns, then remove the task and what it owns" is one clear,
-            # ordered operation rather than something that happens to work
-            # because of an unrelated table's lack of a filter. It is inside
-            # this `try` (not before it) so a failure here -- e.g. the
-            # `eval_runs` table being unavailable -- raises `EvalsDBError`
-            # like every other failure in this method, rather than leaking
-            # sqlite3's own driver exception past this method's documented
-            # contract.
-            run_group_ids = [
-                row["run_group_id"]
-                for row in conn.execute(
-                    "SELECT DISTINCT run_group_id FROM eval_runs "
-                    "WHERE task_id = ? AND run_group_id IS NOT NULL",
-                    (task_id,),
-                ).fetchall()
-            ]
-
             with conn:
+                # Resolve the task's run groups BEFORE the soft-delete below.
+                # This is not read-after-write squeamishness: eval_runs.
+                # task_id points at eval_tasks.id directly and does not care
+                # about eval_tasks.deleted_at, so the lookup would still work
+                # after the soft-delete too. It runs first anyway so "gather
+                # everything this task owns, then remove the task and what it
+                # owns" is one clear, ordered operation rather than something
+                # that happens to work because of an unrelated table's lack
+                # of a filter. It is inside this `try` (not before it) so a
+                # failure here -- e.g. the `eval_runs` table being
+                # unavailable -- raises `EvalsDBError` like every other
+                # failure in this method, rather than leaking sqlite3's own
+                # driver exception past this method's documented contract.
+                #
+                # It is also inside this `with conn:` (not just the `try`),
+                # sharing one transaction with the UPDATE and the cascade
+                # below: a run group whose `eval_runs` row this SELECT
+                # already read is guaranteed to still be resolvable to the
+                # same task by the time the UPDATE runs, and a failure
+                # anywhere in this method -- including in the cascade --
+                # rolls back the soft-delete too, rather than leaving a task
+                # marked deleted with a run group this SELECT never saw.
+                run_group_ids = [
+                    row["run_group_id"]
+                    for row in conn.execute(
+                        "SELECT DISTINCT run_group_id FROM eval_runs "
+                        "WHERE task_id = ? AND run_group_id IS NOT NULL",
+                        (task_id,),
+                    ).fetchall()
+                ]
+
                 cursor = conn.execute(
                     """
                     UPDATE eval_tasks
@@ -929,6 +964,12 @@ class EvalsDB:
         nothing without them, so they are removed with the run rather than
         left orphaned -- see ``delete_task``, the only caller today.
 
+        The id list is deleted in batches of
+        ``_PROBE_ANNOTATION_CASCADE_BATCH_SIZE`` rather than one
+        ``IN (?, ?, ...)`` per id: a bench with more run groups than
+        SQLite's host-parameter limit would otherwise make this call raise
+        and leave the bench undeletable (TASK-1691 phase 3a finding 1).
+
         Args:
             run_group_ids: The run groups whose annotations and review
                 state should be removed. Falsy entries (``None``, ``""``)
@@ -937,26 +978,41 @@ class EvalsDB:
         Returns:
             int: Rows removed across both tables. Zero is a normal result
             -- a run group nobody reviewed has no annotations.
+
+        Raises:
+            EvalsDBError: If a cascade table name fails
+                ``sql_validation.validate_identifier``. Both names are
+                literals defined in this module and this should never
+                happen in practice; the check is defense-in-depth against
+                that assumption changing later.
         """
         ids = [str(rg) for rg in run_group_ids if rg]
         if not ids:
             return 0
-        placeholders = ",".join("?" for _ in ids)
+
+        for table in _PROBE_ANNOTATION_CASCADE_TABLES:
+            if not validate_identifier(table, "table name"):
+                raise EvalsDBError(
+                    f"Refusing to cascade-delete probe annotations: "
+                    f"{table!r} failed SQL identifier validation."
+                )
+
         removed = 0
         conn = self._get_connection()
         with conn:
-            # Table names below come from this two-element literal tuple in
-            # the function's own body, never from a caller; only the
-            # run_group_id values are parameters.
-            for table in (
-                "eval_probe_turn_annotations",
-                "eval_probe_review_state",
-            ):
-                cursor = conn.execute(
-                    f"DELETE FROM {table} WHERE run_group_id IN ({placeholders})",
-                    ids,
-                )
-                removed += cursor.rowcount
+            # Table names come from the literal tuple above, never from a
+            # caller; only the run_group_id values are bind parameters.
+            for table in _PROBE_ANNOTATION_CASCADE_TABLES:
+                for start in range(
+                    0, len(ids), _PROBE_ANNOTATION_CASCADE_BATCH_SIZE
+                ):
+                    batch = ids[start : start + _PROBE_ANNOTATION_CASCADE_BATCH_SIZE]
+                    placeholders = ",".join("?" for _ in batch)
+                    cursor = conn.execute(
+                        f"DELETE FROM {table} WHERE run_group_id IN ({placeholders})",
+                        batch,
+                    )
+                    removed += cursor.rowcount
         return removed
 
     def get_task(

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -27,7 +27,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Dict, Optional, Any, Union, Tuple
+from typing import TYPE_CHECKING, List, Dict, Optional, Any, Union, Tuple, Sequence
 from loguru import logger
 
 if TYPE_CHECKING:
@@ -848,13 +848,52 @@ class EvalsDB:
             raise EvalsDBError(f"Failed to update task: {e}")
 
     def delete_task(self, task_id: str) -> bool:
-        """Soft delete a task."""
+        """Soft delete a task and hard-delete its character-probe annotations.
+
+        The task row itself is soft-deleted (``deleted_at`` set), matching
+        every other delete in this table. Any character-probe turn
+        annotations and review state belonging to the task's run groups are
+        hard-deleted in the same transaction: those two tables carry no
+        ``deleted_at`` column and nothing reads them for an "undeleted"
+        view, so a soft delete would just leave them permanently orphaned.
+        This asymmetry is intentional -- do not "fix" it into a soft delete
+        to match ``eval_tasks``.
+
+        Args:
+            task_id: The task (bench) to delete.
+
+        Returns:
+            bool: True if a live task matched and was deleted, False if no
+            such live task existed (already deleted, or never existed).
+
+        Raises:
+            EvalsDBError: If the delete failed for a reason other than "no
+                matching row".
+        """
         conn = self._get_connection()
+
+        # Resolve the task's run groups BEFORE the soft-delete below. This
+        # is not read-after-write squeamishness: eval_runs.task_id points
+        # at eval_tasks.id directly and does not care about
+        # eval_tasks.deleted_at, so the lookup would still work after the
+        # soft-delete too. It runs first anyway so "gather everything this
+        # task owns, then remove the task and what it owns" is one clear,
+        # ordered operation rather than something that happens to work
+        # because of an unrelated table's lack of a filter.
+        run_group_ids = [
+            row["run_group_id"]
+            for row in conn.execute(
+                "SELECT DISTINCT run_group_id FROM eval_runs "
+                "WHERE task_id = ? AND run_group_id IS NOT NULL",
+                (task_id,),
+            ).fetchall()
+        ]
+
         try:
             with conn:
                 cursor = conn.execute(
                     """
-                    UPDATE eval_tasks 
+                    UPDATE eval_tasks
                     SET deleted_at = datetime('now', 'utc'),
                         updated_at = datetime('now', 'utc')
                     WHERE id = ? AND deleted_at IS NULL
@@ -864,11 +903,56 @@ class EvalsDB:
 
                 if cursor.rowcount > 0:
                     logger.info(f"Deleted eval task: {task_id}")
+                    # Cascades the task's character-probe annotations in
+                    # the same transaction (nested `with conn:` blocks on
+                    # one sqlite3 connection share the current transaction
+                    # rather than opening a separate one, so a failure here
+                    # rolls back the soft-delete above too).
+                    self.delete_probe_annotations_for_run_groups(run_group_ids)
                     return True
                 return False
 
         except Exception as e:
             raise EvalsDBError(f"Failed to delete task: {e}")
+
+    def delete_probe_annotations_for_run_groups(
+        self, run_group_ids: Sequence[str]
+    ) -> int:
+        """Hard-delete every character-probe annotation for these run groups.
+
+        Annotations and review state describe one run's answers and mean
+        nothing without them, so they are removed with the run rather than
+        left orphaned -- see ``delete_task``, the only caller today.
+
+        Args:
+            run_group_ids: The run groups whose annotations and review
+                state should be removed. Falsy entries (``None``, ``""``)
+                are ignored; an empty sequence is a no-op.
+
+        Returns:
+            int: Rows removed across both tables. Zero is a normal result
+            -- a run group nobody reviewed has no annotations.
+        """
+        ids = [str(rg) for rg in run_group_ids if rg]
+        if not ids:
+            return 0
+        placeholders = ",".join("?" for _ in ids)
+        removed = 0
+        conn = self._get_connection()
+        with conn:
+            # Table names below come from this two-element literal tuple in
+            # the function's own body, never from a caller; only the
+            # run_group_id values are parameters.
+            for table in (
+                "eval_probe_turn_annotations",
+                "eval_probe_review_state",
+            ):
+                cursor = conn.execute(
+                    f"DELETE FROM {table} WHERE run_group_id IN ({placeholders})",
+                    ids,
+                )
+                removed += cursor.rowcount
+        return removed
 
     def get_task(
         self, task_id: str, include_deleted: bool = False

--- a/tldw_chatbook/DB/Evals_DB.py
+++ b/tldw_chatbook/DB/Evals_DB.py
@@ -872,24 +872,29 @@ class EvalsDB:
         """
         conn = self._get_connection()
 
-        # Resolve the task's run groups BEFORE the soft-delete below. This
-        # is not read-after-write squeamishness: eval_runs.task_id points
-        # at eval_tasks.id directly and does not care about
-        # eval_tasks.deleted_at, so the lookup would still work after the
-        # soft-delete too. It runs first anyway so "gather everything this
-        # task owns, then remove the task and what it owns" is one clear,
-        # ordered operation rather than something that happens to work
-        # because of an unrelated table's lack of a filter.
-        run_group_ids = [
-            row["run_group_id"]
-            for row in conn.execute(
-                "SELECT DISTINCT run_group_id FROM eval_runs "
-                "WHERE task_id = ? AND run_group_id IS NOT NULL",
-                (task_id,),
-            ).fetchall()
-        ]
-
         try:
+            # Resolve the task's run groups BEFORE the soft-delete below. This
+            # is not read-after-write squeamishness: eval_runs.task_id points
+            # at eval_tasks.id directly and does not care about
+            # eval_tasks.deleted_at, so the lookup would still work after the
+            # soft-delete too. It runs first anyway so "gather everything this
+            # task owns, then remove the task and what it owns" is one clear,
+            # ordered operation rather than something that happens to work
+            # because of an unrelated table's lack of a filter. It is inside
+            # this `try` (not before it) so a failure here -- e.g. the
+            # `eval_runs` table being unavailable -- raises `EvalsDBError`
+            # like every other failure in this method, rather than leaking
+            # sqlite3's own driver exception past this method's documented
+            # contract.
+            run_group_ids = [
+                row["run_group_id"]
+                for row in conn.execute(
+                    "SELECT DISTINCT run_group_id FROM eval_runs "
+                    "WHERE task_id = ? AND run_group_id IS NOT NULL",
+                    (task_id,),
+                ).fetchall()
+            ]
+
             with conn:
                 cursor = conn.execute(
                     """

--- a/tldw_chatbook/Evals/character_probe/models.py
+++ b/tldw_chatbook/Evals/character_probe/models.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass
-from typing import Optional
+from typing import Any, Optional
+
+from .tags import coerce_tag, resolve_vocabulary
 
 
 @dataclass(frozen=True)
@@ -104,6 +106,13 @@ class CharacterProbeConfig:
             two "at least one" checks, this runs unconditionally: it must
             catch genuinely malformed data even on a lenient ``strict=False``
             read.
+        ValueError: If an ``extra_tags`` entry is not a ``Tag`` or a mapping
+            with a ``slug`` and a ``kind``, or if its ``kind`` would change a
+            built-in tag's kind (see ``tags.coerce_tag``/
+            ``tags.resolve_vocabulary``). This is NOT gated on ``strict``: a
+            malformed tag is corrupt data, never a draft state, so it is
+            rejected in every mode, including a lenient ``strict=False``
+            read.
     """
 
     name: str
@@ -116,7 +125,7 @@ class CharacterProbeConfig:
     seed: Optional[int] = None
     temperature: float = 0.8
     max_tokens: int = 512
-    extra_tags: tuple[dict, ...] = ()
+    extra_tags: tuple[Any, ...] = ()
     strict: InitVar[bool] = True
 
     def __post_init__(self, strict: bool) -> None:
@@ -134,6 +143,14 @@ class CharacterProbeConfig:
                     f"character_ids must be int (character_cards.id), got "
                     f"{cid!r} of type {type(cid).__name__}."
                 )
+
+        # Validate and canonicalise the bench's tag extensions. NOT gated on
+        # `strict`: that flag exists so a DRAFT bench with no characters and
+        # no targets can be created and reloaded (phase 2), and a malformed
+        # tag is corrupt data rather than a draft state.
+        coerced = tuple(coerce_tag(raw) for raw in self.extra_tags or ())
+        object.__setattr__(self, "extra_tags", coerced)
+        resolve_vocabulary(coerced)  # rejects a kind change to a built-in
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -26,6 +26,7 @@ from .models import (
     ProbeSet,
 )
 from .prompt import compose_system_prompt
+from .tags import Tag, coerce_tag
 from .targets import ResolvedTarget, resolve_targets
 
 #: Marks a dataset row as holding probes rather than snippets.
@@ -222,6 +223,41 @@ def is_character_bench(task_row: Mapping[str, Any]) -> bool:
     return config_data.get("bench_type") == BENCH_TYPE
 
 
+def _tags_to_json(tags: Sequence[Any]) -> list[dict[str, str]]:
+    """The stored form of a bench's extra tags.
+
+    Args:
+        tags: Validated ``Tag`` objects.
+
+    Returns:
+        list[dict[str, str]]: One JSON-safe mapping per tag.
+    """
+    return [{"slug": t.slug, "label": t.label, "kind": t.kind} for t in tags]
+
+
+def _tags_from_json(raw: Any, owner_id: str) -> tuple[Tag, ...]:
+    """Extra tags read back from a stored row or run snapshot.
+
+    Accepts the raw mappings written before the vocabulary existed, so rows
+    predating this phase still load.
+
+    Args:
+        raw: The stored ``extra_tags`` value, or None.
+        owner_id: The bench or run-group id, named in any error.
+
+    Returns:
+        tuple[Tag, ...]: Validated tags, empty when none were stored.
+
+    Raises:
+        ValueError: If a stored entry is malformed -- naming ``owner_id``, so
+            a corrupt row identifies itself rather than failing anonymously.
+    """
+    try:
+        return tuple(coerce_tag(entry) for entry in raw or ())
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"{owner_id} has a corrupt extra_tags entry: {exc}") from exc
+
+
 def save_character_bench(
     db: EvalsDB, config: CharacterProbeConfig, task_id: Optional[str] = None
 ) -> str:
@@ -276,7 +312,7 @@ def save_character_bench(
         "seed": config.seed,
         "temperature": config.temperature,
         "max_tokens": config.max_tokens,
-        "extra_tags": list(config.extra_tags),
+        "extra_tags": _tags_to_json(config.extra_tags),
     }
     if task_id is not None:
         updated = db.update_task(
@@ -455,8 +491,9 @@ def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
             propagated from ``_stored_int_field`` (see its own docstring)
             for a corrupt ``concurrency``/``samples_per_cell``/
             ``max_tokens``, from ``_stored_seed``/``_stored_temperature``
-            for a corrupt ``seed``/``temperature``, and from
-            ``CharacterProbeConfig.__post_init__`` for a stored
+            for a corrupt ``seed``/``temperature``, from ``_tags_from_json``
+            for a malformed stored ``extra_tags`` entry (naming this bench),
+            and from ``CharacterProbeConfig.__post_init__`` for a stored
             ``concurrency``/``samples_per_cell`` below its ``>= 1`` floor,
             or a non-``int`` element of ``character_ids``.
     """
@@ -477,7 +514,7 @@ def load_character_bench(db: EvalsDB, task_id: str) -> CharacterProbeConfig:
         seed=_stored_seed(data, task_id),
         temperature=_stored_temperature(data, task_id, 0.8),
         max_tokens=_stored_int_field(data, "max_tokens", 512, task_id),
-        extra_tags=tuple(data.get("extra_tags") or ()),
+        extra_tags=_tags_from_json(data.get("extra_tags"), task_id),
         strict=False,
     )
 
@@ -553,7 +590,7 @@ def _probe_run_snapshot(
             "samples_per_cell": config.samples_per_cell,
             "concurrency": config.concurrency,
         },
-        "extra_tags": list(config.extra_tags),
+        "extra_tags": _tags_to_json(config.extra_tags),
         "targets": [
             {
                 "id": target.id,

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -998,7 +998,7 @@ def annotate_turn(
     turn_index: int,
     tags: Sequence[str],
     note: str,
-    vocabulary: Optional[Sequence[Tag]] = None,
+    vocabulary: Optional[Sequence[Any]] = None,
 ) -> None:
     """Record or replace one conversation turn's reviewer annotation.
 
@@ -1040,16 +1040,27 @@ def annotate_turn(
             already (e.g. cached once per run-group review session) avoids
             re-deriving it -- and re-reading the run's snapshot, which
             duplicates every card's text and composed system prompts -- on
-            every single write.
+            every single write. Entries may be ``Tag`` objects or the
+            mapping/JSON form stored rows and run snapshots use (each run
+            through ``coerce_tag``, exactly like a stored vocabulary is);
+            a supplied entry may relabel a built-in but, like any other
+            vocabulary, may not change a built-in's kind (see
+            ``resolve_vocabulary``).
 
     Raises:
         ValueError: If any tag, once canonicalised, is not in the applicable
             vocabulary -- naming the offending slug. When ``vocabulary`` is
             omitted, also propagated from ``run_group_vocabulary`` if no
-            runs share this ``run_group_id``.
+            runs share this ``run_group_id``. When ``vocabulary`` is
+            supplied explicitly, also propagated from ``resolve_vocabulary``/
+            ``coerce_tag`` if an entry is malformed or tries to change a
+            built-in's kind -- naming the offending entry in either case,
+            never an unnamed ``AttributeError``.
     """
     if vocabulary is None:
         vocabulary = run_group_vocabulary(db, run_group_id)
+    else:
+        vocabulary = resolve_vocabulary(vocabulary)
     known = {tag.slug for tag in vocabulary}
     canonical: list[str] = []
     for raw in tags or ():

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -998,6 +998,7 @@ def annotate_turn(
     turn_index: int,
     tags: Sequence[str],
     note: str,
+    vocabulary: Optional[Sequence[Tag]] = None,
 ) -> None:
     """Record or replace one conversation turn's reviewer annotation.
 
@@ -1007,14 +1008,14 @@ def annotate_turn(
     replaces its tags and note rather than accumulating a second row (see
     ``EvalsDB.upsert_probe_turn_annotation``).
 
-    Every tag in ``tags`` is canonicalised and checked against
-    ``run_group_vocabulary(db, run_group_id)`` before anything is written.
-    An unknown tag has no kind, so the summary would have nothing to group
-    it under -- the same fail-loudly rule ``resolve_vocabulary`` and
-    ``coerce_tag`` already enforce for a bench's ``extra_tags``. Validation
-    runs over the whole list before the write, so a rejected annotation
-    leaves nothing behind: no partial write of "the tags checked out before
-    the bad one".
+    Every tag in ``tags`` is canonicalised and checked against ``vocabulary``
+    (or, when omitted, ``run_group_vocabulary(db, run_group_id)``) before
+    anything is written. An unknown tag has no kind, so the summary would
+    have nothing to group it under -- the same fail-loudly rule
+    ``resolve_vocabulary`` and ``coerce_tag`` already enforce for a bench's
+    ``extra_tags``. Validation runs over the whole list before the write, so
+    a rejected annotation leaves nothing behind: no partial write of "the
+    tags checked out before the bad one".
 
     Args:
         db: The evals database handle.
@@ -1028,13 +1029,27 @@ def annotate_turn(
         tags: Tag slugs describing this turn. May be empty -- a note
             without a tag is still a real observation.
         note: Free-text reviewer note for this turn.
+        vocabulary: The vocabulary to validate ``tags`` against. Omit (or
+            pass ``None``) to validate against the run's captured
+            vocabulary, ``run_group_vocabulary(db, run_group_id)`` --
+            today's behaviour, unchanged for every existing caller. Pass an
+            explicit vocabulary to support a tag created during a review
+            session (written to the bench's ``extra_tags`` and added to a
+            live in-memory vocabulary) that is not yet in the run's
+            snapshot; it is also how a caller holding that vocabulary
+            already (e.g. cached once per run-group review session) avoids
+            re-deriving it -- and re-reading the run's snapshot, which
+            duplicates every card's text and composed system prompts -- on
+            every single write.
 
     Raises:
-        ValueError: If any tag, once canonicalised, is not in this run's
-            vocabulary -- naming the offending slug. Also propagated from
-            ``run_group_vocabulary`` if no runs share this ``run_group_id``.
+        ValueError: If any tag, once canonicalised, is not in the applicable
+            vocabulary -- naming the offending slug. When ``vocabulary`` is
+            omitted, also propagated from ``run_group_vocabulary`` if no
+            runs share this ``run_group_id``.
     """
-    vocabulary = run_group_vocabulary(db, run_group_id)
+    if vocabulary is None:
+        vocabulary = run_group_vocabulary(db, run_group_id)
     known = {tag.slug for tag in vocabulary}
     canonical: list[str] = []
     for raw in tags or ():

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -26,7 +26,7 @@ from .models import (
     ProbeSet,
 )
 from .prompt import compose_system_prompt
-from .tags import Tag, coerce_tag
+from .tags import Tag, coerce_tag, resolve_vocabulary
 from .targets import ResolvedTarget, resolve_targets
 
 #: Marks a dataset row as holding probes rather than snippets.
@@ -707,6 +707,39 @@ def load_probe_run_snapshot(db: EvalsDB, run_group_id: str) -> dict[str, Any]:
     overrides = runs[0].get("config_overrides") or {}
     snapshot = overrides.get("snapshot")
     return snapshot if isinstance(snapshot, Mapping) else {}
+
+
+def run_group_vocabulary(db: EvalsDB, run_group_id: str) -> tuple[Tag, ...]:
+    """The tag vocabulary one run group was created under.
+
+    A reviewer annotates a run's answers, so the vocabulary that applies is
+    the one the run captured -- not the bench's current one. This is the same
+    provenance rule the card snapshot follows (see ``_probe_run_snapshot``):
+    editing the bench afterwards must not change what the run shows, and must
+    not orphan an annotation already recorded against a tag the bench has
+    since dropped. The read comes from ``load_probe_run_snapshot``, never
+    from the live ``eval_tasks`` row, for exactly that reason.
+
+    Args:
+        db: The evals database handle.
+        run_group_id: The run group to read.
+
+    Returns:
+        tuple[Tag, ...]: Built-in tags plus whatever extras the snapshot
+        recorded, resolved through ``resolve_vocabulary``. A snapshot with no
+        stored ``extra_tags`` (or no snapshot at all) yields exactly
+        ``BUILTIN_TAGS``.
+
+    Raises:
+        ValueError: Propagated from ``load_probe_run_snapshot`` if no runs
+            share this ``run_group_id`` -- naming the group. Also propagated
+            from ``_tags_from_json`` if the snapshot's stored tags are
+            corrupt -- naming the run group as the owner.
+    """
+    snapshot = load_probe_run_snapshot(db, run_group_id)
+    return resolve_vocabulary(
+        _tags_from_json(snapshot.get("extra_tags"), run_group_id)
+    )
 
 
 def save_conversations(

--- a/tldw_chatbook/Evals/character_probe/storage.py
+++ b/tldw_chatbook/Evals/character_probe/storage.py
@@ -26,7 +26,7 @@ from .models import (
     ProbeSet,
 )
 from .prompt import compose_system_prompt
-from .tags import Tag, coerce_tag, resolve_vocabulary
+from .tags import Tag, canonical_slug, coerce_tag, resolve_vocabulary
 from .targets import ResolvedTarget, resolve_targets
 
 #: Marks a dataset row as holding probes rather than snippets.
@@ -1007,6 +1007,15 @@ def annotate_turn(
     replaces its tags and note rather than accumulating a second row (see
     ``EvalsDB.upsert_probe_turn_annotation``).
 
+    Every tag in ``tags`` is canonicalised and checked against
+    ``run_group_vocabulary(db, run_group_id)`` before anything is written.
+    An unknown tag has no kind, so the summary would have nothing to group
+    it under -- the same fail-loudly rule ``resolve_vocabulary`` and
+    ``coerce_tag`` already enforce for a bench's ``extra_tags``. Validation
+    runs over the whole list before the write, so a rejected annotation
+    leaves nothing behind: no partial write of "the tags checked out before
+    the bad one".
+
     Args:
         db: The evals database handle.
         run_group_id: The run group the conversation belongs to.
@@ -1016,9 +1025,30 @@ def annotate_turn(
         target_id: The target's id, as used in ``save_conversations``'s
             ``run_ids``.
         turn_index: The zero-based turn within the conversation.
-        tags: Tag slugs describing this turn.
+        tags: Tag slugs describing this turn. May be empty -- a note
+            without a tag is still a real observation.
         note: Free-text reviewer note for this turn.
+
+    Raises:
+        ValueError: If any tag, once canonicalised, is not in this run's
+            vocabulary -- naming the offending slug. Also propagated from
+            ``run_group_vocabulary`` if no runs share this ``run_group_id``.
     """
+    vocabulary = run_group_vocabulary(db, run_group_id)
+    known = {tag.slug for tag in vocabulary}
+    canonical: list[str] = []
+    for raw in tags or ():
+        slug = canonical_slug(str(raw))
+        if slug not in known:
+            raise ValueError(
+                f"{slug!r} is not a tag in this run's vocabulary "
+                f"({', '.join(sorted(known))}). Annotations are grouped by "
+                f"tag kind, so an unknown tag would have no kind to group "
+                f"under."
+            )
+        if slug not in canonical:
+            canonical.append(slug)
+
     db.upsert_probe_turn_annotation(
         run_group_id=run_group_id,
         card_id=card_id,
@@ -1026,7 +1056,7 @@ def annotate_turn(
         sample_index=sample_index,
         target_id=target_id,
         turn_index=turn_index,
-        tags=list(tags),
+        tags=canonical,
         note=note,
     )
 

--- a/tldw_chatbook/Evals/character_probe/tags.py
+++ b/tldw_chatbook/Evals/character_probe/tags.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
 
 #: The only kinds a tag may carry. Order is display order, worst first.
 TAG_KINDS: tuple[str, str, str] = ("failure", "notable", "positive")
@@ -71,3 +72,119 @@ BUILTIN_TAGS: tuple[Tag, ...] = (
     Tag("in-character", "In character", "positive"),
     Tag("handled-well", "Handled well", "positive"),
 )
+
+#: Matches every run of characters that cannot appear in a canonical slug.
+_NON_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def canonical_slug(text: str) -> str:
+    """The single stored form of a tag name.
+
+    One canonical form is what makes "does this tag already exist?" a
+    decidable question, which is what limits the ``broke-character`` /
+    ``OOC`` / ``out-of-character`` fragmentation per-bench extension invites.
+
+    Args:
+        text: A human-typed tag name.
+
+    Returns:
+        str: Lowercase, with every run of non-alphanumerics collapsed to a
+        single hyphen and leading/trailing hyphens removed.
+
+    Raises:
+        ValueError: If nothing usable survives -- an empty slug would collide
+            with every other empty slug and silently merge unrelated tags.
+    """
+    slug = _NON_SLUG_RE.sub("-", str(text).strip().lower()).strip("-")
+    if not slug:
+        raise ValueError(f"{text!r} has no characters usable in a tag slug.")
+    return slug
+
+
+def coerce_tag(raw: Any) -> Tag:
+    """One extra-tag entry as a validated ``Tag``.
+
+    Args:
+        raw: A ``Tag``, or a mapping with ``slug`` and ``kind`` and an
+            optional ``label``.
+
+    Returns:
+        Tag: The validated tag, its slug canonicalised.
+
+    Raises:
+        ValueError: If the entry is not a mapping, has no slug, or omits the
+            kind -- naming the slug, since a guessed kind mis-groups the
+            observation in the summary.
+    """
+    if isinstance(raw, Tag):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"An extra tag must be a mapping or Tag, got {raw!r}.")
+    raw_slug = raw.get("slug")
+    if not raw_slug:
+        raise ValueError(f"An extra tag needs a slug: {dict(raw)!r}.")
+    slug = canonical_slug(str(raw_slug))
+    kind = raw.get("kind")
+    if not kind:
+        raise ValueError(
+            f"Extra tag {slug!r} has no kind. Every tag states one of "
+            f"{', '.join(TAG_KINDS)} -- it is never guessed."
+        )
+    label = str(raw.get("label") or slug)
+    return Tag(slug=slug, label=label, kind=str(kind))
+
+
+def resolve_vocabulary(extra_tags: Sequence[Any] = ()) -> tuple[Tag, ...]:
+    """The full tag vocabulary for one bench: built-ins plus its extras.
+
+    An extra whose slug matches a built-in relabels it in place rather than
+    appending a duplicate. It may NOT change a built-in's kind: two benches
+    whose ``failure`` sets mean different things cannot be read in one
+    summary.
+
+    Args:
+        extra_tags: The bench's ``extra_tags``, as ``Tag`` objects or as the
+            raw mappings older rows and run snapshots store.
+
+    Returns:
+        tuple[Tag, ...]: Built-ins in their declared order, with overrides
+        applied in place, then each new extra in the order supplied.
+
+    Raises:
+        ValueError: If an extra is malformed, omits its kind, or tries to
+            change a built-in's kind -- naming the slug in every case.
+    """
+    builtin_kinds = {tag.slug: tag.kind for tag in BUILTIN_TAGS}
+    resolved: dict[str, Tag] = {tag.slug: tag for tag in BUILTIN_TAGS}
+    for raw in extra_tags or ():
+        tag = coerce_tag(raw)
+        builtin_kind = builtin_kinds.get(tag.slug)
+        if builtin_kind is not None and tag.kind != builtin_kind:
+            raise ValueError(
+                f"Extra tag {tag.slug!r} would change the built-in kind "
+                f"{builtin_kind!r} to {tag.kind!r}. Built-in kinds are fixed "
+                f"so one summary can read every bench."
+            )
+        resolved[tag.slug] = tag
+    return tuple(resolved.values())
+
+
+def tag_by_slug(vocabulary: Sequence[Tag], slug: str) -> Tag:
+    """One tag from a vocabulary.
+
+    Args:
+        vocabulary: The bench's resolved vocabulary.
+        slug: The canonical slug to find.
+
+    Returns:
+        Tag: The matching tag.
+
+    Raises:
+        KeyError: If no tag matches -- naming the slug and the vocabulary, so
+            a stored annotation referencing a retired tag says which one.
+    """
+    for tag in vocabulary:
+        if tag.slug == slug:
+            return tag
+    known = ", ".join(t.slug for t in vocabulary)
+    raise KeyError(f"No tag {slug!r} in this bench's vocabulary ({known}).")

--- a/tldw_chatbook/Evals/character_probe/tags.py
+++ b/tldw_chatbook/Evals/character_probe/tags.py
@@ -1,0 +1,73 @@
+"""The character-probe review vocabulary.
+
+Every tag carries a kind so no view can imply "fewer tags is better": a
+``positive`` tag and a ``failure`` tag are both observations, and the summary
+groups by kind rather than counting them together. Creating a tag therefore
+REQUIRES a kind -- the design spec rules out guessing one, and rules out
+``notable`` as a fallback specifically because it would hide genuine failures
+in the view meant to surface them.
+
+Stdlib only, deliberately: this module is imported by the engine, the review
+UI, and the summary, and must never drag a database or Textual behind it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+#: The only kinds a tag may carry. Order is display order, worst first.
+TAG_KINDS: tuple[str, str, str] = ("failure", "notable", "positive")
+
+#: A canonical slug: lowercase, digits, and single interior hyphens.
+_SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+@dataclass(frozen=True)
+class Tag:
+    """One review tag.
+
+    Args:
+        slug: The canonical stored form (lowercase, hyphen-separated).
+        label: What a reviewer reads. Never empty.
+        kind: One of ``TAG_KINDS``.
+
+    Raises:
+        ValueError: If the slug is not canonical, the label is blank, or the
+            kind is not one of ``TAG_KINDS`` -- naming the offending value.
+    """
+
+    slug: str
+    label: str
+    kind: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.slug, str) or not _SLUG_RE.match(self.slug):
+            raise ValueError(
+                f"Tag slug must be lowercase-hyphenated, got {self.slug!r}."
+            )
+        if not isinstance(self.label, str) or not self.label.strip():
+            raise ValueError(f"Tag {self.slug!r} needs a non-empty label.")
+        if self.kind not in TAG_KINDS:
+            raise ValueError(
+                f"Tag {self.slug!r} has kind {self.kind!r}; must be one of "
+                f"{', '.join(TAG_KINDS)}. A kind is never guessed -- the wrong "
+                f"one mis-groups the observation in the summary."
+            )
+
+
+#: The vocabulary every bench starts with (spec, Tags section). A bench
+#: extends this through ``CharacterProbeConfig.extra_tags``; it never
+#: replaces it.
+BUILTIN_TAGS: tuple[Tag, ...] = (
+    Tag("broke-character", "Broke character", "failure"),
+    Tag("refused", "Refused", "failure"),
+    Tag("leaked-prompt", "Leaked the card's prompt", "failure"),
+    Tag("generic-assistant-voice", "Generic assistant voice", "failure"),
+    Tag("contradicted-card", "Contradicted the card", "failure"),
+    Tag("ignored-the-question", "Ignored the question", "failure"),
+    Tag("notable", "Notable", "notable"),
+    Tag("surprising", "Surprising", "notable"),
+    Tag("in-character", "In character", "positive"),
+    Tag("handled-well", "Handled well", "positive"),
+)


### PR DESCRIPTION
Phase 3a of the character-probe eval, per the plan merged in #1209. **Engine only — no UI.** Phase 3b (the review queue) and Phase 4 (the summary) consume all of it.

Plan: `Docs/superpowers/plans/2026-08-02-character-probe-phase3a-tag-vocabulary.md`. Spec: `Docs/superpowers/specs/2026-08-01-character-probe-eval-design.md`.

## What this adds

The spec calls for review tags that are "built-in defaults, extendable per bench", each carrying a kind. Phase 1 shipped the annotation *tables* and write functions, but `extra_tags` was an untyped `tuple[dict, ...]` with no validation and no built-in defaults anywhere, so "every tag carries a kind" was unenforceable.

| | |
|---|---|
| `character_probe/tags.py` (new) | `Tag`, `TAG_KINDS`, the ten `BUILTIN_TAGS`, `canonical_slug`, `coerce_tag`, `resolve_vocabulary`, `tag_by_slug`. Stdlib-only by design — the engine, the review UI, and the summary all import it. |
| `models.py` | `extra_tags` validated and canonicalised at construction, **ungated by `strict`** (that flag is for draft benches; a malformed tag is corrupt data in any mode) |
| `storage.py` | `run_group_vocabulary` — a run's vocabulary comes from **its own snapshot**; `annotate_turn` rejects a slug outside it |
| `Evals_DB.py` | deleting a bench cascades its annotations and review state |

## Two design points

**A run's vocabulary comes from its snapshot, not the bench.** `_probe_run_snapshot` already wrote `extra_tags`, so this reads data that exists. Editing a bench afterwards cannot change what a past run shows or orphan an annotation recorded against a tag the bench has since dropped — the same provenance rule the card snapshot follows. The reviewer traced this statically: `save_character_bench`'s update path only `UPDATE`s `eval_tasks`, while the snapshot lives in `eval_runs.config_overrides`, written once at run creation.

**Nothing sums tags into a number.** `Tag` carries no weight or severity, and the module exports no helper a caller could rank by. The `TAG_KINDS` tuple order is display order only.

## The cross-phase defect the whole-branch review caught

Six per-task reviews came back clean. The whole-branch review then found that **Phase 3b's specified create-a-tag flow could not have worked against this branch**: `annotate_turn` re-derived the vocabulary from the run's snapshot, so a tag created mid-review — Phase 3b's own recommended behaviour — would render as selectable and then raise on apply. Fixed by giving `annotate_turn` an optional `vocabulary` parameter, which also closes the second finding: it was doing a full snapshot parse *per run in the group* on every single tag write, so a 10-card/3-target bench meant three full-snapshot parses per tag click. Phase 3b can now cache the vocabulary per review session.

Also fixed: `delete_task`'s run-group `SELECT` sat outside the `try` and leaked a raw `sqlite3.OperationalError` instead of the `EvalsDBError` its docstring promised; and the word-bench cascade test never opened a run group, so it guarded only the collection `SELECT` and not the `DELETE`'s scoping.

## Back-compatibility

Explicitly signed off. Every legacy `extra_tags` shape now raises naming the bench — but that state is **unreachable in real data**: no in-app path has ever written a non-empty `extra_tags` (the phase-2 editor has no control for it and carries the loaded value verbatim), so every real bench and snapshot holds `[]` and resolves to the built-ins. All three UI load sites already render a message rather than crash.

## Testing

**886 passed, 12 skipped, 0 failed** across `Tests/Evals`, `Tests/UI/test_evals_character_bench_editor.py`, and `Tests/UI/test_evals_screen.py`, run serially (`-p no:randomly`) after rebasing onto current dev.

## Follow-ups (deferred, triaged by the whole-branch review)

`resolve_vocabulary`'s error doesn't name the bench the way `_tags_from_json`'s does · one corrupt extra tag makes a whole run un-annotatable even with built-ins (not reachable today) · `mark_conversation_reviewed` has no run-group existence check while `annotate_turn` now does · the cascade binds one variable per run group and should chunk the `IN` list · tags are coerced twice on load · `canonical_slug` folds diacritics, so `café` and `CAF` both slug to `caf` · the explicit-vocabulary path skips `resolve_vocabulary`'s built-in-kind-immutability check, which matters once Phase 3b constructs a live vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Phase 3a of the character‑probe eval: a typed tag vocabulary with built‑in defaults and per‑bench extras, each with a kind, enforced at bench save/load and during review. Engine‑only; Phase 3b (review) and Phase 4 (summary) use this. Now includes batched, validated cascade deletes and stricter vocabulary handling in `annotate_turn`.

- **New Features**
  - Added `tldw_chatbook/Evals/character_probe/tags.py` with `Tag`, `TAG_KINDS`, `BUILTIN_TAGS`, `canonical_slug`, `coerce_tag`, `resolve_vocabulary`, `tag_by_slug`.
  - `CharacterProbeConfig.extra_tags` is validated and canonicalized on construction (not gated by `strict`).
  - Run group vocabulary comes from its snapshot via `run_group_vocabulary`; `annotate_turn` validates tags against it, canonicalizes slugs, dedupes, and allows notes without tags.
  - `annotate_turn` accepts an optional `vocabulary` param so Phase 3b can allow session‑created tags and avoid re‑parsing snapshots on each write.
  - Storage persists tags as JSON via `_tags_to_json`/`_tags_from_json` and remains backward‑compatible with older raw dict rows/snapshots.

- **Bug Fixes**
  - Bench delete cascade is batched in `Evals_DB.delete_probe_annotations_for_run_groups` to avoid SQLite host‑parameter limits, validates table names via `sql_validation.validate_identifier`, and runs in one transaction alongside the soft delete.
  - `Evals_DB.delete_task` wraps failures in `EvalsDBError` as documented and moves the run‑group lookup inside the same transaction.
  - `annotate_turn` normalizes a supplied `vocabulary` through `resolve_vocabulary`, accepts mapping/JSON entries, and rejects malformed tags or built‑in kind changes.

<sup>Written for commit 69d59aee95f55eabc9ca7401dd4babf7aa398d8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

