### PR TITLE
docs: screen decomposition design + console wave-1 plan

### DIFF
--- a/Docs/superpowers/plans/2026-08-02-console-decomposition-wave1.md
+++ b/Docs/superpowers/plans/2026-08-02-console-decomposition-wave1.md
@@ -23,6 +23,16 @@ The spec's six migration rules, verbatim — all non-negotiable:
 
 House rules:
 
+- **Do not start Task 1 while feature work is active in the Console.** This is an
+  owner ruling (2026-08-02), not a style preference: refactoring `chat_screen.py`
+  concurrently with feature branches in the same file guarantees conflict pain for
+  both sides. The pre-flight gate before dispatching Task 1 is:
+  `git log origin/dev --oneline --since="24 hours ago" -- tldw_chatbook/UI/Screens/chat_screen.py`
+  plus a scan of open `origin/*console*` branches — at the time of the ruling that
+  showed 8 commits in 36 hours and four live console feature branches
+  (`console-cost-usage-foundation`, `console-voice-control-v2`,
+  `console-message-selection-toggle`, `controlbar-save-chatbook-removal`). Start only
+  when the churn has visibly settled AND the owner has confirmed the window is open.
 - Run tests foreground: `/private/tmp/tldw-venv/bin/python -m pytest <paths> -p no:randomly` from the clone root. Never `-q`. **Pass `timeout: 600000` on the Bash call** — this harness auto-backgrounds anything past its 120s default and a backgrounded pytest has stalled implementers repeatedly.
 - COMMIT BEFORE ANY MUTATION CHECK; never `git stash` (shared across 100+ worktrees); never `git checkout --` on uncommitted work.
 - **Rebase onto `origin/dev` before starting each task.** This file moves under you; a stale base guarantees conflicts at merge. CSS-bundle conflicts resolve by `git checkout --theirs` the bundle then regenerating via `build_css.py`.

