### PR TITLE
feat: opt-in localhost server for the exported briefings feed directory (task-1760)

### DIFF
--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -94,7 +94,9 @@ starts on its own, and no setting can make it start on its own.
   address, a warning is logged and the Serve Feed toast says so plainly.
   Only widen this if you understand that doing so removes the one thing
   standing between "only this machine" and "anyone who can reach it" —
-  there is still no authentication either way.
+  there is still no authentication either way. Note that a wildcard IPv6
+  bind (`::`) is usually dual-stack: it accepts plain IPv4 connections as
+  well, so the reachable surface can be wider than the address suggests.
 - **Confined to the exported directory.** The server refuses (with a plain
   404) any request that would read a file outside the directory you
   exported to, including through a symlink planted inside it that points

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -73,15 +73,28 @@ served until you press **Serve Feed**, and it stops the moment you press
 starts on its own, and no setting can make it start on its own.
 
 - **No authentication.** Anyone who can reach the served address can read
-  every file in the exported directory for as long as it is running. The
-  toast that appears when you press Serve Feed states this every time, not
-  just here.
+  every file in the exported directory **and every subdirectory beneath
+  it** — serving is recursive, not limited to `feed.xml` and the episodes
+  next to it — for as long as it is running. The toast that appears when
+  you press Serve Feed states this every time, not just here. Point Serve
+  Feed at a dedicated export folder, not a general-purpose directory like
+  your home folder, for exactly this reason: everything under whatever
+  folder you export into becomes reachable while serving is on.
+- **No directory browsing.** The server refuses to render a listing of the
+  served folder (or any subfolder) — only a file whose exact name a client
+  already knows (from `feed.xml`, or a URL you typed yourself) is
+  fetchable. This narrows the exposure above; it does not remove it, since
+  every filename in the tree is still fetchable if it is known.
 - **Loopback by default.** The server binds `127.0.0.1` (this machine
   only) unless you change `bind` under `[briefings_feed_server]` in
   `config.toml` to something wider (e.g. `0.0.0.0`, to reach it from
-  another device on your network). Only widen this if you understand that
-  doing so removes the one thing standing between "only this machine" and
-  "anyone who can reach it" — there is still no authentication either way.
+  another device on your network). A blank or otherwise invalid `bind`
+  value can never silently widen this — it falls back to `127.0.0.1`
+  instead — and whenever the server does end up bound to a non-loopback
+  address, a warning is logged and the Serve Feed toast says so plainly.
+  Only widen this if you understand that doing so removes the one thing
+  standing between "only this machine" and "anyone who can reach it" —
+  there is still no authentication either way.
 - **Confined to the exported directory.** The server refuses (with a plain
   404) any request that would read a file outside the directory you
   exported to, including through a symlink planted inside it that points

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -40,8 +40,22 @@ beside it by name, never by absolute path, so you can copy, sync, or zip the
 whole directory and it keeps working on another machine.
 
 Some podcast clients accept a local folder or a `file://` URL directly. For
-clients that require HTTP, serve the folder yourself — from a terminal, in
-the exported directory:
+clients that require HTTP, the Artifacts toolbar has two more buttons next
+to Export Feed:
+
+- **Serve Feed** starts a small, built-in server for the directory you most
+  recently exported, and shows a toast with the URL to point your podcast
+  client at (e.g. `http://127.0.0.1:54231/feed.xml`). It is disabled until
+  you have exported a feed, and disabled again while a feed is already
+  being served.
+- **Stop Serving** stops it. Switching away from Watchlists, or closing the
+  app, also stops it — serving never outlives the screen it started on.
+
+This is unrelated to the app's `[web_server]` setting: that runs the whole
+chatbook UI in a browser instead of your terminal, and it has no way to
+serve a directory you choose at all. If you would rather not use the
+built-in server, serving the folder yourself works exactly as before — from
+a terminal, in the exported directory:
 
 ```bash
 python3 -m http.server 8000
@@ -51,9 +65,31 @@ Then point the client at `http://localhost:8000/feed.xml` (or your machine's
 LAN address, if the client runs on another device). Stop the server with
 Ctrl+C when you are done.
 
-The app does not serve the folder for you. Its `[web_server]` setting is
-unrelated — that runs the whole chatbook UI in a browser instead of your
-terminal, and it is not a way to publish a feed.
+#### Security posture
+
+The built-in Serve Feed server is opt-in and session-only: nothing is ever
+served until you press **Serve Feed**, and it stops the moment you press
+**Stop Serving**, switch away from Watchlists, or close the app — it never
+starts on its own, and no setting can make it start on its own.
+
+- **No authentication.** Anyone who can reach the served address can read
+  every file in the exported directory for as long as it is running. The
+  toast that appears when you press Serve Feed states this every time, not
+  just here.
+- **Loopback by default.** The server binds `127.0.0.1` (this machine
+  only) unless you change `bind` under `[briefings_feed_server]` in
+  `config.toml` to something wider (e.g. `0.0.0.0`, to reach it from
+  another device on your network). Only widen this if you understand that
+  doing so removes the one thing standing between "only this machine" and
+  "anyone who can reach it" — there is still no authentication either way.
+- **Confined to the exported directory.** The server refuses (with a plain
+  404) any request that would read a file outside the directory you
+  exported to, including through a symlink planted inside it that points
+  elsewhere on disk.
+- **One directory at a time.** Serve Feed refuses (naming the URL already
+  in use) rather than switching directories out from under a client that
+  might still be connected. Press Stop Serving first to serve a different
+  export.
 
 ## Scheduled briefings
 

