### PR TITLE
Declare the optional numpy dependency the Parakeet loader tests need (TASK-1804)

### DIFF
--- a/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
+++ b/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
@@ -284,7 +284,10 @@ def test_parakeet_file_model_construction_uses_loader(
     than an undeclared test dependency.
 
     Args:
-        service_module: The reloaded transcription service module fixture.
+        service_module: The transcription service module fixture (imports
+            once; returns the cached ``sys.modules`` entry when already
+            loaded, so import-time flags like ``NUMPY_AVAILABLE`` reflect
+            the process's first import).
         monkeypatch: Pytest monkeypatch fixture.
         tmp_path: Temporary directory for the fake audio file.
     """
@@ -337,7 +340,10 @@ def test_parakeet_buffer_model_construction_uses_loader(
     test has to declare the dependency it actually needs.
 
     Args:
-        service_module: The reloaded transcription service module fixture.
+        service_module: The transcription service module fixture (imports
+            once; returns the cached ``sys.modules`` entry when already
+            loaded, so import-time flags like ``NUMPY_AVAILABLE`` reflect
+            the process's first import).
         monkeypatch: Pytest monkeypatch fixture.
     """
 

--- a/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
+++ b/Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py
@@ -273,6 +273,24 @@ def test_parakeet_file_model_construction_uses_loader(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """The file path routes model construction through the lazy loader.
+
+    TASK-1804: ``numpy`` is an OPTIONAL dependency (it appears only under
+    ``[project.optional-dependencies]``), and ``transcription_service``
+    guards it with ``NUMPY_AVAILABLE``. This test builds a real array via
+    ``service_module.np.zeros`` and so genuinely requires it -- without the
+    skip it fails with ``'NoneType' object has no attribute 'zeros'`` in a
+    supported, numpy-less install, which reads as a product defect rather
+    than an undeclared test dependency.
+
+    Args:
+        service_module: The reloaded transcription service module fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory for the fake audio file.
+    """
+
+    if not service_module.NUMPY_AVAILABLE:  # optional dependency
+        pytest.skip("numpy is an optional dependency and is not installed")
     debug_messages: list[str] = []
     monkeypatch.setattr(
         service_module.logger,
@@ -307,6 +325,24 @@ def test_parakeet_file_model_construction_uses_loader(
 def test_parakeet_buffer_model_construction_uses_loader(
     service_module, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The buffer path routes model construction through the lazy loader.
+
+    TASK-1804: ``_transcribe_buffer_with_parakeet_mlx`` raises
+    ``TranscriptionError("NumPy is required for buffer transcription")``
+    *before* it reaches ``_ensure_parakeet_mlx_import``, so in a numpy-less
+    install the loader sentinel below can never fire and the assertion
+    fails with ``assert None is RuntimeError('parakeet loader reached')``.
+    That is the guard working as designed, not the loader being bypassed --
+    numpy is optional (see ``[project.optional-dependencies]``), so this
+    test has to declare the dependency it actually needs.
+
+    Args:
+        service_module: The reloaded transcription service module fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+
+    if not service_module.NUMPY_AVAILABLE:  # optional dependency
+        pytest.skip("numpy is an optional dependency and is not installed")
     service = _service(service_module, monkeypatch)
     sentinel = RuntimeError("parakeet loader reached")
     ensure_import = Mock(side_effect=sentinel)


### PR DESCRIPTION
Closes TASK-1804. Two failures in `Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py` on `dev`, found by sweeping the full suite during unrelated work and filed rather than absorbed.

## Diagnosis: environmental, not a defect

`numpy` appears **only** under `[project.optional-dependencies]`, and `transcription_service` guards it correctly. `_transcribe_buffer_with_parakeet_mlx` raises

```
TranscriptionError("NumPy is required for buffer transcription")
```

at `transcription_service.py:3764` — *before* it reaches `_ensure_parakeet_mlx_import`. So in a numpy-less install the test's loader sentinel can never fire, and the failure reads as

```
assert None is RuntimeError('parakeet loader reached')
```

i.e. "the lazy loader was bypassed" — when the guard is working exactly as designed. The sibling failure is the same cause one step earlier: `'NoneType' object has no attribute 'zeros'` is `np.zeros` with `np is None`.

The production code is right. The tests simply exercise a numpy-requiring path without declaring that they need it, so they fail rather than skip in a supported configuration.

## Why not `pytest.importorskip`

That is the repo's existing idiom and was my first attempt — but it is wrong here, and quietly so. numpy 2.x refuses to be re-imported in a process that already loaded it:

```
could not import 'numpy': cannot load module more than once per process
```

The module fixture reloads, so `importorskip` skips **even where numpy is installed** — including CI. It would have turned a red mark green by silently deleting two tests from every environment.

Skipping on the module's own `NUMPY_AVAILABLE` flag is semantically exact: the test needs the code path that requires numpy, and the module already computes whether that path is live.

## Verification, both directions

Skip guards are an easy place to hide a real failure, so this was checked against an interpreter that *has* numpy rather than assumed:

| environment | result |
|---|---|
| venv with numpy 2.4.4 | **9 passed, 0 skipped** |
| venv without numpy | 7 passed, 2 skipped, with an honest reason |

The tests genuinely run and pass where the dependency exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare the optional `numpy` dependency for the Parakeet loader tests and add skips when `NUMPY_AVAILABLE` is false to prevent false negatives in supported environments. Aligns with TASK-1804 by making the tests reflect the module’s optional `numpy` behavior.

- **Bug Fixes**
  - Added `pytest.skip` guards using `service_module.NUMPY_AVAILABLE` in two tests in `Tests/Local_Ingestion/test_transcription_service_lazy_mlx.py`, and documented the `service_module` fixture’s single-import caching so flags like `NUMPY_AVAILABLE` are accurate.
  - Chose module flag over `pytest.importorskip` to avoid NumPy 2.x re-import errors that would wrongly skip tests even when `numpy` is installed.

<sup>Written for commit 130c03e525d253b3663c7ee06a54a68447093975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