--- a/Docs/superpowers/plans/2026-08-02-console-decomposition-wave1.md
+++ b/Docs/superpowers/plans/2026-08-02-console-decomposition-wave1.md
@@ -1,0 +1,295 @@
+# Console Decomposition — Wave 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove both collaborator kinds from the screen-decomposition design on the Console — three rail region widgets and one controller — landing fast enough that the most concurrently-modified file in the repo is not held hostage by a long-lived branch.
+
+**Architecture:** Per `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`. Region widgets own pixels; controllers do not. New collaborators live in `UI/Console_Modules/` (new package, mirroring `UI/Evals/`). Every extraction preserves DOM ids verbatim and changes no behaviour.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest.
+
+**Why a wave, not the whole screen:** `chat_screen.py` is the most concurrently-modified file in this repository — dev took 161 commits in one recent day, several from sessions working in this exact file. A branch carrying nine cluster extractions would rot before review. Wave 1 proves the pattern (three regions + one controller + the compose skeleton); wave 2 (workspace, session, message, agent, character, image/attachment, composer-orchestration controllers) is planned after wave 1 merges, carrying what it learned. This refines the spec's "one implementation plan per screen" into "per screen, in waves that each land independently" — same intent, honest about this file's churn rate.
+
+## Global Constraints
+
+The spec's six migration rules, verbatim — all non-negotiable:
+
+1. **One region per change.** A change moves exactly one region or extracts exactly one controller. No batch moves.
+2. **Ids are preserved verbatim.** A region widget composes the same ids in the same nesting. If an id must change, that is its own change with its own review, never a passenger on an extraction.
+3. **Painted-geometry assertions before and after.** Every extraction carries a test asserting the moved region's controls are hit-testable — `screen.get_widget_at(*control.region.center)` resolves to the control — at 160x45 AND 235x52. Task 1 writes these against the CURRENT code, so they are proven to pass before anything moves.
+4. **CSS moves with its region** into `css/features/`, and the bundle is regenerated via `build_css.py`. The bundle is never hand-edited.
+5. **Behaviour changes are forbidden in an extraction.** An extraction that also fixes a bug is two changes.
+6. **A characterisation test precedes any extraction whose behaviour is not already covered.**
+
+House rules:
+
+- Run tests foreground: `/private/tmp/tldw-venv/bin/python -m pytest <paths> -p no:randomly` from the clone root. Never `-q`. **Pass `timeout: 600000` on the Bash call** — this harness auto-backgrounds anything past its 120s default and a backgrounded pytest has stalled implementers repeatedly.
+- COMMIT BEFORE ANY MUTATION CHECK; never `git stash` (shared across 100+ worktrees); never `git checkout --` on uncommitted work.
+- **Rebase onto `origin/dev` before starting each task.** This file moves under you; a stale base guarantees conflicts at merge. CSS-bundle conflicts resolve by `git checkout --theirs` the bundle then regenerating via `build_css.py`.
+- Line numbers in this plan are anchors measured at dev `073d640ac`; they WILL have drifted. Re-locate by the named anchor (method name, id, `_frame_console_region` call), never by trusting the number.
+- Existing DOM-driven tests must pass unchanged. Tests reaching into private methods that moved get mechanically retargeted with assertions kept byte-for-byte.
+
+## Verified facts (measured at dev `073d640ac` — re-verify anchors, not conclusions)
+
+- `ChatScreen` spans lines 1559–20338; 567 methods. `compose_content` is lines 12546–13226.
+- `compose_content`'s regions are bounded by **seven `_frame_console_region(...)` calls** at ~12659 (left handle), ~12672 (`left_rail`), ~12771 (main column, a multi-line call), ~13087 (`right_rail`), ~13139 and ~13159 (inspector area, including the `console-run-inspector` Vertical at ~13162), ~13195 (`right_handle`, `variant="quiet"`). These are the extraction seams.
+- `_frame_console_region(widget, *, top=True, variant="solid")` is a static styling helper that adds `console-frame-solid`/`console-frame-quiet` classes and sets `widget.styles.border`. It must move to `UI/Console_Modules/` where all regions can import it — it is the one shared piece.
+- **`on_button_pressed` (368 lines) is NOT a flat dispatch** — it references only ~18 `console-*` ids with substantial per-branch bodies (`console-conversation-browser-*`, `console-session-tab-*`, `console-dictation`, `console-send-message`, `console-agent-drilldown-back`, …). Rail-owned branches move with their rails; the rest stays for wave 2.
+- **`ConsoleComposerBar` already exists** (`#console-native-composer`, see `_console_composer_or_none` ~5137). The composer is NOT a wave-1 region; its screen-side orchestration is a wave-2 controller.
+- `ConsoleRunInspector`, `ConsoleStatusChips`, `ConsoleSetupModal` are already widgets, yielded by `compose_content`.
+- The rail-section machinery on the screen: `_console_rail_state_config` (~9813, 8 lines), `_console_rail_available_columns` (~10232, 4), `_sync_console_rail_sections` (~10553, 10), `_apply_console_rail_section_open` (~10564, 16), `_toggle_console_rail_section` (~10581, 33), `_console_rail_system_line_state` (~3806, 18).
+- Dictation: module-level `ConsoleStreamingDictationSession` (~744, 322 lines), `ConsoleDictationEvent` (~619), `ConsoleDictationLimitSignal` (~643), plus ~20 `*dictation*` methods on the screen (742 lines) and the `self._console_dictation_state` attribute.
+- The shell is responsive: `_sync_compact_shell_controls`, `_compact_console_workbench_widget`, `_hidden_console_workbench_widget` exist, so **at 160x45 some regions may legitimately be hidden or compact**. Task 1 pins what IS, not what "should be".
+- Test harnesses to reuse (verify their real shape first): `ConsoleHarness` in `Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py`, `ConsoleNavigationHarness` in `Tests/UI/test_console_native_chat_flow.py`, `_visible_text` alongside them. `Tests/UI/test_console_internals_decomposition.py` imports all of these — read its top for the working import pattern.
+- `UI/Console_Modules/` does not exist. Create it in Task 2 with an `__init__.py` carrying a module docstring pointing at the spec.
+
+---
+
+### Task 1: Pin the shell's geometry before anything moves
+
+**Files:**
+- Create: `Tests/UI/test_console_shell_regions.py`
+
+**Interfaces:**
+- Consumes: `ConsoleHarness` (or `ConsoleNavigationHarness` — whichever mounts the full shell; verify), `_visible_text`.
+- Produces: the baseline suite every later task must keep green **byte-identical**.
+
+This is spec rule 3 done properly: the assertions are written against the CURRENT code and proven to pass before anything moves, so when Task 3 relocates the left rail, a failure means the move broke something — not that the test was born wrong.
+
+- [ ] **Step 1: Discover the current truth at both sizes**
+
+Write a THROWAWAY probe (do not commit it) that mounts the Console at 160x45 and at 235x52 and prints, for each of these ids, whether it exists, `display`, and `region`: `#console-shell`, `#console-left-rail`, `#console-left-rail-body`, `#console-main-column`, `#console-context-rail-handle`, `#console-inspector-rail-handle`, `#console-control-bar`, `#console-mode-bar`, `#console-native-composer`, `#console-run-inspector`. The shell is responsive — some of these may be hidden or compact at 160x45. Record what you observe in your report.
+
+- [ ] **Step 2: Write the baseline tests from what you observed**
+
+One parametrized test per region id, shaped like this — with the expectation table filled from Step 1's observations, NOT from assumption:
+
+```python
+"""Painted-geometry baseline for the Console shell's regions.
+
+Written BEFORE the wave-1 extractions (spec rule 3, screen-decomposition
+design). Every extraction task must keep this file green and byte-identical.
+If an extraction needs this file to change, the extraction changed behaviour
+-- stop and treat that as a finding.
+
+The expectation table pins what the shell DOES at each size as of the
+baseline commit, including regions that are legitimately hidden in compact
+mode. It does not pin what anyone thinks it should do.
+"""
+
+import pytest
+
+# (id, expected_at_160x45, expected_at_235x52) where expected is
+# "hittable" | "hidden" -- FILL FROM THE STEP-1 PROBE, per observation.
+_REGIONS: list[tuple[str, str, str]] = [
+    ("#console-left-rail", "<observed>", "<observed>"),
+    # ... every id from Step 1 ...
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(160, 45), (235, 52)])
+@pytest.mark.parametrize("region_id,expect_small,expect_large", _REGIONS)
+async def test_region_geometry_is_stable(region_id, expect_small, expect_large, size):
+    expected = expect_small if size == (160, 45) else expect_large
+    async with make_console_pilot(size=size) as pilot:  # the real harness, per its own idiom
+        nodes = pilot.app.screen.query(region_id)
+        if expected == "hidden":
+            assert not nodes or not nodes[0].display
+            return
+        node = nodes[0]
+        assert node.display and node.region.width > 0
+        hit = pilot.app.screen.get_widget_at(*node.region.center)[0]
+        assert hit is node or node in hit.ancestors or hit in node.walk_children()
+```
+
+`make_console_pilot` stands in for however the real harness is entered — copy the exact idiom from `test_console_internals_decomposition.py`'s own tests. The `hit in node.walk_children()` arm exists because a container's center usually resolves to a child; hitting any descendant proves the region paints and receives the mouse.
+
+The `"<observed>"` placeholders MUST all be replaced with `"hittable"` or `"hidden"` before commit — a grep for `<observed>` in the committed file is a task failure.
+
+- [ ] **Step 3: Run the file against unmodified code**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_console_shell_regions.py -p no:randomly` (Bash `timeout: 600000`)
+Expected: PASS on the first complete run. A failure here means the expectation table does not match reality — fix the table, not the shell.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/UI/test_console_shell_regions.py
+git commit -m "test(console): pin shell region geometry before decomposition (wave 1)"
+```
+
+---
+
+### Task 2: The shared frame helper and the package
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/__init__.py`
+- Create: `tldw_chatbook/UI/Console_Modules/frame.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_shell_regions.py` (unchanged — that is the assertion)
+
+**Interfaces:**
+- Produces: `frame_console_region(widget, *, top=True, variant="solid")` — the same behaviour `ChatScreen._frame_console_region` has today, as a module function all wave-1 regions import.
+
+The frame helper is the one piece every region shares. Moving it first means Tasks 3-5 never import from `chat_screen` (which would be a cycle: the screen imports the regions).
+
+- [ ] **Step 1: Read the real `_frame_console_region`** (~12530s, a `@staticmethod` or plain method — check) including the constants it uses (`CONSOLE_QUIET_FRAME_BORDER`, the `ConsoleComposerBar` special-case) and where those constants live.
+
+- [ ] **Step 2: Create the package and move the helper.** `__init__.py` docstring: one paragraph naming the spec and the rule ("a region widget owns pixels; a controller does not"). `frame.py` holds `frame_console_region` as a module function, moved verbatim, with its constants imported from their current homes (import them — do not copy them). `ChatScreen._frame_console_region` becomes a one-line delegation to it (kept temporarily so the not-yet-moved call sites in `compose_content` are untouched; Task 6 removes it).
+
+- [ ] **Step 3: Run the baseline plus the decomposition suite**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_console_shell_regions.py Tests/UI/test_console_internals_decomposition.py -p no:randomly` (timeout 600000)
+Expected: PASS, baseline byte-identical.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tldw_chatbook/UI/Console_Modules/ tldw_chatbook/UI/Screens/chat_screen.py
+git commit -m "refactor(console): shared region frame helper in UI/Console_Modules (wave 1)"
+```
+
+---
+
+### Task 3: The left rail becomes a region widget
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/left_rail.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_left_rail.py` (new), `Tests/UI/test_console_shell_regions.py` (unchanged)
+
+**Interfaces:**
+- Consumes: `frame_console_region` (Task 2).
+- Produces: `ConsoleLeftRail` — composes the block currently at `compose_content` ~12659–12770 (the `left_handle` frame plus the `left_rail` frame's subtree), same ids, same nesting. Messages upward for anything that touches other regions.
+
+- [ ] **Step 1: Map the block.** Read `compose_content` from the `left_handle` frame call to the line before the ~12771 main-column frame call. List every id and every widget class it yields, and every `self.*` it references, in your report. That reference list decides what moves with it.
+
+- [ ] **Step 2: Write the characterisation test first.** `Tests/UI/test_console_left_rail.py`, driving the REAL screen through the real harness: open/collapse a rail section through an actual `pilot.click` on its real control, and assert the persisted outcome (the section's open state after the click, and again after toggling back). Also: pressing a rail section header does not steal focus from the composer if that is today's behaviour — pin whichever way it currently behaves. Run it against unmodified code; it must pass BEFORE the move.
+
+- [ ] **Step 3: Extract.** `ConsoleLeftRail(Vertical)` in `left_rail.py`:
+  - `compose()` yields the moved block verbatim — same ids, same nesting, `frame_console_region` from Task 2.
+  - The rail-section machinery moves onto it: `_console_rail_state_config`, `_console_rail_available_columns`, `_sync_console_rail_sections`, `_apply_console_rail_section_open`, `_toggle_console_rail_section`, `_console_rail_system_line_state` — *if* Step 1's reference map shows they touch only rail state and rail DOM. Any of them that reaches other regions stays on the screen, and the rail posts a message instead:
+
+```python
+    class SectionToggled(Message):
+        """A rail section was opened or closed by the user.
+
+        Args:
+            section_id: The toggled section's id.
+            opened: True when the section is now open.
+        """
+
+        def __init__(self, section_id: str, opened: bool) -> None:
+            self.section_id = section_id
+            self.opened = opened
+            super().__init__()
+```
+
+  - `on_button_pressed` branches whose ids live inside this block move onto the rail as `@on(Button.Pressed, "#<id>")` handlers. Branches whose bodies touch other regions stay on the screen; the rail's job is only to be the place its own buttons are handled.
+  - State the rail needs at construction is passed as named constructor arguments (never `app_instance` wholesale — spec rule).
+  - `compose_content` replaces the moved block with `yield ConsoleLeftRail(...)`.
+
+- [ ] **Step 4: Run everything that touches this surface**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI/test_console_shell_regions.py Tests/UI/test_console_left_rail.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_native_chat_flow.py -p no:randomly` (timeout 600000)
+Expected: PASS; baseline and characterisation files byte-identical to their pre-move state.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Console_Modules/left_rail.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_left_rail.py
+git commit -m "refactor(console): left rail is a region widget (wave 1)"
+```
+
+---
+
+### Task 4: The right rail becomes a region widget
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/right_rail.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_right_rail.py` (new), `Tests/UI/test_console_shell_regions.py` (unchanged)
+
+**Interfaces:**
+- Consumes: `frame_console_region`.
+- Produces: `ConsoleRightRail` — the `right_rail` frame block at ~13087–13158, same contract as Task 3.
+
+Same steps as Task 3, applied to the right-rail block: map the block and its `self.*` references; write the characterisation test against unmodified code (collapse/expand through a real click, pinned persisted state); extract with ids verbatim; move only handlers whose bodies stay inside the rail; message upward otherwise.
+
+One thing to resolve in Step 1 and state in your report: this codebase has ids for BOTH `console-context-rail-*` and `console-inspector-rail-*`. Determine which family lives in this block and name the widget for what it actually is (`ConsoleContextRail` if that is what the block holds) — the class name should match the DOM family, not this plan's guess.
+
+- [ ] **Step 1: Map the block** (as Task 3 Step 1).
+- [ ] **Step 2: Characterisation test first**, passing before the move.
+- [ ] **Step 3: Extract**, ids verbatim, same message pattern.
+- [ ] **Step 4: Run** the same four test files plus the new one (timeout 600000). Expected: PASS.
+- [ ] **Step 5: Commit** — `refactor(console): right rail is a region widget (wave 1)`.
+
+---
+
+### Task 5: The dictation controller
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/dictation.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_dictation_controller.py` (new)
+
+**Interfaces:**
+- Produces: `ConsoleDictationController` — owns `_console_dictation_state` and the dictation lifecycle; the screen delegates. This is wave 1's proof of the controller kind.
+
+Dictation is the most self-contained cluster: its session class (`ConsoleStreamingDictationSession`, 322 lines) and its event types (`ConsoleDictationEvent`, `ConsoleDictationLimitSignal`) are ALREADY module-level in `chat_screen.py`, and the screen's ~20 `*dictation*` methods (~742 lines) cluster around one state attribute.
+
+- [ ] **Step 1: Map the cluster.** List every method matching `*dictation*` on `ChatScreen`, plus the three module-level types, plus every OTHER method that reads `self._console_dictation_state`. The controller boundary is that state attribute: methods that touch it and nothing region-shaped move; methods that merely call into the cluster stay as one-line delegations.
+
+- [ ] **Step 2: Characterisation.** Existing dictation tests exist (`Tests/UI` and `Tests/Audio` — locate them by grep). Run them against unmodified code and record the counts; they are this task's regression net. Where the mic-button flow lacks a DOM-driven test, add one: a real click on `#console-dictation` asserting the persisted state change, passing BEFORE the move.
+
+- [ ] **Step 3: Extract.** Move the three module-level types and the state-owning methods into `dictation.py`. `ConsoleDictationController.__init__` takes named dependencies only — the screen handle for `run_worker`/`call_from_thread`, and the specific app services the mapped methods actually use (found in Step 1), never `app_instance` itself. Workers it starts use `group="console-dictation"` so `exclusive=True` scopes to dictation (spec rule). The screen keeps its public entry points (`action_*`, event handlers) as one-line delegations to `self._dictation`.
+
+- [ ] **Step 4: Run** the dictation tests found in Step 2, the new test, and the Task-1 baseline (timeout 600000). Expected: PASS, with any retargeted private-method tests keeping their assertions byte-for-byte.
+
+- [ ] **Step 5: Commit** — `refactor(console): dictation controller in UI/Console_Modules (wave 1)`.
+
+---
+
+### Task 6: The compose skeleton, the convention, and the record
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `DESIGN.md`
+- Modify: `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`
+- Test: full serial sweep
+
+**Interfaces:** none new — this task closes the wave.
+
+- [ ] **Step 1: Remove the scaffolding.** Delete `ChatScreen._frame_console_region`'s delegation shim if no call site remains inside the screen; if call sites remain (the main column still composes inline until wave 2), keep the shim and say so in the report — do not force it.
+
+- [ ] **Step 2: Measure and record.** In the spec's chat table, annotate the extracted rows with "(wave 1, done)" and record the new `chat_screen.py` line count and `ChatScreen` method count next to the old ones. Honest numbers — the file will still be large; the point is the regions and dictation are owned elsewhere now.
+
+- [ ] **Step 3: Write the convention into `DESIGN.md`.** A "Screen decomposition" section: the one rule (region widget owns pixels; controller does not), where collaborators live (`UI/<Screen>_Modules/`), the six migration rules by reference to the spec, and `UI/Evals/` + wave 1 as the two existence proofs.
+
+- [ ] **Step 4: Full serial sweep**
+
+Run: `/private/tmp/tldw-venv/bin/python -m pytest Tests/UI -p no:randomly -k "console or shell"` then, if green, the full `Tests/UI` serially (timeout 600000 each; the full run takes several minutes).
+Expected: PASS. This repo's parallel runs produce cross-test interference — serial is the gate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py DESIGN.md Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
+git commit -m "refactor(console): wave 1 closed - skeleton, convention, honest numbers"
+```
+
+---
+
+## Wave 1 exit criteria
+
+- The left and right rails are region widgets in `UI/Console_Modules/`, composing the same ids in the same nesting, handling their own buttons, messaging upward for anything cross-region.
+- Dictation state and lifecycle live in a controller; the screen holds one-line delegations.
+- `Tests/UI/test_console_shell_regions.py` is byte-identical to its Task-1 commit and green.
+- Every pre-existing DOM-driven Console test passes unchanged; retargeted private-method tests kept their assertions byte-for-byte.
+- No id changed, no behaviour changed, no CSS rule changed meaning.
+- `DESIGN.md` states the convention; the spec records what wave 1 actually shipped.
+
+## Not in wave 1 (deliberate)
+
+The main-column block (~12771–13054) and its workspace grid; the workspace, session, message, agent, character, and image/attachment controllers; the composer-orchestration controller; `on_key` (190 lines); the `__init__` split. All of that is wave 2, planned after this merges — sized by what these six tasks teach about the real cost of a move. Jump mode and border key hints (tasks 1950/1951) remain separate work that becomes easier after the regions exist.

--- a/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
@@ -1,0 +1,219 @@
+# Screen Decomposition — Design
+
+**Status:** approved 2026-08-02
+**Scope:** `chat_screen.py`, `settings_screen.py`, `library_screen.py`
+
+## Purpose
+
+Three screens carry 52,079 lines between them, each dominated by a single class with
+500–620 methods. They are the hardest files in the codebase to change safely, and they
+are where this project's recurring geometry defects keep appearing. This design defines
+how they come apart.
+
+The immediate trigger is navigation work — jump mode (task-1951) and border key
+hints (task-1950) both need to reason about a screen's regions, which is
+impractical while a screen *is* one object with 567 methods. But the decomposition is
+worth doing on its own terms.
+
+## The measured problem
+
+| | `chat_screen.py` | `settings_screen.py` | `library_screen.py` |
+|---|---|---|---|
+| File lines | 20,338 | 15,922 | 15,819 |
+| Dominant class | `ChatScreen` | `SettingsScreen` | `LibraryScreen` |
+| Class lines | 18,779 (92%) | 14,329 (90%) | 14,973 (95%) |
+| Methods | **567** | **623** | **508** |
+| `__init__` attributes | 27 | 33 | 19 |
+| Distinct `self.*` names | 605 | 547 | 439 |
+| Largest method | `compose_content` 681 | `_render_provider_detail` 530 | `compose_content` 381 |
+
+Two facts shape everything below.
+
+**The state surface is small.** Nineteen to thirty-three instance attributes across
+classes of five hundred–plus methods. Of `ChatScreen`'s 605 distinct `self.*` names,
+roughly 578 are *methods calling other methods*. This is a call-graph problem, not a
+shared-mutable-state swamp — which is why extraction is feasible rather than hopeless.
+
+**The bloat has three different flavours**, and a single technique will not address all
+of them:
+
+- `chat_screen.py` — event dispatch and orchestration. `on_button_pressed` is 368 lines.
+- `settings_screen.py` — per-category rendering. `_render_provider_detail` (530),
+  `_render_detail_pane` (470), `_render_library_rag_editor_fields` (368).
+- `library_screen.py` — composition and data snapshots. `compose_content` (381),
+  `_list_local_source_snapshot` (263).
+
+## What has already been tried, and why the screens still grew
+
+Extraction has happened at scale: 27 modules under `Chat/console_*.py` (25,313 lines)
+and 38 under `Widgets/Console/` (17,693 lines) — roughly 43,000 lines already pulled out
+of the Console's orbit.
+
+It worked, and it did not shrink the Screen. What got extracted was **logic and leaf
+widgets**. What stayed is **Textual glue**: event handlers, action methods, and
+sync/refresh orchestration. A screen that delegates its logic still owns every wire.
+
+The lesson this design takes from that: extracting *what a feature computes* is not
+enough. The unit that has to move is *what a feature owns* — its region of the DOM, its
+events, and its state, together.
+
+## The design: two collaborator kinds, one rule for choosing
+
+**A region widget owns pixels. A controller does not.**
+
+That is the whole rule. It is decidable for every cluster in all three screens, and both
+kinds already exist in this codebase — `Widgets/Console/` holds 58 classes, 38 of which
+define their own `compose()` and 32 of which handle their own `on_*` events. This design
+applies an established pattern at a larger grain; it does not introduce architecture.
+
+### Region widgets
+
+A region widget is a compound `Widget` that:
+
+- composes its own subtree, so `compose_content` becomes a layout skeleton that yields
+  regions rather than 681 lines of inline construction;
+- handles its own events with `@on(...)`, so `on_button_pressed`'s 368-line dispatch
+  mostly evaporates rather than being relocated;
+- posts messages upward for anything the screen must coordinate, rather than being
+  called downward;
+- owns the CSS for its own subtree in `css/features/`.
+
+The screen keeps layout, cross-region coordination, and the Textual lifecycle.
+
+### Controllers
+
+A controller is a plain object that owns state and behaviour with no region of its own.
+It holds the state it is responsible for, takes a screen handle for the framework
+services it genuinely needs (`query_one`, `run_worker`, `call_after_refresh`), and is
+constructed once in `__init__`.
+
+A controller that finds itself calling `query_one` for more than a handful of well-known
+ids is a region widget wearing the wrong hat. That is the review signal.
+
+### Why not controllers alone
+
+Controllers alone were the first proposal and are rejected. They leave `compose_content`
+and `on_button_pressed` standing, because a controller with a screen handle still needs
+the screen to compose and to receive the button event. They do nothing for
+`settings_screen.py`, whose bloat is rendering. And a controller that reaches back
+through `query_one` has the same coupling as before, now hidden behind a facade —
+visible coupling is better than concealed coupling.
+
+### Why not region widgets alone
+
+Non-visual orchestration — session lifecycle, workspace context, agent run bookkeeping —
+would have to become widgets owning no DOM. That is a worse fit than a plain object, and
+it would put state behind a mount lifecycle that does not need one.
+
+## Decomposition targets
+
+These are the clusters the analysis found, with the rule applied. Counts are method
+lines within the dominant class; they size the work, they are not extraction targets to
+hit exactly.
+
+### `chat_screen.py`
+
+The DOM already names its regions — `console-shell` contains `console-left-rail`,
+`console-main-column`, `console-context-rail`, `console-inspector-rail`,
+`console-control-bar`, `console-mode-bar` — but `compose_content` builds them inline,
+yielding twelve raw `Static(...)` calls. The regions exist conceptually and have no code
+of their own. That is the gap.
+
+| Cluster | Lines / methods | Kind |
+|---|---|---|
+| rail + inspector | 958 / 42 | region widgets (left, context, inspector rails) |
+| composer | 377 / 18 | region widget |
+| workspace | 1,382 / 40 | controller |
+| session | 916 / 31 | controller |
+| message | 1,027 / 23 | controller |
+| dictation | 742 / 20 | controller |
+| agent | 612 / 15 | controller + a region widget for its rail section |
+| character | 708 / 14 | controller + a region widget for its rail section |
+| image / attachment | 1,031 / 27 | controller |
+
+### `settings_screen.py`
+
+Bloat is concentrated in per-category detail rendering. Each category's detail pane
+becomes a region widget; the screen keeps category selection and the save path.
+`action_settings_save_category` (517) is the one large non-rendering method and becomes a
+controller.
+
+### `library_screen.py`
+
+`compose_content` (381) splits along the same region lines as the Console.
+`_list_local_source_snapshot` (263) and its siblings are data access with no region and
+become a controller.
+
+## Migration safety
+
+This is the section that matters most, because this refactor walks directly through this
+project's worst-defect territory. Moving a region changes DOM structure and CSS
+selectors, and the recurring failures here have all been geometry: a control pushed out
+of reach three separate times; a bare `Container` defaulting to `height: 1fr` and
+starving its sibling; pane scroll theming left on the wrong node while its contract test
+passed against stale rules; a checkbox no user could toggle while 867 tests passed.
+
+Rules, all non-negotiable:
+
+1. **One region per change.** A change moves exactly one region or extracts exactly one
+   controller. No batch moves.
+2. **Ids are preserved verbatim.** A region widget composes the same ids in the same
+   nesting. If an id must change, that is its own change with its own review, never a
+   passenger on an extraction.
+3. **Painted-geometry assertions before and after.** Every extraction carries a test
+   asserting the moved region's controls are hit-testable —
+   `screen.get_widget_at(*control.region.center)` resolves to the control — at 160x45
+   **and** 235x52. Where such a test already exists for the region, it must pass
+   unchanged; where none exists, it is written *before* the move, against the current
+   code, so it is proven to pass before it is relied upon.
+4. **CSS moves with its region**, into `css/features/`, and the bundle is regenerated via
+   `build_css.py`. The bundle is never hand-edited.
+5. **Behaviour changes are forbidden in an extraction.** An extraction that also fixes a
+   bug is two changes; do the fix separately, before or after, so a regression has one
+   candidate cause.
+6. **A characterisation test precedes any extraction whose behaviour is not already
+   covered.** Extracting untested behaviour is how silent regressions ship.
+
+## Testing
+
+- Existing screen tests must pass unchanged. They are the regression net; a test that
+  needs editing to accommodate an extraction is a signal the extraction changed
+  behaviour.
+- Each new region widget gets its own test file, mounting it in a minimal host app and
+  driving it through `pilot` — real clicks and keypresses, asserting persisted results
+  rather than widget state.
+- Each new controller gets unit tests with no Textual mount.
+- The geometry assertions in rule 3 above.
+- After each screen completes, its full suite runs serially (`-p no:randomly`), because
+  this repo's parallel runs produce cross-test interference that is not a branch signal.
+
+## Order and delivery
+
+One spec — this document — covering the pattern and validating it against all three
+screens. Then **one implementation plan per screen**, each landing independently:
+
+1. **Console** (`chat_screen.py`) — first, because the navigation work that motivated
+   this targets it, and because its regions are already named in the DOM.
+2. **Settings** (`settings_screen.py`) — second; its per-category panes are the cleanest
+   test of whether the region-widget contract generalises beyond the Console's layout.
+3. **Library** (`library_screen.py`) — third.
+
+A screen's plan is not written until the previous screen's is merged, so each plan can
+carry what the last one learned.
+
+Success for a screen is that its dominant class no longer holds regions or feature state
+— not a line-count target. A line count is a proxy that invites splitting a file without
+decoupling anything.
+
+## Not in scope
+
+- **Mixins.** Splitting a class body across files by feature was considered and rejected:
+  it reduces file size while leaving every collaborator able to see all 605 `self.*`
+  names, so nothing becomes independently testable. It is filing, not decoupling.
+- **Behaviour and UX changes.** This design moves code. Jump mode, border key hints, and
+  every other Bagels-derived idea are separate work that becomes easier afterwards.
+- **The other 44 screens.** Three screens account for 61% of `UI/Screens/`. The rest are
+  small enough not to need this, and the convention this establishes is documented in
+  `DESIGN.md` for whichever grows into it next.
+- **A rewrite.** Every step preserves behaviour and ids. There is no point at which the
+  Console is rebuilt.

--- a/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
@@ -1,6 +1,6 @@
 # Screen Decomposition — Design
 
-**Status:** draft for review — 2026-08-02, revision 2
+**Status:** approved 2026-08-02 (revision 3 — composer row corrected after source verification: `ConsoleComposerBar` already exists, so its cluster is a controller, not a new region)
 **Scope:** `chat_screen.py`, `settings_screen.py`, `library_screen.py`
 
 ## Purpose
@@ -165,7 +165,7 @@ of their own. That is the gap.
 | Cluster | Lines / methods | Kind |
 |---|---|---|
 | rail + inspector | 958 / 42 | region widgets (left, context, inspector rails) |
-| composer | 377 / 18 | region widget |
+| composer | 377 / 18 | controller — the region widget already exists (`ConsoleComposerBar` at `#console-native-composer`); the screen-side lines are orchestration (undo/redo, history navigation, action-state sync), not rendering |
 | workspace | 1,382 / 40 | controller |
 | session | 916 / 31 | controller |
 | message | 1,027 / 23 | controller |

--- a/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
@@ -1,6 +1,6 @@
 # Screen Decomposition — Design
 
-**Status:** approved 2026-08-02
+**Status:** draft for review — 2026-08-02, revision 2
 **Scope:** `chat_screen.py`, `settings_screen.py`, `library_screen.py`
 
 ## Purpose
@@ -66,14 +66,35 @@ kinds already exist in this codebase — `Widgets/Console/` holds 58 classes, 38
 define their own `compose()` and 32 of which handle their own `on_*` events. This design
 applies an established pattern at a larger grain; it does not introduce architecture.
 
+**The existence proof is the Evals screen.** `evals_screen.py` is 2,513 lines — the one
+healthy screen among the five largest — precisely because its regions live in
+`UI/Evals/` as widgets (`library_rail.py`, `inspector.py`, the editors) and its
+read-side state lives in a view model (`evals_state.py`). Its screen keeps layout,
+routing, and cross-region coordination, and nothing else. This design is "make the
+other three screens shaped like the Evals screen", stated as rules.
+
+### Where the code lives
+
+Each screen gets a package mirroring `UI/Evals/` and the existing `UI/*_Modules/`
+convention: `UI/Console_Modules/`, `UI/Settings_Modules/`, `UI/Library_Modules/`.
+Region widgets and controllers both live there — one home per screen, so a reader finds
+a screen's collaborators in one place. Existing leaf widgets in `Widgets/Console/` stay
+where they are: they are reusable parts, and a region is a one-place-only composition
+of them. The screen module itself keeps its current path — imports across the repo
+reference it, and moving it is churn with no decoupling value.
+
 ### Region widgets
 
 A region widget is a compound `Widget` that:
 
 - composes its own subtree, so `compose_content` becomes a layout skeleton that yields
   regions rather than 681 lines of inline construction;
-- handles its own events with `@on(...)`, so `on_button_pressed`'s 368-line dispatch
-  mostly evaporates rather than being relocated;
+- handles its own events with `@on(...)`, so the within-region share of
+  `on_button_pressed`'s 368-line dispatch evaporates rather than being relocated; what
+  cannot evaporate — a press whose effect crosses regions — becomes a typed message the
+  screen handles, visible in the type system instead of buried in an if-chain;
+- adopts `RecomposeCaptureGuard` if it ever recomposes — the house convention (seven
+  existing subclasses) for not orphaning mouse capture across its own teardown;
 - posts messages upward for anything the screen must coordinate, rather than being
   called downward;
 - owns the CSS for its own subtree in `css/features/`.
@@ -86,6 +107,17 @@ A controller is a plain object that owns state and behaviour with no region of i
 It holds the state it is responsible for, takes a screen handle for the framework
 services it genuinely needs (`query_one`, `run_worker`, `call_after_refresh`), and is
 constructed once in `__init__`.
+
+`self.app_instance` is `ChatScreen`'s single most-referenced name — 317 references,
+for database handles, config, and notifications. Collaborators do not traverse to it:
+whatever a controller needs from the app is passed at construction, named, so a
+controller's dependencies are its signature. A region widget receives data and posts
+messages; where it genuinely needs an app service, the screen passes that service in,
+never `app_instance` wholesale.
+
+Workers a controller starts run under a group named for that controller, so
+`exclusive=True` scopes to its own work rather than to whichever collaborator last
+used the screen's node.
 
 A controller that finds itself calling `query_one` for more than a handful of well-known
 ids is a region widget wearing the wrong hat. That is the review signal.
@@ -104,6 +136,17 @@ visible coupling is better than concealed coupling.
 Non-visual orchestration — session lifecycle, workspace context, agent run bookkeeping —
 would have to become widgets owning no DOM. That is a worse fit than a plain object, and
 it would put state behind a mount lifecycle that does not need one.
+
+### Bindings and focus
+
+Screen-level `BINDINGS` keep working throughout, because ids and action methods stay on
+the screen until the behaviour they trigger moves. When a region takes ownership of a
+behaviour, its binding moves onto the region widget, where Textual resolves it while
+focus is inside the region; a chord that must work regardless of focus stays on the
+screen and delegates. Nothing here waits on config-driven keybindings (task-1952) — but
+every binding that moves lands in one obvious place, the region, so task-1952 has named
+homes to bind into and jump mode (task-1951) can treat "the regions of the current
+screen" as its target list.
 
 ## Decomposition targets
 
@@ -131,12 +174,22 @@ of their own. That is the gap.
 | character | 708 / 14 | controller + a region widget for its rail section |
 | image / attachment | 1,031 / 27 | controller |
 
+The `sync` cluster — 1,347 lines across 31 methods, the largest verb group in the class
+— splits along the same rule: a sync that repaints one region becomes that region's own
+refresh; a sync that coordinates several regions stays on the screen. That residue is
+why the success criterion below is ownership rather than a line count: the screen
+legitimately keeps cross-region coordination, and it will not end up small.
+
 ### `settings_screen.py`
 
 Bloat is concentrated in per-category detail rendering. Each category's detail pane
-becomes a region widget; the screen keeps category selection and the save path.
-`action_settings_save_category` (517) is the one large non-rendering method and becomes a
-controller.
+becomes a region widget; the screen keeps category selection. The save path is the
+interface that decides whether this screen fits the pattern: today
+`action_settings_save_category` (517 lines) reads every field back out of the rendered
+pane by id. After decomposition each pane owns "collect what I am showing" — returning
+its edited values as one mapping — and a save controller owns validation and
+persistence. A pane that cannot say what it holds without the screen reaching into it
+is drawn at the wrong boundary; that is the review signal for this screen.
 
 ### `library_screen.py`
 
@@ -176,9 +229,13 @@ Rules, all non-negotiable:
 
 ## Testing
 
-- Existing screen tests must pass unchanged. They are the regression net; a test that
-  needs editing to accommodate an extraction is a signal the extraction changed
-  behaviour.
+- Existing tests that drive the screen through the DOM — `pilot` clicks, key presses,
+  id queries — must pass unchanged. They are the regression net; one that needs editing
+  is a signal the extraction changed behaviour.
+- Existing tests that reach into private methods will break when the method moves. That
+  is mechanical, not behavioural: retarget the call and keep the assertion
+  byte-for-byte. An assertion that has to *change* is a finding about the extraction,
+  never a test to accommodate.
 - Each new region widget gets its own test file, mounting it in a minimal host app and
   driving it through `pilot` — real clicks and keypresses, asserting persisted results
   rather than widget state.


### PR DESCRIPTION
Docs only. The design for taking apart the three giant screens, plus the first implementation plan.

## The spec (`Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`)

`chat_screen.py` (20.3k), `settings_screen.py` (15.9k), `library_screen.py` (15.8k) — each one class of 500–620 methods. The design is two collaborator kinds with one rule for choosing: **a region widget owns pixels; a controller does not.**

Grounded in measurement rather than impression:
- The state surface is small (19–33 `__init__` attributes), so this is a call-graph problem, not a shared-state swamp.
- ~43k lines were ALREADY extracted to `Chat/console_*.py` and `Widgets/Console/` without shrinking the screens — logic moved, the Textual glue stayed. The unit that has to move is what a feature *owns*: its DOM region, its events, its state.
- **The existence proof is in-repo:** `evals_screen.py` is 2,513 lines because its regions live in `UI/Evals/` with a view model. The design is 'make the other three shaped like the Evals screen', stated as rules.

Six non-negotiable migration rules, written for this project's paid-for defect history: ids preserved verbatim, one region per change, painted-geometry assertions written BEFORE a move against current code, CSS moves with its region, no behaviour change rides an extraction, characterisation before anything uncovered moves.

## The wave-1 plan (`Docs/superpowers/plans/2026-08-02-console-decomposition-wave1.md`)

Six tasks: geometry baseline pinned first → shared frame helper → left rail region → right rail region → dictation controller → skeleton + `DESIGN.md` convention. Proves both collaborator kinds on the smallest safe surface.

Why a wave and not the whole screen: `chat_screen.py` took 161 dev commits in a single recent day. A nine-cluster branch there would rot before review. Wave 2 (the remaining controllers + main column) is planned after wave 1 merges, sized by what these six tasks teach.

Source-verification highlights that shaped both documents: `compose_content`'s seven `_frame_console_region` calls are the natural extraction seams; `on_button_pressed` is ~18 substantial branches rather than a flat dispatch; and `ConsoleComposerBar` already exists — so the spec's composer row was corrected from 'region widget' to 'controller' before any plan inherited the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the screen decomposition design and the Console wave‑1 implementation plan. This sets clear rules and first steps to break up `chat_screen.py`, `settings_screen.py`, and `library_screen.py` into region widgets and controllers for safer, easier UI changes.

- **Refactors**
  - Defines two collaborator kinds with one rule: region widgets own pixels; controllers do not. Grounded in the existing `evals_screen.py` shape.
  - Establishes `UI/Console_Modules/` for new Console collaborators and a shared frame helper.
  - Wave‑1 scope: extract left and right rails into region widgets, move dictation into a controller, and pin painted‑geometry tests before any moves. Adds a pre‑flight gate to start only when Console feature churn has settled. Ids and behavior stay the same; CSS moves with each region.

<sup>Written for commit e1fda83921a49180c9a13432b14257d17739bec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