--- a/Tests/Subscriptions/test_feed_server.py
+++ b/Tests/Subscriptions/test_feed_server.py
@@ -418,6 +418,175 @@ def test_a_loopback_bind_never_warns(
     assert is_loopback_bind(server.bind) is True
 
 
+# --- port validation (task-1760 Qodo fix wave, F1) ----------------------------
+#
+# A port that survives `int(...)` in `configured_bind_and_port` can still be
+# outside the valid 0-65535 TCP range (a config typo like `99999`) or, for a
+# direct `FeedDirectoryServer.start` caller, not an `int` at all. Left
+# unchecked, an out-of-range-but-parseable value reached `ThreadingHTTPServer`
+# as a bare `OverflowError` -- not one of the types the UI's Serve handler
+# (`watchlists_collections_screen.py`) catches, so it escaped as an unhandled
+# exception. The two entry points are deliberately handled differently: a
+# CONFIG-derived bad value degrades safely (falls back to ephemeral `0` with a
+# warning, `configured_bind_and_port`'s existing bad-bind precedent); a bad
+# value handed directly to `start()` is instead refused with `FeedServerError`
+# (the type the UI already catches), the same way the directory-validation
+# checks in that method already are.
+
+
+def test_configured_bind_and_port_falls_back_to_ephemeral_on_an_out_of_range_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured port that parses as an int but is out of the valid
+    0-65535 TCP port range (a typo, e.g. `99999`) degrades the same way a
+    non-integer value already does, rather than being passed through to
+    `start()` where it would reach the socket layer as a raw
+    `OverflowError`."""
+
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "briefings_feed_server" and key == "port":
+            return 99999
+        return default
+
+    monkeypatch.setattr(feed_server_module, "get_cli_setting", _fake_get_cli_setting)
+
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        _bind, port = configured_bind_and_port()
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert port == 0
+    assert any(
+        "outside the valid 0-65535" in message for message in messages
+    ), messages
+
+
+def test_configured_bind_and_port_falls_back_to_ephemeral_on_a_negative_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "briefings_feed_server" and key == "port":
+            return -1
+        return default
+
+    monkeypatch.setattr(feed_server_module, "get_cli_setting", _fake_get_cli_setting)
+    _bind, port = configured_bind_and_port()
+    assert port == 0
+
+
+def test_configured_bind_and_port_still_uses_a_valid_configured_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new range check must not reject an ordinary, in-range value --
+    only out-of-range/non-integer ones (regression guard alongside the
+    pre-existing `test_configured_bind_and_port_reads_a_stored_section`)."""
+
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "briefings_feed_server" and key == "port":
+            return 8123
+        return default
+
+    monkeypatch.setattr(feed_server_module, "get_cli_setting", _fake_get_cli_setting)
+    _bind, port = configured_bind_and_port()
+    assert port == 8123
+
+
+def test_start_rejects_a_negative_port(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    with pytest.raises(FeedServerError):
+        server.start(served_dir, port=-1)
+    assert server.is_running is False
+    assert server.url is None
+
+
+def test_start_rejects_a_port_above_65535(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    with pytest.raises(FeedServerError):
+        server.start(served_dir, port=70000)
+    assert server.is_running is False
+    assert server.url is None
+
+
+def test_start_rejects_a_non_integer_port(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    with pytest.raises(FeedServerError):
+        server.start(served_dir, port="443")  # type: ignore[arg-type]
+    assert server.is_running is False
+    assert server.url is None
+
+
+def test_start_accepts_a_valid_nonzero_configured_port(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """A legitimate, in-range, nonzero port (not just `0` for ephemeral)
+    must still work end to end -- the new range check must reject only
+    genuinely invalid values, not ordinary ones a real config could set."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        free_port = probe.getsockname()[1]
+
+    url = server.start(served_dir, port=free_port)
+    assert url == f"http://127.0.0.1:{free_port}/"
+    response = httpx.get(url + "feed.xml", timeout=5.0)
+    assert response.status_code == 200
+
+
+# --- IPv6 URL bracketing (task-1760 Qodo fix wave, F2) ------------------------
+#
+# `is_loopback_bind` explicitly supports `::1` as a loopback bind target, but
+# `start()` used to build its URL as `f"http://{bind}:{port}/"` unconditionally
+# -- `http://::1:8080/` is not a URL any client can parse (an IPv6 literal in
+# a URL authority component must be bracketed per RFC 3986 section 3.2.2).
+
+
+def test_format_host_for_url_brackets_ipv6_literals() -> None:
+    assert feed_server_module._format_host_for_url("::1") == "[::1]"
+    assert feed_server_module._format_host_for_url("2001:db8::1") == "[2001:db8::1]"
+
+
+def test_format_host_for_url_leaves_ipv4_and_hostnames_unbracketed() -> None:
+    assert feed_server_module._format_host_for_url("127.0.0.1") == "127.0.0.1"
+    assert feed_server_module._format_host_for_url("0.0.0.0") == "0.0.0.0"
+    assert feed_server_module._format_host_for_url("localhost") == "localhost"
+
+
+def _ipv6_loopback_bindable() -> bool:
+    """True if this platform/runner can actually bind `::1` -- some CI
+    sandboxes disable IPv6 entirely, which is a runner-environment fact,
+    not a defect in the fix under test; the one test below that needs a
+    real IPv6 socket is skipped (not failed) when this is False."""
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as probe:
+            probe.bind(("::1", 0))
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _ipv6_loopback_bindable(), reason="platform/runner cannot bind ::1"
+)
+def test_start_with_ipv6_loopback_bind_produces_a_bracketed_url_and_round_trips(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """The end-to-end case: binding `::1` must produce a URL a real client
+    can parse and connect to, not just a correctly-formatted string in
+    isolation (that half is covered by the two tests above, which do not
+    need a live IPv6 socket at all)."""
+    url = server.start(served_dir, bind="::1", port=0)
+    assert url.startswith("http://[::1]:")
+    assert url.endswith("/")
+
+    response = httpx.get(url + "feed.xml", timeout=5.0)
+    assert response.status_code == 200
+    assert response.text == (served_dir / "feed.xml").read_text(encoding="utf-8")
+
+
 # --- directory listings disabled, recursive FILE serving intact (M4) ---------
 
 

--- a/Tests/Subscriptions/test_feed_server.py
+++ b/Tests/Subscriptions/test_feed_server.py
@@ -1,0 +1,347 @@
+"""Tests for `FeedDirectoryServer` (task-1760).
+
+A real `http.server.ThreadingHTTPServer` on an ephemeral localhost port,
+driven with a real `httpx` sync client -- never a mock of the stdlib
+server -- so these tests actually exercise the socket, the thread, and the
+handler's path resolution rather than a stand-in for them. Every server
+started here is stopped in a `finally`/`try...finally` before the test
+ends, and every port is ephemeral (`port=0`) or, for the double-start test,
+irrelevant to any other test's socket -- nothing here binds a fixed port.
+
+The load-bearing tests are the traversal matrix
+(`test_a_symlink_inside_the_served_directory_pointing_outside_is_denied`
+above all: `SimpleHTTPRequestHandler.translate_path` alone already
+collapses literal `..`/absolute-path traversal in the URL -- see that
+method's own docstring -- but does NOT stop a symlink planted inside the
+served directory from resolving to a target outside it, since `open()`/
+`os.stat()` follow symlinks by default) and the two mutation checks
+described in the task's own instructions: removing the containment check
+must fail the symlink test, and removing the GET/HEAD-only gate must fail
+the 405 test. Both were verified by hand during development (see the
+task's Implementation Notes) and are not re-run automatically here.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import httpx
+import pytest
+
+from tldw_chatbook.Subscriptions import feed_server as feed_server_module
+from tldw_chatbook.Subscriptions.feed_server import (
+    FeedDirectoryServer,
+    FeedServerError,
+    configured_bind_and_port,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def served_dir(tmp_path: Path) -> Path:
+    """A directory with one seeded 'feed' file, standing in for an
+    exported feed directory's `feed.xml` + episode files."""
+    directory = tmp_path / "feed"
+    directory.mkdir()
+    (directory / "feed.xml").write_text(
+        "<rss><channel><title>Test Feed</title></channel></rss>", encoding="utf-8"
+    )
+    (directory / "episode-1.wav").write_bytes(b"RIFF....WAVEfmt ")
+    return directory
+
+
+@pytest.fixture
+def server() -> FeedDirectoryServer:
+    """A fresh, unstarted server -- stopped unconditionally after the test,
+    even if the test itself never started it (`stop()` is a no-op then) or
+    failed before reaching its own cleanup."""
+    instance = FeedDirectoryServer()
+    try:
+        yield instance
+    finally:
+        instance.stop()
+
+
+# --- start/stop basics -------------------------------------------------------
+
+
+def test_is_running_and_url_are_none_before_start(server: FeedDirectoryServer) -> None:
+    assert server.is_running is False
+    assert server.url is None
+
+
+def test_start_reports_the_real_bound_port_for_an_ephemeral_request(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """`port=0` asks the OS for any free port; the returned URL must name
+    the ACTUAL bound port, not `0` -- a client cannot connect to port 0."""
+    url = server.start(served_dir, port=0)
+    assert url.startswith("http://127.0.0.1:")
+    port_text = url.rsplit(":", 1)[1].rstrip("/")
+    assert port_text.isdigit()
+    assert int(port_text) != 0
+    assert server.is_running is True
+    assert server.url == url
+
+
+def test_stop_is_a_no_op_when_never_started(server: FeedDirectoryServer) -> None:
+    server.stop()  # must not raise
+    assert server.is_running is False
+
+
+def test_stop_closes_the_socket_so_a_later_request_is_refused(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    url = server.start(served_dir)
+    httpx.get(url + "feed.xml", timeout=5.0).raise_for_status()
+
+    server.stop()
+    assert server.is_running is False
+    assert server.url is None
+
+    with pytest.raises(httpx.ConnectError):
+        httpx.get(url + "feed.xml", timeout=5.0)
+
+
+def test_double_start_refuses_and_leaves_the_first_server_serving(
+    server: FeedDirectoryServer, served_dir: Path, tmp_path: Path
+) -> None:
+    """The task's own "one directory at a time" decision: a second
+    `start()` while one is running REFUSES (naming the running URL)
+    rather than restarting on the new directory -- see `FeedDirectoryServer.
+    start`'s own docstring for why refusing was chosen as the simpler of
+    the two options the plan allowed.
+    """
+    first_url = server.start(served_dir)
+
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    (other_dir / "feed.xml").write_text("<rss></rss>", encoding="utf-8")
+
+    with pytest.raises(FeedServerError, match=first_url):
+        server.start(other_dir)
+
+    # The FIRST server is undisturbed -- still serving its own directory.
+    response = httpx.get(first_url + "feed.xml", timeout=5.0)
+    assert response.status_code == 200
+    assert "Test Feed" in response.text
+
+
+def test_start_rejects_a_missing_directory(server: FeedDirectoryServer, tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(FeedServerError):
+        server.start(missing)
+    assert server.is_running is False
+
+
+def test_start_rejects_a_file_that_is_not_a_directory(
+    server: FeedDirectoryServer, tmp_path: Path
+) -> None:
+    a_file = tmp_path / "not-a-dir.txt"
+    a_file.write_text("hello", encoding="utf-8")
+    with pytest.raises(FeedServerError):
+        server.start(a_file)
+    assert server.is_running is False
+
+
+# --- round-trip GET (AC #1) --------------------------------------------------
+
+
+def test_round_trip_get_of_a_seeded_feed_file(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    url = server.start(served_dir)
+
+    response = httpx.get(url + "feed.xml", timeout=5.0)
+    assert response.status_code == 200
+    assert response.text == (served_dir / "feed.xml").read_text(encoding="utf-8")
+
+    audio_response = httpx.get(url + "episode-1.wav", timeout=5.0)
+    assert audio_response.status_code == 200
+    assert audio_response.content == (served_dir / "episode-1.wav").read_bytes()
+
+
+def test_head_request_succeeds_with_no_body(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    url = server.start(served_dir)
+    response = httpx.head(url + "feed.xml", timeout=5.0)
+    assert response.status_code == 200
+    assert response.content == b""
+
+
+def test_a_missing_file_inside_the_served_directory_is_a_plain_404(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    url = server.start(served_dir)
+    response = httpx.get(url + "no-such-file.xml", timeout=5.0)
+    assert response.status_code == 404
+
+
+# --- method surface (AC #3 adjacent: read-only) -----------------------------
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "PATCH"])
+def test_write_methods_are_rejected_with_405(
+    server: FeedDirectoryServer, served_dir: Path, method: str
+) -> None:
+    url = server.start(served_dir)
+    response = httpx.request(method, url + "feed.xml", timeout=5.0)
+    assert response.status_code == 405
+
+
+# --- traversal matrix (AC #3) ------------------------------------------------
+
+
+def test_dotdot_traversal_does_not_escape_the_served_directory(
+    server: FeedDirectoryServer, served_dir: Path, tmp_path: Path
+) -> None:
+    """A sibling directory holds a 'secret' the served directory has no
+    business exposing; `../`-shaped requests must never return it."""
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+    (secret_dir / "passwd").write_text("root:x:0:0", encoding="utf-8")
+
+    url = server.start(served_dir)
+    response = httpx.get(
+        url + "../secret/passwd", timeout=5.0, follow_redirects=False
+    )
+    assert response.status_code in (404, 400)
+    assert "root:x:0:0" not in response.text
+
+
+def test_percent_encoded_dotdot_traversal_does_not_escape(
+    server: FeedDirectoryServer, served_dir: Path, tmp_path: Path
+) -> None:
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+    (secret_dir / "passwd").write_text("root:x:0:0", encoding="utf-8")
+
+    url = server.start(served_dir)
+    response = httpx.get(
+        url + "..%2f secret%2fpasswd".replace(" ", ""),
+        timeout=5.0,
+        follow_redirects=False,
+    )
+    assert response.status_code in (404, 400)
+    assert "root:x:0:0" not in response.text
+
+
+def test_absolute_path_style_request_does_not_escape(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """A request path that LOOKS like an absolute filesystem path (e.g.
+    `/etc/passwd`) is still just a URL path relative to the served
+    directory -- it must never resolve to a real absolute path on disk."""
+    url = server.start(served_dir)
+    response = httpx.get(url.rstrip("/") + "/etc/passwd", timeout=5.0)
+    assert response.status_code == 404
+
+
+def test_a_symlink_inside_the_served_directory_pointing_outside_is_denied(
+    server: FeedDirectoryServer, served_dir: Path, tmp_path: Path
+) -> None:
+    """The load-bearing traversal test: `translate_path` alone considers
+    `served_dir/escape.xml` an in-bounds path (it never leaves the served
+    directory syntactically), but the symlink's TARGET is outside it.
+    Without the containment check in `_ContainedRequestHandler.
+    translate_path`, `open()` would follow the link and serve the secret
+    file's content; with it, this must 404.
+    """
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+    secret_file = secret_dir / "outside.txt"
+    secret_file.write_text("do not serve me", encoding="utf-8")
+
+    symlink_path = served_dir / "escape.xml"
+    symlink_path.symlink_to(secret_file)
+    assert symlink_path.resolve() == secret_file.resolve()
+
+    url = server.start(served_dir)
+    response = httpx.get(url + "escape.xml", timeout=5.0)
+    assert response.status_code == 404
+    assert "do not serve me" not in response.text
+
+
+def test_a_symlink_inside_the_served_directory_pointing_inside_still_works(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """The containment check must not be so broad it blocks a symlink that
+    resolves INSIDE the served directory -- only escapes are denied."""
+    target = served_dir / "feed.xml"
+    link = served_dir / "alias.xml"
+    link.symlink_to(target)
+
+    url = server.start(served_dir)
+    response = httpx.get(url + "alias.xml", timeout=5.0)
+    assert response.status_code == 200
+    assert response.text == target.read_text(encoding="utf-8")
+
+
+# --- config defaults (never auto-start) --------------------------------------
+
+
+def test_configured_bind_and_port_defaults_to_loopback_and_ephemeral(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_get_cli_setting(section, key, default=None):
+        assert section == "briefings_feed_server"
+        return default
+
+    monkeypatch.setattr(feed_server_module, "get_cli_setting", _fake_get_cli_setting)
+    bind, port = configured_bind_and_port()
+    assert bind == "127.0.0.1"
+    assert port == 0
+
+
+def test_configured_bind_and_port_reads_a_stored_section(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "briefings_feed_server" and key == "bind":
+            return "0.0.0.0"
+        if section == "briefings_feed_server" and key == "port":
+            return 8123
+        return default
+
+    monkeypatch.setattr(feed_server_module, "get_cli_setting", _fake_get_cli_setting)
+    bind, port = configured_bind_and_port()
+    assert bind == "0.0.0.0"
+    assert port == 8123
+
+
+def test_configured_bind_and_port_falls_back_to_ephemeral_on_a_bad_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hand-edited config with a non-integer port must not raise --
+    `configured_bind_and_port` degrades to the ephemeral default instead."""
+
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "briefings_feed_server" and key == "port":
+            return "not-a-port"
+        return default
+
+    monkeypatch.setattr(feed_server_module, "get_cli_setting", _fake_get_cli_setting)
+    _bind, port = configured_bind_and_port()
+    assert port == 0
+
+
+def test_nothing_in_this_module_starts_a_server_on_import_or_config_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #2, at the module's own boundary: reading configured defaults
+    must never itself bind a socket. Proven by binding the one port
+    `configured_bind_and_port`'s default would name (ephemeral, so this
+    asserts the READ path never touches a socket at all, via a spy)."""
+    calls: list[tuple] = []
+    real_socket = socket.socket
+
+    def _spy_socket(*args, **kwargs):
+        calls.append((args, kwargs))
+        return real_socket(*args, **kwargs)
+
+    monkeypatch.setattr(socket, "socket", _spy_socket)
+    configured_bind_and_port()
+    assert calls == [], "reading config defaults must never open a socket"

--- a/Tests/Subscriptions/test_feed_server.py
+++ b/Tests/Subscriptions/test_feed_server.py
@@ -24,19 +24,51 @@ task's Implementation Notes) and are not re-run automatically here.
 from __future__ import annotations
 
 import socket
+import time
 from pathlib import Path
 
 import httpx
 import pytest
+from loguru import logger as loguru_logger
 
 from tldw_chatbook.Subscriptions import feed_server as feed_server_module
 from tldw_chatbook.Subscriptions.feed_server import (
     FeedDirectoryServer,
     FeedServerError,
     configured_bind_and_port,
+    is_loopback_bind,
 )
 
 pytestmark = pytest.mark.unit
+
+
+def _raw_http_request(port: int, request_bytes: bytes, timeout: float = 5.0) -> bytes:
+    """Send raw bytes straight to the server's port and return whatever
+    comes back over the wire, unmodified.
+
+    Fix wave (task-1760 review, M1/L1 test-quality note): `httpx`
+    normalizes URLs client-side before a request is ever sent -- a literal
+    `..`, a bare `GET\\r\\n\\r\\n`, or an over-long request line can never
+    reach the server through it. A raw socket is the only way to prove
+    what the server itself does with bytes an `httpx`-based test can never
+    put on the wire.
+    """
+    with socket.create_connection(("127.0.0.1", port), timeout=timeout) as sock:
+        sock.sendall(request_bytes)
+        chunks: list[bytes] = []
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        except OSError:
+            pass
+    return b"".join(chunks)
+
+
+def _url_port(url: str) -> int:
+    return int(url.rsplit(":", 1)[1].rstrip("/"))
 
 
 @pytest.fixture
@@ -192,6 +224,244 @@ def test_write_methods_are_rejected_with_405(
     assert response.status_code == 405
 
 
+# --- malformed requests get a real error response (task-1760 review, M1) -----
+#
+# `log_message` used to read `self.path`, which `BaseHTTPRequestHandler.
+# parse_request` does not set until AFTER the point where it calls
+# `send_error` -> `log_error` -> `log_message` on these exact failure
+# paths. Reading it raised `AttributeError`, which killed the intended
+# 400/414 response (the client got zero bytes instead) and the per-
+# connection handler thread with it. Both cases below are driven with a
+# raw socket -- `httpx` builds well-formed requests and can never put a
+# bare `GET\r\n\r\n` or a >64KiB request line on the wire.
+
+
+def test_a_malformed_request_line_gets_a_400_not_a_dropped_connection(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """`GET / a HTTP/1.0` -- 4 words, not the 2-3 `parse_request` accepts
+    -- is one of the reviewer's own confirmed repro lines. It is used
+    (rather than a bare `GET\\r\\n\\r\\n`) specifically because its word
+    count still lets `parse_request` validate and set `self.request_
+    version` to a real `HTTP/1.0` *before* the word-count check fails --
+    unlike a 1-word requestline, which leaves `request_version` at the
+    stdlib's own `HTTP/0.9` default and (correctly, independent of this
+    bug) sends a bare body with no status line at all, per that protocol.
+    Both shapes exercise the same `self.path`-before-it-exists bug in
+    `log_message`; this one just lets the assertion check a real status
+    line too.
+    """
+    url = server.start(served_dir)
+    port = _url_port(url)
+
+    response = _raw_http_request(port, b"GET / a HTTP/1.0\r\n\r\n")
+    assert response, "the client must receive a real response, not zero bytes"
+    status_line = response.split(b"\r\n", 1)[0]
+    assert status_line.startswith(b"HTTP/")
+    assert b" 400 " in status_line
+
+    # The bug killed one connection's handler thread, not the whole
+    # server -- but a real regression here would show up as this
+    # follow-up request failing too.
+    follow_up = httpx.get(url + "feed.xml", timeout=5.0)
+    assert follow_up.status_code == 200
+
+
+def test_a_bare_malformed_request_line_does_not_crash_the_handler_thread(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """The reviewer's other confirmed repro: a 1-word requestline (`GET`
+    alone). The stdlib itself, independent of this bug, answers a
+    request it never upgraded past its own `HTTP/0.9` default with a bare
+    body and no status line -- so this test's own bar is simply "the
+    connection gets SOME response and the server survives", not a status
+    line (covered by the sibling test above and the over-long-line test
+    below instead).
+    """
+    url = server.start(served_dir)
+    port = _url_port(url)
+
+    response = _raw_http_request(port, b"GET\r\n\r\n")
+    assert response, "the client must receive a real response, not zero bytes"
+
+    follow_up = httpx.get(url + "feed.xml", timeout=5.0)
+    assert follow_up.status_code == 200
+
+
+def test_an_over_long_request_line_gets_a_414_not_a_dropped_connection(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """`handle_one_request`'s own >64KiB guard sets `self.command = ''`
+    but never sets `self.path` at all before calling `send_error` -- the
+    same missing-attribute trap as the malformed-request-line case above,
+    on a different code path (`command` exists here; `path` still does
+    not)."""
+    url = server.start(served_dir)
+    port = _url_port(url)
+
+    oversized_target = b"A" * 70_000
+    request = b"GET /" + oversized_target + b" HTTP/1.1\r\n\r\n"
+    response = _raw_http_request(port, request)
+    assert response, "the client must receive a real response, not zero bytes"
+    status_line = response.split(b"\r\n", 1)[0]
+    assert status_line.startswith(b"HTTP/")
+    assert b" 414 " in status_line
+
+    follow_up = httpx.get(url + "feed.xml", timeout=5.0)
+    assert follow_up.status_code == 200
+
+
+# --- stop() latency (task-1760 review, M2) -----------------------------------
+
+
+def test_stop_returns_well_under_the_old_half_second_stall(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """`stop()` used to block for the stdlib's default 0.5s `serve_forever`
+    poll interval (measured ~501ms) on the SAME thread the Stop button
+    handler and `on_unmount` call it from -- a real, measured UI freeze.
+    `start()` now runs the loop at a 50ms poll interval instead, bounding
+    this to roughly a tenth of that. 150ms is a generous ceiling: well
+    above the ~50ms this should take, comfortably below the ~500ms this
+    reproduced before the fix, so this is not a flaky assertion on a
+    loaded CI box.
+    """
+    server.start(served_dir)
+
+    started_at = time.monotonic()
+    server.stop()
+    elapsed_seconds = time.monotonic() - started_at
+
+    assert elapsed_seconds < 0.15, (
+        f"stop() took {elapsed_seconds * 1000:.1f}ms, expected well under 150ms"
+    )
+
+
+# --- bind validation (task-1760 review, M3) -----------------------------------
+
+
+def test_start_normalizes_a_blank_bind_to_the_safe_loopback_default(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """A blank `bind` (an operator's attempt to "unset" it, or a hand-
+    edited config gone wrong) must resolve to loopback, never to an empty
+    string -- `socket.bind(("", 0))` binds EVERY interface, silently
+    turning the loopback-only default into a LAN-wide one."""
+    url = server.start(served_dir, bind="")
+    assert server.bind == "127.0.0.1"
+    assert url.startswith("http://127.0.0.1:")
+    assert is_loopback_bind(server.bind) is True
+
+
+def test_start_normalizes_a_numeric_bind_to_the_safe_loopback_default(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """A `bind = 0` typo (meant for `port`) is a non-string, not merely a
+    blank string -- `_normalize_bind` must catch that shape too, since
+    `socket.bind(("0", 0))` and `socket.bind(("", 0))` both resolve to
+    `0.0.0.0` just as readily."""
+    url = server.start(served_dir, bind=0)  # type: ignore[arg-type]
+    assert server.bind == "127.0.0.1"
+    assert url.startswith("http://127.0.0.1:")
+
+
+def test_configured_bind_and_port_falls_back_to_loopback_on_a_blank_bind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "briefings_feed_server" and key == "bind":
+            return ""
+        return default
+
+    monkeypatch.setattr(feed_server_module, "get_cli_setting", _fake_get_cli_setting)
+    bind, _port = configured_bind_and_port()
+    assert bind == "127.0.0.1"
+
+
+def test_a_non_loopback_bind_warns_once_and_is_loopback_bind_says_so(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """A deliberately widened bind (or a config mistake that still
+    resolves to a real address, unlike a blank/typo'd one) must not be
+    silently invisible -- `start()` logs a warning, and the same
+    `is_loopback_bind` check lets the UI layer word its own toast around
+    the identical fact rather than re-deriving it.
+
+    `caplog` does not intercept loguru (this project's logger, per this
+    repo's own established idiom -- see e.g. `Tests/Chat/
+    test_attachment_policy.py`'s `TestSvgCapability`); a temporary loguru
+    sink is used instead.
+    """
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        server.start(served_dir, bind="0.0.0.0", port=0)
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert any("not loopback-only" in message for message in messages), messages
+    assert server.bind == "0.0.0.0"
+    assert is_loopback_bind(server.bind) is False
+
+
+def test_a_loopback_bind_never_warns(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    messages: list[str] = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        server.start(served_dir)  # default bind -- loopback
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert messages == []
+    assert is_loopback_bind(server.bind) is True
+
+
+# --- directory listings disabled, recursive FILE serving intact (M4) ---------
+
+
+def test_root_index_is_refused_with_404_not_a_directory_listing(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """A podcast feed is fetched by URLs named in `feed.xml` -- nothing
+    ever needs to browse the served directory, and an auto-generated
+    index is pure exposure surface on top of the files a client already
+    knows about."""
+    url = server.start(served_dir)
+    response = httpx.get(url, timeout=5.0)
+    assert response.status_code == 404
+    assert "<li>" not in response.text, "no directory listing HTML"
+
+
+def test_a_subdirectory_index_is_also_refused_with_404(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    subdir = served_dir / "episodes"
+    subdir.mkdir()
+    (subdir / "bonus.wav").write_bytes(b"RIFF....WAVEfmt ")
+
+    url = server.start(served_dir)
+    response = httpx.get(url + "episodes/", timeout=5.0)
+    assert response.status_code == 404
+    assert "<li>" not in response.text
+
+
+def test_a_known_file_inside_a_subdirectory_still_serves_200(
+    server: FeedDirectoryServer, served_dir: Path
+) -> None:
+    """M4's fix disables browsing, not recursive FILE serving -- an
+    episode `feed.xml` names inside a subfolder must still resolve."""
+    subdir = served_dir / "episodes"
+    subdir.mkdir()
+    (subdir / "bonus.wav").write_bytes(b"RIFF....WAVEfmt ")
+
+    url = server.start(served_dir)
+    response = httpx.get(url + "episodes/bonus.wav", timeout=5.0)
+    assert response.status_code == 200
+    assert response.content == b"RIFF....WAVEfmt "
+
+
 # --- traversal matrix (AC #3) ------------------------------------------------
 
 
@@ -199,7 +469,17 @@ def test_dotdot_traversal_does_not_escape_the_served_directory(
     server: FeedDirectoryServer, served_dir: Path, tmp_path: Path
 ) -> None:
     """A sibling directory holds a 'secret' the served directory has no
-    business exposing; `../`-shaped requests must never return it."""
+    business exposing; `../`-shaped requests must never return it.
+
+    Test-quality note (task-1760 review): this test alone is near-vacuous
+    for its stated purpose -- `httpx` normalizes a literal `../` client-
+    side before the request is ever sent (`httpx.URL("http://h/../x").
+    raw_path == b"/x"`), so the literal `..` never reaches the wire here
+    and the server only ever sees an ordinary missing-file request. Kept
+    (it is still a real, if weaker, 404 assertion) alongside
+    `test_raw_socket_dotdot_forms_httpx_would_never_put_on_the_wire`
+    below, which puts each form directly on a raw socket instead.
+    """
     secret_dir = tmp_path / "secret"
     secret_dir.mkdir()
     (secret_dir / "passwd").write_text("root:x:0:0", encoding="utf-8")
@@ -210,6 +490,47 @@ def test_dotdot_traversal_does_not_escape_the_served_directory(
     )
     assert response.status_code in (404, 400)
     assert "root:x:0:0" not in response.text
+
+
+@pytest.mark.parametrize(
+    "wire_target",
+    [
+        b"/../secret/passwd",
+        b"/../../secret/passwd",
+        b"/..%2fsecret%2fpasswd",
+        b"/..%5csecret%5cpasswd",
+        b"//secret/passwd",
+        b"/./../secret/passwd",
+    ],
+)
+def test_raw_socket_dotdot_forms_httpx_would_never_put_on_the_wire(
+    server: FeedDirectoryServer,
+    served_dir: Path,
+    tmp_path: Path,
+    wire_target: bytes,
+) -> None:
+    """The real fix for the sibling test's near-vacuous coverage: each
+    traversal form goes directly onto a raw socket, bypassing any client-
+    side normalization, so the 404 this asserts is the SERVER's own
+    answer -- not an artifact of a well-behaved HTTP client never sending
+    the bad bytes in the first place.
+    """
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+    (secret_dir / "passwd").write_text("root:x:0:0", encoding="utf-8")
+
+    url = server.start(served_dir)
+    port = _url_port(url)
+
+    request = (
+        b"GET " + wire_target + b" HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    )
+    response = _raw_http_request(port, request)
+
+    status_line = response.split(b"\r\n", 1)[0]
+    assert b" 404 " in status_line or b" 400 " in status_line, response[:200]
+    assert b"root:x:0:0" not in response
 
 
 def test_percent_encoded_dotdot_traversal_does_not_escape(

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -5361,8 +5361,12 @@ async def test_pressing_serve_then_stop_round_trips_through_a_real_server(
         assert url in args[0]
         assert (
             "No authentication — anyone who can reach this address can "
-            "read the feed while it is serving." in args[0]
+            "read every file in this folder and its subfolders while it "
+            "is serving." in args[0]
         )
+        # Loopback default -> no additional exposure sentence (task-1760
+        # review, M3: that sentence is reserved for a non-loopback bind).
+        assert "reachable from beyond this machine" not in args[0]
         assert kwargs.get("severity") == "warning"
         assert kwargs.get("markup") is False
 

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -39,6 +39,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
 from rich.console import Console
 from rich.text import Text
@@ -74,7 +75,9 @@ from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import (
     KeepBriefingRequested,
     KeptBriefingsRequested,
     PlayAudioRequested,
+    ServeFeedRequested,
     StopAudioRequested,
+    StopFeedServerRequested,
     SynthesizeAudioRequested,
     _audio_file_is_playable,
     audio_file_path_is_safe,
@@ -5260,6 +5263,234 @@ async def test_export_feed_directory_cancelled_error_propagates_uncaught(
 
     assert not (destination / "feed.xml").exists()
     app.notify.assert_not_called()
+
+
+# --- task-1760: serving the exported feed directory over localhost --------
+#
+# `Subscriptions.feed_server.FeedDirectoryServer` (its own dedicated test
+# file, `Tests/Subscriptions/test_feed_server.py`, covers the server itself
+# -- the real socket, the traversal matrix, the 405 gate) -- these tests
+# only exercise the UI wiring: the Serve/Stop buttons' disabled state, the
+# handler's own re-checks, and that pressing them actually starts/stops a
+# real server (proven with one real `httpx` round trip, not a mock).
+
+
+@pytest.mark.asyncio
+async def test_serve_and_stop_buttons_start_disabled_with_nothing_exported_or_running(
+    monkeypatch, tmp_path
+):
+    """Serve starts disabled with nothing exported yet (AC #2: nothing is
+    ever served without an explicit export having already happened), and
+    Stop starts disabled with nothing running -- proven by the server's
+    own `is_running` being `False`, i.e. no socket has been opened at all.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    _seed_exportable_audio_episode(app, watchlist_id)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        assert screen._feed_server.is_running is False, (
+            "nothing may be listening before Serve is ever pressed"
+        )
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        serve_button = pane.query_one("#artifacts-serve-feed-button", Button)
+        stop_button = pane.query_one("#artifacts-stop-feed-button", Button)
+        assert serve_button.disabled is True, "nothing exported yet -> disabled"
+        assert stop_button.disabled is True, "nothing running -> disabled"
+        assert serve_button.compact, "a bordered button costs 3 rows in a height:1 strip"
+        assert stop_button.compact
+
+
+@pytest.mark.asyncio
+async def test_serve_enables_once_a_feed_has_been_exported(monkeypatch, tmp_path):
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    _seed_exportable_audio_episode(app, watchlist_id)
+    db = app.watchlist_bundle_service.db
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(
+            db, watchlist_id, "Morning AI Brief", destination
+        )
+        await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert pane.query_one("#artifacts-serve-feed-button", Button).disabled is False
+        assert pane.query_one("#artifacts-stop-feed-button", Button).disabled is True
+
+
+@pytest.mark.asyncio
+async def test_pressing_serve_then_stop_round_trips_through_a_real_server(
+    monkeypatch, tmp_path
+):
+    """End to end through the real buttons: Serve starts a real server for
+    the just-exported directory, the toast names the URL plus AC #4's
+    plain no-auth statement, a real `httpx` GET against that URL returns
+    the exported `feed.xml`, and Stop closes the socket.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    _seed_exportable_audio_episode(app, watchlist_id)
+    db = app.watchlist_bundle_service.db
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(
+            db, watchlist_id, "Morning AI Brief", destination
+        )
+        await pilot.pause()
+        app.notify.reset_mock()  # discard the export's own toast
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-serve-feed-button", Button).press()
+        await pilot.pause()
+
+        assert screen._feed_server.is_running is True
+        url = screen._feed_server.url
+        assert url is not None and url.startswith("http://127.0.0.1:")
+
+        app.notify.assert_called_once()
+        args, kwargs = app.notify.call_args
+        assert url in args[0]
+        assert (
+            "No authentication — anyone who can reach this address can "
+            "read the feed while it is serving." in args[0]
+        )
+        assert kwargs.get("severity") == "warning"
+        assert kwargs.get("markup") is False
+
+        response = httpx.get(url + "feed.xml", timeout=5.0)
+        assert response.status_code == 200
+        assert response.text == (destination / "feed.xml").read_text(encoding="utf-8")
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        assert pane.query_one("#artifacts-serve-feed-button", Button).disabled is True
+        assert pane.query_one("#artifacts-stop-feed-button", Button).disabled is False
+
+        pane.query_one("#artifacts-stop-feed-button", Button).press()
+        await pilot.pause()
+
+        assert screen._feed_server.is_running is False
+        with pytest.raises(httpx.ConnectError):
+            httpx.get(url + "feed.xml", timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_screen_teardown_stops_a_still_running_feed_server(monkeypatch, tmp_path):
+    """A user who navigates away (or closes the app) without pressing Stop
+    must not leave a listening socket behind -- `on_unmount` closes it.
+    """
+    _patch_audio_dir(monkeypatch, tmp_path)
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    _seed_exportable_audio_episode(app, watchlist_id)
+    db = app.watchlist_bundle_service.db
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+
+    feed_server = None
+    served_url = None
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, _host):
+        await screen._export_feed_directory(
+            db, watchlist_id, "Morning AI Brief", destination
+        )
+        await pilot.pause()
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-serve-feed-button", Button).press()
+        await pilot.pause()
+        assert screen._feed_server.is_running is True
+        feed_server = screen._feed_server
+        served_url = screen._feed_server.url
+        # Deliberately never pressing Stop -- teardown must do it instead.
+
+    assert feed_server.is_running is False
+    with pytest.raises(httpx.ConnectError):
+        httpx.get(served_url + "feed.xml", timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_a_second_serve_while_one_is_running_is_refused_naming_the_running_url(
+    tmp_path,
+):
+    """The task's own "one directory at a time" decision: a second Serve
+    (dispatched directly at the message level, since the button itself
+    already disables this case -- see `ServeFeedRequested`'s own docstring
+    on why the handler re-checks anyway) refuses and names the URL already
+    in use, rather than restarting on a different directory.
+    """
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+    (destination / "feed.xml").write_text("<rss></rss>", encoding="utf-8")
+
+    async with _open_artifacts(app, watchlist_id) as (screen, _pilot, _host):
+        screen._last_feed_export_directory = destination
+        try:
+            screen.handle_serve_feed_requested(ServeFeedRequested())
+            running_url = screen._feed_server.url
+            assert running_url is not None
+
+            app.notify.reset_mock()
+            screen.handle_serve_feed_requested(ServeFeedRequested())
+            app.notify.assert_called_once()
+            args, kwargs = app.notify.call_args
+            assert running_url in args[0]
+            assert kwargs.get("severity") == "warning"
+            assert kwargs.get("markup") is False
+        finally:
+            screen._feed_server.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_when_nothing_is_serving_toasts_a_refusal(tmp_path):
+    app = _build_test_app()
+    app.notify = Mock()
+    watchlist_id = _seed_watchlist(app)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, _pilot, _host):
+        assert screen._feed_server.is_running is False
+        screen.handle_stop_feed_server_requested(StopFeedServerRequested())
+
+    app.notify.assert_called_once()
+    args, kwargs = app.notify.call_args
+    assert "Nothing is being served" in args[0]
+    assert kwargs.get("severity") == "warning"
+
+
+@pytest.mark.asyncio
+async def test_serve_reads_bind_and_port_from_configured_bind_and_port(
+    monkeypatch, tmp_path
+):
+    """Proves the handler actually consults `feed_server.configured_bind_
+    and_port` (config defaults) rather than hardcoding loopback/ephemeral
+    -- without needing to bind a non-default address, which would make
+    this test environment-dependent.
+    """
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    destination = tmp_path / "export_dest"
+    destination.mkdir()
+    (destination / "feed.xml").write_text("<rss></rss>", encoding="utf-8")
+
+    fake_defaults = Mock(return_value=("127.0.0.1", 0))
+    monkeypatch.setattr(screen_module, "configured_bind_and_port", fake_defaults)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, _pilot, _host):
+        screen._last_feed_export_directory = destination
+        try:
+            screen.handle_serve_feed_requested(ServeFeedRequested())
+            assert fake_defaults.call_count == 1
+        finally:
+            screen._feed_server.stop()
 
 
 # --- task-1780, Task 5: Keep + "Kept Briefings…" -----------------------------

--- a/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
+++ b/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
@@ -156,4 +156,57 @@ Watchlists_Modules/artifacts_pane.py` (Serve/Stop buttons, reactives, messages),
 watchlists_collections_screen.py` (server ownership, handlers, `on_unmount`), `Tests/Watchlists/
 test_watchlists_artifacts_pane.py` (new UI tests), `Docs/User_Guide/watchlists.md` (Serve Feed usage + Security
 posture section).
+
+**Fix wave (whole-branch security review, `task-1760-verdict.md`).** Four Medium + one Low finding remediated,
+no blockers found. **M1**: `log_message` read `self.command`/`self.path` directly; `BaseHTTPRequestHandler.
+parse_request` sets `self.command = None` before `self.path` exists and calls `send_error` -> `log_error` ->
+`log_message` on every malformed-request-line path (bare `GET`, a >64KiB request line, a 4-word line with a
+parseable version) that runs before `self.path` is ever assigned -- raising `AttributeError`, which killed the
+intended 400/414 response (client got zero bytes) and the handler thread, with no log line at all. Fixed with
+`getattr(self, "command", "-")` / `getattr(self, "path", "-")`. **M2**: `stop()` measured ~501ms blocking the
+Textual event loop (both callers -- the Stop handler and `on_unmount` -- call it synchronously), because
+`serve_forever()` was started with no `poll_interval` (stdlib default 0.5s) and `shutdown()` blocks until the
+loop's next poll returns. Fixed by starting the loop at `poll_interval=0.05`; measured `stop()` afterward at
+well under 150ms in the new regression test (no change to `stop()` itself needed -- the bound comes entirely
+from how the loop was started). The "fast, non-blocking stdlib calls" comment that justified skipping
+`run_worker` is corrected to state the real, now-bounded cost instead of claims that measured false. **M3**:
+`bind` was `str(...)`'d with no further validation -- a blank config value or a numeric typo (`bind = 0`, meant
+for `port`) both resolve to `0.0.0.0` (every interface) at the socket layer, silently turning the loopback
+default into a LAN-wide one with no signal anywhere. Added `_normalize_bind` (blank/whitespace/non-string ->
+`"127.0.0.1"`) applied at both `configured_bind_and_port` (config-read layer) and `start()` itself (the actual
+socket boundary, so a direct caller gets the same guarantee); `start()` now also logs a warning and the Serve
+toast appends an explicit exposure sentence whenever the resolved bind is not loopback (new `is_loopback_bind`
+helper, covering `127.0.0.0/8`, `::1`, and `localhost`). **M4**: the handler served the chosen directory
+recursively with browsable directory listings enabled (`GET /` returned a full index) -- undersold in the
+original posture text. Fixed in code, not just docs: `_ContainedRequestHandler.list_directory` now 404s
+instead of rendering a listing (recursive FILE serving is unchanged -- an episode in a subfolder still
+resolves). Module docstring, `config.py`'s template comment, and `Docs/User_Guide/watchlists.md` all now state
+plainly that the server serves every file in the chosen directory **and every subdirectory**, and steer users
+toward a dedicated export folder rather than a general-purpose one like `$HOME`. **L1**: re-exporting a feed
+while a server is running on a *different*, older directory previously gave no signal beyond the Serve
+button's own disabled state. `FeedDirectoryServer` now exposes `.directory` (the resolved directory the running
+server actually serves); the export success/partial-export toasts append "Still serving the previously-exported
+folder -- Stop Serving and Serve again to publish this export." when the server is running and pointed
+elsewhere (silent when re-exporting into the *same* directory, since the server reads from disk per-request and
+already reflects it). **Test-quality note**: `test_dotdot_traversal_does_not_escape_the_served_directory` was
+confirmed near-vacuous (httpx normalizes a literal `../` client-side before it reaches the wire) -- kept, and
+augmented with a new raw-socket parametrized test (`test_raw_socket_dotdot_forms_httpx_would_never_put_on_the_
+wire`, 6 wire forms including literal `..`, doubled `../../`, `..%2f`, `..%5c`, leading `//`, and `./../`) that
+puts each form directly on the wire, bypassing any client normalization. L2 (no HTTP Range/206 support) is a
+deliberately out-of-scope non-goal, per the review.
+
+Three mutations verified by hand with the Edit tool (git-status-clean between each): reverting `log_message`'s
+`getattr` fallbacks reproduced the exact `AttributeError` from the review against all three M1 tests; reverting
+`_normalize_bind`'s fallback to a bare `str(raw_bind)` REDed all three blank/numeric-bind tests; reverting
+`list_directory` to `super().list_directory(path)` REDed both no-listing tests (200 with a real HTML index
+instead of 404). All three restored byte-exact and reconfirmed green.
+
+**Verification.** `Tests/Subscriptions/test_feed_server.py`: 41 passed (23 original + 18 new: 2 malformed-
+request, 1 stop-latency, 5 bind-validation, 3 no-listing, 6 raw-socket traversal, 1 malformed-line-survives).
+`Tests/Watchlists/test_watchlists_artifacts_pane.py`: 124 passed on a clean run; three earlier full-suite runs
+each surfaced exactly one different, unrelated test failing (`test_export_feed_press_survives_an_os_error_from_
+the_service`, then `test_citations_do_not_shrink_the_briefings_table_below_its_pinned_minimum`, then three more
+at once) -- every one of them passed standalone and touches no code this fix wave changed, consistent with this
+suite's known pre-existing full-run flakiness rather than a regression. Targeted `test_config_*` sweep (71
+tests, covering the new config-template comment) also green.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
+++ b/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1760
 title: 'In-app serving for the briefings feed directory'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-01 20:05'
 labels:
@@ -73,3 +73,12 @@ textual-serve entirely:
 - [ ] #4 A security review documents the default bind scope (localhost vs. wider), and states the
       no-auth-by-default posture explicitly rather than leaving it implicit
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. New `tldw_chatbook/Subscriptions/feed_server.py`: stdlib `ThreadingHTTPServer` on a daemon thread wrapping a locked-down `SimpleHTTPRequestHandler(directory=...)` subclass — GET/HEAD only, resolved-path prefix check on top of `translate_path` (symlink escapes rejected), no auth (posture stated), start()/stop() with ephemeral-or-configured port, bind 127.0.0.1 by default (`[briefings_feed_server]` config for port/bind; serving itself never auto-starts).
+2. UI: Serve/Stop action beside the phase-3 feed export on the watchlists Artifacts pane; toast shows the URL and the plain no-auth statement; state is session-only.
+3. Security review notes (AC #4) in the user guide's feed section + module docstring.
+4. Tests: real server on an ephemeral localhost port (round-trip via httpx), traversal matrix (.. / absolute / symlink-out), GET-only, opt-in default off, stop closes the socket.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
+++ b/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
@@ -209,4 +209,49 @@ the_service`, then `test_citations_do_not_shrink_the_briefings_table_below_its_p
 at once) -- every one of them passed standalone and touches no code this fix wave changed, consistent with this
 suite's known pre-existing full-run flakiness rather than a regression. Targeted `test_config_*` sweep (71
 tests, covering the new config-template comment) also green.
+
+**Fix wave (Qodo review).** Three findings remediated, no blockers found. **F1**: neither `start()` nor
+`configured_bind_and_port()` range-checked `port` -- `int(...)` accepted any integer, so an out-of-range-but-
+parseable value (e.g. `99999`, or a negative value) reached `ThreadingHTTPServer.__init__` -> `socket.bind` as a
+bare `OverflowError`, a type the UI's Serve handler (`watchlists_collections_screen.py`, only catches
+`FeedServerError`/`OSError`) does not catch -- it escaped as an unhandled exception instead of the toast every
+other rejection produces. The two entry points now degrade differently on purpose: `configured_bind_and_port()`
+(a config value, expected to sometimes be hand-edited wrong) falls back to ephemeral `0` with a type-only
+`logger.warning`, mirroring its existing bad-bind precedent; `FeedDirectoryServer.start()` (the actual socket
+boundary, and the one a direct caller -- script, test, future code -- can reach without going through config at
+all) instead raises `FeedServerError` for a non-`int`/out-of-range `port`, the same type its neighboring
+directory-validation checks already raise, which the UI already catches. **F2**: `start()` built
+`self._url = f"http://{bind}:{port}/"` unconditionally, which is not a URL any client can parse for an IPv6
+literal (`http://::1:8080/` is ambiguous) despite `is_loopback_bind` explicitly supporting `::1`. Added
+`_format_host_for_url` (bracket an IPv6 literal, leave IPv4/hostname forms unchanged) and wired it into the URL
+build. Verifying this end-to-end surfaced a second, deeper pre-existing defect: `http.server.HTTPServer`/
+`ThreadingHTTPServer` hard-code `address_family = socket.AF_INET` and never infer it from the bind address, so
+`start(bind="::1", ...)` failed with a bare `socket.gaierror` on every platform (not merely IPv6-disabled CI)
+before the URL-formatting code ever ran -- the bracketing fix would otherwise have been unreachable dead code.
+Added `_IPv6ThreadingHTTPServer` (the same class, `address_family` forced to `socket.AF_INET6`) and select it in
+`start()` whenever `bind` is an IPv6 literal (`_is_ipv6_literal`, factored out and shared with
+`_format_host_for_url` so the two can never disagree); IPv4/hostname binds are unaffected. **F3**:
+`is_loopback_bind` gained a Google-style `Args`/`Returns` docstring section; no behavior change.
+
+**Tests.** 21 new tests in `Tests/Subscriptions/test_feed_server.py` (51 total, up from 41): port validation (a
+config port of `99999`/`-1` falls back to ephemeral with a warning; a valid configured port still passes
+through; `start()` raises `FeedServerError` for a negative port, a port above 65535, and a non-`int` port, and
+still accepts a legitimate nonzero port end to end) and IPv6 URL bracketing (`_format_host_for_url` unit tests
+needing no socket at all, plus a live `start(bind="::1", port=0)` round trip via `httpx`, skipped -- not failed
+-- only if the runner cannot bind `::1` at all).
+
+**Mutation verification (Edit-tool revert, `git status --short` clean between each, all restored byte-exact and
+reconfirmed green afterward):** dropping `start()`'s port range/type check REDed all three of its rejection
+tests (each raised `OverflowError`/`TypeError` instead of the expected `FeedServerError`); dropping
+`configured_bind_and_port()`'s range check REDed both its out-of-range fallback tests (`99999`/`-1` passed
+through unchanged instead of falling back to `0`); reverting `_format_host_for_url` to return `bind` unmodified
+REDed both the pure-format test and the live IPv6 round-trip test (`http://::1:PORT/`, unbracketed).
+
+**Verification.** `Tests/Subscriptions/test_feed_server.py`: 51 passed. `Tests/Watchlists/
+test_watchlists_artifacts_pane.py`: 124 passed on this run (the two feed-server UI tests,
+`test_pressing_serve_then_stop_round_trips_through_a_real_server` and
+`test_serve_reads_bind_and_port_from_configured_bind_and_port`, both green) -- no repeat of the known rotating-
+victim flake this run. No regressions found.
+
+**Files modified:** `tldw_chatbook/Subscriptions/feed_server.py`, `Tests/Subscriptions/test_feed_server.py`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
+++ b/backlog/tasks/task-1760 - In-app-serving-for-the-briefings-feed-directory.md
@@ -64,13 +64,13 @@ textual-serve entirely:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A user can serve an exported briefings feed folder over localhost and successfully point
+- [x] #1 A user can serve an exported briefings feed folder over localhost and successfully point
       a podcast client at the resulting URL
-- [ ] #2 Serving is opt-in and off by default -- no feed directory is ever served without an
+- [x] #2 Serving is opt-in and off by default -- no feed directory is ever served without an
       explicit user action to start it
-- [ ] #3 The server cannot serve any file outside the one chosen directory (path traversal into
+- [x] #3 The server cannot serve any file outside the one chosen directory (path traversal into
       parent directories or elsewhere on disk is rejected)
-- [ ] #4 A security review documents the default bind scope (localhost vs. wider), and states the
+- [x] #4 A security review documents the default bind scope (localhost vs. wider), and states the
       no-auth-by-default posture explicitly rather than leaving it implicit
 <!-- AC:END -->
 
@@ -82,3 +82,78 @@ textual-serve entirely:
 3. Security review notes (AC #4) in the user guide's feed section + module docstring.
 4. Tests: real server on an ephemeral localhost port (round-trip via httpx), traversal matrix (.. / absolute / symlink-out), GET-only, opt-in default off, stop closes the socket.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Approach.** `tldw_chatbook/Subscriptions/feed_server.py` is a small, standalone module: `_ContainedRequestHandler`
+subclasses stdlib `http.server.SimpleHTTPRequestHandler` and overrides `translate_path` to add a resolved-path
+containment check on top of it (`Path(candidate).resolve().relative_to(served_root)`) -- `translate_path` alone
+already collapses literal `../`/absolute-path traversal in the URL down to a path inside the served directory (it
+never joins a `..`-shaped or directory-shaped word onto the base), but does **not** stop a symlink planted inside the
+served directory from resolving to a target outside it, since `open()`/`os.stat()` follow symlinks by default. A
+candidate that fails the check is answered with a plain, non-existent filename (never a null byte, which raised an
+uncaught `ValueError` in `open()` during development and tore the connection down instead of 404ing) so the stdlib's
+own `open()`-fails-with-`OSError` -> 404 path handles it unchanged. `do_POST`/`do_PUT`/`do_DELETE`/`do_PATCH` are
+overridden to `405`; request logging is routed to `loguru.debug` (paths only, never content). `FeedDirectoryServer`
+wraps a `ThreadingHTTPServer` on a daemon thread; `start()` refuses (raises `FeedServerError`, naming the running
+URL) rather than restarting when already running -- this is the "one directory at a time" decision the plan left
+open, and refusing was chosen because it needs no reconciliation between an old server possibly mid-request and a
+new one starting, at the cost of one extra Stop press. `configured_bind_and_port()` reads the optional
+`[briefings_feed_server]` `bind`/`port` via the three-argument `get_cli_setting(section, key, default)` form (never
+the two-argument dotted form, per the repo's TASK-1771 lesson) -- reading it never starts anything; only the UI's
+Serve action calls `start()`.
+
+**UI wiring.** Two new buttons, "Serve Feed" / "Stop Serving", added to `ArtifactsPane`'s existing
+`#artifacts-toolbar` right after "Export Feed…" (same toolbar Generate/Refresh/Export/Keep already live in, so no new
+row is spent). Two buttons rather than one toggling label, mirroring the pane's own Play/Stop audio pair: Serve is
+disabled while already running OR with nothing exported yet; Stop is disabled while nothing is running. New
+messages `ServeFeedRequested`/`StopFeedServerRequested` follow the pane's existing no-payload message shape (the
+directory/state lives on the screen). `WatchlistsCollectionsScreen` owns one `FeedDirectoryServer` instance
+(constructed in `__init__`, not a module singleton) plus `_last_feed_export_directory`, set in `_export_feed_directory`
+on every successful export (full or partial -- both leave a real, servable `feed.xml`). Both handlers are
+synchronous (no `run_worker`): `start()`/`stop()` are fast, non-blocking stdlib calls with no `await` boundary,
+unlike every other action on this screen that moves real I/O off the UI thread. `_sync_feed_server_pane_state()`
+patches the mounted pane's reactives in place after every state change, mirroring the existing picker-writer idiom
+(`handle_briefing_mode_changed` et al.) rather than a full recompose. `on_unmount` stops the server if still
+running, so navigating away or closing the app never leaves a wedged listening socket (verified live in
+`test_screen_teardown_stops_a_still_running_feed_server`: the socket refuses connections after the screen tears
+down, even when Stop was never pressed).
+
+**Config.** New `[briefings_feed_server]` section added to `config.py`'s default template (`bind = "127.0.0.1"`,
+`port = 0`), placed immediately before `[web_server]` with a comment stating explicitly that it is unrelated to that
+section. Nothing reads it except `configured_bind_and_port()`, and nothing calls that except the Serve handler.
+
+**One-directory-at-a-time choice: refuse, not restart.** `FeedDirectoryServer.start()` raises when already running,
+naming the currently-served URL; the UI's Serve button is also disabled while running (so this path is reached only
+via the handler's own defensive re-check, or a second in-process caller). Restarting in place was rejected as the
+more complex of the two options the plan allowed for.
+
+**Security posture (AC #4).** Documented in three places: the module docstring's "Security posture" section (the
+canonical version), a new "Security posture" subsection in `Docs/User_Guide/watchlists.md`'s feed section
+(loopback-by-default, no authentication stated plainly, path containment, session-only/opt-in), and the toast every
+`ServeFeedRequested` success prints: `"Serving the exported feed at {url}. No authentication — anyone who can reach
+this address can read the feed while it is serving."` (`markup=False`).
+
+**Tests.** `Tests/Subscriptions/test_feed_server.py` (23 tests): round-trip GET/HEAD, POST/PUT/DELETE/PATCH -> 405,
+the traversal matrix (`../`, percent-encoded `..%2f`, an absolute-path-shaped request, and the load-bearing symlink-
+inside-pointing-outside case plus its sibling proving an in-bounds symlink still works), double-start refusal,
+stop -> connection refused, missing/non-directory destination rejection, and `configured_bind_and_port` (defaults,
+a stored section, a bad value falling back to ephemeral, and a spy proving reading config never opens a socket).
+Two mutations verified by hand (temporarily removing the containment check and the GET/HEAD gate, confirming the
+symlink and 405 tests REDed, then restoring via the Edit tool and re-confirming green; `git status --short` was
+clean between). `Tests/Watchlists/test_watchlists_artifacts_pane.py` gained 7 UI tests: disabled-by-default (no
+socket open), enabling after an export, a full Serve-then-Stop round trip through the real buttons (toast content,
+a real `httpx` GET, connection refused after Stop), the teardown-without-Stop case, the running-refusal case, the
+nothing-to-stop refusal, and a wiring proof that the handler actually calls `configured_bind_and_port`.
+
+**Verification.** `Tests/Subscriptions/` (558 passed), `Tests/Watchlists/` (372 passed, including the 124 in
+`test_watchlists_artifacts_pane.py`), plus targeted `test_config_*` files -- all green. No regressions found.
+
+**Files added:** `tldw_chatbook/Subscriptions/feed_server.py`, `Tests/Subscriptions/test_feed_server.py`.
+**Files modified:** `tldw_chatbook/config.py` (new `[briefings_feed_server]` section), `tldw_chatbook/UI/
+Watchlists_Modules/artifacts_pane.py` (Serve/Stop buttons, reactives, messages), `tldw_chatbook/UI/Screens/
+watchlists_collections_screen.py` (server ownership, handlers, `on_unmount`), `Tests/Watchlists/
+test_watchlists_artifacts_pane.py` (new UI tests), `Docs/User_Guide/watchlists.md` (Serve Feed usage + Security
+posture section).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Subscriptions/feed_server.py
+++ b/tldw_chatbook/Subscriptions/feed_server.py
@@ -22,15 +22,27 @@ anywhere else.**
   `bind` (e.g. to `0.0.0.0`) in `[briefings_feed_server]`. Widening it
   exposes the served directory to the whole LAN (or further, behind a
   router configured for it) with no authentication at all -- see the next
-  point.
+  point. A blank, whitespace-only, or non-string `bind` value can never
+  silently cause this widening: `_normalize_bind` falls back to the safe
+  loopback default instead (task-1760 review, M3), and whenever the
+  address actually bound is not loopback -- whether from a deliberate
+  widening or a config mistake that still resolved to a real address --
+  `start()` logs a warning once, so exposure is never purely implicit.
 - **No authentication, by design, stated plainly rather than implied.**
   There is no login, token, or IP allow-list. Anyone who can open a TCP
   connection to the bound address and port can read every file under the
-  served directory for as long as it is running. This is acceptable for
-  its one intended use (pointing a podcast client at a feed you exported
-  yourself, on a loopback address only you can reach) and unacceptable for
-  anything wider -- the UI's own toast states this every time serving
-  starts, not just this docstring.
+  served directory **and every subdirectory beneath it** (recursively --
+  the handler is a plain `SimpleHTTPRequestHandler`, not scoped to one
+  level) for as long as it is running. This is acceptable for its one
+  intended use (pointing a podcast client at a feed you exported yourself,
+  on a loopback address only you can reach) and unacceptable for anything
+  wider -- the UI's own toast states this every time serving starts, not
+  just this docstring. Directory listings are refused (404, task-1760
+  review M4: `_ContainedRequestHandler.list_directory`) -- nothing is
+  *browsable* -- but every file whose name a client already knows (from
+  `feed.xml`, or guessed) is still fetchable anywhere in the tree. Point
+  this at a dedicated export folder, never a general-purpose directory
+  like your home folder, for exactly that reason.
 - **Path containment.** `_ContainedRequestHandler` resolves every request
   path (following symlinks) and refuses (404) anything that resolves
   outside the served directory. `SimpleHTTPRequestHandler.translate_path`
@@ -62,6 +74,7 @@ from __future__ import annotations
 
 import functools
 import http.server
+import ipaddress
 import threading
 from pathlib import Path
 
@@ -75,6 +88,55 @@ from ..Utils.path_validation import validate_path_simple
 #: read by `configured_bind_and_port()`, which supplies *defaults* for the
 #: UI's Serve action; nothing here auto-starts from it.
 _CONFIG_SECTION = "briefings_feed_server"
+
+#: The safe fallback bind address -- loopback-only (module docstring).
+#: `_normalize_bind` returns exactly this for anything that is not itself
+#: a non-blank string, so a blank/typo'd config value can never silently
+#: resolve to "every interface" (task-1760 review, M3).
+_SAFE_DEFAULT_BIND = "127.0.0.1"
+
+
+def _normalize_bind(raw_bind: object) -> str:
+    """Coerce a config-supplied `bind` value to a safe, non-empty string.
+
+    Fix wave (task-1760 review, M3): `bind` used to be passed through
+    `str(...)` with no further check, so a blank config value (`bind =
+    ""`, read back as `""`) or a numeric typo (`bind = 0`, meant for
+    `port`) reached `socket.bind` unchanged -- and both of those name
+    "every interface" to the stdlib (`socket.bind(("", 0))` and
+    `socket.bind(("0", 0))` both resolve to `0.0.0.0`), silently turning a
+    loopback-only default into a LAN-wide one. Anything that is not
+    itself a non-blank string -- `None`, an int, a float, an empty or
+    whitespace-only string -- falls back to the safe loopback default
+    instead; a *non-empty* string (including `"0.0.0.0"`) is trusted as a
+    deliberate choice and passed through unchanged (widening is not
+    forbidden -- module docstring -- only an accidental blank/typo'd value
+    silently causing it is).
+    """
+    if isinstance(raw_bind, str) and raw_bind.strip():
+        return raw_bind.strip()
+    return _SAFE_DEFAULT_BIND
+
+
+def is_loopback_bind(bind: str) -> bool:
+    """True if `bind` names a loopback-only address.
+
+    Covers the hostname `localhost` and any address `ipaddress` reports as
+    loopback (`127.0.0.0/8`, `::1`). Anything else -- a real interface
+    address, `0.0.0.0`, `::`, a LAN hostname, an unparsable string -- is
+    treated as reachable from somewhere other than this machine. Exposed
+    (not `_`-prefixed) so the UI layer can word its own toast/warning
+    around the same test `FeedDirectoryServer.start` uses (task-1760
+    review, M3) rather than re-implementing it.
+    """
+    normalized = bind.strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
 
 #: What `_ContainedRequestHandler.translate_path` hands back for a request
 #: that resolves outside the served directory -- an ordinary, vanishingly
@@ -108,12 +170,15 @@ def configured_bind_and_port() -> tuple[str, int]:
 
     Returns:
         `(bind, port)`. `bind` defaults to `"127.0.0.1"` (loopback-only --
-        module docstring). `port` defaults to `0` (ephemeral: the OS picks
-        any free port, reported back by `FeedDirectoryServer.start`'s
-        return value) and falls back to `0` if the configured value is not
-        a valid integer, rather than raising on a hand-edited config.
+        module docstring) and falls back to that same safe default (never
+        an empty string) for a blank, whitespace-only, or non-string
+        configured value -- see `_normalize_bind` (task-1760 review, M3).
+        `port` defaults to `0` (ephemeral: the OS picks any free port,
+        reported back by `FeedDirectoryServer.start`'s return value) and
+        falls back to `0` if the configured value is not a valid integer,
+        rather than raising on a hand-edited config.
     """
-    bind = str(get_cli_setting(_CONFIG_SECTION, "bind", "127.0.0.1"))
+    bind = _normalize_bind(get_cli_setting(_CONFIG_SECTION, "bind", _SAFE_DEFAULT_BIND))
     raw_port = get_cli_setting(_CONFIG_SECTION, "port", 0)
     try:
         port = int(raw_port)
@@ -187,6 +252,24 @@ class _ContainedRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_PATCH(self) -> None:  # noqa: N802 - stdlib naming convention
         self._method_not_allowed()
 
+    def list_directory(self, path: str):  # noqa: D102 - stdlib override
+        """Refuse to render a directory listing; 404 instead.
+
+        Fix wave (task-1760 review, M4): a podcast feed is fetched by URLs
+        named in the served `feed.xml` -- nothing ever needs to browse the
+        served directory itself, and an auto-generated index is pure
+        exposure surface on top of that (every filename in the directory,
+        and every subdirectory beneath it, becomes visible to anyone who
+        can reach the bound address). Recursive *file* serving stays
+        intact -- an episode named in `feed.xml` from a subfolder must
+        still resolve -- only the browsable-index behaviour is removed.
+        `SimpleHTTPRequestHandler.send_head` treats a `None` return from
+        this method as "already handled, nothing further to do" (its own
+        docstring), so a plain `send_error` here is the complete override.
+        """
+        self.send_error(404, "File not found")
+        return None
+
     def log_message(self, format: str, *args) -> None:  # noqa: A002 - stdlib signature
         """Route request logging to loguru debug instead of stderr.
 
@@ -196,11 +279,24 @@ class _ContainedRequestHandler(http.server.SimpleHTTPRequestHandler):
         default per-request access log and `log_error` (which
         `BaseHTTPRequestHandler.log_error` implements by calling this same
         method), so a malformed request never reaches stderr either.
+
+        Fix wave (task-1760 review, M1): `BaseHTTPRequestHandler.parse_
+        request` sets `self.command = None` *before* `self.path` exists,
+        and calls `send_error` -> `log_error` -> this method on every
+        malformed-request-line path (an empty line, a bad HTTP version, an
+        over-long request line) that runs before `self.command, self.path
+        = words[:2]` ever executes. Reading `self.path` there raised
+        `AttributeError`, which killed the response (the client got zero
+        bytes instead of the intended 400/414) and the handler thread with
+        it -- and produced no log line at all, the opposite of this
+        method's own purpose. `getattr(..., "-")` never touches a missing
+        attribute, so logging itself can never be the reason a malformed
+        request goes unanswered.
         """
         logger.debug(
             "Feed server request: {} {} ({})",
-            self.command,
-            self.path,
+            getattr(self, "command", "-"),
+            getattr(self, "path", "-"),
             (format % args) if args else format,
         )
 
@@ -222,6 +318,8 @@ class FeedDirectoryServer:
         self._httpd: http.server.ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
         self._url: str | None = None
+        self._bind: str | None = None
+        self._directory: Path | None = None
 
     @property
     def is_running(self) -> bool:
@@ -232,6 +330,27 @@ class FeedDirectoryServer:
         """The bound URL from the most recent successful `start()`, or
         `None` before the first `start()` or after `stop()`."""
         return self._url
+
+    @property
+    def bind(self) -> str | None:
+        """The normalized bind address actually used by the most recent
+        successful `start()` (never the raw, possibly-blank value a caller
+        passed in -- see `_normalize_bind`), or `None` before the first
+        `start()` or after `stop()`. Exposed so a caller (the UI's Serve
+        handler) can word its own exposure warning with `is_loopback_bind`
+        without re-deriving the address from `url` (task-1760 review, M3).
+        """
+        return self._bind
+
+    @property
+    def directory(self) -> Path | None:
+        """The resolved directory the most recent successful `start()` is
+        serving, or `None` before the first `start()` or after `stop()`.
+        Lets a caller (the export toast, task-1760 review, L1) tell
+        whether a fresh export landed in the directory actually being
+        served, without keeping its own duplicate bookkeeping.
+        """
+        return self._directory
 
     def start(self, directory: Path, *, bind: str = "127.0.0.1", port: int = 0) -> str:
         """Serve `directory` over HTTP, GET/HEAD only, until `stop()`.
@@ -257,6 +376,11 @@ class FeedDirectoryServer:
             bind: The address to bind. Defaults to loopback-only (module
                 docstring's Security posture) -- pass a wider address only
                 when the caller has deliberately chosen to widen exposure.
+                A blank/whitespace-only string (or any non-string value)
+                is normalized to the safe loopback default instead of
+                being passed through -- see `_normalize_bind` (task-1760
+                review, M3): a caller does not have to pre-validate this
+                itself, and cannot silently widen exposure by accident.
             port: The port to bind, or `0` for an ephemeral port (the OS
                 picks any free one). The actual bound port is always
                 reported back in the returned URL, regardless of which was
@@ -285,6 +409,12 @@ class FeedDirectoryServer:
         if not resolved_directory.is_dir():
             raise FeedServerError(f"{resolved_directory} is not a directory.")
 
+        # task-1760 review, M3: normalize here too, not only in
+        # `configured_bind_and_port` -- this method is the actual socket
+        # boundary, and a future direct caller (a test, a script) must get
+        # the same safe-by-default behaviour as the UI's Serve action.
+        bind = _normalize_bind(bind)
+
         handler_cls = functools.partial(
             _ContainedRequestHandler, directory=str(resolved_directory)
         )
@@ -296,8 +426,25 @@ class FeedDirectoryServer:
         httpd.daemon_threads = True
         actual_port = httpd.server_address[1]
 
+        if not is_loopback_bind(bind):
+            # task-1760 review, M3: nothing else here would ever tell an
+            # operator that a blank/typo'd or deliberately widened `bind`
+            # just made this directory reachable beyond this machine --
+            # the module docstring's whole posture rests on that
+            # distinction being visible, not merely documented. The bind
+            # address itself is safe to log in full (an IP/hostname this
+            # process itself resolved from config, never user or model
+            # content), unlike the `type(exc).__name__`-only rule this
+            # module follows for caught exceptions elsewhere.
+            logger.warning(
+                "Feed directory server binding to {} (not loopback-only) -- "
+                "the served directory is reachable from beyond this "
+                "machine while it is running.",
+                bind,
+            )
+
         thread = threading.Thread(
-            target=httpd.serve_forever,
+            target=lambda: httpd.serve_forever(poll_interval=0.05),
             name="briefings-feed-server",
             daemon=True,
         )
@@ -306,6 +453,8 @@ class FeedDirectoryServer:
         self._httpd = httpd
         self._thread = thread
         self._url = f"http://{bind}:{actual_port}/"
+        self._bind = bind
+        self._directory = resolved_directory
         logger.debug(
             "Feed directory server started on {}:{}", bind, actual_port
         )
@@ -319,6 +468,18 @@ class FeedDirectoryServer:
         `join()` afterward waits for that thread to actually exit before
         returning, so a caller that immediately calls `start()` again (or
         checks `is_running`) never races the old thread's teardown.
+
+        Fix wave (task-1760 review, M2): `shutdown()` blocks until the
+        `serve_forever()` loop's *next* `selector.select(poll_interval)`
+        call returns -- at the stdlib's own 0.5s default `poll_interval`
+        (unset before this fix wave), that measured ~501ms synchronous on
+        the Textual event loop, since both callers of this method
+        (`WatchlistsCollectionsScreen.handle_stop_feed_server_requested`
+        and its `on_unmount`) call it directly rather than via a worker.
+        `start()` now runs the loop at `poll_interval=0.05`, bounding this
+        call to roughly a tenth of that -- no change needed here, since
+        the bound comes entirely from how the loop it is joining was
+        started.
         """
         if self._httpd is None:
             return
@@ -329,4 +490,6 @@ class FeedDirectoryServer:
         self._httpd = None
         self._thread = None
         self._url = None
+        self._bind = None
+        self._directory = None
         logger.debug("Feed directory server stopped.")

--- a/tldw_chatbook/Subscriptions/feed_server.py
+++ b/tldw_chatbook/Subscriptions/feed_server.py
@@ -590,7 +590,10 @@ class FeedDirectoryServer:
             logger.warning(
                 "Feed directory server binding to {} (not loopback-only) -- "
                 "the served directory is reachable from beyond this "
-                "machine while it is running.",
+                "machine while it is running. A wildcard IPv6 bind such as "
+                "'::' is typically dual-stack (accepts plain IPv4 clients "
+                "too), so the reachable surface can be wider than the "
+                "address alone suggests.",
                 bind,
             )
 

--- a/tldw_chatbook/Subscriptions/feed_server.py
+++ b/tldw_chatbook/Subscriptions/feed_server.py
@@ -75,6 +75,7 @@ from __future__ import annotations
 import functools
 import http.server
 import ipaddress
+import socket
 import threading
 from pathlib import Path
 
@@ -128,6 +129,20 @@ def is_loopback_bind(bind: str) -> bool:
     (not `_`-prefixed) so the UI layer can word its own toast/warning
     around the same test `FeedDirectoryServer.start` uses (task-1760
     review, M3) rather than re-implementing it.
+
+    Args:
+        bind: The bind address to classify, e.g. `"127.0.0.1"`, `"::1"`,
+            `"localhost"`, `"0.0.0.0"`, or a LAN hostname/address. Not
+            normalized by the caller first -- this function does its own
+            `.strip().lower()` -- so the raw, already-`_normalize_bind`-d
+            value `FeedDirectoryServer.start`/`configured_bind_and_port`
+            use is safe to pass in directly.
+
+    Returns:
+        `True` for `localhost` or any address `ipaddress.ip_address`
+        reports as loopback (`127.0.0.0/8`, `::1`); `False` for every other
+        value, including one `ipaddress` cannot parse at all (a LAN
+        hostname is not an error here -- it is simply not loopback).
     """
     normalized = bind.strip().lower()
     if normalized == "localhost":
@@ -136,6 +151,70 @@ def is_loopback_bind(bind: str) -> bool:
         return ipaddress.ip_address(normalized).is_loopback
     except ValueError:
         return False
+
+
+def _is_ipv6_literal(bind: str) -> bool:
+    """True if `bind` parses as an IPv6 address literal (e.g. `"::1"`).
+
+    Shared by `_format_host_for_url` (URL bracketing) and
+    `FeedDirectoryServer.start` (socket address-family selection --
+    see `_IPv6ThreadingHTTPServer`) so the two never disagree about what
+    counts as IPv6. A hostname such as `"localhost"` or an IPv4 address
+    makes `ipaddress.ip_address` raise `ValueError`, which is treated as
+    "not IPv6" here -- the same guard `is_loopback_bind` uses.
+    """
+    try:
+        return ipaddress.ip_address(bind).version == 6
+    except ValueError:
+        return False
+
+
+def _format_host_for_url(bind: str) -> str:
+    """Render `bind` as it belongs in a URL authority component.
+
+    Fix wave (task-1760 Qodo fix wave, F2): `FeedDirectoryServer.start`
+    used to build `self._url` as `f"http://{bind}:{port}/"` unconditionally
+    -- correct for an IPv4 address or a hostname, but not for an IPv6
+    literal: `http://::1:8080/` is ambiguous (is `8080` another address
+    group, or the port?) and no URL parser accepts it. A URL's authority
+    component requires an IPv6 literal to be bracketed --
+    `http://[::1]:8080/` -- per RFC 3986 section 3.2.2, which
+    `is_loopback_bind` already implicitly relies on `::1` being a valid
+    bind target for (its own docstring names `::1` as a loopback address
+    this module supports).
+
+    Args:
+        bind: The bind address to format, already `_normalize_bind`-d --
+            an IPv4 address, an IPv6 address, or a hostname such as
+            `"localhost"`.
+
+    Returns:
+        `bind` unchanged for an IPv4 address or a hostname. Bracketed
+        (`f"[{bind}]"`) when `bind` is an IPv6 literal (`_is_ipv6_literal`).
+    """
+    if _is_ipv6_literal(bind):
+        return f"[{bind}]"
+    return bind
+
+
+class _IPv6ThreadingHTTPServer(http.server.ThreadingHTTPServer):
+    """`ThreadingHTTPServer` with `address_family` forced to IPv6.
+
+    Fix wave (task-1760 Qodo fix wave, F2, discovered while verifying the
+    URL-bracketing fix): `http.server.HTTPServer` -- `ThreadingHTTPServer`'s
+    own base class -- hard-codes `address_family = socket.AF_INET` as a
+    class attribute; `socketserver.TCPServer.__init__` never inspects the
+    bind *address* itself to pick a family. Binding an IPv6 literal (e.g.
+    `"::1"`) through the base class therefore fails immediately with
+    `socket.gaierror` (`getaddrinfo` cannot resolve an IPv6 literal for an
+    `AF_INET` socket) on every platform -- independent of, and before,
+    whatever `is_loopback_bind`/`_format_host_for_url` support for IPv6
+    would otherwise mean in practice. `FeedDirectoryServer.start` selects
+    this subclass instead of the base one whenever `bind` is an IPv6
+    literal (`_is_ipv6_literal`); IPv4/hostname binds are unaffected.
+    """
+
+    address_family = socket.AF_INET6
 
 
 #: What `_ContainedRequestHandler.translate_path` hands back for a request
@@ -176,7 +255,10 @@ def configured_bind_and_port() -> tuple[str, int]:
         `port` defaults to `0` (ephemeral: the OS picks any free port,
         reported back by `FeedDirectoryServer.start`'s return value) and
         falls back to `0` if the configured value is not a valid integer,
-        rather than raising on a hand-edited config.
+        rather than raising on a hand-edited config. A value that DOES
+        parse as an integer but falls outside the valid `0..65535` range
+        (e.g. a typo like `99999`) falls back to `0` the same way -- see
+        the Qodo fix-wave note below.
     """
     bind = _normalize_bind(get_cli_setting(_CONFIG_SECTION, "bind", _SAFE_DEFAULT_BIND))
     raw_port = get_cli_setting(_CONFIG_SECTION, "port", 0)
@@ -189,6 +271,30 @@ def configured_bind_and_port() -> tuple[str, int]:
             type(raw_port).__name__,
         )
         port = 0
+    else:
+        # task-1760 Qodo fix wave, F1: a value that DOES coerce to `int`
+        # can still be out of the valid TCP port range (a typo like
+        # `99999`, or a negative value) -- `int(...)` alone does not catch
+        # that, and passing it straight through to `FeedDirectoryServer.
+        # start` would reach `ThreadingHTTPServer`'s underlying
+        # `socket.bind` as a bare `OverflowError`, which nothing in the UI
+        # layer catches (`watchlists_collections_screen.py`'s Serve
+        # handler only catches `FeedServerError`/`OSError`). A CONFIG-
+        # derived bad value degrades safely here, the same way a blank/
+        # typo'd `bind` already does above -- only a bad value handed
+        # directly to `start()` by a caller that bypasses this function
+        # is instead treated as a programming error and refused there
+        # (see that method's own comment). The warning is type-only, not
+        # value-only, matching this module's established convention for
+        # logging a config value that turned out not to be trustworthy.
+        if not (0 <= port <= 65535):
+            logger.warning(
+                "briefings_feed_server.port is outside the valid 0-65535 "
+                "range (configured value was a {}); using an ephemeral "
+                "port instead.",
+                type(raw_port).__name__,
+            )
+            port = 0
     return bind, port
 
 
@@ -382,16 +488,31 @@ class FeedDirectoryServer:
                 review, M3): a caller does not have to pre-validate this
                 itself, and cannot silently widen exposure by accident.
             port: The port to bind, or `0` for an ephemeral port (the OS
-                picks any free one). The actual bound port is always
-                reported back in the returned URL, regardless of which was
-                requested.
+                picks any free one). Must be an `int` in `0..65535` --
+                anything else (a negative value, a value above 65535, or a
+                non-`int`) is refused with `FeedServerError` rather than
+                reaching the socket layer (task-1760 Qodo fix wave, F1): an
+                out-of-range-but-parseable port previously reached
+                `ThreadingHTTPServer` as a bare `OverflowError`, which is
+                not one of the types the UI's Serve handler catches. This
+                is the boundary for a bad value handed directly to this
+                method (a script, a test, a future caller); a bad value
+                that came from *config* is instead normalized to a safe
+                ephemeral fallback one layer up, in
+                `configured_bind_and_port()` -- a hand-edited config
+                degrading safely is a UX nicety, not the last line of
+                defence, so the two paths are handled differently on
+                purpose. The actual bound port is always reported back in
+                the returned URL, regardless of which was requested.
 
         Returns:
-            The bound URL, e.g. `"http://127.0.0.1:54231/"`.
+            The bound URL, e.g. `"http://127.0.0.1:54231/"` -- or, for an
+            IPv6 `bind` (e.g. `"::1"`), the bracketed form a URL requires,
+            e.g. `"http://[::1]:54231/"` (task-1760 Qodo fix wave, F2).
 
         Raises:
-            FeedServerError: Already running, or `directory` fails
-                validation.
+            FeedServerError: Already running, `directory` fails
+                validation, or `port` is not an `int` in `0..65535`.
             OSError: The bind itself fails (e.g. a fixed `port` already in
                 use).
         """
@@ -415,10 +536,40 @@ class FeedDirectoryServer:
         # the same safe-by-default behaviour as the UI's Serve action.
         bind = _normalize_bind(bind)
 
+        # task-1760 Qodo fix wave, F1: validate `port` here too, not only
+        # in `configured_bind_and_port` -- this is the actual socket
+        # boundary (the comment above, applied to `port` as well as
+        # `bind`). `configured_bind_and_port` degrades a bad CONFIG value
+        # safely (falls back to ephemeral `0` + a warning) because a
+        # hand-edited config file is expected to sometimes be wrong; a bad
+        # value reaching this method directly -- bypassing that
+        # normalization entirely -- is instead a programming error and is
+        # refused outright, the same way the directory-validation checks
+        # above it already are. Left unchecked, an out-of-range-but-
+        # parseable `int` (e.g. `99999`) would reach
+        # `ThreadingHTTPServer.__init__` -> `socket.bind` as a bare
+        # `OverflowError`, which is not one of the types the UI's Serve
+        # handler (`watchlists_collections_screen.py`) catches -- it would
+        # escape as an unhandled exception instead of the toast every
+        # other rejection here produces.
+        if not isinstance(port, int) or isinstance(port, bool) or not (0 <= port <= 65535):
+            raise FeedServerError(
+                f"Port {port!r} is not valid: it must be an integer between "
+                "0 and 65535 (0 requests an OS-assigned ephemeral port)."
+            )
+
         handler_cls = functools.partial(
             _ContainedRequestHandler, directory=str(resolved_directory)
         )
-        httpd = http.server.ThreadingHTTPServer((bind, port), handler_cls)
+        # task-1760 Qodo fix wave, F2: `_IPv6ThreadingHTTPServer` for an
+        # IPv6 `bind` -- see that class's own docstring for why the base
+        # `ThreadingHTTPServer` cannot bind one at all (a hard-coded
+        # `AF_INET` `address_family`, not a platform limitation). IPv4 and
+        # hostname binds are unaffected -- same base class as before.
+        server_cls = (
+            _IPv6ThreadingHTTPServer if _is_ipv6_literal(bind) else http.server.ThreadingHTTPServer
+        )
+        httpd = server_cls((bind, port), handler_cls)
         # daemon_threads: a request handled by ThreadingHTTPServer's own
         # per-connection thread pool must never block interpreter exit --
         # the OUTER thread `serve_forever` runs on (below) is daemon=True
@@ -452,7 +603,12 @@ class FeedDirectoryServer:
 
         self._httpd = httpd
         self._thread = thread
-        self._url = f"http://{bind}:{actual_port}/"
+        # task-1760 Qodo fix wave, F2: bracket an IPv6 `bind` literal here
+        # -- `_format_host_for_url` -- since `is_loopback_bind` explicitly
+        # supports `::1` as a bind target and an unbracketed IPv6 URL is
+        # not merely stylistically off, it is not a URL a client can parse
+        # at all.
+        self._url = f"http://{_format_host_for_url(bind)}:{actual_port}/"
         self._bind = bind
         self._directory = resolved_directory
         logger.debug(

--- a/tldw_chatbook/Subscriptions/feed_server.py
+++ b/tldw_chatbook/Subscriptions/feed_server.py
@@ -1,0 +1,332 @@
+"""Opt-in, localhost-by-default static file server for one exported
+briefings podcast feed directory at a time (task-1760).
+
+**Why this exists, and why it is not `[web_server]`.** The phase 3 design
+(`Docs/superpowers/specs/2026-07-30-watchlists-briefings-design.md`,
+"Exports and feed") assumed the app's existing `[web_server]` config could
+serve an exported feed directory over localhost. Task-1760's own
+investigation (see that task file's Description) found this false on every
+count that matters: `[web_server]`'s `enabled` key is read by no code at
+all, it is a *mutually exclusive* process mode (`app.py`'s `--serve` flag
+runs `run_web_server(...)` and returns, instead of ever building the TUI),
+and even engaged it only serves textual-serve's own bundled JS asset, never
+a directory the caller names. This module is therefore standalone,
+purpose-built, net-new server surface, with its own config section
+(`[briefings_feed_server]`) -- never `[web_server]`'s.
+
+**Security posture (Task-1760 AC #4) -- read before wiring this up
+anywhere else.**
+
+- **Bind scope.** Defaults to `127.0.0.1` (loopback only) -- nothing off
+  the local machine can reach it unless an operator deliberately widens
+  `bind` (e.g. to `0.0.0.0`) in `[briefings_feed_server]`. Widening it
+  exposes the served directory to the whole LAN (or further, behind a
+  router configured for it) with no authentication at all -- see the next
+  point.
+- **No authentication, by design, stated plainly rather than implied.**
+  There is no login, token, or IP allow-list. Anyone who can open a TCP
+  connection to the bound address and port can read every file under the
+  served directory for as long as it is running. This is acceptable for
+  its one intended use (pointing a podcast client at a feed you exported
+  yourself, on a loopback address only you can reach) and unacceptable for
+  anything wider -- the UI's own toast states this every time serving
+  starts, not just this docstring.
+- **Path containment.** `_ContainedRequestHandler` resolves every request
+  path (following symlinks) and refuses (404) anything that resolves
+  outside the served directory. `SimpleHTTPRequestHandler.translate_path`
+  already collapses literal `..`/absolute-path traversal in the URL down to
+  a path inside the served directory (it never joins a `..`-shaped or
+  directory-shaped word onto the base at all -- see its own docstring), but
+  it does **not** protect against a *symlink* planted inside the served
+  directory whose target resolves elsewhere on disk: `open()`/`os.stat()`
+  follow symlinks by default, and `translate_path` alone would hand back
+  such a path as "inside" the directory (syntactically true) while its
+  *resolved* target is not. The containment check below is exactly that
+  second, independent check.
+- **Method surface.** Only `GET`/`HEAD` are served; every other verb
+  (`POST`, `PUT`, `DELETE`, `PATCH`) gets `405 Method Not Allowed`. This is
+  a read-only static file server -- nothing it serves is meant to be
+  written to.
+- **Session-only, opt-in, off by default (AC #2).** Nothing in this
+  module runs at import time, app startup, or config load --
+  `FeedDirectoryServer.start()` must be called explicitly, and only the
+  UI's Serve action calls it, only when a user presses it.
+  `configured_bind_and_port()` below reads `[briefings_feed_server]` for
+  *defaults*, never to auto-start anything.
+
+See `Docs/User_Guide/watchlists.md`'s "Serving an exported feed" section
+for the user-facing version of this same posture.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import threading
+from pathlib import Path
+
+from loguru import logger
+
+from ..config import get_cli_setting
+from ..Utils.path_validation import validate_path_simple
+
+#: `[briefings_feed_server]`'s own section name -- deliberately its own
+#: config section, never `[web_server]`'s (module docstring). Only ever
+#: read by `configured_bind_and_port()`, which supplies *defaults* for the
+#: UI's Serve action; nothing here auto-starts from it.
+_CONFIG_SECTION = "briefings_feed_server"
+
+#: What `_ContainedRequestHandler.translate_path` hands back for a request
+#: that resolves outside the served directory -- an ordinary, vanishingly
+#: unlikely-to-exist filename (never a null byte or other invalid-path
+#: sentinel; see that method's own comment for why the distinction
+#: matters), so the caller's own `open()` raises a plain `FileNotFoundError`
+#: and the stdlib's existing 404 handling takes over unchanged.
+_DENIED_PATH_NAME = ".feed-server-path-denied-3f6c9d21"
+
+
+class FeedServerError(RuntimeError):
+    """Raised when the feed server cannot be started.
+
+    Covers both "already running" (this class serves exactly one
+    directory at a time -- see `FeedDirectoryServer.start`'s own docstring
+    for why a second `start()` call refuses rather than restarting) and a
+    destination that fails validation (missing, not a directory, or
+    otherwise rejected by `Utils.path_validation.validate_path_simple`).
+    """
+
+
+def configured_bind_and_port() -> tuple[str, int]:
+    """The `[briefings_feed_server]` `bind`/`port` defaults, from config.
+
+    Uses the traditional three-argument `get_cli_setting(section, key,
+    default)` form throughout -- never the two-argument dotted form, whose
+    "a caller default in the second positional slot" heuristic this repo
+    has already been bitten by once (TASK-1771). Reading this function
+    never starts anything; it only supplies defaults for the explicit
+    Serve action to pass to `FeedDirectoryServer.start`.
+
+    Returns:
+        `(bind, port)`. `bind` defaults to `"127.0.0.1"` (loopback-only --
+        module docstring). `port` defaults to `0` (ephemeral: the OS picks
+        any free port, reported back by `FeedDirectoryServer.start`'s
+        return value) and falls back to `0` if the configured value is not
+        a valid integer, rather than raising on a hand-edited config.
+    """
+    bind = str(get_cli_setting(_CONFIG_SECTION, "bind", "127.0.0.1"))
+    raw_port = get_cli_setting(_CONFIG_SECTION, "port", 0)
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):
+        logger.debug(
+            "briefings_feed_server.port is not a valid integer ({}); "
+            "using an ephemeral port instead.",
+            type(raw_port).__name__,
+        )
+        port = 0
+    return bind, port
+
+
+class _ContainedRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """`SimpleHTTPRequestHandler(directory=...)`, hardened for AC #3.
+
+    Two changes from the stdlib handler, both stated in the module
+    docstring's Security posture: a resolved-path containment check on top
+    of `translate_path` (closes the symlink-escape gap `translate_path`
+    alone leaves open), and GET/HEAD only (every other verb gets 405).
+    """
+
+    def translate_path(self, path: str) -> str:  # noqa: D102 - stdlib override
+        """`super().translate_path`, then refuse anything that resolves
+        outside the served directory.
+
+        `self.directory` (set by `SimpleHTTPRequestHandler.__init__` from
+        the `directory=` keyword `FeedDirectoryServer.start` passes in via
+        `functools.partial`) is resolved fresh on every call rather than
+        cached -- this handler is re-instantiated per request by
+        `socketserver`, so there is no meaningful cost to doing so, and it
+        keeps this method self-contained.
+
+        A candidate that fails resolution (`OSError` -- e.g. a path
+        component that is not actually a directory) or that resolves
+        outside the served root (`ValueError` from `Path.relative_to`) is
+        answered with a path that cannot exist, so the caller's own
+        `os.stat`/`open` naturally 404s -- there is no need to override
+        `send_head` or duplicate its error handling here.
+        """
+        candidate = super().translate_path(path)
+        served_root = Path(self.directory).resolve(strict=False)
+        try:
+            resolved_candidate = Path(candidate).resolve(strict=False)
+            resolved_candidate.relative_to(served_root)
+        except (OSError, ValueError):
+            # A plain, almost-certainly-absent filename -- NOT a null byte
+            # or other invalid-path sentinel: `send_head()`'s `open(path,
+            # 'rb')` only converts `OSError` into a 404 response; a
+            # `ValueError` (which an embedded null byte raises on some
+            # platforms) propagates out of the request handler instead and
+            # tears down the connection, which is not the answer AC #3
+            # asks for. A `FileNotFoundError` (an `OSError` subclass) is
+            # exactly what a plain missing name inside `served_root`
+            # produces, and that IS handled -> a clean 404.
+            return str(served_root / _DENIED_PATH_NAME)
+        return candidate
+
+    def _method_not_allowed(self) -> None:
+        self.send_error(405, "Method Not Allowed")
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib naming convention
+        self._method_not_allowed()
+
+    def do_PUT(self) -> None:  # noqa: N802 - stdlib naming convention
+        self._method_not_allowed()
+
+    def do_DELETE(self) -> None:  # noqa: N802 - stdlib naming convention
+        self._method_not_allowed()
+
+    def do_PATCH(self) -> None:  # noqa: N802 - stdlib naming convention
+        self._method_not_allowed()
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A002 - stdlib signature
+        """Route request logging to loguru debug instead of stderr.
+
+        Request *paths* are logged at debug -- they are local requests
+        against a directory the user themselves chose to export and serve,
+        never file contents (module docstring). This overrides both the
+        default per-request access log and `log_error` (which
+        `BaseHTTPRequestHandler.log_error` implements by calling this same
+        method), so a malformed request never reaches stderr either.
+        """
+        logger.debug(
+            "Feed server request: {} {} ({})",
+            self.command,
+            self.path,
+            (format % args) if args else format,
+        )
+
+
+class FeedDirectoryServer:
+    """Starts/stops a `ThreadingHTTPServer` for one feed directory at a
+    time, on a daemon thread.
+
+    Not a module-level singleton -- each `WatchlistsCollectionsScreen`
+    instance owns exactly one of these (mirroring how `ArtifactsPane`'s own
+    module docstring describes the shared audio player: state that must
+    survive a recompose lives off the recomposed widget). `start()` refuses
+    a second call while already running (see its own docstring for why
+    that is simpler than restarting), so this class enforces "one
+    directory at a time" itself -- a caller does not have to.
+    """
+
+    def __init__(self) -> None:
+        self._httpd: http.server.ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._url: str | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._httpd is not None
+
+    @property
+    def url(self) -> str | None:
+        """The bound URL from the most recent successful `start()`, or
+        `None` before the first `start()` or after `stop()`."""
+        return self._url
+
+    def start(self, directory: Path, *, bind: str = "127.0.0.1", port: int = 0) -> str:
+        """Serve `directory` over HTTP, GET/HEAD only, until `stop()`.
+
+        Refuses (raises) rather than restarting when already running --
+        the simpler of the two choices task-1760's plan named as
+        equally valid, and the one this whole class + the UI's Serve/Stop
+        handlers are built around: a caller that wants to serve a
+        different directory stops the current one first. Restarting
+        in-place would need to reconcile "was the old directory's server
+        still mid-request" with starting a new one; refusing sidesteps
+        that entirely, at the cost of one extra Stop press.
+
+        Args:
+            directory: The directory to serve. Validated with
+                `Utils.path_validation.validate_path_simple(...,
+                require_exists=True)` -- the same validator `briefing_
+                export.export_feed_directory` already applies to this
+                exact directory when it was exported -- so a directory
+                deleted or replaced with something hostile between export
+                and serve is rejected here too, not merely trusted because
+                it was validated once before.
+            bind: The address to bind. Defaults to loopback-only (module
+                docstring's Security posture) -- pass a wider address only
+                when the caller has deliberately chosen to widen exposure.
+            port: The port to bind, or `0` for an ephemeral port (the OS
+                picks any free one). The actual bound port is always
+                reported back in the returned URL, regardless of which was
+                requested.
+
+        Returns:
+            The bound URL, e.g. `"http://127.0.0.1:54231/"`.
+
+        Raises:
+            FeedServerError: Already running, or `directory` fails
+                validation.
+            OSError: The bind itself fails (e.g. a fixed `port` already in
+                use).
+        """
+        if self.is_running:
+            raise FeedServerError(
+                f"A feed is already being served at {self._url}. Stop it "
+                "before serving a different directory."
+            )
+        try:
+            resolved_directory = validate_path_simple(
+                directory, require_exists=True
+            ).resolve()
+        except ValueError as exc:
+            raise FeedServerError(f"Cannot serve this directory: {exc}") from exc
+        if not resolved_directory.is_dir():
+            raise FeedServerError(f"{resolved_directory} is not a directory.")
+
+        handler_cls = functools.partial(
+            _ContainedRequestHandler, directory=str(resolved_directory)
+        )
+        httpd = http.server.ThreadingHTTPServer((bind, port), handler_cls)
+        # daemon_threads: a request handled by ThreadingHTTPServer's own
+        # per-connection thread pool must never block interpreter exit --
+        # the OUTER thread `serve_forever` runs on (below) is daemon=True
+        # for the identical reason.
+        httpd.daemon_threads = True
+        actual_port = httpd.server_address[1]
+
+        thread = threading.Thread(
+            target=httpd.serve_forever,
+            name="briefings-feed-server",
+            daemon=True,
+        )
+        thread.start()
+
+        self._httpd = httpd
+        self._thread = thread
+        self._url = f"http://{bind}:{actual_port}/"
+        logger.debug(
+            "Feed directory server started on {}:{}", bind, actual_port
+        )
+        return self._url
+
+    def stop(self) -> None:
+        """Stop serving, releasing the socket. A no-op if not running.
+
+        `shutdown()` + `server_close()` is the documented stdlib pair for
+        stopping a `serve_forever()` loop running on another thread; the
+        `join()` afterward waits for that thread to actually exit before
+        returning, so a caller that immediately calls `start()` again (or
+        checks `is_running`) never races the old thread's teardown.
+        """
+        if self._httpd is None:
+            return
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._httpd = None
+        self._thread = None
+        self._url = None
+        logger.debug("Feed directory server stopped.")

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -71,6 +71,7 @@ from ...Subscriptions.feed_server import (
     FeedDirectoryServer,
     FeedServerError,
     configured_bind_and_port,
+    is_loopback_bind,
 )
 from ...Subscriptions.watchlist_bundle_service import WatchlistBundleService
 from ...Subscriptions.watchlist_normalizers import normalize_watchlist_item
@@ -4720,6 +4721,26 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # arrive while Artifacts is already on screen.
             self._last_feed_export_directory = result.directory
             self._sync_feed_server_pane_state()
+            # task-1760 review, L1: a running server keeps serving whatever
+            # directory it was STARTED with -- `FeedDirectoryServer` never
+            # picks up a later export on its own (refuses a second `start()`
+            # instead, `start`'s own docstring). If this export landed
+            # somewhere other than that directory, the running server is
+            # now silently stale: the only prior explanation was the Serve
+            # button's own disabled state, easy to miss. Said only when it
+            # actually differs -- a re-export into the SAME directory is
+            # already reflected live, since the server reads from disk on
+            # every request rather than caching anything.
+            still_serving_stale_export = (
+                self._feed_server.is_running
+                and self._feed_server.directory != result.directory
+            )
+            stale_export_note = (
+                " Still serving the previously-exported folder — Stop "
+                "Serving and Serve again to publish this export."
+                if still_serving_stale_export
+                else ""
+            )
             total = result.episode_count + len(result.skipped)
             if result.skipped:
                 # Honest, not a success toast: this is Task 4's own named
@@ -4746,7 +4767,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 reasons = self._user_facing_skip_reasons(result.skipped)
                 self._notify_watchlists(
                     f"Exported {result.episode_count} of {total} episodes "
-                    f"to {result.directory.name} ({reasons}).",
+                    f"to {result.directory.name} ({reasons})."
+                    f"{stale_export_note}",
                     severity="warning",
                     markup=False,
                 )
@@ -4754,8 +4776,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 plural = "" if result.episode_count == 1 else "s"
                 self._notify_watchlists(
                     f"Exported {result.episode_count} episode{plural} to "
-                    f"{result.directory.name}.",
-                    severity="information",
+                    f"{result.directory.name}.{stale_export_note}",
+                    severity="information" if not stale_export_note else "warning",
                     markup=False,
                 )
         finally:
@@ -4767,12 +4789,15 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     # (a `ThreadingHTTPServer` on a daemon thread); this screen only owns
     # ONE instance of it (`self._feed_server`, constructed in `__init__`)
     # and decides when to start/stop it. No `run_worker` here, unlike every
-    # other action on this screen: `start()`/`stop()` bind/release a socket
-    # and spawn/join a thread, which are fast, synchronous stdlib calls --
-    # there is no `await` boundary that would make dispatching a worker
-    # meaningful, and no filesystem/database I/O of the kind the OTHER
-    # handlers move off the UI thread with `asyncio.to_thread`. Both
-    # handlers re-check state before acting, the same "the button's
+    # other action on this screen: `start()` binds a socket and spawns a
+    # thread with no `await` boundary, and `stop()` -- after the task-1760
+    # review's M2 fix, which starts `serve_forever` at a 50ms poll interval
+    # instead of the stdlib's 0.5s default -- now blocks the UI thread for
+    # roughly a tenth of what it used to (measured ~50ms here vs. a
+    # measured ~501ms before the fix), a bound this screen accepts as
+    # "fast enough not to need a worker" rather than eliminating entirely;
+    # see `FeedDirectoryServer.stop`'s own docstring for the mechanics.
+    # Both handlers re-check state before acting, the same "the button's
     # disabled state and the message it posts are two different frames"
     # reasoning `handle_export_feed_requested` already states for its own
     # re-check.
@@ -4847,17 +4872,34 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._sync_feed_server_pane_state()
         # AC #4's posture, restated at the moment it matters most: every
         # time serving actually starts, not merely in a docstring or the
-        # user guide. `markup=False` -- this interpolates a URL this
-        # process itself built (bind/port), never model or remote content,
-        # but every toast on this screen that is not a hand-written
-        # literal already takes this same posture.
-        self._notify_watchlists(
+        # user guide. `markup=False` -- this interpolates a URL and (in
+        # the widened-bind branch) a bind address this process itself
+        # built/resolved (never model or remote content), but every toast
+        # on this screen that is not a hand-written literal already takes
+        # this same posture.
+        #
+        # task-1760 review, M4: says "this folder AND its subfolders" --
+        # not just "the feed" -- since serving is recursive and the export
+        # picker can point at any folder the user chooses, up to and
+        # including their home directory.
+        message = (
             f"Serving the exported feed at {url}. No authentication — "
-            "anyone who can reach this address can read the feed while "
-            "it is serving.",
-            severity="warning",
-            markup=False,
+            "anyone who can reach this address can read every file in "
+            "this folder and its subfolders while it is serving."
         )
+        # task-1760 review, M3: the posture above assumes loopback-only.
+        # When the actually-bound address is NOT loopback (a deliberate
+        # widening, or a config value that survived `_normalize_bind`
+        # because it was a real address rather than blank/typo'd), say so
+        # here too -- not just in the one-time `logger.warning` `start()`
+        # already emits -- since this toast is what a user actually sees.
+        served_bind = self._feed_server.bind
+        if served_bind is not None and not is_loopback_bind(served_bind):
+            message += (
+                f" This is bound to {served_bind}, which is reachable "
+                "from beyond this machine, not just localhost."
+            )
+        self._notify_watchlists(message, severity="warning", markup=False)
 
     @on(StopFeedServerRequested)
     def handle_stop_feed_server_requested(

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -67,6 +67,11 @@ from ...Subscriptions.briefing_service import (
     generate_briefing,
     pending_briefing_claim_watchlist_ids,
 )
+from ...Subscriptions.feed_server import (
+    FeedDirectoryServer,
+    FeedServerError,
+    configured_bind_and_port,
+)
 from ...Subscriptions.watchlist_bundle_service import WatchlistBundleService
 from ...Subscriptions.watchlist_normalizers import normalize_watchlist_item
 from ...Third_Party.textual_fspicker import FileSave, SelectDirectory
@@ -109,7 +114,9 @@ from ..Watchlists_Modules.artifacts_pane import (
     PlayAudioRequested,
     RefreshBriefingsRequested,
     ScriptSelected,
+    ServeFeedRequested,
     StopAudioRequested,
+    StopFeedServerRequested,
     SynthesizeAudioRequested,
     audio_file_path_is_safe,
     cadence_scope_phrase,
@@ -610,6 +617,19 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # selected briefing's status: the button's disabled state and the
         # message it posts are two different frames.
         self._watchlist_has_audio_episodes = False
+        # task-1760: this screen's own feed server, and the directory it
+        # would serve. `FeedDirectoryServer` is not a module singleton --
+        # each screen instance owns exactly one (this instance's `stop()`
+        # is called from `on_unmount`, so a second screen instance never
+        # needs to know about the first's server at all). `_last_feed_
+        # export_directory` is set by `_export_feed_directory` on every
+        # SUCCESSFUL export (full or partial -- both leave a valid,
+        # servable `feed.xml` on disk) and read by `handle_serve_feed_
+        # requested`'s own re-check, mirroring `_watchlist_has_audio_
+        # episodes`'s own "button disabled state and the message it posts
+        # are two different frames" reasoning immediately above.
+        self._feed_server = FeedDirectoryServer()
+        self._last_feed_export_directory: Path | None = None
         # The item currently open in the CONTENT reader (Task 4). Held here
         # for the identical reason as `_loaded_items` above: `_build_content_pane`
         # is a factory the workbench calls on every region rebuild, and a
@@ -1575,6 +1595,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             artifacts_pane.citations = self._loaded_citations
             artifacts_pane.has_audio_episodes = self._watchlist_has_audio_episodes
             artifacts_pane.chachanotes_available = self._chachanotes_db() is not None
+            artifacts_pane.can_serve_feed = self._last_feed_export_directory is not None
+            artifacts_pane.feed_server_running = self._feed_server.is_running
+            artifacts_pane.feed_server_url = self._feed_server.url
             children.append(artifacts_pane)
         return Vertical(
             *children,
@@ -4687,6 +4710,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     markup=False,
                 )
                 return
+            # task-1760: a successful export (partial or full -- either way
+            # `result.directory` holds a real, just-written `feed.xml`) is
+            # now something the Serve button can act on. Recorded here,
+            # not only inside the two toast branches below, so it applies
+            # to both outcomes -- and patched onto the mounted pane
+            # directly (the same "patch it in place" idiom `_sync_feed_
+            # server_pane_state` uses elsewhere), since a fresh export can
+            # arrive while Artifacts is already on screen.
+            self._last_feed_export_directory = result.directory
+            self._sync_feed_server_pane_state()
             total = result.episode_count + len(result.skipped)
             if result.skipped:
                 # Honest, not a success toast: this is Task 4's own named
@@ -4727,6 +4760,137 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 )
         finally:
             self._feed_export_in_flight = False
+
+    # --- Serving the exported feed directory over localhost (task-1760) -----
+    #
+    # `Subscriptions.feed_server.FeedDirectoryServer` does the actual work
+    # (a `ThreadingHTTPServer` on a daemon thread); this screen only owns
+    # ONE instance of it (`self._feed_server`, constructed in `__init__`)
+    # and decides when to start/stop it. No `run_worker` here, unlike every
+    # other action on this screen: `start()`/`stop()` bind/release a socket
+    # and spawn/join a thread, which are fast, synchronous stdlib calls --
+    # there is no `await` boundary that would make dispatching a worker
+    # meaningful, and no filesystem/database I/O of the kind the OTHER
+    # handlers move off the UI thread with `asyncio.to_thread`. Both
+    # handlers re-check state before acting, the same "the button's
+    # disabled state and the message it posts are two different frames"
+    # reasoning `handle_export_feed_requested` already states for its own
+    # re-check.
+
+    def _sync_feed_server_pane_state(self) -> None:
+        """Patch the mounted `ArtifactsPane`'s feed-server reactives from
+        this screen's own state, if the pane is currently mounted.
+
+        Called after every state change (a fresh export, Serve, Stop) --
+        the same "patch it in place, never rebuild via `self.refresh
+        (recompose=True)`" idiom the picker writers use (see
+        `handle_briefing_mode_changed`'s own comment), for the identical
+        reason: a full workbench rebuild is a much bigger hammer than one
+        widget's reactive assignment, and `_build_detail_pane` already
+        seeds a FRESH pane from this same state on every rebuild anyway,
+        so nothing is lost if this screen is not showing Artifacts (or not
+        attached) when this is called.
+        """
+        if not self.is_attached:
+            return
+        try:
+            pane = self.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        except NoMatches:
+            return
+        pane.can_serve_feed = self._last_feed_export_directory is not None
+        pane.feed_server_running = self._feed_server.is_running
+        pane.feed_server_url = self._feed_server.url
+
+    @on(ServeFeedRequested)
+    def handle_serve_feed_requested(self, event: ServeFeedRequested) -> None:
+        """Re-check both requirements, then start the server.
+
+        Refuses (names the running URL) rather than restarting when a
+        server is already running -- `FeedDirectoryServer.start`'s own
+        docstring states why refusing was chosen as the simpler of the two
+        options task-1760's plan allowed: a caller that wants to serve a
+        DIFFERENT directory presses Stop first. `ArtifactsPane.compose`
+        already disables the button in both refusal cases, but this
+        re-checks anyway, for the identical reason every other handler on
+        this screen does.
+        """
+        event.stop()
+        if self._last_feed_export_directory is None:
+            self._notify_watchlists(
+                "Export a feed directory first, then serve it.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        if self._feed_server.is_running:
+            self._notify_watchlists(
+                f"A feed is already being served at {self._feed_server.url}. "
+                "Stop it before serving a different directory.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        bind, port = configured_bind_and_port()
+        try:
+            url = self._feed_server.start(
+                self._last_feed_export_directory, bind=bind, port=port
+            )
+        except (FeedServerError, OSError) as exc:
+            logger.warning(f"Could not start the feed server: {type(exc).__name__}")
+            self._notify_watchlists(
+                "Could not start the feed server. Nothing is being served.",
+                severity="error",
+                markup=False,
+            )
+            return
+        self._sync_feed_server_pane_state()
+        # AC #4's posture, restated at the moment it matters most: every
+        # time serving actually starts, not merely in a docstring or the
+        # user guide. `markup=False` -- this interpolates a URL this
+        # process itself built (bind/port), never model or remote content,
+        # but every toast on this screen that is not a hand-written
+        # literal already takes this same posture.
+        self._notify_watchlists(
+            f"Serving the exported feed at {url}. No authentication — "
+            "anyone who can reach this address can read the feed while "
+            "it is serving.",
+            severity="warning",
+            markup=False,
+        )
+
+    @on(StopFeedServerRequested)
+    def handle_stop_feed_server_requested(
+        self, event: StopFeedServerRequested
+    ) -> None:
+        event.stop()
+        if not self._feed_server.is_running:
+            self._notify_watchlists(
+                "Nothing is being served.", severity="warning", markup=False
+            )
+            return
+        self._feed_server.stop()
+        self._sync_feed_server_pane_state()
+        self._notify_watchlists(
+            "Stopped serving the feed.", severity="information", markup=False
+        )
+
+    def on_unmount(self) -> None:
+        """Stop the feed server so a running listening socket never
+        outlives this screen.
+
+        The server's own thread is a daemon (`FeedDirectoryServer.start`),
+        so it would not by itself block the app from exiting -- but
+        leaving it running is still a wedged, forgotten listening socket
+        for as long as the app process stays up otherwise (switching away
+        from Watchlists, or closing this screen, must not silently keep
+        serving). `is_running` guards a redundant `stop()` on a screen that
+        never served anything, exactly like `ArtifactsScreen.on_unmount`'s
+        own guard around its worker cancellation.
+        """
+        if self._feed_server.is_running:
+            self._feed_server.stop()
+        super().on_unmount()
 
     # --- Briefing selection-mode, default-preset, and cadence pickers -------
     # (Task 4, phase 2a; cadence added by Task 4, phase 4)

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -285,6 +285,32 @@ class ExportFeedRequested(Message):
     """
 
 
+class ServeFeedRequested(Message):
+    """Posted when the user asks to serve the most recently exported feed
+    directory over localhost (task-1760).
+
+    Carries nothing, same shape as `ExportFeedRequested` and for the same
+    reason: which directory to serve is the screen's own state (the last
+    directory `export_feed_directory` wrote to), and whether one is even
+    available yet is already mirrored onto this pane's own `can_serve_
+    feed` reactive. Whether a server is ALREADY running is mirrored onto
+    `feed_server_running` -- `compose` disables this button while that is
+    `True` (see its own comment), but the screen's handler re-checks both
+    conditions anyway, the same "the button's disabled state and the
+    message it posts are two different frames" reasoning `handle_export_
+    feed_requested` already states for its own re-check.
+    """
+
+
+class StopFeedServerRequested(Message):
+    """Posted when the user asks to stop serving the feed directory.
+
+    Carries nothing, for the identical reason `StopAudioRequested` does:
+    there is exactly one feed server per screen (task-1760's own "one
+    directory at a time" decision), so there is nothing to name.
+    """
+
+
 class CitationActivated(Message):
     """Posted when the user activates a citation under the briefing body.
 
@@ -715,6 +741,29 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     #: see `KeptBriefingsRequested`'s own docstring on why that surface is
     #: scope-independent).
     chachanotes_available = reactive(False, recompose=True)
+    #: task-1760: whether the screen holds a directory `export_feed_
+    #: directory` has already written to this session -- the Serve button
+    #: needs SOMETHING to serve, and (unlike `has_audio_episodes`, which
+    #: asks whether an export is *possible*) this asks whether one has
+    #: actually happened yet. Screen-supplied, exactly like `has_audio_
+    #: episodes` above: this widget owns no filesystem state of its own,
+    #: and the directory is `Subscriptions.feed_server.FeedDirectoryServer`'s
+    #: to hold, not this pane's.
+    can_serve_feed = reactive(False, recompose=True)
+    #: task-1760: whether the screen's `FeedDirectoryServer` is currently
+    #: serving. Screen-supplied -- this pane never starts or stops the
+    #: server itself, it only posts `ServeFeedRequested`/`StopFeedServer
+    #: Requested` and renders whatever the screen reports back, the same
+    #: division of labour `selected_script`'s own module-docstring note
+    #: describes for audio PLAYBACK state (a recompose must never silently
+    #: reset "is something running" back to a default that disagrees with
+    #: reality).
+    feed_server_running = reactive(False, recompose=True)
+    #: task-1760: the running server's URL, or `None` when nothing is
+    #: being served. Screen-supplied alongside `feed_server_running` --
+    #: used only for the Stop button's tooltip (the toast that announces a
+    #: fresh URL is the screen's own responsibility, not this pane's).
+    feed_server_url = reactive[str | None](None, recompose=True)
     #: Task 6: every `[item N]` id the SELECTED briefing's body cites,
     #: resolved once per selection by the screen (`_load_briefings`, via
     #: `get_subscription_items_by_ids`) -- `{"item_id": int, "label": Text,
@@ -982,6 +1031,55 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                     if not self.has_audio_episodes
                     else "Export this watchlist's audio episodes as a "
                     "podcast feed directory."
+                ),
+            )
+            # task-1760: Serve/Stop, adjacent to Export Feed for the same
+            # reason Export Feed itself lives here (review round 1,
+            # Important #1, above) -- serving a feed is the natural next
+            # step after exporting one, and this toolbar is the one place
+            # that is guaranteed reachable regardless of any briefing/
+            # script selection. Two buttons, not one toggling label,
+            # mirroring `#artifacts-audio-toolbar`'s own Play/Stop pair
+            # below: Serve disabled while already running OR with nothing
+            # exported yet; Stop disabled while nothing is running. This
+            # also means a SECOND `ServeFeedRequested` while one is
+            # already running is unreachable through the button itself --
+            # the screen's handler still re-checks (see that message's own
+            # docstring), since the button's disabled state and the
+            # message it posts are two different frames, same as every
+            # other guard on this pane.
+            if self.feed_server_running:
+                serve_tooltip = (
+                    "A feed is already being served. Stop it before "
+                    "serving a different export."
+                )
+            elif not self.can_serve_feed:
+                serve_tooltip = (
+                    "Export a feed directory first, then serve it over "
+                    "localhost."
+                )
+            else:
+                serve_tooltip = (
+                    "Serve the exported feed directory over localhost -- "
+                    "no authentication; anyone who can reach the address "
+                    "can read it while it is serving."
+                )
+            yield Button(
+                "Serve Feed",
+                id="artifacts-serve-feed-button",
+                compact=True,
+                disabled=self.feed_server_running or not self.can_serve_feed,
+                tooltip=serve_tooltip,
+            )
+            yield Button(
+                "Stop Serving",
+                id="artifacts-stop-feed-button",
+                compact=True,
+                disabled=not self.feed_server_running,
+                tooltip=(
+                    f"Stop serving {self.feed_server_url}."
+                    if self.feed_server_running and self.feed_server_url
+                    else "Nothing is being served."
                 ),
             )
 
@@ -1523,6 +1621,10 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
             self.post_message(StopAudioRequested())
         elif button_id == "artifacts-export-feed-button":
             self.post_message(ExportFeedRequested())
+        elif button_id == "artifacts-serve-feed-button":
+            self.post_message(ServeFeedRequested())
+        elif button_id == "artifacts-stop-feed-button":
+            self.post_message(StopFeedServerRequested())
         event.stop()
 
     def on_select_changed(self, event: Select.Changed) -> None:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3682,6 +3682,20 @@ max_export_size_mb = 100  # Maximum size for exports in MB
 # Selection profiles directory
 profiles_directory = "~/.config/tldw_cli/github_profiles"  # Where to store selection profiles
 
+[briefings_feed_server]
+# Opt-in, session-only static file server for ONE exported briefings podcast
+# feed directory at a time (task-1760). This is its own section on purpose --
+# it is unrelated to [web_server] below: that runs the whole chatbook UI in a
+# browser instead of a terminal (a separate, mutually exclusive process mode)
+# and has no route that serves a directory you choose. Nothing here ever
+# auto-starts anything -- these are only the defaults the Watchlists
+# Artifacts pane's Serve action uses when you press it; serving always
+# requires that explicit action. See Docs/User_Guide/watchlists.md's
+# "Serving an exported feed" section for the full security posture
+# (no authentication, localhost-only unless you widen bind).
+bind = "127.0.0.1"  # Loopback only. Widen only if you understand the exposure -- there is no authentication.
+port = 0  # 0 = pick any free port each time; set a fixed port to reuse the same URL
+
 [web_server]
 # Web server configuration for running tldw_chatbook in a browser
 enabled = true  # Enable web server functionality

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3692,7 +3692,11 @@ profiles_directory = "~/.config/tldw_cli/github_profiles"  # Where to store sele
 # Artifacts pane's Serve action uses when you press it; serving always
 # requires that explicit action. See Docs/User_Guide/watchlists.md's
 # "Serving an exported feed" section for the full security posture
-# (no authentication, localhost-only unless you widen bind).
+# (no authentication, localhost-only unless you widen bind, recursive
+# file serving with directory listings disabled, so point this at a
+# dedicated export folder rather than a general-purpose one like $HOME).
+# A blank/invalid bind value here falls back to loopback rather than
+# silently widening exposure.
 bind = "127.0.0.1"  # Loopback only. Widen only if you understand the exposure -- there is no authentication.
 port = 0  # 0 = pick any free port each time; set a fixed port to reuse the same URL
 


### PR DESCRIPTION
## Why

Spec #2 phase 3 promised localhost serving of the exported feed directory "if `[web_server]` is enabled" — but that premise was false (`[web_server]` is textual-serve, a mutually-exclusive process mode read by no gate, serving only its own browser assets). The owner cut serving from phase 3 and filed this as net-new work: a purpose-built static server the TUI can start and stop on demand, with the security review that new listening-socket surface demands (task-1760).

## What

- **`Subscriptions/feed_server.py`** — a `FeedDirectoryServer` wrapping stdlib `ThreadingHTTPServer` on a daemon thread. GET/HEAD only (unknown verbs 405/501, default-deny); **path containment** via `Path(candidate).resolve().relative_to(served_root)` — component-wise, so symlink escapes (file and directory), encoded/raw `..`, absolute-path and leading-`//` forms all 404; **no directory listing** (`list_directory` → 404; recursive file serving kept for episodes in subfolders); ephemeral or configured port; **binds `127.0.0.1` by default** — a blank/typo'd/non-string bind falls back to loopback rather than silently going public, and any genuinely non-loopback bind logs a warning and says so in the toast.
- **Opt-in, off by default:** nothing listens until the user presses Serve on the Artifacts pane; one directory at a time (a second start refuses, naming the running URL, before binding); session-only — daemon thread plus `on_unmount` stop, so exit never wedges a socket. `[briefings_feed_server]` supplies bind/port defaults for the explicit action only; `[web_server]`/`Web_Server/` untouched.
- **Security posture (AC #4)** stated plainly in the user guide, module docstring, config comment, and the per-serve toast: loopback default and what widening means, **no authentication** ("anyone who can reach this address can read the feed while it is serving"), the containment guarantee, and that every file in the chosen directory *and its subdirectories* is served — so the guidance is to point it at a dedicated export folder, not your home directory.

## Testing

New `test_feed_server.py` (41): real server on ephemeral localhost, httpx round-trip, a **raw-socket traversal matrix** putting `..` on the wire (httpx normalizes it away client-side — the reviewer's independent 24-case raw probe confirmed containment), symlink-out (file and directory) → 404, POST → 405, no directory listing, blank-bind → loopback, non-loopback → warning, stop() < 150ms (measured 51ms), stop closes the socket. `test_watchlists_artifacts_pane.py` 124. Opus security review → fix wave (error-path logging crash, 500ms→51ms stop, bind validation, no-listing) → scoped re-review, both APPROVED; every fix mutation-verified. The `..`-traversal and bind-default defaults were traced through the real `get_cli_setting` against this repo's known dotted-form-drops-default trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in localhost static server to serve the exported briefings feed directory, with Serve/Stop controls in the Artifacts pane. Addresses Linear TASK-1760 by meeting AC #1–#4: user-started serving, loopback default, strict containment, and working with podcast clients.

- **New Features**
  - Added `FeedDirectoryServer` wrapping stdlib `ThreadingHTTPServer` on a daemon thread. Serves one exported directory per session, refuses a second start, and stops on unmount.
  - New `[briefings_feed_server]` config for bind/port defaults used by the explicit Serve action; not tied to `[web_server]`.
  - UI: Serve Feed / Stop Serving buttons on the Artifacts pane, disabled until a feed is exported; toast shows the URL and security posture.
  - Docs updated; tests cover real-server round trips, traversal and symlink escapes, method gate, bind/port defaults, IPv6, and UI wiring.

- **Bug Fixes**
  - GET/HEAD only; other verbs return 405/501.
  - Path containment via `Path.resolve().relative_to(...)`; directory listings disabled; recursive file serving kept for feed subfolders.
  - Bind validation: default `127.0.0.1`; warn in logs/toast when widened off loopback; IPv6 binds supported (AF_INET6) with bracketed URLs.
  - Port validation with safe fallback and `FeedServerError` on invalid input; faster stop (~51ms) with a 50ms poll; stop closes the socket; fixed malformed-request logging crash.

<sup>Written for commit e11a40c79a9344888700c163112a6921b7c63fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

