### PR TITLE
docs: Agent Change Review PRD + tasks 1970-1980

### DIFF
--- a/Docs/superpowers/specs/2026-08-02-agent-change-review-design.md
+++ b/Docs/superpowers/specs/2026-08-02-agent-change-review-design.md
@@ -1,0 +1,274 @@
+# Agent Change Review — PRD / design spec
+
+**Date:** 2026-08-02
+**Status:** Approved design, pending implementation
+**Feature name:** Agent Change Review (working name; "Turn Review" in UI copy)
+
+## Problem
+
+After an agent turn that touches disk, the user has no in-app way to see what
+actually changed. The transcript shows tool markers (`⚙ write_file → ok`), but
+not the content of the change, not script side effects, and not a way to back
+anything out. Staying "in the loop" today means leaving the app for `git diff`
+— and only works if the workspace happens to be a repo the user manages.
+
+Codex GUI's post-turn review (compact "Edited N files ±x/y" card → full
+tree-plus-diff surface with undo) is the reference UX.
+
+## Goal
+
+After every agent turn that modified files in the active workspace's folder
+roots, the user can — without leaving the app:
+
+1. see that changes happened (count, +adds/−dels) at a glance in the transcript;
+2. open a full review: changed files grouped by Added/Modified/Deleted/Renamed,
+   with syntax-highlighted diffs;
+3. revert any single file, or the whole turn, safely;
+4. browse the change history of previous turns.
+
+## Non-goals (v1)
+
+- Per-hunk revert / partial apply (phase 3 candidate).
+- "Mark reviewed" bookkeeping state.
+- Commit/push of the user's own repos, PR creation (the reference UI's
+  "Commit or push" button is explicitly out).
+- Remote filesystems (no fsspec/universal_pathlib dependency).
+- Gated review-then-apply mode (phase 2 — designed-for, see §10).
+- Redaction inside diffs: the review shows the user their own files on their
+  own screen; unlike logs/exports, no secret masking is applied.
+
+## Decisions taken (with reasons)
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | **Apply-then-review** in v1; gated mode phased later | Matches reference UX; today's write path untouched; gated mode needs merge machinery |
+| 2 | **Track everything on disk** (snapshot diff), not tool logs | Script/skill side effects are exactly what "fully in the loop" must catch |
+| 3 | **App-managed shadow git repo** per root | Works for non-repo roots; the user's own `.git` (repo, index, HEAD, stashes) is never touched |
+| 4 | Transcript card + **dedicated Review screen** | Diffs need real estate; the Console pane is already width-starved (TASK-1846) |
+| 5 | v1 actions: **Undo-all + per-file revert** | Covers real needs; both are clean restores from snapshots |
+| 6 | **Feature gates on the `git` binary** | One pipeline; a difflib twin would be a permanent silent-divergence liability |
+| 7 | **No new dependencies** | browsr is an app, not a library; we render a changed-file *list*, not a filesystem browser, so universal-directorytree buys nothing |
+
+## 1. Tracking substrate: the shadow repo
+
+One shadow repo per **canonical root path** (symlinks resolved, `~` expanded),
+shared across workspaces that include the same root, stored under the app data
+dir:
+
+```
+~/.local/share/tldw_cli/<user>/change_review/<sha256(root)[:16]>/git/
+```
+
+- `GIT_DIR` lives there; `core.worktree` points at the root. Nothing named
+  `.git` is ever created inside the user's tree.
+- Every git invocation passes explicit `--git-dir`/`--work-tree`, never `cd`s,
+  and runs with `GIT_*` environment variables scrubbed.
+- **Config pinned at init** (each one is a real failure on real machines):
+  - `user.name` / `user.email` → fixed app identity (commit fails without one);
+  - `commit.gpgsign=false` (a global `gpgsign=true` would sign — or prompt on —
+    every snapshot);
+  - `core.hooksPath` → empty dir (global husky-style hooks must not fire on
+    snapshots);
+  - `gc.auto=0` (GC is ours to schedule, §6).
+- The user's `.gitignore` files are respected automatically. Forced excludes
+  (`.git/`, common junk: `node_modules/`, `.venv/`, `__pycache__/`, build
+  dirs) live in the shadow repo's `info/exclude`, plus **dynamic oversize
+  excludes**: git cannot exclude by size, so a pre-scan appends paths larger
+  than `max_file_bytes` to `info/exclude` (recorded, surfaced in the review as
+  "N oversized files untracked").
+
+### Nested repos (known hole, handled honestly)
+
+`git add` records a child repo as a **gitlink**: uncommitted changes *inside*
+a nested clone are invisible to the snapshot. A root that *is* a repo works
+fine (its top-level `.git` is just excluded). A root *containing* repos — the
+common `~/projects` shape — does not.
+
+- **v1:** detect nested repos during root scan; the card and Review screen
+  state plainly: "N nested repositories inside this root are not tracked."
+- **Fast-follow (task-filed):** auto-register detected nested repos as their
+  own tracked sub-roots (own shadow repos, excluded from the parent's).
+
+## 2. Turn protocol
+
+A "turn" is one agent run (`run_reply`). Around it:
+
+1. **Run start:** `add -A` + snapshot commit → baseline **B** (skipped if the
+   tree is clean relative to the previous snapshot — then B = previous tip).
+2. **Run end:** same → **E**.
+3. `B == E` → no changes, no card.
+4. The turn's changes are exactly `diff(B, E)`; summary via
+   `diff --numstat -M`, per-file content via `diff -M` / `show`.
+
+The **first snapshot of a root happens at root registration time** (background
+worker), not on the first send — first-turn latency must not absorb the cost
+of hashing a whole tree.
+
+**Failure posture: tracking never blocks the agent.** A failed snapshot logs,
+the run proceeds, and the card degrades to "change tracking failed (reason)".
+No `git` binary (checked once per session via `shutil.which`) → the feature is
+absent with honest Settings copy, and runs behave exactly as today.
+
+### Concurrency
+
+- Per-root lock (in-process asyncio/threading lock + `flock` file lock for
+  cross-process safety) around snapshot/revert; `index.lock` collisions retried
+  with backoff. Two fleet sessions writing one workspace is a today-case, not
+  a corner.
+- Overlapping runs on one root share the timeline; each run's record still
+  stores its own (B, E). Attribution of interleaved writes is imperfect and
+  documented (§5).
+
+## 3. Data model
+
+New AgentRunsDB table (schema bump per repo discipline), coordinated with run
+retention:
+
+```
+change_snapshots(
+  run_id TEXT NOT NULL,          -- FK to runs
+  root TEXT NOT NULL,            -- canonical root path
+  baseline_sha TEXT NOT NULL,    -- B
+  end_sha TEXT NOT NULL,         -- E
+  files_changed INTEGER, adds INTEGER, dels INTEGER,
+  reverted TEXT DEFAULT '',      -- '', 'all', or JSON list of reverted paths
+  tracking_error TEXT DEFAULT ''
+)
+```
+
+Multi-root workspaces: one row per (run, root); the UI aggregates.
+
+## 4. Review UI
+
+### Transcript surface
+
+A per-turn change-summary row in the Console transcript (same display-only
+family as TOOL markers, `markup=False` — the literal-backslash lesson):
+
+```
+✎ Edited 3 files  +92 −468 — review with `v`
+```
+
+Selected-row actions gain `review` (`v`); the run inspector's actionable
+group gains a "Review changes" row. "Undo all" lives on the Review screen, not
+the transcript row — a one-keystroke destructive action in the transcript
+would repeat the mistake TASK-1845 fixed on the approval card.
+
+### Review screen
+
+`UI/Screens/change_review_screen.py`, reached via `push_screen`, `Esc` returns
+to the Console. Layout:
+
+- **Header:** turn selector ("Last turn ▾" — previous turns from
+  `change_snapshots`), workspace + root labels, totals, and any honesty
+  banners (nested repos untracked, oversized files untracked, tracking error).
+- **Left — changed-file tree:** grouped Added / Modified / Deleted / Renamed,
+  flat within groups, built on the repo's existing Tree widgets. Badges:
+  per-file `+a −d`; `⚠ outside file tools` (§5); `binary`.
+- **Right — diff viewer:** unified diff per file with syntax highlighting;
+  windowed/lazy rendering (only the focused file's hunks are mounted — a 50k
+  line generated file must not freeze the screen); per-file line cap with an
+  explicit "diff truncated — N more lines" row; binary files render as
+  `Binary (2.1 KB → 3.4 KB)`; renames render as `old → new` with content diff.
+- **Keyboard-first:** `j/k` file next/prev, `Enter` focus diff, `u` revert
+  file (confirm), `U` undo all (confirm), `Esc` back. All states legible in
+  monochrome (PRODUCT.md rule).
+
+### Empty/degraded states
+
+- No changes this turn → no card (the screen, if opened from history, says
+  "No file changes in this turn").
+- Ephemeral (temporary) sessions: write tools are already refused, so review
+  naturally shows nothing; no special casing.
+- Workspace has no folder roots → feature dormant, Settings copy explains.
+
+## 5. Attribution: honest limits + the badge
+
+`diff(B, E)` attributes **everything that changed during the run window** to
+the turn — including a user's own mid-run edits and any external writer.
+Post-run async writes (a background process the agent started) land in the
+next turn's baseline move and are invisible. Both limits are documented in
+the review's help text; phase 2's gated mode is the real fix.
+
+**Tool-log cross-reference badge:** the run's recorded steps (AgentRunsDB)
+name the paths its file tools touched. A changed file that no recorded file
+tool touched gets a `⚠ changed outside direct file tools` badge — turning the
+attribution limit into signal (that badge is how a script side effect or an
+external writer becomes visible *as such*). Badge absence is not proof of
+tool provenance (script writes are the point); copy says "outside direct
+file tools", never "not by the agent".
+
+## 6. Cost bounds & retention
+
+- `max_files` / `max_total_bytes` budget per root, checked during the
+  registration scan: over budget → tracking disabled for that root with
+  honest copy ("narrow the root or add excludes"), never a silent half-track.
+- Dynamic oversize excludes per §1.
+- **Retention:** turn snapshots pruned past `retention_days` (default 30):
+  drop `change_snapshots` rows, then `reflog expire` + `git gc --prune` in the
+  shadow repo, scheduled off the existing maintenance path. Orphaned shadow
+  repos (root removed/renamed) are GC'd by age.
+
+## 7. Revert semantics
+
+- **Per-file revert** = restore that path to its B state:
+  - modified → `checkout B -- path`;
+  - deleted → same (restores);
+  - **created → guarded `rm`** — `checkout B -- path` errors on a path absent
+    from B; un-create is an explicit delete;
+  - renamed → restore old path, remove new.
+- **Undo all** = the above for every file in the turn's diff.
+- **User-edited-since guard:** before any revert, each target file's disk
+  state is compared to E. Files that differ (the user — or a later turn —
+  changed them after this turn) are listed *by name* in the confirm dialog
+  before anything is overwritten.
+- Every revert is followed by a fresh snapshot commit, and the turn's
+  `reverted` field is updated — history stays true.
+- Reverts are app actions (not agent tool calls): they bypass the tool gate
+  by design but run under the same per-root lock, and each file's outcome is
+  reported individually — a partial failure is never silent.
+
+## 8. Configuration
+
+```toml
+[workspaces.change_review]
+enabled = true            # global kill; per-workspace override in Settings
+max_file_bytes = 5_000_000
+max_files = 50_000
+max_total_bytes = 2_000_000_000
+retention_days = 30
+diff_display_max_lines = 2000   # per file, truncation disclosed
+```
+
+Per-workspace toggle surfaces in Settings alongside folder roots. Env-var
+overrides follow the repo's `TLDW_<SECTION>_<KEY>` convention.
+
+## 9. Testing posture
+
+- **Real git, no mocks:** tmp-dir shadow repos against tmp roots; every claim
+  exercised against actual `git` output.
+- **Revert round-trips** for each of create/modify/delete/rename, plus the
+  user-edited-since guard (edit E-state before reverting → confirm lists it).
+- **Hardening tests:** global `commit.gpgsign=true` and a global `hooksPath`
+  simulated in a scratch `HOME` — snapshots must still succeed silently.
+- **Nested repo test:** child repo inside root → gitlink change does NOT
+  surface as content; the warning does.
+- **Sabotage-verification** (project standing rule): each guard demonstrated
+  to fail when its production half is removed.
+- **UI tests load the shipped stylesheet** (bare-harness measurements are
+  fiction — TASK-1846) and wait on conditions, not pause counts (TASK-1900).
+- **Live tmux verification** before merge: real app, real root, real agent
+  run with a file edit; review opened, diff read, revert performed, at 80×24
+  and 212×64.
+
+## 10. Phasing
+
+- **v1 (this spec):** everything above.
+- **Fast-follows (task-filed with v1):** nested-repo auto-sub-roots;
+  tool-badge refinements.
+- **Phase 2 — gated mode (designed-for, not built):** per-workspace opt-in;
+  the agent's file-root resolution swaps to an app-managed `git worktree`
+  checked out from the shadow repo's tip; Accept applies the diff to the real
+  root, Reject drops the worktree. The by-root shadow repo and (B, E) records
+  are exactly the substrate this needs — no v1 rework anticipated.
+- **Phase 3 candidates:** per-hunk revert; "mark reviewed"; open-in-$EDITOR.

--- a/Docs/superpowers/specs/2026-08-02-agent-change-review-design.md
+++ b/Docs/superpowers/specs/2026-08-02-agent-change-review-design.md
@@ -56,9 +56,16 @@ shared across workspaces that include the same root, stored under the app data
 dir:
 
 ```
-~/.local/share/tldw_cli/<user>/change_review/<sha256(root)[:16]>/git/
+<app data dir>/change_review/<sha256(root)[:16]>/git/   # via the app's data-dir helper
 ```
 
+(A flat `[change_review]` config section, deliberately not nested under
+`[workspaces]`: `get_cli_setting`'s dotted-section form has a recorded
+history of silently dropping caller defaults in this repo.)
+
+- All porcelain/diff parsing uses `-z` NUL-delimited output: paths with
+  spaces, newlines, or arbitrary UTF-8 are data, and revert executes
+  deletions from parsed paths.
 - `GIT_DIR` lives there; `core.worktree` points at the root. Nothing named
   `.git` is ever created inside the user's tree.
 - Every git invocation passes explicit `--git-dir`/`--work-tree`, never `cd`s,
@@ -70,12 +77,20 @@ dir:
   - `core.hooksPath` → empty dir (global husky-style hooks must not fire on
     snapshots);
   - `gc.auto=0` (GC is ours to schedule, §6).
-- The user's `.gitignore` files are respected automatically. Forced excludes
+- The user's `.gitignore` files are respected for noise control — **with one
+  carve-out that protects the core promise**: any path the run's recorded
+  file tools touched is force-added (`git add -f`) at snapshot time, so a
+  direct agent edit to an ignored file (`.env` is the canonical case)
+  ALWAYS surfaces in the review. Script side effects into ignored
+  directories remain a documented blind spot until phase 2. Forced excludes
   (`.git/`, common junk: `node_modules/`, `.venv/`, `__pycache__/`, build
   dirs) live in the shadow repo's `info/exclude`, plus **dynamic oversize
   excludes**: git cannot exclude by size, so a pre-scan appends paths larger
   than `max_file_bytes` to `info/exclude` (recorded, surfaced in the review as
-  "N oversized files untracked").
+  "N oversized files untracked"). The oversize scan also runs on NEW files
+  at every snapshot (cheap — `status` already lists them), so a large
+  artifact the agent downloads mid-turn is excluded and disclosed rather
+  than committed into the shadow store.
 
 ### Nested repos (known hole, handled honestly)
 
