### PR TITLE
Agents: real-tool and real-DB coverage for the built-in gate (TASK-696)

### DIFF
--- a/Tests/Agents/test_builtin_gate_real_tool_coverage.py
+++ b/Tests/Agents/test_builtin_gate_real_tool_coverage.py
@@ -46,7 +46,9 @@ class _RealToolProvider:
 
 
 @pytest.mark.unit
-def test_a_real_reads_tagged_tool_reaches_the_approval_card_not_silence():
+def test_a_real_reads_tagged_tool_reaches_the_approval_card_not_silence(
+    tmp_path, monkeypatch
+):
     """AC#1: enabling `read_file` produces a PROMPT, not a silent execution.
 
     Drives the real `ReadFileTool` (risk_tags `("reads",)`) through the real
@@ -58,7 +60,21 @@ def test_a_real_reads_tagged_tool_reaches_the_approval_card_not_silence():
     the floor consulting them) kept the suite green while `read_file` ran
     without asking.
     """
+    from tldw_chatbook.Tools import file_operation_tools as fot
+    from tldw_chatbook.Tools import workspace_file_roots as wfr
     from tldw_chatbook.Tools.file_operation_tools import ReadFileTool
+
+    # Hermetic (review finding): the hook's path precheck would otherwise
+    # touch the real sandbox root and workspace-registry DB from a unit
+    # test. Same seams the sibling precheck test patches.
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox.resolve())
+
+    def _no_registry():
+        raise RuntimeError("no workspace registry in this test")
+
+    monkeypatch.setattr(wfr, "_registry_factory", _no_registry)
 
     tool = ReadFileTool()
     assert "reads" in tool.risk_tags, "precondition: the real tag set"
@@ -95,14 +111,22 @@ def test_create_note_persists_through_a_real_db_on_a_worker_thread(
     """AC#2: the design-spec claim the nominal test never proved.
 
     `Tests/Agents/test_builtin_gate_live_tools.py` monkeypatches
-    `NotesInteropService` away, proving only that `asyncio.run` works off the
-    main thread. The spec's actual question: does `CharactersRAGDB` -- built
-    for cross-thread use via `threading.local` connections and
-    `check_same_thread=False` -- really work on the agent's worker thread?
-    This runs the REAL `CreateNoteTool.execute` on a real non-main thread
-    against a real `CharactersRAGDB` at a temp path, then reads the row back
-    on the MAIN thread through the same instance -- both directions of the
-    cross-thread contract.
+    `NotesInteropService` away, proving only that `asyncio.run` works off
+    the main thread. This runs the REAL `CreateNoteTool.execute` on a real
+    non-main thread against a real `CharactersRAGDB` file, twice over:
+
+    * the PRODUCTION write path -- `_get_db` constructs its own
+      `CharactersRAGDB` (same file, `client_id=user_id`) ON the worker
+      thread, exactly as a live agent run does, and the row must be durable
+      to a main-thread reader of the same file; and
+    * the SINGLE-INSTANCE seam the spec named -- `threading.local`
+      connections + `check_same_thread=False` -- by reading through THIS
+      test's own instance from BOTH threads.
+
+    A review finding caught the first version claiming the second while
+    exercising only the first: `_get_db` does not reuse `global_db_to_use`,
+    it re-instantiates against its path -- so "same instance across
+    threads" must be asserted on an instance this test actually holds.
     """
     from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
     from tldw_chatbook.Tools import note_management_tools as nmt
@@ -126,6 +150,13 @@ def test_create_note_persists_through_a_real_db_on_a_worker_thread(
                     )
                 )
             )
+            # The single-instance cross-thread seam: THIS test's instance,
+            # used on the worker thread. `threading.local` must mint this
+            # thread its own connection rather than raise or return the
+            # main thread's.
+            note_id = result.get("note_id")
+            if note_id:
+                result["worker_read"] = db.get_note_by_id(str(note_id))
         except BaseException as exc:  # noqa: BLE001 -- surfaced below
             error.append(exc)
 
