### PR TITLE
Workspaces: ShadowRepoService — hardened per-root shadow git (TASK-1970)

### DIFF
--- a/Tests/Workspaces/test_change_tracking.py
+++ b/Tests/Workspaces/test_change_tracking.py
@@ -74,7 +74,10 @@ def test_snapshot_succeeds_from_a_hostile_home(service, root, monkeypatch, tmp_p
 
 def test_symlinked_and_direct_root_resolve_to_one_shadow_repo(service, root, tmp_path):
     link = tmp_path / "root_link"
-    link.symlink_to(root)
+    try:
+        link.symlink_to(root, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks unsupported on this platform/permission level")
     direct = service.repo_for_root(root)
     via_link = service.repo_for_root(link)
     assert direct.git_dir == via_link.git_dir
@@ -203,6 +206,61 @@ def test_hostile_filename_roundtrips_snapshot_diff_and_restore(service, root):
 
     repo.restore_paths(b, [name])
     assert hostile.read_text() == "original\n"
+
+
+def test_a_toplevel_git_file_is_never_tracked_or_restored(service, root):
+    """A linked git WORKTREE carries a `.git` FILE at its root. Git's own
+    path special-casing refuses to track it (verified before writing this),
+    and the exclude pins that guarantee against future edits -- restoring a
+    worktree's `.git` link would corrupt the user's worktree.
+    """
+    (root / ".git").write_text("gitdir: /main/repo/.git/worktrees/x\n")
+    (root / "code.py").write_text("x = 1\n")
+    repo = service.repo_for_root(root)
+    b = repo.snapshot("baseline")
+    (root / "code.py").write_text("x = 2\n")
+    e = repo.snapshot("end")
+    assert [c.path for c in repo.changed_files(b, e)] == ["code.py"]
+    proc = repo._run("ls-tree", "-r", "--name-only", e)
+    assert ".git" not in str(proc.stdout).split()
+
+
+def test_mixed_case_git_env_vars_are_scrubbed(service, root, monkeypatch, tmp_path):
+    """Windows env vars are case-insensitive: `Git_Index_File` reaches git
+    exactly as GIT_INDEX_FILE does. Asserted on the env builder directly --
+    POSIX git ignores the lowercase spelling, so a subprocess test could not
+    tell scrubbed from ignored.
+    """
+    monkeypatch.setenv("Git_Index_File", str(tmp_path / "wrong-index"))
+    repo = service.repo_for_root(root)
+    assert "Git_Index_File" not in repo._env()
+
+
+def test_a_missing_root_fails_fast_with_a_clear_error(service, tmp_path):
+    from tldw_chatbook.Workspaces.change_tracking import ChangeTrackingError
+
+    with pytest.raises(ChangeTrackingError, match="not a directory"):
+        service.repo_for_root(tmp_path / "vanished")
+
+
+def test_a_typechange_status_passes_through_verbatim(service, root):
+    """file -> symlink is git status `T`; coercing it to A/M/D/R would lie.
+    Documented pass-through, consumers bucket unknown letters as "other".
+    """
+    target = root / "pointee.txt"
+    target.write_text("data\n")
+    changer = root / "changer"
+    changer.write_text("was a file\n")
+    repo = service.repo_for_root(root)
+    b = repo.snapshot("baseline")
+    changer.unlink()
+    try:
+        changer.symlink_to(target)
+    except OSError:
+        pytest.skip("symlinks unsupported on this platform/permission level")
+    e = repo.snapshot("end")
+    by_path = {c.path: c for c in repo.changed_files(b, e)}
+    assert by_path["changer"].status == "T"
 
 
 # -- change classification --------------------------------------------------

--- a/Tests/Workspaces/test_change_tracking.py
+++ b/Tests/Workspaces/test_change_tracking.py
@@ -1,0 +1,281 @@
+"""TASK-1970: ShadowRepoService — hardened per-root shadow git.
+
+Every test drives REAL git in tmp dirs (no mocks — the whole point is that
+git's actual behavior on real machines is the risk surface). The hostile-HOME
+test is the crown jewel: each of its three hazards is a real first-turn
+failure on a real dev machine.
+"""
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Workspaces.change_tracking import (
+    ChangeTrackingUnavailableError,
+    ShadowRepoService,
+)
+
+
+@pytest.fixture()
+def service(tmp_path) -> ShadowRepoService:
+    return ShadowRepoService(data_dir=tmp_path / "appdata")
+
+
+@pytest.fixture()
+def root(tmp_path) -> Path:
+    r = tmp_path / "root"
+    r.mkdir()
+    return r
+
+
+def _tree(path: Path) -> set[str]:
+    return {str(p.relative_to(path)) for p in path.rglob("*")}
+
+
+# -- the hostile HOME -------------------------------------------------------
+
+
+def test_snapshot_succeeds_from_a_hostile_home(service, root, monkeypatch, tmp_path):
+    """No identity + global gpgsign=true + a failing global hook: all three
+    are real per-machine failures. Local pinned config must win over every
+    one of them, silently.
+    """
+    home = tmp_path / "hostile_home"
+    hooks = home / "hooks"
+    hooks.mkdir(parents=True)
+    hook = hooks / "pre-commit"
+    hook.write_text("#!/bin/sh\necho HOSTILE HOOK RAN >&2\nexit 1\n")
+    hook.chmod(0o755)
+    (home / ".gitconfig").write_text(
+        "[commit]\n\tgpgsign = true\n"
+        f"[core]\n\thooksPath = {hooks}\n"
+        # deliberately NO [user] section: commit fails without identity
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(home / ".config"))
+
+    (root / "a.txt").write_text("one\n")
+    repo = service.repo_for_root(root)
+    first = repo.snapshot("baseline")
+    (root / "a.txt").write_text("two\n")
+    second = repo.snapshot("end")
+
+    assert first and second and first != second
+    changed = repo.changed_files(first, second)
+    assert [c.path for c in changed] == ["a.txt"]
+
+
+# -- identity & isolation ---------------------------------------------------
+
+
+def test_symlinked_and_direct_root_resolve_to_one_shadow_repo(service, root, tmp_path):
+    link = tmp_path / "root_link"
+    link.symlink_to(root)
+    direct = service.repo_for_root(root)
+    via_link = service.repo_for_root(link)
+    assert direct.git_dir == via_link.git_dir
+
+
+def test_nothing_is_ever_created_inside_the_tracked_root(service, root):
+    (root / "a.txt").write_text("content\n")
+    before = _tree(root)
+    repo = service.repo_for_root(root)
+    repo.snapshot("baseline")
+    (root / "b.txt").write_text("more\n")
+    repo.snapshot("end")
+    after = _tree(root)
+    assert after - before == {"b.txt"}, (
+        f"the service polluted the tracked root: {sorted(after - before)}"
+    )
+
+
+# -- concurrency ------------------------------------------------------------
+
+
+def test_concurrent_snapshots_serialize(service, root):
+    (root / "seed.txt").write_text("seed\n")
+    repo = service.repo_for_root(root)
+    repo.snapshot("baseline")
+    errors: list[BaseException] = []
+
+    def worker(n: int) -> None:
+        try:
+            (root / f"file{n}.txt").write_text(f"{n}\n")
+            service.repo_for_root(root).snapshot(f"turn {n}")
+        except BaseException as exc:  # noqa: BLE001 -- surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert not errors, f"index.lock (or worse) leaked through: {errors!r}"
+
+
+def test_a_stale_lockdir_is_taken_over(service, root):
+    (root / "a.txt").write_text("x\n")
+    repo = service.repo_for_root(root)
+    repo.ensure_initialized()
+    stale = repo.lock_dir
+    stale.mkdir(parents=True, exist_ok=True)
+    old = time.time() - 3600
+    import os
+
+    os.utime(stale, (old, old))
+    sha = repo.snapshot("after stale lock")
+    assert sha, "a crashed process's hour-old lockdir starved snapshots forever"
+
+
+# -- availability -----------------------------------------------------------
+
+
+def test_git_absent_is_reported_not_raised(tmp_path):
+    svc = ShadowRepoService(
+        data_dir=tmp_path / "appdata", git_executable="/nonexistent/git-binary"
+    )
+    assert svc.available is False
+    with pytest.raises(ChangeTrackingUnavailableError):
+        svc.repo_for_root(tmp_path)
+
+
+def test_hostile_git_env_vars_are_scrubbed(service, root, monkeypatch, tmp_path):
+    """The app itself can run under a git hook or IDE task that exports
+    GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE — inherited by our subprocesses,
+    they would redirect the snapshot into the WRONG repository.
+    """
+    monkeypatch.setenv("GIT_DIR", str(tmp_path / "wrong-repo"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(tmp_path / "wrong-index"))
+
+    (root / "a.txt").write_text("x\n")
+    repo = service.repo_for_root(root)
+    sha = repo.snapshot("under hostile env")
+    assert sha
+    assert (repo.git_dir / "HEAD").exists()
+    # GIT_DIR/GIT_WORK_TREE are already defeated by our explicit flags; the
+    # live hazard is GIT_INDEX_FILE, which flags do NOT override -- without
+    # scrubbing, the snapshot's index lands in the leaked path.
+    assert not (tmp_path / "wrong-index").exists(), (
+        "the leaked GIT_INDEX_FILE was used — env scrubbing is not happening"
+    )
+    assert (repo.git_dir / "index").exists()
+
+
+# -- excludes ---------------------------------------------------------------
+
+
+def test_forced_excludes_are_honored(service, root):
+    (root / "app.py").write_text("print()\n")
+    junk = root / "node_modules" / "pkg"
+    junk.mkdir(parents=True)
+    repo = service.repo_for_root(root)
+    b = repo.snapshot("baseline")
+    (junk / "index.js").write_text("junk\n")
+    (root / "app.py").write_text("print(1)\n")
+    e = repo.snapshot("end")
+    assert [c.path for c in repo.changed_files(b, e)] == ["app.py"]
+
+
+# -- hostile filenames (the -z contract) ------------------------------------
+
+
+def test_hostile_filename_roundtrips_snapshot_diff_and_restore(service, root):
+    """Spaces AND a newline in the name: paths are data, and restore executes
+    file operations from parsed paths. Newline-in-filename is exactly what
+    breaks non-z porcelain parsing silently.
+    """
+    name = "weird name\nwith newline.txt"
+    hostile = root / name
+    hostile.write_text("original\n")
+    repo = service.repo_for_root(root)
+    b = repo.snapshot("baseline")
+    hostile.write_text("modified\n")
+    e = repo.snapshot("end")
+
+    changed = repo.changed_files(b, e)
+    assert [c.path for c in changed] == [name]
+    assert changed[0].status == "M"
+
+    repo.restore_paths(b, [name])
+    assert hostile.read_text() == "original\n"
+
+
+# -- change classification --------------------------------------------------
+
+
+def test_changed_files_classifies_add_modify_delete_rename_binary(service, root):
+    (root / "keep.txt").write_text("keep\n")
+    (root / "edit.txt").write_text("before\n")
+    (root / "gone.txt").write_text("delete me\n")
+    (root / "old_name.txt").write_text("stable content that identifies a rename\n" * 5)
+    (root / "image.bin").write_bytes(b"\x00\x01\x02")
+    repo = service.repo_for_root(root)
+    b = repo.snapshot("baseline")
+
+    (root / "new.txt").write_text("created\n")
+    (root / "edit.txt").write_text("after\n")
+    (root / "gone.txt").unlink()
+    (root / "old_name.txt").rename(root / "new_name.txt")
+    (root / "image.bin").write_bytes(b"\x00\x01\x02\x03\x04")
+    e = repo.snapshot("end")
+
+    by_path = {c.path: c for c in repo.changed_files(b, e)}
+    assert by_path["new.txt"].status == "A"
+    assert by_path["edit.txt"].status == "M"
+    assert by_path["gone.txt"].status == "D"
+    assert by_path["new_name.txt"].status == "R"
+    assert by_path["new_name.txt"].old_path == "old_name.txt"
+    assert by_path["image.bin"].binary is True
+    assert by_path["edit.txt"].adds == 1 and by_path["edit.txt"].dels == 1
+    assert "keep.txt" not in by_path
+
+    diff = repo.diff_text(b, e, "edit.txt")
+    assert "-before" in diff and "+after" in diff
+    assert repo.file_bytes(b, "edit.txt") == b"before\n"
+
+
+# -- snapshot economics -----------------------------------------------------
+
+
+def test_clean_tree_snapshot_returns_existing_tip_without_new_commit(service, root):
+    (root / "a.txt").write_text("x\n")
+    repo = service.repo_for_root(root)
+    first = repo.snapshot("baseline")
+    second = repo.snapshot("no changes")
+    assert first == second
+
+
+def test_first_snapshot_of_an_empty_root_still_produces_a_tip(service, root):
+    repo = service.repo_for_root(root)
+    tip = repo.snapshot("baseline of empty root")
+    assert tip
+
+
+# -- portability ------------------------------------------------------------
+
+
+def test_no_flock_dependency_in_the_module():
+    """Windows CI lanes exist; fcntl does not exist there.
+
+    Asserted on the module's IMPORTS (ast walk), not its prose -- the
+    docstring legitimately explains WHY flock is not used, and a substring
+    check would forbid the explanation.
+    """
+    import ast
+    import inspect
+
+    from tldw_chatbook.Workspaces import change_tracking
+
+    tree = ast.parse(inspect.getsource(change_tracking))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    assert not any(m.split(".")[0] == "fcntl" for m in imported), imported

--- a/backlog/tasks/task-1970 - Change-review-ShadowRepoService.md
+++ b/backlog/tasks/task-1970 - Change-review-ShadowRepoService.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1970
 title: 'Change review: ShadowRepoService — hardened per-root shadow git'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -22,12 +22,36 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A snapshot commit of a scratch root succeeds in a scratch HOME configured with NO git identity, `commit.gpgsign=true`, and a global `core.hooksPath` whose hook would fail the run — all three hazards proven by test
-- [ ] #2 The same root reached through a symlink and directly resolves to ONE shadow repo
-- [ ] #3 No file or directory is ever created inside the tracked root (asserted by tree comparison)
-- [ ] #4 Two concurrent snapshot calls on one root serialize instead of failing on index.lock
-- [ ] #5 `shutil.which('git')` absent -> the service reports unavailable; nothing raises
-- [ ] #6 Forced excludes (.git/, node_modules/, .venv/, __pycache__/, build dirs) live in info/exclude and are honored
-- [ ] #7 All porcelain/diff parsing is `-z` NUL-delimited: a filename containing spaces AND a newline round-trips through snapshot, diff, and revert
-- [ ] #8 The cross-process lock is portable (atomic mkdir lockdir, no flock) and passes on the Windows CI lane
+- [x] #1 A snapshot commit of a scratch root succeeds in a scratch HOME configured with NO git identity, `commit.gpgsign=true`, and a global `core.hooksPath` whose hook would fail the run — all three hazards proven by test
+- [x] #2 The same root reached through a symlink and directly resolves to ONE shadow repo
+- [x] #3 No file or directory is ever created inside the tracked root (asserted by tree comparison)
+- [x] #4 Two concurrent snapshot calls on one root serialize instead of failing on index.lock
+- [x] #5 `shutil.which('git')` absent -> the service reports unavailable; nothing raises
+- [x] #6 Forced excludes (.git/, node_modules/, .venv/, __pycache__/, build dirs) live in info/exclude and are honored
+- [x] #7 All porcelain/diff parsing is `-z` NUL-delimited: a filename containing spaces AND a newline round-trips through snapshot, diff, and revert
+- [x] #8 The cross-process lock is portable (atomic mkdir lockdir, no flock) and passes on the Windows CI lane
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD in `Tests/Workspaces/test_change_tracking.py` against real git: hostile-HOME snapshot (no identity + gpgsign=true + failing global hooksPath), symlink/direct one-repo, nothing-in-root tree comparison, concurrent serialize, git-absent typed unavailability, forced excludes, hostile-filename (spaces+newline) roundtrip through snapshot/numstat/restore, stale-lockdir recovery, changed-file classification (A/M/D/R/binary).
+2. `tldw_chatbook/Workspaces/change_tracking.py`: `ShadowRepoService` (data-dir via `Utils.paths.get_user_data_dir`, canonical-root keying by sha256(resolved path)) and `ShadowRepo` (ensure_initialized pins identity/gpgsign=false/empty hooksPath/gc.auto=0/core.untrackedCache=true + info/exclude; `snapshot()` = add -A + commit-if-dirty with --no-verify, --allow-empty first commit; `changed_files()` = -z -M numstat+name-status merge; `diff_text`/`file_bytes`; low-level `restore_paths` checkout primitive — full revert semantics stay in TASK-1974).
+3. Locking: per-repo in-process threading.Lock + portable atomic-mkdir lockdir with backoff and stale-age takeover; no fcntl/flock anywhere.
+4. Every git call: explicit --git-dir/--work-tree, GIT_* env scrubbed, GIT_TERMINAL_PROMPT=0, subprocess timeout.
+5. Sabotage pass on the guards that pass first try.
+
+AC#5 interpretation (recorded): "nothing raises" = constructing the service and probing `.available` never raise; USING an unavailable service raises the typed `ChangeTrackingUnavailableError` — a silent no-op snapshot would be this programme's canonical false-pass bug.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`tldw_chatbook/Workspaces/change_tracking.py` + `Tests/Workspaces/test_change_tracking.py` (13 tests, all against real git in tmp dirs — zero mocks).
+
+`ShadowRepoService.repo_for_root` canonicalizes (expanduser+resolve, sha256-keyed) so every spelling of a root shares one repo; `ShadowRepo` pins the four hostile-machine configs at every `ensure_initialized` (self-healing), snapshots with `add -A` + commit-if-dirty (`--no-verify`, `--allow-empty` only for the first tip), parses ONLY `-z` NUL streams (name-status + numstat merged, rename- and binary-aware), and takes an in-process lock + portable mkdir lockdir with logged stale takeover. `restore_paths` is deliberately a low-level checkout primitive — un-create and guards are TASK-1974's.
+
+AC#5 interpretation recorded in the plan: constructing/probing never raises; USING an unavailable service raises the typed error (silent no-op snapshots are this programme's canonical false-pass).
+
+**The sabotage pass earned its keep twice.** My first harness used an unquoted heredoc that collapsed `\0` — the parsing sabotage silently never applied, and "mutation survived" was actually "mutation never ran" (the harness now asserts replacement counts). And the env-scrub test originally asserted on `GIT_DIR`, which our explicit `--git-dir` flag already defeats — the LIVE hazard is `GIT_INDEX_FILE`, which flags do NOT override; the test now proves the index lands in the shadow repo, not the leaked path. Three sabotages (config pins removed / non-z parsing / scrub removed) each fail exactly one test.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -39,7 +39,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Sequence
 
 from loguru import logger
 
@@ -47,7 +47,13 @@ from loguru import logger
 #: carry. The user's own ``.gitignore`` files are additionally honored by git
 #: itself (with the tool-touched force-add carve-out applied in TASK-1971).
 FORCED_EXCLUDES: tuple[str, ...] = (
+    # Both spellings: `.git/` (directory) and `.git` (the FILE a linked git
+    # worktree carries). Git's own path special-casing already refuses to
+    # track a top-level `.git` of either kind -- verified empirically -- so
+    # these are belt-and-braces pinning the guarantee against future
+    # exclude edits, not a live bug fix.
     ".git/",
+    ".git",
     "node_modules/",
     ".venv/",
     "venv/",
@@ -85,7 +91,11 @@ class ChangedFile:
 
     Attributes:
         path: Path relative to the root (the NEW path for renames).
-        status: ``"A"``/``"M"``/``"D"``/``"R"`` (added/modified/deleted/renamed).
+        status: ``"A"``/``"M"``/``"D"``/``"R"`` (added/modified/deleted/
+            renamed) for the overwhelmingly common cases; rarer git letters
+            (``"T"`` typechange, ``"C"`` copy) pass through VERBATIM rather
+            than being coerced into a lie -- consumers group unknown letters
+            into an "other" bucket.
         adds: Added-line count (0 for binary).
         dels: Deleted-line count (0 for binary).
         old_path: The pre-rename path, or ``None``.
@@ -163,6 +173,14 @@ class ShadowRepoService:
                 "change tracking needs git — install git to enable"
             )
         canonical = Path(root).expanduser().resolve()
+        if not canonical.is_dir():
+            # Roots come from the workspace registry, not from agent input,
+            # so this is a sanity guard rather than a security boundary --
+            # but a vanished/mistyped root must fail HERE with a clear
+            # message, not five calls later inside a git subprocess.
+            raise ChangeTrackingError(
+                f"change tracking root is not a directory: {canonical}"
+            )
         key = hashlib.sha256(str(canonical).encode("utf-8")).hexdigest()[:16]
         repo_home = self._data_dir / key
         assert self._git is not None  # narrowed by `available`
@@ -196,7 +214,14 @@ class ShadowRepo:
 
     def _env(self) -> dict[str, str]:
         """Environment for git calls: ``GIT_*`` scrubbed, prompts disabled."""
-        env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+        # Case-INSENSITIVE match: Windows environment variables are
+        # case-insensitive, so `Git_Index_File` reaches git just as
+        # GIT_INDEX_FILE does. Harmless over-scrub on POSIX.
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.upper().startswith("GIT_")
+        }
         env["GIT_TERMINAL_PROMPT"] = "0"
         return env
 
@@ -318,7 +343,11 @@ class ShadowRepo:
     # -- snapshots ---------------------------------------------------------
 
     def tip(self) -> str | None:
-        """Current snapshot tip sha, or ``None`` before the first snapshot."""
+        """Return the current snapshot tip.
+
+        Returns:
+            The tip commit sha, or ``None`` before the first snapshot.
+        """
         proc = self._run("rev-parse", "--verify", "HEAD", check=False)
         if proc.returncode != 0:
             return None
@@ -330,6 +359,15 @@ class ShadowRepo:
         A clean tree returns the existing tip without a new commit. The very
         first snapshot commits even an empty tree (``--allow-empty``) so a
         baseline tip always exists.
+
+        Args:
+            message: Commit message recorded on the snapshot (turn labels).
+
+        Returns:
+            The tip sha after the snapshot.
+
+        Raises:
+            ChangeTrackingError: A git step failed or produced no tip.
         """
         with self._locked():
             self.ensure_initialized()
@@ -360,6 +398,13 @@ class ShadowRepo:
         Merges ``--name-status -z`` (status/rename pairs) with
         ``--numstat -z`` (line counts, binary detection). Both streams are
         NUL-delimited; paths are data.
+
+        Args:
+            base: Older snapshot sha (exclusive).
+            end: Newer snapshot sha (inclusive).
+
+        Returns:
+            One :class:`ChangedFile` per changed path, in git's diff order.
         """
         status_by_path: dict[str, tuple[str, str | None]] = {}
         ordered: list[str] = []
@@ -421,12 +466,29 @@ class ShadowRepo:
         return [t.decode("utf-8", "surrogateescape") for t in raw.split(b"\0") if t]
 
     def diff_text(self, base: str, end: str, path: str) -> str:
-        """Unified diff for one file between two snapshots."""
+        """Return the unified diff for one file between two snapshots.
+
+        Args:
+            base: Older snapshot sha.
+            end: Newer snapshot sha.
+            path: Root-relative path to diff.
+
+        Returns:
+            Unified diff text (rename-aware), empty for no change.
+        """
         proc = self._run("diff", "-M", base, end, "--", path)
         return str(proc.stdout)
 
     def file_bytes(self, commit: str, path: str) -> bytes | None:
-        """A file's content at a snapshot, or ``None`` if absent there."""
+        """Return a file's content at a snapshot.
+
+        Args:
+            commit: Snapshot sha to read from.
+            path: Root-relative path.
+
+        Returns:
+            Raw bytes, or ``None`` when the path does not exist there.
+        """
         proc = self._run("show", f"{commit}:{path}", check=False, binary=True)
         if proc.returncode != 0:
             return None
@@ -440,6 +502,14 @@ class ShadowRepo:
         Low-level primitive: every path must EXIST at ``commit`` (un-create —
         deleting a path absent from the snapshot — is TASK-1974's guarded
         delete, deliberately not hidden inside this call).
+
+        Args:
+            commit: Snapshot sha to restore from.
+            paths: Root-relative paths, all present at ``commit``.
+
+        Raises:
+            ChangeTrackingError: The checkout failed (including any path
+                absent from ``commit``).
         """
         if not paths:
             return

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -1,0 +1,447 @@
+"""Shadow-git change tracking for workspace roots (Agent Change Review).
+
+TASK-1970, spec `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
+
+One shadow repo per CANONICAL root path (symlinks resolved), `GIT_DIR` under
+the app data dir, `core.worktree` pointing at the root — nothing named
+``.git`` is ever created inside the user's tree, and the user's own git
+state (repo, index, HEAD, stashes) is never touched.
+
+Hardening that is not optional (each item is a real first-turn failure on a
+real dev machine):
+
+* local ``user.name``/``user.email`` — ``git commit`` fails outright without
+  an identity;
+* ``commit.gpgsign=false`` — a global ``gpgsign=true`` would try to sign (or
+  prompt on) every snapshot;
+* ``core.hooksPath`` pinned to an empty directory — global husky-style hooks
+  must not fire on snapshots (``--no-verify`` is belt-and-braces on top);
+* ``gc.auto=0`` — GC is scheduled by retention (TASK-1975), never mid-turn;
+* every invocation passes explicit ``--git-dir``/``--work-tree``, scrubs
+  ``GIT_*`` from the environment, and sets ``GIT_TERMINAL_PROMPT=0``.
+
+All porcelain/diff parsing is ``-z`` NUL-delimited: paths containing spaces,
+newlines, or arbitrary UTF-8 are data, and ``restore_paths`` executes file
+operations from parsed paths.
+
+Locking is a per-repo in-process lock plus a portable atomic-``mkdir``
+lockdir (``flock`` does not exist on Windows and CI runs Windows lanes),
+with stale-lock takeover so a crashed process cannot starve snapshots.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from loguru import logger
+
+#: Patterns for the shadow repo's ``info/exclude`` — noise no review should
+#: carry. The user's own ``.gitignore`` files are additionally honored by git
+#: itself (with the tool-touched force-add carve-out applied in TASK-1971).
+FORCED_EXCLUDES: tuple[str, ...] = (
+    ".git/",
+    "node_modules/",
+    ".venv/",
+    "venv/",
+    "__pycache__/",
+    ".mypy_cache/",
+    ".pytest_cache/",
+    ".ruff_cache/",
+    ".tox/",
+    "dist/",
+    "build/",
+)
+
+#: A lockdir older than this is treated as abandoned by a crashed process and
+#: taken over. Snapshot operations are seconds, not minutes.
+_STALE_LOCK_SECONDS = 300.0
+
+_LOCK_TIMEOUT_SECONDS = 60.0
+_LOCK_RETRY_SECONDS = 0.05
+
+_GIT_TIMEOUT_SECONDS = 120.0
+
+
+class ChangeTrackingError(Exception):
+    """A shadow-repo operation failed. Callers treat this as degradation,
+    never as a reason to block an agent run (spec §2 failure posture)."""
+
+
+class ChangeTrackingUnavailableError(ChangeTrackingError):
+    """No usable ``git`` binary — the feature is absent, honestly."""
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    """One file's change between two snapshots.
+
+    Attributes:
+        path: Path relative to the root (the NEW path for renames).
+        status: ``"A"``/``"M"``/``"D"``/``"R"`` (added/modified/deleted/renamed).
+        adds: Added-line count (0 for binary).
+        dels: Deleted-line count (0 for binary).
+        old_path: The pre-rename path, or ``None``.
+        binary: True when git's numstat reports the change as binary.
+    """
+
+    path: str
+    status: str
+    adds: int = 0
+    dels: int = 0
+    old_path: str | None = None
+    binary: bool = False
+
+
+#: In-process per-repo locks, keyed by git-dir string. Module-level so every
+#: `ShadowRepo` instance for one root shares the same lock.
+_REPO_LOCKS: dict[str, threading.Lock] = {}
+_REPO_LOCKS_GUARD = threading.Lock()
+
+
+def _in_process_lock(key: str) -> threading.Lock:
+    with _REPO_LOCKS_GUARD:
+        return _REPO_LOCKS.setdefault(key, threading.Lock())
+
+
+class ShadowRepoService:
+    """Factory/owner of per-root shadow repos.
+
+    Constructing the service and probing :attr:`available` never raise —
+    using an unavailable service raises :class:`ChangeTrackingUnavailableError`
+    (a silent no-op snapshot would be this programme's canonical false-pass
+    bug, so unavailability is loud at the call site and soft at the probe).
+    """
+
+    def __init__(
+        self,
+        data_dir: Path | None = None,
+        git_executable: str | None = None,
+    ) -> None:
+        """Args:
+        data_dir: Base directory for shadow repos; defaults to the app
+            data dir's ``change_review/`` subtree.
+        git_executable: Override for tests; defaults to ``git`` on PATH.
+        """
+        if data_dir is None:
+            from tldw_chatbook.Utils.paths import get_user_data_dir
+
+            data_dir = get_user_data_dir() / "change_review"
+        self._data_dir = Path(data_dir)
+        self._git = (
+            git_executable
+            if git_executable is not None
+            else shutil.which("git")
+        )
+
+    @property
+    def available(self) -> bool:
+        """Whether a git binary is usable. Never raises."""
+        if not self._git:
+            return False
+        return Path(self._git).exists() or shutil.which(self._git) is not None
+
+    def repo_for_root(self, root: Path | str) -> "ShadowRepo":
+        """Return the shadow repo for ``root``'s canonical path.
+
+        Args:
+            root: A workspace folder root; symlinks are resolved so every
+                spelling of one directory shares one shadow repo.
+
+        Raises:
+            ChangeTrackingUnavailableError: No usable git binary.
+        """
+        if not self.available:
+            raise ChangeTrackingUnavailableError(
+                "change tracking needs git — install git to enable"
+            )
+        canonical = Path(root).expanduser().resolve()
+        key = hashlib.sha256(str(canonical).encode("utf-8")).hexdigest()[:16]
+        repo_home = self._data_dir / key
+        assert self._git is not None  # narrowed by `available`
+        return ShadowRepo(
+            root=canonical,
+            git_dir=repo_home / "git",
+            hooks_dir=repo_home / "hooks_empty",
+            lock_dir=repo_home / "lock.d",
+            git_executable=self._git,
+        )
+
+
+class ShadowRepo:
+    """One root's shadow repo. All operations run under the per-repo lock."""
+
+    def __init__(
+        self,
+        root: Path,
+        git_dir: Path,
+        hooks_dir: Path,
+        lock_dir: Path,
+        git_executable: str,
+    ) -> None:
+        self.root = root
+        self.git_dir = git_dir
+        self.hooks_dir = hooks_dir
+        self.lock_dir = lock_dir
+        self._git = git_executable
+
+    # -- plumbing ----------------------------------------------------------
+
+    def _env(self) -> dict[str, str]:
+        """Environment for git calls: ``GIT_*`` scrubbed, prompts disabled."""
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        return env
+
+    def _run(
+        self,
+        *args: str,
+        check: bool = True,
+        binary: bool = False,
+    ) -> subprocess.CompletedProcess:
+        cmd = [
+            self._git,
+            "--git-dir",
+            str(self.git_dir),
+            "--work-tree",
+            str(self.root),
+            *args,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                env=self._env(),
+                timeout=_GIT_TIMEOUT_SECONDS,
+                text=not binary,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ChangeTrackingError(
+                f"git {args[0]} timed out after {_GIT_TIMEOUT_SECONDS:.0f}s"
+            ) from exc
+        except OSError as exc:
+            raise ChangeTrackingUnavailableError(str(exc)) from exc
+        if check and proc.returncode != 0:
+            stderr = proc.stderr if isinstance(proc.stderr, str) else (
+                proc.stderr.decode("utf-8", "replace") if proc.stderr else ""
+            )
+            raise ChangeTrackingError(
+                f"git {args[0]} failed ({proc.returncode}): {stderr.strip()[:400]}"
+            )
+        return proc
+
+    def _locked(self):
+        """Context manager: in-process lock + portable cross-process lockdir."""
+        repo = self
+
+        class _Lock:
+            def __enter__(self) -> None:
+                self._thread_lock = _in_process_lock(str(repo.git_dir))
+                if not self._thread_lock.acquire(timeout=_LOCK_TIMEOUT_SECONDS):
+                    raise ChangeTrackingError(
+                        "change-tracking lock timed out (in-process)"
+                    )
+                deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+                repo.lock_dir.parent.mkdir(parents=True, exist_ok=True)
+                while True:
+                    try:
+                        repo.lock_dir.mkdir()
+                        return
+                    except FileExistsError:
+                        try:
+                            age = time.time() - repo.lock_dir.stat().st_mtime
+                        except OSError:
+                            continue  # holder released between mkdir and stat
+                        if age > _STALE_LOCK_SECONDS:
+                            # A crashed process must not starve snapshots
+                            # forever. Takeover is logged, not silent.
+                            logger.warning(
+                                "change_tracking: taking over stale lock "
+                                f"({age:.0f}s old) at {repo.lock_dir}"
+                            )
+                            try:
+                                repo.lock_dir.rmdir()
+                            except OSError:
+                                pass
+                            continue
+                        if time.monotonic() > deadline:
+                            self._thread_lock.release()
+                            raise ChangeTrackingError(
+                                "change-tracking lock timed out (cross-process)"
+                            )
+                        time.sleep(_LOCK_RETRY_SECONDS)
+
+            def __exit__(self, *exc_info) -> None:
+                try:
+                    repo.lock_dir.rmdir()
+                except OSError:
+                    pass
+                self._thread_lock.release()
+
+        return _Lock()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def ensure_initialized(self) -> None:
+        """Create + pin the shadow repo. Idempotent, self-healing (config and
+        excludes rewritten every call — they are cheap, and drift heals)."""
+        if not (self.git_dir / "HEAD").exists():
+            self.git_dir.parent.mkdir(parents=True, exist_ok=True)
+            self._run("init", "--quiet")
+        self.hooks_dir.mkdir(parents=True, exist_ok=True)
+        pins = (
+            ("user.name", "tldw-chatbook change review"),
+            ("user.email", "change-review@tldw-chatbook.invalid"),
+            ("commit.gpgsign", "false"),
+            ("core.hooksPath", str(self.hooks_dir)),
+            ("gc.auto", "0"),
+            ("core.untrackedCache", "true"),
+            ("core.worktree", str(self.root)),
+        )
+        for key, value in pins:
+            self._run("config", key, value)
+        exclude = self.git_dir / "info" / "exclude"
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        exclude.write_text(
+            "# managed by tldw-chatbook change review (TASK-1970)\n"
+            + "\n".join(FORCED_EXCLUDES)
+            + "\n"
+        )
+
+    # -- snapshots ---------------------------------------------------------
+
+    def tip(self) -> str | None:
+        """Current snapshot tip sha, or ``None`` before the first snapshot."""
+        proc = self._run("rev-parse", "--verify", "HEAD", check=False)
+        if proc.returncode != 0:
+            return None
+        return str(proc.stdout).strip()
+
+    def snapshot(self, message: str) -> str:
+        """Stage everything and commit if anything changed; return the tip.
+
+        A clean tree returns the existing tip without a new commit. The very
+        first snapshot commits even an empty tree (``--allow-empty``) so a
+        baseline tip always exists.
+        """
+        with self._locked():
+            self.ensure_initialized()
+            self._run("add", "-A", "--", ".")
+            had_tip = self.tip() is not None
+            if had_tip:
+                staged = self._run("diff", "--cached", "--quiet", check=False)
+                if staged.returncode == 0:
+                    return self.tip()  # type: ignore[return-value]
+                if staged.returncode not in (0, 1):
+                    raise ChangeTrackingError(
+                        "git diff --cached failed while checking cleanliness"
+                    )
+            commit_args = ["commit", "--quiet", "--no-verify", "-m", message]
+            if not had_tip:
+                commit_args.append("--allow-empty")
+            self._run(*commit_args)
+            new_tip = self.tip()
+            if not new_tip:
+                raise ChangeTrackingError("snapshot commit produced no tip")
+            return new_tip
+
+    # -- reading changes ---------------------------------------------------
+
+    def changed_files(self, base: str, end: str) -> list[ChangedFile]:
+        """The files changed between two snapshots, rename-aware.
+
+        Merges ``--name-status -z`` (status/rename pairs) with
+        ``--numstat -z`` (line counts, binary detection). Both streams are
+        NUL-delimited; paths are data.
+        """
+        status_by_path: dict[str, tuple[str, str | None]] = {}
+        ordered: list[str] = []
+        tokens = self._z_tokens("diff", "-M", "--name-status", "-z", base, end)
+        i = 0
+        while i < len(tokens):
+            raw_status = tokens[i]
+            code = raw_status[:1]
+            if code == "R":
+                old, new = tokens[i + 1], tokens[i + 2]
+                status_by_path[new] = ("R", old)
+                ordered.append(new)
+                i += 3
+            else:
+                path = tokens[i + 1]
+                status_by_path[path] = (code, None)
+                ordered.append(path)
+                i += 2
+
+        counts: dict[str, tuple[int, int, bool]] = {}
+        tokens = self._z_tokens("diff", "-M", "--numstat", "-z", base, end)
+        i = 0
+        while i < len(tokens):
+            head = tokens[i]
+            adds_s, dels_s, rest = head.split("\t", 2)
+            if rest == "":
+                # Rename record: counts \t\0 old \0 new \0
+                path = tokens[i + 2]
+                i += 3
+            else:
+                path = rest
+                i += 1
+            binary = adds_s == "-"
+            counts[path] = (
+                0 if binary else int(adds_s),
+                0 if binary else int(dels_s),
+                binary,
+            )
+
+        out: list[ChangedFile] = []
+        for path in ordered:
+            code, old = status_by_path[path]
+            adds, dels, binary = counts.get(path, (0, 0, False))
+            out.append(
+                ChangedFile(
+                    path=path,
+                    status=code,
+                    adds=adds,
+                    dels=dels,
+                    old_path=old,
+                    binary=binary,
+                )
+            )
+        return out
+
+    def _z_tokens(self, *args: str) -> list[str]:
+        proc = self._run(*args, binary=True)
+        raw: bytes = proc.stdout or b""
+        return [t.decode("utf-8", "surrogateescape") for t in raw.split(b"\0") if t]
+
+    def diff_text(self, base: str, end: str, path: str) -> str:
+        """Unified diff for one file between two snapshots."""
+        proc = self._run("diff", "-M", base, end, "--", path)
+        return str(proc.stdout)
+
+    def file_bytes(self, commit: str, path: str) -> bytes | None:
+        """A file's content at a snapshot, or ``None`` if absent there."""
+        proc = self._run("show", f"{commit}:{path}", check=False, binary=True)
+        if proc.returncode != 0:
+            return None
+        return bytes(proc.stdout or b"")
+
+    # -- low-level restore (full revert semantics live in TASK-1974) -------
+
+    def restore_paths(self, commit: str, paths: Sequence[str]) -> None:
+        """Restore ``paths`` in the work tree to their state at ``commit``.
+
+        Low-level primitive: every path must EXIST at ``commit`` (un-create —
+        deleting a path absent from the snapshot — is TASK-1974's guarded
+        delete, deliberately not hidden inside this call).
+        """
+        if not paths:
+            return
+        with self._locked():
+            self._run("checkout", commit, "--", *paths)


### PR DESCRIPTION
First implementation task of the Agent Change Review programme (spec merged in #1224). The service that everything else builds on: one shadow git repo per **canonical root path**, `GIT_DIR` under the app data dir, worktree pointing at the root — nothing named `.git` ever created in the user's tree, their own git state untouched.

**Hardening** (each item is a real first-turn failure on a real dev machine, and each is pinned self-healingly at init): local identity, `commit.gpgsign=false`, empty `hooksPath`, `gc.auto=0`. Every invocation: explicit `--git-dir`/`--work-tree`, `GIT_*` env scrubbed, prompts disabled, timeouts. All porcelain parsing `-z` NUL-delimited. Locking: in-process lock + portable `mkdir` lockdir (no `fcntl` — Windows CI lanes), logged stale takeover.

**13 tests, real git, zero mocks.** The hostile-HOME test drives all three machine hazards at once (no identity + global gpgsign + failing global hook). Hostile-filename (spaces **and** a newline) round-trips snapshot → numstat → restore.

**The sabotage pass caught two defects in my own verification:**
1. an unquoted heredoc collapsed `\0`, so the parsing mutation *silently never applied* — "mutation survived" was actually "mutation never ran"; the harness now asserts replacement counts;
2. the env-scrub test asserted on `GIT_DIR`, which our explicit `--git-dir` flag already defeats — the live hazard is `GIT_INDEX_FILE`, which flags do **not** override; the test now proves the index lands in the shadow repo, not the leaked path.

Three sabotages (config pins removed / non-`-z` parsing / scrub removed) each fail exactly one test. 164 passed in `Tests/Workspaces`.

Next up the critical path: TASK-1971 (B/E turn protocol + `change_snapshots` schema).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a hardened per-root shadow Git repo for workspaces to power change review without touching user repos. Completes TASK-1970 and lays the foundation for Agent Change Review.

- **New Features**
  - `ShadowRepoService` creates one shadow repo per canonical root under app data; nothing named `.git` is created in the user’s tree.
  - Snapshots stage all changes and commit only if dirty; the first snapshot creates a baseline and returns the tip SHA.
  - Read/restore APIs: `changed_files` (rename/binary-aware via `-z` parsing), `diff_text`, `file_bytes`, and `restore_paths` for targeted restores.
  - Forced excludes are written to `info/exclude` to ignore common noise (e.g., `.git/`, `.git`, `node_modules/`, `.venv/`, `__pycache__/`, build dirs).
  - Hardened and isolated: pins local identity, `commit.gpgsign=false`, empty `hooksPath`, `gc.auto=0`; always uses `--git-dir`/`--work-tree`, scrubs `GIT_*`, sets `GIT_TERMINAL_PROMPT=0`, and applies subprocess timeouts.
  - Concurrency and portability: per-repo in-process lock plus portable `mkdir` lockdir with stale takeover; no `fcntl` dependency (Windows-safe).
  - Availability: reports unavailable when `git` is missing; using it raises `ChangeTrackingUnavailableError`.
  - Tests: 17 real-`git` tests cover hostile HOME/env, symlink vs direct path identity, newline-in-filename safety, concurrency, stale lock takeover, excludes, change classification, and restore behavior.

- **Bug Fixes**
  - Env scrubbing now matches `GIT_*` case-insensitively (Windows-honest), preventing leaked `Git_Index_File`.
  - `ChangedFile.status` passes through rare git codes like `T`/`C` verbatim instead of coercing.
  - Top-level `.git` file spelling is explicitly excluded and not tracked; belt-and-braces on future exclude edits.
  - Non-directory roots fail fast with a clear typed error (not deferred to a git subprocess).

<sup>Written for commit aa84f4c091b0a081877c6088a3c9bb5b775d3655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

