### PR TITLE
Add direct-local transcribe.cpp batch STT provider

### DIFF
--- a/Docs/superpowers/plans/2026-08-02-task-604-direct-local-transcribe-cpp.md
+++ b/Docs/superpowers/plans/2026-08-02-task-604-direct-local-transcribe-cpp.md
@@ -1,0 +1,68 @@
+# TASK-604 Direct-Local transcribe.cpp Batch STT Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user select an existing compatible GGUF and complete a real Library audio/video transcription with the pinned optional `transcribe.cpp` runtime.
+
+**Architecture:** Keep direct-local execution inside the existing spawned Library parse worker. Revalidate the GGUF immediately before one native model load, derive one exact model declaration from the loaded runtime, seal it into the existing provider registry, run the existing coordinator, and return only picklable normalized transcript/provenance or a bounded path-safe failure envelope to the parent writer/UI.
+
+**Tech Stack:** Python 3.11+, Textual, existing spawn parse pool and STT contracts, `transcribe-cpp==0.1.3`, ffmpeg/WAV normalization, pytest.
+
+---
+
+## Preconditions and scope
+
+- Work only in `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-604-transcribe-cpp` on `codex/task-604-transcribe-cpp`.
+- Governing designs: `Docs/superpowers/specs/2026-07-23-stt-parakeet-onnx-transcribe-cpp-design.md` and `Docs/superpowers/specs/2026-08-01-task-597-local-gguf-import-design.md`.
+- ADR required: no.
+- ADR path: `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md` and `backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md`.
+- Reason: the accepted ADRs already govern the provider/runtime boundary, direct-local config ownership, worker-side revalidation, provenance, and the explicit no-managed-store/no-resident-executor scope.
+- Run only tests and static checks for files and behavior changed by this task. Do not run or wait for the repository-wide suite or unrelated CI.
+- Do not add downloads, copying, hashing, artifact activation, a resident executor, semantic-default participation, or automatic fallback. The deferred managed-store code remains untouched for TASK-1915.
+
+## File map
+
+- Create `tldw_chatbook/STT/transcribe_cpp.py` for the lazy runtime adapter, capability conversion, single-load lifecycle, normalized output, and safe failure translation.
+- Modify `tldw_chatbook/Local_Ingestion/transcription_service.py`, `audio_processing.py`, `video_processing.py`, `local_file_ingestion.py`, and `ingest_parse_worker.py` only as needed to carry the direct-local request/result/failure through the existing production worker path.
+- Modify `tldw_chatbook/Local_Ingestion/stt_batch_routing.py` and `tldw_chatbook/app.py` for exact manual routing, configured path injection, request lineage, and explicit faster-whisper retry overrides.
+- Modify `tldw_chatbook/Library/ingest_capabilities.py`, `tldw_chatbook/Widgets/Library/library_ingest_canvas.py`, `tldw_chatbook/UI/Screens/library_screen.py`, and the first-run speech step only for the provider choice, GGUF picker/admission, key-only config persistence, and bounded recovery buttons.
+- Modify `pyproject.toml` for the exact optional extra.
+- Add focused tests beside the existing STT, Local_Ingestion, Library, and first-run tests; reuse TASK-597 GGUF fixtures and wheel-target declarations.
+
+### Task 1: Add the pinned, lazy, single-job provider adapter
+
+- [ ] Write failing adapter tests with a fake `transcribe_cpp` module/model covering: no import at module import time; worker-call import/ABI failure; TASK-597 revalidation immediately before one model construction; capabilities read after load and used identically by declaration/probe; one session run; close on success/failure; segment/timing/device/language normalization; and path/raw-exception redaction.
+- [ ] Add the exact marker-free `transcription_transcribe_cpp = ["transcribe-cpp==0.1.3"]` optional extra.
+- [ ] Implement the smallest adapter/run helper that imports `transcribe_cpp` only inside the execution call, silences native logging, loads one model, builds `model_id=local-gguf:<architecture>`, seals built-ins plus this one non-default model, invokes `TranscriptionCoordinator`, and closes the model in `finally`.
+- [ ] Normalize every input to 16 kHz mono signed-16-bit WAV before converting samples to float32 for `Session.run`; request only supported timestamp/language/task combinations.
+- [ ] Run only the new adapter/package tests and lint/format checks for these files.
+
+### Task 2: Carry normalized success and safe failure through production ingestion
+
+- [ ] Write failing audio and video ingestion tests proving manual `transcribe-cpp` reaches the provider helper and that `transcription_model` plus the validated provenance document survive parse payload and parent-side persistence.
+- [ ] Add request identity/lineage fields to the existing worker options and pass the configured GGUF path separately from the Library form snapshot.
+- [ ] Propagate normalized result metadata without changing other providers' legacy result shapes.
+- [ ] Add one picklable, bounded direct-local failure type/envelope. Convert admission/runtime/coordinator failures into stable codes, a sanitized failed-attempt document, and only eligible `choose_another_gguf`/`retry_faster_whisper` action strings; pass these through `run_parse_job` and `mark_failed` without raw paths or native exception text.
+- [ ] Run only the touched Local_Ingestion and Library queue tests, including a spawned-worker crash/shutdown regression.
+
+### Task 3: Add exact manual routing and explicit retry lineage
+
+- [ ] Write failing routing/app tests proving `transcribe-cpp` is accepted only when explicitly selected, never chosen by `default`, and never silently falls back.
+- [ ] Extend the batch route with the manual provider while preserving `en` as the UI/default omitted language and leaving all semantic-default behavior unchanged.
+- [ ] Add an app/registry retry seam that clones a failed job with only the audio/video provider changed to `faster-whisper`, retaining `retry_of_job_id` and the source failure snapshot already supported by the queue.
+- [ ] Write and run focused tests proving the explicit retry uses faster-whisper and its successful provenance links to the failed direct-local attempt.
+
+### Task 4: Add the provider picker and bounded recovery UI
+
+- [ ] Write failing Library canvas/screen and first-run speech-step tests for: exact provider option; `Choose GGUF…`; `.gguf` filtering; off-loop admission; success persistence only to `[transcription.transcribe_cpp].model_path` via one `save_settings_to_cli_config` call; restart prefill without generic path rendering; and no persistence on cancel/failure.
+- [ ] Reuse the existing Textual file picker. Keep the model path out of `library.ingest_options.*`; read it from the dedicated config section only when dispatching the spawned job.
+- [ ] Render only a path-free configured/not-configured status. Add `Choose another GGUF…` and `Retry with faster-whisper` buttons only when the worker's allowlisted action names are present.
+- [ ] Wire the recovery buttons to the same picker and explicit retry seam, then run only the touched UI/state tests.
+
+### Task 5: Focused vertical verification and closeout
+
+- [ ] Add one focused production-path integration test: Library form snapshot -> app dispatch -> spawn-safe parse entry -> fake native model -> parent writer -> stored transcript/provenance.
+- [ ] Add static package/provider smoke covering the exact optional pin and all five TASK-597 wheel target pairs. Preserve Linux ABI/wheel resolution as a gate for a Linux-capable environment; do not claim local execution for unavailable Windows/Linux hosts.
+- [ ] Run only the focused TASK-604 test files, `py_compile`/Ruff for modified Python files, the relevant TOML parse check, and `git diff --check`.
+- [ ] Self-review the complete branch diff for path leakage, startup imports, silent fallback, shutdown cleanup, and scope creep.
+- [ ] Update TASK-604 acceptance criteria and concise Implementation Notes through Backlog CLI only after focused verification passes.

