### PR TITLE
docs(backlog): Bagels UI/UX follow-ups (1950-1952)

### DIFF
--- a/backlog/tasks/task-1950 - Draw-each-controls-shortcut-into-its-own-border.md
+++ b/backlog/tasks/task-1950 - Draw-each-controls-shortcut-into-its-own-border.md
@@ -1,0 +1,47 @@
+---
+id: TASK-1950
+title: Draw each control's shortcut into its own border
+status: To Do
+assignee: []
+created_date: '2026-08-02 20:30'
+labels:
+  - ux
+  - navigation
+  - design-system
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Borrowed from [Bagels](https://github.com/EnhancedJax/Bagels) (TUI expense tracker,
+Textual, 2.9k stars) after reviewing its screenshots.
+
+Bagels prints a control's key **on the control**, in its border, rather than only in a
+footer legend or a help screen. Its Templates pane carries `1 - 9` in its bottom border
+and each template button carries its own digit; the period stepper carries `← . →`; the
+account switcher carries `[ ]`; a Date/Person toggle carries `q w`. The footer still
+exists, but it is a reminder rather than the only source of truth.
+
+In Textual this is `border_title` (top-left) and `border_subtitle` (bottom-right) — one
+line per widget, no new machinery.
+
+We have 47 screens in `UI/Screens/` and 34 `BINDINGS` blocks. A user cannot hold that,
+and today the only way to learn a screen's keys is the footer, which is truncated on
+narrow terminals and cannot name a key that belongs to one specific control. This is the
+cheapest discoverability win available to us and it composes with [[task-1951]]
+(jump mode) rather than competing with it.
+
+Scope this as a convention plus a first application, not an app-wide sweep: pick two or
+three dense screens (Console and Evals are the obvious candidates), establish the rule in
+`DESIGN.md`, and let the rest follow as those screens are touched.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] `DESIGN.md` states the convention: a control with a dedicated key shows it in its `border_subtitle`, and a pane whose children share a key range shows the range in its own
+- [ ] The convention says what to do when a control has no border, and when a key is configurable rather than fixed
+- [ ] At least two dense screens apply it, and the keys shown are the keys that actually fire
+- [ ] A test asserts the rendered hint matches the widget's real binding, so a renamed action cannot leave a lying label behind
+- [ ] Hints stay legible at 80x24 as well as 160x45 and 235x52, and never push a control out of reach
+<!-- AC:END -->

--- a/backlog/tasks/task-1950 - Draw-each-controls-shortcut-into-its-own-border.md
+++ b/backlog/tasks/task-1950 - Draw-each-controls-shortcut-into-its-own-border.md
@@ -29,8 +29,8 @@ line per widget, no new machinery.
 We have 47 screens in `UI/Screens/` and 34 `BINDINGS` blocks. A user cannot hold that,
 and today the only way to learn a screen's keys is the footer, which is truncated on
 narrow terminals and cannot name a key that belongs to one specific control. This is the
-cheapest discoverability win available to us and it composes with [[task-1951]]
-(jump mode) rather than competing with it.
+cheapest discoverability win available to us, and it composes with a jump-mode
+overlay (filed separately) rather than competing with it.
 
 Scope this as a convention plus a first application, not an app-wide sweep: pick two or
 three dense screens (Console and Evals are the obvious candidates), establish the rule in
@@ -39,7 +39,7 @@ three dense screens (Console and Evals are the obvious candidates), establish th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] `DESIGN.md` states the convention: a control with a dedicated key shows it in its `border_subtitle`, and a pane whose children share a key range shows the range in its own
+- [ ] `DESIGN.md` states the convention: a control with a dedicated key shows it in its `border_subtitle`, and a pane whose children share a key range shows the range in its own border subtitle
 - [ ] The convention says what to do when a control has no border, and when a key is configurable rather than fixed
 - [ ] At least two dense screens apply it, and the keys shown are the keys that actually fire
 - [ ] A test asserts the rendered hint matches the widget's real binding, so a renamed action cannot leave a lying label behind

