### PR TITLE
test: unify the watchlists harness DB path across eager and lazy consumers (task-1631)

### DIFF
--- a/Tests/UI/app_factory.py
+++ b/Tests/UI/app_factory.py
@@ -30,6 +30,13 @@ from tldw_chatbook.runtime_policy import RuntimeSourceState
 # root conftest's autouse cleanup after each test.
 _created_dirs: list[Path] = []
 
+# Every still-running `get_subscriptions_db_path` patch started by
+# `_build_test_app` (task-1631); stopped by the root conftest's autouse
+# cleanup after each test. See `_build_test_app`'s own comment for why this
+# one patch cannot simply live inside the function's `ExitStack` like the
+# others.
+_active_service_patches: list = []
+
 
 def drain_created_dirs() -> int:
     """Remove every user-data dir created since the last drain.
@@ -47,6 +54,25 @@ def drain_created_dirs() -> int:
     while _created_dirs:
         path = _created_dirs.pop()
         shutil.rmtree(path, ignore_errors=True)
+        drained += 1
+    return drained
+
+
+def drain_active_service_patches() -> int:
+    """Stop every still-running service patch started by `_build_test_app`.
+
+    Called by the root conftest's autouse cleanup fixture after each test
+    (mirroring `drain_created_dirs`), so a patch that must outlive
+    `_build_test_app`'s own call (task-1631: `get_subscriptions_db_path`)
+    never leaks into the next test.
+
+    Returns:
+        The number of patches stopped.
+    """
+    drained = 0
+    while _active_service_patches:
+        patcher = _active_service_patches.pop()
+        patcher.stop()
         drained += 1
     return drained
 
@@ -77,7 +103,9 @@ def _build_test_app(
 
     Returns:
         A freshly constructed ``TldwCli`` whose config, DB paths, and service
-        initialisers were all patched for the duration of ``__init__``.
+        initialisers were all patched for the duration of ``__init__`` --
+        except ``get_subscriptions_db_path``, which stays patched for the
+        rest of the test (see the comment where it is started, below).
     """
     user_data_dir = Path(
         tempfile.mkdtemp(prefix="tldw-chatbook-test-")
@@ -88,6 +116,25 @@ def _build_test_app(
         # `PrivatePathError: link_or_non_regular` before its first assertion.
     ).resolve(strict=True)
     _created_dirs.append(user_data_dir)
+
+    # task-1631: started (not entered via the `with ExitStack()` below) and
+    # left running -- `LocalWatchlistsService.db_factory` (wired inside
+    # `TldwCli._wire_watchlists_and_notifications_services`) is a lambda that
+    # re-resolves `get_subscriptions_db_path()` fresh on every call, not once
+    # at construction, so any call made after this function returns -- i.e.
+    # every call the running screen makes -- must still see this same patch,
+    # not the real, unpatched fallback. The eager, init-time consumers
+    # (`subscriptions_db` / `WatchlistProjection` / `watchlist_bundle_service`,
+    # all built while this patch is live either way) and the lazy
+    # `db_factory` therefore now agree on one on-disk file for the app's
+    # whole life. `drain_active_service_patches` (called by the root
+    # conftest's autouse teardown) stops it once the test ends.
+    subscriptions_patcher = patch(
+        "tldw_chatbook.app.get_subscriptions_db_path",
+        return_value=user_data_dir / "subscriptions.sqlite",
+    )
+    subscriptions_patcher.start()
+    _active_service_patches.append(subscriptions_patcher)
 
     def fake_runtime_policy(app):
         context = SimpleNamespace(
@@ -154,10 +201,6 @@ def _build_test_app(
             patch(
                 "tldw_chatbook.app.get_notifications_db_path",
                 return_value=":memory:",
-            ),
-            patch(
-                "tldw_chatbook.app.get_subscriptions_db_path",
-                return_value=user_data_dir / "subscriptions.sqlite",
             ),
             patch(
                 "tldw_chatbook.app.get_research_db_path",

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1003,6 +1003,38 @@ async def test_overlapping_navigate_requests_complete_in_fifo_order() -> None:
 from Tests.UI.app_factory import _build_test_app  # noqa: F401,E402
 
 
+def test_local_watchlists_service_db_factory_resolves_the_same_path_as_the_eager_subscriptions_db():
+    """task-1631: `_build_test_app`'s `get_subscriptions_db_path` patch must
+    stay in effect for the WHOLE test, not just `TldwCli.__init__`.
+
+    `LocalWatchlistsService.db_factory` (wired inside
+    `_wire_watchlists_and_notifications_services`) is a lambda that
+    re-resolves `get_subscriptions_db_path()` fresh on every call rather than
+    once at construction, so calling it here -- well after `_build_test_app()`
+    has already returned -- exercises exactly the "every call the running
+    screen makes" case the split used to break. `watchlist_bundle_service.db`
+    is the SAME eager `subscriptions_db` built during `__init__`
+    (`self.watchlist_bundle_service = WatchlistBundleService(subscriptions_db)`),
+    so it is the other half of the comparison.
+
+    Compares RESOLVED PATHS, not object identity: `db_factory()` builds a
+    brand-new `SubscriptionsDB` instance on every call by design (mirroring
+    production), so the two sides are never the same object even when the
+    harness is correct -- only the underlying on-disk file must match.
+    """
+    app = _build_test_app()
+
+    eager_path = app.watchlist_bundle_service.db.db_path
+    lazy_path = app.local_watchlists_service.db_factory().db_path
+
+    assert lazy_path == eager_path, (
+        "local_watchlists_service.db_factory() resolved a DIFFERENT on-disk "
+        f"file ({lazy_path}) than the eagerly-built subscriptions_db "
+        f"({eager_path}) -- the get_subscriptions_db_path patch fell out of "
+        "scope before this call, splitting the app across two databases"
+    )
+
+
 def test_file_notes_owner_is_injected_into_fresh_library_workspaces(
     monkeypatch,
     tmp_path,

--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -1305,21 +1305,11 @@ async def test_the_inspector_still_saves_every_shipped_default_selector():
 def _seed_new_item(app, *, content_hash: str) -> tuple[Any, int, int]:
     """Seed one subscription with one "new" item through the real database.
 
-    Seeded through `app.local_watchlists_service._db()` -- the connection
-    the Items pane's own real load path resolves to (`_load_items` -> the
-    controller -> `LocalWatchlistsService`) -- and NOT
-    `app.watchlist_bundle_service.db`, even though the latter is what
-    `WatchlistsCollectionsScreen._briefings_db()` (the queue-toggle write
-    path) reaches. In the running app both resolve to the identical on-disk
-    file, but in THIS harness they do not:
-    `_build_test_app()`'s `get_subscriptions_db_path` patch only lives for
-    the duration of `TldwCli.__init__`, so `watchlist_bundle_service`'s
-    connection (built EAGERLY, inside that init, while the patch is live)
-    and `local_watchlists_service`'s connection (built LAZILY, per call, once
-    the patch has already exited) resolve to two DIFFERENT temp files here.
-    `_open_items_with_seeded_item` below points `watchlist_bundle_service`
-    at THIS connection once the screen's initial load has settled, so
-    `_briefings_db()` agrees with what the Items pane reads.
+    Seeded through `app.local_watchlists_service._db()`, the same on-disk
+    file `app.watchlist_bundle_service.db` uses (task-1631 unified them via
+    `_build_test_app`, so `_open_items_with_seeded_item`'s
+    `watchlist_bundle_service._db = db` realignment below is now a belt-
+    and-suspenders identity pin rather than a fix for a real file split).
 
     Returns:
         `(db, source_id, item_id)` -- `db` is the connection to read the

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -2799,25 +2799,9 @@ async def test_activating_an_available_citation_opens_it_in_the_reader_and_marks
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app, items=2)
     db = app.watchlist_bundle_service.db
-    # `_build_test_app`'s `patch("tldw_chatbook.app.get_subscriptions_db_path",
-    # ...)` is only active while `TldwCli()` itself is constructing (see its
-    # nested `with` blocks) -- long enough for the EAGERLY-built
-    # `watchlist_bundle_service.db` to see it, but `LocalWatchlistsService`'s
-    # own `db_factory` is a lambda that re-resolves `get_subscriptions_db_
-    # path()` LAZILY, on its first real call, which happens well after that
-    # patch has already been undone -- so, in this harness only,
-    # `app.local_watchlists_service._db()` falls through to the real,
-    # unpatched path instead of this test's isolated one (confirmed directly:
-    # a debug probe printed the two `db_path`s and they differ). That is the
-    # SAME database `_mark_item_read_on_open`'s write actually reaches
-    # (`_controller` -> `WatchlistScopeService` -> `LocalWatchlistsService.
-    # update_item` -> `self._db()`), so without this redirect the write
-    # would target a database this test's seeded item was never in. This is
-    # a test-harness-only artifact (in the real app both resolve to the same
-    # configured path), not something Task 6 introduces, so it is patched
-    # here rather than in the shared `_build_test_app`/`_seed_watchlist`
-    # helpers, which every other test in this file already relies on as-is.
-    monkeypatch.setattr(app.local_watchlists_service, "db_factory", lambda: db)
+    # `_build_test_app` unifies `local_watchlists_service.db_factory()` with
+    # `watchlist_bundle_service.db` onto the same on-disk file (task-1631),
+    # so no `db_factory` redirect is needed here anymore.
     cited = _seeded_item_rows(app)[0]
     assert db.get_item_status(cited["id"]) == "new", "fixture precondition"
     _use_fake_chat(
@@ -2950,12 +2934,9 @@ async def test_pressing_enter_on_a_citation_activates_it_through_the_real_table(
     app.notify = Mock()
     watchlist_id = _seed_watchlist(app, items=2)
     db = app.watchlist_bundle_service.db
-    # See the identical redirect + comment in
-    # `test_activating_an_available_citation_opens_it_in_the_reader_and_
-    # marks_it_read` above: `local_watchlists_service`'s lazy `db_factory`
-    # resolves the real, unpatched db path in this harness, which is a
-    # different database than the one this test seeds and asserts against.
-    monkeypatch.setattr(app.local_watchlists_service, "db_factory", lambda: db)
+    # `_build_test_app` unifies `local_watchlists_service.db_factory()` with
+    # `watchlist_bundle_service.db` onto the same on-disk file (task-1631),
+    # so no `db_factory` redirect is needed here anymore.
     cited = _seeded_item_rows(app)[0]
     _use_fake_chat(
         monkeypatch,

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -250,12 +250,18 @@ def install_css_parse_cache() -> "Iterator[None]":
 
 @pytest.fixture(autouse=True)
 def drain_test_app_user_data_dirs() -> "Iterator[None]":
-    """Remove the user-data dirs the shared app factory created during a test.
+    """Remove the user-data dirs and stop the service patches the shared app
+    factory created during a test.
 
     ``Tests/UI/app_factory._build_test_app`` records every ``mkdtemp`` it
     makes; draining here (task-1458) stops the per-call leak that accumulated
-    324k orphaned sandboxes (~285GB) on one dev machine. The import is lazy
-    and conditional so the ~18k tests that never build an app pay nothing.
+    324k orphaned sandboxes (~285GB) on one dev machine. It also stops every
+    still-running service patch the factory started (task-1631:
+    ``get_subscriptions_db_path`` is patched OUTSIDE the factory's own
+    ``ExitStack`` so it stays in effect for the whole test, not just
+    ``TldwCli.__init__`` -- see that module for why), so it never leaks into
+    the next test. The import is lazy and conditional so the ~18k tests that
+    never build an app pay nothing.
 
     Yields:
         None. Draining happens in teardown.
@@ -263,6 +269,7 @@ def drain_test_app_user_data_dirs() -> "Iterator[None]":
     yield
     factory = sys.modules.get("Tests.UI.app_factory")
     if factory is not None:
+        factory.drain_active_service_patches()
         factory.drain_created_dirs()
 
 

--- a/backlog/tasks/task-1631 - Watchlists-test-harness-_build_test_app-misses-local_watchlists_service-lazy-db-factory.md
+++ b/backlog/tasks/task-1631 - Watchlists-test-harness-_build_test_app-misses-local_watchlists_service-lazy-db-factory.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1631
 title: "Watchlists test harness: _build_test_app misses local_watchlists_service's lazy db factory"
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-31 19:03'
 labels:
@@ -48,3 +48,11 @@ free from the harness.
 - [ ] #2 The three documented workarounds (`test_watchlists_inspector.py`'s `_seed_new_item`, `test_watchlists_read_status.py`'s direct `_db()` seeding, `test_watchlists_artifacts_pane.py`'s `db_factory` monkeypatch) are removed or reduced to a one-line comment, since the split they route around no longer exists
 - [ ] #3 `Tests/Subscriptions/`, `Tests/Watchlists/`, `Tests/UI/test_watchlists_inspector.py`, and `Tests/UI/ -k watchlist` remain green after the harness change
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Fix in the harness (`Tests/UI/test_screen_navigation.py::_build_test_app`): make `get_subscriptions_db_path` resolve to the SAME temp path for the app's whole lifetime (widen the patch beyond __init__, or pre-resolve the path and patch with a constant-returning lambda held for the app fixture's duration), so the lazy `db_factory` and the eager init-time consumers agree. Prefer harness-side over caching in production `LocalWatchlistsService._db()` (production semantics unchanged).
+2. Remove/reduce the three documented workarounds (inspector `_seed_new_item` re-route, read_status direct `_db()` seeding, artifacts_pane `db_factory` monkeypatch ×2) per AC #2.
+3. AC #3 sweep: Tests/Subscriptions/, Tests/Watchlists/, test_watchlists_inspector.py, Tests/UI -k watchlist.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1631 - Watchlists-test-harness-_build_test_app-misses-local_watchlists_service-lazy-db-factory.md
+++ b/backlog/tasks/task-1631 - Watchlists-test-harness-_build_test_app-misses-local_watchlists_service-lazy-db-factory.md
@@ -44,9 +44,9 @@ free from the harness.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `_build_test_app()` gives every consumer of watchlist data -- `local_watchlists_service`, the eagerly-built `subscriptions_db`/`WatchlistProjection`, and any other `get_subscriptions_db_path()` caller -- the same on-disk database, whether the patch scope is widened or the factory's first resolution is cached
-- [ ] #2 The three documented workarounds (`test_watchlists_inspector.py`'s `_seed_new_item`, `test_watchlists_read_status.py`'s direct `_db()` seeding, `test_watchlists_artifacts_pane.py`'s `db_factory` monkeypatch) are removed or reduced to a one-line comment, since the split they route around no longer exists
-- [ ] #3 `Tests/Subscriptions/`, `Tests/Watchlists/`, `Tests/UI/test_watchlists_inspector.py`, and `Tests/UI/ -k watchlist` remain green after the harness change
+- [x] #1 `_build_test_app()` gives every consumer of watchlist data -- `local_watchlists_service`, the eagerly-built `subscriptions_db`/`WatchlistProjection`, and any other `get_subscriptions_db_path()` caller -- the same on-disk database, whether the patch scope is widened or the factory's first resolution is cached
+- [x] #2 The three documented workarounds (`test_watchlists_inspector.py`'s `_seed_new_item`, `test_watchlists_read_status.py`'s direct `_db()` seeding, `test_watchlists_artifacts_pane.py`'s `db_factory` monkeypatch) are removed or reduced to a one-line comment, since the split they route around no longer exists
+- [x] #3 `Tests/Subscriptions/`, `Tests/Watchlists/`, `Tests/UI/test_watchlists_inspector.py`, and `Tests/UI/ -k watchlist` remain green after the harness change
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -56,3 +56,77 @@ free from the harness.
 2. Remove/reduce the three documented workarounds (inspector `_seed_new_item` re-route, read_status direct `_db()` seeding, artifacts_pane `db_factory` monkeypatch ×2) per AC #2.
 3. AC #3 sweep: Tests/Subscriptions/, Tests/Watchlists/, test_watchlists_inspector.py, Tests/UI -k watchlist.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Harness fix** (`Tests/UI/app_factory.py::_build_test_app`): the
+`get_subscriptions_db_path` patch is now `start()`ed independently of the
+function's own `with ExitStack()` (which still owns every other init-time-only
+patch) and tracked in a new module-level `_active_service_patches` list, so it
+stays in effect for the app's whole life instead of reverting the instant
+`_build_test_app()` returns. `Tests/conftest.py`'s existing
+`drain_test_app_user_data_dirs` autouse fixture (already responsible for
+draining `_created_dirs` after each test) now also calls the new
+`drain_active_service_patches()` first, so the patch never leaks into the next
+test. This makes the eager, init-time consumers (`subscriptions_db` /
+`WatchlistProjection` / `watchlist_bundle_service`) and the lazy
+`LocalWatchlistsService.db_factory` (re-resolved on every call) agree on one
+on-disk file for as long as the built app is used -- closing every call site
+named in AC #1, including background workers like
+`_backfill_subscription_items_fts` that only run after a real `on_mount`.
+
+**New harness test** (`Tests/UI/test_screen_navigation.py`):
+`test_local_watchlists_service_db_factory_resolves_the_same_path_as_the_eager_subscriptions_db`
+compares `app.watchlist_bundle_service.db.db_path` (the eager side) against
+`app.local_watchlists_service.db_factory().db_path` (the lazy side, called
+well after `_build_test_app()` returns) -- resolved paths, not object identity,
+since `db_factory()` builds a fresh `SubscriptionsDB` every call by design.
+Mutation-verified directly: temporarily reverted the patch back into the
+`ExitStack` (the original bug) and confirmed this test reds (lazy path fell
+through to the real, HOME-redirected fallback while the eager side kept the
+temp path), then restored the fix and confirmed green again.
+
+**AC #2 workarounds:**
+- `test_watchlists_inspector.py::_seed_new_item` -- docstring's 14-line
+  "two different temp files" explanation replaced with a 3-line note that
+  task-1631 unified the paths; the seeding-through-`_db()` code and
+  `_open_items_with_seeded_item`'s `watchlist_bundle_service._db = db`
+  realignment are UNCHANGED (kept as a harmless belt-and-suspenders identity
+  pin per the task's "still a convenient utility" allowance, since removing
+  and re-verifying cross-connection SQLite visibility wasn't worth the risk
+  for a low-priority harness task).
+- `test_watchlists_artifacts_pane.py` -- both `db_factory` monkeypatch
+  occurrences (with their ~18-line and ~5-line justifying comments) are
+  DELETED outright (not just trimmed): they are now fully redundant, since
+  `db_factory()` already resolves to the same file `watchlist_bundle_service.db`
+  uses. Replaced with a 3-line comment pointing at task-1631. Verified by
+  running the full `Tests/Watchlists/` suite after deletion (365 passed).
+- `test_watchlists_read_status.py` -- inspected for the "two DBs" explanation
+  named in the task description; none exists in this file (no docstring or
+  comment mentions the split -- only the bare `app.local_watchlists_service.
+  _db()` seeding pattern, four call sites). Left unchanged: there is nothing
+  stale to trim, and the pattern is already the sanctioned "convenient utility
+  routed through the now-unified path" case.
+
+**AC #3 verification** (all via `.venv/bin/python -m pytest`, no `-q`):
+- `Tests/Subscriptions/`: 535 passed
+- `Tests/Watchlists/`: 365 passed (one apparent failure,
+  `test_export_feed_press_survives_an_os_error_from_the_service`, turned out to
+  be a resource-contention flake from accidentally running two concurrent full
+  suites at once during verification, not a real regression -- confirmed by
+  re-running the file alone, twice, both clean)
+- `Tests/UI/test_watchlists_inspector.py`: 34 passed
+- `Tests/UI/ -k watchlist` (excluding the pre-existing, unrelated
+  `test_watchlists_source_create_form.py::test_a_source_can_be_created_end_to_end_through_the_form`,
+  confirmed failing 2/2 in isolation with a Textual `Select` widget
+  `NoMatches: No nodes match '#label'` error unrelated to this change): 253
+  passed
+
+**Files changed:** `Tests/UI/app_factory.py`, `Tests/conftest.py`,
+`Tests/UI/test_screen_navigation.py` (new harness test),
+`Tests/UI/test_watchlists_inspector.py`,
+`Tests/Watchlists/test_watchlists_artifacts_pane.py`.
+
+Left In Progress per instructions (not moved to Done in this pass).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1631 - Watchlists-test-harness-_build_test_app-misses-local_watchlists_service-lazy-db-factory.md
+++ b/backlog/tasks/task-1631 - Watchlists-test-harness-_build_test_app-misses-local_watchlists_service-lazy-db-factory.md
@@ -130,3 +130,8 @@ temp path), then restored the fix and confirmed green again.
 
 Left In Progress per instructions (not moved to Done in this pass).
 <!-- SECTION:NOTES:END -->
+
+Review correction (2026-08-02): the residual-risk audit line "no test builds two apps in one test"
+was overstated — two same-test double-builds exist (`test_console_resize_reflow.py` converge test,
+`test_console_fleet_discoverability.py` restart test); both are safe because the first app is fully
+torn down before the second build, i.e. safe by test structure, not by harness guarantee.


### PR DESCRIPTION
## Why

`_build_test_app` patched `get_subscriptions_db_path` only for the duration of `TldwCli.__init__`, but `LocalWatchlistsService`'s `db_factory` re-resolves that path on every access — so every post-init call fell through to the real fallback while init-time consumers kept the patched path: one test app silently split across two temp databases. Three suites carried independently-rediscovered workarounds (task-1631).

## What

Tests-only. The patch now outlives init: started outside the init-scoped `ExitStack`, tracked in a module-level registry, and drained by the existing autouse teardown in `Tests/conftest.py` (exception-path-safe: the registry append is immediately after `.start()`, before anything that can raise; LIFO stop order handles same-test double-builds). A new harness test pins the unification by comparing resolved DB paths — independently mutation-verified by the reviewer (reverting to the init-scoped patch reds it with the exact eager-vs-fallback mismatch). The three workarounds are removed or reduced to short comments; no "two different temp files" documentation remains.

## Testing

`Tests/Subscriptions/` 535, `Tests/Watchlists/` 365, `Tests/UI/test_watchlists_inspector.py` 34, `Tests/UI/ -k watchlist` 253 — all green. Excluded with note: `test_watchlists_source_create_form.py`'s end-to-end pair, which fails 2/2 in isolation on the dev tip itself (pre-existing, untouched files). Review approved; its one informational (an overstated audit line in the report) is corrected in the task file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the watchlists test harness DB path so eager and lazy consumers use the same SQLite file. Addresses task-1631; tests-only, removes workarounds and adds a guard test.

- **Bug Fixes**
  - Keep `tldw_chatbook.app.get_subscriptions_db_path` patched for the entire test: started outside `ExitStack`, tracked via `_active_service_patches`, and stopped in `Tests/conftest.py` autouse teardown.
  - Add a harness test that asserts `local_watchlists_service.db_factory().db_path` matches the eager `watchlist_bundle_service.db.db_path`.
  - Remove `db_factory` redirects and long “two DBs” comments in `test_watchlists_artifacts_pane.py`; trim the inspector helper docstring; update the backlog task notes.

<sup>Written for commit b67602261fae645e1ac2d612b841a89c90acbdb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

