### PR TITLE
docs(backlog): tasks 1990-1995 — markdown rendering improvements (frogmouth comparison)

### DIFF
--- a/backlog/tasks/task-1990 - Console-transcript-full-markdown-rendering-for-assistant-replies.md
+++ b/backlog/tasks/task-1990 - Console-transcript-full-markdown-rendering-for-assistant-replies.md
@@ -1,0 +1,44 @@
+---
+id: TASK-1990
+title: 'Console transcript: full markdown rendering for assistant replies (streaming-aware)'
+status: To Do
+assignee: []
+created_date: '2026-08-02 22:30'
+labels:
+  - console
+  - chat
+  - markdown
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Assistant replies in the Console render through a hand-rolled safe-subset span renderer (TASK-372: headings, `**bold**`, `` `code` `` + roleplay flavor). Everything else arrives as literal text: fenced code blocks show their ` ``` ` fences, tables show raw `|` pipes, lists show raw `-`/`1.` markers, links show `[text](url)`, blockquotes show `>`. The chat-behavior checklist items "Messages support markdown rendering" and "Code blocks are properly formatted" have never been checkable.
+
+A Frogmouth-vs-chatbook comparison (2026-08-02) established that the installed Textual (8.2.7) ships the missing piece Frogmouth predates: `Markdown.append()` / `Markdown.get_stream()` (`MarkdownStream`), purpose-built for LLM streaming — incremental block parsing instead of a full re-parse per tick.
+
+**Spike evidence — branch `spike/console-markdown-stream` (env gate `TLDW_CONSOLE_MD_SPIKE=1`):** assistant rows swapped to a `Vertical(header Static, Markdown)` widget, streaming prefix-diffed deltas through `Markdown.append()`. Live-verified in tmux (235x52, scratch profile, local SSE stub at 0.12s/chunk): fenced Python block, bordered table, ordered/unordered lists, blockquote and link all rendered correctly **mid-stream and at completion**; tail-follow held through growth; click-to-select worked through the Markdown widget (action row mounted); completion caused no re-render blink (identical content short-circuits). Smoke test asserts append-only on prefix growth (zero `update()` calls), full-update fallback on non-prefix edits, and gate-off leaves rows untouched. A/B baseline capture of the identical reply shows the span renderer's literal fences/pipes/brackets.
+
+**Remaining engineering (why the spike is not mergeable as-is):**
+- Attachment chips, citation notices, variant/sibling headers and selected-state styling need parity with `ConsoleTranscriptMessage`.
+- Safety review: the span renderer guaranteed literal text (styles via `(text, style)` tuples, never markup parsing — Qodo #823). The Markdown widget *parses* assistant content; confirm USER/SYSTEM/TOOL rows stay verbatim and assistant markdown cannot trigger unintended link handling (`open_links` policy needed).
+- `to_plain_text` exports and reconciliation signatures must stay exact.
+- Long-transcript cost: one Markdown widget per assistant row vs today's single Static; measure mount/scroll behavior on a large session.
+- Decide default-on vs a Console setting; the env gate is spike-only.
+
+**Timing constraint:** Console changes intersect the held screen-decomposition program (owner ruling 2026-08-02: execution held until Console churn settles). Coordinate before starting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Assistant replies render fenced code blocks, tables, ordered/unordered lists, blockquotes and links with real structure (no literal marker characters) in the live Console
+- [ ] #2 Streaming applies deltas incrementally — no full-message re-parse per sync tick (asserted by test, as in the spike smoke test)
+- [ ] #3 USER, SYSTEM and TOOL rows keep verbatim text rendering (their #/**/backtick characters may be literal and meaningful)
+- [ ] #4 Tail-follow, click-to-select, j/k selection, the action row, and plain-text export behavior are unchanged
+- [ ] #5 Attachment chips, citation notices and variant/sibling headers render with parity to current assistant rows
+- [ ] #6 Link clicks follow an explicit policy (open browser or no-op) — never silent partial handling
+- [ ] #7 Live tmux capture at 235x52 recorded before merge, including a mid-stream capture (render-verification convention)
+<!-- AC:END -->

--- a/backlog/tasks/task-1991 - HF-README-viewer-resolve-relative-links-and-anchors.md
+++ b/backlog/tasks/task-1991 - HF-README-viewer-resolve-relative-links-and-anchors.md
@@ -1,0 +1,32 @@
+---
+id: TASK-1991
+title: 'HF README viewer: resolve relative links and #anchors (Frogmouth-style tiers)'
+status: To Do
+assignee: []
+created_date: '2026-08-02 22:30'
+labels:
+  - huggingface
+  - markdown
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Widgets/HuggingFace/model_card_viewer.py` renders model READMEs in a default-configured `Markdown` widget. Real READMEs are full of relative links (`./docs/usage.md`, images) and heading anchors (`#quickstart`) — today those either do nothing useful or fail silently; only absolute URLs behave.
+
+Frogmouth (MIT — port freely) solved exactly this in `screens/main.py` `on_markdown_link_clicked` with tiered resolution: absolute URL → open; relative href while viewing a remote doc → join against the document's base URL; `#anchor` → `Markdown.goto_anchor()` (present in installed Textual 8.2.7); anything unresolvable → an explicit "can't handle this link" message instead of silence. For the model-card viewer the base URL is the model repo's canonical blob root (e.g. `https://huggingface.co/<repo>/blob/main/`).
+
+Scope note: opening resolved links in the system browser is sufficient; in-app remote markdown browsing is out of scope. Any future in-app fetch must go through the `Utils/egress.py` SSRF policy, not a raw client.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Clicking an absolute URL in a rendered README opens it in the browser (current behavior preserved)
+- [ ] #2 Clicking a relative link resolves it against the model repo's base URL and opens the resolved URL in the browser
+- [ ] #3 Clicking a `#anchor` link scrolls the README pane to that heading via goto_anchor
+- [ ] #4 An unresolvable href produces a visible notify with the href — never a silent no-op
+- [ ] #5 No fetch path is added that bypasses the egress policy
+<!-- AC:END -->

