### PR TITLE
feat(anthropic): complete prompt caching (cost ticker PR2)

### DIFF
--- a/Docs/superpowers/plans/2026-08-02-console-cost-ticker-pr2-caching.md
+++ b/Docs/superpowers/plans/2026-08-02-console-cost-ticker-pr2-caching.md
@@ -1,0 +1,694 @@
+# Console Cost Ticker PR2 — Prompt-Caching Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete Anthropic prompt caching by adding the per-turn message breakpoint (making the whole conversation prefix reusable turn over turn), a `[caching]` kill-switch, and a cache_control 400-degrade — and amend the spec whose PR2 premise went stale.
+
+**Architecture:** Task-323 (already merged to dev, before this program's spec was written against an older snapshot) ships `cache_control` on the system block and last tool for **every** `chat_with_anthropic` caller, gated on `_anthropic_supports_caching(model)`. PR1 already maps Anthropic cache fields and OpenAI `cached_tokens` into the disjoint usage buckets. PR2 therefore: (1) amends the spec's stale premise; (2) adds the one missing breakpoint — last content block of the final message; (3) adds `[caching] anthropic_enabled` (default true) gating **all three** breakpoints at the provider level (matching shipped reality — all callers benefit; the spec's "console-gateway-only injection" note is part of the stale premise being amended); (4) adds a 400-naming-cache_control retry-once-without fallback; (5) pins prefix stability with tests.
+
+**Tech Stack:** Python ≥3.11, requests (mocked in tests), pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md` — PR2 section, as amended by Task 1 of this plan.
+
+## Global Constraints
+
+- Worktree `/private/tmp/tldw-cost-ticker`, branch `feat/console-prompt-caching` (off origin/dev @ `814521ed4`). Venv exists: run pytest ONLY via `/private/tmp/tldw-cost-ticker/.venv/bin/pytest`, FOREGROUND. NEVER `git stash`.
+- Caching must **never break sends**: a 4xx naming `cache_control` triggers exactly one retry without breakpoints + a diagnostic log; all other errors behave exactly as before.
+- TTL is the 5-minute default only — never emit a `ttl` key (1-hour doubles the write premium; out of scope per spec).
+- Breakpoint budget: system(1) + last-tool(1) + per-turn(1) = 3 of Anthropic's 4 allowed — assert the total in tests.
+- `[caching] anthropic_enabled` defaults **true** when the section/key is absent — the 5 existing caching tests in `Tests/Chat/test_anthropic_native_tools.py:813-866` stub no config and MUST stay green unmodified.
+- Non-caching models (`claude-2*`, `*instant*`) and non-Anthropic providers: zero behavior change.
+- Config reads use the 3-arg form `get_cli_setting("caching", "anthropic_enabled", True)` (the 2-arg dotted form has the TASK-1771 default-dropping hazard).
+- Line anchors below verified at `814521ed4` — re-locate by symbol if drifted.
+
+---
+
+### Task 1: Amend the spec's stale PR2 premise
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md` (Problem bullet 3 at ~line 25-27; the PR2 section)
+
+**Interfaces:** none (docs).
+
+- [ ] **Step 1: Amend the Problem section**
+
+Replace the third Problem bullet ("No request ever sets `cache_control` — for Anthropic there is currently no cache to break...") with:
+
+```markdown
+- Anthropic caching is PARTIAL (amended 2026-08-02: task-323 landed system-block
+  + last-tool `cache_control` for all callers after this spec's exploration
+  snapshot): conversation HISTORY is never cached — no per-turn message
+  breakpoint exists, so every send re-pays the full message history. There is
+  no config kill-switch and no degrade path if an endpoint rejects
+  `cache_control`. OpenAI-style providers cache automatically; PR1's adapters
+  already account for it.
+```
+
+- [ ] **Step 2: Amend the PR2 section**
+
+At the top of the "PR2 — Prompt-caching enablement" section, insert:
+
+```markdown
+> **Amended 2026-08-02 (PR2 planning):** task-323 shipped the system-block and
+> last-tool breakpoints for ALL `chat_with_anthropic` callers (not console-only)
+> before PR2 started, and PR1 shipped the OpenAI implicit-cache accounting.
+> PR2's remaining scope: the per-turn message breakpoint, the
+> `[caching] anthropic_enabled` toggle (provider-level, gating all three
+> breakpoints, default on — matching shipped reality; the original
+> "injected by the console gateway only" note described a world that no longer
+> exists), the 4xx degrade, and prefix-stability tests. The
+> "system string → block array" implementation note is already implemented.
+```
+
+Also strike (with `~~strikethrough~~` + "(amended: already shipped via task-323/PR1)") the OpenAI implicit-caching bullet and the system-string conversion implementation note.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md
+git commit -m "docs(console): amend cost-ticker spec for task-323 caching reality"
+```
+
+---
+
+### Task 2: `[caching] anthropic_enabled` kill-switch
+
+**Files:**
+- Modify: `tldw_chatbook/LLM_Calls/LLM_API_Calls.py` (new helper near `_anthropic_supports_caching` at :946; gate sites :1214 and :1255)
+- Modify: `tldw_chatbook/config.py` (default TOML template — add a `[caching]` section near `[splash_screen]` at ~:2264)
+- Test: `Tests/Chat/test_anthropic_native_tools.py` (append)
+
+**Interfaces:**
+- Consumes: `get_cli_setting(section, key, default)` from `tldw_chatbook.config` (config.py:4447).
+- Produces (Tasks 3-4 rely on): `_anthropic_caching_enabled() -> bool` module function in LLM_API_Calls.py; a local `caching_active: bool` computed once inside `chat_with_anthropic` and used by every breakpoint site.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/Chat/test_anthropic_native_tools.py` (reuse its `_sent_anthropic` helper at :795-810; caching model string used by the existing tests):
+
+```python
+@patch("requests.Session.post")
+def test_caching_disabled_via_config_strips_all_breakpoints(mock_post):
+    """[caching] anthropic_enabled = false removes system AND tool AND
+    message breakpoints; payload shape otherwise unchanged."""
+    with patch(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls.get_cli_setting",
+        side_effect=lambda section, key=None, default=None: (
+            False if (section, key) == ("caching", "anthropic_enabled") else default
+        ),
+    ):
+        sent = _sent_anthropic(
+            mock_post, "claude-sonnet-4-6", system_message="be terse", tools=OPENAI_TOOLS
+        )
+    assert isinstance(sent["system"], str)  # string form, no block array
+    assert "cache_control" not in json.dumps(sent)
+
+
+@patch("requests.Session.post")
+def test_caching_default_on_when_section_absent(mock_post):
+    """No [caching] section -> enabled (the existing task-323 behavior)."""
+    sent = _sent_anthropic(mock_post, "claude-sonnet-4-6", system_message="be terse")
+    assert isinstance(sent["system"], list)
+    assert sent["system"][-1]["cache_control"] == {"type": "ephemeral"}
+```
+
+Note: the patch target is the name as imported INTO LLM_API_Calls — Step 3 imports it at module top so `tldw_chatbook.LLM_Calls.LLM_API_Calls.get_cli_setting` is patchable. If `json` is not already imported in the test file, add it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /private/tmp/tldw-cost-ticker && .venv/bin/pytest Tests/Chat/test_anthropic_native_tools.py -k caching -v`
+Expected: the two new tests FAIL (no gate exists; patch target missing); the 5 pre-existing caching tests PASS.
+
+- [ ] **Step 3: Implement**
+
+1. In `LLM_API_Calls.py`, add a module-level import `from tldw_chatbook.config import get_cli_setting` (check it isn't already imported; config.py imports must not cycle — `config.py` does not import `LLM_API_Calls`, verified by the existing `load_settings` usage).
+2. Add next to `_anthropic_supports_caching` (:946):
+
+```python
+def _anthropic_caching_enabled() -> bool:
+    """[caching].anthropic_enabled kill-switch for ALL Anthropic cache_control.
+
+    Defaults to True when the section or key is absent (prompt caching is the
+    shipped task-323 behavior; this gate only adds an opt-out). Any config
+    read failure also defaults to True so a broken config file cannot
+    silently change request shapes.
+
+    Returns:
+        True when cache_control breakpoints should be emitted.
+    """
+    try:
+        return bool(get_cli_setting("caching", "anthropic_enabled", True))
+    except Exception:
+        return True
+```
+
+3. In `chat_with_anthropic`, compute once before the payload build (just above the `data = {` literal at :1207):
+
+```python
+    caching_active = _anthropic_supports_caching(current_model) and _anthropic_caching_enabled()
+```
+
+and change the two existing gate sites from `if _anthropic_supports_caching(current_model) and system_prompt:` (:1214) to `if caching_active and system_prompt:`, and `if _anthropic_supports_caching(current_model) and tools_payload:` (:1255) to `if caching_active and tools_payload:`.
+
+4. In `config.py`'s default TOML template (near `[splash_screen]` at ~:2264), add:
+
+```toml
+[caching]
+# Anthropic prompt caching (cache_control breakpoints on system prompt, tool
+# list, and the latest message). Cache writes bill at 1.25x input and reads at
+# ~0.1x, so multi-turn chat wins after two sends inside the 5-minute TTL.
+# Set false to disable all Anthropic cache_control emission.
+anthropic_enabled = true
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest Tests/Chat/test_anthropic_native_tools.py -v`
+Expected: all PASS including the 5 pre-existing caching tests unmodified.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py tldw_chatbook/config.py Tests/Chat/test_anthropic_native_tools.py
+git commit -m "feat(anthropic): [caching] anthropic_enabled kill-switch for cache_control"
+```
+
+---
+
+### Task 3: Per-turn message breakpoint
+
+**Files:**
+- Modify: `tldw_chatbook/LLM_Calls/LLM_API_Calls.py` (insertion at :1266, after `data["output_config"] = output_config`, before `api_url = (`)
+- Test: `Tests/Chat/test_anthropic_native_tools.py` (append)
+
+**Interfaces:**
+- Consumes: `caching_active` local from Task 2.
+- Produces: the outbound body's final message carries `cache_control` on its last content block; total breakpoints ≤ 4 in every combination.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def _count_cache_controls(obj):
+    """Count every cache_control key anywhere in the payload."""
+    if isinstance(obj, dict):
+        return ("cache_control" in obj) + sum(
+            _count_cache_controls(v) for v in obj.values()
+        )
+    if isinstance(obj, list):
+        return sum(_count_cache_controls(item) for item in obj)
+    return 0
+
+
+@patch("requests.Session.post")
+def test_caching_model_marks_last_message_block(mock_post):
+    """The final message's LAST content block carries the per-turn breakpoint;
+    earlier messages and earlier blocks of the final message carry none."""
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        messages_payload=[
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second question"},
+        ],
+    )
+    messages = sent["messages"]
+    assert messages[-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert _count_cache_controls(messages[:-1]) == 0
+    assert _count_cache_controls(messages[-1]["content"][:-1]) == 0
+
+
+@patch("requests.Session.post")
+def test_breakpoint_budget_never_exceeds_four(mock_post):
+    """system + last-tool + per-turn = 3 total, within Anthropic's 4-cap."""
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        system_message="be terse",
+        tools=OPENAI_TOOLS,
+        messages_payload=[{"role": "user", "content": "hi"}],
+    )
+    assert _count_cache_controls(sent) == 3
+
+
+@patch("requests.Session.post")
+def test_non_caching_model_gets_no_message_breakpoint(mock_post):
+    sent = _sent_anthropic(
+        mock_post, "claude-2.1", messages_payload=[{"role": "user", "content": "hi"}]
+    )
+    assert _count_cache_controls(sent) == 0
+
+
+@patch("requests.Session.post")
+def test_message_breakpoint_never_emits_ttl_key(mock_post):
+    """5-minute default only — a ttl key would double the write premium."""
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        messages_payload=[{"role": "user", "content": "hi"}],
+    )
+    assert sent["messages"][-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert "ttl" not in json.dumps(sent)
+```
+
+Note: `_sent_anthropic` hardcodes `messages_payload=[{"role": "user", "content": "hi"}]` — extend the helper to accept an optional `messages_payload=None` parameter defaulting to that list (backward-compatible; existing callers unchanged).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest Tests/Chat/test_anthropic_native_tools.py -k "message_breakpoint or budget or marks_last" -v`
+Expected: FAIL — no cache_control on messages today.
+
+- [ ] **Step 3: Implement**
+
+At `LLM_API_Calls.py:1266` (immediately after the `output_config` assignment, before `api_url = (` — payload complete, ahead of the streaming branch so both modes get it):
+
+```python
+    if (
+        caching_active
+        and anthropic_messages
+        and isinstance(anthropic_messages[-1].get("content"), list)
+        and anthropic_messages[-1]["content"]
+    ):
+        # Per-turn breakpoint (cost-ticker PR2): mark the last content block
+        # of the final message so the WHOLE conversation prefix becomes a
+        # reusable cache entry next turn -- the task-323 system/tools
+        # breakpoints alone never cache message history. Budget:
+        # system(1) + last-tool(1) + this(1) = 3 of the 4 allowed.
+        # Fresh dict so no caller-held block is mutated (same rule as the
+        # tools breakpoint above).
+        last_content = anthropic_messages[-1]["content"]
+        last_content[-1] = {
+            **last_content[-1],
+            "cache_control": {"type": "ephemeral"},
+        }
+```
+
+(The task-263 conversion always emits list-form `content`, so the isinstance guard is belt-and-suspenders for exotic future branches, not a live path.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest Tests/Chat/test_anthropic_native_tools.py Tests/Chat/test_anthropic_streaming_usage.py -v`
+Expected: all PASS (streaming-usage file is the adjacency regression check).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_anthropic_native_tools.py
+git commit -m "feat(anthropic): per-turn cache_control breakpoint on the final message"
+```
+
+---
+
+### Task 4: 400-naming-cache_control degrade (retry once without breakpoints)
+
+**Files:**
+- Modify: `tldw_chatbook/LLM_Calls/LLM_API_Calls.py` (the session/post block at :1282-1301; helper next to `_anthropic_caching_enabled`)
+- Test: `Tests/Chat/test_anthropic_caching_degrade.py` (new)
+
+**Interfaces:**
+- Consumes: payloads that may carry cache_control (Tasks 2-3).
+- Produces: `_without_cache_control(obj)` and `_contains_cache_control(obj)` module helpers (recursive, pure); the post block checks status INSIDE the `with` (the current code calls `raise_for_status()` after the session closes — the retry must happen while the session is open).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Chat/test_anthropic_caching_degrade.py
+"""A 400 naming cache_control retries ONCE without breakpoints; any other
+error behaves exactly as before (caching must never break sends)."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.LLM_Calls.LLM_API_Calls import (
+    _contains_cache_control,
+    _without_cache_control,
+)
+
+
+def _ok_response(text="ok"):
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status = Mock()
+    response.json.return_value = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-x",
+        "content": [{"type": "text", "text": text}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    return response
+
+
+def _bad_response(body):
+    response = Mock()
+    response.status_code = 400
+    response.text = body
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        response=response
+    )
+    return response
+
+
+@patch("requests.Session.post")
+def test_400_naming_cache_control_retries_stripped(mock_post):
+    bad = _bad_response('{"error": {"message": "cache_control is not supported"}}')
+    mock_post.side_effect = [bad, _ok_response()]
+
+    chat_api_call(
+        "anthropic",
+        messages_payload=[{"role": "user", "content": "hi"}],
+        api_key="test-key",
+        model="claude-sonnet-4-6",
+        system_message="be terse",
+        streaming=False,
+    )
+
+    assert mock_post.call_count == 2
+    retry_body = mock_post.call_args_list[1][1]["json"]
+    assert "cache_control" not in json.dumps(retry_body)
+    # system degrades from block-array back to plain blocks sans cache keys
+    first_body = mock_post.call_args_list[0][1]["json"]
+    assert "cache_control" in json.dumps(first_body)
+
+
+@patch("requests.Session.post")
+def test_400_not_naming_cache_control_raises_unretried(mock_post):
+    bad = _bad_response('{"error": {"message": "max_tokens too large"}}')
+    mock_post.return_value = bad
+
+    with pytest.raises(Exception):
+        chat_api_call(
+            "anthropic",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test-key",
+            model="claude-sonnet-4-6",
+            streaming=False,
+        )
+    assert mock_post.call_count == 1
+
+
+@patch("requests.Session.post")
+def test_no_retry_when_payload_has_no_cache_control(mock_post):
+    """Non-caching model: even a cache_control-naming 400 must not retry
+    (nothing to strip -- the guard requires the param in OUR payload)."""
+    bad = _bad_response('{"error": {"message": "cache_control invalid"}}')
+    mock_post.return_value = bad
+
+    with pytest.raises(Exception):
+        chat_api_call(
+            "anthropic",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test-key",
+            model="claude-2.1",
+            streaming=False,
+        )
+    assert mock_post.call_count == 1
+
+
+def test_without_cache_control_strips_recursively():
+    data = {
+        "system": [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}],
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+                ],
+            }
+        ],
+        "tools": [{"name": "t", "cache_control": {"type": "ephemeral"}}],
+        "max_tokens": 5,
+    }
+    stripped = _without_cache_control(data)
+    assert "cache_control" not in json.dumps(stripped)
+    assert stripped["messages"][0]["content"][0]["text"] == "hi"
+    assert stripped["max_tokens"] == 5
+    assert _contains_cache_control(data) is True
+    assert _contains_cache_control(stripped) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest Tests/Chat/test_anthropic_caching_degrade.py -v`
+Expected: ImportError on the helpers, then retry-count failures.
+
+- [ ] **Step 3: Implement**
+
+1. Module helpers next to `_anthropic_caching_enabled`:
+
+```python
+def _without_cache_control(obj: Any) -> Any:
+    """Deep-copy ``obj`` with every ``cache_control`` key removed.
+
+    Args:
+        obj: Any JSON-shaped structure (dicts/lists/scalars).
+
+    Returns:
+        The same structure minus all ``cache_control`` entries.
+    """
+    if isinstance(obj, dict):
+        return {
+            key: _without_cache_control(value)
+            for key, value in obj.items()
+            if key != "cache_control"
+        }
+    if isinstance(obj, list):
+        return [_without_cache_control(item) for item in obj]
+    return obj
+
+
+def _contains_cache_control(obj: Any) -> bool:
+    """True when any nested dict carries a ``cache_control`` key."""
+    if isinstance(obj, dict):
+        return "cache_control" in obj or any(
+            _contains_cache_control(value) for value in obj.values()
+        )
+    if isinstance(obj, list):
+        return any(_contains_cache_control(item) for item in obj)
+    return False
+```
+
+2. Restructure the post block (:1282-1301). The current shape closes the session BEFORE `raise_for_status()` — move the degrade check inside the `with` (mirroring `chat_with_openai`'s stream_options degrade at :715-742):
+
+```python
+        with requests.Session() as session:
+            session.mount("https://", adapter)
+            response = session.post(
+                api_url,
+                headers=headers,
+                json=data,
+                stream=current_streaming,
+                timeout=180,
+            )
+            if (
+                response.status_code == 400
+                and _contains_cache_control(data)
+                and "cache_control" in (response.text or "")
+            ):
+                # Caching must never break sends (cost-ticker PR2): odd
+                # proxies/gateways can reject cache_control. Retry exactly
+                # once without any breakpoints; every other error path is
+                # untouched. Reading .text here is safe -- it is the error
+                # body, not a stream.
+                logger.warning(
+                    "Anthropic: endpoint rejected cache_control; retrying without prompt caching."
+                )
+                response = session.post(
+                    api_url,
+                    headers=headers,
+                    json=_without_cache_control(data),
+                    stream=current_streaming,
+                    timeout=180,
+                )
+        response.raise_for_status()
+```
+
+(`urllib3 Retry`'s status_forcelist covers only 429/5xx, so the 400 reaches this check untouched. `response.iter_lines()` in the streaming branch still works on the retried response object — it was created with `stream=current_streaming`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest Tests/Chat/test_anthropic_caching_degrade.py Tests/Chat/test_anthropic_native_tools.py Tests/Chat/test_anthropic_streaming_usage.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/LLM_Calls/LLM_API_Calls.py Tests/Chat/test_anthropic_caching_degrade.py
+git commit -m "feat(anthropic): degrade gracefully when an endpoint rejects cache_control"
+```
+
+---
+
+### Task 5: Prefix-stability pins
+
+**Files:**
+- Test: `Tests/Chat/test_anthropic_prefix_stability.py` (new; test-only task)
+
+**Interfaces:**
+- Consumes: the full payload build from Tasks 2-3 via the `_call_anthropic`-style mock idiom.
+
+- [ ] **Step 1: Write the tests (they should PASS immediately — they pin invariants)**
+
+```python
+# Tests/Chat/test_anthropic_prefix_stability.py
+"""Cache-prefix stability pins (cost-ticker PR2).
+
+Anthropic caching is a byte-exact prefix match over tools -> system ->
+messages. These tests pin that consecutive turn builds keep the shared
+prefix identical: same system bytes, same tool bytes, and message history
+content-identical except (a) the appended turn and (b) the per-turn
+cache_control marker, which MOVES to the newest message each build
+(metadata designating the cache boundary -- earlier content bytes stay
+identical, which is what the server matches on).
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.LLM_Calls.LLM_API_Calls import _without_cache_control
+
+
+def _sent_body(mock_post, messages):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.json.return_value = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-x",
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    mock_post.return_value = mock_response
+    chat_api_call(
+        "anthropic",
+        messages_payload=messages,
+        api_key="test-key",
+        model="claude-sonnet-4-6",
+        system_message="You are terse.\n\nAlways answer in one line.",
+        streaming=False,
+    )
+    return mock_post.call_args[1]["json"]
+
+
+TURN_1 = [{"role": "user", "content": "first question"}]
+TURN_2 = TURN_1 + [
+    {"role": "assistant", "content": "first answer"},
+    {"role": "user", "content": "second question"},
+]
+
+
+@patch("requests.Session.post")
+def test_system_bytes_identical_across_consecutive_builds(mock_post):
+    body_1 = _sent_body(mock_post, TURN_1)
+    body_2 = _sent_body(mock_post, TURN_2)
+    assert json.dumps(body_1["system"], sort_keys=True) == json.dumps(
+        body_2["system"], sort_keys=True
+    )
+
+
+@patch("requests.Session.post")
+def test_history_prefix_content_identical_across_builds(mock_post):
+    """Build 2's earlier messages == build 1's messages, modulo the moved
+    per-turn marker (strip cache_control from both sides before comparing)."""
+    body_1 = _sent_body(mock_post, TURN_1)
+    body_2 = _sent_body(mock_post, TURN_2)
+    prefix_2 = _without_cache_control(body_2["messages"][: len(body_1["messages"])])
+    stripped_1 = _without_cache_control(body_1["messages"])
+    assert prefix_2 == stripped_1
+
+
+@patch("requests.Session.post")
+def test_marker_sits_only_on_newest_message_each_build(mock_post):
+    body_2 = _sent_body(mock_post, TURN_2)
+    dumped_history = json.dumps(body_2["messages"][:-1])
+    assert "cache_control" not in dumped_history
+    assert body_2["messages"][-1]["content"][-1]["cache_control"] == {
+        "type": "ephemeral"
+    }
+
+
+@patch("requests.Session.post")
+def test_no_volatile_keys_reach_the_wire(mock_post):
+    """No timestamps/uuids/internal annotations in the request body."""
+    body = _sent_body(mock_post, TURN_2)
+    dumped = json.dumps(body)
+    for forbidden in ("_native_message_id", "timestamp", "uuid"):
+        assert forbidden not in dumped
+```
+
+- [ ] **Step 2: Run and confirm all pass**
+
+Run: `.venv/bin/pytest Tests/Chat/test_anthropic_prefix_stability.py -v`
+Expected: all PASS. If any fails, that is a REAL prefix-stability bug found by this task — stop and report rather than adjusting the assertion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/Chat/test_anthropic_prefix_stability.py
+git commit -m "test(anthropic): pin cache-prefix stability across consecutive turns"
+```
+
+---
+
+### Task 6: Gates + push + PR
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Touched-area suites**
+
+Run: `.venv/bin/pytest Tests/Chat/ Tests/LLM_Calls/ -q`
+Expected: green (Tests/Chat was 3029 passed at branch time).
+
+- [ ] **Step 2: Config regression**
+
+Run: `.venv/bin/pytest Tests/Config/ -q 2>/dev/null || .venv/bin/pytest Tests/ -k "config and caching" -q`
+Expected: green (locate the config-template tests if any assert the default TOML's section list — update in lockstep if one pins sections).
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/console-prompt-caching
+gh pr create --base dev --title "feat(anthropic): complete prompt caching (cost ticker PR2)" --body "$(cat <<'EOF'
+PR2 of the Console cost-ticker program (spec amended in-PR: the original PR2 premise predated task-323, which already shipped system+tool breakpoints).
+
+- Per-turn cache_control breakpoint on the final message — conversation history becomes a reusable cache prefix (task-323's system/tools breakpoints never cached history). Budget: 3 of 4 allowed breakpoints.
+- `[caching] anthropic_enabled` kill-switch (default on; absent section = shipped behavior; the 5 pre-existing task-323 tests pass unmodified).
+- Degrade path: a 400 naming cache_control retries exactly once with all breakpoints stripped — caching can never break sends.
+- Prefix-stability pins: system/tool bytes identical across consecutive turn builds; history content-identical modulo the moving per-turn marker; no volatile keys on the wire.
+- Accounting rides PR1 unchanged (cache_read/cache_write buckets, usage_json, pricing catalog cache rates).
+
+Live acceptance (needs a real key, per spec): `cache_read_input_tokens > 0` on the second consecutive Console send — visible in the PR1 usage records.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Spec-coverage checklist (PR2 section, as amended by Task 1)
+
+| Requirement | Task |
+|---|---|
+| Spec premise corrected (task-323 reality) | 1 |
+| Per-turn breakpoint, incremental prefix growth | 3 |
+| 5-min TTL only, never a ttl key | 3 (test) |
+| `[caching] anthropic_enabled` default on | 2 |
+| Never-break-sends 4xx degrade + diagnostic | 4 |
+| Sub-minimum prefixes silently uncached | nothing to do (server behavior; PR3 shows ground truth) |
+| Prefix-stability audit + byte-identical consecutive builds | 5 |
+| Leading-system extraction stability | 5 (system-bytes test rides the real extraction path via chat_api_call) |
+| OpenAI implicit accounting | already shipped in PR1 (amended out of scope) |
+| Cache accounting into PR1 buckets | already shipped (provider_usage.py:177-185; test_cache_usage_metrics.py) |
+| Legacy-path unaffected | 2 (default-on test) + existing task-323 suite unmodified |
+| Live acceptance: cache_read > 0 on 2nd send | 6 (PR body; user-verifiable with a real key) |

--- a/Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md
+++ b/Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md
@@ -165,23 +165,49 @@ round-trip on real in-memory SQLite.
 > before PR2 started, and PR1 shipped the OpenAI implicit-cache accounting.
 > PR2's remaining scope: the per-turn message breakpoint, the
 > `[caching] anthropic_enabled` toggle (provider-level, gating all three
-> breakpoints, default on — matching shipped reality; the original
-> "injected by the console gateway only" note described a world that no longer
-> exists), the 4xx degrade, and prefix-stability tests. The
-> "system string → block array" implementation note is already implemented.
+> breakpoints, default on — matching shipped reality), the 4xx degrade, and
+> prefix-stability tests. The "system string → block array" implementation
+> note is already implemented.
+>
+> **Re-amended 2026-08-02 (final review):** the original "injected by the
+> console gateway only" scoping is NOT obsolete — it is still correct for the
+> per-turn breakpoint, and PR2's first cut wrongly made that one
+> provider-wide too, taxing every one-shot Anthropic call in the app. See
+> "Breakpoint containment" below for the shipped split.
 
-Only the **native Anthropic console path** changes requests; every other
-provider's requests are untouched. `cache_control` is injected by the
-console gateway — non-console callers of `chat_with_anthropic` are
-unaffected (pass-through test asserts legacy paths emit no
-`cache_control`).
+**Breakpoint containment (amended 2026-08-02, final review).** The three
+breakpoints are NOT all provider-wide:
+
+- The **system-block** and **last-tool** breakpoints are provider-wide —
+  every `chat_with_anthropic` caller gets them (task-323, shipped before
+  PR2). That is economically safe for a one-shot call: a short system
+  prefix sits below Anthropic's cacheable minimum, so it is simply not
+  cached and nothing is billed differently.
+- The **per-turn message** breakpoint is **Console-opt-in**. It marks the
+  whole conversation prefix for caching, which bills at the 1.25× write
+  premium; a one-shot caller (media summarization loops, websearch, evals,
+  prompt engineering, the document generator) never sends a second turn
+  and so can never read the entry back — it would just pay ~25% more input
+  forever. The Console gateway therefore stamps
+  `ConsoleProviderResolution.prompt_caching = True` (Anthropic resolutions
+  only, and only when `[caching] anthropic_enabled` is on);
+  `chat_api_call` forwards it via `PROVIDER_PARAM_MAP["anthropic"]`, and
+  `chat_with_anthropic` gates the per-turn site on
+  `caching_active and prompt_caching`. Every other provider's map omits
+  the key, so it is silently dropped.
+
+Non-console callers of `chat_with_anthropic` therefore never get the
+per-turn breakpoint — the pass-through test asserts exactly that
+(`Tests/Chat/test_anthropic_native_tools.py::test_message_breakpoint_absent_without_opt_in`,
+plus the None/False variants).
 
 ### Anthropic explicit caching
 
-- **Breakpoints (2 of 4 allowed)**: one on the last system-prompt block,
-  one on the last content block of the newest message turn. The per-turn
-  breakpoint makes the conversation prefix reusable and grows it
-  incrementally each turn.
+- **Breakpoints: 3 of 4 allowed (system + last tool + per-turn)**: one on
+  the last system-prompt block, one on the last converted tool, one on the
+  last content block of the newest message turn. The per-turn breakpoint
+  makes the conversation prefix reusable and grows it incrementally each
+  turn. The 4th slot is deliberately held in reserve (see Risks).
 - **TTL**: 5-minute ephemeral only. (1-hour doubles the write premium —
   wrong trade for interactive chat; not in v1.)
 - **Config**: `[caching] anthropic_enabled`, default **on** (console chat
@@ -203,9 +229,15 @@ unaffected (pass-through test asserts legacy paths emit no
 - System prompt: verified byte-stable — `_leading_system_message()`
   passes `self.system_prompt` verbatim, no interpolation. Keep it that
   way; add a test asserting two consecutive payload builds are
-  byte-identical except for the appended turn.
+  byte-identical except for the appended turn. **Done** —
+  `Tests/Chat/test_anthropic_prefix_stability.py`.
 - The gateway's leading-system-row extraction must produce byte-identical
-  system blocks across turns — dedicated test.
+  system blocks across turns — dedicated test. **Done** —
+  `Tests/Chat/test_console_provider_gateway.py::test_chat_api_kwargs_system_message_is_byte_stable_across_turns`.
+  Correction to an earlier claim: that extraction is **not** verbatim — it
+  `.strip()`s each leading system row and joins them with `"\n\n"`. It is
+  however a pure function of those rows, so the same rows always produce the
+  same bytes, which is all prefix caching requires.
 - Skill substitution and chat dictionaries rewrite **only the final user
   turn**, at/after the last breakpoint — cache-safe, no change needed.
 - Staged workspace sources appear only in the context-snapshot/inspector
@@ -228,9 +260,10 @@ into the PR1 `cache_read` bucket.~~ (amended: already shipped via task-323/PR1)
 
 Payload-shape tests via the stub provider (breakpoint placement/count);
 byte-identical consecutive-build test; leading-system stability test;
-per-provider cache-field accounting tests; legacy-path no-`cache_control`
-pass-through test. Live acceptance signal:
-`cache_read_input_tokens > 0` on the second consecutive real send.
+per-provider cache-field accounting tests; legacy-path pass-through test
+(non-console callers get **no per-turn `cache_control`**; the provider-wide
+system/tool breakpoints are expected and asserted present). Live acceptance
+signal: `cache_read_input_tokens > 0` on the second consecutive real send.
 
 ---
 
@@ -369,6 +402,18 @@ isolation across session tabs.
   ticker itself makes this visible (write costs appear in the breakdown),
   and `[caching] anthropic_enabled = false` is the escape hatch; an
   auto-disable heuristic is listed as a follow-up.
+- **Cache lookback window (~20 blocks)**: Anthropic looks back only a
+  bounded number of content blocks (~20) from each `cache_control`
+  breakpoint when matching a prefix. A tool-heavy agent turn can add more
+  than that in a SINGLE exchange (tool_use + tool_result blocks
+  accumulate fast), pushing the previous breakpoint out of range — the
+  next send then silently misses and re-writes the whole prefix at 1.25×
+  instead of reading it at ~0.1×. There is no error; the only signal is
+  `cache_read_input_tokens == 0` in the ticker. We ship 3 of the 4 allowed
+  breakpoints and deliberately hold the 4th in reserve: the mitigation is
+  a second, older message breakpoint that keeps a long turn inside the
+  window. Follow-up candidate, not in this PR — it needs live
+  hit-rate evidence to place correctly.
 - **Pricing staleness**: mitigated by `as_of` date in tooltip + config
   overrides; never fabricate a price for unknown models (tokens-only
   display instead).

--- a/Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md
+++ b/Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md
@@ -22,9 +22,13 @@ Today the app has **none** of the required substrate:
   table has no usage column.
 - There is no real pricing table (only a stale, blended $/1K list used by
   Evals).
-- No request ever sets `cache_control` — for Anthropic there is currently no
-  cache to break. OpenAI-style providers cache automatically but the app
-  never accounts for it.
+- Anthropic caching is PARTIAL (amended 2026-08-02: task-323 landed system-block
+  + last-tool `cache_control` for all callers after this spec's exploration
+  snapshot): conversation HISTORY is never cached — no per-turn message
+  breakpoint exists, so every send re-pays the full message history. There is
+  no config kill-switch and no degrade path if an endpoint rejects
+  `cache_control`. OpenAI-style providers cache automatically; PR1's adapters
+  already account for it.
 
 ## Decisions (user-approved during brainstorming)
 
@@ -156,6 +160,16 @@ round-trip on real in-memory SQLite.
 
 ## PR2 — Prompt-caching enablement
 
+> **Amended 2026-08-02 (PR2 planning):** task-323 shipped the system-block and
+> last-tool breakpoints for ALL `chat_with_anthropic` callers (not console-only)
+> before PR2 started, and PR1 shipped the OpenAI implicit-cache accounting.
+> PR2's remaining scope: the per-turn message breakpoint, the
+> `[caching] anthropic_enabled` toggle (provider-level, gating all three
+> breakpoints, default on — matching shipped reality; the original
+> "injected by the console gateway only" note described a world that no longer
+> exists), the 4xx degrade, and prefix-stability tests. The
+> "system string → block array" implementation note is already implemented.
+
 Only the **native Anthropic console path** changes requests; every other
 provider's requests are untouched. `cache_control` is injected by the
 console gateway — non-console callers of `chat_with_anthropic` are
@@ -178,11 +192,11 @@ unaffected (pass-through test asserts legacy paths emit no
   breakpoints and log a diagnostic. Caching must never break sends.
 - Sub-minimum prefixes silently don't cache (no error) — PR3 shows this
   honestly as "no cache" from usage ground truth.
-- Implementation note: the gateway extracts leading system rows into the
+- ~~Implementation note: the gateway extracts leading system rows into the
   provider call's `system_message` string parameter, so
   `chat_with_anthropic` must convert that string into a system **block
   array** to carry `cache_control` — the byte-stability test covers the
-  conversion.
+  conversion.~~ (amended: already shipped via task-323/PR1)
 
 ### Prefix-stability audit (part of PR2)
 
@@ -207,8 +221,8 @@ unaffected (pass-through test asserts legacy paths emit no
 
 ### OpenAI implicit caching
 
-Zero request changes. Start reading `prompt_tokens_details.cached_tokens`
-into the PR1 `cache_read` bucket.
+~~Zero request changes. Start reading `prompt_tokens_details.cached_tokens`
+into the PR1 `cache_read` bucket.~~ (amended: already shipped via task-323/PR1)
 
 ### PR2 testing
 

--- a/Tests/Chat/test_anthropic_caching_degrade.py
+++ b/Tests/Chat/test_anthropic_caching_degrade.py
@@ -1,0 +1,118 @@
+"""A 400 naming cache_control retries ONCE without breakpoints; any other
+error behaves exactly as before (caching must never break sends)."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.LLM_Calls.LLM_API_Calls import (
+    _contains_cache_control,
+    _without_cache_control,
+)
+
+
+def _ok_response(text="ok"):
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status = Mock()
+    response.json.return_value = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-x",
+        "content": [{"type": "text", "text": text}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    return response
+
+
+def _bad_response(body):
+    response = Mock()
+    response.status_code = 400
+    response.text = body
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        response=response
+    )
+    return response
+
+
+@patch("requests.Session.post")
+def test_400_naming_cache_control_retries_stripped(mock_post):
+    bad = _bad_response('{"error": {"message": "cache_control is not supported"}}')
+    mock_post.side_effect = [bad, _ok_response()]
+
+    chat_api_call(
+        "anthropic",
+        messages_payload=[{"role": "user", "content": "hi"}],
+        api_key="test-key",
+        model="claude-sonnet-4-6",
+        system_message="be terse",
+        streaming=False,
+    )
+
+    assert mock_post.call_count == 2
+    retry_body = mock_post.call_args_list[1][1]["json"]
+    assert "cache_control" not in json.dumps(retry_body)
+    # system degrades from block-array back to plain blocks sans cache keys
+    first_body = mock_post.call_args_list[0][1]["json"]
+    assert "cache_control" in json.dumps(first_body)
+
+
+@patch("requests.Session.post")
+def test_400_not_naming_cache_control_raises_unretried(mock_post):
+    bad = _bad_response('{"error": {"message": "max_tokens too large"}}')
+    mock_post.return_value = bad
+
+    with pytest.raises(Exception):
+        chat_api_call(
+            "anthropic",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test-key",
+            model="claude-sonnet-4-6",
+            streaming=False,
+        )
+    assert mock_post.call_count == 1
+
+
+@patch("requests.Session.post")
+def test_no_retry_when_payload_has_no_cache_control(mock_post):
+    """Non-caching model: even a cache_control-naming 400 must not retry
+    (nothing to strip -- the guard requires the param in OUR payload)."""
+    bad = _bad_response('{"error": {"message": "cache_control invalid"}}')
+    mock_post.return_value = bad
+
+    with pytest.raises(Exception):
+        chat_api_call(
+            "anthropic",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test-key",
+            model="claude-2.1",
+            streaming=False,
+        )
+    assert mock_post.call_count == 1
+
+
+def test_without_cache_control_strips_recursively():
+    data = {
+        "system": [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}],
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+                ],
+            }
+        ],
+        "tools": [{"name": "t", "cache_control": {"type": "ephemeral"}}],
+        "max_tokens": 5,
+    }
+    stripped = _without_cache_control(data)
+    assert "cache_control" not in json.dumps(stripped)
+    assert stripped["messages"][0]["content"][0]["text"] == "hi"
+    assert stripped["max_tokens"] == 5
+    assert _contains_cache_control(data) is True
+    assert _contains_cache_control(stripped) is False

--- a/Tests/Chat/test_anthropic_caching_degrade.py
+++ b/Tests/Chat/test_anthropic_caching_degrade.py
@@ -9,6 +9,7 @@ import requests
 
 from tldw_chatbook.Chat.Chat_Functions import chat_api_call
 from tldw_chatbook.LLM_Calls.LLM_API_Calls import (
+    _anthropic_caching_enabled,
     _contains_cache_control,
     _without_cache_control,
 )
@@ -123,6 +124,30 @@ def test_no_retry_when_payload_has_no_cache_control(mock_post):
             streaming=False,
         )
     assert mock_post.call_count == 1
+
+
+def test_caching_enabled_defaults_true_and_warns_on_config_read_failure():
+    """A broken config read must fail OPEN (never silently change request
+    shapes) but must not fail SILENT -- the operator needs a signal that the
+    kill-switch read is broken, not just that caching happened to stay on."""
+    from loguru import logger as loguru_logger
+
+    messages = []
+    sink_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        with patch(
+            "tldw_chatbook.LLM_Calls.LLM_API_Calls.get_cli_setting",
+            side_effect=RuntimeError("config store unavailable"),
+        ):
+            result = _anthropic_caching_enabled()
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert result is True
+    assert len(messages) == 1
+    assert "caching config read failed" in messages[0]
+    assert "defaulting anthropic prompt caching ON" in messages[0]
+    assert "config store unavailable" in messages[0]
 
 
 def test_without_cache_control_strips_recursively():

--- a/Tests/Chat/test_anthropic_caching_degrade.py
+++ b/Tests/Chat/test_anthropic_caching_degrade.py
@@ -55,11 +55,40 @@ def test_400_naming_cache_control_retries_stripped(mock_post):
     )
 
     assert mock_post.call_count == 2
+    # The retry is the SAME payload with every cache_control key stripped --
+    # the system block array survives as a block array, it just loses its
+    # cache key (`_without_cache_control` removes only that one key).
     retry_body = mock_post.call_args_list[1][1]["json"]
     assert "cache_control" not in json.dumps(retry_body)
-    # system degrades from block-array back to plain blocks sans cache keys
+    assert retry_body["system"] == [{"type": "text", "text": "be terse"}]
+    # ...and the FIRST attempt did carry a breakpoint, so the retry is a real
+    # degrade rather than a payload that never had one.
     first_body = mock_post.call_args_list[0][1]["json"]
     assert "cache_control" in json.dumps(first_body)
+    assert retry_body["messages"] == _without_cache_control(first_body["messages"])
+
+
+@patch("requests.Session.post")
+def test_degrade_is_visible_to_metrics(mock_post):
+    """A silent degrade is a silent cost regression: every send would pay the
+    cache-write premium and never read. Emit a counter so it is observable."""
+    bad = _bad_response('{"error": {"message": "cache_control is not supported"}}')
+    mock_post.side_effect = [bad, _ok_response()]
+
+    with patch(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls.log_counter"
+    ) as mock_log_counter:
+        chat_api_call(
+            "anthropic",
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key="test-key",
+            model="claude-sonnet-4-6",
+            system_message="be terse",
+            streaming=False,
+        )
+
+    counters = [call.args[0] for call in mock_log_counter.call_args_list if call.args]
+    assert "anthropic_cache_control_degrade" in counters
 
 
 @patch("requests.Session.post")

--- a/Tests/Chat/test_anthropic_native_tools.py
+++ b/Tests/Chat/test_anthropic_native_tools.py
@@ -867,3 +867,28 @@ def test_caching_model_no_tools_system_only(mock_post):
     sent = _sent_anthropic(mock_post, "claude-3-opus-20240229", system_message="Hi.")
     assert isinstance(sent["system"], list)
     assert "tools" not in sent  # no tools passed -> no tools key
+
+
+@patch("requests.Session.post")
+def test_caching_disabled_via_config_strips_all_breakpoints(mock_post):
+    """[caching] anthropic_enabled = false removes system AND tool AND
+    message breakpoints; payload shape otherwise unchanged."""
+    with patch(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls.get_cli_setting",
+        side_effect=lambda section, key=None, default=None: (
+            False if (section, key) == ("caching", "anthropic_enabled") else default
+        ),
+    ):
+        sent = _sent_anthropic(
+            mock_post, "claude-sonnet-4-6", system_message="be terse", tools=OPENAI_TOOLS
+        )
+    assert isinstance(sent["system"], str)  # string form, no block array
+    assert "cache_control" not in json.dumps(sent)
+
+
+@patch("requests.Session.post")
+def test_caching_default_on_when_section_absent(mock_post):
+    """No [caching] section -> enabled (the existing task-323 behavior)."""
+    sent = _sent_anthropic(mock_post, "claude-sonnet-4-6", system_message="be terse")
+    assert isinstance(sent["system"], list)
+    assert sent["system"][-1]["cache_control"] == {"type": "ephemeral"}

--- a/Tests/Chat/test_anthropic_native_tools.py
+++ b/Tests/Chat/test_anthropic_native_tools.py
@@ -197,7 +197,15 @@ def test_openai_tool_history_converts_to_anthropic_blocks(mock_post):
     assert sent[2]["role"] == "user"
     assert sent[2]["content"] == [
         {"type": "tool_result", "tool_use_id": "toolu_A", "content": "4"},
-        {"type": "tool_result", "tool_use_id": "toolu_B", "content": "6"},
+        {
+            "type": "tool_result",
+            "tool_use_id": "toolu_B",
+            "content": "6",
+            # claude-3-opus (the fixture's default model) supports caching, so
+            # the last content block of the FINAL message picks up the
+            # per-turn breakpoint (task-323 PR2).
+            "cache_control": {"type": "ephemeral"},
+        },
     ]
     assert len(sent) == 3
 
@@ -231,6 +239,8 @@ def test_assistant_text_plus_tool_calls_keeps_text_block_first(mock_post):
             "id": "toolu_1",
             "name": "calculator",
             "input": {"expression": "2+2"},
+            # last block of the FINAL message: per-turn breakpoint (PR2).
+            "cache_control": {"type": "ephemeral"},
         },
     ]
 
@@ -254,7 +264,14 @@ def test_malformed_tool_call_arguments_become_empty_input(mock_post):
     sent = _call_anthropic(mock_post, messages)["messages"]
 
     assert sent[1]["content"] == [
-        {"type": "tool_use", "id": "toolu_1", "name": "calculator", "input": {}}
+        {
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "calculator",
+            "input": {},
+            # last block of the FINAL message: per-turn breakpoint (PR2).
+            "cache_control": {"type": "ephemeral"},
+        }
     ]
 
 
@@ -269,7 +286,17 @@ def test_plain_chat_payload_unchanged(mock_post):
     assert "tools" not in sent
     assert sent["messages"] == [
         {"role": "user", "content": [{"type": "text", "text": "hi"}]},
-        {"role": "assistant", "content": [{"type": "text", "text": "there"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "there",
+                    # last block of the FINAL message: per-turn breakpoint (PR2).
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
     ]
 
 
@@ -291,7 +318,14 @@ def test_all_junk_tool_calls_fall_back_to_plain_content(mock_post):
     sent = _call_anthropic(mock_post, messages)["messages"]
 
     assert sent[1]["role"] == "assistant"
-    assert sent[1]["content"] == [{"type": "text", "text": "hello"}]
+    assert sent[1]["content"] == [
+        {
+            "type": "text",
+            "text": "hello",
+            # last block of the FINAL message: per-turn breakpoint (PR2).
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
 
 
 @patch("requests.Session.post")
@@ -323,6 +357,8 @@ def test_junk_tool_call_skipped_among_valid_entries(mock_post):
             "id": "toolu_1",
             "name": "calculator",
             "input": {"expression": "2+2"},
+            # last block of the FINAL message: per-turn breakpoint (PR2).
+            "cache_control": {"type": "ephemeral"},
         }
     ]
 
@@ -792,7 +828,7 @@ def test_streaming_two_interleaved_tool_blocks_reassemble_distinctly(mock_post):
     assert json.loads(calls[1]["function"]["arguments"]) == {}
 
 
-def _sent_anthropic(mock_post, model, **extra):
+def _sent_anthropic(mock_post, model, messages_payload=None, **extra):
     """Drive chat_with_anthropic with an explicit model; return the sent JSON."""
     mock_response = Mock()
     mock_response.json.return_value = _anthropic_text_response()
@@ -801,7 +837,9 @@ def _sent_anthropic(mock_post, model, **extra):
     mock_post.return_value = mock_response
     chat_api_call(
         "anthropic",
-        messages_payload=[{"role": "user", "content": "hi"}],
+        messages_payload=messages_payload
+        if messages_payload is not None
+        else [{"role": "user", "content": "hi"}],
         api_key="test-key",
         model=model,
         streaming=False,
@@ -892,3 +930,66 @@ def test_caching_default_on_when_section_absent(mock_post):
     sent = _sent_anthropic(mock_post, "claude-sonnet-4-6", system_message="be terse")
     assert isinstance(sent["system"], list)
     assert sent["system"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def _count_cache_controls(obj):
+    """Count every cache_control key anywhere in the payload."""
+    if isinstance(obj, dict):
+        return ("cache_control" in obj) + sum(
+            _count_cache_controls(v) for v in obj.values()
+        )
+    if isinstance(obj, list):
+        return sum(_count_cache_controls(item) for item in obj)
+    return 0
+
+
+@patch("requests.Session.post")
+def test_caching_model_marks_last_message_block(mock_post):
+    """The final message's LAST content block carries the per-turn breakpoint;
+    earlier messages and earlier blocks of the final message carry none."""
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        messages_payload=[
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second question"},
+        ],
+    )
+    messages = sent["messages"]
+    assert messages[-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert _count_cache_controls(messages[:-1]) == 0
+    assert _count_cache_controls(messages[-1]["content"][:-1]) == 0
+
+
+@patch("requests.Session.post")
+def test_breakpoint_budget_never_exceeds_four(mock_post):
+    """system + last-tool + per-turn = 3 total, within Anthropic's 4-cap."""
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        system_message="be terse",
+        tools=OPENAI_TOOLS,
+        messages_payload=[{"role": "user", "content": "hi"}],
+    )
+    assert _count_cache_controls(sent) == 3
+
+
+@patch("requests.Session.post")
+def test_non_caching_model_gets_no_message_breakpoint(mock_post):
+    sent = _sent_anthropic(
+        mock_post, "claude-2.1", messages_payload=[{"role": "user", "content": "hi"}]
+    )
+    assert _count_cache_controls(sent) == 0
+
+
+@patch("requests.Session.post")
+def test_message_breakpoint_never_emits_ttl_key(mock_post):
+    """5-minute default only — a ttl key would double the write premium."""
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        messages_payload=[{"role": "user", "content": "hi"}],
+    )
+    assert sent["messages"][-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert "ttl" not in json.dumps(sent)

--- a/Tests/Chat/test_anthropic_native_tools.py
+++ b/Tests/Chat/test_anthropic_native_tools.py
@@ -197,15 +197,7 @@ def test_openai_tool_history_converts_to_anthropic_blocks(mock_post):
     assert sent[2]["role"] == "user"
     assert sent[2]["content"] == [
         {"type": "tool_result", "tool_use_id": "toolu_A", "content": "4"},
-        {
-            "type": "tool_result",
-            "tool_use_id": "toolu_B",
-            "content": "6",
-            # claude-3-opus (the fixture's default model) supports caching, so
-            # the last content block of the FINAL message picks up the
-            # per-turn breakpoint (task-323 PR2).
-            "cache_control": {"type": "ephemeral"},
-        },
+        {"type": "tool_result", "tool_use_id": "toolu_B", "content": "6"},
     ]
     assert len(sent) == 3
 
@@ -239,8 +231,6 @@ def test_assistant_text_plus_tool_calls_keeps_text_block_first(mock_post):
             "id": "toolu_1",
             "name": "calculator",
             "input": {"expression": "2+2"},
-            # last block of the FINAL message: per-turn breakpoint (PR2).
-            "cache_control": {"type": "ephemeral"},
         },
     ]
 
@@ -264,14 +254,7 @@ def test_malformed_tool_call_arguments_become_empty_input(mock_post):
     sent = _call_anthropic(mock_post, messages)["messages"]
 
     assert sent[1]["content"] == [
-        {
-            "type": "tool_use",
-            "id": "toolu_1",
-            "name": "calculator",
-            "input": {},
-            # last block of the FINAL message: per-turn breakpoint (PR2).
-            "cache_control": {"type": "ephemeral"},
-        }
+        {"type": "tool_use", "id": "toolu_1", "name": "calculator", "input": {}}
     ]
 
 
@@ -286,17 +269,7 @@ def test_plain_chat_payload_unchanged(mock_post):
     assert "tools" not in sent
     assert sent["messages"] == [
         {"role": "user", "content": [{"type": "text", "text": "hi"}]},
-        {
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "text",
-                    "text": "there",
-                    # last block of the FINAL message: per-turn breakpoint (PR2).
-                    "cache_control": {"type": "ephemeral"},
-                }
-            ],
-        },
+        {"role": "assistant", "content": [{"type": "text", "text": "there"}]},
     ]
 
 
@@ -318,14 +291,7 @@ def test_all_junk_tool_calls_fall_back_to_plain_content(mock_post):
     sent = _call_anthropic(mock_post, messages)["messages"]
 
     assert sent[1]["role"] == "assistant"
-    assert sent[1]["content"] == [
-        {
-            "type": "text",
-            "text": "hello",
-            # last block of the FINAL message: per-turn breakpoint (PR2).
-            "cache_control": {"type": "ephemeral"},
-        }
-    ]
+    assert sent[1]["content"] == [{"type": "text", "text": "hello"}]
 
 
 @patch("requests.Session.post")
@@ -357,8 +323,6 @@ def test_junk_tool_call_skipped_among_valid_entries(mock_post):
             "id": "toolu_1",
             "name": "calculator",
             "input": {"expression": "2+2"},
-            # last block of the FINAL message: per-turn breakpoint (PR2).
-            "cache_control": {"type": "ephemeral"},
         }
     ]
 
@@ -918,7 +882,12 @@ def test_caching_disabled_via_config_strips_all_breakpoints(mock_post):
         ),
     ):
         sent = _sent_anthropic(
-            mock_post, "claude-sonnet-4-6", system_message="be terse", tools=OPENAI_TOOLS
+            mock_post,
+            "claude-sonnet-4-6",
+            system_message="be terse",
+            tools=OPENAI_TOOLS,
+            # even an explicit Console opt-in loses to the kill-switch
+            prompt_caching=True,
         )
     assert isinstance(sent["system"], str)  # string form, no block array
     assert "cache_control" not in json.dumps(sent)