@@ -138,7 +169,14 @@ def test_create_note_persists_through_a_real_db_on_a_worker_thread(
     note_id = result.get("note_id")
     assert note_id, result
 
-    # Main thread, same instance: the row must be durable and readable.
+    worker_row = result.get("worker_read")
+    assert worker_row is not None, (
+        "the shared instance could not read on the worker thread -- the "
+        "threading.local seam the spec flagged"
+    )
+    assert worker_row["title"] == "worker-thread note"
+
+    # Main thread, same instance again: durable and readable both sides.
     row = db.get_note_by_id(str(note_id))
     assert row is not None, "the note vanished across threads"
     assert row["title"] == "worker-thread note"

--- a/Tests/Agents/test_builtin_gate_real_tool_coverage.py
+++ b/Tests/Agents/test_builtin_gate_real_tool_coverage.py
@@ -1,0 +1,145 @@
+"""TASK-696: coverage for two ACs previously satisfied only by inspection.
+
+Both behaviors were verified manually during TASK-545 P2's review and never
+protected by the suite -- a regression would pass CI. Both tests here drive
+REAL objects (the real tool, the real gate, the real DB) rather than the
+synthetic doubles the neighbouring suites use, because "the double behaves"
+is exactly what those reviews found insufficient.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from tldw_chatbook.Agents.agent_models import ToolCall
+from tldw_chatbook.Agents.builtin_tool_gate import BuiltinToolGate
+from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
+from tldw_chatbook.MCP.permission_store import BUILTIN_TOOL_SERVER_KEY
+
+
+class _SessionApprovalService:
+    """`unified_mcp_service`-shaped double: the REAL gate's read/write seam."""
+
+    def __init__(self) -> None:
+        self._approved: set[tuple[str, str]] = set()
+
+    def get_kill_switch(self) -> bool:
+        return False
+
+    def approve_for_session(self, server_key: str, tool_name: str) -> None:
+        self._approved.add((server_key, tool_name))
+
+    def is_session_approved(self, server_key: str, tool_name: str) -> bool:
+        return (server_key, tool_name) in self._approved
+
+
+class _RealToolProvider:
+    """Provider double that serves REAL Tool objects by name."""
+
+    def __init__(self, *tools) -> None:
+        self._tools = {tool.name: tool for tool in tools}
+
+    def tool_for(self, name: str):
+        return self._tools.get(name)
+
+
+@pytest.mark.unit
+def test_a_real_reads_tagged_tool_reaches_the_approval_card_not_silence():
+    """AC#1: enabling `read_file` produces a PROMPT, not a silent execution.
+
+    Drives the real `ReadFileTool` (risk_tags `("reads",)`) through the real
+    `BuiltinToolGate` and `build_tool_review_hook`. The chain under test:
+    empty permission payload -> inherited allow -> `resolve_builtin_state`
+    floors a high-risk tag to "ask" -> the hook emits a pending approval row
+    for the card. The only prior hook-level risk coverage used the synthetic
+    `_FakeMutatingRiskyTool`; a regression in the REAL tool's tags (or in
+    the floor consulting them) kept the suite green while `read_file` ran
+    without asking.
+    """
+    from tldw_chatbook.Tools.file_operation_tools import ReadFileTool
+
+    tool = ReadFileTool()
+    assert "reads" in tool.risk_tags, "precondition: the real tag set"
+
+    gate = BuiltinToolGate(_SessionApprovalService())
+    rows = []
+
+    def request_approvals(pending):
+        rows.extend(pending)
+        return {row.call_id or row.llm_name: "deny" for row in pending}
+
+    hook = build_tool_review_hook(
+        gate, _RealToolProvider(tool), None, request_approvals
+    )
+    verdicts = hook(
+        [ToolCall(name="read_file", args={"file_path": "notes.md"}, call_id="c1")]
+    )
+
+    assert [row.llm_name for row in rows] == ["read_file"], (
+        "the real reads-tagged tool never reached the approval card -- it "
+        f"would have executed silently: {rows}"
+    )
+    assert rows[0].server_key == BUILTIN_TOOL_SERVER_KEY
+    assert rows[0].reason == "risk_floored", rows[0]
+    assert verdicts.get("c1") not in (None, "proceed"), (
+        f"the user's refusal did not reach the runtime: {verdicts}"
+    )
+
+
+@pytest.mark.integration
+def test_create_note_persists_through_a_real_db_on_a_worker_thread(
+    tmp_path, monkeypatch
+):
+    """AC#2: the design-spec claim the nominal test never proved.
+
+    `Tests/Agents/test_builtin_gate_live_tools.py` monkeypatches
+    `NotesInteropService` away, proving only that `asyncio.run` works off the
+    main thread. The spec's actual question: does `CharactersRAGDB` -- built
+    for cross-thread use via `threading.local` connections and
+    `check_same_thread=False` -- really work on the agent's worker thread?
+    This runs the REAL `CreateNoteTool.execute` on a real non-main thread
+    against a real `CharactersRAGDB` at a temp path, then reads the row back
+    on the MAIN thread through the same instance -- both directions of the
+    cross-thread contract.
+    """
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    from tldw_chatbook.Tools import note_management_tools as nmt
+
+    db = CharactersRAGDB(tmp_path / "worker.db", "task-696-test")
+    monkeypatch.setattr("tldw_chatbook.config.chachanotes_db", db, raising=False)
+    monkeypatch.setattr(nmt, "_resolve_user_id", lambda: "worker_user")
+    monkeypatch.setattr(nmt, "_notes_db_base_dir", lambda: str(tmp_path))
+
+    result: dict = {}
+    error: list[BaseException] = []
+
+    def _worker() -> None:
+        assert threading.current_thread() is not threading.main_thread()
+        try:
+            result.update(
+                asyncio.run(
+                    nmt.CreateNoteTool().execute(
+                        title="worker-thread note",
+                        content="written off the main thread",
+                    )
+                )
+            )
+        except BaseException as exc:  # noqa: BLE001 -- surfaced below
+            error.append(exc)
+
+    thread = threading.Thread(target=_worker, name="agent-worker")
+    thread.start()
+    thread.join(timeout=30)
+    assert not thread.is_alive(), "worker thread hung"
+    assert not error, f"execute raised on the worker thread: {error!r}"
+    assert "error" not in result, result
+    note_id = result.get("note_id")
+    assert note_id, result
+
+    # Main thread, same instance: the row must be durable and readable.
+    row = db.get_note_by_id(str(note_id))
+    assert row is not None, "the note vanished across threads"
+    assert row["title"] == "worker-thread note"
+    assert row["content"] == "written off the main thread"

--- a/backlog/tasks/task-696 - Close-two-coverage-gaps-in-the-built-in-tool-gate-review-hook-and-real-DB-worker-thread.md
+++ b/backlog/tasks/task-696 - Close-two-coverage-gaps-in-the-built-in-tool-gate-review-hook-and-real-DB-worker-thread.md
@@ -3,7 +3,7 @@ id: TASK-696
 title: >-
   Close two coverage gaps in the built-in tool gate (review hook, real-DB
   worker thread)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-26 06:45'
 labels:
@@ -27,7 +27,19 @@ TASK-545 P2's whole-branch review found two acceptance criteria that are satisfi
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] A test drives a real gated built-in tool call through `build_tool_review_hook` and asserts an approval row is emitted for it, replacing reliance on the synthetic risky-tool double for this path
-- [ ] A test executes `create_note` on a non-main thread against a real `CharactersRAGDB` (temp path) and asserts the row persists and is readable
-- [ ] Both tests fail if the behavior they cover regresses (demonstrate, e.g. by sabotage)
+- [x] A test drives a real gated built-in tool call through `build_tool_review_hook` and asserts an approval row is emitted for it, replacing reliance on the synthetic risky-tool double for this path
+- [x] A test executes `create_note` on a non-main thread against a real `CharactersRAGDB` (temp path) and asserts the row persists and is readable
+- [x] Both tests fail if the behavior they cover regresses (demonstrate, e.g. by sabotage)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`Tests/Agents/test_builtin_gate_real_tool_coverage.py`, two tests:
+
+**AC#1** drives the real `ReadFileTool` (`risk_tags ("reads",)`) through the real `BuiltinToolGate` + `build_tool_review_hook` and asserts a pending approval row (reason `risk_floored`, `server_key` builtin) reaches the card callback -- and that the refusal travels back per call id. Sabotage: dropping `reads` from `BUILTIN_HIGH_RISK_TAGS` fails it with "would have executed silently: []" -- the exact regression the AC feared.
+
+**AC#2** runs the real `CreateNoteTool.execute` on a real non-main thread against a real `CharactersRAGDB` at a temp path (the config global patched to it -- redirected, not faked away), then reads the row back on the MAIN thread through the same instance: both directions of the cross-thread contract the design spec flagged. Sabotage: severing `add_note`'s write fails it with "the note vanished across threads".
+
+Both tests passed on first run and were therefore sabotage-verified immediately (AC#3), per the programme's standing rule that a first-run pass proves nothing until the failure mode is demonstrated.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Two ACs from TASK-545 P2 were satisfied only by inspection — verified manually during review, protected by nothing, so a regression would pass CI. Both new tests drive **real objects** where the neighbouring suites use doubles, because "the double behaves" is exactly what those reviews found insufficient.

## AC#1 — a real reads-tagged tool must prompt, not run

The only hook-level risk coverage used the synthetic `_FakeMutatingRiskyTool`. The new test drives the **real `ReadFileTool`** (`risk_tags ("reads",)`) through the **real `BuiltinToolGate`** and `build_tool_review_hook`, asserting a pending approval row (reason `risk_floored`, builtin `server_key`) reaches the card callback — and that the user's refusal travels back per call id.

**Sabotage-verified:** dropping `reads` from `BUILTIN_HIGH_RISK_TAGS` fails it with *"would have executed silently: []"* — the exact regression the AC feared.

## AC#2 — the cross-thread DB contract, actually exercised

The nominal worker-thread test monkeypatches `NotesInteropService` away, proving only that `asyncio.run` works off the main thread. The new test answers the design spec's actual question — does `CharactersRAGDB` really work on the agent's worker thread — by running the **real `CreateNoteTool.execute`** on a real non-main thread against a **real `CharactersRAGDB`** at a temp path (the config global *redirected* to it, not faked away), then reading the row back on the **main** thread through the same instance: both directions of the contract.

**Sabotage-verified:** severing `add_note`'s write fails it with *"the note vanished across threads"*.

Both tests passed on first run — which is precisely why both were sabotage-verified before being trusted (AC#3).

917 passed across the Agents and controller suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two real-object tests to protect the built-in tool gate and the worker-thread DB contract (TASK-696).
They now run hermetically and verify that `ReadFileTool` (tag `reads`) triggers a pending approval via real `BuiltinToolGate`/`build_tool_review_hook` (reason `risk_floored`, refusal returned), and that `CreateNoteTool.execute` on a worker thread writes to a real `CharactersRAGDB` and is readable both via the production write path and via the same-instance cross-thread seam (`threading.local`, `check_same_thread=False`) on worker and main threads.

<sup>Written for commit a27ca4ef1964253a605acfe978d7efb57741f656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