--- a/backlog/tasks/task-1992 - Table-of-contents-for-long-markdown-surfaces.md
+++ b/backlog/tasks/task-1992 - Table-of-contents-for-long-markdown-surfaces.md
@@ -1,0 +1,28 @@
+---
+id: TASK-1992
+title: Table of contents for long markdown surfaces (MarkdownTableOfContents)
+status: To Do
+assignee: []
+created_date: '2026-08-02 22:30'
+labels:
+  - ux
+  - markdown
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+No markdown surface in the app offers a table of contents; long documents (HF model READMEs, media content/analysis panes, Library note previews) are scroll-only. Textual ships the pieces unused: `MarkdownTableOfContents` fed by `Markdown.TableOfContentsUpdated` events, plus `scroll_to_block()` to jump to a heading. Frogmouth's wiring (`widgets/navigation_panes/table_of_contents.py` + `Viewer.scroll_to_block`) is a direct reference implementation, including the decoupled-ToC construction workaround (throwaway `Markdown()` argument).
+
+Start with the HF README pane (longest documents, clearest win). Team convention requires a live render-capture before building on complex widgets — `MarkdownTableOfContents` wraps a `Tree`, which is capture-verified elsewhere, but the gate still applies.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The HF README pane offers a heading-tree table of contents for the rendered document
+- [ ] #2 Selecting a TOC entry scrolls the document to that heading
+- [ ] #3 The TOC stays out of the way in tight layouts (collapsed or hidden by default at compact heights; the 32-row contract keeps working)
+- [ ] #4 Live tmux capture recorded showing the TOC populated from a real README and a successful jump
+<!-- AC:END -->

--- a/backlog/tasks/task-1993 - Front-matter-aware-markdown-parsing-for-notes-previews.md
+++ b/backlog/tasks/task-1993 - Front-matter-aware-markdown-parsing-for-notes-previews.md
@@ -1,0 +1,30 @@
+---
+id: TASK-1993
+title: Front-matter-aware markdown parsing for notes/library previews
+status: To Do
+assignee: []
+created_date: '2026-08-02 22:30'
+labels:
+  - notes
+  - library
+  - markdown
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Notes synced from files commonly carry YAML front matter (`---` blocks). Textual's `Markdown` widget with its default gfm-like parser renders the front-matter delimiters as a thematic break plus stray text — noise at the top of every preview.
+
+Frogmouth passes `parser_factory=lambda: MarkdownIt("gfm-like").use(front_matter.front_matter_plugin)` (from `mdit-py-plugins`) so front matter is consumed, not rendered. Textual's default is already gfm-like, so the plugin is the only delta. `mdit-py-plugins` should be an optional extra following the `optional_deps.py` pattern; when absent, previews render exactly as today.
+
+Primary surface: the Library note preview (`Widgets/Library/library_notes_canvas.py`). Apply the same factory to other markdown preview surfaces only where front matter can plausibly appear.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A note whose content starts with YAML front matter previews without rendering the front-matter block
+- [ ] #2 With mdit-py-plugins not installed, previews render exactly as today (graceful degradation, no import error)
+- [ ] #3 The dependency is declared as an optional extra and checked via the optional-deps pattern
+<!-- AC:END -->

--- a/backlog/tasks/task-1994 - Scroll-keybindings-for-read-only-markdown-panes.md
+++ b/backlog/tasks/task-1994 - Scroll-keybindings-for-read-only-markdown-panes.md
@@ -1,0 +1,28 @@
+---
+id: TASK-1994
+title: Scroll keybindings (j/k/space/b) for read-only markdown panes
+status: To Do
+assignee: []
+created_date: '2026-08-02 22:30'
+labels:
+  - ux
+  - keyboard
+  - markdown
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Frogmouth's viewer binds `j`/`k` (line scroll), `space` (page down) and `b` (page up) on its document container — cheap, expected-by-terminal-users navigation. Chatbook's read-only markdown surfaces (HF README pane, media content/analysis panes, Library note preview) support only mouse/native scroll when focused.
+
+Deliberate exclusion: the Console transcript already binds `j`/`k` for message SELECTION — it is out of scope and must not change. Scope is read-only viewer panes only, and bindings must be discoverable through the existing footer/key-hint convention.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The HF README pane, media content/analysis panes, and Library note preview scroll by line with j/k and by page with space/b when focused
+- [ ] #2 Console transcript selection keys are untouched (existing transcript tests stay green)
+- [ ] #3 The bindings are discoverable via the footer/key-hint convention on those panes
+<!-- AC:END -->