--- a/backlog/tasks/task-1951 - Jump-mode-overlay-navigation.md
+++ b/backlog/tasks/task-1951 - Jump-mode-overlay-navigation.md
@@ -1,0 +1,66 @@
+---
+id: TASK-1951
+title: Jump mode overlay navigation
+status: To Do
+assignee: []
+created_date: '2026-08-02 20:30'
+labels:
+  - ux
+  - navigation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Borrowed from [Bagels](https://github.com/EnhancedJax/Bagels), which lists "Jump Mode
+Navigation" as a headline feature and binds it to `v` in its footer.
+
+**The mechanic**, read from Bagels' `components/jumper.py` (59 lines) and
+`components/jump_overlay.py` (92 lines), and confirmed against its own snapshot test
+`TestBasic.test_4_jump_screen.svg`:
+
+- `Jumper` walks `screen.walk_children(Widget)`, keeps those whose `id` is in an
+  id-to-key map (or that satisfy a `Jumpable` protocol exposing `jump_key`), and returns
+  `{Offset: JumpInfo(key, widget)}` using `screen.get_offset(child)`. Widgets not
+  currently laid out raise `NoWidget` and are skipped, so hidden panes cost nothing.
+- `JumpOverlay` is a `ModalScreen` with a 25%-black background. It paints a `Label` per
+  target with `label.styles.offset = offset`, plus a centred "Press a key to jump" and
+  "ESC to dismiss". `on_key` dismisses with the chosen widget.
+- Its snapshot shows the label drawn as a small box over each pane's **top-left border
+  corner**, replacing the first characters of the border title — `╭─a─╮ccounts`,
+  `╭─t─╮emplates`, `╭─p─╮eriod`, `╭─r─╮ecords`, `╭─i─╮nsights`. The keys are **mnemonic
+  first letters, not arbitrary Vimium labels**, so on a stable layout they become
+  muscle memory rather than something to read every time.
+- It explicitly stops bubbling for a named set of keys, so a key pressed to jump cannot
+  also be handled by the parent after dismissal and move focus a second time.
+
+**Licensing — take it from Posting, not Bagels.** Bagels is GPL-3.0. Its jumper is
+derived from [Posting](https://github.com/darrenburns/posting), which is **Apache-2.0**
+and ships the same `jumper.py` / `jump_overlay.py`. We are AGPL-3.0-or-later; sourcing
+from Posting removes the licence question entirely. Keep the attribution notice either
+way.
+
+**Why it fits us specifically.** With 47 screens and 34 `BINDINGS` blocks, our problem is
+not too few shortcuts — it is that nobody can hold them. Jump mode replaces "memorise a
+binding per control" with "one binding, then look at the screen". It also sidesteps a
+defect family our own history keeps producing: a jump target is focused by id, so it
+cannot be made unreachable by a layout change that moves a control out from under the
+mouse.
+
+**The one adaptation we need.** Bagels assigns jump keys from a static config map for a
+single screen. With 47 screens we want keys resolved per *visible* screen at overlay
+time — which the `walk_children` design already supports, since it only sees what is
+laid out. Depends on nothing, but reads much better once [[task-1950]] exists, because
+the two use the same "the key lives on the control" idea.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] One global binding opens a jump overlay over the current screen
+- [ ] Every jumpable target on the visible screen shows a single mnemonic key at its own position; hidden or unlaid-out widgets are skipped without error
+- [ ] Pressing a target's key dismisses the overlay and focuses that widget; ESC dismisses without moving focus
+- [ ] A key pressed to jump does not also reach the underlying screen and move focus a second time
+- [ ] Two screens with different layouts are covered, and a test drives a real keypress through `pilot` and asserts which widget ended up focused
+- [ ] Attribution and licence provenance recorded for whatever implementation we source
+<!-- AC:END -->

--- a/backlog/tasks/task-1952 - Config-driven-keybindings.md
+++ b/backlog/tasks/task-1952 - Config-driven-keybindings.md
@@ -1,0 +1,49 @@
+---
+id: TASK-1952
+title: Config-driven keybindings
+status: To Do
+assignee: []
+created_date: '2026-08-02 20:30'
+labels:
+  - ux
+  - navigation
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Borrowed from [Bagels](https://github.com/EnhancedJax/Bagels), which lists "Customizable
+Keybindings and Defaults" as a headline feature.
+
+We have **no user-configurable keybindings at all** — every one of our 34 `BINDINGS`
+blocks is a hardcoded literal. Bagels reads its hotkeys from config under a nested
+namespace (`CONFIG.hotkeys.new`, `CONFIG.hotkeys.edit`, `CONFIG.hotkeys.delete`,
+`CONFIG.hotkeys.home.new_transfer`), which buys two things beyond user preference:
+
+1. **Code can reason about keys by name.** Bagels' jump overlay suppresses key bubbling
+   by referring to `CONFIG.hotkeys.new` rather than the literal `"a"`. Any code that must
+   know "is this key spoken for?" — a jump overlay, a modal, a text input that must not
+   swallow a global — needs exactly this.
+2. **Collision detection becomes possible.** With 34 independent hardcoded blocks we
+   cannot currently answer "does this new single-letter binding collide with anything?"
+   except by reading all of them. That question is a blocker for [[task-1951]].
+
+This is a real migration rather than a weekend: config schema, defaults, a resolution
+layer that builds `BINDINGS` from it, per-screen namespacing, and a migration path for
+users who have never had this setting. Worth scoping as its own small plan.
+
+Deliberately NOT in scope: remapping keys through the UI. A config file the user edits is
+enough for v1; a settings screen for it is a later question.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] Keybindings resolve from config with the current hardcoded values as defaults, so an untouched install behaves exactly as it does today
+- [ ] The namespace is per-screen, so two screens can bind the same key to different actions without ambiguity
+- [ ] Code can refer to a binding by name rather than by literal, and at least one caller does
+- [ ] A malformed or unknown key in config fails loudly at startup naming the offending entry, rather than silently dropping the binding
+- [ ] Collisions within one screen's resolved set are detected and reported
+- [ ] Documented in `DESIGN.md` and in whatever the user-facing config reference is
+<!-- AC:END -->


### PR DESCRIPTION
Backlog-only. Three navigation/discoverability tasks from a review of [Bagels](https://github.com/EnhancedJax/Bagels) — its source, README, and screenshots.

| Task | Why |
|---|---|
| **1950** — draw each control's shortcut into its own border | Cheapest of the three, and the one the screenshots surfaced. Bagels prints `1 - 9` in the Templates pane border and the digit on each template button; `← . →` on the period stepper; `q w` on a toggle. In Textual that is `border_subtitle`, one line per widget. We have 47 screens and 34 `BINDINGS` blocks and no way to learn a screen's keys except a truncatable footer. |
| **1951** — jump mode overlay | Bagels' headline navigation feature, 151 lines of source. Its own snapshot test shows the mechanic: dim the screen, draw a boxed **mnemonic** letter over each pane's border-title corner (`╭─a─╮ccounts`, `╭─r─╮ecords`), focus by id on keypress. **Source it from [Posting](https://github.com/darrenburns/posting) (Apache-2.0), not Bagels (GPL-3.0)** — same code, and we are AGPL-3.0-or-later, so the licence question disappears. |
| **1952** — config-driven keybindings | We have none. Beyond user preference it buys two things 1951 needs: code that can refer to a key *by name* (Bagels' overlay suppresses bubbling via `CONFIG.hotkeys.new`, not a literal), and the ability to answer 'does this new single-letter binding collide?' across 34 independent blocks. |

Ordering: 1950 stands alone and is cheap. 1951 reads better after 1950 (same 'the key lives on the control' idea) and is safer after 1952 (collision detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three backlog tasks to improve TUI navigation: per-control shortcut hints on borders (`border_title`/`border_subtitle`) (1950), a mnemonic jump‑mode overlay (1951) sourced from `Posting` (Apache‑2.0), and config‑driven, per‑screen keybindings (1952).
ACs updated (including 1950 fix); 1952 adds named bindings and collision checks needed for 1951.

<sup>Written for commit 0166c3574defbfea96fa1adafc97ef945beec6f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