--- a/Tests/App/test_submit_library_ingest_job.py
+++ b/Tests/App/test_submit_library_ingest_job.py
@@ -16,6 +16,7 @@ from tldw_chatbook.Library.library_ingest_jobs import (
 from tldw_chatbook.Library.library_ingest_state import LibraryIngestFormState
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.app import TldwCli
+import tldw_chatbook.app as app_module
 
 
 def _minimal_app(media_db: Any = None) -> TldwCli:
@@ -44,6 +45,26 @@ def _make_job(
         chunk_size=chunk_size,
         ingest_options=ingest_options or {},
     )
+
+
+def _direct_failed_attempt() -> dict[str, object]:
+    return {
+        "attempt_id": "attempt-1",
+        "batch_id": None,
+        "job_id": "ingest-job-1",
+        "provider_id": "transcribe-cpp",
+        "model_id": "local-gguf:whisper",
+        "artifact_root": None,
+        "artifact_dependencies": [],
+        "precision": "native",
+        "requested_device": "auto",
+        "effective_device": None,
+        "requested_language": "en",
+        "effective_language": "en",
+        "detected_language": None,
+        "task": "transcribe",
+        "error_code": "inference_failed",
+    }
 
 
 class TestIngestJobOptions:
@@ -249,6 +270,50 @@ class TestIngestJobOptions:
         assert options["language"] == "ja"
         assert options["translation_target_language"] == "en"
 
+    def test_transcribe_cpp_reads_dedicated_path_into_private_worker_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        secret_path = "/private/models/speech.gguf"
+        monkeypatch.setattr(
+            app_module,
+            "get_cli_setting",
+            lambda key, *args: secret_path
+            if key == "transcription.transcribe_cpp.model_path"
+            else args[0]
+            if args
+            else None,
+        )
+        app = _minimal_app()
+        job = _make_job(
+            source_path="/tmp/test.mp3",
+            ingest_options={
+                "audio_video": {
+                    "transcription_provider": "transcribe-cpp",
+                    "language": "en",
+                    "timestamps": True,
+                }
+            },
+        )
+
+        options = app._ingest_job_options(job)
+
+        assert options["transcription_provider"] == "transcribe-cpp"
+        assert options["transcription_model"] is None
+        assert options["transcription_precision"] == "native"
+        assert options["language"] == "en"
+        assert options["transcription_context"] == {
+            "model_path": secret_path,
+            "attempt_id": "ingest-job-test-attempt-1",
+            "batch_id": None,
+            "job_id": "ingest-job-test",
+            "retry_of_attempt_id": None,
+            "retry_of_job_id": None,
+            "retry_source_failure_provenance": None,
+        }
+        assert "transcription_model_path" not in options
+        assert secret_path not in str(job.ingest_options)
+
     def test_untouched_exact_faster_whisper_model_uses_visible_base_default(
         self,
     ) -> None:
@@ -415,6 +480,46 @@ class TestSubmitLibraryIngestJob:
         assert job.error == "Media database is unavailable."
         # ingest_options should still be preserved on the failed job.
         assert job.ingest_options == {"generic": {"analyze": True}}
+
+    def test_explicit_faster_whisper_retry_overrides_only_provider_and_links_job(
+        self,
+    ) -> None:
+        app = _minimal_app(media_db="present")
+        original = app.submit_library_ingest_job(
+            source_path="/tmp/test.mp3",
+            ingest_options={
+                "generic": {"chunk": True},
+                "audio_video": {
+                    "transcription_provider": "transcribe-cpp",
+                    "language": "en",
+                    "timestamps": True,
+                },
+            },
+        )
+        failed = app.library_ingest_jobs.mark_failed(
+            original.job_id,
+            error="Speech-to-text inference failed.",
+            stt_failure_provenance=_direct_failed_attempt(),
+        )
+
+        retry = app.retry_library_ingest_job_with_provider(
+            failed.job_id,
+            "faster-whisper",
+        )
+
+        assert retry.retry_of_job_id == failed.job_id
+        assert retry.retry_source_failure_provenance == _direct_failed_attempt()
+        assert retry.ingest_options == {
+            "generic": {"chunk": True},
+            "audio_video": {
+                "transcription_provider": "faster-whisper",
+                "language": "en",
+                "timestamps": True,
+            },
+        }
+        assert original.ingest_options["audio_video"]["transcription_provider"] == (
+            "transcribe-cpp"
+        )
 
 
 @pytest.mark.parametrize(

--- a/Tests/Library/test_ingest_capabilities.py
+++ b/Tests/Library/test_ingest_capabilities.py
@@ -152,6 +152,7 @@ def test_get_capabilities_audio_video() -> None:
         "default",
         "parakeet-onnx",
         "faster-whisper",
+        "transcribe-cpp",
     )
     assert provider_field.default == "default"
 

--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -1019,6 +1019,64 @@ async def test_shutdown_flag_stops_late_parse_completion_callbacks(
         assert app._ingest_parse_pool is not None
 
 
+@pytest.mark.asyncio
+async def test_parse_completion_preserves_direct_local_stt_failure_provenance(
+    tmp_path: Path,
+) -> None:
+    db = _make_db(tmp_path)
+    pool = _FakeIngestParsePool(auto_run=False)
+    app = _IngestRunnerHarness(db, pool_factory=lambda: pool)
+    source = tmp_path / "speech.wav"
+    source.write_bytes(b"fixture")
+    failed_attempt = {
+        "attempt_id": "attempt-1",
+        "batch_id": None,
+        "job_id": "ingest-job-1",
+        "provider_id": "transcribe-cpp",
+        "model_id": "local-gguf:whisper",
+        "artifact_root": None,
+        "artifact_dependencies": [],
+        "precision": "native",
+        "requested_device": "auto",
+        "effective_device": None,
+        "requested_language": "en",
+        "effective_language": "en",
+        "detected_language": None,
+        "task": "transcribe",
+        "error_code": "artifact_incompatible",
+    }
+
+    async with app.run_test() as pilot:
+        job = app.submit_library_ingest_job(source_path=str(source))
+        await pilot.pause()
+        pool.trigger_success(
+            0,
+            {
+                "ok": False,
+                "error": "The selected GGUF cannot be used by transcribe.cpp.",
+                "permanent": False,
+                "error_detail": {
+                    "category": "stt_failure",
+                    "code": "artifact_incompatible",
+                    "message": "The selected GGUF cannot be used by transcribe.cpp.",
+                    "actions": [
+                        "choose_another_gguf",
+                        "retry_faster_whisper",
+                    ],
+                },
+                "stt_failure_provenance": failed_attempt,
+            },
+        )
+        await _wait_for_job_state(app, pilot, job.job_id, IngestJobState.FAILED)
+
+        failed = app.library_ingest_jobs.get_job(job.job_id)
+        assert failed.error_detail["actions"] == [
+            "choose_another_gguf",
+            "retry_faster_whisper",
+        ]
+        assert failed.stt_failure_provenance == failed_attempt
+
+
 # --- F3 Task 4 review fixes: quit-deadlock guard + payload-sparing ----------
 #
 # The Task 4 review found a quit-time deadlock race: Textual's

--- a/Tests/Local_Ingestion/test_transcribe_cpp_ingestion.py
+++ b/Tests/Local_Ingestion/test_transcribe_cpp_ingestion.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_chatbook.Local_Ingestion import local_file_ingestion
+from tldw_chatbook.Local_Ingestion.audio_processing import LocalAudioProcessor
+from tldw_chatbook.Local_Ingestion.ingest_parse_worker import run_parse_job
+from tldw_chatbook.Local_Ingestion.video_processing import LocalVideoProcessor
+from tldw_chatbook.STT.contracts import (
+    ExecutionDevice,
+    ProducedCapabilities,
+    TimestampGranularity,
+    TranscriptionFailureCode,
+    TranscriptionProvenance,
+    TranscriptionResult,
+    TranscriptionTask,
+    TranscriptionTimings,
+)
+from tldw_chatbook.STT.persistence import (
+    FailedTranscriptionAttempt,
+    dump_failed_transcription_attempt,
+    load_failed_transcription_attempt,
+)
+
+
+def _result() -> TranscriptionResult:
+    return TranscriptionResult(
+        text="hello world",
+        segments=(),
+        provenance=TranscriptionProvenance(
+            schema_version=1,
+            attempt_id="attempt-1",
+            batch_id=None,
+            job_id="ingest-job-1",
+            retry_of_attempt_id=None,
+            retry_of_job_id=None,
+            provider_id="transcribe-cpp",
+            model_id="local-gguf:whisper",
+            artifact_root=None,
+            artifact_dependencies=(),
+            precision="native",
+            requested_device=ExecutionDevice.AUTO,
+            effective_device=ExecutionDevice.CPU,
+            requested_language="en",
+            effective_language="en",
+            detected_language=None,
+            task=TranscriptionTask.TRANSCRIBE,
+        ),
+        produced_capabilities=ProducedCapabilities(
+            timestamps=TimestampGranularity.NONE,
+            punctuation=False,
+            capitalization=False,
+            vad=False,
+            diarization=False,
+        ),
+        duration_seconds=0.1,
+        timings=TranscriptionTimings(total_seconds=0.1),
+    )
+
+
+def _failed_attempt() -> dict[str, object]:
+    return load_failed_transcription_attempt(
+        dump_failed_transcription_attempt(
+            FailedTranscriptionAttempt(
+                attempt_id="attempt-1",
+                batch_id=None,
+                job_id="ingest-job-1",
+                provider_id="transcribe-cpp",
+                model_id="local-gguf:whisper",
+                artifact_root=None,
+                artifact_dependencies=(),
+                precision="native",
+                requested_device=ExecutionDevice.AUTO,
+                effective_device=None,
+                requested_language="en",
+                effective_language="en",
+                detected_language=None,
+                task=TranscriptionTask.TRANSCRIBE,
+                error_code=TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
+            )
+        )
+    )
+
+
+def test_audio_processor_uses_direct_runner_and_returns_normalized_provenance(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from tldw_chatbook.STT import transcribe_cpp
+
+    audio_path = tmp_path / "speech.wav"
+    model_path = tmp_path / "model.gguf"
+    audio_path.write_bytes(b"not-read-by-fake")
+    calls: list[dict[str, object]] = []
+
+    def fake_transcribe_file(**kwargs):
+        calls.append(kwargs)
+        return _result()
+
+    monkeypatch.setattr(transcribe_cpp, "transcribe_file", fake_transcribe_file)
+    processor = LocalAudioProcessor(media_db=None)
+
+    batch = processor.process_audio_files(
+        inputs=[str(audio_path)],
+        transcription_provider="transcribe-cpp",
+        transcription_language="en",
+        transcription_context={
+            "model_path": str(model_path),
+            "attempt_id": "attempt-1",
+            "job_id": "ingest-job-1",
+        },
+        timestamp_option=False,
+        perform_chunking=False,
+        perform_analysis=False,
+    )
+
+    assert calls == [
+        {
+            "audio_path": audio_path,
+            "model_path": model_path,
+            "attempt_id": "attempt-1",
+            "batch_id": None,
+            "job_id": "ingest-job-1",
+            "retry_of_attempt_id": None,
+            "retry_of_job_id": None,
+            "language": "en",
+            "timestamps": False,
+            "ffmpeg_path": None,
+        }
+    ]
+    row = batch["results"][0]
+    assert row["status"] == "Success"
+    assert row["content"] == "hello world"
+    assert row["transcription_model"] == "local-gguf:whisper"
+    assert row["transcription_provenance"]["provider_id"] == "transcribe-cpp"
+    assert row["transcription_provenance"]["artifact_root"] is None
+
+
+def test_audio_parse_payload_preserves_model_and_provenance(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = tmp_path / "speech.wav"
+    source.write_bytes(b"fixture")
+    provenance = {"provider_id": "transcribe-cpp"}
+
+    class StubAudioProcessor:
+        def __init__(self, _media_db=None) -> None:
+            pass
+
+        def process_audio_files(self, **_kwargs):
+            return {
+                "results": [
+                    {
+                        "status": "Success",
+                        "content": "hello world",
+                        "metadata": {"title": "Speech", "author": "Unknown"},
+                        "chunks": [],
+                        "analysis": "",
+                        "transcription_model": "local-gguf:whisper",
+                        "transcription_provenance": provenance,
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(local_file_ingestion, "LocalAudioProcessor", StubAudioProcessor)
+
+    payload = local_file_ingestion.parse_local_file_for_ingest(
+        str(source),
+        {"transcription_provider": "transcribe-cpp"},
+    )
+
+    assert payload["transcription_model"] == "local-gguf:whisper"
+    assert payload["transcription_provenance"] is provenance
+
+
+def test_video_processor_preserves_direct_transcription_metadata(
+    tmp_path: Path,
+) -> None:
+    audio_path = tmp_path / "video-audio.mp3"
+    audio_path.write_bytes(b"fixture")
+    processor = LocalVideoProcessor(media_db=None)
+
+    class StubAudioProcessor:
+        def _process_single_audio(self, **_kwargs):
+            return {
+                "status": "Success",
+                "content": "hello video",
+                "segments": [],
+                "chunks": [],
+                "analysis": "",
+                "warnings": [],
+                "metadata": {},
+                "transcription_model": "local-gguf:whisper",
+                "transcription_provenance": {"provider_id": "transcribe-cpp"},
+            }
+
+    processor.audio_processor = StubAudioProcessor()
+
+    result = processor.process_videos(
+        inputs=[str(audio_path)],
+        download_video_flag=False,
+    )["results"][0]
+
+    assert result["status"] == "Success"
+    assert result["transcription_model"] == "local-gguf:whisper"
+    assert result["transcription_provenance"] == {"provider_id": "transcribe-cpp"}
+
+
+def test_parse_worker_preserves_bounded_stt_failure_and_failed_attempt(
+    monkeypatch,
+) -> None:
+    failed_attempt = _failed_attempt()
+    error = local_file_ingestion.DirectLocalSTTIngestError(
+        "The selected GGUF cannot be used by transcribe.cpp.",
+        error_detail={
+            "category": "stt_failure",
+            "code": "artifact_incompatible",
+            "message": "The selected GGUF cannot be used by transcribe.cpp.",
+            "actions": ["choose_another_gguf", "retry_faster_whisper"],
+        },
+        failed_attempt=failed_attempt,
+    )
+
+    def fail(_path: str, _options: dict[str, object]) -> None:
+        raise error
+
+    monkeypatch.setattr(local_file_ingestion, "parse_local_file_for_ingest", fail)
+
+    result = run_parse_job("/private/model-owner/audio.wav", {})
+
+    assert result == {
+        "ok": False,
+        "error": "The selected GGUF cannot be used by transcribe.cpp.",
+        "permanent": False,
+        "error_detail": {
+            "category": "stt_failure",
+            "code": "artifact_incompatible",
+            "message": "The selected GGUF cannot be used by transcribe.cpp.",
+            "actions": ["choose_another_gguf", "retry_faster_whisper"],
+        },
+        "stt_failure_provenance": failed_attempt,
+    }
+    assert "/private/model-owner" not in str(result)

--- a/Tests/Local_Ingestion/test_transcribe_cpp_ingestion.py
+++ b/Tests/Local_Ingestion/test_transcribe_cpp_ingestion.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import json
+import sys
+import wave
 from pathlib import Path
+from types import SimpleNamespace
 
+import tldw_chatbook.app as app_module
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.Local_Ingestion import local_file_ingestion
 from tldw_chatbook.Local_Ingestion.audio_processing import LocalAudioProcessor
 from tldw_chatbook.Local_Ingestion.ingest_parse_worker import run_parse_job
 from tldw_chatbook.Local_Ingestion.video_processing import LocalVideoProcessor
+from tldw_chatbook.Library.library_ingest_jobs import LibraryIngestJob
+from tldw_chatbook.app import TldwCli
 from tldw_chatbook.STT.contracts import (
     ExecutionDevice,
     ProducedCapabilities,
@@ -242,3 +250,115 @@ def test_parse_worker_preserves_bounded_stt_failure_and_failed_attempt(
         "stt_failure_provenance": failed_attempt,
     }
     assert "/private/model-owner" not in str(result)
+
+
+def test_manual_library_job_reaches_fake_native_model_and_parent_writer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """One focused production-path proof from Library options to stored row."""
+    from tldw_chatbook.STT import transcribe_cpp
+
+    audio_path = tmp_path / "speech.wav"
+    with wave.open(str(audio_path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16_000)
+        wav_file.writeframes(b"\x00\x00" * 1_600)
+    model_path = tmp_path / "private-model.gguf"
+    model_path.write_bytes(b"fixture")
+    calls: list[str] = []
+
+    class Session:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def run(self, _pcm, **_kwargs):
+            calls.append("run")
+            return SimpleNamespace(
+                text="vertical hello",
+                language="en",
+                segments=(
+                    SimpleNamespace(text="vertical hello", t0_ms=0, t1_ms=100),
+                ),
+                timings=SimpleNamespace(mel_ms=1.0, encode_ms=2.0, decode_ms=3.0),
+            )
+
+    class Model:
+        def __init__(self, path: str):
+            assert path == str(model_path)
+            calls.append("load")
+            self.arch = "whisper"
+            self.backend = "cpu"
+            self.device = SimpleNamespace(kind="cpu")
+            self.capabilities = SimpleNamespace(
+                native_sample_rate=16_000,
+                languages=("en",),
+                max_timestamp_kind="segment",
+                supports_language_detect=True,
+                supports_translate=True,
+                supports_streaming=False,
+                supports_spec_decode=False,
+                max_audio_ms=None,
+                translate_target_languages=("en",),
+            )
+
+        def session(self):
+            return Session()
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transcribe_cpp",
+        SimpleNamespace(Model=Model, set_log_callback=lambda _callback: None),
+    )
+    monkeypatch.setattr(
+        transcribe_cpp,
+        "validate_local_gguf",
+        lambda path: SimpleNamespace(
+            path=path,
+            metadata=SimpleNamespace(architecture="whisper"),
+        ),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_cli_setting",
+        lambda key, *args: str(model_path)
+        if key == "transcription.transcribe_cpp.model_path"
+        else args[0]
+        if args
+        else None,
+    )
+
+    app = object.__new__(TldwCli)
+    job = LibraryIngestJob(
+        job_id="ingest-job-vertical",
+        source_path=str(audio_path),
+        ingest_options={
+            "audio_video": {
+                "transcription_provider": "transcribe-cpp",
+                "language": "en",
+                "timestamps": True,
+            }
+        },
+    )
+    options = app._ingest_job_options(job)
+
+    parsed = run_parse_job(job.source_path, options)
+
+    assert parsed["ok"] is True, parsed
+    db = MediaDatabase(":memory:", client_id="transcribe-cpp-vertical")
+    media_id, _, _ = local_file_ingestion.persist_parsed_media(parsed["payload"], db)
+    row = db.get_media_by_id(media_id)
+    provenance = json.loads(row["transcription_provenance_json"])
+    assert row["content"] == "vertical hello"
+    assert row["transcription_model"] == "local-gguf:whisper"
+    assert provenance["provider_id"] == "transcribe-cpp"
+    assert provenance["model_id"] == "local-gguf:whisper"
+    assert str(model_path) not in repr(provenance)
+    assert calls == ["load", "run", "close"]

--- a/Tests/STT/test_contracts.py
+++ b/Tests/STT/test_contracts.py
@@ -128,7 +128,7 @@ def test_enums_have_exact_stable_string_values() -> None:
             "inference",
             "engine_crash",
         ),
-        ExecutionDevice: ("auto", "cpu", "cuda", "metal"),
+        ExecutionDevice: ("auto", "cpu", "cuda", "metal", "vulkan"),
         TranscriptionFailureCode: (
             "model_not_installed",
             "artifact_corrupt",

--- a/Tests/STT/test_transcribe_cpp.py
+++ b/Tests/STT/test_transcribe_cpp.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import tomllib
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _write_pcm_wav(path: Path) -> None:
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16_000)
+        wav_file.writeframes(b"\x00\x00" * 1_600)
+
+
+class _FakeSession:
+    def __init__(self, calls: list[tuple[str, object]]) -> None:
+        self._calls = calls
+
+    def __enter__(self) -> "_FakeSession":
+        self._calls.append(("session_enter", None))
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self._calls.append(("session_exit", None))
+
+    def run(self, pcm: object, **kwargs: object) -> object:
+        self._calls.append(("run", (pcm, kwargs)))
+        return SimpleNamespace(
+            text="hello world",
+            language="en",
+            segments=(SimpleNamespace(text="hello world", t0_ms=0, t1_ms=100),),
+            timings=SimpleNamespace(
+                mel_ms=1.0,
+                encode_ms=2.0,
+                decode_ms=3.0,
+            ),
+        )
+
+
+class _FakeModel:
+    def __init__(self, path: str, calls: list[tuple[str, object]]) -> None:
+        self._calls = calls
+        calls.append(("model", path))
+        self.arch = "whisper"
+        self.variant = "base"
+        self.backend = "cpu"
+        self.device = SimpleNamespace(kind="cpu")
+        self.capabilities = SimpleNamespace(
+            native_sample_rate=16_000,
+            languages=("en", "fr"),
+            max_timestamp_kind="segment",
+            supports_language_detect=True,
+            supports_translate=True,
+            supports_streaming=False,
+            supports_spec_decode=False,
+            max_audio_ms=None,
+            translate_target_languages=("en",),
+        )
+
+    def session(self) -> _FakeSession:
+        self._calls.append(("session", None))
+        return _FakeSession(self._calls)
+
+    def close(self) -> None:
+        self._calls.append(("close", None))
+
+
+def _fake_runtime(calls: list[tuple[str, object]]) -> object:
+    class Model:
+        def __new__(cls, path: str) -> _FakeModel:
+            return _FakeModel(path, calls)
+
+    def set_log_callback(callback: object) -> None:
+        calls.append(("set_log_callback", callback))
+
+    return SimpleNamespace(Model=Model, set_log_callback=set_log_callback)
+
+
+def test_module_import_does_not_import_native_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(sys.modules, "transcribe_cpp", raising=False)
+
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    importlib.reload(module)
+
+    assert "transcribe_cpp" not in sys.modules
+
+
+def test_optional_extra_pins_exact_runtime_without_platform_marker() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["optional-dependencies"][
+        "transcription_transcribe_cpp"
+    ] == ["transcribe-cpp==0.1.3"]
+
+
+def test_transcribe_file_revalidates_then_loads_once_and_normalizes_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    audio_path = tmp_path / "audio.wav"
+    model_path = tmp_path / "private-model.gguf"
+    _write_pcm_wav(audio_path)
+    model_path.write_bytes(b"fixture")
+    calls: list[tuple[str, object]] = []
+    monkeypatch.setitem(sys.modules, "transcribe_cpp", _fake_runtime(calls))
+
+    def validate(path: Path) -> object:
+        calls.append(("validate", path))
+        return SimpleNamespace(
+            path=path,
+            metadata=SimpleNamespace(architecture="whisper"),
+        )
+
+    monkeypatch.setattr(module, "validate_local_gguf", validate)
+
+    result = module.transcribe_file(
+        audio_path=audio_path,
+        model_path=model_path,
+        attempt_id="attempt-1",
+        job_id="ingest-job-1",
+        language="en",
+        timestamps=True,
+    )
+
+    event_names = [name for name, _value in calls]
+    assert event_names.index("validate") < event_names.index("model")
+    assert event_names.count("model") == 1
+    assert event_names.count("run") == 1
+    assert event_names[-1] == "close"
+    pcm, run_kwargs = next(value for name, value in calls if name == "run")
+    assert len(pcm) == 1_600
+    assert run_kwargs == {
+        "task": "transcribe",
+        "language": "en",
+        "timestamps": "segment",
+    }
+    assert result.text == "hello world"
+    assert result.segments[0].start_seconds == 0
+    assert result.segments[0].end_seconds == pytest.approx(0.1)
+    assert result.duration_seconds == pytest.approx(0.1)
+    assert result.provenance.provider_id == "transcribe-cpp"
+    assert result.provenance.model_id == "local-gguf:whisper"
+    assert result.provenance.artifact_root is None
+    assert result.provenance.artifact_dependencies == ()
+    assert result.provenance.precision == "native"
+    assert result.provenance.effective_device.value == "cpu"
+
+
+def test_loaded_capabilities_are_identical_in_declaration_and_probe() -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    calls: list[tuple[str, object]] = []
+    model = _FakeModel("ignored.gguf", calls)
+
+    adapter = module.TranscribeCppAdapter(
+        model=model,
+        architecture="whisper",
+        model_load_seconds=0.01,
+    )
+    described = adapter.describe()[0]
+    observed = adapter.probe(described.model_id)
+
+    assert observed.available is True
+    assert observed.capabilities == described.capabilities
+    assert described.semantic_default_eligible is False
+
+
+def test_native_import_failure_is_sanitized_and_path_private(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    secret = tmp_path / "secret-model.gguf"
+    audio_path = tmp_path / "audio.wav"
+    _write_pcm_wav(audio_path)
+
+    def unavailable(_name: str) -> object:
+        raise ImportError(f"bad ABI near {secret}")
+
+    monkeypatch.setattr(module.importlib, "import_module", unavailable)
+
+    with pytest.raises(module.TranscribeCppFailure) as raised:
+        module.transcribe_file(
+            audio_path=audio_path,
+            model_path=secret,
+            attempt_id="attempt-1",
+            language="en",
+        )
+
+    assert raised.value.code.value == "provider_unavailable"
+    assert str(secret) not in str(raised.value)
+    assert str(secret) not in repr(raised.value)
+    assert "bad ABI" not in str(raised.value)
+
+
+def test_native_model_load_failure_closes_nothing_and_never_leaks_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    secret = tmp_path / "secret-model.gguf"
+    audio_path = tmp_path / "audio.wav"
+    _write_pcm_wav(audio_path)
+    calls: list[tuple[str, object]] = []
+
+    class FailingModel:
+        def __init__(self, path: str) -> None:
+            calls.append(("model", path))
+            raise RuntimeError(f"native load failed for {path}")
+
+    runtime = SimpleNamespace(Model=FailingModel, set_log_callback=lambda _cb: None)
+    monkeypatch.setitem(sys.modules, "transcribe_cpp", runtime)
+    monkeypatch.setattr(
+        module,
+        "validate_local_gguf",
+        lambda path: SimpleNamespace(
+            path=path,
+            metadata=SimpleNamespace(architecture="whisper"),
+        ),
+    )
+
+    with pytest.raises(module.TranscribeCppFailure) as raised:
+        module.transcribe_file(
+            audio_path=audio_path,
+            model_path=secret,
+            attempt_id="attempt-1",
+            language="en",
+        )
+
+    assert raised.value.code.value == "artifact_incompatible"
+    assert raised.value.actions == ("choose_another_gguf", "retry_faster_whisper")
+    assert str(secret) not in str(raised.value)
+    assert str(secret) not in repr(raised.value)
+    assert [name for name, _value in calls] == ["model"]

--- a/Tests/STT/test_transcribe_cpp.py
+++ b/Tests/STT/test_transcribe_cpp.py
@@ -154,6 +154,9 @@ def test_transcribe_file_revalidates_then_loads_once_and_normalizes_result(
     assert result.provenance.artifact_dependencies == ()
     assert result.provenance.precision == "native"
     assert result.provenance.effective_device.value == "cpu"
+    assert result.timings.total_seconds == pytest.approx(
+        result.timings.model_load_seconds + result.timings.inference_seconds
+    )
 
 
 def test_loaded_capabilities_are_identical_in_declaration_and_probe() -> None:

--- a/Tests/STT/test_transcribe_cpp.py
+++ b/Tests/STT/test_transcribe_cpp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import sys
 import tomllib
+import traceback
 import wave
 from pathlib import Path
 from types import SimpleNamespace
@@ -173,6 +174,111 @@ def test_loaded_capabilities_are_identical_in_declaration_and_probe() -> None:
     assert described.semantic_default_eligible is False
 
 
+@pytest.mark.parametrize(
+    ("native_maximum", "expected"),
+    [
+        ("none", {"none"}),
+        ("segment", {"none", "segment"}),
+        ("word", {"none", "segment", "word"}),
+        ("token", {"none", "segment", "word"}),
+    ],
+)
+def test_native_timestamp_maximum_maps_to_supported_contract_granularities(
+    native_maximum: str,
+    expected: set[str],
+) -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+
+    mapped = module._timestamp_capabilities(native_maximum)
+
+    assert {granularity.value for granularity in mapped} == expected
+
+
+@pytest.mark.parametrize(
+    ("native_kind", "expected"),
+    [
+        ("cpu", "cpu"),
+        ("accel", "cpu"),
+        ("cpu_accel", "cpu"),
+        ("metal", "metal"),
+        ("mps", "metal"),
+        ("vulkan", "vulkan"),
+        ("cuda", "cuda"),
+    ],
+)
+def test_native_device_kind_maps_to_supported_contract_device(
+    native_kind: str,
+    expected: str,
+) -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    model = SimpleNamespace(device=SimpleNamespace(kind=native_kind))
+
+    mapped = module._device_from_model(model)
+
+    assert mapped.value == expected
+
+
+def test_missing_configured_model_fails_with_picker_action_before_runtime_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    audio_path = tmp_path / "audio.wav"
+    _write_pcm_wav(audio_path)
+    imports: list[str] = []
+
+    def record_import(name: str) -> object:
+        imports.append(name)
+        return object()
+
+    monkeypatch.setattr(module.importlib, "import_module", record_import)
+
+    with pytest.raises(module.TranscribeCppFailure) as raised:
+        module.transcribe_file(
+            audio_path=audio_path,
+            model_path=None,
+            attempt_id="attempt-1",
+            language="en",
+        )
+
+    assert raised.value.code.value == "model_not_installed"
+    assert raised.value.actions == ("choose_another_gguf", "retry_faster_whisper")
+    assert imports == []
+
+
+def test_invalid_model_is_rejected_before_runtime_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("tldw_chatbook.STT.transcribe_cpp")
+    audio_path = tmp_path / "audio.wav"
+    model_path = tmp_path / "changed.gguf"
+    _write_pcm_wav(audio_path)
+    imports: list[str] = []
+    monkeypatch.setattr(
+        module,
+        "validate_local_gguf",
+        lambda _path: (_ for _ in ()).throw(ValueError("private path detail")),
+    )
+    monkeypatch.setattr(
+        module.importlib,
+        "import_module",
+        lambda name: imports.append(name),
+    )
+
+    with pytest.raises(module.TranscribeCppFailure) as raised:
+        module.transcribe_file(
+            audio_path=audio_path,
+            model_path=model_path,
+            attempt_id="attempt-1",
+            language="en",
+        )
+
+    assert raised.value.code.value == "artifact_incompatible"
+    assert raised.value.actions == ("choose_another_gguf", "retry_faster_whisper")
+    assert imports == []
+
+
 def test_native_import_failure_is_sanitized_and_path_private(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -181,6 +287,14 @@ def test_native_import_failure_is_sanitized_and_path_private(
     secret = tmp_path / "secret-model.gguf"
     audio_path = tmp_path / "audio.wav"
     _write_pcm_wav(audio_path)
+    monkeypatch.setattr(
+        module,
+        "validate_local_gguf",
+        lambda path: SimpleNamespace(
+            path=path,
+            metadata=SimpleNamespace(architecture="whisper"),
+        ),
+    )
 
     def unavailable(_name: str) -> object:
         raise ImportError(f"bad ABI near {secret}")
@@ -199,6 +313,11 @@ def test_native_import_failure_is_sanitized_and_path_private(
     assert str(secret) not in str(raised.value)
     assert str(secret) not in repr(raised.value)
     assert "bad ABI" not in str(raised.value)
+    rendered = "".join(
+        traceback.format_exception(raised.type, raised.value, raised.tb)
+    )
+    assert str(secret) not in rendered
+    assert "bad ABI" not in rendered
 
 
 def test_native_model_load_failure_closes_nothing_and_never_leaks_path(
@@ -239,4 +358,9 @@ def test_native_model_load_failure_closes_nothing_and_never_leaks_path(
     assert raised.value.actions == ("choose_another_gguf", "retry_faster_whisper")
     assert str(secret) not in str(raised.value)
     assert str(secret) not in repr(raised.value)
+    rendered = "".join(
+        traceback.format_exception(raised.type, raised.value, raised.tb)
+    )
+    assert str(secret) not in rendered
+    assert "native load failed" not in rendered
     assert [name for name, _value in calls] == ["model"]

--- a/Tests/STT/test_transcribe_cpp_config.py
+++ b/Tests/STT/test_transcribe_cpp_config.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.STT import transcribe_cpp_config
+
+
+def test_configure_model_path_admits_then_writes_only_dedicated_key(
+    tmp_path, monkeypatch
+):
+    selected = tmp_path / "private-model.gguf"
+    admitted = selected.absolute()
+    calls: list[object] = []
+
+    monkeypatch.setattr(
+        transcribe_cpp_config,
+        "validate_local_gguf",
+        lambda path: calls.append(("validate", path)) or SimpleNamespace(path=admitted),
+    )
+    monkeypatch.setattr(
+        transcribe_cpp_config,
+        "save_settings_to_cli_config",
+        lambda values: calls.append(("save", values)) or True,
+    )
+
+    transcribe_cpp_config.configure_model_path(selected)
+
+    assert calls == [
+        ("validate", selected),
+        (
+            "save",
+            {"transcription.transcribe_cpp": {"model_path": str(admitted)}},
+        ),
+    ]
+
+
+def test_configure_model_path_does_not_persist_failed_admission(tmp_path, monkeypatch):
+    selected = tmp_path / "private-model.gguf"
+
+    def save(_values):
+        pytest.fail("invalid GGUF must not be persisted")
+
+    monkeypatch.setattr(
+        transcribe_cpp_config,
+        "validate_local_gguf",
+        lambda _path: (_ for _ in ()).throw(ValueError("invalid model")),
+    )
+    monkeypatch.setattr(transcribe_cpp_config, "save_settings_to_cli_config", save)
+
+    with pytest.raises(ValueError, match="invalid model"):
+        transcribe_cpp_config.configure_model_path(selected)
+
+
+def test_configure_model_path_uses_path_safe_persistence_failure(tmp_path, monkeypatch):
+    selected = tmp_path / "private-model.gguf"
+    monkeypatch.setattr(
+        transcribe_cpp_config,
+        "validate_local_gguf",
+        lambda _path: SimpleNamespace(path=selected.absolute()),
+    )
+    monkeypatch.setattr(
+        transcribe_cpp_config, "save_settings_to_cli_config", lambda _values: False
+    )
+
+    with pytest.raises(transcribe_cpp_config.TranscribeCppConfigError) as exc_info:
+        transcribe_cpp_config.configure_model_path(selected)
+
+    assert str(selected) not in str(exc_info.value)
+    assert str(selected) not in repr(exc_info.value)
+
+
+def test_gguf_filter_accepts_only_gguf_suffix():
+    assert transcribe_cpp_config.is_gguf_file(Path("model.GGUF"))
+    assert not transcribe_cpp_config.is_gguf_file(Path("model.bin"))

--- a/Tests/Transcription/test_stt_batch_routing.py
+++ b/Tests/Transcription/test_stt_batch_routing.py
@@ -105,6 +105,28 @@ def test_exact_faster_whisper_retains_requested_language_and_task() -> None:
     assert route.target_language == "en"
 
 
+@pytest.mark.parametrize("language", [None, "", "en", "DE", "auto"])
+def test_transcribe_cpp_is_an_exact_manual_only_route(language: str | None) -> None:
+    route = resolve_batch_stt_route(provider="transcribe-cpp", language=language)
+
+    assert route.requested_provider == "transcribe-cpp"
+    assert route.provider == "transcribe-cpp"
+    assert route.model is None
+    assert route.requested_language == (language or "en").strip().lower() or "en"
+    assert route.precision == "native"
+    assert route.local_files_only is True
+    assert route.reason == "explicit_transcribe_cpp"
+
+
+def test_transcribe_cpp_rejects_translation_without_fallback() -> None:
+    with pytest.raises(BatchSTTRoutingError, match="does not support translation"):
+        resolve_batch_stt_route(
+            provider="transcribe-cpp",
+            language="de",
+            target_language="en",
+        )
+
+
 @pytest.mark.parametrize(
     ("provider", "parakeet_defaults_enabled"),
     [

--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -44,6 +44,7 @@ class _MessageRecordingHost(App):
         self.option_changes: list[LibraryIngestCanvas.OptionValueChanged] = []
         self.panel_toggles: list[LibraryIngestCanvas.OptionPanelToggled] = []
         self.parakeet_install_requests = 0
+        self.transcribe_cpp_gguf_requests = 0
 
     def compose(self) -> ComposeResult:
         yield LibraryIngestCanvas(self._state, id="library-ingest-canvas")
@@ -61,6 +62,12 @@ class _MessageRecordingHost(App):
         self, _event: LibraryIngestCanvas.ParakeetInstallRequested
     ) -> None:
         self.parakeet_install_requests += 1
+
+    @on(LibraryIngestCanvas.TranscribeCppGGUFRequested)
+    def _record_transcribe_cpp_gguf_request(
+        self, _event: LibraryIngestCanvas.TranscribeCppGGUFRequested
+    ) -> None:
+        self.transcribe_cpp_gguf_requests += 1
 
 
 def _default_form() -> LibraryIngestFormState:
@@ -702,6 +709,78 @@ async def test_retry_button_hidden_for_unsupported_file_type():
         assert len(pilot.app.query("#library-ingest-retry-ingest-job-1")) == 0
         # The structured-error surface is still available.
         assert pilot.app.query_one("#library-ingest-details-ingest-job-1", Button)
+
+
+@pytest.mark.asyncio
+async def test_transcribe_cpp_failure_renders_only_eligible_recovery_actions():
+    job = LibraryIngestJob(
+        job_id="ingest-job-1",
+        source_path="/private/voice.wav",
+        state=IngestJobState.FAILED,
+        error="The selected GGUF cannot be used by transcribe.cpp.",
+        permanent=False,
+        error_detail={
+            "category": "stt_failure",
+            "code": "artifact_incompatible",
+            "message": "The selected GGUF cannot be used by transcribe.cpp.",
+            "actions": ["choose_another_gguf", "retry_faster_whisper"],
+        },
+    )
+    state = build_library_ingest_state((job,), form=_default_form())
+    app = _CanvasHost(state)
+
+    async with app.run_test() as pilot:
+        choose = pilot.app.query_one(
+            "#library-ingest-choose-gguf-ingest-job-1", Button
+        )
+        retry = pilot.app.query_one(
+            "#library-ingest-retry-faster-whisper-ingest-job-1", Button
+        )
+        assert "Choose another GGUF" in str(choose.label)
+        assert str(retry.label) == "Retry with faster-whisper"
+        assert not list(pilot.app.query("#library-ingest-retry-ingest-job-1"))
+
+
+@pytest.mark.asyncio
+async def test_transcribe_cpp_provider_shows_path_free_configured_picker():
+    form = _default_form()
+    form.type_options = {
+        "audio_video": {"transcription_provider": "transcribe-cpp"}
+    }
+    state = build_library_ingest_state(
+        (),
+        form=form,
+        preflight=PreflightResult(
+            type_groups={"audio_video": ["/tmp/voice.wav"]},
+            warnings=[],
+            errors=[],
+            total_size=1,
+            truncated=False,
+            total_files=1,
+        ),
+        transcribe_cpp_configured=True,
+    )
+    app = _MessageRecordingHost(state)
+
+    with patch(
+        "tldw_chatbook.Widgets.Library.library_ingest_canvas._is_installed",
+        return_value=True,
+    ):
+        async with app.run_test() as pilot:
+            button = pilot.app.query_one(
+                "#opt-audio_video-choose-transcribe-cpp-gguf", Button
+            )
+            status = pilot.app.query_one(
+                "#opt-audio_video-transcribe-cpp-status", Static
+            )
+            assert "Choose another GGUF" in str(button.label)
+            assert "configured" in str(status.renderable).lower()
+            assert "/" not in str(status.renderable)
+
+            button.press()
+            await pilot.pause()
+
+    assert app.transcribe_cpp_gguf_requests == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_screen.py
+++ b/Tests/UI/test_library_screen.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Library.library_ingest_jobs import (
 )
 from tldw_chatbook.Library.library_ingest_state import LibraryIngestFormState
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from Tests.UI.test_library_shell import (
     LIBRARY_TEST_SIZE,
     LibraryHarness,
@@ -50,6 +51,7 @@ def _minimal_ingest_screen() -> LibraryScreen:
     """Return a LibraryScreen instance without mounting the full UI."""
     screen = object.__new__(LibraryScreen)
     screen._library_ingest_form = LibraryIngestFormState()
+    screen._transcribe_cpp_configured = False
     # Set by ``__init__``, which this shortcut bypasses.
     screen._library_ingest_preflight_worker = None
     return screen
@@ -184,6 +186,7 @@ def test_load_ingest_options_from_config(monkeypatch) -> None:
         ("library.ingest_options.pdf", "pdf_engine"): "docling",
         ("library.ingest_options.pdf", "ocr"): True,
         ("library.ingest_options.audio_video", "transcription_model"): "small",
+        ("transcription.transcribe_cpp", "model_path"): "/private/model.gguf",
     }
 
     def fake_get_cli_setting(section: str, key: str = None, default: object = None):
@@ -203,6 +206,75 @@ def test_load_ingest_options_from_config(monkeypatch) -> None:
     assert screen._library_ingest_form.type_options["audio_video"] == {
         "transcription_model": "small"
     }
+    assert screen._transcribe_cpp_configured is True
+    assert "/private/model.gguf" not in repr(screen._library_ingest_form)
+
+
+def test_transcribe_cpp_picker_filters_to_gguf() -> None:
+    filters = library_screen_module._transcribe_cpp_gguf_filters()
+
+    assert filters.selections == [("GGUF models", 0)]
+    assert filters[0](Path("model.gguf"))
+    assert not filters[0](Path("model.bin"))
+
+
+def test_transcribe_cpp_config_worker_reports_path_free_success(
+    tmp_path, monkeypatch
+) -> None:
+    screen = _minimal_ingest_screen()
+    selected = tmp_path / "private-model.gguf"
+    configured: list[Path] = []
+    fake_app = MagicMock()
+    monkeypatch.setattr(
+        LibraryScreen, "app", property(lambda _self: fake_app)
+    )
+    monkeypatch.setattr(
+        library_screen_module,
+        "configure_transcribe_cpp_model_path",
+        lambda path: configured.append(path),
+    )
+    screen._apply_transcribe_cpp_gguf_result = MagicMock()
+
+    LibraryScreen._configure_transcribe_cpp_gguf.__wrapped__(
+        screen, selected, retry_job_id="ingest-job-1"
+    )
+
+    assert configured == [selected]
+    fake_app.call_from_thread.assert_called_once_with(
+        screen._apply_transcribe_cpp_gguf_result,
+        True,
+        "ingest-job-1",
+    )
+    assert str(selected) not in repr(fake_app.call_from_thread.call_args)
+
+
+def test_transcribe_cpp_config_success_requeues_failed_job_without_path() -> None:
+    screen = _minimal_ingest_screen()
+    screen.app_instance = MagicMock()
+    screen.refresh = MagicMock()
+
+    screen._apply_transcribe_cpp_gguf_result(True, "ingest-job-1")
+
+    screen.app_instance.retry_library_ingest_job.assert_called_once_with(
+        "ingest-job-1"
+    )
+    assert screen._transcribe_cpp_configured is True
+    assert "GGUF configured" in screen.app_instance.notify.call_args.args[0]
+
+
+def test_faster_whisper_recovery_handler_uses_explicit_provider() -> None:
+    screen = _minimal_ingest_screen()
+    screen.app_instance = MagicMock()
+    screen.refresh = MagicMock()
+    event = MagicMock()
+    event.button.id = "library-ingest-retry-faster-whisper-ingest-job-1"
+
+    screen.handle_library_ingest_retry_faster_whisper(event)
+
+    event.stop.assert_called_once_with()
+    screen.app_instance.retry_library_ingest_job_with_provider.assert_called_once_with(
+        "ingest-job-1", "faster-whisper"
+    )
 
 
 # ----- Pre-flight retry (Task 18) -------------------------------------------

--- a/Tests/Wizards/test_first_run_speech_step.py
+++ b/Tests/Wizards/test_first_run_speech_step.py
@@ -165,6 +165,55 @@ async def test_compose_shows_recommended_defaults_and_disables_unavailable_optio
         assert not any(str(b.label).upper().startswith("INT8") for b in disabled)
 
 
+@pytest.mark.asyncio
+async def test_compose_exposes_path_free_existing_gguf_configuration():
+    wizard = _wizard(
+        app_instance=MagicMock(
+            app_config={
+                "transcription": {
+                    "transcribe_cpp": {"model_path": "/private/model.gguf"}
+                }
+            }
+        )
+    )
+    step = _step(wizard=wizard)
+    app = _StepHost(step)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        button = step.query_one("#setup-speech-choose-transcribe-cpp-gguf", Button)
+        status = step.query_one("#setup-speech-transcribe-cpp-status", Static)
+        assert "Choose another GGUF" in str(button.label)
+        assert "configured" in str(status.renderable).lower()
+        assert "/private/model.gguf" not in str(status.renderable)
+
+
+def test_transcribe_cpp_config_worker_reports_path_free_success(
+    tmp_path, monkeypatch
+):
+    import tldw_chatbook.UI.Wizards.FirstRunSetupWizard as wizard_module
+
+    selected = tmp_path / "private-model.gguf"
+    configured: list[Path] = []
+    fake_app = _patch_app(monkeypatch)
+    monkeypatch.setattr(
+        wizard_module,
+        "configure_transcribe_cpp_model_path",
+        lambda path: configured.append(path),
+    )
+    step = _step()
+    step._apply_transcribe_cpp_gguf_result = MagicMock()
+
+    SpeechSetupStep._configure_transcribe_cpp_gguf.__wrapped__(step, selected)
+
+    assert configured == [selected]
+    fake_app.call_from_thread.assert_called_once_with(
+        step._apply_transcribe_cpp_gguf_result,
+        True,
+    )
+    assert str(selected) not in repr(fake_app.call_from_thread.call_args)
+
+
 def test_compose_step_alone_does_no_io():
     """compose_step() itself (before any I/O-triggering lifecycle hook runs)
     must build entirely from pure catalog/curated-registry state -- neither

--- a/backlog/tasks/task-604 - Add-direct-local-transcribe.cpp-batch-STT-provider.md
+++ b/backlog/tasks/task-604 - Add-direct-local-transcribe.cpp-batch-STT-provider.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-604
 title: Add direct-local transcribe.cpp batch STT provider
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-24 01:04'
+updated_date: '2026-08-02 22:00'
 labels:
   - stt
   - gguf
@@ -37,3 +39,17 @@ Let a user choose an existing local GGUF and complete real Library audio/video b
 - [ ] #6 transcribe.cpp never participates in semantic default routing or silent fallback. Worker failures extend the existing bounded `error_detail` payload with a path-safe STT failure code and only eligible `choose_another_gguf` and `retry_faster_whisper` actions; the parent job record and Library failure UI preserve those actions, including the explicit provenance-linked **Retry with faster-whisper** flow.
 - [ ] #7 Focused tests cover picker/config restart, key-only persistence, the complete production Library ingestion path, worker-side revalidation, lazy import, final ABI probe, load-before-seal capability equality, typed failure/action propagation, native path redaction, crash containment, shutdown, and package-resolution/provider smoke for all five released OS/CPU wheel lanes including Linux ABI coverage.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add the exact optional pin and a lazy single-job transcribe.cpp adapter; revalidate before one native load, derive authoritative capabilities, seal the per-job registry, and normalize output through the existing coordinator.
+2. Carry the direct-local request, normalized provenance, and a bounded path-safe failure envelope through the existing spawn parser and parent writer for audio/video.
+3. Add exact manual-only batch routing plus an explicit faster-whisper retry override that preserves existing job/attempt lineage.
+4. Add the Library and first-run Choose GGUF picker, off-loop admission, dedicated key-only config persistence, and the two bounded recovery actions.
+5. Run only focused TASK-604 tests/static checks, self-review the branch diff, and document completion.
+
+ADR required: no
+ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md and backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md
+Reason: the accepted ADRs already govern the provider/runtime boundary, direct-local configuration, worker revalidation, provenance, and explicit no-managed-store/no-resident-executor scope.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-604 - Add-direct-local-transcribe.cpp-batch-STT-provider.md
+++ b/backlog/tasks/task-604 - Add-direct-local-transcribe.cpp-batch-STT-provider.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-02 22:51'
+updated_date: '2026-08-02 23:05'
 labels:
   - stt
   - gguf
@@ -62,4 +62,6 @@ Implemented the direct-local transcribe.cpp Library batch provider without addin
 Review hardening added Vulkan provenance for the default Linux/Windows backend, CPU-accelerator aliases, token-to-word timestamp capability normalization, admission-before-runtime failure ordering, missing-config recovery, and traceback-level native path redaction. Existing ADR-025 and ADR-041 remain authoritative; no new ADR was required.
 
 Focused verification: 307 TASK-604/shared-contract cases passed. Ruff passed for modified scope (legacy FirstRun E402/F401 and two unrelated Library-runner F841/F401 findings were isolated and not changed); py_compile, TOML parsing, and git diff --check passed. Published 0.1.3 package metadata was checked for macOS arm64/x86_64, Linux aarch64/x86_64 manylinux, and Windows x86_64 wheels. Windows/Linux native execution was unavailable locally, so that platform gate remains preserved and is not claimed as executed.
+
+Post-review remediation: rebased cleanly onto origin/dev at c53880843; aligned inference_seconds and total_seconds to the same wall-clock basis, completed Google-style public API docstrings, and documented why the worker-local native import intentionally bypasses optional_deps so ABI/backend failures remain sanitized. Re-ran the focused TASK-604 suite after the rebase: 307 passed; scoped Ruff, py_compile, TOML parsing, and diff checks passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-604 - Add-direct-local-transcribe.cpp-batch-STT-provider.md
+++ b/backlog/tasks/task-604 - Add-direct-local-transcribe.cpp-batch-STT-provider.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-604
 title: Add direct-local transcribe.cpp batch STT provider
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-24 01:04'
-updated_date: '2026-08-02 22:00'
+updated_date: '2026-08-02 22:51'
 labels:
   - stt
   - gguf
@@ -31,13 +31,13 @@ Let a user choose an existing local GGUF and complete real Library audio/video b
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The optional extra pins transcribe.cpp 0.1.3 exactly, imports it only inside the spawn-isolated ingestion worker, and reports final wheel/ABI or runtime unavailability without affecting application startup.
-- [ ] #2 Provider settings expose **Choose GGUF…**, validate the selection off the Textual event loop, persist only `[transcription.transcribe_cpp] model_path` through key-only atomic config persistence, and never log or generically render the path value.
-- [ ] #3 The real Library audio/video ingest form offers the exact manual `transcribe-cpp` provider, and a submitted job reaches the production spawn worker, parent-side writer, persisted transcript, and normalized provenance rather than stopping at adapter-only wiring.
-- [ ] #4 Inside the worker, TASK-597 admission reruns immediately before a single native model load; the worker then reads authoritative capabilities, constructs the exact per-job declaration and sealed registry, and coordinator preflight equality-checks that already-loaded observation before inference. Missing, changed, symlinked, malformed, incompatible, or unsupported files fail clearly with **Choose another GGUF…** recovery.
-- [ ] #5 The adapter normalizes required 16 kHz mono audio, obeys the existing one-heavy-job gate, returns precise normalized results with `model_id=local-gguf:<allowlisted-architecture>`, null artifact identity, and no local path, runtime-version schema addition, or raw native exception in provenance, logs, result representations, or generic errors.
-- [ ] #6 transcribe.cpp never participates in semantic default routing or silent fallback. Worker failures extend the existing bounded `error_detail` payload with a path-safe STT failure code and only eligible `choose_another_gguf` and `retry_faster_whisper` actions; the parent job record and Library failure UI preserve those actions, including the explicit provenance-linked **Retry with faster-whisper** flow.
-- [ ] #7 Focused tests cover picker/config restart, key-only persistence, the complete production Library ingestion path, worker-side revalidation, lazy import, final ABI probe, load-before-seal capability equality, typed failure/action propagation, native path redaction, crash containment, shutdown, and package-resolution/provider smoke for all five released OS/CPU wheel lanes including Linux ABI coverage.
+- [x] #1 The optional extra pins transcribe.cpp 0.1.3 exactly, imports it only inside the spawn-isolated ingestion worker, and reports final wheel/ABI or runtime unavailability without affecting application startup.
+- [x] #2 Provider settings expose **Choose GGUF…**, validate the selection off the Textual event loop, persist only `[transcription.transcribe_cpp] model_path` through key-only atomic config persistence, and never log or generically render the path value.
+- [x] #3 The real Library audio/video ingest form offers the exact manual `transcribe-cpp` provider, and a submitted job reaches the production spawn worker, parent-side writer, persisted transcript, and normalized provenance rather than stopping at adapter-only wiring.
+- [x] #4 Inside the worker, TASK-597 admission reruns immediately before a single native model load; the worker then reads authoritative capabilities, constructs the exact per-job declaration and sealed registry, and coordinator preflight equality-checks that already-loaded observation before inference. Missing, changed, symlinked, malformed, incompatible, or unsupported files fail clearly with **Choose another GGUF…** recovery.
+- [x] #5 The adapter normalizes required 16 kHz mono audio, obeys the existing one-heavy-job gate, returns precise normalized results with `model_id=local-gguf:<allowlisted-architecture>`, null artifact identity, and no local path, runtime-version schema addition, or raw native exception in provenance, logs, result representations, or generic errors.
+- [x] #6 transcribe.cpp never participates in semantic default routing or silent fallback. Worker failures extend the existing bounded `error_detail` payload with a path-safe STT failure code and only eligible `choose_another_gguf` and `retry_faster_whisper` actions; the parent job record and Library failure UI preserve those actions, including the explicit provenance-linked **Retry with faster-whisper** flow.
+- [x] #7 Focused tests cover picker/config restart, key-only persistence, the complete production Library ingestion path, worker-side revalidation, lazy import, final ABI probe, load-before-seal capability equality, typed failure/action propagation, native path redaction, crash containment, shutdown, and package-resolution/provider smoke for all five released OS/CPU wheel lanes including Linux ABI coverage.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -53,3 +53,13 @@ ADR required: no
 ADR path: backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md and backlog/decisions/041-direct-local-gguf-before-managed-acquisition.md
 Reason: the accepted ADRs already govern the provider/runtime boundary, direct-local configuration, worker revalidation, provenance, and explicit no-managed-store/no-resident-executor scope.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the direct-local transcribe.cpp Library batch provider without adding managed acquisition or a resident executor. The optional extra pins transcribe-cpp 0.1.3; worker execution revalidates the selected GGUF, lazily imports and ABI-checks the runtime, loads once, derives exact capabilities, routes through the sealed STT coordinator, persists normalized transcript/provenance, and closes the model. Library and first-run surfaces now provide a path-private GGUF picker, and failures retain only allowlisted Choose another GGUF / Retry with faster-whisper actions with retry lineage.
+
+Review hardening added Vulkan provenance for the default Linux/Windows backend, CPU-accelerator aliases, token-to-word timestamp capability normalization, admission-before-runtime failure ordering, missing-config recovery, and traceback-level native path redaction. Existing ADR-025 and ADR-041 remain authoritative; no new ADR was required.
+
+Focused verification: 307 TASK-604/shared-contract cases passed. Ruff passed for modified scope (legacy FirstRun E402/F401 and two unrelated Library-runner F841/F401 findings were isolated and not changed); py_compile, TOML parsing, and git diff --check passed. Published 0.1.3 package metadata was checked for macOS arm64/x86_64, Linux aarch64/x86_64 manylinux, and Windows x86_64 wheels. Windows/Linux native execution was unavailable locally, so that platform gate remains preserved and is not claimed as executed.
+<!-- SECTION:NOTES:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ transcription_faster_whisper = [
 transcription_parakeet_onnx = [
     "onnx-asr[cpu]==0.12.0",  # Cross-platform Parakeet ONNX runtime
 ]
+transcription_transcribe_cpp = [
+    "transcribe-cpp==0.1.3",  # Optional direct-local GGUF runtime
+]
 transcription_lightning_whisper = [
     "lightning-whisper-mlx; sys_platform == 'darwin'",  # Fast Whisper for Apple Silicon
 ]

--- a/tldw_chatbook/Library/ingest_capabilities.py
+++ b/tldw_chatbook/Library/ingest_capabilities.py
@@ -345,7 +345,12 @@ _TYPE_GROUPS: dict[str, TypeGroupCapabilities] = {
                 label="Transcription provider",
                 type="select",
                 default="default",
-                options=("default", "parakeet-onnx", "faster-whisper"),
+                options=(
+                    "default",
+                    "parakeet-onnx",
+                    "faster-whisper",
+                    "transcribe-cpp",
+                ),
                 depends_on="audio_processing",
             ),
             OptionField(

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -890,7 +890,12 @@ class LibraryIngestJobRegistry:
         self._persist(updated)
         return _copy_job(updated)
 
-    def requeue(self, job_id: str) -> LibraryIngestJob | None:
+    def requeue(
+        self,
+        job_id: str,
+        *,
+        ingest_options: dict[str, Any] | None = None,
+    ) -> LibraryIngestJob | None:
         """Append a fresh ``QUEUED`` copy of a ``FAILED`` job, superseding it.
 
         Only works on a ``FAILED``, not-yet-hidden, not-``permanent`` job --
@@ -920,6 +925,9 @@ class LibraryIngestJobRegistry:
 
         Args:
             job_id: The failed job to requeue.
+            ingest_options: Optional replacement option snapshot for an explicit
+                user-selected recovery action. Omitted retries preserve the
+                source snapshot unchanged.
 
         Returns:
             The newly appended ``QUEUED`` job (a copy), or ``None`` when
@@ -952,7 +960,9 @@ class LibraryIngestJobRegistry:
             chunk_enabled=source.chunk_enabled,
             chunk_size=source.chunk_size,
             detected_type=source.detected_type,
-            ingest_options=source.ingest_options,
+            ingest_options=deepcopy(
+                source.ingest_options if ingest_options is None else ingest_options
+            ),
             state=IngestJobState.QUEUED,
             submitted_at=time.monotonic(),
             retry_count=source.retry_count + 1,

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -442,6 +442,8 @@ class LibraryIngestCanvasState:
             from the registry snapshot, limited to 10. Dismissed jobs are
             intentionally excluded because the registry's ``jobs()`` snapshot
             already filters them out.
+        transcribe_cpp_configured: Whether a dedicated local GGUF path exists.
+            The path itself never enters this render state.
     """
 
     header: str
@@ -477,6 +479,7 @@ class LibraryIngestCanvasState:
     #: Whether to offer switching backends -- only meaningful when a
     #: server is actually configured.
     show_backend_switch: bool = False
+    transcribe_cpp_configured: bool = False
 
 
 def _basename(source_path: str) -> str:
@@ -739,6 +742,7 @@ def build_library_ingest_state(
     preflight_checking: bool | None = None,
     ingest_backend: str = "local",
     server_ingest_available: bool = False,
+    transcribe_cpp_configured: bool = False,
 ) -> LibraryIngestCanvasState:
     """Build the ingest canvas's full display state.
 
@@ -765,6 +769,8 @@ def build_library_ingest_state(
         preflight_checking: Whether a pre-flight analysis is currently in
             progress. When ``None`` (the default), the value is taken from
             ``form.preflight_checking``.
+        transcribe_cpp_configured: Whether the dedicated direct-local model
+            setting exists. Only the boolean reaches render state.
 
     Returns:
         The canvas's full display state.
@@ -889,6 +895,7 @@ def build_library_ingest_state(
         type_groups=type_groups_list,
         unsupported_files=unsupported_files,
         recent_jobs=recent_jobs,
+        transcribe_cpp_configured=transcribe_cpp_configured,
     )
 
 

--- a/tldw_chatbook/Local_Ingestion/audio_processing.py
+++ b/tldw_chatbook/Local_Ingestion/audio_processing.py
@@ -716,7 +716,7 @@ class LocalAudioProcessor:
                 attempt_id = f"direct-local-{uuid.uuid4().hex}"
             normalized = transcribe_file(
                 audio_path=Path(audio_path),
-                model_path=Path(model_path) if model_path else Path(),
+                model_path=Path(model_path) if model_path else None,
                 attempt_id=attempt_id,
                 batch_id=kwargs.get("batch_id"),
                 job_id=kwargs.get("job_id"),

--- a/tldw_chatbook/Local_Ingestion/audio_processing.py
+++ b/tldw_chatbook/Local_Ingestion/audio_processing.py
@@ -319,11 +319,50 @@ class LocalAudioProcessor:
         transcription_batch_route_resolved: bool = False,
         transcription_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        """
-        Process multiple audio inputs (URLs or local files).
+        """Process multiple audio inputs from URLs or local files.
+
+        Args:
+            inputs: Audio URLs or local file paths to process.
+            transcription_provider: Exact STT provider or semantic default.
+            transcription_model: Provider-specific model identifier.
+            transcription_model_dir: Optional local model directory.
+            transcription_language: Language code or ``auto``.
+            translation_target_language: Optional translation target language.
+            perform_chunking: Whether to chunk the resulting transcript.
+            chunk_method: Optional transcript chunking strategy.
+            max_chunk_size: Maximum chunk size for the selected strategy.
+            chunk_overlap: Requested overlap between adjacent chunks.
+            use_adaptive_chunking: Whether to enable adaptive chunk sizing.
+            use_multi_level_chunking: Whether to emit multiple chunk levels.
+            chunk_language: Optional language hint for chunking.
+            diarize: Whether to request speaker diarization.
+            vad_use: Whether to request voice activity detection.
+            timestamp_option: Whether to request transcript timestamps.
+            start_time: Optional media start-time bound.
+            end_time: Optional media end-time bound.
+            perform_analysis: Whether to analyze the transcript after STT.
+            api_name: Optional analysis provider identifier.
+            api_key: Optional analysis provider credential.
+            custom_prompt: Optional analysis user prompt.
+            system_prompt: Optional analysis system prompt.
+            summarize_recursively: Whether to recursively summarize chunks.
+            use_cookies: Whether media download may use configured cookies.
+            cookies: Optional cookies source for media download.
+            keep_original: Whether to retain the normalized audio artifact.
+            custom_title: Optional title override.
+            author: Optional author override.
+            temp_dir: Optional caller-owned processing directory.
+            transcription_progress_callback: Optional STT progress callback.
+            transcription_precision: Optional normalized precision choice.
+            transcription_local_files_only: Whether network model access is
+                forbidden for this route.
+            transcription_batch_route_resolved: Whether Library routing already
+                resolved provider/model semantics.
+            transcription_context: Optional worker-private direct-local model
+                path and retry-lineage values.
 
         Returns:
-            Dict with processing results
+            A dictionary containing per-input processing results and errors.
         """
         results = []
         errors = []

--- a/tldw_chatbook/Local_Ingestion/audio_processing.py
+++ b/tldw_chatbook/Local_Ingestion/audio_processing.py
@@ -317,6 +317,7 @@ class LocalAudioProcessor:
         transcription_precision: Optional[str] = None,
         transcription_local_files_only: bool = False,
         transcription_batch_route_resolved: bool = False,
+        transcription_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Process multiple audio inputs (URLs or local files).
@@ -354,6 +355,7 @@ class LocalAudioProcessor:
                         transcription_precision=transcription_precision,
                         transcription_local_files_only=transcription_local_files_only,
                         transcription_batch_route_resolved=transcription_batch_route_resolved,
+                        transcription_context=transcription_context,
                         perform_chunking=perform_chunking,
                         chunk_method=chunk_method,
                         max_chunk_size=max_chunk_size,
@@ -497,6 +499,23 @@ class LocalAudioProcessor:
             transcription_start = time.time()
             try:
                 logger.info("[AUDIO] Calling _transcribe_audio()")
+                context = kwargs.get("transcription_context") or {}
+                direct_local_kwargs = (
+                    {
+                        "model_path": context.get("model_path"),
+                        "attempt_id": context.get("attempt_id"),
+                        "batch_id": context.get("batch_id"),
+                        "job_id": context.get("job_id"),
+                        "retry_of_attempt_id": context.get("retry_of_attempt_id"),
+                        "retry_of_job_id": context.get("retry_of_job_id"),
+                        "retry_source_failure_provenance": context.get(
+                            "retry_source_failure_provenance"
+                        ),
+                        "timestamps": kwargs.get("timestamp_option", True),
+                    }
+                    if provider == "transcribe-cpp"
+                    else {}
+                )
                 transcription_result = self._transcribe_audio(
                     audio_path,
                     provider=provider,
@@ -514,12 +533,20 @@ class LocalAudioProcessor:
                     vad_filter=kwargs.get("vad_use", False),
                     diarize=kwargs.get("diarize", False),
                     progress_callback=transcription_progress_callback,
+                    **direct_local_kwargs,
                 )
                 logger.info("[AUDIO] _transcribe_audio() returned successfully")
             except Exception as e:
-                logger.opt(exception=True).error(
-                    f"[AUDIO] Transcription failed: {type(e).__name__}: {str(e)}"
-                )
+                error_detail = getattr(e, "error_detail", None)
+                if isinstance(error_detail, dict):
+                    logger.error(
+                        "[AUDIO] Direct-local transcription failed: code={}",
+                        error_detail.get("code", "inference_failed"),
+                    )
+                else:
+                    logger.opt(exception=True).error(
+                        f"[AUDIO] Transcription failed: {type(e).__name__}: {str(e)}"
+                    )
                 raise
 
             transcription_time = time.time() - transcription_start
@@ -550,6 +577,12 @@ class LocalAudioProcessor:
 
             result["segments"] = transcription_result.get("segments", [])
             result["content"] = transcription_result.get("text", "")
+            result["transcription_model"] = transcription_result.get(
+                "transcription_model"
+            )
+            result["transcription_provenance"] = transcription_result.get(
+                "transcription_provenance"
+            )
 
             logger.info(
                 f"[AUDIO] Final result content length: {len(result['content'])} chars, segments: {len(result['segments'])}"
@@ -637,9 +670,21 @@ class LocalAudioProcessor:
                     result["warnings"].append(f"Could not save audio file: {str(e)}")
 
         except Exception as e:
-            logger.opt(exception=True).error(f"Error processing audio: {str(e)}")
+            error_detail = getattr(e, "error_detail", None)
+            if isinstance(error_detail, dict):
+                logger.error(
+                    "[AUDIO] Direct-local processing failed: code={}",
+                    error_detail.get("code", "inference_failed"),
+                )
+            else:
+                logger.opt(exception=True).error(f"Error processing audio: {str(e)}")
             result["status"] = "Error"
             result["error"] = str(e)
+            if isinstance(error_detail, dict):
+                result["error_detail"] = error_detail
+            failed_attempt = getattr(e, "stt_failure_provenance", None)
+            if isinstance(failed_attempt, dict):
+                result["stt_failure_provenance"] = failed_attempt
 
         return result
 
@@ -658,6 +703,46 @@ class LocalAudioProcessor:
         logger.info(
             f"[AUDIO] Transcription kwargs: provider={kwargs.get('provider')}, model={kwargs.get('model')}, language={kwargs.get('language')}"
         )
+
+        if kwargs.get("provider") == "transcribe-cpp":
+            from tldw_chatbook.STT.persistence import (
+                build_transcription_provenance_document,
+            )
+            from tldw_chatbook.STT.transcribe_cpp import transcribe_file
+
+            model_path = kwargs.get("model_path")
+            attempt_id = kwargs.get("attempt_id")
+            if not isinstance(attempt_id, str) or not attempt_id:
+                attempt_id = f"direct-local-{uuid.uuid4().hex}"
+            normalized = transcribe_file(
+                audio_path=Path(audio_path),
+                model_path=Path(model_path) if model_path else Path(),
+                attempt_id=attempt_id,
+                batch_id=kwargs.get("batch_id"),
+                job_id=kwargs.get("job_id"),
+                retry_of_attempt_id=kwargs.get("retry_of_attempt_id"),
+                retry_of_job_id=kwargs.get("retry_of_job_id"),
+                language=kwargs.get("language") or "en",
+                timestamps=bool(kwargs.get("timestamps", True)),
+                ffmpeg_path=get_cli_setting("media_processing.ffmpeg_path"),
+            )
+            provenance = build_transcription_provenance_document(
+                normalized,
+                failed_attempt=kwargs.get("retry_source_failure_provenance"),
+            )
+            return {
+                "text": normalized.text,
+                "segments": [
+                    {
+                        "start": segment.start_seconds,
+                        "end": segment.end_seconds,
+                        "text": segment.text,
+                    }
+                    for segment in normalized.segments
+                ],
+                "transcription_model": normalized.provenance.model_id,
+                "transcription_provenance": provenance,
+            }
 
         # Wrap progress callback to check for cancellation
         def cancellable_progress_callback(progress, message, data=None):

--- a/tldw_chatbook/Local_Ingestion/ingest_parse_worker.py
+++ b/tldw_chatbook/Local_Ingestion/ingest_parse_worker.py
@@ -148,6 +148,8 @@ def run_parse_job(file_path: str, options: Dict[str, Any]) -> Dict[str, Any]:
     except Exception as exc:  # noqa: BLE001 - must never raise across the process boundary
         message = str(exc).strip() or exc.__class__.__name__
         permanent = classify_parse_failure(exc)
+        stt_error_detail = getattr(exc, "error_detail", None)
+        stt_failure_provenance = getattr(exc, "stt_failure_provenance", None)
         category = (
             "unsupported_file_type"
             if str(exc).strip().startswith("Unsupported file type")
@@ -155,14 +157,19 @@ def run_parse_job(file_path: str, options: Dict[str, Any]) -> Dict[str, Any]:
             if isinstance(exc, FileNotFoundError)
             else "parse_error"
         )
-        return {
+        failure = {
             "ok": False,
             "error": message,
             "permanent": permanent,
-            "error_detail": {
+            "error_detail": stt_error_detail
+            if isinstance(stt_error_detail, dict)
+            else {
                 "category": category,
                 "message": message,
                 "exception_type": exc.__class__.__name__,
             },
         }
+        if isinstance(stt_failure_provenance, dict):
+            failure["stt_failure_provenance"] = stt_failure_provenance
+        return failure
     return {"ok": True, "payload": payload}

--- a/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
+++ b/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
@@ -117,6 +117,21 @@ class PermanentIngestError(FileIngestionError):
     """
 
 
+class DirectLocalSTTIngestError(FileIngestionError):
+    """A sanitized direct-local STT failure crossing the spawn boundary."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_detail: dict[str, Any],
+        failed_attempt: dict[str, Any],
+    ) -> None:
+        self.error_detail = error_detail
+        self.stt_failure_provenance = failed_attempt
+        super().__init__(message)
+
+
 _VIDEO_URL_HOSTS = ("youtube.com", "youtu.be", "vimeo.com", "dailymotion.com")
 _VIDEO_EXTS = (
     ".mp4",
@@ -593,6 +608,7 @@ def parse_local_file_for_ingest(
                     "transcription_provider", "faster-whisper"
                 ),
                 transcription_model_dir=options.get("transcription_model_dir"),
+                transcription_context=options.get("transcription_context"),
                 transcription_model=options.get(
                     "transcription_model",
                     chunk_options.get("transcription_model", "base"),
@@ -633,6 +649,12 @@ def parse_local_file_for_ingest(
             if results["results"]:
                 result_data = results["results"][0]
                 if result_data["status"] == "Error":
+                    if result_data.get("error_detail", {}).get("category") == "stt_failure":
+                        raise DirectLocalSTTIngestError(
+                            result_data.get("error", "Speech-to-text failed."),
+                            error_detail=result_data["error_detail"],
+                            failed_attempt=result_data["stt_failure_provenance"],
+                        )
                     raise FileIngestionError(
                         f"Audio processing failed: {result_data.get('error', 'Unknown error')}"
                     )
@@ -647,6 +669,10 @@ def parse_local_file_for_ingest(
                     "chunks": result_data.get("chunks", []),
                     "analysis": result_data.get("analysis", ""),
                     "metadata": result_data.get("metadata", {}),
+                    "transcription_model": result_data.get("transcription_model"),
+                    "transcription_provenance": result_data.get(
+                        "transcription_provenance"
+                    ),
                 }
             else:
                 raise FileIngestionError("Audio processing returned no results")
@@ -664,6 +690,7 @@ def parse_local_file_for_ingest(
                     "transcription_provider", "faster-whisper"
                 ),
                 transcription_model_dir=options.get("transcription_model_dir"),
+                transcription_context=options.get("transcription_context"),
                 transcription_model=options.get(
                     "transcription_model",
                     chunk_options.get("transcription_model", "base"),
@@ -704,6 +731,12 @@ def parse_local_file_for_ingest(
             if results["results"]:
                 result_data = results["results"][0]
                 if result_data["status"] == "Error":
+                    if result_data.get("error_detail", {}).get("category") == "stt_failure":
+                        raise DirectLocalSTTIngestError(
+                            result_data.get("error", "Speech-to-text failed."),
+                            error_detail=result_data["error_detail"],
+                            failed_attempt=result_data["stt_failure_provenance"],
+                        )
                     raise FileIngestionError(
                         f"Video processing failed: {result_data.get('error', 'Unknown error')}"
                     )
@@ -718,6 +751,10 @@ def parse_local_file_for_ingest(
                     "chunks": result_data.get("chunks", []),
                     "analysis": result_data.get("analysis", ""),
                     "metadata": result_data.get("metadata", {}),
+                    "transcription_model": result_data.get("transcription_model"),
+                    "transcription_provenance": result_data.get(
+                        "transcription_provenance"
+                    ),
                 }
             else:
                 raise FileIngestionError("Video processing returned no results")
@@ -837,8 +874,12 @@ def parse_local_file_for_ingest(
             'metadata': media_metadata,
             'file_path': raw_source if is_url else str(file_path),
             'warnings': warnings,
+            'transcription_model': result.get('transcription_model'),
+            'transcription_provenance': result.get('transcription_provenance'),
         }
 
+    except DirectLocalSTTIngestError:
+        raise
     except PermanentIngestError:
         # keep the permanent classification intact for classify_parse_failure
         raise

--- a/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
+++ b/tldw_chatbook/Local_Ingestion/stt_batch_routing.py
@@ -11,6 +11,7 @@ PARAKEET_V3_MODEL = "nemo-parakeet-tdt-0.6b-v3"
 _DEFAULT_PROVIDER = "default"
 _FASTER_WHISPER_PROVIDER = "faster-whisper"
 _PARAKEET_PROVIDER = "parakeet-onnx"
+_TRANSCRIBE_CPP_PROVIDER = "transcribe-cpp"
 _AUTO_LANGUAGE = "auto"
 # Qodo review (task-1301 PR #1184): this set used to be a hand-duplicated
 # copy of tldw_chatbook.STT.routing's validated-v3 allowlist. Now sourced
@@ -81,6 +82,22 @@ def resolve_batch_stt_route(
             requested_provider,
             requested_language,
             normalized_target,
+        )
+
+    if requested_provider == _TRANSCRIBE_CPP_PROVIDER:
+        if normalized_target is not None:
+            raise BatchSTTRoutingError(
+                "transcribe-cpp does not support translation in Library batch ingest."
+            )
+        return BatchSTTRoute(
+            requested_provider=requested_provider,
+            provider=_TRANSCRIBE_CPP_PROVIDER,
+            model=None,
+            requested_language=requested_language,
+            target_language=None,
+            precision="native",
+            local_files_only=True,
+            reason="explicit_transcribe_cpp",
         )
 
     if requested_provider != _DEFAULT_PROVIDER:

--- a/tldw_chatbook/Local_Ingestion/video_processing.py
+++ b/tldw_chatbook/Local_Ingestion/video_processing.py
@@ -743,6 +743,20 @@ class LocalVideoProcessor:
                 logger.debug(
                     f"[VIDEO] Full audio result keys: {list(audio_result.keys()) if audio_result else 'None'}"
                 )
+                if audio_result.get("status") == "Error":
+                    result["status"] = "Error"
+                    result["error"] = audio_result.get(
+                        "error", "Speech-to-text failed."
+                    )
+                    if isinstance(audio_result.get("error_detail"), dict):
+                        result["error_detail"] = audio_result["error_detail"]
+                    if isinstance(
+                        audio_result.get("stt_failure_provenance"), dict
+                    ):
+                        result["stt_failure_provenance"] = audio_result[
+                            "stt_failure_provenance"
+                        ]
+                    return result
             else:
                 logger.error("[VIDEO] Audio processing failed - no result returned")
                 raise Exception("Audio processing failed - no result returned")
@@ -757,6 +771,12 @@ class LocalVideoProcessor:
                     "analysis": audio_result.get("analysis"),
                     "analysis_details": audio_result.get("analysis_details"),
                     "warnings": audio_result.get("warnings", []),
+                    "transcription_model": audio_result.get(
+                        "transcription_model"
+                    ),
+                    "transcription_provenance": audio_result.get(
+                        "transcription_provenance"
+                    ),
                 }
             )
 

--- a/tldw_chatbook/STT/contracts.py
+++ b/tldw_chatbook/STT/contracts.py
@@ -109,6 +109,7 @@ class ExecutionDevice(str, Enum):
     CPU = "cpu"
     CUDA = "cuda"
     METAL = "metal"
+    VULKAN = "vulkan"
 
 
 class DeviceFailureOrigin(str, Enum):

--- a/tldw_chatbook/STT/transcribe_cpp.py
+++ b/tldw_chatbook/STT/transcribe_cpp.py
@@ -52,6 +52,11 @@ from .routing import (
     build_builtin_registry,
     default_routing_policy,
 )
+from .persistence import (
+    FailedTranscriptionAttempt,
+    dump_failed_transcription_attempt,
+    load_failed_transcription_attempt,
+)
 
 
 PROVIDER_ID = "transcribe-cpp"
@@ -63,7 +68,13 @@ _RETRY_FASTER_WHISPER = "retry_faster_whisper"
 class TranscribeCppFailure(Exception):
     """Path-safe direct-local failure with bounded recovery actions."""
 
-    __slots__ = ("actions", "code", "model_id")
+    __slots__ = (
+        "actions",
+        "code",
+        "error_detail",
+        "model_id",
+        "stt_failure_provenance",
+    )
 
     def __init__(
         self,
@@ -71,11 +82,20 @@ class TranscribeCppFailure(Exception):
         *,
         model_id: str = "local-gguf:unavailable",
         actions: tuple[str, ...] = (),
+        failed_attempt: dict[str, Any] | None = None,
     ) -> None:
         self.code = code
         self.model_id = model_id
         self.actions = actions
-        super().__init__(_failure_message(code))
+        message = _failure_message(code)
+        self.error_detail = {
+            "category": "stt_failure",
+            "code": code.value,
+            "message": message,
+            "actions": list(actions),
+        }
+        self.stt_failure_provenance = failed_attempt
+        super().__init__(message)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(code={self.code.value!r})"
@@ -367,6 +387,35 @@ def _failure_actions(code: TranscriptionFailureCode) -> tuple[str, ...]:
     return (_RETRY_FASTER_WHISPER,)
 
 
+def _failed_attempt_document(
+    *,
+    code: TranscriptionFailureCode,
+    attempt_id: str,
+    batch_id: str | None,
+    job_id: str | None,
+    model_id: str,
+    language: str,
+) -> dict[str, Any]:
+    attempt = FailedTranscriptionAttempt(
+        attempt_id=attempt_id,
+        batch_id=batch_id,
+        job_id=job_id,
+        provider_id=PROVIDER_ID,
+        model_id=model_id,
+        artifact_root=None,
+        artifact_dependencies=(),
+        precision=PRECISION,
+        requested_device=ExecutionDevice.AUTO,
+        effective_device=None,
+        requested_language=language,
+        effective_language=language,
+        detected_language=None,
+        task=TranscriptionTask.TRANSCRIBE,
+        error_code=code,
+    )
+    return load_failed_transcription_attempt(dump_failed_transcription_attempt(attempt))
+
+
 def transcribe_file(
     *,
     audio_path: Path,
@@ -387,10 +436,33 @@ def transcribe_file(
     payload, while the native runtime remains absent from module scope.
     """
 
+    normalized_language = (language or "en").strip().lower()
+
+    def failure(
+        code: TranscriptionFailureCode,
+        *,
+        model_id: str = "local-gguf:unavailable",
+        actions: tuple[str, ...] | None = None,
+    ) -> TranscribeCppFailure:
+        selected_actions = _failure_actions(code) if actions is None else actions
+        return TranscribeCppFailure(
+            code,
+            model_id=model_id,
+            actions=selected_actions,
+            failed_attempt=_failed_attempt_document(
+                code=code,
+                attempt_id=attempt_id,
+                batch_id=batch_id,
+                job_id=job_id,
+                model_id=model_id,
+                language=normalized_language,
+            ),
+        )
+
     try:
         runtime = importlib.import_module("transcribe_cpp")
     except Exception as error:
-        raise TranscribeCppFailure(
+        raise failure(
             TranscriptionFailureCode.PROVIDER_UNAVAILABLE,
             actions=(_RETRY_FASTER_WHISPER,),
         ) from error
@@ -398,7 +470,7 @@ def transcribe_file(
     try:
         admission = validate_local_gguf(model_path)
     except Exception as error:
-        raise TranscribeCppFailure(
+        raise failure(
             TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
             actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
         ) from error
@@ -426,7 +498,7 @@ def transcribe_file(
             close = getattr(model, "close", None)
             if callable(close):
                 close()
-        raise TranscribeCppFailure(
+        raise failure(
             TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
             model_id=model_id,
             actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
@@ -458,7 +530,7 @@ def transcribe_file(
             source=FileAudioSource(audio_path),
             provider_id=PROVIDER_ID,
             model_id=model_id,
-            language=(language or "en").strip().lower(),
+            language=normalized_language,
             task=TranscriptionTask.TRANSCRIBE,
             precision=PRECISION,
             device=ExecutionDevice.AUTO,
@@ -472,7 +544,7 @@ def transcribe_file(
         )
         return coordinator.transcribe(request)
     except TranscriptionCoordinatorError as error:
-        raise TranscribeCppFailure(
+        raise failure(
             error.failure.code,
             model_id=model_id,
             actions=_failure_actions(error.failure.code),
@@ -480,7 +552,7 @@ def transcribe_file(
     except TranscribeCppFailure:
         raise
     except Exception as error:
-        raise TranscribeCppFailure(
+        raise failure(
             TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
             model_id=model_id,
             actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),

--- a/tldw_chatbook/STT/transcribe_cpp.py
+++ b/tldw_chatbook/STT/transcribe_cpp.py
@@ -1,0 +1,497 @@
+"""Direct-local adapter for the optional pinned ``transcribe.cpp`` runtime.
+
+The native package is intentionally imported only by :func:`transcribe_file`,
+which the Library ingestion pipeline calls inside its spawn worker. Importing
+this module is safe during normal application startup.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import wave
+from array import array
+from pathlib import Path
+from typing import Any
+
+from tldw_chatbook.Model_Artifacts.gguf_admission import validate_local_gguf
+
+from .contracts import (
+    CancellationGranularity,
+    ExecutionDevice,
+    FileAudioSource,
+    InputKind,
+    LanguageInputMode,
+    PipelineCapabilities,
+    PrivacyRequirements,
+    ProducedCapabilities,
+    ResolvedTranscriptionRequest,
+    TimestampGranularity,
+    TranscriptionFailureCode,
+    TranscriptionRequest,
+    TranscriptionSegment,
+    TranscriptionTask,
+    TranscriptionTimings,
+)
+from .coordinator import TranscriptionCoordinator, TranscriptionCoordinatorError
+from .registry import (
+    CapabilitySet,
+    CatalogDeclarations,
+    ModelMetadata,
+    ProviderMetadata,
+    ProviderTranscriptionOutput,
+    RuntimeObservation,
+)
+from .routing import (
+    TranscriptionRouter,
+    build_builtin_registry,
+    default_routing_policy,
+)
+
+
+PROVIDER_ID = "transcribe-cpp"
+PRECISION = "native"
+_CHOOSE_ANOTHER_GGUF = "choose_another_gguf"
+_RETRY_FASTER_WHISPER = "retry_faster_whisper"
+
+
+class TranscribeCppFailure(Exception):
+    """Path-safe direct-local failure with bounded recovery actions."""
+
+    __slots__ = ("actions", "code", "model_id")
+
+    def __init__(
+        self,
+        code: TranscriptionFailureCode,
+        *,
+        model_id: str = "local-gguf:unavailable",
+        actions: tuple[str, ...] = (),
+    ) -> None:
+        self.code = code
+        self.model_id = model_id
+        self.actions = actions
+        super().__init__(_failure_message(code))
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(code={self.code.value!r})"
+
+
+def _failure_message(code: TranscriptionFailureCode) -> str:
+    if code is TranscriptionFailureCode.PROVIDER_UNAVAILABLE:
+        return "The transcribe.cpp runtime is unavailable."
+    if code in {
+        TranscriptionFailureCode.ARTIFACT_CORRUPT,
+        TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
+        TranscriptionFailureCode.MODEL_NOT_INSTALLED,
+    }:
+        return "The selected GGUF cannot be used by transcribe.cpp."
+    return "transcribe.cpp could not complete this transcription."
+
+
+def _device_from_model(model: object) -> ExecutionDevice:
+    device = getattr(getattr(model, "device", None), "kind", None)
+    if not isinstance(device, str):
+        device = getattr(model, "backend", None)
+    normalized = device.casefold() if isinstance(device, str) else ""
+    mapping = {
+        "cpu": ExecutionDevice.CPU,
+        "cuda": ExecutionDevice.CUDA,
+        "metal": ExecutionDevice.METAL,
+        "mps": ExecutionDevice.METAL,
+    }
+    if normalized not in mapping:
+        raise ValueError("unsupported transcribe.cpp execution device")
+    return mapping[normalized]
+
+
+def _timestamp_capabilities(maximum: object) -> frozenset[TimestampGranularity]:
+    normalized = maximum.casefold() if isinstance(maximum, str) else "none"
+    values = {TimestampGranularity.NONE}
+    if normalized in {"segment", "word"}:
+        values.add(TimestampGranularity.SEGMENT)
+    if normalized == "word":
+        values.add(TimestampGranularity.WORD)
+    return frozenset(values)
+
+
+def _runtime_capabilities(model: object) -> CapabilitySet:
+    native = getattr(model, "capabilities")
+    languages = frozenset(
+        language.strip().lower()
+        for language in getattr(native, "languages", ())
+        if isinstance(language, str) and language.strip() and language != "auto"
+    )
+    automatic = bool(getattr(native, "supports_language_detect", False))
+    language_mode = (
+        LanguageInputMode.AUTOMATIC if automatic else LanguageInputMode.ENFORCED
+    )
+    tasks = {TranscriptionTask.TRANSCRIBE}
+    if bool(getattr(native, "supports_translate", False)):
+        tasks.add(TranscriptionTask.TRANSLATE)
+    return CapabilitySet(
+        languages=languages,
+        automatic_language=automatic,
+        tasks=frozenset(tasks),
+        inputs=frozenset({InputKind.FILE}),
+        timestamps=_timestamp_capabilities(
+            getattr(native, "max_timestamp_kind", "none")
+        ),
+        true_streaming=False,
+        batch=False,
+        cancellation=CancellationGranularity.BEFORE_EXECUTION,
+        vad=False,
+        diarization=False,
+        punctuation=False,
+        capitalization=False,
+        language_input_mode=language_mode,
+        execution_devices=frozenset({_device_from_model(model)}),
+        precisions=frozenset({PRECISION}),
+    )
+
+
+def _read_normalized_wav(path: Path) -> tuple[array[float], float]:
+    with wave.open(str(path), "rb") as wav_file:
+        if (
+            wav_file.getnchannels() != 1
+            or wav_file.getsampwidth() != 2
+            or wav_file.getframerate() != 16_000
+            or wav_file.getcomptype() != "NONE"
+        ):
+            raise ValueError("audio is not normalized")
+        frame_count = wav_file.getnframes()
+        samples = array("h")
+        samples.frombytes(wav_file.readframes(frame_count))
+    if sys.byteorder != "little":
+        samples.byteswap()
+    return array("f", (sample / 32768.0 for sample in samples)), frame_count / 16_000
+
+
+def _pcm_16k_mono(
+    audio_path: Path,
+    *,
+    ffmpeg_path: str | None,
+) -> tuple[array[float], float]:
+    try:
+        return _read_normalized_wav(audio_path)
+    except (OSError, EOFError, ValueError, wave.Error):
+        pass
+
+    executable = ffmpeg_path or shutil.which("ffmpeg")
+    if not executable:
+        raise ValueError("ffmpeg is unavailable")
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="tldw_stt_", suffix=".wav", delete=False
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            try:
+                os.chmod(temporary_path, 0o600)
+            except OSError:
+                pass
+        subprocess.run(
+            [
+                executable,
+                "-i",
+                str(audio_path),
+                "-ar",
+                "16000",
+                "-ac",
+                "1",
+                "-c:a",
+                "pcm_s16le",
+                "-y",
+                str(temporary_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        return _read_normalized_wav(temporary_path)
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except OSError:
+                pass
+
+
+class TranscribeCppAdapter:
+    """One already-loaded direct-local model, owned by one worker job."""
+
+    def __init__(
+        self,
+        *,
+        model: object,
+        architecture: str,
+        model_load_seconds: float,
+        ffmpeg_path: str | None = None,
+    ) -> None:
+        self._model = model
+        self._model_load_seconds = model_load_seconds
+        self._ffmpeg_path = ffmpeg_path
+        self._closed = False
+        self._provider = ProviderMetadata(PROVIDER_ID, "transcribe.cpp", True)
+        capabilities = _runtime_capabilities(model)
+        mode = capabilities.language_input_mode
+        self._metadata = ModelMetadata(
+            provider_id=PROVIDER_ID,
+            model_id=f"local-gguf:{architecture}",
+            display_name=f"Local {architecture} GGUF",
+            capabilities=capabilities,
+            default_precision=PRECISION,
+            semantic_default_eligible=False,
+            enforces_language_hint=mode
+            in {LanguageInputMode.ENFORCED, LanguageInputMode.AUTOMATIC},
+        )
+
+    def provider(self) -> ProviderMetadata:
+        return self._provider
+
+    def describe(self) -> tuple[ModelMetadata, ...]:
+        return (self._metadata,)
+
+    def probe(self, model_id: str) -> RuntimeObservation:
+        if model_id != self._metadata.model_id or self._closed:
+            return RuntimeObservation(
+                provider_id=PROVIDER_ID,
+                model_id=model_id,
+                available=False,
+                capabilities=None,
+                detail_code="model_unavailable",
+            )
+        return RuntimeObservation(
+            provider_id=PROVIDER_ID,
+            model_id=model_id,
+            available=True,
+            capabilities=self._metadata.capabilities,
+        )
+
+    def transcribe(
+        self,
+        request: ResolvedTranscriptionRequest,
+    ) -> ProviderTranscriptionOutput:
+        source = request.request.source
+        if type(source) is not FileAudioSource:
+            raise TypeError("transcribe.cpp requires a file source")
+        pcm, duration = _pcm_16k_mono(
+            source.path,
+            ffmpeg_path=self._ffmpeg_path,
+        )
+        timestamp_kind = request.request.timestamps.value
+        language = (
+            None if request.effective_language == "auto" else request.effective_language
+        )
+        started = time.perf_counter()
+        with self._model.session() as session:
+            native_result = session.run(
+                pcm,
+                task=request.request.task.value,
+                language=language,
+                timestamps=timestamp_kind,
+            )
+        inference_seconds = time.perf_counter() - started
+        segments = ()
+        if request.request.timestamps is not TimestampGranularity.NONE:
+            segments = tuple(
+                TranscriptionSegment(
+                    start_seconds=float(segment.t0_ms) / 1000,
+                    end_seconds=float(segment.t1_ms) / 1000,
+                    text=str(segment.text),
+                )
+                for segment in getattr(native_result, "segments", ())
+            )
+        native_timings = getattr(native_result, "timings", None)
+        reported_inference = (
+            sum(
+                float(getattr(native_timings, name, 0.0) or 0.0)
+                for name in ("mel_ms", "encode_ms", "decode_ms")
+            )
+            / 1000
+            if native_timings is not None
+            else inference_seconds
+        )
+        detected = (
+            str(getattr(native_result, "language", "")).strip().lower() or None
+            if request.request.language == "auto"
+            else None
+        )
+        return ProviderTranscriptionOutput(
+            text=str(getattr(native_result, "text", "")),
+            segments=segments,
+            effective_language=request.effective_language,
+            detected_language=detected,
+            effective_device=_device_from_model(self._model),
+            produced_capabilities=ProducedCapabilities(
+                timestamps=request.request.timestamps,
+                punctuation=False,
+                capitalization=False,
+                vad=False,
+                diarization=False,
+            ),
+            duration_seconds=duration,
+            timings=TranscriptionTimings(
+                model_load_seconds=self._model_load_seconds,
+                inference_seconds=reported_inference,
+                total_seconds=self._model_load_seconds + inference_seconds,
+            ),
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        close = getattr(self._model, "close", None)
+        if callable(close):
+            close()
+            return
+        exit_method = getattr(self._model, "__exit__", None)
+        if callable(exit_method):
+            exit_method(None, None, None)
+
+
+def _failure_actions(code: TranscriptionFailureCode) -> tuple[str, ...]:
+    if code in {
+        TranscriptionFailureCode.MODEL_NOT_INSTALLED,
+        TranscriptionFailureCode.ARTIFACT_CORRUPT,
+        TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
+    }:
+        return (_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER)
+    if code is TranscriptionFailureCode.CANCELLED:
+        return ()
+    return (_RETRY_FASTER_WHISPER,)
+
+
+def transcribe_file(
+    *,
+    audio_path: Path,
+    model_path: Path,
+    attempt_id: str,
+    batch_id: str | None = None,
+    job_id: str | None = None,
+    retry_of_attempt_id: str | None = None,
+    retry_of_job_id: str | None = None,
+    language: str = "en",
+    timestamps: bool = False,
+    ffmpeg_path: str | None = None,
+) -> Any:
+    """Run one direct-local job and return its normalized result.
+
+    The return annotation is deliberately broad at this legacy bridge: callers
+    serialize the validated ``TranscriptionResult`` into their existing dict
+    payload, while the native runtime remains absent from module scope.
+    """
+
+    try:
+        runtime = importlib.import_module("transcribe_cpp")
+    except Exception as error:
+        raise TranscribeCppFailure(
+            TranscriptionFailureCode.PROVIDER_UNAVAILABLE,
+            actions=(_RETRY_FASTER_WHISPER,),
+        ) from error
+
+    try:
+        admission = validate_local_gguf(model_path)
+    except Exception as error:
+        raise TranscribeCppFailure(
+            TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
+            actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
+        ) from error
+
+    model: object | None = None
+    adapter: TranscribeCppAdapter | None = None
+    model_id = f"local-gguf:{admission.metadata.architecture}"
+    try:
+        set_log_callback = getattr(runtime, "set_log_callback", None)
+        if callable(set_log_callback):
+            set_log_callback(lambda *_args: None)
+        load_started = time.perf_counter()
+        model = runtime.Model(str(admission.path))
+        load_seconds = time.perf_counter() - load_started
+        if getattr(model, "arch", None) != admission.metadata.architecture:
+            raise ValueError("native model architecture mismatch")
+        adapter = TranscribeCppAdapter(
+            model=model,
+            architecture=admission.metadata.architecture,
+            model_load_seconds=load_seconds,
+            ffmpeg_path=ffmpeg_path,
+        )
+    except Exception as error:
+        if model is not None and adapter is None:
+            close = getattr(model, "close", None)
+            if callable(close):
+                close()
+        raise TranscribeCppFailure(
+            TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
+            model_id=model_id,
+            actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
+        ) from error
+
+    policy = default_routing_policy()
+    declarations = CatalogDeclarations(
+        providers=(adapter.provider(),),
+        models=adapter.describe(),
+    )
+    try:
+        registry = build_builtin_registry(
+            policy,
+            adapters=(adapter,),
+            extra_declarations=declarations,
+        )
+        maximum_timestamps = adapter.describe()[0].capabilities.timestamps
+        timestamp_request = (
+            TimestampGranularity.SEGMENT
+            if timestamps and TimestampGranularity.SEGMENT in maximum_timestamps
+            else TimestampGranularity.NONE
+        )
+        request = TranscriptionRequest(
+            attempt_id=attempt_id,
+            batch_id=batch_id,
+            job_id=job_id,
+            retry_of_attempt_id=retry_of_attempt_id,
+            retry_of_job_id=retry_of_job_id,
+            source=FileAudioSource(audio_path),
+            provider_id=PROVIDER_ID,
+            model_id=model_id,
+            language=(language or "en").strip().lower(),
+            task=TranscriptionTask.TRANSCRIBE,
+            precision=PRECISION,
+            device=ExecutionDevice.AUTO,
+            timestamps=timestamp_request,
+            privacy=PrivacyRequirements(allow_remote_processing=False),
+        )
+        coordinator = TranscriptionCoordinator(
+            registry=registry,
+            router=TranscriptionRouter(policy),
+            pipeline=PipelineCapabilities(),
+        )
+        return coordinator.transcribe(request)
+    except TranscriptionCoordinatorError as error:
+        raise TranscribeCppFailure(
+            error.failure.code,
+            model_id=model_id,
+            actions=_failure_actions(error.failure.code),
+        ) from error
+    except TranscribeCppFailure:
+        raise
+    except Exception as error:
+        raise TranscribeCppFailure(
+            TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
+            model_id=model_id,
+            actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
+        ) from error
+    finally:
+        adapter.close()
+
+
+__all__ = [
+    "PROVIDER_ID",
+    "TranscribeCppAdapter",
+    "TranscribeCppFailure",
+    "transcribe_file",
+]

--- a/tldw_chatbook/STT/transcribe_cpp.py
+++ b/tldw_chatbook/STT/transcribe_cpp.py
@@ -120,9 +120,12 @@ def _device_from_model(model: object) -> ExecutionDevice:
     normalized = device.casefold() if isinstance(device, str) else ""
     mapping = {
         "cpu": ExecutionDevice.CPU,
+        "accel": ExecutionDevice.CPU,
+        "cpu_accel": ExecutionDevice.CPU,
         "cuda": ExecutionDevice.CUDA,
         "metal": ExecutionDevice.METAL,
         "mps": ExecutionDevice.METAL,
+        "vulkan": ExecutionDevice.VULKAN,
     }
     if normalized not in mapping:
         raise ValueError("unsupported transcribe.cpp execution device")
@@ -132,9 +135,9 @@ def _device_from_model(model: object) -> ExecutionDevice:
 def _timestamp_capabilities(maximum: object) -> frozenset[TimestampGranularity]:
     normalized = maximum.casefold() if isinstance(maximum, str) else "none"
     values = {TimestampGranularity.NONE}
-    if normalized in {"segment", "word"}:
+    if normalized in {"segment", "word", "token"}:
         values.add(TimestampGranularity.SEGMENT)
-    if normalized == "word":
+    if normalized in {"word", "token"}:
         values.add(TimestampGranularity.WORD)
     return frozenset(values)
 
@@ -419,7 +422,7 @@ def _failed_attempt_document(
 def transcribe_file(
     *,
     audio_path: Path,
-    model_path: Path,
+    model_path: Path | None,
     attempt_id: str,
     batch_id: str | None = None,
     job_id: str | None = None,
@@ -459,21 +462,27 @@ def transcribe_file(
             ),
         )
 
-    try:
-        runtime = importlib.import_module("transcribe_cpp")
-    except Exception as error:
+    if model_path is None:
         raise failure(
-            TranscriptionFailureCode.PROVIDER_UNAVAILABLE,
-            actions=(_RETRY_FASTER_WHISPER,),
-        ) from error
+            TranscriptionFailureCode.MODEL_NOT_INSTALLED,
+            actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
+        )
 
     try:
         admission = validate_local_gguf(model_path)
-    except Exception as error:
+    except Exception:
         raise failure(
             TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
             actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
-        ) from error
+        ) from None
+
+    try:
+        runtime = importlib.import_module("transcribe_cpp")
+    except Exception:
+        raise failure(
+            TranscriptionFailureCode.PROVIDER_UNAVAILABLE,
+            actions=(_RETRY_FASTER_WHISPER,),
+        ) from None
 
     model: object | None = None
     adapter: TranscribeCppAdapter | None = None
@@ -493,7 +502,7 @@ def transcribe_file(
             model_load_seconds=load_seconds,
             ffmpeg_path=ffmpeg_path,
         )
-    except Exception as error:
+    except Exception:
         if model is not None and adapter is None:
             close = getattr(model, "close", None)
             if callable(close):
@@ -502,7 +511,7 @@ def transcribe_file(
             TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
             model_id=model_id,
             actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
-        ) from error
+        ) from None
 
     policy = default_routing_policy()
     declarations = CatalogDeclarations(
@@ -548,15 +557,15 @@ def transcribe_file(
             error.failure.code,
             model_id=model_id,
             actions=_failure_actions(error.failure.code),
-        ) from error
+        ) from None
     except TranscribeCppFailure:
         raise
-    except Exception as error:
+    except Exception:
         raise failure(
             TranscriptionFailureCode.ARTIFACT_INCOMPATIBLE,
             model_id=model_id,
             actions=(_CHOOSE_ANOTHER_GGUF, _RETRY_FASTER_WHISPER),
-        ) from error
+        ) from None
     finally:
         adapter.close()
 

--- a/tldw_chatbook/STT/transcribe_cpp.py
+++ b/tldw_chatbook/STT/transcribe_cpp.py
@@ -329,16 +329,6 @@ class TranscribeCppAdapter:
                 )
                 for segment in getattr(native_result, "segments", ())
             )
-        native_timings = getattr(native_result, "timings", None)
-        reported_inference = (
-            sum(
-                float(getattr(native_timings, name, 0.0) or 0.0)
-                for name in ("mel_ms", "encode_ms", "decode_ms")
-            )
-            / 1000
-            if native_timings is not None
-            else inference_seconds
-        )
         detected = (
             str(getattr(native_result, "language", "")).strip().lower() or None
             if request.request.language == "auto"
@@ -360,7 +350,7 @@ class TranscribeCppAdapter:
             duration_seconds=duration,
             timings=TranscriptionTimings(
                 model_load_seconds=self._model_load_seconds,
-                inference_seconds=reported_inference,
+                inference_seconds=inference_seconds,
                 total_seconds=self._model_load_seconds + inference_seconds,
             ),
         )
@@ -437,6 +427,25 @@ def transcribe_file(
     The return annotation is deliberately broad at this legacy bridge: callers
     serialize the validated ``TranscriptionResult`` into their existing dict
     payload, while the native runtime remains absent from module scope.
+
+    Args:
+        audio_path: Local audio file to normalize and transcribe.
+        model_path: Configured local GGUF path, or ``None`` when unset.
+        attempt_id: Stable identity for this transcription attempt.
+        batch_id: Optional identity shared by a batch of ingest jobs.
+        job_id: Optional Library ingest job identity.
+        retry_of_attempt_id: Optional immediately preceding attempt identity.
+        retry_of_job_id: Optional immediately preceding Library job identity.
+        language: Explicit language code or ``auto``.
+        timestamps: Whether to request segment timestamps when supported.
+        ffmpeg_path: Optional explicit ffmpeg executable path.
+
+    Returns:
+        A validated provider-neutral ``TranscriptionResult``.
+
+    Raises:
+        TranscribeCppFailure: If admission, runtime loading, preflight, or
+            inference fails. The exception contains only bounded recovery data.
     """
 
     normalized_language = (language or "en").strip().lower()
@@ -477,6 +486,10 @@ def transcribe_file(
         ) from None
 
     try:
+        # Deliberately keep this native ABI load at the worker boundary instead
+        # of require_dependency(): that helper logs ImportError details and only
+        # normalizes import-related exceptions, while this path must redact every
+        # native loader/ABI failure before it can cross the spawn boundary.
         runtime = importlib.import_module("transcribe_cpp")
     except Exception:
         raise failure(

--- a/tldw_chatbook/STT/transcribe_cpp_config.py
+++ b/tldw_chatbook/STT/transcribe_cpp_config.py
@@ -15,12 +15,27 @@ class TranscribeCppConfigError(RuntimeError):
 
 
 def is_gguf_file(path: Path) -> bool:
-    """Return whether a picker entry has the GGUF suffix."""
+    """Return whether a picker entry has the GGUF suffix.
+
+    Args:
+        path: Candidate picker entry.
+
+    Returns:
+        True when the candidate filename ends in ``.gguf`` case-insensitively.
+    """
     return path.suffix.casefold() == ".gguf"
 
 
 def configure_model_path(path: str | Path) -> None:
-    """Admit one local GGUF and atomically persist only its dedicated key."""
+    """Admit one local GGUF and atomically persist only its dedicated key.
+
+    Args:
+        path: User-selected local GGUF path.
+
+    Raises:
+        GGUFError: If the selected file fails bounded GGUF admission.
+        TranscribeCppConfigError: If the admitted path cannot be persisted.
+    """
     admission = validate_local_gguf(path)
     saved = save_settings_to_cli_config(
         {CONFIG_SECTION: {"model_path": str(admission.path)}}

--- a/tldw_chatbook/STT/transcribe_cpp_config.py
+++ b/tldw_chatbook/STT/transcribe_cpp_config.py
@@ -1,0 +1,31 @@
+"""Path-safe configuration for one user-selected transcribe.cpp GGUF."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_chatbook.Model_Artifacts.gguf_admission import validate_local_gguf
+from tldw_chatbook.config import save_settings_to_cli_config
+
+CONFIG_SECTION = "transcription.transcribe_cpp"
+
+
+class TranscribeCppConfigError(RuntimeError):
+    """A path-safe failure to persist the selected local GGUF."""
+
+
+def is_gguf_file(path: Path) -> bool:
+    """Return whether a picker entry has the GGUF suffix."""
+    return path.suffix.casefold() == ".gguf"
+
+
+def configure_model_path(path: str | Path) -> None:
+    """Admit one local GGUF and atomically persist only its dedicated key."""
+    admission = validate_local_gguf(path)
+    saved = save_settings_to_cli_config(
+        {CONFIG_SECTION: {"model_path": str(admission.path)}}
+    )
+    if not saved:
+        raise TranscribeCppConfigError(
+            "The transcribe.cpp GGUF configuration could not be saved."
+        )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -180,6 +180,10 @@ from ...Skills_Interop.skill_remote_fetch import (
     classify_skill_source_url,
     install_skill_from_url,
 )
+from ...STT.transcribe_cpp_config import (
+    configure_model_path as configure_transcribe_cpp_model_path,
+    is_gguf_file,
+)
 from ...Sync_Interop.sync_promotion_state import build_sync_promotion_state
 from ...Sync_Interop.sync_readiness import (
     DEFAULT_SYNC_ELIGIBILITY_REGISTRY,
@@ -432,6 +436,11 @@ def _ingestible_file_filters() -> Filters:
         ("Importable files", _is_ingestible),
         ("All files", lambda _path: True),
     )
+
+
+def _transcribe_cpp_gguf_filters() -> Filters:
+    """Restrict the direct-local model picker to GGUF files."""
+    return Filters(("GGUF models", is_gguf_file))
 
 
 def _library_carries_forward_line(titles: Sequence[str]) -> str:
@@ -1276,6 +1285,7 @@ class LibraryScreen(BaseAppScreen):
         # re-entry (see ``_reset_library_ingest_transient_state``); the
         # job queue itself is registry-owned, not screen state.
         self._library_ingest_form: LibraryIngestFormState = LibraryIngestFormState()
+        self._transcribe_cpp_configured = False
         # Dedupe counter for the "poke the source snapshot on transitions
         # into done" rule (Task 5's registry listener): only re-fetch when
         # the registry's done-job count has grown since the last time this
@@ -5658,6 +5668,7 @@ class LibraryScreen(BaseAppScreen):
             registry_available=registry is not None,
             ingest_backend=ingest_backend,
             server_ingest_available=server_ingest_available,
+            transcribe_cpp_configured=self._transcribe_cpp_configured,
         )
 
     def _ensure_library_notes_sync_config_loaded(self) -> None:
@@ -12203,6 +12214,81 @@ class LibraryScreen(BaseAppScreen):
             return
         self._parakeet_v2_install_worker = self._run_parakeet_v2_preflight()
 
+    @on(LibraryIngestCanvas.TranscribeCppGGUFRequested)
+    def handle_transcribe_cpp_gguf_requested(
+        self,
+        event: LibraryIngestCanvas.TranscribeCppGGUFRequested,
+    ) -> None:
+        """Open the direct-local GGUF picker from provider settings."""
+        event.stop()
+        self._open_transcribe_cpp_gguf_picker()
+
+    def _open_transcribe_cpp_gguf_picker(
+        self, *, retry_job_id: str | None = None
+    ) -> None:
+        """Pick one GGUF, then validate and persist it in a worker thread."""
+
+        async def picker_callback(selected_path: Path | None) -> None:
+            if selected_path is not None:
+                self._configure_transcribe_cpp_gguf(
+                    selected_path, retry_job_id=retry_job_id
+                )
+
+        self.app.push_screen(
+            FileOpen(
+                location=self._library_ingest_browse_location(),
+                title="Choose transcribe.cpp GGUF",
+                filters=_transcribe_cpp_gguf_filters(),
+            ),
+            picker_callback,
+        )
+
+    @work(
+        thread=True,
+        group="library_transcribe_cpp_gguf",
+        exclusive=True,
+        exit_on_error=False,
+    )
+    def _configure_transcribe_cpp_gguf(
+        self, selected_path: Path, *, retry_job_id: str | None = None
+    ) -> None:
+        """Admit and persist a selected GGUF off the Textual event loop."""
+        try:
+            configure_transcribe_cpp_model_path(selected_path)
+        except Exception:
+            self.app.call_from_thread(
+                self._apply_transcribe_cpp_gguf_result,
+                False,
+                retry_job_id,
+            )
+            return
+        self.app.call_from_thread(
+            self._apply_transcribe_cpp_gguf_result,
+            True,
+            retry_job_id,
+        )
+
+    def _apply_transcribe_cpp_gguf_result(
+        self, configured: bool, retry_job_id: str | None
+    ) -> None:
+        """Show a path-free result and optionally requeue the failed job."""
+        if not configured:
+            self.app_instance.notify(
+                "That GGUF cannot be used by transcribe.cpp. Choose another GGUF.",
+                severity="warning",
+            )
+            return
+        self.app_instance.notify(
+            "Local GGUF configured for transcribe.cpp.",
+            severity="information",
+        )
+        self._transcribe_cpp_configured = True
+        if retry_job_id is not None:
+            retry = getattr(self.app_instance, "retry_library_ingest_job", None)
+            if callable(retry):
+                retry(retry_job_id)
+        self.refresh(recompose=True)
+
     @on(InstallProgressed)
     def handle_model_install_progressed(self, event: InstallProgressed) -> None:
         """Retain and render progress after the consent modal is dismissed."""
@@ -12576,6 +12662,11 @@ class LibraryScreen(BaseAppScreen):
         last-used options from previous sessions.
         """
         form = self._library_ingest_form
+        self._transcribe_cpp_configured = bool(
+            get_cli_setting(
+                "transcription.transcribe_cpp", "model_path", None
+            )
+        )
         for group in list_type_groups():
             cap = get_capabilities(group)
             prefix = f"library.ingest_options.{group}"
@@ -12779,6 +12870,34 @@ class LibraryScreen(BaseAppScreen):
             # not already superseded/dismissed) -- a stale or now-wrong-state
             # job id is a safe no-op, not a mis-targeted retry.
             retry(job_id)
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, ".library-ingest-choose-gguf")
+    def handle_library_ingest_choose_gguf(self, event: Button.Pressed) -> None:
+        """Choose a replacement GGUF and requeue the same manual provider."""
+        event.stop()
+        job_id = self._ingest_job_id_from_button(
+            event.button.id, "library-ingest-choose-gguf-"
+        )
+        if job_id is not None:
+            self._open_transcribe_cpp_gguf_picker(retry_job_id=job_id)
+
+    @on(Button.Pressed, ".library-ingest-retry-faster-whisper")
+    def handle_library_ingest_retry_faster_whisper(
+        self, event: Button.Pressed
+    ) -> None:
+        """Explicitly retry a direct-local failure with faster-whisper."""
+        event.stop()
+        job_id = self._ingest_job_id_from_button(
+            event.button.id, "library-ingest-retry-faster-whisper-"
+        )
+        if job_id is None:
+            return
+        retry = getattr(
+            self.app_instance, "retry_library_ingest_job_with_provider", None
+        )
+        if callable(retry):
+            retry(job_id, "faster-whisper")
         self.refresh(recompose=True)
 
     @on(Button.Pressed, ".library-ingest-cancel")

--- a/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
+++ b/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
@@ -8,6 +8,7 @@ this module renders them and owns persistence via one exclusive worker.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from loguru import logger
@@ -27,6 +28,11 @@ from tldw_chatbook.Local_Ingestion.parakeet_v2_artifact import (
     run_parakeet_v2_provision,
 )
 from tldw_chatbook.Model_Artifacts.store import managed_model_artifact_root
+from tldw_chatbook.STT.transcribe_cpp_config import (
+    configure_model_path as configure_transcribe_cpp_model_path,
+    is_gguf_file,
+)
+from tldw_chatbook.Third_Party.textual_fspicker import FileOpen, Filters
 from tldw_chatbook.UI.Screens.model_browser_state import install_failure_message
 from tldw_chatbook.UI.Screens.model_installed_view import lifecycle_failure_message
 from tldw_chatbook.UI.Wizards import first_run_speech_step_state as speech_state
@@ -1164,6 +1170,22 @@ class SpeechSetupStep(SetupStep):
         # made THROUGH THIS STEP during this run -- see commit()'s use via
         # first_run_speech_step_state.should_persist_speech_config.
         self._acted_this_run = False
+        app_config = getattr(self.wizard.app_instance, "app_config", {}) or {}
+        transcription = (
+            app_config.get("transcription", {})
+            if isinstance(app_config, Mapping)
+            else {}
+        )
+        direct_config = (
+            transcription.get("transcribe_cpp", {})
+            if isinstance(transcription, Mapping)
+            else {}
+        )
+        self._transcribe_cpp_configured = bool(
+            direct_config.get("model_path")
+            if isinstance(direct_config, Mapping)
+            else False
+        )
 
     def compose_step(self) -> ComposeResult:
         """Render the title/prefill/status/action block, then the language
@@ -1228,6 +1250,20 @@ class SpeechSetupStep(SetupStep):
                     id="setup-speech-use-as-default",
                     variant="primary",
                 )
+            yield Static(
+                "Existing local transcribe.cpp GGUF configured."
+                if self._transcribe_cpp_configured
+                else "No existing local transcribe.cpp GGUF configured.",
+                id="setup-speech-transcribe-cpp-status",
+                classes="setup-subtitle",
+                markup=False,
+            )
+            yield Button(
+                "Choose another GGUF…"
+                if self._transcribe_cpp_configured
+                else "Use an existing transcribe.cpp GGUF…",
+                id="setup-speech-choose-transcribe-cpp-gguf",
+            )
             yield Static("", classes="setup-step-error")
             yield Label("Language", classes="setup-field-label")
             with RadioSet(id="setup-speech-language-choice", classes="setup-choice-list"):
@@ -1523,6 +1559,59 @@ class SpeechSetupStep(SetupStep):
         self._acted_this_run = True
         self.notify(
             "Parakeet v2 will become your default when you continue.",
+            severity="information",
+        )
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#setup-speech-choose-transcribe-cpp-gguf")
+    def _choose_transcribe_cpp_gguf_pressed(self) -> None:
+        """Open a GGUF-only picker for optional direct-local transcription."""
+
+        async def picker_callback(selected_path: Path | None) -> None:
+            if selected_path is not None:
+                self._configure_transcribe_cpp_gguf(selected_path)
+
+        self.app.push_screen(
+            FileOpen(
+                location=Path.home(),
+                title="Choose transcribe.cpp GGUF",
+                filters=Filters(("GGUF models", is_gguf_file)),
+            ),
+            picker_callback,
+        )
+
+    @work(
+        thread=True,
+        group="setup-speech-transcribe-cpp-gguf",
+        exclusive=True,
+        exit_on_error=False,
+    )
+    def _configure_transcribe_cpp_gguf(self, selected_path: Path) -> None:
+        """Admit and persist a selected GGUF off the Textual event loop."""
+        try:
+            configure_transcribe_cpp_model_path(selected_path)
+        except Exception:
+            self.app.call_from_thread(
+                self._apply_transcribe_cpp_gguf_result,
+                False,
+            )
+            return
+        self.app.call_from_thread(
+            self._apply_transcribe_cpp_gguf_result,
+            True,
+        )
+
+    def _apply_transcribe_cpp_gguf_result(self, configured: bool) -> None:
+        """Apply a path-free direct-local GGUF configuration result."""
+        if not configured:
+            self.notify(
+                "That GGUF cannot be used by transcribe.cpp. Choose another GGUF.",
+                severity="warning",
+            )
+            return
+        self._transcribe_cpp_configured = True
+        self.notify(
+            "Local GGUF configured for transcribe.cpp.",
             severity="information",
         )
         self.refresh(recompose=True)

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -21,6 +21,24 @@ from tldw_chatbook.Library.library_ingest_state import (
     LibraryIngestCanvasState,
 )
 
+_STT_RECOVERY_ACTIONS = frozenset(
+    {"choose_another_gguf", "retry_faster_whisper"}
+)
+
+
+def _stt_recovery_actions(error_detail: dict[str, Any] | None) -> frozenset[str]:
+    """Return only the bounded STT recovery actions implemented here."""
+    if not error_detail or error_detail.get("category") != "stt_failure":
+        return frozenset()
+    actions = error_detail.get("actions")
+    if not isinstance(actions, list):
+        return frozenset()
+    return frozenset(
+        action
+        for action in actions
+        if isinstance(action, str) and action in _STT_RECOVERY_ACTIONS
+    )
+
 
 def _summarise_option(field: Any, value: Any) -> str:
     """Describe one option for the collapsed panel title, in plain language.
@@ -69,6 +87,9 @@ class LibraryIngestCanvas(VerticalScroll):
 
     class ParakeetInstallRequested(Message):
         """The user requested the curated Parakeet v2 installer."""
+
+    class TranscribeCppGGUFRequested(Message):
+        """The user requested a local transcribe.cpp GGUF picker."""
 
     def __init__(self, state: LibraryIngestCanvasState, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -166,6 +187,26 @@ class LibraryIngestCanvas(VerticalScroll):
                     disabled=provider_value != "parakeet-onnx",
                 )
             )
+            if provider_value == "transcribe-cpp":
+                configured = self.state.transcribe_cpp_configured
+                children.append(
+                    Static(
+                        "Local GGUF configured."
+                        if configured
+                        else "No local GGUF configured.",
+                        id="opt-audio_video-transcribe-cpp-status",
+                        classes="type-group-scope",
+                        markup=False,
+                    )
+                )
+                children.append(
+                    Button(
+                        "Choose another GGUF…" if configured else "Choose GGUF…",
+                        id="opt-audio_video-choose-transcribe-cpp-gguf",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                )
 
         children.append(
             Button(
@@ -398,6 +439,7 @@ class LibraryIngestCanvas(VerticalScroll):
             # mount time (the L3a lesson; mirrors
             # ``library_rag_history_children``'s escaped Button labels).
             row_classes = "library-ingest-row"
+            stt_actions = _stt_recovery_actions(row.error_detail)
             has_actions = (
                 row.can_open
                 or row.can_open_on_server
@@ -405,6 +447,7 @@ class LibraryIngestCanvas(VerticalScroll):
                 or row.can_dismiss
                 or row.can_cancel
                 or bool(row.error_detail)
+                or bool(stt_actions)
             )
             if has_actions:
                 # A row with action buttons below it gets its own
@@ -494,7 +537,31 @@ class LibraryIngestCanvas(VerticalScroll):
                             ),
                             compact=True,
                         )
-                    if row.can_retry:
+                    if "choose_another_gguf" in stt_actions:
+                        yield Button(
+                            "Choose another GGUF…",
+                            id=f"library-ingest-choose-gguf-{row.job_id}",
+                            classes=(
+                                "library-canvas-action library-ingest-choose-gguf "
+                                "library-ingest-row-action"
+                            ),
+                            compact=True,
+                        )
+                    if "retry_faster_whisper" in stt_actions:
+                        yield Button(
+                            "Retry with faster-whisper",
+                            id=(
+                                "library-ingest-retry-faster-whisper-"
+                                f"{row.job_id}"
+                            ),
+                            classes=(
+                                "library-canvas-action "
+                                "library-ingest-retry-faster-whisper "
+                                "library-ingest-row-action"
+                            ),
+                            compact=True,
+                        )
+                    if row.can_retry and not stt_actions:
                         yield Button(
                             "Retry",
                             id=f"library-ingest-retry-{row.job_id}",
@@ -607,3 +674,9 @@ class LibraryIngestCanvas(VerticalScroll):
         """Request explicit install confirmation from the owning screen."""
         event.stop()
         self.post_message(self.ParakeetInstallRequested())
+
+    @on(Button.Pressed, "#opt-audio_video-choose-transcribe-cpp-gguf")
+    def _request_transcribe_cpp_gguf(self, event: Button.Pressed) -> None:
+        """Request the shared local-GGUF picker from the owning screen."""
+        event.stop()
+        self.post_message(self.TranscribeCppGGUFRequested())

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2504,6 +2504,7 @@ class LibraryIngestQueueMixin:
                 error=error_text or "Library ingest parsing failed.",
                 permanent=bool(result.get("permanent", False)),
                 error_detail=result.get("error_detail"),
+                stt_failure_provenance=result.get("stt_failure_provenance"),
             )
         self._top_up_ingest_parse_pool()
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -30,6 +30,7 @@ import sys
 import threading
 import time
 import traceback
+from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, Any, Dict, List, Callable, Mapping
 from textual.widget import Widget
 
@@ -1979,7 +1980,12 @@ class LibraryIngestQueueMixin:
         self._top_up_ingest_parse_pool()
         return job
 
-    def retry_library_ingest_job(self, job_id: str) -> Optional[LibraryIngestJob]:
+    def retry_library_ingest_job(
+        self,
+        job_id: str,
+        *,
+        transcription_provider: str | None = None,
+    ) -> Optional[LibraryIngestJob]:
         """Requeue a previously failed job and top up the parse pool.
 
         UI-thread only. A thin wrapper over
@@ -1994,7 +2000,21 @@ class LibraryIngestQueueMixin:
             when ``media_db`` is unavailable), or ``None`` when nothing was
             requeued.
         """
-        requeued = self.library_ingest_jobs.requeue(job_id)
+        replacement_options = None
+        if transcription_provider not in {None, "faster-whisper"}:
+            return None
+        if transcription_provider is not None:
+            source = self.library_ingest_jobs.get_job(job_id)
+            if source is None:
+                return None
+            replacement_options = deepcopy(source.ingest_options)
+            replacement_options.setdefault("audio_video", {})[
+                "transcription_provider"
+            ] = transcription_provider
+        requeued = self.library_ingest_jobs.requeue(
+            job_id,
+            ingest_options=replacement_options,
+        )
         if requeued is None:
             return None
         if self.media_db is None:
@@ -2004,6 +2024,20 @@ class LibraryIngestQueueMixin:
             return failed if failed is not None else requeued
         self._top_up_ingest_parse_pool()
         return requeued
+
+    def retry_library_ingest_job_with_provider(
+        self,
+        job_id: str,
+        provider: str,
+    ) -> Optional[LibraryIngestJob]:
+        """Run the one supported explicit cross-provider recovery action."""
+
+        if provider != "faster-whisper":
+            return None
+        return self.retry_library_ingest_job(
+            job_id,
+            transcription_provider=provider,
+        )
 
     # -- Parse-pool sizing + lifecycle (coordinator) -----------------------
 
@@ -2233,7 +2267,10 @@ class LibraryIngestQueueMixin:
             )
             options["transcription_model_dir"] = selected_model_dir or None
             selected_model = route.model
-            if selected_model is None and route.requested_provider != "default":
+            if (
+                selected_model is None
+                and route.requested_provider not in {"default", "transcribe-cpp"}
+            ):
                 selected_model = flat_opts.get("model") or flat_opts.get(
                     "transcription_model"
                 )
@@ -2247,6 +2284,26 @@ class LibraryIngestQueueMixin:
             options["transcription_batch_route_resolved"] = True
             options["timestamps"] = flat_opts.get("timestamps", True)
             options["diarization"] = flat_opts.get("diarization", False)
+            failed_attempt = job.retry_source_failure_provenance
+            if route.provider == "transcribe-cpp":
+                configured_path = get_cli_setting(
+                    "transcription.transcribe_cpp.model_path"
+                )
+                options["transcription_context"] = {
+                    "model_path": configured_path
+                    if isinstance(configured_path, str) and configured_path
+                    else None,
+                    "attempt_id": f"{job.job_id}-attempt-{job.retry_count + 1}",
+                    "batch_id": failed_attempt.get("batch_id")
+                    if failed_attempt
+                    else None,
+                    "job_id": job.job_id,
+                    "retry_of_attempt_id": failed_attempt.get("attempt_id")
+                    if failed_attempt
+                    else None,
+                    "retry_of_job_id": job.retry_of_job_id,
+                    "retry_source_failure_provenance": failed_attempt,
+                }
         elif group == "ebook":
             options["extraction_method"] = (
                 flat_opts.get("extraction_method")


### PR DESCRIPTION
## Summary
- add the pinned, spawn-worker-only `transcribe-cpp==0.1.3` adapter for user-selected local GGUF models
- wire exact manual Library audio/video ingestion through normalized transcript/provenance persistence
- add path-private GGUF configuration plus explicit Choose another GGUF and faster-whisper retry recovery
- normalize Vulkan/CPU-accelerator devices and token timestamp capability while preserving semantic default routing

## Focused verification
- 307 TASK-604 and shared STT contract tests passed
- scoped Ruff checks passed; only documented unrelated legacy ignores were used
- `py_compile`, TOML parsing, and `git diff --check` passed

## Platform gate
Published 0.1.3 metadata covers macOS arm64/x86_64, Linux aarch64/x86_64 manylinux, and Windows x86_64 wheel lanes. Windows/Linux native execution was unavailable locally, so those execution gates remain preserved and are not claimed as run.

## Architecture
No new ADR. ADR-025 and ADR-041 remain authoritative. Managed GGUF acquisition and the resident executor remain deferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a direct-local batch STT provider using `transcribe-cpp==0.1.3`, letting users pick a local GGUF and run real Library audio/video transcription with clear error provenance and bounded recovery actions. Meets TASK-604 by wiring the manual route, safe GGUF config, ingestion, and UI retry flows end-to-end.

- New Features
  - Added `transcribe-cpp` adapter for local GGUF models; manual-only, no translation, local files only; exposed in ingest provider options and routed with native precision.
  - Ingestion runs in the spawn parse worker and returns normalized transcripts or a sanitized STT failure with provenance/error_detail; audio/video and the parse worker preserve these fields.
  - Path-safe GGUF selection persisted under `transcription.transcribe_cpp.model_path`; GGUF-only picker and status in Library and First Run; never logs the path.
  - Bounded recovery in the Ingest UI: “Choose another GGUF” or retry with `faster-whisper`; `retry_library_ingest_job` can switch provider via `requeue(..., ingest_options=...)`.
  - Extended `ExecutionDevice` with `vulkan` and standardized timestamp capability routing; native runtime import remains confined to the worker.

- Migration
  - Install the optional extra: `transcription_transcribe_cpp` (includes `transcribe-cpp==0.1.3`).
  - Choose a local GGUF in the First Run wizard or Library screen, then select `transcribe-cpp` in ingest options; transcription only (no translation).

<sup>Written for commit c8e8aaf90c809ac26c985e13ec5a19cec7272c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