--- a/backlog/tasks/task-1995 - Markdown-rendering-hygiene-batch.md
+++ b/backlog/tasks/task-1995 - Markdown-rendering-hygiene-batch.md
@@ -1,0 +1,33 @@
+---
+id: TASK-1995
+title: 'Markdown rendering hygiene: About-pane markup, reading-mode mangling, dead CSS'
+status: To Do
+assignee: []
+created_date: '2026-08-02 22:30'
+labels:
+  - bug
+  - markdown
+  - hygiene
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Three defects found by the 2026-08-02 markdown-rendering audit (all verified on origin/dev `cf1b345f2`):
+
+1. **About pane feeds Rich markup into a Markdown widget.** `UI/Tools_Settings_Window.py:3356-3381` builds `about_text` out of Rich console markup (`[bold]…[/bold]`, `[italic]`, `[link=…]`) and yields `Markdown(about_text)`. Textual's Markdown does not interpret Rich markup, so the tags render literally. Convert the text to actual markdown (the widget's link handler at `on_markdown_link_clicked` already works) or render via a markup-enabled Static.
+
+2. **Media "reading mode" and search highlighting corrupt markdown/code content.** `Widgets/Media/media_viewer_panel.py:1045-1085`: `_format_content_for_reading` regex-injects paragraph breaks after sentence punctuation and rewrites `^\d+.` lines into `##` headings — mangling code blocks and pre-existing markdown; `_highlight_matches` wraps search hits in backticks/bold, injecting markup into user content (breaks inside fenced blocks). Make both transforms markdown-aware (skip fenced regions at minimum) or restrict them to plain-text content kinds.
+
+3. **Dead CSS.** `Constants.py:1550` styles `Markdown#web-search-results` — no such widget exists anywhere in `UI/` or `Widgets/`. Remove the rule.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The About section renders styled text with no literal bracket tags, verified in a live capture
+- [ ] #2 Reading mode and search highlighting no longer alter the inside of fenced code blocks (test with a code-block-bearing media document)
+- [ ] #3 The dead Markdown#web-search-results CSS rule is gone
+- [ ] #4 Existing tests for the touched surfaces stay green
+<!-- AC:END -->


### PR DESCRIPTION
Files six backlog tasks produced by the 2026-08-02 Frogmouth-vs-chatbook markdown rendering comparison. Tasks only — no code.

- **task-1990 (high)**: Console transcript full markdown rendering for assistant replies, streaming-aware via `Markdown.append()`. Carries live-verified spike evidence from branch `spike/console-markdown-stream` (mid-stream fenced code/table rendering, tail-follow, click-to-select, no completion blink; A/B baseline captures). Timing gated on the held screen-decomposition program.
- **task-1991 (medium)**: HF README viewer — Frogmouth-style tiered link resolution (relative links, `#anchor` via `goto_anchor`, explicit unresolvable notify).
- **task-1992 (medium)**: Table of contents for long markdown surfaces (`MarkdownTableOfContents` + `scroll_to_block`), HF README first.
- **task-1993 (low)**: Front-matter-aware note previews (`mdit-py-plugins` front-matter plugin as optional dep).
- **task-1994 (low)**: j/k/space/b scroll bindings on read-only markdown panes (Console transcript explicitly excluded).
- **task-1995 (medium)**: Hygiene — About pane feeds Rich markup into a Markdown widget (renders literally), media reading-mode/highlighting mangles fenced code, dead `Markdown#web-search-results` CSS.

ID block 1990-1995 claimed after an all-branches (292) + all-worktrees (134) sweep; max taken was 1980. Two-namespace dup check clean on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six backlog tasks to improve markdown rendering and viewer UX, based on the Frogmouth comparison. Documentation-only; no code changes.

- **New Features**
  - Console assistant replies: full markdown with stream-aware `Markdown.append()`; keep USER/SYSTEM/TOOL verbatim.
  - HF README: resolve relative links and `#anchors` (`goto_anchor`), with explicit notify on unresolvable links.
  - Table of contents for long markdown via `MarkdownTableOfContents` and `scroll_to_block()`.
  - Front-matter-aware previews using `mdit-py-plugins` as an optional dependency.
  - j/k/space/b scroll bindings for read-only markdown panes (Console transcript excluded).

- **Bug Fixes**
  - About pane stops rendering literal Rich tags; use proper markdown or a markup-enabled widget.
  - Media reading mode and search highlighting avoid changing fenced code; restrict transforms to plain text.
  - Remove dead `Markdown#web-search-results` CSS.

<sup>Written for commit 523c83131227d2cd64dceafcc545cae21ff32bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