@@ -95,7 +110,14 @@ A "turn" is one agent run (`run_reply`). Around it:
 
 1. **Run start:** `add -A` + snapshot commit → baseline **B** (skipped if the
    tree is clean relative to the previous snapshot — then B = previous tip).
-2. **Run end:** same → **E**.
+   B is kicked **in parallel with the model request** and awaited at the
+   tool-dispatch gate: it must complete before the first tool executes, not
+   before the send, so the model's own first-token latency absorbs the
+   snapshot cost. `core.untrackedCache=true` keeps the per-turn status scan
+   cheap on large roots.
+2. **Run end:** same → **E** — on EVERY terminal path, including failed and
+   cancelled runs: a run that died halfway through editing is when review
+   matters most.
 3. `B == E` → no changes, no card.
 4. The turn's changes are exactly `diff(B, E)`; summary via
    `diff --numstat -M`, per-file content via `diff -M` / `show`.
@@ -111,8 +133,9 @@ absent with honest Settings copy, and runs behave exactly as today.
 
 ### Concurrency
 
-- Per-root lock (in-process asyncio/threading lock + `flock` file lock for
-  cross-process safety) around snapshot/revert; `index.lock` collisions retried
+- Per-root lock (in-process lock + a portable atomic-`mkdir` lockdir for
+  cross-process safety — `flock` does not exist on Windows and CI runs
+  Windows lanes) around snapshot/revert; `index.lock` collisions retried
   with backoff. Two fleet sessions writing one workspace is a today-case, not
   a corner.
 - Overlapping runs on one root share the timeline; each run's record still
