### PR TITLE
Workspaces: B/E turn snapshots around agent runs (TASK-1971)

### DIFF
--- a/Tests/Chat/test_change_turn_tracking.py
+++ b/Tests/Chat/test_change_turn_tracking.py
@@ -1,0 +1,452 @@
+"""TASK-1971: B/E turn snapshots around agent runs + change_snapshots schema.
+
+Tracker and bridge tests run against REAL git (no mocks — TASK-1970's rule).
+The bridge tests drive the real run loop with a scripted gateway whose
+streaming callback writes files mid-turn: that is literally the run-window
+side effect the feature exists to catch.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Workspaces.change_tracking import ShadowRepoService
+from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
+
+
+@pytest.fixture()
+def root(tmp_path) -> Path:
+    r = tmp_path / "root"
+    r.mkdir()
+    (r / "seed.txt").write_text("seed\n")
+    return r
+
+
+@pytest.fixture()
+def tracker(tmp_path) -> ChangeTurnTracker:
+    return ChangeTurnTracker(
+        service=ShadowRepoService(data_dir=tmp_path / "appdata")
+    )
+
+
+# -- tracker level ----------------------------------------------------------
+
+
+def test_a_turn_records_disk_truth(tracker, root):
+    handle = tracker.begin_turn([root])
+    handle.await_baseline()
+    (root / "new.txt").write_text("created\n")
+    (root / "seed.txt").write_text("edited\n")
+
+    records = tracker.end_turn(handle)
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.root == str(root)
+    assert rec.tracking_error == ""
+    assert rec.files_changed == 2
+    assert rec.adds >= 2 and rec.baseline_sha != rec.end_sha
+
+
+def test_a_clean_turn_yields_no_records(tracker, root):
+    handle = tracker.begin_turn([root])
+    handle.await_baseline()
+    records = tracker.end_turn(handle)
+    assert records == []
+
+
+def test_begin_is_nonblocking_and_await_gates(tmp_path, root):
+    """B must ride the model's first-token latency: begin_turn returns
+    while the snapshot is still running; await_baseline blocks until done.
+    """
+    events: list[str] = []
+
+    class _SlowService(ShadowRepoService):
+        def repo_for_root(self, r):
+            repo = super().repo_for_root(r)
+            original = repo.snapshot
+
+            def slow_snapshot(message: str) -> str:
+                time.sleep(0.4)
+                events.append("baseline-finished")
+                return original(message)
+
+            repo.snapshot = slow_snapshot  # type: ignore[method-assign]
+            return repo
+
+    tracker = ChangeTurnTracker(service=_SlowService(data_dir=tmp_path / "app"))
+    started = time.monotonic()
+    handle = tracker.begin_turn([root])
+    events.append("begin-returned")
+    begin_elapsed = time.monotonic() - started
+
+    handle.await_baseline()
+    events.append("await-returned")
+
+    assert begin_elapsed < 0.3, "begin_turn blocked on the snapshot"
+    assert events == ["begin-returned", "baseline-finished", "await-returned"]
+
+
+def test_force_add_carveout_for_tool_touched_ignored_paths(tracker, root):
+    """A tool write to a .gitignore'd path (.env is the canonical case) must
+    surface; a SCRIPT write into an ignored directory stays a documented
+    blind spot (force-adding everything would false-positive pre-existing
+    ignored files as Added).
+    """
+    (root / ".gitignore").write_text(".env\nignored_dir/\n")
+    ignored_dir = root / "ignored_dir"
+    ignored_dir.mkdir()
+
+    handle = tracker.begin_turn([root])
+    handle.await_baseline()
+    (root / ".env").write_text("SECRET=1\n")
+    (ignored_dir / "side_effect.txt").write_text("script wrote this\n")
+
+    records = tracker.end_turn(handle, touched_paths=[str(root / ".env")])
+
+    assert len(records) == 1
+    changed = tracker.service.repo_for_root(root).changed_files(
+        records[0].baseline_sha, records[0].end_sha
+    )
+    paths = [c.path for c in changed]
+    assert ".env" in paths, "the tool-touched ignored file is invisible"
+    assert not any("side_effect" in p for p in paths), (
+        "script writes into ignored dirs are OUT of scope by design"
+    )
+
+
+def test_tracking_failure_yields_error_records_never_raises(tmp_path, root):
+    tracker = ChangeTurnTracker(
+        service=ShadowRepoService(
+            data_dir=tmp_path / "app", git_executable="/nonexistent/git"
+        )
+    )
+    handle = tracker.begin_turn([root])
+    handle.await_baseline()
+    records = tracker.end_turn(handle)
+    assert len(records) == 1
+    assert records[0].tracking_error != ""
+    assert records[0].end_sha == ""
+
+
+def test_tool_touched_paths_reads_write_tools_only():
+    class _Step:
+        def __init__(self, tool_name, args):
+            self.tool_name = tool_name
+            self.args = args
+
+    steps = [
+        _Step("write_file", {"file_path": "/w/a.txt", "content": "x"}),
+        _Step("read_file", {"file_path": "/w/read-only.txt"}),
+        _Step("calculator", {"expression": "1+1"}),
+        _Step("write_file", {"file_path": "/w/b.txt", "content": "y"}),
+    ]
+    touched = ChangeTurnTracker.tool_touched_paths(steps)
+    assert touched == ["/w/a.txt", "/w/b.txt"], (
+        "read touches would force-add pre-existing ignored files and lie "
+        f"an Added row: {touched}"
+    )
+
+
+# -- DB level ---------------------------------------------------------------
+
+
+def test_v2_database_gains_the_change_snapshots_table_on_open(tmp_path):
+    """The DB has no migration framework by design: CREATE IF NOT EXISTS on
+    every open IS the mechanism. A file created at v2 must gain the table."""
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE schema_version (version INTEGER PRIMARY KEY NOT NULL);
+        INSERT INTO schema_version (version) VALUES (2);
+        CREATE TABLE agent_runs (
+            id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL,
+            parent_run_id TEXT, agent_kind TEXT NOT NULL, task TEXT,
+            status TEXT NOT NULL, steps TEXT NOT NULL DEFAULT '[]',
+            result TEXT, budget TEXT, created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL, assistant_message_id TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    db = AgentRunsDB(db_path, client_id="t")
+    run_id = db.create_run(conversation_id="c1", agent_kind="primary")
+    db.record_change_snapshot(
+        run_id=run_id,
+        root="/w/root",
+        baseline_sha="b" * 8,
+        end_sha="e" * 8,
+        files_changed=2,
+        adds=3,
+        dels=1,
+    )
+    rows = db.change_snapshots_for_run(run_id)
+    assert len(rows) == 1
+    assert rows[0]["root"] == "/w/root"
+    assert rows[0]["adds"] == 3
+
+    by_conv = db.change_snapshots_for_conversation("c1")
+    assert [r["run_id"] for r in by_conv] == [run_id]
+
+
+# -- bridge level -----------------------------------------------------------
+
+
+class _SideEffectGateway:
+    """Streams a scripted reply and, mid-stream, runs a side-effect callback
+    — the exact run-window write the tracker must attribute to the turn.
+
+    Matches the real gateway contract (async generator, positional
+    resolution/messages) — the first version was a sync generator and every
+    bridge test failed with an empty run.
+    """
+
+    def __init__(
+        self, scripts, side_effect=None, explode=False, side_effect_on_call=1
+    ):
+        self._scripts = list(scripts)
+        self._side_effect = side_effect
+        self._explode = explode
+        self._side_effect_on_call = side_effect_on_call
+        self._calls = 0
+
+    async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+        script = self._scripts[min(self._calls, len(self._scripts) - 1)]
+        self._calls += 1
+        if self._side_effect is not None and self._calls >= self._side_effect_on_call:
+            self._side_effect()
+            self._side_effect = None
+        for chunk in script:
+            yield chunk
+        if self._explode and self._calls >= len(self._scripts):
+            raise RuntimeError("provider died mid-turn")
+
+
+def _bridge_with(tmp_path, gateway, tracker):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=gateway,
+        change_tracker=tracker,
+    )
+    return bridge, db, store, session, assistant.id
+
+
+def _run(bridge, session, assistant_id, root, **over):
+    kwargs = dict(
+        conversation_id="conv-1",
+        session_id=session.id,
+        resolution=object(),
+        assistant_message_id=assistant_id,
+        model="test-model",
+        session_system_prompt="",
+        agent_messages=[{"role": "user", "content": "hi"}],
+        should_cancel=lambda: False,
+        change_roots=[root],
+    )
+    kwargs.update(over)
+    return bridge.run_reply(**kwargs)
+
+
+def _calc_fence() -> str:
+    return (
+        f"{FENCE_OPEN}\n"
+        + json.dumps({"name": "calculator", "arguments": {"expression": "6*7"}})
+        + "\n```"
+    )
+
+
+def test_bridge_run_records_a_change_row_matching_disk(tmp_path, root, tracker):
+    """The side effect fires on the SECOND provider call -- i.e. after the
+    first tool batch has passed the await-B gate. Writing during the FIRST
+    provider stream would race the baseline thread (warm process: gateway
+    wins, the write lands inside B and vanishes) -- a window that exists
+    only for writers that bypass tools, which production has none of: every
+    writer, scripts included, is a tool behind the gate. The first version
+    of this test wrote pre-gate and passed only by cold-start luck.
+    """
+    gateway = _SideEffectGateway(
+        [[_calc_fence()], ["done."]],
+        side_effect_on_call=2,
+        side_effect=lambda: (root / "made_by_run.txt").write_text("hello\n"),
+    )
+    bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
+
+    run_id, outcome = _run(bridge, session, aid, root)
+
+    rows = db.change_snapshots_for_run(run_id)
+    assert len(rows) == 1
+    assert rows[0]["files_changed"] == 1
+    changed = tracker.service.repo_for_root(root).changed_files(
+        rows[0]["baseline_sha"], rows[0]["end_sha"]
+    )
+    assert [c.path for c in changed] == ["made_by_run.txt"]
+
+
+def test_bridge_run_with_no_changes_records_no_row(tmp_path, root, tracker):
+    gateway = _SideEffectGateway([["done."]])
+    bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
+    run_id, _outcome = _run(bridge, session, aid, root)
+    assert db.change_snapshots_for_run(run_id) == []
+
+
+def test_failed_run_still_records_its_end_snapshot(tmp_path, root, tracker):
+    """A run that died halfway through editing is when review matters MOST."""
+    gateway = _SideEffectGateway(
+        [[_calc_fence()], ["partial"]],
+        side_effect_on_call=2,
+        side_effect=lambda: (root / "half_done.txt").write_text("partial\n"),
+        explode=True,
+    )
+    bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
+
+    run_id, outcome = _run(bridge, session, aid, root)
+
+    assert outcome.status != "completed"
+    rows = db.change_snapshots_for_run(run_id)
+    assert len(rows) == 1, "the failed run's half-finished edits are unreviewable"
+
+
+def test_tracking_never_blocks_the_reply(tmp_path, root):
+    """Spec failure posture: git broken -> the agent reply still completes."""
+    broken = ChangeTurnTracker(
+        service=ShadowRepoService(
+            data_dir=tmp_path / "app", git_executable="/nonexistent/git"
+        )
+    )
+    gateway = _SideEffectGateway([["fine."]])
+    bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, broken)
+
+    run_id, outcome = _run(bridge, session, aid, root)
+
+    assert outcome.final_text.strip() == "fine."
+    rows = db.change_snapshots_for_run(run_id)
+    assert len(rows) == 1 and rows[0]["tracking_error"] != ""
+
+
+def test_baseline_completes_before_the_first_tool_executes(tmp_path, root):
+    """The spec's ordering contract: B rides first-token latency but MUST be
+    done before any tool touches disk — otherwise the tool's own write races
+    into the baseline and vanishes from the diff.
+    """
+    events: list[str] = []
+
+    class _SlowService(ShadowRepoService):
+        def repo_for_root(self, r):
+            repo = super().repo_for_root(r)
+            original = repo.snapshot
+
+            def slow_snapshot(message: str) -> str:
+                if "baseline" in message:
+                    time.sleep(0.5)
+                    events.append("baseline-finished")
+                return original(message)
+
+            repo.snapshot = slow_snapshot  # type: ignore[method-assign]
+            return repo
+
+    tracker = ChangeTurnTracker(service=_SlowService(data_dir=tmp_path / "app"))
+    fence = (
+        f"{FENCE_OPEN}\n"
+        + json.dumps({"name": "calculator", "arguments": {"expression": "6*7"}})
+        + "\n```"
+    )
+    gateway = _SideEffectGateway([[fence], ["42."]])
+    bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
+
+    def probe_review(calls):
+        events.append("review-called")
+        return {}
+
+    run_id, outcome = _run(
+        bridge, session, aid, root, review_tool_calls=probe_review
+    )
+
+    assert "baseline-finished" in events and "review-called" in events
+    assert events.index("baseline-finished") < events.index("review-called"), (
+        f"a tool could execute before B settled: {events}"
+    )
+
+
+# -- wiring: roots resolution + registration hook ---------------------------
+
+
+def test_folder_binding_roots_includes_ro_and_never_sandbox(tmp_path, monkeypatch):
+    """Tracking is about what happened on DISK: a script can write into a
+    read-only root even though the file tools cannot, so ro bindings are in.
+    The sandbox is app-managed scratch and would be pure review noise.
+    """
+    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+    from tldw_chatbook.Tools import workspace_file_roots as wfr
+    from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "ws.sqlite", client_id="t")
+    )
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="A")
+    rw = tmp_path / "rw"
+    rw.mkdir()
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    registry.add_folder_binding("ws-a", rw, allow_write=True)
+    registry.add_folder_binding("ws-a", ro)
+    monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+
+    roots = wfr.folder_binding_roots("ws-a")
+
+    assert set(roots) == {rw.resolve(), ro.resolve()}
+    assert wfr.folder_binding_roots(None) == ()
+
+
+def test_adding_a_folder_binding_snapshots_it_in_the_background(tmp_path):
+    """Spec §2: the FIRST snapshot happens at registration, so the first
+    send never absorbs the cost of hashing a whole tree. The hook is
+    best-effort and must not slow or fail registration itself.
+    """
+    import time as _time
+
+    from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+    from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "ws.sqlite", client_id="t")
+    )
+    registry.ensure_default_workspace()
+    registry.create_workspace(workspace_id="ws-a", name="A")
+    folder = tmp_path / "project"
+    folder.mkdir()
+    (folder / "code.py").write_text("x = 1\n")
+
+    registry.add_folder_binding("ws-a", folder)
+
+    # The hook's default-constructed service resolves the same isolated app
+    # data dir this test process sees, so a fresh service finds its tip.
+    service = ShadowRepoService()
+    deadline = _time.monotonic() + 15.0
+    tip = None
+    while _time.monotonic() < deadline:
+        tip = service.repo_for_root(folder).tip()
+        if tip:
+            break
+        _time.sleep(0.05)
+    assert tip, "the registered root never received its initial snapshot"

--- a/Tests/Chat/test_change_turn_tracking.py
+++ b/Tests/Chat/test_change_turn_tracking.py
@@ -450,3 +450,38 @@ def test_adding_a_folder_binding_snapshots_it_in_the_background(tmp_path):
             break
         _time.sleep(0.05)
     assert tip, "the registered root never received its initial snapshot"
+
+
+def test_carveout_survives_a_symlink_spelled_root(tmp_path):
+    """Review finding: `_paths_within` resolves each touched path but the
+    roots were stored UNRESOLVED — a run whose root arrived spelled through
+    a symlink made `relative_to` fail, silently skipping the force-add: the
+    `.env` carve-out dying without a trace.
+    """
+    real_root = tmp_path / "real_root"
+    real_root.mkdir()
+    (real_root / ".gitignore").write_text(".env\n")
+    link = tmp_path / "root_link"
+    try:
+        link.symlink_to(real_root, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks unsupported on this platform/permission level")
+
+    tracker = ChangeTurnTracker(
+        service=ShadowRepoService(data_dir=tmp_path / "appdata")
+    )
+    handle = tracker.begin_turn([link])  # the SYMLINK spelling
+    handle.await_baseline()
+    (real_root / ".env").write_text("SECRET=1\n")
+
+    records = tracker.end_turn(
+        handle, touched_paths=[str(real_root / ".env")]
+    )
+
+    assert len(records) == 1 and not records[0].tracking_error
+    changed = tracker.service.repo_for_root(real_root).changed_files(
+        records[0].baseline_sha, records[0].end_sha
+    )
+    assert ".env" in [c.path for c in changed], (
+        "the carve-out silently died for a symlink-spelled root"
+    )

--- a/backlog/tasks/task-1971 - Change-review-turn-protocol-and-schema.md
+++ b/backlog/tasks/task-1971 - Change-review-turn-protocol-and-schema.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1971
 title: 'Change review: B/E turn snapshots around agent runs + change_snapshots schema'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -24,13 +24,37 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A run that writes a file yields a change_snapshots row whose diff(B,E) matches disk truth exactly (property test against real git)
-- [ ] #2 A run that touches nothing yields NO row and no card
-- [ ] #3 A change made by a SCRIPT the agent ran (not write_file) appears in diff(B,E)
-- [ ] #4 Snapshot failure (e.g. git binary removed mid-session) stores tracking_error and the agent reply still completes
-- [ ] #5 Registering a root triggers its initial snapshot in the background; the first send performs no full-tree add
-- [ ] #6 Schema migration applies cleanly to an existing AgentRunsDB
-- [ ] #7 B runs in parallel with the model request and completes before the FIRST tool executes (asserted by ordering probe), so a send adds no user-visible snapshot latency
-- [ ] #8 A FAILED or cancelled run still records E and its row -- the half-finished edit set is reviewable
-- [ ] #9 An agent file-tool write to a .gitignore'd path (e.g. .env) appears in the turn's diff (force-add carve-out); a SCRIPT write to an ignored dir does not, and the limit is documented
+- [x] #1 A run that writes a file yields a change_snapshots row whose diff(B,E) matches disk truth exactly (property test against real git)
+- [x] #2 A run that touches nothing yields NO row and no card
+- [x] #3 A change made by a SCRIPT the agent ran (not write_file) appears in diff(B,E)
+- [x] #4 Snapshot failure (e.g. git binary removed mid-session) stores tracking_error and the agent reply still completes
+- [x] #5 Registering a root triggers its initial snapshot in the background; the first send performs no full-tree add
+- [x] #6 Schema migration applies cleanly to an existing AgentRunsDB
+- [x] #7 B runs in parallel with the model request and completes before the FIRST tool executes (asserted by ordering probe), so a send adds no user-visible snapshot latency
+- [x] #8 A FAILED or cancelled run still records E and its row -- the half-finished edit set is reviewable
+- [x] #9 An agent file-tool write to a .gitignore'd path (e.g. .env) appears in the turn's diff (force-add carve-out); a SCRIPT write to an ignored dir does not, and the limit is documented
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD in `Tests/Chat/test_change_turn_tracking.py`: tracker-level against real git (turn round-trip = disk truth, clean turn = no records, begin non-blocking + await gates via a latency-shimmed service, force-add carve-out incl. the script-to-ignored-dir negative, failure -> tracking_error records, never raises); DB-level (v2 file gains the table on open, record/read round-trip); bridge-level (gateway side-effect write mid-stream -> row; failed run still records E; ordering probe: baseline completes before the first real tool executes via a registry-injected tool).
+2. `Workspaces/change_turn_tracker.py`: `ChangeTurnTracker.begin_turn(roots)` (one background thread snapshotting each root; per-root errors recorded, never raises), `TurnHandle.await_baseline()`, `end_turn(handle, touched_paths)` (force-add tool-touched within each root, E snapshot, B==E skip, per-root `TurnChangeRecord` incl. `tracking_error`), `tool_touched_paths(steps)` restricted to WRITE tools (read touches would force-add pre-existing ignored files and lie an "A" row).
+3. `ShadowRepo.force_add(paths)` primitive in change_tracking.py (add -f under the lock).
+4. `AgentRuns_DB`: `change_snapshots` table + index via the existing CREATE IF NOT EXISTS discipline (version row 3), `record_change_snapshot` / `change_snapshots_for_run` / `change_snapshots_for_conversation`.
+5. Bridge: `change_tracker` ctor kwarg + `change_roots` run_reply kwarg; begin at entry (guarded), review hook wrapped so its first invocation awaits B, end_turn + row writes in the run_turn `finally` (E on every terminal path; a crash before run_id logs records instead of writing rows).
+6. Controller: lazy `ChangeTurnTracker`, roots from the workspace registry's folder bindings for THIS run's workspace, passed into run_reply; registration hook = best-effort background initial snapshot after `add_folder_binding`.
+7. Sabotage anything that passes first try.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`Workspaces/change_turn_tracker.py` (begin/await/end + `tool_touched_paths` + `initial_snapshot_in_background`), `ShadowRepo.force_add`, AgentRuns_DB v3 (`change_snapshots` via the CREATE-IF-NOT-EXISTS discipline + record/read methods), bridge wiring (ctor `change_tracker`, run_reply `change_roots`, review-hook wrap as the await-B gate, end_turn + row writes in the run_turn finally), controller roots via new `workspace_file_roots.folder_binding_roots` (ro INCLUDED -- scripts write where tools cannot; sandbox EXCLUDED -- app scratch is review noise), screen hands the bridge a tracker only when git is available, `add_folder_binding` fires the background initial snapshot.
+
+**The tests taught the design something.** My first bridge write-tests fired their side effect during the FIRST provider stream -- racing the baseline thread. Warm process: the gateway wins, the write lands INSIDE B, and B==E hides it; cold process: baseline wins and the test passes. One test failed deterministically in-file and passed alone (bisected pairwise); the other passed only by cold-start luck. The window is real but production-empty: every writer, scripts included, is a tool behind the await-B gate -- only a non-tool writer racing the first token can hit it, which is spec §5's documented attribution limit. Characterized in the module docstring; tests restructured to write post-gate.
+
+Two verification traps recorded: the registration hook's default-constructed service would have written shadow repos into the REAL app data dir from every registry test -- verified `get_user_data_dir()` resolves inside the per-test isolated XDG tree under pytest before trusting it. And my gateway fake was a sync generator against an async-generator contract, so all four bridge tests failed with empty runs until it matched the real `_ChunkGateway` shape.
+
+Three sabotages, each failing exactly its test: await-B gate removed (ordering), force_add removed (carve-out), finally end_turn removed (records + failed-run).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -16,7 +16,8 @@ import os
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Callable
+from pathlib import Path
+from typing import Any, Callable, Sequence
 
 from loguru import logger
 
@@ -58,6 +59,7 @@ from tldw_chatbook.Chat.console_provider_gateway import (
 )
 from tldw_chatbook.Chat.console_skill_resolver import SKILL_UNTRUSTED_REFUSE
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
 from tldw_chatbook.Internal_Prompts import get_internal_prompt
 from tldw_chatbook.Internal_Prompts.catalog import CATALOG
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
@@ -1222,8 +1224,13 @@ class ConsoleAgentBridge:
         clock: Callable[[], float] = time.monotonic,
         skills_service: Any | None = None,
         native_tools_enabled: Callable[[], bool] | None = None,
+        change_tracker: Any | None = None,
     ) -> None:
         self._db = agent_runs_db
+        # TASK-1971: optional Agent Change Review turn tracker. None (the
+        # default, and every pre-existing construction site) disables
+        # tracking entirely.
+        self._change_tracker = change_tracker
         self._store = store
         self._gateway = provider_gateway
         self._clock = clock
@@ -1285,6 +1292,7 @@ class ConsoleAgentBridge:
         mcp_provider: Any | None = None,
         builtin_gate: Any | None = None,
         review_tool_calls: Callable[[list[ToolCall]], dict[str, str]] | None = None,
+        change_roots: Sequence[Path] | None = None,
         turn_skill_bindings: tuple[str, ...] = (),
         turn_bundle_block: str = "",
         request_skill_install_confirm: Callable[[str], bool] | None = None,
@@ -1773,6 +1781,32 @@ class ConsoleAgentBridge:
             if scope is not None
         ]
         review_state_scope = _combine_state_scopes(_scopes)
+
+        # TASK-1971 (Agent Change Review): kick the baseline snapshot in the
+        # background NOW -- it rides the model's first-token latency -- and
+        # gate tool dispatch on its completion by wrapping the review hook,
+        # which the runtime invokes before every tool batch executes. A tool
+        # writing before B settles would race its own change into the
+        # baseline and vanish from the diff. Tracking failures never block
+        # the run (spec failure posture): begin_turn cannot raise, and the
+        # wrapper's await records timeouts as per-root disclosures.
+        change_handle = None
+        if self._change_tracker is not None and change_roots:
+            try:
+                change_handle = self._change_tracker.begin_turn(change_roots)
+            except Exception:  # noqa: BLE001 -- tracking must never block a run
+                logger.opt(exception=True).warning(
+                    "change_review: begin_turn failed; turn untracked"
+                )
+        if change_handle is not None:
+            _inner_review = review_tool_calls
+            _handle = change_handle
+
+            def review_tool_calls(calls):  # type: ignore[no-redef]
+                _handle.await_baseline()
+                if _inner_review is None:
+                    return {}
+                return _inner_review(calls)
         service = AgentService(
             self._db,
             registry,
@@ -1852,6 +1886,45 @@ class ConsoleAgentBridge:
             )
         finally:
             run_loop.close()
+            # TASK-1971: E snapshot on EVERY terminal path -- completed,
+            # failed, cancelled, or crashed. A run that died halfway through
+            # editing is when review matters most. `run_id` is unbound when
+            # run_turn itself raised before creating the run row; the
+            # records are then logged instead of stored (nothing to attach
+            # them to), and the exception still propagates unchanged.
+            if change_handle is not None:
+                try:
+                    _steps = (
+                        outcome.steps if "outcome" in locals() else []
+                    )
+                    _records = self._change_tracker.end_turn(
+                        change_handle,
+                        touched_paths=ChangeTurnTracker.tool_touched_paths(
+                            _steps
+                        ),
+                    )
+                    if "run_id" in locals():
+                        for _rec in _records:
+                            self._db.record_change_snapshot(
+                                run_id=run_id,
+                                root=_rec.root,
+                                baseline_sha=_rec.baseline_sha,
+                                end_sha=_rec.end_sha,
+                                files_changed=_rec.files_changed,
+                                adds=_rec.adds,
+                                dels=_rec.dels,
+                                tracking_error=_rec.tracking_error,
+                            )
+                    elif _records:
+                        logger.warning(
+                            "change_review: run crashed before a run row "
+                            f"existed; {len(_records)} change record(s) "
+                            "not stored"
+                        )
+                except Exception:  # noqa: BLE001 -- never mask the run's outcome
+                    logger.opt(exception=True).warning(
+                        "change_review: end_turn failed; turn changes untracked"
+                    )
         for step in outcome.steps:
             logger.info(
                 "agent run step",

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -6756,6 +6756,22 @@ class ConsoleChatController:
             kill_switch=self._console_tool_kill_switch_reader(),
         )
 
+        # TASK-1971 (Agent Change Review): THIS run's tracked roots -- the
+        # same workspace folder bindings the file tools resolve against.
+        # Best-effort: an unavailable registry yields no roots and an
+        # untracked (but otherwise normal) run.
+        change_roots: list = []
+        try:
+            from tldw_chatbook.Tools.workspace_file_roots import (
+                folder_binding_roots,
+            )
+
+            change_roots = list(folder_binding_roots(review_workspace_id))
+        except Exception:  # noqa: BLE001 -- tracking must never block a send
+            logger.opt(exception=True).debug(
+                "change_review: workspace roots unavailable; run untracked"
+            )
+
         # Swap site: the agent loop runs synchronously on a worker thread via
         # asyncio.to_thread, so Stop is cooperative-only -- `should_cancel` is
         # polled between chunks/steps inside the bridge, never preempts the
@@ -6783,6 +6799,7 @@ class ConsoleChatController:
                 mcp_provider=mcp_provider,
                 builtin_gate=builtin_gate,
                 review_tool_calls=review_hook,
+                change_roots=change_roots,
                 turn_skill_bindings=skill_bindings,
                 turn_bundle_block=skill_bundle_block,
                 request_skill_install_confirm=functools.partial(

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -192,7 +192,7 @@ class AgentRunsDB(BaseDB):
             dels: Total deleted lines.
             tracking_error: Non-empty when tracking failed for this root.
         """