@@ -950,6 +919,7 @@ def test_caching_model_marks_last_message_block(mock_post):
     sent = _sent_anthropic(
         mock_post,
         "claude-sonnet-4-6",
+        prompt_caching=True,
         messages_payload=[
             {"role": "user", "content": "first question"},
             {"role": "assistant", "content": "first answer"},
@@ -970,6 +940,7 @@ def test_breakpoint_budget_never_exceeds_four(mock_post):
         "claude-sonnet-4-6",
         system_message="be terse",
         tools=OPENAI_TOOLS,
+        prompt_caching=True,
         messages_payload=[{"role": "user", "content": "hi"}],
     )
     assert _count_cache_controls(sent) == 3
@@ -978,7 +949,10 @@ def test_breakpoint_budget_never_exceeds_four(mock_post):
 @patch("requests.Session.post")
 def test_non_caching_model_gets_no_message_breakpoint(mock_post):
     sent = _sent_anthropic(
-        mock_post, "claude-2.1", messages_payload=[{"role": "user", "content": "hi"}]
+        mock_post,
+        "claude-2.1",
+        prompt_caching=True,
+        messages_payload=[{"role": "user", "content": "hi"}],
     )
     assert _count_cache_controls(sent) == 0
 
@@ -989,7 +963,60 @@ def test_message_breakpoint_never_emits_ttl_key(mock_post):
     sent = _sent_anthropic(
         mock_post,
         "claude-sonnet-4-6",
+        prompt_caching=True,
         messages_payload=[{"role": "user", "content": "hi"}],
     )
     assert sent["messages"][-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
     assert "ttl" not in json.dumps(sent)
+
+
+# ---- per-turn breakpoint is CONSOLE-ONLY (spec's pass-through guarantee) ----
+#
+# The per-turn breakpoint bills the whole conversation prefix at the 1.25x
+# cache-write premium. A one-shot caller (media summarization loops,
+# websearch, evals, prompt engineering, the document generator) never sends
+# a second turn, so it can never read that entry back -- it would just pay
+# ~25% more input forever. These tests pin that only an explicit
+# `prompt_caching=True` (stamped by the Console gateway) turns it on.
+
+
+@patch("requests.Session.post")
+def test_message_breakpoint_absent_without_opt_in(mock_post):
+    """Default (no `prompt_caching` kwarg): NO per-turn message breakpoint,
+    while the provider-wide task-323 system/tool breakpoints stay."""
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        system_message="be terse",
+        tools=OPENAI_TOOLS,
+        messages_payload=[
+            {"role": "user", "content": "summarize this"},
+        ],
+    )
+    assert _count_cache_controls(sent["messages"]) == 0
+    # task-323 breakpoints are untouched by the opt-in gate:
+    assert sent["system"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert sent["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert _count_cache_controls(sent) == 2
+
+
+@patch("requests.Session.post")
+def test_message_breakpoint_absent_when_opt_in_is_none(mock_post):
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        prompt_caching=None,
+        messages_payload=[{"role": "user", "content": "hi"}],
+    )
+    assert _count_cache_controls(sent["messages"]) == 0
+
+
+@patch("requests.Session.post")
+def test_message_breakpoint_absent_when_opt_in_is_false(mock_post):
+    sent = _sent_anthropic(
+        mock_post,
+        "claude-sonnet-4-6",
+        prompt_caching=False,
+        messages_payload=[{"role": "user", "content": "hi"}],
+    )
+    assert _count_cache_controls(sent["messages"]) == 0

--- a/Tests/Chat/test_anthropic_prefix_stability.py
+++ b/Tests/Chat/test_anthropic_prefix_stability.py
@@ -1,0 +1,87 @@
+"""Cache-prefix stability pins (cost-ticker PR2).
+
+Anthropic caching is a byte-exact prefix match over tools -> system ->
+messages. These tests pin that consecutive turn builds keep the shared
+prefix identical: same system bytes, same tool bytes, and message history
+content-identical except (a) the appended turn and (b) the per-turn
+cache_control marker, which MOVES to the newest message each build
+(metadata designating the cache boundary -- earlier content bytes stay
+identical, which is what the server matches on).
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.LLM_Calls.LLM_API_Calls import _without_cache_control
+
+
+def _sent_body(mock_post, messages):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.json.return_value = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-x",
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    mock_post.return_value = mock_response
+    chat_api_call(
+        "anthropic",
+        messages_payload=messages,
+        api_key="test-key",
+        model="claude-sonnet-4-6",
+        system_message="You are terse.\n\nAlways answer in one line.",
+        streaming=False,
+    )
+    return mock_post.call_args[1]["json"]
+
+
+TURN_1 = [{"role": "user", "content": "first question"}]
+TURN_2 = TURN_1 + [
+    {"role": "assistant", "content": "first answer"},
+    {"role": "user", "content": "second question"},
+]
+
+
+@patch("requests.Session.post")
+def test_system_bytes_identical_across_consecutive_builds(mock_post):
+    body_1 = _sent_body(mock_post, TURN_1)
+    body_2 = _sent_body(mock_post, TURN_2)
+    assert json.dumps(body_1["system"], sort_keys=True) == json.dumps(
+        body_2["system"], sort_keys=True
+    )
+
+
+@patch("requests.Session.post")
+def test_history_prefix_content_identical_across_builds(mock_post):
+    """Build 2's earlier messages == build 1's messages, modulo the moved
+    per-turn marker (strip cache_control from both sides before comparing)."""
+    body_1 = _sent_body(mock_post, TURN_1)
+    body_2 = _sent_body(mock_post, TURN_2)
+    prefix_2 = _without_cache_control(body_2["messages"][: len(body_1["messages"])])
+    stripped_1 = _without_cache_control(body_1["messages"])
+    assert prefix_2 == stripped_1
+
+
+@patch("requests.Session.post")
+def test_marker_sits_only_on_newest_message_each_build(mock_post):
+    body_2 = _sent_body(mock_post, TURN_2)
+    dumped_history = json.dumps(body_2["messages"][:-1])
+    assert "cache_control" not in dumped_history
+    assert body_2["messages"][-1]["content"][-1]["cache_control"] == {
+        "type": "ephemeral"
+    }
+
+
+@patch("requests.Session.post")
+def test_no_volatile_keys_reach_the_wire(mock_post):
+    """No timestamps/uuids/internal annotations in the request body."""
+    body = _sent_body(mock_post, TURN_2)
+    dumped = json.dumps(body)
+    for forbidden in ("_native_message_id", "timestamp", "uuid"):
+        assert forbidden not in dumped

--- a/Tests/Chat/test_anthropic_prefix_stability.py
+++ b/Tests/Chat/test_anthropic_prefix_stability.py
@@ -37,6 +37,10 @@ def _sent_body(mock_post, messages):
         model="claude-sonnet-4-6",
         system_message="You are terse.\n\nAlways answer in one line.",
         streaming=False,
+        # Console shape: the per-turn breakpoint is opt-in, and prefix
+        # stability only matters for the multi-turn (Console) path that
+        # actually sets it.
+        prompt_caching=True,
     )
     return mock_post.call_args[1]["json"]
 

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2694,6 +2694,154 @@ def test_chat_api_kwargs_without_system_rows_omits_system_message() -> None:
     assert kwargs["messages_payload"] == messages
 
 
+def test_chat_api_kwargs_system_message_is_byte_stable_across_turns() -> None:
+    """The extracted system_message must be BYTE-identical turn over turn.
+
+    Anthropic prompt caching matches on an exact byte prefix (tools ->
+    system -> messages), so any drift in the extracted system string -- a
+    changed join, an interpolated timestamp, a re-ordered row -- silently
+    invalidates the cache and re-pays the 1.25x write premium on every send.
+    This is the seam the cost-ticker spec names: the gateway's
+    leading-system-row extraction, not the controller's verbatim prompt.
+
+    Note the extraction is normalizing, not verbatim: rows are stripped and
+    joined with "\\n\\n". That is fine for caching precisely because it is
+    deterministic -- the same rows always produce the same bytes.
+    """
+    system_rows = [
+        {"role": "system", "content": "You are terse.\n\nAnswer in one line."},
+        {"role": "system", "content": "Never use emoji."},
+    ]
+    turn_1 = system_rows + [{"role": "user", "content": "first question"}]
+    turn_2 = turn_1 + [
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "second question"},
+    ]
+
+    kwargs_1 = ConsoleProviderGateway._chat_api_kwargs(_bare_resolution(), turn_1)
+    kwargs_2 = ConsoleProviderGateway._chat_api_kwargs(_bare_resolution(), turn_2)
+
+    assert kwargs_1["system_message"] == kwargs_2["system_message"]
+    assert (
+        kwargs_1["system_message"].encode() == kwargs_2["system_message"].encode()
+    )
+    # and the history prefix itself is untouched by the extraction
+    assert kwargs_2["messages_payload"][: len(kwargs_1["messages_payload"])] == (
+        kwargs_1["messages_payload"]
+    )
+
+
+# ---- per-turn cache_control opt-in (Console-only) ----
+
+
+def test_chat_api_kwargs_omits_prompt_caching_for_non_anthropic() -> None:
+    """`prompt_caching=None` is stripped, so non-Anthropic kwargs are
+    unchanged from before prompt caching existed."""
+    resolution = ConsoleProviderResolution(
+        provider="openai",
+        base_url="",
+        model="gpt-4.1",
+        ready=True,
+        execution_key="openai",
+        api_key="k",
+        streaming=False,
+    )
+
+    kwargs = ConsoleProviderGateway._chat_api_kwargs(
+        resolution, [{"role": "user", "content": "hi"}]
+    )
+
+    assert "prompt_caching" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_anthropic_resolution_forwards_prompt_caching_opt_in() -> None:
+    """Console sends are multi-turn, so they opt into the per-turn
+    breakpoint; one-shot callers of `chat_with_anthropic` never do."""
+    calls: list[dict] = []
+
+    def fake_chat_api_call(**kwargs):
+        calls.append(kwargs)
+        return "done"
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {"api_settings": {"anthropic": {"api_key": "k"}}},
+        chat_api_call_fn=fake_chat_api_call,
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="anthropic",
+            explicit_model="claude-sonnet-4-6",
+            streaming=False,
+        )
+    )
+
+    assert resolution.prompt_caching is True
+
+    _ = [
+        chunk
+        async for chunk in gateway.stream_chat(
+            resolution, [{"role": "user", "content": "hi"}]
+        )
+    ]
+
+    assert calls[0]["api_endpoint"] == "anthropic"
+    assert calls[0]["prompt_caching"] is True
+
+
+@pytest.mark.asyncio
+async def test_anthropic_resolution_respects_caching_kill_switch() -> None:
+    """`[caching] anthropic_enabled = false` turns the opt-in off at the
+    gateway too (the provider's own kill-switch is the second line)."""
+    calls: list[dict] = []
+
+    def fake_chat_api_call(**kwargs):
+        calls.append(kwargs)
+        return "done"
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {"anthropic": {"api_key": "k"}},
+            "caching": {"anthropic_enabled": False},
+        },
+        chat_api_call_fn=fake_chat_api_call,
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="anthropic",
+            explicit_model="claude-sonnet-4-6",
+            streaming=False,
+        )
+    )
+
+    assert resolution.prompt_caching is False
+
+    _ = [
+        chunk
+        async for chunk in gateway.stream_chat(
+            resolution, [{"role": "user", "content": "hi"}]
+        )
+    ]
+
+    # falsy either way: the per-turn marker is off
+    assert not calls[0].get("prompt_caching")
+
+
+@pytest.mark.asyncio
+async def test_non_anthropic_resolution_has_no_prompt_caching_flag() -> None:
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {"api_settings": {"openai": {"api_key": "sk-test"}}},
+        chat_api_call_fn=lambda **_kwargs: "done",
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="openai", explicit_model="gpt-4.1", streaming=False
+        )
+    )
+
+    assert resolution.prompt_caching is None
+
+
 @pytest.mark.asyncio
 async def test_stream_chat_records_usage_payload_from_sse_chunk() -> None:
     usage_line = (

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2828,9 +2828,36 @@ async def test_anthropic_resolution_respects_caching_kill_switch() -> None:
 
 
 @pytest.mark.asyncio
+async def test_anthropic_resolution_respects_kill_switch_in_load_settings_shape() -> None:
+    """The live Console's config_provider is `load_settings()` output, which
+    nests the raw TOML under COMPREHENSIVE_CONFIG_RAW and never projects
+    `[caching]` to the top level the way it does `api_settings` (Qodo
+    finding, PR #1239): a plain `app_config.get("caching")` always misses
+    and the kill-switch silently reads as always-on. Pin resolution against
+    exactly that shape."""
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {"anthropic": {"api_key": "k"}},
+            "COMPREHENSIVE_CONFIG_RAW": {"caching": {"anthropic_enabled": False}},
+        },
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="anthropic",
+            explicit_model="claude-sonnet-4-6",
+            streaming=False,
+        )
+    )
+
+    assert resolution.prompt_caching is False
+
+
+@pytest.mark.asyncio
 async def test_non_anthropic_resolution_has_no_prompt_caching_flag() -> None:
     gateway = ConsoleProviderGateway(
-        config_provider=lambda: {"api_settings": {"openai": {"api_key": "sk-test"}}},
+        config_provider=lambda: {
+            "api_settings": {"openai": {"api_key": "sk-test-placeholder-not-a-key"}}
+        },
         chat_api_call_fn=lambda **_kwargs: "done",
     )
     resolution = await gateway.resolve_for_send(

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -179,6 +179,10 @@ PROVIDER_PARAM_MAP = {
         "stop": "stop_sequences",  # Anthropic uses stop_sequences
         "thinking_effort": "thinking_effort",
         "thinking_budget_tokens": "thinking_budget_tokens",
+        # Console-only opt-in for the per-turn cache_control breakpoint.
+        # Deliberately absent from every other provider's map: the loop below
+        # only forwards mapped keys, so non-Anthropic calls drop it silently.
+        "prompt_caching": "prompt_caching",
     },
     "cohere": {
         "api_key": "api_key",
@@ -731,6 +735,7 @@ def chat_api_call(
     verbosity: Optional[str] = None,
     thinking_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
+    prompt_caching: Optional[bool] = None,
     llm_fixed_tokens_kobold: Optional[bool] = False,  # Added
 ):
     """
@@ -774,6 +779,10 @@ def chat_api_call(
         verbosity: Provider-specific response verbosity setting for OpenAI-compatible reasoning models.
         thinking_effort: Provider-specific thinking level for Anthropic-style thinking models.
         thinking_budget_tokens: Optional thinking token budget for Anthropic-style thinking models.
+        prompt_caching: Anthropic-only opt-in for the per-turn `cache_control`
+            breakpoint (multi-turn callers such as the Console gateway). Only
+            `PROVIDER_PARAM_MAP["anthropic"]` maps it, so it is silently
+            dropped for every other provider.
 
     Returns:
         The LLM's response. This can be a string for non-streaming responses or

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -272,6 +272,10 @@ class ConsoleProviderResolution:
         top_k: Optional top-k sampling value.
         max_tokens: Optional response token limit.
         streaming: Whether streaming responses are requested.
+        prompt_caching: Opt-in for the Anthropic per-turn ``cache_control``
+            breakpoint. Set only for Anthropic resolutions (and only when
+            ``[caching] anthropic_enabled`` is on); ``None`` everywhere else,
+            which drops the kwarg entirely in ``_chat_api_kwargs``.
     """
 
     provider: str
@@ -297,6 +301,7 @@ class ConsoleProviderResolution:
     thinking_effort: str | None = None
     thinking_budget_tokens: int | None = None
     streaming: bool = True
+    prompt_caching: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -986,6 +991,18 @@ class ConsoleProviderGateway:
                 api_key_source=readiness.api_key_source,
             )
 
+        # Console sends are multi-turn by construction, so they -- and ONLY
+        # they -- opt into the Anthropic per-turn cache_control breakpoint.
+        # A one-shot caller of `chat_with_anthropic` (summarization, evals,
+        # websearch) would pay the 1.25x cache-write premium on its whole
+        # prefix and never read it back, so the flag is stamped here rather
+        # than defaulted on inside the provider.
+        prompt_caching: bool | None = None
+        if identity.execution_key == "anthropic":
+            prompt_caching = bool(
+                _mapping_value(app_config, "caching").get("anthropic_enabled", True)
+            )
+
         return ConsoleProviderResolution(
             provider=selection.provider,
             base_url=selection.base_url or "",
@@ -995,6 +1012,7 @@ class ConsoleProviderGateway:
             execution_key=identity.execution_key,
             api_key=readiness.api_key,
             api_key_source=readiness.api_key_source,
+            prompt_caching=prompt_caching,
             temperature=selection.temperature,
             top_p=selection.top_p,
             min_p=selection.min_p,
@@ -1387,6 +1405,14 @@ class ConsoleProviderGateway:
         # themselves when the payload has none, so the extraction is
         # provider-neutral. Mid-array system rows never occur on this path
         # (`_provider_message_payloads` emits user/assistant only).
+        #
+        # The join deliberately normalizes: each row is `.strip()`ed and the
+        # rows are joined with "\n\n". The result is therefore NOT byte-verbatim
+        # with respect to the source rows -- but it IS a pure function of them,
+        # so the same rows always produce the same bytes. That determinism is
+        # what Anthropic prefix caching needs (a stable system block across
+        # consecutive turns); see the cache-stability test in
+        # Tests/Chat/test_console_provider_gateway.py.
         payload = list(messages)
         system_parts: list[str] = []
         while payload and payload[0].get("role") == "system":
@@ -1416,6 +1442,10 @@ class ConsoleProviderGateway:
             "thinking_effort": resolution.thinking_effort,
             "thinking_budget_tokens": resolution.thinking_budget_tokens,
             "tools": tools,
+            # None for every non-Anthropic resolution, so the strip below
+            # removes the key entirely and other providers' kwargs are byte
+            # for byte what they were before prompt caching existed.
+            "prompt_caching": resolution.prompt_caching,
         }
         return {key: value for key, value in kwargs.items() if value is not None}
 

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -997,10 +997,21 @@ class ConsoleProviderGateway:
         # websearch) would pay the 1.25x cache-write premium on its whole
         # prefix and never read it back, so the flag is stamped here rather
         # than defaulted on inside the provider.
+        #
+        # NOTE: this flag does not gate the kill-switch end-to-end by
+        # itself -- `chat_with_anthropic` ANDs it with
+        # `_anthropic_caching_enabled()`, which reads `[caching]
+        # anthropic_enabled` directly via `get_cli_setting()` and already
+        # disables every cache_control breakpoint (system, tool, AND this
+        # per-turn one) when the switch is off, regardless of what this
+        # resolution carries. This value only needs to be *truthful* for
+        # whatever inspects `ConsoleProviderResolution.prompt_caching`
+        # (introspection/tests/telemetry), which is why the config-shape
+        # bug below mattered even though sends were never at risk.
         prompt_caching: bool | None = None
         if identity.execution_key == "anthropic":
             prompt_caching = bool(
-                _mapping_value(app_config, "caching").get("anthropic_enabled", True)
+                _caching_config_value(app_config).get("anthropic_enabled", True)
             )
 
         return ConsoleProviderResolution(
@@ -1604,6 +1615,26 @@ class ConsoleProviderGateway:
 def _mapping_value(source: Mapping[str, object], key: str) -> Mapping[str, object]:
     value = source.get(key, {})
     return value if isinstance(value, Mapping) else {}
+
+
+def _caching_config_value(app_config: Mapping[str, object]) -> Mapping[str, object]:
+    """Return the ``[caching]`` section from either config shape.
+
+    Boot-time/live Console config (``load_settings()``) never projects
+    ``[caching]`` to the top level the way it does ``api_settings`` or
+    ``chat_defaults`` -- it only survives nested under
+    ``COMPREHENSIVE_CONFIG_RAW`` (see ``config.py``'s ``load_settings``).
+    A plain ``app_config.get("caching")`` therefore always misses on the
+    live Console config and silently reads the kill-switch as always-on
+    (Qodo finding, PR #1239). Prefer a top-level ``caching`` key when a
+    caller supplies one directly (e.g. tests), and fall back to the
+    nested raw-TOML shape otherwise.
+    """
+    top_level = _mapping_value(app_config, "caching")
+    if top_level:
+        return top_level
+    raw = _mapping_value(app_config, "COMPREHENSIVE_CONFIG_RAW")
+    return _mapping_value(raw, "caching")
 
 
 def _is_iterable_response(response: Any) -> bool:

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -1283,6 +1283,25 @@ def chat_with_anthropic(
     if output_config is not None:
         data["output_config"] = output_config
 
+    if (
+        caching_active
+        and anthropic_messages
+        and isinstance(anthropic_messages[-1].get("content"), list)
+        and anthropic_messages[-1]["content"]
+    ):
+        # Per-turn breakpoint (cost-ticker PR2): mark the last content block
+        # of the final message so the WHOLE conversation prefix becomes a
+        # reusable cache entry next turn -- the task-323 system/tools
+        # breakpoints alone never cache message history. Budget:
+        # system(1) + last-tool(1) + this(1) = 3 of the 4 allowed.
+        # Fresh dict so no caller-held block is mutated (same rule as the
+        # tools breakpoint above).
+        last_content = anthropic_messages[-1]["content"]
+        last_content[-1] = {
+            **last_content[-1],
+            "cache_control": {"type": "ephemeral"},
+        }
+
     api_url = (
         anthropic_config.get("api_base_url", "https://api.anthropic.com/v1").rstrip("/")
         + "/messages"

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -44,7 +44,7 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatProviderError,
     ChatConfigurationError,
 )
-from tldw_chatbook.config import get_runtime_config_snapshot, load_settings
+from tldw_chatbook.config import get_cli_setting, get_runtime_config_snapshot, load_settings
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.Utils.input_validation import validate_url
 #
@@ -961,6 +961,23 @@ def _anthropic_supports_caching(model: str) -> bool:
     )
 
 
+def _anthropic_caching_enabled() -> bool:
+    """[caching].anthropic_enabled kill-switch for ALL Anthropic cache_control.
+
+    Defaults to True when the section or key is absent (prompt caching is the
+    shipped task-323 behavior; this gate only adds an opt-out). Any config
+    read failure also defaults to True so a broken config file cannot
+    silently change request shapes.
+
+    Returns:
+        True when cache_control breakpoints should be emitted.
+    """
+    try:
+        return bool(get_cli_setting("caching", "anthropic_enabled", True))
+    except Exception:
+        return True
+
+
 def _anthropic_tools_payload(tools: list) -> list:
     """Convert OpenAI function-format tool entries to Anthropic's format.
 
@@ -1204,6 +1221,7 @@ def chat_with_anthropic(
         "anthropic-version": anthropic_config.get("api_version", "2023-06-01"),
         "Content-Type": "application/json",
     }
+    caching_active = _anthropic_supports_caching(current_model) and _anthropic_caching_enabled()
     data = {
         "model": current_model,
         "max_tokens": current_max_tokens,  # Changed from max_tokens_to_sample to the parameter
@@ -1211,7 +1229,7 @@ def chat_with_anthropic(
         "stream": current_streaming,
     }
     if system_prompt is not None:
-        if _anthropic_supports_caching(current_model) and system_prompt:
+        if caching_active and system_prompt:
             # cache_control on the system prompt (the largest stable prefix)
             # activates Anthropic prompt caching; per the tools->system->messages
             # hierarchy this caches tools+system. Applied for both streaming and
@@ -1252,7 +1270,7 @@ def chat_with_anthropic(
         data["stop_sequences"] = stop_sequences
     if tools is not None:
         tools_payload = _anthropic_tools_payload(tools)
-        if _anthropic_supports_caching(current_model) and tools_payload:
+        if caching_active and tools_payload:
             # Optional second breakpoint on the last converted tool. A fresh dict
             # so the caller's input `tools` are never mutated.
             tools_payload[-1] = {

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -974,7 +974,10 @@ def _anthropic_caching_enabled() -> bool:
     """
     try:
         return bool(get_cli_setting("caching", "anthropic_enabled", True))
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            f"caching config read failed; defaulting anthropic prompt caching ON: {exc!r}"
+        )
         return True
 
 
@@ -1091,6 +1094,30 @@ def chat_with_anthropic(
     """Call the Anthropic Messages API (streaming or non-streaming).
 
     Args:
+        input_data: List of message objects (OpenAI-style ``role``/``content``
+            dicts). ``role: "tool"`` entries are converted to Anthropic
+            ``tool_result`` blocks; assistant ``tool_calls`` echoes are
+            converted to ``tool_use`` blocks.
+        model: Anthropic model ID. Falls back to config, then
+            ``"claude-sonnet-5"``.
+        api_key: Anthropic API key. Falls back to config; raises if still
+            missing.
+        system_prompt: Optional system prompt sent as the top-level
+            ``system`` field.
+        temp: Sampling temperature. Falls back to config, then ``0.7``.
+        topp: Nucleus sampling parameter (Anthropic ``top_p``).
+        topk: Anthropic ``top_k`` sampling parameter.
+        streaming: Whether to stream the response via SSE. Falls back to
+            config, then ``False``.
+        max_tokens: Maximum tokens to generate. Falls back to config
+            (``max_tokens_to_sample``/``max_tokens``), then ``4096``.
+        stop_sequences: Custom stop sequences (Anthropic ``stop_sequences``).
+        tools: Tools in OpenAI function-call or native Anthropic shape;
+            normalized to Anthropic's ``{name, description, input_schema}``.
+        thinking_effort: Extended-thinking effort level, when the model
+            supports it (translated to a thinking token budget).
+        thinking_budget_tokens: Explicit extended-thinking token budget;
+            takes precedence over ``thinking_effort`` when both are set.
         prompt_caching: Opt-in for the PER-TURN message ``cache_control``
             breakpoint. Only multi-turn callers (the Console gateway) should
             pass True: the breakpoint bills the whole conversation prefix at
@@ -1100,7 +1127,28 @@ def chat_with_anthropic(
             last-tool breakpoints are NOT gated on this flag — those shipped
             provider-wide in task-323 and are harmless for one-shots, whose
             short system prefix falls below the cacheable minimum and is
-            simply not cached.
+            simply not cached. Also subject to the provider-wide
+            ``[caching].anthropic_enabled`` kill-switch
+            (``_anthropic_caching_enabled()``), which disables ALL
+            ``cache_control`` breakpoints regardless of this flag.
+        custom_prompt_arg: Legacy/unused prompt override, retained for call
+            signature compatibility.
+
+    Returns:
+        Non-streaming: a normalized OpenAI-style response dict (``choices``
+        with ``message``, ``usage``, etc.) built from the Anthropic Messages
+        API response. Streaming: a generator yielding OpenAI-style SSE
+        strings (``"data: {...}\\n\\n"``, terminated by ``"data: [DONE]\\n\\n"``).
+
+    Raises:
+        ChatConfigurationError: No API key is available (argument or config).
+        ChatBadRequestError: No valid user message could be built from
+            ``input_data``, or the API returned a 4xx error other than 401/429.
+        ChatAuthenticationError: The API returned 401 (invalid/expired key).
+        ChatRateLimitError: The API returned 429 (rate limited).
+        ChatProviderError: Any other HTTP error status, a network-level
+            request failure, or an unexpected exception while calling the
+            API.
     """
     # Assuming load_settings is defined elsewhere
     loaded_config_data = load_settings()

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -1082,11 +1082,26 @@ def chat_with_anthropic(
     tools: Optional[List[Dict[str, Any]]] = None,  # New: Anthropic tool format
     thinking_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
+    prompt_caching: Optional[bool] = None,
     # Anthropic doesn't typically use seed, response_format (for JSON object mode directly), n, user identifier, logit_bias,
     # presence_penalty, frequency_penalty, logprobs, top_logprobs in the same way as OpenAI.
     # tool_choice is usually implicit with tools or controlled differently.
     custom_prompt_arg: Optional[str] = None,  # Legacy
 ):
+    """Call the Anthropic Messages API (streaming or non-streaming).
+
+    Args:
+        prompt_caching: Opt-in for the PER-TURN message ``cache_control``
+            breakpoint. Only multi-turn callers (the Console gateway) should
+            pass True: the breakpoint bills the whole conversation prefix at
+            the 1.25x cache-write premium, which a one-shot call (media
+            summarization, websearch, evals, document generation) can never
+            earn back because it never sends a second turn. The system and
+            last-tool breakpoints are NOT gated on this flag — those shipped
+            provider-wide in task-323 and are harmless for one-shots, whose
+            short system prefix falls below the cacheable minimum and is
+            simply not cached.
+    """
     # Assuming load_settings is defined elsewhere
     loaded_config_data = load_settings()
     anthropic_config = loaded_config_data.get("anthropic_api", {})
@@ -1323,6 +1338,7 @@ def chat_with_anthropic(
 
     if (
         caching_active
+        and prompt_caching
         and anthropic_messages
         and isinstance(anthropic_messages[-1].get("content"), list)
         and anthropic_messages[-1]["content"]
@@ -1332,6 +1348,14 @@ def chat_with_anthropic(
         # reusable cache entry next turn -- the task-323 system/tools
         # breakpoints alone never cache message history. Budget:
         # system(1) + last-tool(1) + this(1) = 3 of the 4 allowed.
+        #
+        # OPT-IN (`prompt_caching`), unlike the two breakpoints above: this
+        # one bills the entire conversation prefix at the 1.25x write
+        # premium, so a one-shot caller pays ~25% extra input and can never
+        # read the entry back. Only the Console gateway (multi-turn by
+        # construction) sets the flag; every other caller of
+        # `chat_with_anthropic` leaves it None and is unaffected.
+        #
         # Fresh dict so no caller-held block is mutated (same rule as the
         # tools breakpoint above).
         last_content = anthropic_messages[-1]["content"]
@@ -1385,6 +1409,10 @@ def chat_with_anthropic(
                 # body, not a stream.
                 logger.warning(
                     "Anthropic: endpoint rejected cache_control; retrying without prompt caching."
+                )
+                log_counter(
+                    "anthropic_cache_control_degrade",
+                    labels={"model": current_model},
                 )
                 response = session.post(
                     api_url,

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -978,6 +978,44 @@ def _anthropic_caching_enabled() -> bool:
         return True
 
 
+def _without_cache_control(obj: Any) -> Any:
+    """Deep-copy ``obj`` with every ``cache_control`` key removed.
+
+    Args:
+        obj: Any JSON-shaped structure (dicts/lists/scalars).
+
+    Returns:
+        The same structure minus all ``cache_control`` entries.
+    """
+    if isinstance(obj, dict):
+        return {
+            key: _without_cache_control(value)
+            for key, value in obj.items()
+            if key != "cache_control"
+        }
+    if isinstance(obj, list):
+        return [_without_cache_control(item) for item in obj]
+    return obj
+
+
+def _contains_cache_control(obj: Any) -> bool:
+    """True when any nested dict carries a ``cache_control`` key.
+
+    Args:
+        obj: Any JSON-shaped structure (dicts/lists/scalars).
+
+    Returns:
+        True when ``cache_control`` appears anywhere within ``obj``.
+    """
+    if isinstance(obj, dict):
+        return "cache_control" in obj or any(
+            _contains_cache_control(value) for value in obj.values()
+        )
+    if isinstance(obj, list):
+        return any(_contains_cache_control(item) for item in obj)
+    return False
+
+
 def _anthropic_tools_payload(tools: list) -> list:
     """Convert OpenAI function-format tool entries to Anthropic's format.
 
@@ -1335,7 +1373,27 @@ def chat_with_anthropic(
                 stream=current_streaming,
                 timeout=180,
             )
-        response.raise_for_status()
+            if (
+                response.status_code == 400
+                and _contains_cache_control(data)
+                and "cache_control" in (response.text or "")
+            ):
+                # Caching must never break sends (cost-ticker PR2): odd
+                # proxies/gateways can reject cache_control. Retry exactly
+                # once without any breakpoints; every other error path is
+                # untouched. Reading .text here is safe -- it is the error
+                # body, not a stream.
+                logger.warning(
+                    "Anthropic: endpoint rejected cache_control; retrying without prompt caching."
+                )
+                response = session.post(
+                    api_url,
+                    headers=headers,
+                    json=_without_cache_control(data),
+                    stream=current_streaming,
+                    timeout=180,
+                )
+            response.raise_for_status()
 
         if current_streaming:
             logger.debug(

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2261,6 +2261,13 @@ ingest_directory_scan_limit = 1000
 # Per-type ingestion options are persisted here by the Library ingest canvas.
 [library.ingest_options]
 
+[caching]
+# Anthropic prompt caching (cache_control breakpoints on system prompt, tool
+# list, and the latest message). Cache writes bill at 1.25x input and reads at
+# ~0.1x, so multi-turn chat wins after two sends inside the 5-minute TTL.
+# Set false to disable all Anthropic cache_control emission.
+anthropic_enabled = true
+
 [splash_screen]
 # Splash screen configuration for startup animations
 # See Docs/Examples/SPLASH_SCREENS_CATALOG.md for all available splash screens

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2262,10 +2262,18 @@ ingest_directory_scan_limit = 1000
 [library.ingest_options]
 
 [caching]
-# Anthropic prompt caching (cache_control breakpoints on system prompt, tool
-# list, and the latest message). Cache writes bill at 1.25x input and reads at
-# ~0.1x, so multi-turn chat wins after two sends inside the 5-minute TTL.
-# Set false to disable all Anthropic cache_control emission.
+# Anthropic prompt caching (cache_control breakpoints on the system prompt and
+# the tool list for every Anthropic call; plus one on the latest message for
+# Console sends only, which are the multi-turn ones). Cache writes bill at
+# 1.25x input and reads at ~0.1x, so multi-turn chat wins after two sends
+# inside the 5-minute TTL.
+# The loss condition: sends more than ~5 minutes apart never hit a live cache,
+# so every send re-pays the 1.25x write premium on the conversation prefix
+# with no reads at all -- the cost ticker will show it (writes in the
+# breakdown, no cache-read line). Set false if that is your usage pattern.
+# Set false to disable the cache_control breakpoints this client adds;
+# caller-supplied native Anthropic tool dicts already carrying cache_control
+# still pass through verbatim.
 anthropic_enabled = true
 
 [splash_screen]


### PR DESCRIPTION
PR2 of the Console cost-ticker program. The spec is amended in-PR twice: once for the stale premise (task-323 had already shipped system+tool breakpoints provider-wide before this program's snapshot), and once after the final whole-branch review caught a real economics hazard in my first cut.

- **Per-turn cache_control breakpoint on the final message — Console-opt-in only.** The Console gateway stamps `prompt_caching=True` on Anthropic resolutions; `chat_with_anthropic` places the third breakpoint only when asked. One-shot callers (media summarization, websearch, evals, prompt engineering) are structurally excluded — the final review showed a provider-wide version would have taxed them ~1.25× on input with a guaranteed zero read rate. Non-console pass-through is pinned by tests.
- Conversation history now becomes a reusable cache prefix for Console chat (task-323's system/tools breakpoints never cached history). Budget: 3 of 4 breakpoints; writes are incremental per Anthropic prefix semantics (verified in review).
- **`[caching] anthropic_enabled` kill-switch** (default on; absent section = shipped behavior; the 5 pre-existing task-323 tests pass unmodified). Config comment states both the win and the loss condition (slow-cadence writes).
- **Degrade path**: a 400 naming cache_control retries exactly once with all breakpoints stripped + a `anthropic_cache_control_degrade` counter — caching can never break sends.
- **Prefix-stability pins**: gateway system-extraction byte-stability across turns (the spec-named seam), history content-identity modulo the moving marker, marker placement, no volatile keys.
- Accounting rides PR1 unchanged (cache_read/cache_write buckets → usage_json → pricing catalog).

Known limit documented in the spec's Risks: Anthropic's ~20-block cache lookback can silently miss on tool-heavy agent turns; the 4th breakpoint is held in reserve pending live hit-rate evidence (follow-up).

Live acceptance (real key): `cache_read_input_tokens > 0` on the second consecutive Console send, visible in PR1's usage records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes Anthropic prompt caching with a Console‑only per‑turn breakpoint, a `[caching] anthropic_enabled` kill‑switch, and a safe degrade path. Conversation history is now cache‑reusable in Console chat, while one‑shot calls and non‑Anthropic providers are unaffected.

- **New Features**
  - Console‑opt‑in per‑turn `cache_control` on the final message when `prompt_caching=True` (Console gateway stamps this for Anthropic; other providers drop it). System + last‑tool breakpoints remain provider‑wide; total 3/4.
  - `[caching] anthropic_enabled` config toggle (default true) gating Anthropic caching end‑to‑end (gateway + provider).
  - 400s naming `cache_control` retry once without breakpoints; logs `anthropic_cache_control_degrade`. No `ttl` emitted (5‑minute default).
  - Prefix‑stability tests pin system extraction and history identity across turns; docs/spec updated to reflect provider‑wide system/tool breakpoints and Console‑only per‑turn.

- **Bug Fixes**
  - Scoped the per‑turn breakpoint to Console sends to prevent 1.25× write costs on one‑shot Anthropic calls.
  - Console gateway now honors the kill‑switch in the live `load_settings()` shape (`COMPREHENSIVE_CONFIG_RAW.caching`); config read failures warn and default caching ON.

<sup>Written for commit 57e673d2f563fde9295e2ddb18f491e048e13596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