@@ -204,6 +227,8 @@ file tools", never "not by the agent".
   registration scan: over budget → tracking disabled for that root with
   honest copy ("narrow the root or add excludes"), never a silent half-track.
 - Dynamic oversize excludes per §1.
+- History rows whose snapshots were pruned render as "pruned by retention"
+  in the turn selector rather than erroring.
 - **Retention:** turn snapshots pruned past `retention_days` (default 30):
   drop `change_snapshots` rows, then `reflog expire` + `git gc --prune` in the
   shadow repo, scheduled off the existing maintenance path. Orphaned shadow
@@ -224,6 +249,10 @@ file tools", never "not by the agent".
   before anything is overwritten.
 - Every revert is followed by a fresh snapshot commit, and the turn's
   `reverted` field is updated — history stays true.
+- **Reverts refuse while any run is active on the root** ("finish or stop
+  the run first"): the per-root lock serializes git operations, but the
+  agent's own file tools do not take it — reverting under a writing agent
+  would interleave clobbers.
 - Reverts are app actions (not agent tool calls): they bypass the tool gate
   by design but run under the same per-root lock, and each file's outcome is
   reported individually — a partial failure is never silent.
@@ -231,7 +260,7 @@ file tools", never "not by the agent".
 ## 8. Configuration
 
 ```toml
-[workspaces.change_review]
+[change_review]
 enabled = true            # global kill; per-workspace override in Settings
 max_file_bytes = 5_000_000
 max_files = 50_000

--- a/backlog/tasks/task-1970 - Change-review-ShadowRepoService.md
+++ b/backlog/tasks/task-1970 - Change-review-ShadowRepoService.md
@@ -1,0 +1,31 @@
+---
+id: TASK-1970
+title: 'Change review: ShadowRepoService — hardened per-root shadow git'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - workspaces
+  - change-review
+  - agents
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Foundation for Agent Change Review. A service owning one shadow git repo per CANONICAL root path (symlinks resolved), GIT_DIR under the app data dir, `core.worktree` pointing at the root — the user's own `.git` is never touched. Every invocation passes explicit `--git-dir`/`--work-tree` with `GIT_*` env scrubbed. Init must pin the four configs that break on real machines: app-local `user.name`/`user.email` (commit fails without identity), `commit.gpgsign=false` (a global gpgsign signs or prompts on every snapshot), empty `core.hooksPath` (global husky-style hooks must not fire), `gc.auto=0`. Provides snapshot-commit, numstat, per-file diff/show, and a per-root lock (in-process + flock) with index.lock retry.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A snapshot commit of a scratch root succeeds in a scratch HOME configured with NO git identity, `commit.gpgsign=true`, and a global `core.hooksPath` whose hook would fail the run — all three hazards proven by test
+- [ ] #2 The same root reached through a symlink and directly resolves to ONE shadow repo
+- [ ] #3 No file or directory is ever created inside the tracked root (asserted by tree comparison)
+- [ ] #4 Two concurrent snapshot calls on one root serialize instead of failing on index.lock
+- [ ] #5 `shutil.which('git')` absent -> the service reports unavailable; nothing raises
+- [ ] #6 Forced excludes (.git/, node_modules/, .venv/, __pycache__/, build dirs) live in info/exclude and are honored
+<!-- AC:END -->

--- a/backlog/tasks/task-1970 - Change-review-ShadowRepoService.md
+++ b/backlog/tasks/task-1970 - Change-review-ShadowRepoService.md
@@ -28,4 +28,6 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 - [ ] #4 Two concurrent snapshot calls on one root serialize instead of failing on index.lock
 - [ ] #5 `shutil.which('git')` absent -> the service reports unavailable; nothing raises
 - [ ] #6 Forced excludes (.git/, node_modules/, .venv/, __pycache__/, build dirs) live in info/exclude and are honored
+- [ ] #7 All porcelain/diff parsing is `-z` NUL-delimited: a filename containing spaces AND a newline round-trips through snapshot, diff, and revert
+- [ ] #8 The cross-process lock is portable (atomic mkdir lockdir, no flock) and passes on the Windows CI lane
 <!-- AC:END -->

--- a/backlog/tasks/task-1971 - Change-review-turn-protocol-and-schema.md
+++ b/backlog/tasks/task-1971 - Change-review-turn-protocol-and-schema.md
@@ -30,4 +30,7 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 - [ ] #4 Snapshot failure (e.g. git binary removed mid-session) stores tracking_error and the agent reply still completes
 - [ ] #5 Registering a root triggers its initial snapshot in the background; the first send performs no full-tree add
 - [ ] #6 Schema migration applies cleanly to an existing AgentRunsDB
+- [ ] #7 B runs in parallel with the model request and completes before the FIRST tool executes (asserted by ordering probe), so a send adds no user-visible snapshot latency
+- [ ] #8 A FAILED or cancelled run still records E and its row -- the half-finished edit set is reviewable
+- [ ] #9 An agent file-tool write to a .gitignore'd path (e.g. .env) appears in the turn's diff (force-add carve-out); a SCRIPT write to an ignored dir does not, and the limit is documented
 <!-- AC:END -->

--- a/backlog/tasks/task-1971 - Change-review-turn-protocol-and-schema.md
+++ b/backlog/tasks/task-1971 - Change-review-turn-protocol-and-schema.md
@@ -1,0 +1,33 @@
+---
+id: TASK-1971
+title: 'Change review: B/E turn snapshots around agent runs + change_snapshots schema'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - workspaces
+  - change-review
+  - agents
+  - db
+dependencies:
+  - TASK-1970
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wire the turn protocol: baseline snapshot B at run start (skipped when clean — B = previous tip), end snapshot E at run end; B == E means no changes. Records go in a new AgentRunsDB `change_snapshots` table (run_id, root, baseline_sha, end_sha, files_changed, adds, dels, reverted, tracking_error; schema bump per repo discipline). One row per (run, root) for multi-root workspaces. The FIRST snapshot of a root happens at root-registration time on a background worker — never as first-send latency. Failure posture: tracking never blocks the agent; a failed snapshot logs, stores tracking_error, and the run proceeds.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A run that writes a file yields a change_snapshots row whose diff(B,E) matches disk truth exactly (property test against real git)
+- [ ] #2 A run that touches nothing yields NO row and no card
+- [ ] #3 A change made by a SCRIPT the agent ran (not write_file) appears in diff(B,E)
+- [ ] #4 Snapshot failure (e.g. git binary removed mid-session) stores tracking_error and the agent reply still completes
+- [ ] #5 Registering a root triggers its initial snapshot in the background; the first send performs no full-tree add
+- [ ] #6 Schema migration applies cleanly to an existing AgentRunsDB
+<!-- AC:END -->

--- a/backlog/tasks/task-1972 - Change-review-transcript-summary-row.md
+++ b/backlog/tasks/task-1972 - Change-review-transcript-summary-row.md
@@ -10,6 +10,7 @@ labels:
   - ux
 dependencies:
   - TASK-1971
+  - TASK-1973
 priority: high
 ---
 

--- a/backlog/tasks/task-1972 - Change-review-transcript-summary-row.md
+++ b/backlog/tasks/task-1972 - Change-review-transcript-summary-row.md
@@ -1,0 +1,31 @@
+---
+id: TASK-1972
+title: 'Change review: per-turn transcript summary row + inspector action'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - console
+  - change-review
+  - ux
+dependencies:
+  - TASK-1971
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Display surfaces for a turn's changes: a transcript row in the TOOL-marker display-only family (`✎ Edited 3 files  +92 −468 — review with `v``, markup=False), a `review` selected-row action, and a 'Review changes' row in the run inspector's actionable group. Deliberately NO destructive control here: Undo-all lives on the Review screen behind a confirm — a one-keystroke destructive action in the transcript would repeat the approval-card mistake TASK-1845 fixed. Honesty degradations surface here too: 'change tracking failed (reason)', 'N nested repositories not tracked'.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A turn with changes renders the summary row with real counts; a turn without renders nothing
+- [ ] #2 The row survives subsequent messages and session switch/resume (TOOL-marker anchoring rules)
+- [ ] #3 `v` on the selected row and the inspector action both open the Review screen for THAT turn
+- [ ] #4 tracking_error and nested-repo warnings render on the row/inspector, in monochrome-legible text
+- [ ] #5 No control in the transcript mutates files
+<!-- AC:END -->

--- a/backlog/tasks/task-1973 - Change-review-screen-tree-and-diff.md
+++ b/backlog/tasks/task-1973 - Change-review-screen-tree-and-diff.md
@@ -1,0 +1,33 @@
+---
+id: TASK-1973
+title: 'Change review: Review screen — changed-file tree, windowed diff viewer, turn history'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - console
+  - change-review
+  - ux
+dependencies:
+  - TASK-1971
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The dedicated screen (push_screen, Esc returns): header with turn selector (previous turns from change_snapshots), workspace/root labels, totals, honesty banners; left tree of changed files grouped Added/Modified/Deleted/Renamed (existing Tree widgets — no new deps) with per-file +a/−d and badges; right unified diff with syntax highlighting, rename detection (-M), binary rows as `Binary (2.1 KB → 3.4 KB)`, per-file line cap with explicit 'diff truncated — N more lines'. Windowed rendering: only the focused file's hunks are mounted, so a 50k-line generated file cannot freeze the screen. Keyboard-first: j/k files, Enter to diff, Esc back.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every group renders correctly for a turn containing an add, an edit, a delete, a rename, and a binary change (real-git fixture)
+- [ ] #2 The diff pane renders markup=False/escaped — a file containing Rich markup or [brackets] displays verbatim
+- [ ] #3 A file over diff_display_max_lines shows the truncation row with an accurate count
+- [ ] #4 Only the focused file's diff is mounted (asserted via widget census on a many-file turn)
+- [ ] #5 Turn selector navigates to a previous turn's diff
+- [ ] #6 UI tests load the shipped stylesheet bundle and wait on conditions, not pause counts
+- [ ] #7 All states legible in monochrome
+<!-- AC:END -->

--- a/backlog/tasks/task-1974 - Change-review-reverts.md
+++ b/backlog/tasks/task-1974 - Change-review-reverts.md
@@ -1,0 +1,34 @@
+---
+id: TASK-1974
+title: 'Change review: per-file revert and Undo-all with user-edit guards'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - console
+  - change-review
+  - safety
+dependencies:
+  - TASK-1970
+  - TASK-1971
+  - TASK-1973
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore-to-B actions from the Review screen: per-file (`u`) and whole-turn Undo-all (`U`), both confirmed. Modified/deleted restore via checkout from B; CREATED files un-create via explicit guarded delete (`checkout B -- path` errors on a path absent from B); renames restore old and remove new. Guard: before any revert, each target's disk state is compared to E — files that differ (user or later turn edited them) are listed BY NAME in the confirm before anything is overwritten. Every revert takes a fresh snapshot and updates the row's `reverted` field. Runs under the per-root lock; per-file outcomes reported individually — partial failure is never silent.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Round-trip tests: create/modify/delete/rename each reverted back to exact B state on disk
+- [ ] #2 Un-create removes the file without touching neighbors; revert of a B-absent path never calls checkout
+- [ ] #3 Editing a file after E then reverting lists that file by name in the confirm dialog (sabotage: removing the guard fails the test)
+- [ ] #4 Undo-all on a turn whose file was ALSO changed by a later turn warns before clobbering
+- [ ] #5 After revert, a fresh snapshot exists and `reverted` reflects what happened
+- [ ] #6 A revert failure on one file reports that file and completes the rest
+<!-- AC:END -->

--- a/backlog/tasks/task-1974 - Change-review-reverts.md
+++ b/backlog/tasks/task-1974 - Change-review-reverts.md
@@ -31,4 +31,6 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 - [ ] #4 Undo-all on a turn whose file was ALSO changed by a later turn warns before clobbering
 - [ ] #5 After revert, a fresh snapshot exists and `reverted` reflects what happened
 - [ ] #6 A revert failure on one file reports that file and completes the rest
+- [ ] #7 Revert refuses with 'finish or stop the run first' while ANY run is active on the root (sabotage: removing the guard fails the test)
+- [ ] #8 Undo-all on a multi-root turn restores every root's files
 <!-- AC:END -->

--- a/backlog/tasks/task-1975 - Change-review-cost-bounds-and-retention.md
+++ b/backlog/tasks/task-1975 - Change-review-cost-bounds-and-retention.md
@@ -28,5 +28,7 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 - [ ] #2 A file exceeding max_file_bytes lands in info/exclude, is absent from diffs, and the untracked count is disclosed in the review
 - [ ] #3 Retention run prunes rows older than the cutoff AND shrinks the shadow repo (object count measured before/after)
 - [ ] #4 A shadow repo whose root no longer exists is removed by GC
-- [ ] #5 All knobs read from [workspaces.change_review] with env-var overrides per repo convention
+- [ ] #5 All knobs read from the flat [change_review] section (NOT dotted-nested -- the get_cli_setting dotted form has dropped defaults before) with env-var overrides per repo convention
+- [ ] #6 An oversized file CREATED during a turn is excluded at E-snapshot time and disclosed, never committed to the shadow store
+- [ ] #7 A history row whose snapshots were pruned renders 'pruned by retention' instead of erroring
 <!-- AC:END -->

--- a/backlog/tasks/task-1975 - Change-review-cost-bounds-and-retention.md
+++ b/backlog/tasks/task-1975 - Change-review-cost-bounds-and-retention.md
@@ -1,0 +1,32 @@
+---
+id: TASK-1975
+title: 'Change review: root budgets, oversize excludes, snapshot retention/GC'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - workspaces
+  - change-review
+  - performance
+dependencies:
+  - TASK-1970
+  - TASK-1971
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Keep the substrate bounded. Registration scan enforces max_files/max_total_bytes per root — over budget disables tracking for that root with honest copy ('narrow the root or add excludes'), never a silent half-track. Git cannot exclude by size, so the scan appends files over max_file_bytes to info/exclude dynamically and the review discloses 'N oversized files untracked'. Retention: prune change_snapshots rows past retention_days (default 30), then reflog expire + git gc --prune on the shadow repo, on the existing maintenance path; orphaned shadow repos (root removed) GC'd by age.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An over-budget root registers with tracking disabled and the stated copy; an in-budget root tracks
+- [ ] #2 A file exceeding max_file_bytes lands in info/exclude, is absent from diffs, and the untracked count is disclosed in the review
+- [ ] #3 Retention run prunes rows older than the cutoff AND shrinks the shadow repo (object count measured before/after)
+- [ ] #4 A shadow repo whose root no longer exists is removed by GC
+- [ ] #5 All knobs read from [workspaces.change_review] with env-var overrides per repo convention
+<!-- AC:END -->

--- a/backlog/tasks/task-1976 - Change-review-nested-repo-detection.md
+++ b/backlog/tasks/task-1976 - Change-review-nested-repo-detection.md
@@ -1,0 +1,29 @@
+---
+id: TASK-1976
+title: 'Change review: detect nested repos and disclose the tracking hole'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - workspaces
+  - change-review
+dependencies:
+  - TASK-1971
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+git records a child repo as a gitlink: uncommitted changes INSIDE a nested clone are invisible to the snapshot — silently violating the feature's core promise for the common ~/projects root shape. v1 detects nested repos during the registration scan and discloses honestly: card/inspector and Review screen banners state 'N nested repositories inside this root are not tracked', naming them on the Review screen. (Auto-registering them as sub-roots is TASK-1977.)
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A root containing a child repo reports the child by path in the Review screen banner
+- [ ] #2 An edit inside the child repo produces NO diff rows AND the banner is present (the hole is disclosed, not hidden)
+- [ ] #3 A root that IS a repo (no children) shows no banner and tracks normally
+- [ ] #4 Detection runs in the registration scan, not per-turn
+<!-- AC:END -->

--- a/backlog/tasks/task-1977 - Change-review-nested-repo-sub-roots.md
+++ b/backlog/tasks/task-1977 - Change-review-nested-repo-sub-roots.md
@@ -1,0 +1,29 @@
+---
+id: TASK-1977
+title: 'Change review: auto-register nested repos as tracked sub-roots (fast-follow)'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - workspaces
+  - change-review
+dependencies:
+  - TASK-1976
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the nested-repo hole: repos detected inside a root become their own tracked sub-roots — own shadow repos keyed by their canonical paths, excluded from the parent's shadow repo, bounded depth. The review aggregates parent + sub-root diffs per turn; the TASK-1976 banner disappears for auto-registered children.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An edit inside a nested repo now appears in the turn's review, attributed to the sub-root
+- [ ] #2 The parent's shadow repo excludes the child (no gitlink churn rows)
+- [ ] #3 Sub-root discovery is bounded (depth/count) with disclosure when the bound truncates
+- [ ] #4 Removing the child repo un-registers its sub-root via existing GC
+<!-- AC:END -->

--- a/backlog/tasks/task-1978 - Change-review-tool-log-badge.md
+++ b/backlog/tasks/task-1978 - Change-review-tool-log-badge.md
@@ -1,0 +1,31 @@
+---
+id: TASK-1978
+title: 'Change review: 'changed outside direct file tools' badge'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - console
+  - change-review
+  - agents
+dependencies:
+  - TASK-1971
+  - TASK-1973
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Cross-reference the run's recorded steps (AgentRunsDB) with the turn's changed files: a file no recorded file tool touched gets a `⚠ changed outside direct file tools` badge in the tree — turning the B..E attribution limit into signal (script side effects and external writers become visible AS SUCH). Copy is exact: 'outside direct file tools', never 'not by the agent' — script writes are agent work too, and badge absence is not proof of tool provenance.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A write_file-modified file carries no badge; a file created by a script the agent ran carries the badge
+- [ ] #2 Badge text matches the spec copy exactly and renders in monochrome
+- [ ] #3 A run with no recorded steps (older data) renders without badges rather than badging everything
+- [ ] #4 Badge derivation is tested against real recorded step shapes, not hand-built dicts
+<!-- AC:END -->

--- a/backlog/tasks/task-1978 - Change-review-tool-log-badge.md
+++ b/backlog/tasks/task-1978 - Change-review-tool-log-badge.md
@@ -1,6 +1,6 @@
 ---
 id: TASK-1978
-title: 'Change review: 'changed outside direct file tools' badge'
+title: 'Change review: ''changed outside direct file tools'' badge'
 status: To Do
 assignee: []
 created_date: '2026-08-02 21:00'

--- a/backlog/tasks/task-1979 - Change-review-settings-and-gating.md
+++ b/backlog/tasks/task-1979 - Change-review-settings-and-gating.md
@@ -1,0 +1,30 @@
+---
+id: TASK-1979
+title: 'Change review: Settings surface, per-workspace toggle, git-absent gating'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - settings
+  - change-review
+  - workspaces
+dependencies:
+  - TASK-1971
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User control and honest availability: [workspaces.change_review] config section (enabled, max_file_bytes, max_files, max_total_bytes, retention_days, diff_display_max_lines) with env overrides; a per-workspace toggle in Settings beside folder roots; feature-absent states with honest copy — no git binary ('Change review needs git — install git to enable'), no folder roots configured. Toggles take effect without restart (poke the live config tree — the app_config-captured-once trap).
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Disabling per-workspace stops snapshots for that workspace's roots on the NEXT run without restart
+- [ ] #2 git absent -> Settings and card copy state the reason; runs behave exactly as with the feature off
+- [ ] #3 Every knob is read live from config with the documented env-var override
+- [ ] #4 Settings copy passes the monochrome/persistence-badge conventions of the Settings screen
+<!-- AC:END -->

--- a/backlog/tasks/task-1979 - Change-review-settings-and-gating.md
+++ b/backlog/tasks/task-1979 - Change-review-settings-and-gating.md
@@ -16,7 +16,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-User control and honest availability: [workspaces.change_review] config section (enabled, max_file_bytes, max_files, max_total_bytes, retention_days, diff_display_max_lines) with env overrides; a per-workspace toggle in Settings beside folder roots; feature-absent states with honest copy — no git binary ('Change review needs git — install git to enable'), no folder roots configured. Toggles take effect without restart (poke the live config tree — the app_config-captured-once trap).
+User control and honest availability: flat [change_review] config section (enabled, max_file_bytes, max_files, max_total_bytes, retention_days, diff_display_max_lines) with env overrides; a per-workspace toggle in Settings beside folder roots; feature-absent states with honest copy — no git binary ('Change review needs git — install git to enable'), no folder roots configured. Toggles take effect without restart (poke the live config tree — the app_config-captured-once trap).
 
 Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 <!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-1980 - Change-review-live-UAT.md
+++ b/backlog/tasks/task-1980 - Change-review-live-UAT.md
@@ -1,0 +1,31 @@
+---
+id: TASK-1980
+title: 'Change review: live end-to-end verification (real app, real agent run)'
+status: To Do
+assignee: []
+created_date: '2026-08-02 21:00'
+labels:
+  - change-review
+  - verification
+dependencies:
+  - TASK-1972
+  - TASK-1973
+  - TASK-1974
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The programme's standing lesson: green tests are not a usable feature. Drive the REAL app in tmux with an isolated TLDW_CONFIG_PATH profile: register a scratch root, run a real agent turn that creates+edits+deletes files (including one via a script side effect), read the summary row, open the Review screen, read each diff, revert one file, Undo-all a turn — at 80×24 and 212×64. File defects found as tasks before closing.
+
+Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The full journey above completes on the live app at both sizes, evidenced by captured panes
+- [ ] #2 The script-side-effect file appears in the review (with its TASK-1978 badge if merged)
+- [ ] #3 Reverted files verified on DISK, not just in the UI
+- [ ] #4 Any defect found is filed as a backlog task and linked here
+<!-- AC:END -->


### PR DESCRIPTION
PRD for Codex-GUI-style post-turn change review (spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`), brainstormed and design-reviewed this session, plus its decomposition into eleven dependency-ordered backlog tasks (TASK-1970…1980).