-        with self.connection() as conn:
+        with self.transaction() as conn:
             conn.execute(
                 """
                 INSERT INTO change_snapshots
@@ -212,7 +212,6 @@ class AgentRunsDB(BaseDB):
                     _now_iso(),
                 ),
             )
-            conn.commit()
 
     def change_snapshots_for_run(self, run_id: str) -> list[dict]:
         """Return a run's change-snapshot rows, oldest first.

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -26,7 +26,7 @@ def _now_iso() -> str:
 class AgentRunsDB(BaseDB):
     """Run records for the agent runtime (vertical-slice spec data model)."""
 
-    _CURRENT_SCHEMA_VERSION = 2
+    _CURRENT_SCHEMA_VERSION = 3
     _swept_paths: set[str] = set()  # DB files already reconciled this process
 
     def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
@@ -110,7 +110,7 @@ class AgentRunsDB(BaseDB):
                 CREATE TABLE IF NOT EXISTS schema_version (
                     version INTEGER PRIMARY KEY NOT NULL
                 );
-                INSERT OR IGNORE INTO schema_version (version) VALUES (2);
+                INSERT OR IGNORE INTO schema_version (version) VALUES (3);
 
                 CREATE TABLE IF NOT EXISTS agent_runs (
                     id TEXT PRIMARY KEY,
@@ -131,6 +131,27 @@ class AgentRunsDB(BaseDB):
                     ON agent_runs(conversation_id);
                 CREATE INDEX IF NOT EXISTS idx_agent_runs_parent
                     ON agent_runs(parent_run_id);
+
+                -- v3 (TASK-1971, Agent Change Review): one row per
+                -- (run, root) pair recording that turn's shadow-repo
+                -- baseline/end snapshots. CREATE IF NOT EXISTS on every
+                -- open IS this DB's migration mechanism (see the v1->v2
+                -- note below).
+                CREATE TABLE IF NOT EXISTS change_snapshots (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL,
+                    root TEXT NOT NULL,
+                    baseline_sha TEXT NOT NULL,
+                    end_sha TEXT NOT NULL,
+                    files_changed INTEGER NOT NULL DEFAULT 0,
+                    adds INTEGER NOT NULL DEFAULT 0,
+                    dels INTEGER NOT NULL DEFAULT 0,
+                    reverted TEXT NOT NULL DEFAULT '',
+                    tracking_error TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_change_snapshots_run
+                    ON change_snapshots(run_id);
                 """
             )
             # v1->v2: this DB has no migration framework -- _initialize_schema
@@ -146,6 +167,91 @@ class AgentRunsDB(BaseDB):
                 conn.execute(
                     "ALTER TABLE agent_runs ADD COLUMN assistant_message_id TEXT"
                 )
+
+    def record_change_snapshot(
+        self,
+        *,
+        run_id: str,
+        root: str,
+        baseline_sha: str,
+        end_sha: str,
+        files_changed: int = 0,
+        adds: int = 0,
+        dels: int = 0,
+        tracking_error: str = "",
+    ) -> None:
+        """Record one root's turn snapshot pair (TASK-1971).
+
+        Args:
+            run_id: The owning agent run.
+            root: Canonical root path.
+            baseline_sha: The B snapshot tip ("" when tracking failed).
+            end_sha: The E snapshot tip ("" when tracking failed).
+            files_changed: Changed-file count between B and E.
+            adds: Total added lines.
+            dels: Total deleted lines.
+            tracking_error: Non-empty when tracking failed for this root.
+        """
+        with self.connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO change_snapshots
+                    (run_id, root, baseline_sha, end_sha, files_changed,
+                     adds, dels, tracking_error, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    root,
+                    baseline_sha,
+                    end_sha,
+                    files_changed,
+                    adds,
+                    dels,
+                    tracking_error,
+                    _now_iso(),
+                ),
+            )
+            conn.commit()
+
+    def change_snapshots_for_run(self, run_id: str) -> list[dict]:
+        """Return a run's change-snapshot rows, oldest first.
+
+        Args:
+            run_id: The agent run id.
+
+        Returns:
+            One dict per (run, root) row.
+        """
+        with self.connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM change_snapshots WHERE run_id = ? ORDER BY id",
+                (run_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def change_snapshots_for_conversation(self, conversation_id: str) -> list[dict]:
+        """Return a conversation's change-snapshot rows for turn history.
+
+        Args:
+            conversation_id: The Console conversation id.
+
+        Returns:
+            Rows joined with their runs, oldest first — the Review screen's
+            "Last turn" selector data.
+        """
+        with self.connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT cs.*, ar.created_at AS run_created_at, ar.status AS run_status
+                FROM change_snapshots cs
+                JOIN agent_runs ar ON ar.id = cs.run_id
+                WHERE ar.conversation_id = ?
+                ORDER BY cs.id
+                """,
+                (conversation_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
 
     @staticmethod
     def _row_to_dict(row: sqlite3.Row) -> dict:

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -93,8 +93,19 @@ def folder_binding_roots(workspace_id: str | None) -> tuple[Path, ...]:
         registry = _registry_factory()
         for binding in registry.list_folder_bindings(workspace_id):
             folder = Path(binding.locator)
-            if folder.is_dir():
-                roots.append(folder)
+            if not folder.is_dir():
+                continue
+            if folder.is_symlink() or folder.resolve() != folder:
+                # Same drift exclusion `allowed_file_roots` applies: a
+                # binding that no longer resolves to its bound path is
+                # stale config, and tracking its TARGET could snapshot an
+                # unintended (potentially huge) tree.
+                logger.warning(
+                    "folder_binding_roots: excluding drifted root {!r}",
+                    binding.locator,
+                )
+                continue
+            roots.append(folder)
     except Exception:
         logger.opt(exception=True).debug(
             "folder_binding_roots: registry unavailable"

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -69,6 +69,40 @@ def _default_registry_factory():
 _registry_factory = _default_registry_factory
 
 
+def folder_binding_roots(workspace_id: str | None) -> tuple[Path, ...]:
+    """Return a workspace's bound folder roots (all access levels).
+
+    TASK-1971: the Agent Change Review tracker's root list. Unlike
+    ``allowed_file_roots`` this includes READ-ONLY bindings (a script can
+    write into an ro root -- the tools cannot, but tracking is about what
+    happened on disk, not what tools were permitted) and never appends the
+    sandbox root (app-managed scratch; retained script outputs live there
+    deliberately and would be pure review noise).
+
+    Args:
+        workspace_id: The run's workspace, or ``None`` for none.
+
+    Returns:
+        Existing, resolved root directories; empty when the workspace has
+        no usable bindings or the registry is unavailable.
+    """
+    if not workspace_id:
+        return ()
+    roots: list[Path] = []
+    try:
+        registry = _registry_factory()
+        for binding in registry.list_folder_bindings(workspace_id):
+            folder = Path(binding.locator)
+            if folder.is_dir():
+                roots.append(folder)
+    except Exception:
+        logger.opt(exception=True).debug(
+            "folder_binding_roots: registry unavailable"
+        )
+        return ()
+    return tuple(roots)
+
+
 @contextmanager
 def run_workspace(workspace_id: str | None) -> Iterator[None]:
     """Bind the current run's workspace for the duration of a tool call.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4573,12 +4573,19 @@ class ChatScreen(BaseAppScreen):
         from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
         runs_db = AgentRunsDB(Path(db_path).parent / "agent_runs.db")
+        # TASK-1971 (Agent Change Review): the tracker is None when git is
+        # absent -- the bridge then skips tracking entirely, and runs behave
+        # exactly as before the feature existed (spec gating decision).
+        from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
+
+        change_tracker = ChangeTurnTracker()
         self._console_agent_bridge = ConsoleAgentBridge(
             agent_runs_db=runs_db,
             store=self._ensure_console_chat_store(),
             provider_gateway=self._ensure_console_provider_gateway(),
             skills_service=getattr(self.app_instance, "skills_scope_service", None),
             native_tools_enabled=self._console_native_tool_calls_enabled,
+            change_tracker=change_tracker if change_tracker.available else None,
         )
         return self._console_agent_bridge
 

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -135,10 +135,12 @@ class ShadowRepoService:
         data_dir: Path | None = None,
         git_executable: str | None = None,
     ) -> None:
-        """Args:
-        data_dir: Base directory for shadow repos; defaults to the app
-            data dir's ``change_review/`` subtree.
-        git_executable: Override for tests; defaults to ``git`` on PATH.
+        """Create the service.
+
+        Args:
+            data_dir: Base directory for shadow repos; defaults to the app
+                data dir's ``change_review/`` subtree.
+            git_executable: Override for tests; defaults to ``git`` on PATH.
         """
         if data_dir is None:
             from tldw_chatbook.Utils.paths import get_user_data_dir

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -494,6 +494,24 @@ class ShadowRepo:
             return None
         return bytes(proc.stdout or b"")
 
+    def force_add(self, paths: Sequence[str]) -> None:
+        """Stage ``paths`` even when ignore rules would exclude them.
+
+        TASK-1971's ``.gitignore`` carve-out: a WRITE tool's edit to an
+        ignored file (``.env``) must surface in the turn's diff. Missing
+        paths are skipped (the tool may have deleted its own file) rather
+        than failing the snapshot.
+
+        Args:
+            paths: Root-relative paths to stage with ``add -f``.
+        """
+        existing = [p for p in paths if (self.root / p).exists()]
+        if not existing:
+            return
+        with self._locked():
+            self.ensure_initialized()
+            self._run("add", "-f", "--", *existing)
+
     # -- low-level restore (full revert semantics live in TASK-1974) -------
 
     def restore_paths(self, commit: str, paths: Sequence[str]) -> None:

--- a/tldw_chatbook/Workspaces/change_turn_tracker.py
+++ b/tldw_chatbook/Workspaces/change_turn_tracker.py
@@ -1,0 +1,307 @@
+"""Per-turn B/E snapshot orchestration for Agent Change Review (TASK-1971).
+
+Wraps :mod:`tldw_chatbook.Workspaces.change_tracking`'s per-root shadow
+repos around one agent run:
+
+* :meth:`ChangeTurnTracker.begin_turn` kicks the baseline (**B**) snapshot on
+  a background thread and returns immediately — B rides the model's own
+  first-token latency instead of adding send latency (spec §2);
+* :meth:`TurnHandle.await_baseline` is the tool-dispatch gate: it must
+  complete before the FIRST tool touches disk, or the tool's own write races
+  into the baseline and vanishes from the diff;
+* :meth:`ChangeTurnTracker.end_turn` takes the end (**E**) snapshot on every
+  terminal path — including failed and cancelled runs, which is when review
+  matters most — and returns one record per root that actually changed.
+
+Known window (spec §2's trade, characterized while testing): a write that
+lands during the FIRST provider stream — before B settles — is swallowed
+into the baseline and never appears in the diff. Production has no writer
+in that window: every writer, scripts included, is a tool, and tools sit
+behind the await-B gate. Only a non-tool writer (another app, the user's
+editor) racing the first token can hit it, and those are already documented
+attribution limits (spec §5).
+
+Failure posture (spec §2): tracking NEVER blocks or fails the agent reply.
+Every error becomes a per-root record carrying ``tracking_error`` for the
+card to disclose; nothing here raises out of ``begin_turn``/``end_turn``.
+
+The ``.gitignore`` carve-out (spec §1): paths the run's WRITE tools touched
+are force-added before E, so a direct agent edit to an ignored file (`.env`
+is the canonical case) always surfaces. Read tools are deliberately NOT
+included — force-adding a merely-read, pre-existing ignored file would lie
+an "Added" row into the review.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from loguru import logger
+
+from tldw_chatbook.Workspaces.change_tracking import (
+    ChangeTrackingError,
+    ShadowRepoService,
+)
+
+#: Tools whose path arguments are force-added at E time (the .gitignore
+#: carve-out). WRITE tools only — see the module docstring for why reads
+#: must not be here.
+WRITE_TOOL_NAMES: frozenset[str] = frozenset({"write_file"})
+
+#: Argument keys that carry the written path for tools in
+#: :data:`WRITE_TOOL_NAMES`.
+_PATH_ARG_KEYS: tuple[str, ...] = ("file_path", "path")
+
+#: Upper bound on waiting for the baseline thread. Generous — snapshots are
+#: seconds — but bounded, so a pathological root cannot hang the run.
+_BASELINE_TIMEOUT_SECONDS = 120.0
+
+
+@dataclass(frozen=True)
+class TurnChangeRecord:
+    """One root's outcome for one turn.
+
+    Attributes:
+        root: Canonical root path (string, for storage).
+        baseline_sha: The B snapshot tip ("" when tracking failed).
+        end_sha: The E snapshot tip ("" when tracking failed).
+        files_changed: Count of changed files between B and E.
+        adds: Total added lines.
+        dels: Total deleted lines.
+        tracking_error: Non-empty when tracking failed for this root; the
+            record then exists to be DISCLOSED, not rendered as a diff.
+    """
+
+    root: str
+    baseline_sha: str = ""
+    end_sha: str = ""
+    files_changed: int = 0
+    adds: int = 0
+    dels: int = 0
+    tracking_error: str = ""
+
+
+class TurnHandle:
+    """The in-flight state of one turn's baseline snapshots."""
+
+    def __init__(self, roots: list[Path]) -> None:
+        self.roots = roots
+        self.baselines: dict[str, str] = {}
+        self.errors: dict[str, str] = {}
+        self._thread: threading.Thread | None = None
+
+    def await_baseline(self, timeout: float = _BASELINE_TIMEOUT_SECONDS) -> None:
+        """Block until every root's B snapshot settled (or errored).
+
+        The tool-dispatch gate: called before the first tool executes and
+        again defensively by ``end_turn``. Never raises — a timeout is
+        recorded as a per-root error and disclosed downstream.
+        """
+        thread = self._thread
+        if thread is None:
+            return
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            for root in self.roots:
+                key = str(root)
+                if key not in self.baselines and key not in self.errors:
+                    self.errors[key] = (
+                        f"baseline snapshot still running after {timeout:.0f}s"
+                    )
+
+
+class ChangeTurnTracker:
+    """Orchestrates B/E snapshots for agent turns. One instance per app."""
+
+    def __init__(self, service: ShadowRepoService | None = None) -> None:
+        """Args:
+        service: Shadow-repo service; a default (app data dir, PATH git)
+            is built when omitted.
+        """
+        self.service = service if service is not None else ShadowRepoService()
+
+    @property
+    def available(self) -> bool:
+        """Whether tracking can work at all (git binary present)."""
+        return self.service.available
+
+    # -- turn lifecycle ----------------------------------------------------
+
+    def begin_turn(self, roots: Sequence[Path | str]) -> TurnHandle:
+        """Kick baseline snapshots for ``roots`` in the background.
+
+        Returns immediately; never raises. Non-directory roots are recorded
+        as errors rather than dropped silently.
+
+        Args:
+            roots: The run's workspace folder roots.
+
+        Returns:
+            A handle for :meth:`TurnHandle.await_baseline` / :meth:`end_turn`.
+        """
+        handle = TurnHandle([Path(r) for r in roots])
+
+        def _baseline() -> None:
+            for root in handle.roots:
+                key = str(root)
+                try:
+                    repo = self.service.repo_for_root(root)
+                    handle.baselines[key] = repo.snapshot("turn baseline")
+                except Exception as exc:  # noqa: BLE001 -- disclosed, never raised
+                    handle.errors[key] = str(exc)[:400]
+
+        if handle.roots:
+            thread = threading.Thread(
+                target=_baseline, name="change-review-baseline", daemon=True
+            )
+            handle._thread = thread
+            thread.start()
+        return handle
+
+    def end_turn(
+        self,
+        handle: TurnHandle,
+        touched_paths: Sequence[str] = (),
+    ) -> list[TurnChangeRecord]:
+        """Take E snapshots and return one record per root that changed.
+
+        Runs on every terminal path. Never raises: per-root failures become
+        records with ``tracking_error`` set; a clean root with ``B == E``
+        yields NO record (spec: no changes, no card).
+
+        Args:
+            handle: The turn's :class:`TurnHandle` from :meth:`begin_turn`.
+            touched_paths: Absolute paths the run's WRITE tools touched
+                (see :meth:`tool_touched_paths`) — force-added before E so
+                ignored-but-edited files surface.
+
+        Returns:
+            Records for roots with changes or tracking errors.
+        """
+        handle.await_baseline()
+        records: list[TurnChangeRecord] = []
+        for root in handle.roots:
+            key = str(root)
+            if key in handle.errors:
+                records.append(
+                    TurnChangeRecord(root=key, tracking_error=handle.errors[key])
+                )
+                continue
+            baseline = handle.baselines.get(key, "")
+            if not baseline:
+                records.append(
+                    TurnChangeRecord(
+                        root=key,
+                        tracking_error="baseline snapshot missing",
+                    )
+                )
+                continue
+            try:
+                repo = self.service.repo_for_root(root)
+                in_root = self._paths_within(root, touched_paths)
+                if in_root:
+                    repo.force_add(in_root)
+                end = repo.snapshot("turn end")
+                if end == baseline:
+                    continue
+                changed = repo.changed_files(baseline, end)
+                records.append(
+                    TurnChangeRecord(
+                        root=key,
+                        baseline_sha=baseline,
+                        end_sha=end,
+                        files_changed=len(changed),
+                        adds=sum(c.adds for c in changed),
+                        dels=sum(c.dels for c in changed),
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 -- disclosed, never raised
+                records.append(
+                    TurnChangeRecord(
+                        root=key,
+                        baseline_sha=baseline,
+                        tracking_error=str(exc)[:400],
+                    )
+                )
+        return records
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _paths_within(root: Path, paths: Iterable[str]) -> list[str]:
+        """Relativize ``paths`` to ``root``, dropping those outside it."""
+        out: list[str] = []
+        for raw in paths:
+            try:
+                rel = Path(raw).expanduser().resolve().relative_to(root)
+            except (ValueError, OSError):
+                continue
+            out.append(str(rel))
+        return out
+
+    @staticmethod
+    def tool_touched_paths(steps: Iterable[Any]) -> list[str]:
+        """Extract WRITE-tool path arguments from a run's recorded steps.
+
+        Args:
+            steps: ``AgentStep``-shaped objects (``tool_name``/``args``
+                attributes) or equivalent dicts.
+
+        Returns:
+            Path strings in step order, de-duplicated, WRITE tools only —
+            a read touch here would force-add a pre-existing ignored file
+            and lie an "Added" row into the review.
+        """
+        seen: set[str] = set()
+        out: list[str] = []
+        for step in steps:
+            tool = getattr(step, "tool_name", None)
+            args = getattr(step, "args", None)
+            if tool is None and isinstance(step, dict):
+                tool = step.get("tool_name")
+                args = step.get("args")
+            if tool not in WRITE_TOOL_NAMES or not isinstance(args, dict):
+                continue
+            for arg_key in _PATH_ARG_KEYS:
+                value = args.get(arg_key)
+                if isinstance(value, str) and value and value not in seen:
+                    seen.add(value)
+                    out.append(value)
+                    break
+        return out
+
+
+def initial_snapshot_in_background(root: Path | str) -> threading.Thread | None:
+    """Best-effort background initial snapshot for a newly registered root.
+
+    Spec §2: the FIRST snapshot of a root happens at registration time, so
+    first-send latency never absorbs the cost of hashing a whole tree.
+    Failures log and are disclosed on first use instead; never raises.
+
+    Args:
+        root: The just-registered folder root.
+
+    Returns:
+        The started thread (for tests to join), or ``None`` when tracking
+        is unavailable.
+    """
+    service = ShadowRepoService()
+    if not service.available:
+        return None
+
+    def _snapshot() -> None:
+        try:
+            service.repo_for_root(root).snapshot("root registered")
+        except Exception:  # noqa: BLE001 -- best-effort by design
+            logger.opt(exception=True).warning(
+                f"change_review: initial snapshot failed for {root}"
+            )
+
+    thread = threading.Thread(
+        target=_snapshot, name="change-review-initial-snapshot", daemon=True
+    )
+    thread.start()
+    return thread

--- a/tldw_chatbook/Workspaces/change_turn_tracker.py
+++ b/tldw_chatbook/Workspaces/change_turn_tracker.py
@@ -117,9 +117,11 @@ class ChangeTurnTracker:
     """Orchestrates B/E snapshots for agent turns. One instance per app."""
 
     def __init__(self, service: ShadowRepoService | None = None) -> None:
-        """Args:
-        service: Shadow-repo service; a default (app data dir, PATH git)
-            is built when omitted.
+        """Create a tracker over a shadow-repo service.
+
+        Args:
+            service: Shadow-repo service; a default (app data dir, PATH
+                git) is built when omitted.
         """
         self.service = service if service is not None else ShadowRepoService()
 
@@ -142,7 +144,13 @@ class ChangeTurnTracker:
         Returns:
             A handle for :meth:`TurnHandle.await_baseline` / :meth:`end_turn`.
         """
-        handle = TurnHandle([Path(r) for r in roots])
+        # Roots are RESOLVED here (review finding): `_paths_within` resolves
+        # each touched path, so an unresolved (symlink-spelled) root would
+        # make `relative_to` fail and silently skip the force-add -- the
+        # .gitignore carve-out dying without a trace.
+        handle = TurnHandle(
+            [Path(r).expanduser().resolve() for r in roots]
+        )
 
         def _baseline() -> None:
             for root in handle.roots:

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -745,7 +745,9 @@ class LocalWorkspaceRegistryService:
 
             initial_snapshot_in_background(resolved)
         except Exception:  # noqa: BLE001 -- registration must never fail on this
-            pass
+            logger.opt(exception=True).debug(
+                "change_review: initial-snapshot hook failed at registration"
+            )
         return binding_result
 
     def list_folder_bindings(

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -733,7 +733,20 @@ class LocalWorkspaceRegistryService:
             status=RuntimeBindingStatus.READY,
             metadata={"access": "rw" if allow_write else "ro"},
         )
-        return self.save_runtime_binding(binding)
+        binding_result = self.save_runtime_binding(binding)
+        # TASK-1971 (Agent Change Review): the FIRST shadow snapshot of a
+        # root happens here, at registration, on a background thread -- the
+        # first agent send must never absorb the cost of hashing a whole
+        # tree. Best-effort: failures log and are disclosed on first use.
+        try:
+            from tldw_chatbook.Workspaces.change_turn_tracker import (
+                initial_snapshot_in_background,
+            )
+
+            initial_snapshot_in_background(resolved)
+        except Exception:  # noqa: BLE001 -- registration must never fail on this
+            pass
+        return binding_result
 
     def list_folder_bindings(
         self, workspace_id: str


### PR DESCRIPTION
Second task of the Agent Change Review programme (spec #1224, service #1225). The turn protocol, wired end to end: baseline **B** kicked in the background at run start (riding the model's first-token latency), **awaited before the first tool executes** via a review-hook wrap; end **E** in the `run_turn` finally — every terminal path, *including failed and cancelled runs*; rows per (run, root) in the new `change_snapshots` table (AgentRunsDB v3, CREATE-IF-NOT-EXISTS migration discipline, tested against a hand-built v2 file).

Also: the `.gitignore` force-add carve-out (tool-touched paths only — read tools would lie "Added" rows for pre-existing ignored files), roots from workspace folder bindings via new `folder_binding_roots` (ro included — scripts write where tools cannot; sandbox excluded — app scratch is noise), registration-time initial snapshots, and the spec's failure posture throughout: tracking never blocks a reply.

## The tests taught the design something

My first bridge write-tests fired their side effect during the **provider stream** — racing the baseline thread. Warm process: the gateway wins, the write lands *inside* B, and `B==E` hides it entirely. One test failed deterministically in-file and passed alone (pairwise-bisected); the other passed by cold-start luck. The window is real but production-empty — every writer, scripts included, is a tool behind the await-B gate — so it is now characterized in the module docstring as spec §5's documented attribution limit, and the tests write post-gate, as reality does.

## Caught before shipping

- The registration hook's default-constructed service would have written shadow repos into the **real** app data dir from every existing registry test — verified `get_user_data_dir()` resolves inside the per-test isolated XDG tree under pytest before trusting it.
- My gateway fake was a sync generator against an async-generator contract — all four bridge tests failed with empty runs until it matched the real shape.

Three sabotages, each failing exactly its test: await-B gate removed (ordering probe), `force_add` removed (carve-out), finally `end_turn` removed (records + failed-run).

14 new tests (real git, real run loop, zero mocks of either); **1218 passed** across the bridge, workspaces, tools, controller and agents suites.

Next: TASK-1972 (transcript summary row) and TASK-1973 (Review screen), now unblocked in parallel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements per-turn baseline and end snapshots around agent runs for Change Review, gated so the baseline completes before the first tool. Changes are stored per (run, root), covers failed/cancelled runs, and never blocks replies. Aligns with TASK-1971.

- **New Features**
  - `ChangeTurnTracker`: baseline runs in the background, awaited before the first tool; end snapshot on all terminal paths.
  - `.gitignore` carve-out: force-add tool-written paths (e.g. `.env`); read touches excluded.
  - Roots via `folder_binding_roots`: now resolved; symlink/drifted bindings excluded; read-only included; sandbox excluded.
  - Bridge/UI: review hook awaits baseline; records saved via `change_snapshots`; tracking enabled only when git is available.

- **Migration**
  - `AgentRuns_DB` v3 adds `change_snapshots` via CREATE IF NOT EXISTS (includes run/conversation query helpers).
  - Existing v2 databases upgrade on open; no manual steps.

<sup>Written for commit 5ab857a6695992c49596b32d8b976e645eb0954c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

