### PR TITLE
fix(mcp): search_rag tool always failed with "'coroutine' object is not iterable"

### DIFF
--- a/Tests/MCP/test_rag_search_tool.py
+++ b/Tests/MCP/test_rag_search_tool.py
@@ -1,0 +1,105 @@
+# Tests/MCP/test_rag_search_tool.py
+"""Regression coverage for the `search_rag` MCP tool returning
+`[{"error": "'coroutine' object is not iterable"}]` on every call.
+
+`MCPTools.perform_rag_search` dispatched `SimplifiedRAGSearchService`'s
+`semantic_search` / `keyword_search` through `asyncio.to_thread`, but both
+are async methods — calling one in a worker thread just creates the
+coroutine object and returns it unawaited, so the result-formatting loop
+raised `TypeError: 'coroutine' object is not iterable` and the blanket
+except handed that string to the agent. Both the semantic and keyword
+branches were affected, so the tool had never returned a result.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.MCP.tools import MCPTools
+
+
+class _StubRAGSearchService:
+    """Mirrors the SimplifiedRAGSearchService interface: async methods
+    returning the raw result-dict shape from search_service.py."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def semantic_search(self, query, limit=10, media_types=None):
+        self.calls.append(("semantic", query, limit, media_types))
+        return [
+            {
+                "id": "media-1",
+                "title": "Semantic Result",
+                "content": "semantic content",
+                "media_type": "video",
+                "url": "https://example.com/v1",
+                "file_path": None,
+                "score": 0.9,
+                "metadata": {"title": "Semantic Result"},
+            }
+        ]
+
+    async def keyword_search(self, query, limit=10, media_types=None):
+        self.calls.append(("keyword", query, limit, media_types))
+        return [
+            {
+                "id": "media-2",
+                "title": "Keyword Result",
+                "content": "keyword content",
+                "media_type": "pdf",
+                "url": None,
+                "file_path": "/docs/a.pdf",
+                "score": 0.5,
+                "metadata": {},
+            }
+        ]
+
+
+def _make_tools() -> tuple[MCPTools, _StubRAGSearchService]:
+    tools = MCPTools.__new__(MCPTools)
+    stub = _StubRAGSearchService()
+    tools.rag_service = stub
+    return tools, stub
+
+
+@pytest.mark.asyncio
+async def test_perform_rag_search_semantic_returns_formatted_results():
+    tools, stub = _make_tools()
+
+    results = await tools.perform_rag_search("test query", limit=3)
+
+    assert results == [
+        {
+            "id": "media-1",
+            "title": "Semantic Result",
+            "content": "semantic content",
+            "media_type": "video",
+            "source": "https://example.com/v1",
+            "score": 0.9,
+            "metadata": {"title": "Semantic Result"},
+        }
+    ]
+    assert stub.calls == [("semantic", "test query", 3, None)]
+
+
+@pytest.mark.asyncio
+async def test_perform_rag_search_keyword_returns_formatted_results():
+    tools, stub = _make_tools()
+
+    results = await tools.perform_rag_search(
+        "test query", use_semantic=False, media_types=["pdf"]
+    )
+
+    assert results == [
+        {
+            "id": "media-2",
+            "title": "Keyword Result",
+            "content": "keyword content",
+            "media_type": "pdf",
+            "source": "/docs/a.pdf",
+            "score": 0.5,
+            "metadata": {},
+        }
+    ]
+    assert stub.calls == [("keyword", "test query", 10, ["pdf"])]

--- a/tldw_chatbook/MCP/tools.py
+++ b/tldw_chatbook/MCP/tools.py
@@ -289,17 +289,17 @@ class MCPTools:
             List of search results with content and metadata
         """
         try:
-            # Perform search
+            # Perform search (both service methods are coroutines — they must
+            # be awaited directly, not dispatched via asyncio.to_thread, which
+            # would return the unawaited coroutine object)
             if use_semantic and hasattr(self.rag_service, "semantic_search"):
-                results = await asyncio.to_thread(
-                    self.rag_service.semantic_search,
+                results = await self.rag_service.semantic_search(
                     query=query,
                     limit=limit,
                     media_types=media_types,
                 )
             else:
-                results = await asyncio.to_thread(
-                    self.rag_service.keyword_search,
+                results = await self.rag_service.keyword_search(
                     query=query,
                     limit=limit,
                     media_types=media_types,


### PR DESCRIPTION
## Summary

A user's agent reported the RAG tool erroring with `'coroutine' object is not iterable` on every call. Root cause: `MCPTools.perform_rag_search` dispatched `SimplifiedRAGSearchService.semantic_search` / `keyword_search` through `asyncio.to_thread` — but both are **async methods**. Calling an async function in a worker thread just creates the coroutine object and returns it unawaited, so the result-formatting loop raised `TypeError: 'coroutine' object is not iterable`, and the blanket `except` handed exactly that string back to the agent as `[{"error": ...}]`.

Both branches (semantic and keyword) were equally affected, and both entry points route here — the MCP server's `search_rag` tool and the local runtime delegate's `_tool_search_rag` — so the tool had **never returned a result** since its introduction (`a70d69df8`). The DB was never even queried.

## Fix

Await the service methods directly. They are already async and handle their own thread offloading for blocking work internally (`run_in_executor` / connection pool), so the `to_thread` wrapper was pure error.

## Test

`Tests/MCP/test_rag_search_tool.py` — exercises the real `perform_rag_search` against a stub service mirroring the real async interface, one test per branch, asserting formatted results and argument pass-through. Written first and watched fail with the exact production error (`[{'error': "'coroutine' object is not iterable"}]` plus the `coroutine ... was never awaited` RuntimeWarning) before the fix.

## Verification

- `Tests/MCP/` + `Tests/MCP_Governance/`: **417 passed** locally (CI checks here are intentionally cancelled by another build — verified locally per repo convention)
- `ruff check` clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP `search_rag` tool failing with `'coroutine' object is not iterable` by awaiting the async search methods directly instead of using `asyncio.to_thread`. Restores working RAG search for both semantic and keyword paths.

- **Bug Fixes**
  - Await `semantic_search` and `keyword_search` coroutines in `MCPTools.perform_rag_search` instead of dispatching via `asyncio.to_thread`.
  - Added regression tests for both paths, asserting formatted results and argument pass-through.

<sup>Written for commit 30618a51abd2f7e39bef6dcd8e5dfaed7e204748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