**The feature:** after an agent turn that touched disk — transcript summary row (`✎ Edited 3 files +92 −468`) → dedicated Review screen: changed-file tree grouped by status, syntax-highlighted windowed diffs, per-file revert + Undo-all with user-edit guards, turn history. Tracks *everything on disk* (script side effects included) via an app-managed shadow git repo per root that never touches the user's own `.git`. Phase 2 (gated review-then-apply on worktrees) is designed-for, not built.

**Design review caught three would-be ship-blockers**, folded in:
1. shadow commits failing on real machines (missing git identity; global `gpgsign`; global `hooksPath`) — pinned at init, tested from a hostile `HOME`;
2. nested repos recorded as gitlinks silently hiding changes — v1 discloses honestly, TASK-1977 closes the hole;
3. unbounded `add -A` cost on big roots — budgets, dynamic oversize excludes, registration-time initial snapshot, retention/GC.

Docs + backlog only; no code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Agent Change Review PRD and an ordered backlog (TASK-1970–1980). After any agent turn that touches disk, show a transcript summary and a Review screen with grouped diffs, safe reverts, and turn history using a per-root shadow `git` repo that never touches the user’s `.git`.

- **New Features**
  - Per-root shadow repo tracks all on-disk changes; gates on `git`; tracking never blocks runs. Hardened init (pinned identity/signing/hooks), portable lockdir, NUL-delimited parsing, flat `[change_review]` config.
  - Turn protocol: baseline snapshot kicked in parallel and awaited before the first tool; end snapshot on every terminal path (including failed/cancelled runs); transcript row (“Edited N files +a −d”); Review screen with grouped file tree, windowed syntax-highlighted diffs, history, and a “changed outside direct file tools” badge.
  - Safe reverts: per-file and Undo-all with “user-edited since” guards; refuses while any run is active on the root; fresh snapshot updates history after each revert.
  - Safety/perf: root budgets, dynamic oversize excludes, registration-time initial snapshot, retention/GC with “pruned by retention”; nested repos disclosed in v1 with a fast-follow to auto-track sub-roots.
  - Spec hardening: force-add ignored paths touched by recorded file tools so direct edits (e.g., `.env`) always surface; oversize scan also runs on NEW files at each snapshot.

<sup>Written for commit 53661fc4599b0ea6c23c6b49cbbebb9d3178e804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

