### PR TITLE
Console: the tool kill switch covers every tool family (TASK-631, +630/632 hygiene)

### DIFF
--- a/Tests/Chat/test_console_agent_swap.py
+++ b/Tests/Chat/test_console_agent_swap.py
@@ -1506,9 +1506,9 @@ async def test_compose_mcp_provider_publishes_none_counts_when_no_service(tmp_pa
     controller, _store, _db = _controller(tmp_path, [["ok."]])
     controller.app = _fake_app()  # no unified_mcp_service attribute at all
 
-    provider, hook = await controller._compose_mcp_provider()
+    provider = await controller._compose_mcp_provider()
 
-    assert provider is None and hook is None
+    assert provider is None
     assert controller.app.console_mcp_tool_count is None
     assert controller.app.console_mcp_not_connected_count is None
 
@@ -1522,9 +1522,9 @@ async def test_compose_mcp_provider_publishes_none_counts_when_kill_switch_on(tm
     )
     controller.app = _fake_app(service)
 
-    provider, hook = await controller._compose_mcp_provider()
+    provider = await controller._compose_mcp_provider()
 
-    assert provider is None and hook is None
+    assert provider is None
     assert controller.app.console_mcp_tool_count is None
     assert controller.app.console_mcp_not_connected_count is None
 
@@ -1535,9 +1535,9 @@ async def test_compose_mcp_provider_publishes_none_counts_when_catalog_empty(tmp
     service = FakeMCPService()  # no catalog records, no builtin inventory
     controller.app = _fake_app(service)
 
-    provider, hook = await controller._compose_mcp_provider()
+    provider = await controller._compose_mcp_provider()
 
-    assert provider is None and hook is None
+    assert provider is None
     assert controller.app.console_mcp_tool_count is None
     assert controller.app.console_mcp_not_connected_count is None
 
@@ -1555,9 +1555,9 @@ async def test_compose_mcp_provider_publishes_none_counts_when_get_kill_switch_r
     controller.app = _fake_app()
     controller.app.unified_mcp_service = _RaisingService()
 
-    provider, hook = await controller._compose_mcp_provider()
+    provider = await controller._compose_mcp_provider()
 
-    assert provider is None and hook is None
+    assert provider is None
     assert controller.app.console_mcp_tool_count is None
     assert controller.app.console_mcp_not_connected_count is None
 
@@ -1580,10 +1580,9 @@ async def test_compose_mcp_provider_publishes_counts_when_eligible(tmp_path):
     )
     controller.app = _fake_app(service)
 
-    provider, hook = await controller._compose_mcp_provider()
+    provider = await controller._compose_mcp_provider()
 
     assert provider is not None
-    assert callable(hook)
     assert controller.app.console_mcp_tool_count == len(provider.list_catalog())
     assert controller.app.console_mcp_tool_count == 2
     assert (

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -3881,3 +3881,102 @@ async def test_trim_budgets_against_resolution_model_not_controller_state(monkey
     assert gateway.messages_seen is not None
     assert len(gateway.messages_seen) < 13
     assert gateway.messages_seen[-1]["content"] == "current question here"
+
+
+# -- TASK-631: the kill switch must cover EVERY tool call the hook sees ----
+
+
+@pytest.mark.unit
+def test_kill_switch_refuses_unclaimed_tool_calls_at_the_review_hook():
+    """The kill switch's label promises "block tool calls in chat" -- all of
+    them. MCP composition is skipped and `BuiltinToolGate.check` refuses when
+    the switch is on, but a name NEITHER provider claims (a skill,
+    `spawn_subagent`, `find_tools`, `load_tools`) passed through the review
+    hook unreviewed and dispatched normally: flipping the switch to stop all
+    tool calls left four tool families running. A false sense of security in
+    a security-relevant control.
+
+    The hook is the one place every parsed call passes, and the runtime
+    turns any non-"proceed" verdict into the call's result without
+    dispatching it -- so enforcing here covers the unclaimed families with
+    no new plumbing.
+    """
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Chat.console_chat_controller import (
+        KILL_SWITCH_REFUSAL,
+        build_tool_review_hook,
+    )
+
+    class _Gate:
+        def begin_turn(self): pass
+        def resolve(self, tool):
+            return SimpleNamespace(state="ask", risk_floored=False)
+        def stamp(self, name, decision): pass
+        def is_session_approved(self, name): return False
+        def options_for(self, tool):
+            return ("approve_once", "approve_session", "deny")
+
+    class _Provider:
+        def tool_for(self, name): return None  # claims nothing
+
+    prompted = []
+
+    def request_approvals(pending):
+        prompted.append(pending)
+        return {}
+
+    hook = build_tool_review_hook(
+        _Gate(), _Provider(), None, request_approvals,
+        workspace_id=None,
+        kill_switch=lambda: True,
+    )
+    verdicts = hook([
+        ToolCall(name="spawn_subagent", args={"task": "x"}, call_id="c1"),
+        ToolCall(name="skill__notes__summarize", args={}, call_id="c2"),
+        ToolCall(name="find_tools", args={"query": "q"}),
+    ])
+
+    assert not prompted, "the kill switch must refuse, not prompt"
+    assert verdicts.get("c1") == KILL_SWITCH_REFUSAL
+    assert verdicts.get("c2") == KILL_SWITCH_REFUSAL
+    assert verdicts.get("find_tools") == KILL_SWITCH_REFUSAL, (
+        "an id-less call must be refused by name, or the fence path "
+        f"escapes the switch: {verdicts}"
+    )
+
+
+@pytest.mark.unit
+def test_kill_switch_off_changes_nothing():
+    """With the switch off (or absent) the hook behaves exactly as before."""
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
+
+    class _Gate:
+        def begin_turn(self): pass
+        def resolve(self, tool):
+            return SimpleNamespace(state="ask", risk_floored=False)
+        def stamp(self, name, decision): pass
+        def is_session_approved(self, name): return False
+        def options_for(self, tool):
+            return ("approve_once", "approve_session", "deny")
+
+    class _Provider:
+        def tool_for(self, name): return SimpleNamespace(name=name)
+
+    def request_approvals(pending):
+        return {row.call_id: "approve_once" for row in pending}
+
+    for switch in (None, lambda: False):
+        hook = build_tool_review_hook(
+            _Gate(), _Provider(), None, request_approvals,
+            workspace_id=None,
+            kill_switch=switch,
+        )
+        verdicts = hook(
+            [ToolCall(name="read_file", args={"path": "a"}, call_id="c1")]
+        )
+        assert verdicts.get("c1", "proceed") == "proceed", (switch, verdicts)

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -3888,9 +3888,11 @@ async def test_trim_budgets_against_resolution_model_not_controller_state(monkey
 
 @pytest.mark.unit
 def test_kill_switch_refuses_unclaimed_tool_calls_at_the_review_hook():
-    """The kill switch's label promises "block tool calls in chat" -- all of
-    them. MCP composition is skipped and `BuiltinToolGate.check` refuses when
-    the switch is on, but a name NEITHER provider claims (a skill,
+    """The kill switch must refuse every call, including unclaimed names.
+
+    Its label promises "block tool calls in chat" -- all of them. MCP
+    composition is skipped and `BuiltinToolGate.check` refuses when the
+    switch is on, but a name NEITHER provider claims (a skill,
     `spawn_subagent`, `find_tools`, `load_tools`) passed through the review
     hook unreviewed and dispatched normally: flipping the switch to stop all
     tool calls left four tool families running. A false sense of security in

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -3674,9 +3674,8 @@ async def test_console_run_inspector_mcp_row_reflects_real_compose_mcp_provider(
             catalog_records=[_catalog_record("srv", [_tool_dict("run")])],
         )
 
-        provider, review_hook = await controller._compose_mcp_provider()
+        provider = await controller._compose_mcp_provider()
         assert provider is not None
-        assert callable(review_hook)
         assert app.console_mcp_tool_count == 1
         assert app.console_mcp_not_connected_count == 0
 
@@ -3712,9 +3711,8 @@ async def test_console_run_inspector_mcp_row_shows_blocked_when_stale_server_has
             ],
         )
 
-        provider, review_hook = await controller._compose_mcp_provider()
+        provider = await controller._compose_mcp_provider()
         assert provider is not None
-        assert callable(review_hook)
         assert app.console_mcp_tool_count == 1
         assert app.console_mcp_not_connected_count == 1
 

--- a/backlog/tasks/task-630 - Update-stale-request_mcp_approvals-docstring-for-built-in-rows.md
+++ b/backlog/tasks/task-630 - Update-stale-request_mcp_approvals-docstring-for-built-in-rows.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-630
 title: Update stale request_mcp_approvals docstring for built-in tool rows
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-25'
 labels: [docs, tools, tech-debt]
@@ -17,7 +17,13 @@ priority: low
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] `request_mcp_approvals`'s docstring no longer claims the batch is exclusively "MCP tool calls" or that the method is bound only as `MCPToolProvider`'s `approval_callback`
-- [ ] The docstring states plainly that the method is owner-agnostic and serves both MCP and built-in (`agent:builtin`) approval rows
-- [ ] No behavior change — this is a documentation-only fix, verified by an unchanged diff outside the docstring/comment
+- [x] `request_mcp_approvals`'s docstring no longer claims the batch is exclusively "MCP tool calls" or that the method is bound only as `MCPToolProvider`'s `approval_callback`
+- [x] The docstring states plainly that the method is owner-agnostic and serves both MCP and built-in (`agent:builtin`) approval rows
+- [x] No behavior change — this is a documentation-only fix, verified by an unchanged diff outside the docstring/comment
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Docstring rewritten: the method is owner-agnostic (MCP rows AND `agent:builtin` rows through one card and one Event loop), stated up front with the reason a reader would otherwise go hunting for a second path. The `mcp` name is kept deliberately -- it is the wire between this method, `resolve_pending_approval` and the round-id plumbing, and renaming is churn without a defect. No behavior change.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-631 - Kill-switch-label-over-claims-tool-call-coverage.md
+++ b/backlog/tasks/task-631 - Kill-switch-label-over-claims-tool-call-coverage.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-631
 title: Kill switch label over-claims tool-call coverage
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-25'
 labels: [ux, security, mcp, tools]
@@ -19,7 +19,19 @@ That claim is broader than reality. `build_tool_review_hook`'s own docstring is 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] Either (a) the kill switch's label/tooltip wording is narrowed to accurately describe what it covers today (MCP tools + built-in agent-runtime tools, not skills/spawn/find/load), or (b) the switch's enforcement is extended so skill tools, `spawn_subagent`, `find_tools`, and `load_tools` all also honor it
-- [ ] Whichever approach is chosen, a test or docstring makes the actual coverage explicit so a future reader cannot reintroduce the same gap silently
-- [ ] If narrowing wording only: the change is confined to the label/tooltip strings, with no behavior change
+- [x] Either (a) the kill switch's label/tooltip wording is narrowed to accurately describe what it covers today (MCP tools + built-in agent-runtime tools, not skills/spawn/find/load), or (b) the switch's enforcement is extended so skill tools, `spawn_subagent`, `find_tools`, and `load_tools` all also honor it
+- [x] Whichever approach is chosen, a test or docstring makes the actual coverage explicit so a future reader cannot reintroduce the same gap silently
+- [x] If narrowing wording only: the change is confined to the label/tooltip strings, with no behavior change
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Option (b): enforcement extended, label untouched -- the label's promise is now TRUE.**
+
+`build_tool_review_hook` takes `kill_switch: Callable[[], bool] | None` and, when it reports on, refuses EVERY call in the batch without prompting -- `KILL_SWITCH_REFUSAL` per call id (name for id-less fence calls, fail-closed per TASK-1861's reasoning). The hook is the one place every parsed call passes, including the four families neither provider claims (skills, `spawn_subagent`, `find_tools`, `load_tools`) that previously ran normally with the switch on; the runtime already converts non-"proceed" verdicts into results without dispatch (pinned by the TASK-1861 tests), so no new plumbing.
+
+A callable, read fresh per turn, so a mid-run flip takes effect on the next batch; an unreadable switch fails CLOSED -- the only safe answer for a security control that cannot be read. Wired via `_console_tool_kill_switch_reader()` (None without a service, matching `_compose_mcp_provider`).
+
+Mutation-verified: deleting the hook's check fails the refusal test. Also corrected the hook docstring's stale "verdict map is purely documentary" claim, false since TASK-1861.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-632 - Remove-dead-second-return-of-_compose_mcp_provider.md
+++ b/backlog/tasks/task-632 - Remove-dead-second-return-of-_compose_mcp_provider.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-632
 title: Remove dead second return element of _compose_mcp_provider
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-25'
 labels: [tech-debt, tools, tests]
@@ -19,7 +19,15 @@ It is being kept only because two out-of-scope test files pin the 2-tuple shape 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] `_compose_mcp_provider` returns only what is actually consumed by its production call site, or its second element's continued existence is justified in its docstring
-- [ ] All test call sites (`Tests/UI/test_console_internals_decomposition.py`, `Tests/Chat/test_console_agent_swap.py`) are updated to match the (possibly narrowed) return shape and pass
-- [ ] No behavior change to the composed `MCPToolProvider` or to MCP tool-call review/approval flow
+- [x] `_compose_mcp_provider` returns only what is actually consumed by its production call site, or its second element's continued existence is justified in its docstring
+- [x] All test call sites (`Tests/UI/test_console_internals_decomposition.py`, `Tests/Chat/test_console_agent_swap.py`) are updated to match the (possibly narrowed) return shape and pass
+- [x] No behavior change to the composed `MCPToolProvider` or to MCP tool-call review/approval flow
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`_compose_mcp_provider` returns the provider alone; the dead `build_mcp_review_hook` closure is no longer constructed per run. All 8 pinned test call sites updated to single-value unpacking (the None-cases' `hook is None` assertions dropped with the element). The stale `Returns` paragraph documenting the tuple went with it.
+
+`build_mcp_review_hook` itself is KEPT: it has no production callers but 7 direct test call sites exercising shared logic (`_collect_mcp_pending` etc.), an arrangement its extraction comment already documents. Deleting it is beyond this task's AC.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -146,6 +146,14 @@ _LEGACY_PENDING_APPROVAL_ROUND_ID = "__legacy_pending_approval__"
 #: the same whether it was stopped here or at the gate.
 USER_DENIED_REFUSAL = "tool call denied by the user: {name}"
 
+#: TASK-631: the result every tool call gets while the kill switch is on.
+#: Enforced at the review hook -- the one place EVERY parsed call passes,
+#: including the families neither provider claims (skills, spawn_subagent,
+#: find_tools, load_tools) that previously ran normally with the switch on.
+#: Deliberately names the switch so the model (and a user reading the
+#: transcript) can tell this from a per-call denial.
+KILL_SWITCH_REFUSAL = "tool call blocked: chat tool calls are disabled (kill switch)"
+
 #: TASK-1861: how broad each approval scope is. A session/always grant is
 #: recorded against a tool NAME, so when per-call rows of one tool are
 #: approved at different scopes only one can be stamped -- and it must be the
@@ -333,8 +341,21 @@ def build_tool_review_hook(
     request_approvals: Callable[[list["MCPPendingCall"]], dict[str, str]],
     *,
     workspace_id: str | None = None,
+    kill_switch: Callable[[], bool] | None = None,
 ) -> Callable[[list["ToolCall"]], dict[str, str]]:
     """Build THIS run's run-level `review_tool_calls` hook (P5-T6/task-545).
+
+    TASK-631: when ``kill_switch`` reports on, EVERY call in the batch is
+    refused here, without prompting -- the runtime turns any non-"proceed"
+    verdict into the call's result and skips dispatch. MCP composition is
+    already skipped and ``BuiltinToolGate.check`` already refuses with the
+    switch on, but names neither provider claims (skills,
+    ``spawn_subagent``, ``find_tools``, ``load_tools``) used to pass
+    through unreviewed and RUN NORMALLY -- the switch's label promises
+    "block tool calls in chat", and this hook is the one place every
+    parsed call passes, so this is where the promise is kept. Read fresh
+    per turn (a callable, not a bool) so flipping the switch mid-run takes
+    effect on the next batch.
 
     Unlike `build_mcp_review_hook`, this is wired UNCONDITIONALLY -- every
     run gets one, even a user with no MCP servers configured at all --
@@ -411,11 +432,11 @@ def build_tool_review_hook(
     owner. Decisions are then applied back to each owner separately:
     `mcp_provider.apply_batch_decisions(...)` for MCP rows,
     `builtin_gate.stamp(name, decision)` for built-in rows. The returned
-    verdict map is `{name: "proceed"}` for every call this hook gated this
-    turn (MCP or built-in), purely documentary like
-    `build_mcp_review_hook`'s own -- the actual allow/deny outcome is left
-    to `invoke()`'s gate on dispatch, which is the single place that
-    produces refusal copy and records the audit decision.
+    verdict map carries "proceed" for approved calls and REFUSAL STRINGS
+    for per-call denials (TASK-1861) and kill-switch blocks (TASK-631) --
+    the runtime enforces those directly, skipping dispatch. Approvals are
+    still left to `invoke()`'s gate on dispatch, which records the audit
+    decision.
 
     Args:
         builtin_gate: THIS run's `BuiltinToolGate` -- the SAME instance
@@ -461,6 +482,29 @@ def build_tool_review_hook(
 
     def review_tool_calls(calls: list["ToolCall"]) -> dict[str, str]:
         builtin_gate.begin_turn()
+        # TASK-631: the kill switch outranks everything -- no prompting, no
+        # stamps, every call refused. Per-call keys where the runtime can
+        # address them; an id-less (fence-path) call is refused by NAME,
+        # which stops every same-name call -- fail-closed, same reasoning
+        # as TASK-1861's refusal fallback.
+        if kill_switch is not None:
+            try:
+                switch_on = bool(kill_switch())
+            except Exception:  # noqa: BLE001 -- an unreadable switch fails CLOSED
+                logger.opt(exception=True).warning(
+                    "build_tool_review_hook: kill-switch read failed; "
+                    "refusing this turn's tool calls"
+                )
+                switch_on = True
+            if switch_on:
+                if mcp_provider is not None:
+                    mcp_provider.apply_batch_decisions({})
+                return {
+                    (str(getattr(call, "call_id", "") or "") or call.name): (
+                        KILL_SWITCH_REFUSAL
+                    )
+                    for call in calls
+                }
         if mcp_provider is not None:
             mcp_provider.apply_batch_decisions({})
 
@@ -2274,7 +2318,18 @@ class ConsoleChatController:
     def request_mcp_approvals(
         self, pending: list[MCPPendingCall], *, session_id: str | None = None
     ) -> dict[str, str]:
-        """Bridge one batch of pending MCP tool calls to the Console UI and back.
+        """Bridge one batch of pending tool-approval rows to the Console UI and back.
+
+        TASK-630: OWNER-AGNOSTIC, despite the legacy ``mcp`` in the name.
+        Since TASK-545/P1's run-level ``build_tool_review_hook``, the rows
+        handed here may come from MCP tools OR from built-in agent-runtime
+        tools (``server_key="agent:builtin"``); every row is marshalled to
+        the same ``ChatApprovalCard`` and resolved through the same
+        Event-polling loop below. There is no separate approval path for
+        built-ins -- a reader assuming "MCP-only" here would go looking for
+        one that does not exist. (The name is kept: it is the wire between
+        this method, ``resolve_pending_approval``, and the round-id
+        plumbing, and renaming it is churn without a defect.)
 
         WORKER THREAD. Bound (via a ``functools.partial`` binding this
         run's ``session_id``, Task 9) as ``MCPToolProvider``'s
@@ -2780,12 +2835,30 @@ class ConsoleChatController:
         self.app.console_mcp_tool_count = tool_count
         self.app.console_mcp_not_connected_count = not_connected_count
 
+    def _console_tool_kill_switch_reader(self) -> Callable[[], bool] | None:
+        """Return a fresh-per-call kill-switch reader, or ``None`` without a service.
+
+        TASK-631. A callable rather than a bool so `build_tool_review_hook`
+        observes a mid-run flip on the next batch; reading raises -> the
+        hook fails CLOSED (refuses the turn), which is the only safe answer
+        for a security control that cannot be read.
+
+        Returns:
+            A zero-arg callable returning the switch state, or ``None``
+            when the app has no ``unified_mcp_service`` (nothing to honor).
+        """
+        service = getattr(self.app, "unified_mcp_service", None)
+        if service is None:
+            return None
+        getter = getattr(service, "get_kill_switch", None)
+        if not callable(getter):
+            return None
+        return lambda: bool(getter())
+
     async def _compose_mcp_provider(
         self,
         session_id: str | None = None,
-    ) -> tuple[
-        MCPToolProvider | None, Callable[[list["ToolCall"]], dict[str, str]] | None
-    ]:
+    ) -> MCPToolProvider | None:
         """Build + compose THIS run's MCPToolProvider on the running main loop.
 
         MUST be awaited from an async caller with the real Textual main
@@ -2796,7 +2869,13 @@ class ConsoleChatController:
         (``local_external_catalog()``) that is documented to run on the
         main loop at registration time.
 
-        Returns ``(None, None)`` whenever MCP tools should not be offered
+        TASK-632: returns the provider ALONE. It used to also build and
+        return a per-run `build_mcp_review_hook` closure, but TASK-545's
+        run-level `build_tool_review_hook` made that second element dead --
+        the production call site unpacked it into `_unused_...` and threw it
+        away, while the closure was still constructed on every run.
+
+        Returns ``None`` whenever MCP tools should not be offered
         this run: no ``unified_mcp_service`` on the app, the kill switch
         is on, ``get_kill_switch``/``compose_catalog`` raised, or the
         composed catalog is empty (nothing to register, and -- since
@@ -2820,15 +2899,14 @@ class ConsoleChatController:
                 ``request_mcp_approvals``' legacy no-session behavior.
 
         Returns:
-            ``(provider, review_tool_calls)`` when eligible -- a composed
-            ``MCPToolProvider`` ready to hand to ``ConsoleAgentBridge.
-            run_reply`` and this run's ``build_mcp_review_hook``-built
-            batch-review closure; ``(None, None)`` otherwise.
+            A composed ``MCPToolProvider`` ready to hand to
+            ``ConsoleAgentBridge.run_reply`` when eligible; ``None``
+            otherwise.
         """
         service = getattr(self.app, "unified_mcp_service", None)
         if service is None:
             self._publish_mcp_inspector_counts(None, None)
-            return None, None
+            return None
         try:
             kill_switch = service.get_kill_switch()
         except Exception:  # noqa: BLE001 -- fail closed to "no MCP this run"
@@ -2836,10 +2914,10 @@ class ConsoleChatController:
                 "ConsoleChatController: get_kill_switch failed; skipping MCP this run"
             )
             self._publish_mcp_inspector_counts(None, None)
-            return None, None
+            return None
         if kill_switch:
             self._publish_mcp_inspector_counts(None, None)
-            return None, None
+            return None
         bound_request_approvals = functools.partial(
             self.request_mcp_approvals, session_id=session_id
         )
@@ -2855,13 +2933,13 @@ class ConsoleChatController:
                 "ConsoleChatController: MCP compose_catalog failed; skipping MCP this run"
             )
             self._publish_mcp_inspector_counts(None, None)
-            return None, None
+            return None
         catalog = provider.list_catalog()
         if not catalog:
             self._publish_mcp_inspector_counts(None, None)
-            return None, None
+            return None
         self._publish_mcp_inspector_counts(len(catalog), provider.not_connected_count)
-        return provider, build_mcp_review_hook(provider, bound_request_approvals)
+        return provider
 
     def resolve_pending_approval(
         self, decisions: dict[str, str], *, round_id: str | None = None
@@ -6537,7 +6615,7 @@ class ConsoleChatController:
         # outside this task's file scope, so keeping that function
         # byte-identical and building the run-level hook separately here
         # is the lower-blast-radius choice.
-        mcp_provider, _unused_mcp_only_review_hook = await self._compose_mcp_provider(
+        mcp_provider = await self._compose_mcp_provider(
             session_id
         )
         self._mcp_provider = mcp_provider
@@ -6585,6 +6663,12 @@ class ConsoleChatController:
             mcp_provider,
             functools.partial(self.request_mcp_approvals, session_id=session_id),
             workspace_id=review_workspace_id,
+            # TASK-631: the switch must cover the tool families NEITHER
+            # provider claims (skills/spawn/find/load), and this hook is the
+            # only choke point they all pass. Read fresh per turn so a
+            # mid-run flip takes effect on the next batch. Absent service ->
+            # no switch to honor (None), matching `_compose_mcp_provider`.
+            kill_switch=self._console_tool_kill_switch_reader(),
         )
 
         # Swap site: the agent loop runs synchronously on a worker thread via


### PR DESCRIPTION
Three tasks from the TASK-545 review backlog, ordered by weight.

## TASK-631 — the kill switch now keeps its promise

Its label reads **"block tool calls in chat"**, but names neither provider claims — skills, `spawn_subagent`, `find_tools`, `load_tools` — never touched either provider's gate. Flipping the switch left four tool families running normally: a false sense of security in a security-relevant control.

**Enforcement extended rather than wording narrowed.** `build_tool_review_hook` takes `kill_switch: Callable[[], bool] | None`; when it reports on, **every** call in the batch is refused without prompting — `KILL_SWITCH_REFUSAL` keyed per call id, by name for id-less fence calls (fail-closed, TASK-1861's reasoning). The hook is the one place every parsed call passes, and the runtime already converts non-"proceed" verdicts into results without dispatch (pinned by the TASK-1861 suite), so coverage is total with **no new plumbing**.

A callable read fresh per turn, so a mid-run flip bites on the next batch. An unreadable switch fails **closed** — the only safe answer for a security control that cannot be read.

Mutation-verified: deleting the hook's check fails the refusal test. Also corrects the hook docstring's *"verdict map is purely documentary"* claim — false since TASK-1861 made refusals travel the map.

## TASK-632 — the dead second return

`_compose_mcp_provider` returns the provider alone. Its second element (a per-run `build_mcp_review_hook` closure) has been dead since TASK-545's run-level hook — the call site unpacked it into `_unused_...` and threw it away while the closure was still built on every run. All 8 pinned test call sites updated. `build_mcp_review_hook` itself is **kept**: no production callers, but 7 direct test consumers exercising shared logic, an arrangement its extraction comment already documents.

## TASK-630 — the misleading docstring

`request_mcp_approvals` no longer claims to bridge "MCP tool calls": it is owner-agnostic (MCP and `agent:builtin` rows through one card and one Event loop), and says so up front — a reader assuming MCP-only goes hunting for a second approval path that does not exist. The `mcp` *name* is kept: it is the wire between this method, `resolve_pending_approval` and the round-id plumbing, and renaming is churn without a defect.

3958 passed across the Chat, Agents, approval and internals suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the chat tool kill switch to block every tool family at the review hook, including skills and unclaimed calls, so no tools run while enabled. Also remove the dead second return from MCP composition and update approvals docs to reflect MCP + `agent:builtin` coverage; addresses TASK-631, TASK-632, and TASK-630.

- **Bug Fixes**
  - Enforce the kill switch in `build_tool_review_hook` so all tool calls return a refusal, including id-less calls; mid-run flips are honored and unreadable switches fail closed.
  - Add tests verifying unclaimed tool names are refused and that behavior is unchanged when the switch is off.

- **Refactors**
  - `_compose_mcp_provider` now returns only the provider; no per-run MCP review hook is built, and tests are updated.
  - Added `_console_tool_kill_switch_reader()` to read the switch fresh per turn.
  - `request_mcp_approvals` docstring clarified to be owner-agnostic (MCP and `agent:builtin`).

<sup>Written for commit e32d1dcb304e3237b34316a33d7dcbc499f592cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

