### PR TITLE
Move remote install workers to LLMScreen; one install lock across curated and remote (TASK-1914)

### DIFF
--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -327,6 +327,12 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
         # an exact point. State lives on the SCREEN now (TASK-1803), not
         # on the CuratedView instance -- it must survive the instance
         # being torn down below.
+        # TASK-1914: _model_install_kind routes _model_install_progressed's
+        # apply_progress call to the right view now that CuratedView and
+        # RemoteView are both mounted at once -- set explicitly here since
+        # this test drives _provision_curated directly rather than through
+        # _curated_install_requested (which sets it in production).
+        screen._model_install_kind = "curated"
         screen._model_install_reference = reference
         screen._model_install_service = MagicMock()
         screen._model_install_registry = MagicMock()
@@ -366,7 +372,7 @@ async def test_curated_install_progress_survives_a_screen_level_recompose(monkey
 
         # Half 1 of the fix: hydration. The fresh instance was never told
         # about the install directly -- LLMScreen re-applied the last
-        # known progress to it via _hydrate_curated_progress.
+        # known progress to it via _hydrate_model_install_progress.
         assert "encoder.onnx" in _progress_text(fresh_curated)
 
         # Half 2 of the fix: still updating. This tick is delivered by
@@ -712,14 +718,24 @@ async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatc
     content-only assertions (like the recompose tests above) cannot
     distinguish from two or three.
 
+    TASK-1914 also wraps ``RemoteView.apply_progress`` with the same
+    counting shim and asserts it is called ZERO times: ``LLMManagementWindow``
+    composes every rail view eagerly, so ``RemoteView`` is mounted (just not
+    visible) throughout this curated-only tick, and ``_active_install_view``
+    (keyed by ``_model_install_kind``) is the only thing standing between
+    "one view renders the tick" and "both views render it" now that a
+    single ``_model_install_progressed`` handler serves both flows.
+
     Args:
         monkeypatch: pytest's monkeypatch fixture, used to wrap
-            ``CuratedView.apply_progress`` with a call-counting shim;
-            reverted automatically after the test.
+            ``CuratedView.apply_progress``/``RemoteView.apply_progress``
+            with call-counting shims; reverted automatically after the
+            test.
     """
     from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
     from tldw_chatbook.Model_Artifacts.service import ArtifactRef
     from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
     from tldw_chatbook.Widgets.ModelArtifacts import InstallProgressed
 
     calls: list[AcquisitionProgress] = []
@@ -731,6 +747,15 @@ async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatc
 
     monkeypatch.setattr(CuratedView, "apply_progress", counting_apply_progress)
 
+    remote_calls: list[AcquisitionProgress] = []
+    original_remote_apply_progress = RemoteView.apply_progress
+
+    def counting_remote_apply_progress(self, progress):
+        remote_calls.append(progress)
+        return original_remote_apply_progress(self, progress)
+
+    monkeypatch.setattr(RemoteView, "apply_progress", counting_remote_apply_progress)
+
     app = _app()
     async with app.run_test(size=(120, 40)) as pilot:
         screen = await _models_screen(app)
@@ -739,6 +764,13 @@ async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatc
 
         reference = ArtifactRef("parakeet-v2", "immutable-revision", "int8")
         progress = AcquisitionProgress("fetch", reference, "encoder.onnx", 1, 2)
+
+        # TASK-1914: _model_install_kind now decides which view
+        # _model_install_progressed forwards to (CuratedView and
+        # RemoteView are both mounted at once) -- set explicitly since
+        # this test posts directly rather than through
+        # _curated_install_requested.
+        screen._model_install_kind = "curated"
 
         # The production entry point for a live tick (TASK-1803):
         # LLMScreen's own worker calls exactly this. Bubbles through
@@ -754,6 +786,11 @@ async def test_curated_install_progress_renders_exactly_once_per_tick(monkeypatc
     assert len(calls) == 1, (
         f"expected exactly one apply_progress call for one progress tick, "
         f"got {len(calls)}"
+    )
+    assert remote_calls == [], (
+        "a curated-install tick must never reach RemoteView.apply_progress "
+        "-- _active_install_view routes by _model_install_kind precisely "
+        "to prevent this"
     )
 
 
@@ -1506,3 +1543,1002 @@ async def test_pressing_remote_still_waits_for_explicit_search(monkeypatch):
         assert window.active_view == "remote"
         assert window.query_one("#remote-models-view", RemoteView)
         assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# TASK-1914: RemoteView's preflight/provision workers, moved here from
+# model_remote_view.py mirroring TASK-1803's move of CuratedView's. Small
+# local helpers below build a one-item remote catalog/report without any
+# real network or filesystem I/O, reused across the tests that follow.
+# ---------------------------------------------------------------------------
+
+
+def _resolved_remote_model(
+    repository: str = "owner/repository",
+    *,
+    license_id: str = "apache-2.0",
+):
+    from tldw_chatbook.Model_Artifacts.remote_huggingface import (
+        RemoteGGUFCandidate,
+        RemoteGGUFFile,
+        ResolvedRemoteModel,
+    )
+
+    commit = "a" * 40
+    digest = "b" * 64
+    candidate = RemoteGGUFCandidate(
+        label=f"{repository} · model-q4.gguf",
+        files=(RemoteGGUFFile("model-q4.gguf", 1024, digest),),
+        total_bytes=1024,
+    )
+    return ResolvedRemoteModel(
+        repository=repository,
+        commit=commit,
+        license_id=license_id,
+        review_url=f"https://huggingface.co/{repository}/tree/{commit}",
+        candidates=(candidate,),
+        total_candidate_count=1,
+        warnings=(),
+    )
+
+
+def _remote_catalog(*, license_id: str = "apache-2.0"):
+    from tldw_chatbook.Model_Artifacts.remote_huggingface import build_remote_catalog
+
+    resolved = _resolved_remote_model(license_id=license_id)
+    return build_remote_catalog(resolved, resolved.candidates[0])
+
+
+def _remote_report_for(catalog, destination):
+    from tldw_chatbook.Model_Artifacts.acquisition import (
+        ArtifactPreflightEntry,
+        PreflightReport,
+    )
+    from tldw_chatbook.Model_Artifacts.service import ProvenanceClass
+
+    descriptor = catalog.artifact
+    return PreflightReport(
+        root=descriptor.reference,
+        closure_fingerprint="f" * 64,
+        entries=(
+            ArtifactPreflightEntry(
+                ref=descriptor.reference,
+                source_url=descriptor.source_url,
+                repository=descriptor.upstream_repository,
+                revision=descriptor.upstream_revision,
+                license_id=descriptor.license_id,
+                license_url=descriptor.license_url,
+                precision=descriptor.precision,
+                total_bytes=descriptor.expected_installed_bytes,
+                file_count=len(descriptor.files),
+                already_installed=False,
+                provenance=(ProvenanceClass.LOCAL_INTEGRITY_RECORDED,),
+            ),
+        ),
+        download_bytes=descriptor.expected_installed_bytes,
+        already_staged_bytes=0,
+        staging_overhead_bytes=128,
+        retained_bytes=0,
+        destination=destination,
+        free_bytes=4096,
+        required_bytes=descriptor.expected_installed_bytes + 128,
+        sufficient_space=True,
+        gating_errors=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_install_progress_survives_a_screen_level_recompose(monkeypatch):
+    """TASK-1914 mirror of ``test_curated_install_progress_survives_a_screen_
+    level_recompose``, for the remote flow: exercises the real ``LLMScreen.
+    _provision_remote`` code path against a stubbed
+    ``ArtifactAcquisitionService`` so this test controls exactly when a
+    second progress tick fires relative to a real screen-level recompose,
+    then asserts both halves of the fix -- the freshly (re)mounted
+    ``RemoteView`` is hydrated with the last known progress, and a tick
+    emitted AFTER the recompose (delivered through this screen's own
+    still-running worker) still reaches the fresh view.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+    from tldw_chatbook.Widgets.ModelArtifacts.install_progress import (
+        ModelInstallProgress,
+    )
+
+    catalog = _remote_catalog()
+    reference = catalog.artifact.reference
+    first_progress = AcquisitionProgress("fetch", reference, "model-part-1.gguf", 100, 1024)
+    second_progress = AcquisitionProgress("fetch", reference, "model-part-2.gguf", 400, 1024)
+    resume = asyncio.Event()
+
+    class _FakeAcquisitionService:
+        """Stands in for the real, network-capable acquisition service."""
+
+        def __init__(self, _service, *, credential_resolver=None) -> None:
+            """Accept and discard the managed-store service/resolver the
+            real constructor takes.
+
+            Args:
+                _service: The managed-store service (unused by the fake).
+                credential_resolver: The credential resolver (unused).
+            """
+
+        async def provision(self, root, consent, catalog, *, sources, progress, activate):
+            """Deliver two progress ticks with the recompose in between.
+
+            Args:
+                root: The reference this closure is rooted at (unused).
+                consent: The granted consent object (unused).
+                catalog: The remote catalog (unused).
+                sources: File source map (unused).
+                progress: The real ``deliver`` callback ``LLMScreen.
+                    _provision_remote`` built.
+                activate: Must be ``False`` for the remote flow (asserted
+                    by the sibling ``test_provision_remote_never_activates``
+                    test; not re-asserted here).
+
+            Returns:
+                A sentinel standing in for the real installed-path result.
+            """
+            progress(first_progress)
+            await resume.wait()
+            progress(second_progress)
+            return object()
+
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
+    )
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+        window = screen.query_one(LLMManagementWindow)
+        remote = window.query_one(RemoteView)
+
+        # State lives on the SCREEN now (TASK-1914), not on the RemoteView
+        # instance -- it must survive the instance being torn down below.
+        screen._model_install_kind = "remote"
+        screen._model_install_reference = reference
+        screen._model_install_service = MagicMock()
+        screen._model_install_catalog = catalog
+        screen._model_install_credential_resolver = MagicMock()
+        fake_report = MagicMock(root=reference)
+
+        provision_task = asyncio.create_task(
+            screen._provision_remote(fake_report, catalog)
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        def _progress_text(view: RemoteView) -> str:
+            widget = view.query_one(
+                "#remote-model-install-progress", ModelInstallProgress
+            )
+            detail = widget.query_one("#model-install-progress-detail", Static)
+            return str(detail.renderable)
+
+        assert "model-part-1.gguf" in _progress_text(remote)
+
+        screen.refresh(recompose=True)
+        for _ in range(5):
+            await pilot.pause()
+
+        fresh_window = screen.query_one(LLMManagementWindow)
+        fresh_remote = fresh_window.query_one(RemoteView)
+        assert fresh_remote is not remote, (
+            "test setup bug: recompose did not actually replace RemoteView"
+        )
+
+        # Half 1 of the fix: hydration.
+        assert "model-part-1.gguf" in _progress_text(fresh_remote)
+
+        # Half 2 of the fix: still updating, via this screen's own
+        # still-running worker -- never owned by the RemoteView instance
+        # the recompose tore down.
+        resume.set()
+        await provision_task
+        await pilot.pause()
+        await pilot.pause()
+
+        assert "model-part-2.gguf" in _progress_text(fresh_remote)
+
+
+@pytest.mark.asyncio
+async def test_remote_install_progress_after_recompose_still_mirrors_into_installed_view(
+    monkeypatch,
+):
+    """TASK-1914 mirror of ``test_curated_install_progress_after_recompose_
+    still_mirrors_into_installed_view``: checks the MIRRORING handler's own
+    effect on ``InstalledView`` for a remote install, after a real
+    screen-level recompose.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.UI.Screens.model_installed_view import InstalledView
+
+    catalog = _remote_catalog()
+    reference = catalog.artifact.reference
+    first_progress = AcquisitionProgress("fetch", reference, "model-part-1.gguf", 100, 1024)
+    second_progress = AcquisitionProgress("fetch", reference, "model-part-2.gguf", 400, 1024)
+    resume = asyncio.Event()
+
+    class _FakeAcquisitionService:
+        def __init__(self, _service, *, credential_resolver=None) -> None:
+            """See the sibling recompose test above for this fake's rationale."""
+
+        async def provision(self, root, consent, catalog, *, sources, progress, activate):
+            progress(first_progress)
+            await resume.wait()
+            progress(second_progress)
+            return object()
+
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
+    )
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+        window = screen.query_one(LLMManagementWindow)
+        installed = window.query_one(InstalledView)
+
+        screen._model_install_kind = "remote"
+        screen._model_install_reference = reference
+        screen._model_install_service = MagicMock()
+        screen._model_install_catalog = catalog
+        screen._model_install_credential_resolver = MagicMock()
+        fake_report = MagicMock(root=reference)
+
+        provision_task = asyncio.create_task(
+            screen._provision_remote(fake_report, catalog)
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert installed._install_progress == first_progress
+        assert installed._install_active is True
+
+        screen.refresh(recompose=True)
+        for _ in range(5):
+            await pilot.pause()
+
+        fresh_window = screen.query_one(LLMManagementWindow)
+        fresh_installed = fresh_window.query_one(InstalledView)
+        assert fresh_installed is not installed, (
+            "test setup bug: recompose did not actually replace InstalledView"
+        )
+
+        resume.set()
+        await provision_task
+        for _ in range(3):
+            await pilot.pause()
+
+        assert fresh_installed._install_progress == second_progress, (
+            "InstalledView's mirroring handler never observed the "
+            "post-recompose tick"
+        )
+        assert fresh_installed._install_active is True
+
+
+@pytest.mark.asyncio
+async def test_remote_install_progress_renders_exactly_once_per_tick_and_never_reaches_curated_view(
+    monkeypatch,
+):
+    """TASK-1914: the mirror image of ``test_curated_install_progress_
+    renders_exactly_once_per_tick``'s own new assertion -- a remote-install
+    tick must render exactly once, on ``RemoteView``, and never reach the
+    unrelated, currently-idle ``CuratedView`` (both are mounted at once;
+    only ``_model_install_kind``-based routing in ``_active_install_view``
+    prevents this).
+    """
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+    from tldw_chatbook.Widgets.ModelArtifacts import InstallProgressed
+
+    remote_calls: list[AcquisitionProgress] = []
+    original_remote_apply_progress = RemoteView.apply_progress
+
+    def counting_remote_apply_progress(self, progress):
+        remote_calls.append(progress)
+        return original_remote_apply_progress(self, progress)
+
+    monkeypatch.setattr(RemoteView, "apply_progress", counting_remote_apply_progress)
+
+    curated_calls: list[AcquisitionProgress] = []
+    original_curated_apply_progress = CuratedView.apply_progress
+
+    def counting_curated_apply_progress(self, progress):
+        curated_calls.append(progress)
+        return original_curated_apply_progress(self, progress)
+
+    monkeypatch.setattr(CuratedView, "apply_progress", counting_curated_apply_progress)
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        for _ in range(5):
+            await pilot.pause()
+
+        catalog = _remote_catalog()
+        reference = catalog.artifact.reference
+        progress = AcquisitionProgress("fetch", reference, "model-q4.gguf", 1, 2)
+
+        screen._model_install_kind = "remote"
+        screen._deliver_curated(InstallProgressed(progress))
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+    assert remote_calls == [progress]
+    assert len(remote_calls) == 1, (
+        f"expected exactly one apply_progress call for one progress tick, "
+        f"got {len(remote_calls)}"
+    )
+    assert curated_calls == [], (
+        "a remote-install tick must never reach CuratedView.apply_progress "
+        "-- _active_install_view routes by _model_install_kind precisely "
+        "to prevent this"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_install_click_reaches_the_shared_consent_modal(monkeypatch):
+    """A real candidate click -- not a direct call to an internal method --
+    posts ``RemoteView.InstallRequested``, which ``LLMScreen`` resolves
+    (through a stubbed acquisition service, so this stays network-free)
+    into the exact shared ``ModelInstallModal``. Mirrors ``test_curated_
+    install_click_reaches_the_shared_consent_modal``.
+    """
+    from unittest.mock import MagicMock
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+    from tldw_chatbook.Model_Artifacts.remote_huggingface import (
+        HuggingFaceRemoteAdapter,
+        build_remote_catalog,
+    )
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+    from textual.widgets import Input
+
+    resolved = _resolved_remote_model()
+
+    async def fake_resolve(self, repository, *, token=None):
+        return resolved
+
+    class _FakeAcquisitionService:
+        def __init__(self, _service, *, credential_resolver=None) -> None:
+            """Accept and discard the managed-store service/resolver."""
+
+        async def preflight(self, ref, _catalog, *, sources):
+            """Resolve a fake plan rooted at whatever reference was clicked."""
+            report = MagicMock()
+            report.root = ref
+            return report
+
+    monkeypatch.setattr(HuggingFaceRemoteAdapter, "resolve", fake_resolve)
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _FakeAcquisitionService
+    )
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _models_screen(app)
+        monkeypatch.setattr(app, "push_screen", MagicMock())
+        for _ in range(5):
+            await pilot.pause()
+
+        remote_row = next(
+            row for row in _rail_rows(screen) if row.lab_view_key == "remote"
+        )
+        remote_row.press()
+        await pilot.pause()
+
+        window = screen.query_one(LLMManagementWindow)
+        remote = window.query_one(RemoteView)
+
+        remote.query_one("#remote-model-query", Input).value = resolved.repository
+        await pilot.click("#remote-model-search")
+        for _ in range(50):
+            if remote._resolved is not None:
+                break
+            await pilot.pause()
+        assert remote._resolved is not None, "Remote view never finished resolving"
+
+        button = remote.query_one(".remote-candidate")
+        await pilot.click(button)
+        await pilot.pause()
+        await pilot.pause()
+
+        for _ in range(20):
+            if app.push_screen.called:
+                break
+            await pilot.pause()
+        assert app.push_screen.called, "clicking a candidate never reached push_screen"
+
+        modal, callback = app.push_screen.call_args[0]
+        assert isinstance(modal, ModelInstallModal)
+        expected_catalog = build_remote_catalog(resolved, resolved.candidates[0])
+        assert modal.report.root == expected_catalog.artifact.reference
+        assert callback == screen._confirm_remote_install
+        assert screen._model_install_pending_report is modal.report
+
+
+@pytest.mark.parametrize(
+    ("license_id", "expected_acknowledgment"),
+    (
+        (
+            "NOASSERTION",
+            "No license was declared. I reviewed the source and want to continue.",
+        ),
+        ("apache-2.0", None),
+    ),
+)
+def test_apply_remote_preflight_result_requires_acknowledgment_only_for_unknown_license(
+    license_id, expected_acknowledgment, tmp_path, monkeypatch
+):
+    """TASK-1914 mirror of ``RemoteView``'s former ``test_preflight_modal_
+    requires_acknowledgment_only_for_unknown_license``, now driving
+    ``LLMScreen._apply_remote_preflight_result`` directly -- this is where
+    that logic lives now.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
+
+    catalog = _remote_catalog(license_id=license_id)
+    candidate = _resolved_remote_model(license_id=license_id).candidates[0]
+    report = _remote_report_for(catalog, tmp_path / "managed")
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_worker = MagicMock()
+    screen._model_install_catalog = catalog
+    screen._model_install_candidate = candidate
+
+    module.LLMScreen._apply_remote_preflight_result(screen, report, None)
+
+    modal, callback = fake_app.push_screen.call_args.args
+    assert isinstance(modal, ModelInstallModal)
+    assert modal.required_acknowledgment == expected_acknowledgment
+    # The source map is keyed by the MANAGED path (e.g. "model.gguf" for a
+    # single non-sharded file, see remote_huggingface._managed_paths), not
+    # the upstream filename -- read it back off the built catalog rather
+    # than hardcoding that internal naming convention here.
+    managed_path = catalog.artifact.files[0].path
+    assert modal.selected_file_details == (
+        (
+            "model-q4.gguf",
+            1024,
+            "b" * 64,
+            catalog.sources[catalog.artifact.reference][managed_path],
+        ),
+    )
+    assert callback == screen._confirm_remote_install
+    assert screen._model_install_pending_report is report
+
+
+@pytest.mark.parametrize("operation", ("preflight", "installation"))
+def test_remote_install_failures_log_exact_context(operation, monkeypatch, tmp_path):
+    """Worker diagnostics classify remote failures without logging exception
+    details, mirroring ``test_curated_install_failures_log_exact_artifact_
+    context``'s shape but pinning the remote-specific ``error_type=``/
+    ``retryable=`` format (unchanged from ``RemoteView``'s own pre-TASK-1914
+    worker methods).
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.acquisition import TransferError
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    marker = "PRIVATE-REMOTE-INSTALL-DETAIL"
+    catalog = _remote_catalog()
+    fake_app = MagicMock()
+    fake_logger = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+    monkeypatch.setattr(module, "logger", fake_logger)
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_catalog = catalog
+
+    if operation == "preflight":
+
+        async def fail_preflight(_catalog):
+            raise TransferError(marker, retryable=True)
+
+        screen._preflight_remote = fail_preflight
+        module.LLMScreen._run_remote_preflight.__wrapped__(screen)
+    else:
+        report = _remote_report_for(catalog, tmp_path / "managed")
+        screen._model_install_pending_report = report
+
+        async def fail_provision(_report, _catalog):
+            raise TransferError(marker, retryable=True)
+
+        screen._provision_remote = fail_provision
+        module.LLMScreen._run_remote_provision.__wrapped__(screen)
+
+    logged = " ".join(str(value) for value in fake_logger.error.call_args.args)
+    assert "TransferError" in logged
+    assert "retryable" in logged.casefold()
+    assert "True" in logged
+    assert marker not in logged
+    assert marker not in str(fake_app.call_from_thread.call_args)
+
+
+def test_remote_preflight_failure_notifies_and_does_not_push_a_modal(monkeypatch):
+    """Sibling failure branch of ``test_remote_install_click_reaches_the_
+    shared_consent_modal``, adapted from ``RemoteView``'s former direct
+    coverage of ``_apply_preflight_result``'s failure path -- ``LLMScreen``
+    resolves it now.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+
+    catalog = _remote_catalog()
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    view = MagicMock()
+    screen._remote_view = MagicMock(return_value=view)
+    screen._model_install_worker = MagicMock()
+    screen._model_install_reference = catalog.artifact.reference
+    screen._model_install_service = MagicMock()
+    screen._model_install_catalog = catalog
+    screen._model_install_candidate = None
+    screen._model_install_credential_resolver = MagicMock()
+    screen._model_install_pending_report = None
+    screen._model_install_kind = "remote"
+
+    module.LLMScreen._apply_remote_preflight_result(screen, None, "boom")
+
+    screen.notify.assert_called_once_with("boom", severity="error")
+    fake_app.push_screen.assert_not_called()
+    assert screen._model_install_worker is None
+    assert screen._model_install_reference is None
+    assert screen._model_install_service is None
+    assert screen._model_install_catalog is None
+    assert screen._model_install_candidate is None
+    assert screen._model_install_credential_resolver is None
+    assert screen._model_install_kind is None
+    view.cancel_pending_install.assert_called_once_with("boom")
+
+
+def test_declining_the_remote_consent_modal_does_not_start_the_install_worker():
+    """Mirrors ``test_declining_the_consent_modal_does_not_start_the_
+    install_worker`` for the remote flow."""
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    catalog = _remote_catalog()
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    view = MagicMock()
+    screen._remote_view = MagicMock(return_value=view)
+    screen._run_remote_provision = MagicMock()
+    screen._model_install_worker = None
+    screen._model_install_reference = catalog.artifact.reference
+    screen._model_install_service = MagicMock()
+    screen._model_install_catalog = catalog
+    screen._model_install_candidate = None
+    screen._model_install_credential_resolver = MagicMock()
+    screen._model_install_pending_report = object()
+    screen._model_install_kind = "remote"
+
+    module.LLMScreen._confirm_remote_install(screen, False)
+
+    screen._run_remote_provision.assert_not_called()
+    assert screen._model_install_reference is None
+    assert screen._model_install_pending_report is None
+    assert screen._model_install_kind is None
+    view.cancel_pending_install.assert_called_once_with(None)
+
+
+@pytest.mark.parametrize(
+    ("first_kind", "second_kind"),
+    (("curated", "remote"), ("remote", "curated")),
+)
+def test_a_second_concurrent_install_of_either_kind_is_refused_by_the_shared_lock(
+    first_kind, second_kind
+):
+    """TASK-1914: curated and remote installs share ONE screen-level lock
+    (``_model_install_worker``), not two independent ones -- documented in
+    that field's own docstring: the managed store's own
+    ``ArtifactAcquisitionService.provision`` already serializes concurrent
+    installs behind one in-process lease regardless of which view started
+    them, so tracking two locks would only mean paying for a wasted
+    preflight before the second one blocked anyway. Parametrized both
+    directions: a running CURATED install refuses a REMOTE request, and a
+    running REMOTE install refuses a CURATED request.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    running_worker = MagicMock()
+    running_worker.is_finished = False
+    running_reference = ArtifactRef("model-a", "a" * 40, "int8")
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._run_curated_preflight = MagicMock()
+    screen._run_remote_preflight = MagicMock()
+    curated_view = MagicMock()
+    remote_view = MagicMock()
+    screen._curated_view = MagicMock(return_value=curated_view)
+    screen._remote_view = MagicMock(return_value=remote_view)
+    screen._model_install_kind = first_kind
+    screen._model_install_worker = running_worker
+    screen._model_install_reference = running_reference
+    screen._model_install_service = MagicMock()
+    screen._model_install_registry = MagicMock() if first_kind == "curated" else None
+    screen._model_install_sources = {} if first_kind == "curated" else None
+    screen._model_install_catalog = _remote_catalog() if first_kind == "remote" else None
+    screen._model_install_candidate = None
+    screen._model_install_credential_resolver = (
+        MagicMock() if first_kind == "remote" else None
+    )
+
+    if second_kind == "curated":
+        event = CuratedView.InstallRequested(
+            ArtifactRef("model-b", "b" * 40, "int8"),
+            service=MagicMock(),
+            registry=MagicMock(),
+            sources={},
+        )
+        event.stop = MagicMock()
+        module.LLMScreen._curated_install_requested(screen, event)
+        released_view = curated_view
+        screen._run_curated_preflight.assert_not_called()
+    else:
+        second_catalog = _remote_catalog(license_id="mit")
+        second_candidate = _resolved_remote_model(license_id="mit").candidates[0]
+        event = RemoteView.InstallRequested(
+            second_catalog,
+            second_candidate,
+            service=MagicMock(),
+            credential_resolver=MagicMock(),
+        )
+        event.stop = MagicMock()
+        module.LLMScreen._remote_install_requested(screen, event)
+        released_view = remote_view
+        screen._run_remote_preflight.assert_not_called()
+
+    event.stop.assert_called_once_with()
+    screen.notify.assert_called_once()
+    released_view.cancel_pending_install.assert_called_once_with()
+    # The running install's own retained state must survive untouched.
+    assert screen._model_install_kind == first_kind
+    assert screen._model_install_reference is running_reference
+    assert screen._model_install_worker is running_worker
+
+
+@pytest.mark.parametrize(
+    ("catalog", "candidate", "service", "credential_resolver"),
+    (
+        (None, "candidate", "service", "resolver"),
+        ("not-a-catalog", "candidate", "service", "resolver"),
+        (object(), "candidate", "service", "resolver"),
+    ),
+)
+def test_remote_install_requested_refuses_an_invalid_catalog_without_starting_a_worker(
+    catalog, candidate, service, credential_resolver
+):
+    """TASK-1914, applying TASK-1803 review round 2's lesson from the
+    start: an invalid ``event.catalog`` must never be stored or acted on.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._run_remote_preflight = MagicMock()
+    view = MagicMock()
+    screen._remote_view = MagicMock(return_value=view)
+    screen._model_install_worker = None
+    screen._model_install_reference = None
+    screen._model_install_service = None
+    screen._model_install_catalog = None
+    screen._model_install_candidate = None
+    screen._model_install_credential_resolver = None
+    screen._model_install_pending_report = None
+    screen._model_install_kind = None
+
+    event = RemoteView.InstallRequested(
+        catalog,
+        candidate,
+        service=service,
+        credential_resolver=credential_resolver,
+    )
+    event.stop = MagicMock()
+
+    module.LLMScreen._remote_install_requested(screen, event)
+
+    event.stop.assert_called_once_with()
+    screen._run_remote_preflight.assert_not_called()
+    screen.notify.assert_called_once_with(
+        "Could not start the model install: invalid request.",
+        severity="error",
+    )
+    # _clear_remote_install_state's default message=None reaches
+    # RemoteView.cancel_pending_install as an explicit None (unlike
+    # CuratedView.cancel_pending_install, which takes no argument at all).
+    view.cancel_pending_install.assert_called_once_with(None)
+    assert screen._model_install_worker is None
+    assert screen._model_install_reference is None
+    assert screen._model_install_kind is None
+
+
+@pytest.mark.parametrize(
+    ("missing_field",),
+    (("candidate",), ("service",), ("credential_resolver",)),
+)
+def test_remote_install_requested_refuses_when_candidate_service_or_resolver_is_missing(
+    missing_field,
+):
+    """Same validation as above, covering ``event.candidate``/``event.
+    service``/``event.credential_resolver`` being missing/invalid, not
+    only a malformed ``event.catalog``.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    catalog = _remote_catalog()
+    fields = {
+        "candidate": _resolved_remote_model().candidates[0],
+        "service": "service",
+        "credential_resolver": "resolver",
+    }
+    fields[missing_field] = None
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._run_remote_preflight = MagicMock()
+    view = MagicMock()
+    screen._remote_view = MagicMock(return_value=view)
+    screen._model_install_worker = None
+    screen._model_install_reference = None
+    screen._model_install_service = None
+    screen._model_install_catalog = None
+    screen._model_install_candidate = None
+    screen._model_install_credential_resolver = None
+
+    event = RemoteView.InstallRequested(catalog, **fields)
+    event.stop = MagicMock()
+
+    module.LLMScreen._remote_install_requested(screen, event)
+
+    screen._run_remote_preflight.assert_not_called()
+    screen.notify.assert_called_once_with(
+        "Could not start the model install: invalid request.",
+        severity="error",
+    )
+    assert screen._model_install_reference is None
+
+
+def test_run_remote_preflight_schedules_apply_result_when_catalog_is_none(monkeypatch):
+    """Defense-in-depth mirror of ``test_run_curated_preflight_schedules_
+    apply_result_when_reference_is_none``: ``_run_remote_preflight`` must
+    never trust that ``_curated_install_requested``'s sibling validation
+    always ran first.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_catalog = None
+
+    module.LLMScreen._run_remote_preflight.__wrapped__(screen)
+
+    fake_app.call_from_thread.assert_called_once()
+    args = fake_app.call_from_thread.call_args[0]
+    assert args[0] == screen._apply_remote_preflight_result
+    assert args[1] is None
+    assert isinstance(args[2], str) and args[2]
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_severity", "expected_message"),
+    (
+        (
+            None,
+            "information",
+            "Model downloaded and managed. Runtime compatibility has not "
+            "been verified.",
+        ),
+        ("boom", "error", "boom"),
+    ),
+)
+def test_apply_remote_provision_result_notifies_mirrors_and_resets_state(
+    error, expected_severity, expected_message, monkeypatch
+):
+    """Mirrors ``test_apply_curated_provision_result_notifies_mirrors_and_
+    resets_state`` for the remote flow -- including the different success
+    copy (no activation) and that ``RemoteView.finish_install`` receives
+    the exact same message text as ``notify``.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    fake_app = MagicMock()
+    monkeypatch.setattr(module.LLMScreen, "app", property(lambda self: fake_app))
+
+    catalog = _remote_catalog()
+    reference = catalog.artifact.reference
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen.notify = MagicMock()
+    screen._deliver_curated = MagicMock()
+    view = MagicMock()
+    screen._remote_view = MagicMock(return_value=view)
+    screen._model_install_worker = MagicMock()
+    screen._model_install_reference = reference
+    screen._model_install_service = MagicMock()
+    screen._model_install_catalog = catalog
+    screen._model_install_candidate = None
+    screen._model_install_credential_resolver = MagicMock()
+    screen._model_install_pending_report = object()
+    screen._model_install_kind = "remote"
+
+    module.LLMScreen._apply_remote_provision_result(screen, error)
+
+    screen.notify.assert_called_once_with(expected_message, severity=expected_severity)
+    assert screen._model_install_worker is None
+    assert screen._model_install_pending_report is None
+    assert screen._model_install_reference is None
+    assert screen._model_install_service is None
+    assert screen._model_install_catalog is None
+    assert screen._model_install_candidate is None
+    assert screen._model_install_credential_resolver is None
+    assert screen._model_install_kind is None
+
+    screen._deliver_curated.assert_called_once()
+    delivered = screen._deliver_curated.call_args[0][0]
+    assert isinstance(delivered, module.InstallStatusChanged)
+    assert delivered.reference == reference
+    assert delivered.active is False
+    assert delivered.succeeded == (error is None)
+
+    view.finish_install.assert_called_once_with(expected_message)
+
+
+@pytest.mark.asyncio
+async def test_preflight_remote_receives_exact_catalog_sources_and_credential_resolver(
+    tmp_path, monkeypatch
+):
+    """Mirrors ``RemoteView``'s former ``test_preflight_receives_exact_
+    catalog_sources_and_fresh_resolver``, now against ``LLMScreen.
+    _preflight_remote``.
+    """
+    from unittest.mock import MagicMock
+
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    catalog = _remote_catalog()
+    report = _remote_report_for(catalog, tmp_path / "managed")
+    core = object()
+    resolver = object()
+    captured: dict[str, object] = {}
+
+    class _Acquisition:
+        def __init__(self, received_core, *, credential_resolver) -> None:
+            captured["core"] = received_core
+            captured["resolver"] = credential_resolver
+
+        async def preflight(self, root, received_catalog, *, sources):
+            captured["preflight"] = (root, received_catalog, sources)
+            return report
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+
+    monkeypatch.setattr(acquisition_module, "ArtifactAcquisitionService", _Acquisition)
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_service = core
+    screen._model_install_credential_resolver = resolver
+
+    actual = await screen._preflight_remote(catalog)
+
+    assert actual is report
+    assert captured == {
+        "core": core,
+        "resolver": resolver,
+        "preflight": (
+            catalog.artifact.reference,
+            catalog,
+            catalog.sources,
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_provision_remote_reuses_exact_preflight_values_without_activation(
+    tmp_path, monkeypatch
+):
+    """Mirrors ``RemoteView``'s former ``test_provision_reuses_exact_
+    preflight_values_without_activation``, now against ``LLMScreen.
+    _provision_remote``: any catalog/source substitution or activation
+    would violate reviewed consent.
+    """
+    from unittest.mock import MagicMock
+
+    import tldw_chatbook.Model_Artifacts.acquisition as acquisition_module
+    from tldw_chatbook.UI.Screens import llm_screen as module
+
+    catalog = _remote_catalog()
+    report = _remote_report_for(catalog, tmp_path / "managed")
+    core = object()
+    resolver = object()
+    captured: dict[str, object] = {}
+
+    class _Acquisition:
+        def __init__(self, received_core, *, credential_resolver) -> None:
+            captured["core"] = received_core
+            captured["resolver"] = credential_resolver
+
+        async def provision(
+            self,
+            root,
+            consent,
+            received_catalog,
+            *,
+            sources,
+            progress,
+            activate,
+        ):
+            captured["provision"] = (
+                root,
+                consent,
+                received_catalog,
+                sources,
+                progress,
+                activate,
+            )
+
+    monkeypatch.setattr(
+        acquisition_module, "ArtifactAcquisitionService", _Acquisition
+    )
+
+    screen = module.LLMScreen.__new__(module.LLMScreen)
+    screen._model_install_service = core
+    screen._model_install_credential_resolver = resolver
+    screen._deliver_curated = MagicMock()
+
+    await screen._provision_remote(report, catalog)
+
+    root, consent, actual_catalog, sources, progress, activate = captured["provision"]
+    assert captured["core"] is core
+    assert captured["resolver"] is resolver
+    assert root == report.root
+    assert consent == report.grant()
+    assert actual_catalog is catalog
+    assert sources is catalog.sources
+    assert callable(progress)
+    assert activate is False

--- a/Tests/UI/test_llm_screen_lab_adoption.py
+++ b/Tests/UI/test_llm_screen_lab_adoption.py
@@ -1040,16 +1040,19 @@ def test_declining_the_consent_modal_does_not_start_the_install_worker():
 def test_curated_install_requested_refuses_a_second_concurrent_install():
     """TASK-1803 review round 1 (Important, gap #2): untested until now.
 
-    ``_curated_install_requested``'s worker-in-flight guard (mirroring
-    ``LibraryScreen.handle_parakeet_v2_install_requested``'s own) must
-    refuse a second request while one install is still running -- not
-    start a competing preflight worker, not touch the running install's
-    own retained reference/service/registry/sources, and not touch its
-    worker handle -- and must release only the freshly clicking
-    ``CuratedView``'s own in-flight indicator (see the method's own
-    docstring for why that view, specifically, is the one instance a
-    screen-level recompose can hand a second chance to click Install
-    while the original install is still in flight elsewhere).
+    ``_curated_install_requested``'s concurrency guard (``_install_in_
+    progress()``, mirroring ``LibraryScreen.handle_parakeet_v2_install_
+    requested``'s own worker-in-flight guard, generalized in TASK-1914
+    fix round 2 to span the whole install lifecycle rather than only
+    "a worker happens to be running") must refuse a second request while
+    one install is still in progress -- not start a competing preflight
+    worker, not touch the running install's own retained reference/
+    service/registry/sources, and not touch its worker handle -- and must
+    release only the freshly clicking ``CuratedView``'s own in-flight
+    indicator (see the method's own docstring for why that view,
+    specifically, is the one instance a screen-level recompose can hand a
+    second chance to click Install while the original install is still in
+    progress elsewhere).
     """
     from unittest.mock import MagicMock
 
@@ -1069,6 +1072,7 @@ def test_curated_install_requested_refuses_a_second_concurrent_install():
     screen._run_curated_preflight = MagicMock()
     view = MagicMock()
     screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_kind = "curated"
     screen._model_install_worker = running_worker
     screen._model_install_reference = running_reference
     screen._model_install_service = running_service
@@ -1145,6 +1149,7 @@ def test_curated_install_requested_refuses_an_invalid_payload_without_starting_a
     screen._run_curated_preflight = MagicMock()
     view = MagicMock()
     screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_kind = None
     screen._model_install_worker = None
     screen._model_install_reference = None
     screen._model_install_service = None
@@ -1206,6 +1211,7 @@ def test_curated_install_requested_refuses_when_service_registry_or_sources_is_n
     screen._run_curated_preflight = MagicMock()
     view = MagicMock()
     screen._curated_view = MagicMock(return_value=view)
+    screen._model_install_kind = None
     screen._model_install_worker = None
     screen._model_install_reference = None
     screen._model_install_service = None
@@ -2151,21 +2157,52 @@ def test_declining_the_remote_consent_modal_does_not_start_the_install_worker():
 
 
 @pytest.mark.parametrize(
-    ("first_kind", "second_kind"),
-    (("curated", "remote"), ("remote", "curated")),
+    ("first_kind", "second_kind", "phase"),
+    (
+        ("curated", "remote", "worker"),
+        ("remote", "curated", "worker"),
+        ("curated", "curated", "pending_consent"),
+        ("remote", "remote", "pending_consent"),
+        ("curated", "remote", "pending_consent"),
+        ("remote", "curated", "pending_consent"),
+    ),
 )
-def test_a_second_concurrent_install_of_either_kind_is_refused_by_the_shared_lock(
-    first_kind, second_kind
+def test_a_second_concurrent_install_is_refused_regardless_of_kind_or_phase(
+    first_kind, second_kind, phase
 ):
-    """TASK-1914: curated and remote installs share ONE screen-level lock
-    (``_model_install_worker``), not two independent ones -- documented in
-    that field's own docstring: the managed store's own
-    ``ArtifactAcquisitionService.provision`` already serializes concurrent
-    installs behind one in-process lease regardless of which view started
-    them, so tracking two locks would only mean paying for a wasted
-    preflight before the second one blocked anyway. Parametrized both
-    directions: a running CURATED install refuses a REMOTE request, and a
-    running REMOTE install refuses a CURATED request.
+    """TASK-1914 fix round 2: curated and remote installs share ONE
+    screen-level concurrency guard, ``_install_in_progress()`` (checking
+    ``_model_install_kind``), not two independent ones and not a check on
+    the worker handle -- documented in ``_install_in_progress``'s own
+    docstring: the managed store's own ``ArtifactAcquisitionService.
+    provision`` already serializes concurrent installs behind one
+    in-process lease regardless of which view started them, so tracking
+    two locks would only mean paying for a wasted preflight before the
+    second one blocked anyway.
+
+    Parametrized over both the kind pairing (same-flow and cross-flow)
+    AND the phase the first install is in:
+
+    - ``"worker"``: a preflight/provision thread is actually running
+      (``_model_install_worker`` set, not finished) -- the case the
+      original (pre-fix-round-2) guard already covered.
+    - ``"pending_consent"``: the PR #1245 automated-review finding this
+      round fixes. Preflight has already succeeded and the shared consent
+      modal is up, awaiting the user's decision -- ``_model_install_
+      worker`` is ``None`` here (see ``_apply_curated_preflight_result``/
+      ``_apply_remote_preflight_result``, which reset it to ``None``
+      before pushing the modal), which is exactly the window a
+      worker-handle-only guard could not see. ``_model_install_kind``
+      stays set through this window (cleared only in the terminal
+      apply-provision-result/clear-state paths), so the fixed guard still
+      refuses here.
+
+    Every combination asserts the same contract: the second request is
+    refused, notified, only the second (freshly clicking) view's own
+    in-flight indicator is released, and the FIRST install's own
+    ``_model_install_kind``/reference/pending-report survive byte-
+    identical -- not merely equal, but the exact same retained objects,
+    proving the second request never touched them before being refused.
     """
     from unittest.mock import MagicMock
 
@@ -2174,9 +2211,17 @@ def test_a_second_concurrent_install_of_either_kind_is_refused_by_the_shared_loc
     from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
     from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
 
-    running_worker = MagicMock()
-    running_worker.is_finished = False
     running_reference = ArtifactRef("model-a", "a" * 40, "int8")
+    running_report = object()
+    if phase == "worker":
+        running_worker = MagicMock()
+        running_worker.is_finished = False
+    else:
+        # The exact state _apply_curated_preflight_result/_apply_remote_
+        # preflight_result leave behind the moment the shared consent
+        # modal is pushed: no worker running, but the install is very
+        # much still in progress.
+        running_worker = None
 
     screen = module.LLMScreen.__new__(module.LLMScreen)
     screen.notify = MagicMock()
@@ -2197,6 +2242,7 @@ def test_a_second_concurrent_install_of_either_kind_is_refused_by_the_shared_loc
     screen._model_install_credential_resolver = (
         MagicMock() if first_kind == "remote" else None
     )
+    screen._model_install_pending_report = running_report
 
     if second_kind == "curated":
         event = CuratedView.InstallRequested(
@@ -2226,9 +2272,12 @@ def test_a_second_concurrent_install_of_either_kind_is_refused_by_the_shared_loc
     event.stop.assert_called_once_with()
     screen.notify.assert_called_once()
     released_view.cancel_pending_install.assert_called_once_with()
-    # The running install's own retained state must survive untouched.
+    # The in-progress install's own retained state must survive untouched
+    # -- byte-identical (`is`), not merely equal, proving the second
+    # request never overwrote it before being refused.
     assert screen._model_install_kind == first_kind
     assert screen._model_install_reference is running_reference
+    assert screen._model_install_pending_report is running_report
     assert screen._model_install_worker is running_worker
 
 
@@ -2319,6 +2368,7 @@ def test_remote_install_requested_refuses_when_candidate_service_or_resolver_is_
     screen._run_remote_preflight = MagicMock()
     view = MagicMock()
     screen._remote_view = MagicMock(return_value=view)
+    screen._model_install_kind = None
     screen._model_install_worker = None
     screen._model_install_reference = None
     screen._model_install_service = None

--- a/Tests/UI/test_model_curated_view.py
+++ b/Tests/UI/test_model_curated_view.py
@@ -349,3 +349,41 @@ def test_finish_install_clears_the_indicator_and_reloads_despite_a_missing_progr
     assert view._operation_reference is None
     assert view._progress is None
     view.ensure_loaded.assert_called_once_with(force=True)
+
+
+# ---------------------------------------------------------------------------
+# Module-scope import boundary (TASK-1914 fix round 1).
+#
+# Not previously covered by a dedicated test for this module: the review
+# that added the AST-based check for model_remote_view.py confirmed
+# CuratedView has the identical gap (nothing here enforced "acquisition
+# only inside functions" beyond code review), and the STT/Model_Artifacts
+# subprocess import-recording suite (test_credentials_and_boundaries.py)
+# does not cover this module either -- its script only ever imports
+# STT/transcription/registry/store modules.
+# ---------------------------------------------------------------------------
+
+
+def test_curated_view_does_not_import_acquisition_at_module_scope() -> None:
+    """``CuratedView`` posts intents; only ``LLMScreen``'s worker methods
+    import ``Model_Artifacts.acquisition``.
+
+    Reuses ``test_model_remote_view.py``'s AST-based ``module_scope_
+    forbidden_acquisition_imports`` -- both modules are held to the
+    identical rule, so one AST walker implementation backs both tests
+    rather than two independent (and independently stale-able) substring
+    scans.
+    """
+    import inspect
+
+    from tldw_chatbook.UI.Screens import model_curated_view as module
+    from Tests.UI.test_model_remote_view import (
+        module_scope_forbidden_acquisition_imports,
+    )
+
+    source = inspect.getsource(module)
+    assert "class CuratedView(Widget):" in source
+    findings = module_scope_forbidden_acquisition_imports(source)
+    assert findings == [], (
+        f"model_curated_view.py imports acquisition/fetch at module scope: {findings}"
+    )

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -1,15 +1,35 @@
-"""Focused behavior tests for lazy managed Remote model discovery."""
+"""Focused behavior tests for lazy managed Remote model discovery (TASK-1914).
+
+``RemoteView`` also has a discovery-flow-only concern set: metadata search
+and repository resolution (``_search_remote``/``_resolve_remote``) stay
+owned by this view -- a read-only listing concern, mirroring
+``CuratedView._load_curated``, which TASK-1803 also left in place. Most of
+this file's coverage of that half is unchanged by TASK-1914.
+
+TASK-1914 moved this view's preflight/provision workers to ``LLMScreen``,
+mirroring TASK-1803's move of the equivalent ``CuratedView`` workers.
+Tests that used to drive this view's own ``_preflight_model``/
+``_confirm_install``/``_apply_preflight_result``/``_provision_model``/
+``_apply_provision_result`` directly (the plan-resolution, consent-modal-
+push, activation, and failure-logging coverage) moved to
+``test_llm_screen_lab_adoption.py``, against ``LLMScreen``, which now owns
+that logic; what belongs here instead is ``RemoteView``'s own render-only
+contract: reviewing a candidate posts ``InstallRequested`` and, once told
+the outcome, calls ``cancel_pending_install()``/``finish_install()``/
+``apply_progress()``.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from pathlib import Path
 from threading import Event
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from textual import on
 from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Model_Artifacts.remote_huggingface import (
@@ -21,13 +41,6 @@ from tldw_chatbook.Model_Artifacts.remote_huggingface import (
     ResolvedRemoteModel,
     build_remote_catalog,
 )
-from tldw_chatbook.Model_Artifacts.acquisition import (
-    AcquisitionProgress,
-    ArtifactPreflightEntry,
-    PreflightReport,
-    TransferError,
-)
-from tldw_chatbook.Model_Artifacts.service import ProvenanceClass
 
 
 _COMMIT = "a" * 40
@@ -118,64 +131,30 @@ def _catalog(*, license_id: str = "apache-2.0"):
     return build_remote_catalog(resolved, resolved.candidates[0])
 
 
-def _report_for(catalog, destination: Path) -> PreflightReport:
-    descriptor = catalog.artifact
-    return PreflightReport(
-        root=descriptor.reference,
-        closure_fingerprint="f" * 64,
-        entries=(
-            ArtifactPreflightEntry(
-                ref=descriptor.reference,
-                source_url=descriptor.source_url,
-                repository=descriptor.upstream_repository,
-                revision=descriptor.upstream_revision,
-                license_id=descriptor.license_id,
-                license_url=descriptor.license_url,
-                precision=descriptor.precision,
-                total_bytes=descriptor.expected_installed_bytes,
-                file_count=len(descriptor.files),
-                already_installed=False,
-                provenance=(ProvenanceClass.LOCAL_INTEGRITY_RECORDED,),
-            ),
-        ),
-        download_bytes=descriptor.expected_installed_bytes,
-        already_staged_bytes=0,
-        staging_overhead_bytes=128,
-        retained_bytes=0,
-        destination=destination,
-        free_bytes=4096,
-        required_bytes=descriptor.expected_installed_bytes + 128,
-        sufficient_space=True,
-        gating_errors=(),
-    )
-
-
 class _RemoteApp(App):
     def __init__(self, view) -> None:
         self.view = view
-        self.install_statuses: list[object] = []
         super().__init__()
 
     def compose(self) -> ComposeResult:
         yield self.view
 
-    def on_install_status_changed(self, event) -> None:
-        self.install_statuses.append(event)
-
 
 def _view(
     *,
     adapter_factory: Callable[[], object],
-    resolver_factory: Callable[[], object],
+    resolver_factory: Callable[[], object] | None = None,
     service_factory: Callable[[], object] = MagicMock,
 ):
     from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
 
-    return RemoteView(
-        adapter_factory=adapter_factory,
-        credential_resolver_factory=resolver_factory,
-        service_factory=service_factory,
-    )
+    kwargs: dict[str, object] = {
+        "adapter_factory": adapter_factory,
+        "service_factory": service_factory,
+    }
+    if resolver_factory is not None:
+        kwargs["credential_resolver_factory"] = resolver_factory
+    return RemoteView(**kwargs)
 
 
 async def _submit(app: _RemoteApp, pilot, query: str) -> None:
@@ -229,6 +208,23 @@ async def test_exact_repository_submission_resolves_without_searching() -> None:
     assert adapter.resolve_calls == [("owner/repository", "configured-token")]
     assert resolver_calls == ["owner/repository"]
     assert "owner/repository · model-q4.gguf" in rendered
+
+
+@pytest.mark.asyncio
+async def test_no_user_visible_string_contains_artifact() -> None:
+    """No rendered Static text says "artifact" -- the UI says "model" throughout."""
+    adapter = _Adapter(resolved=_resolved())
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: _Resolver([]),
+    )
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
+        rendered = _text(view)
+
+    assert "artifact" not in rendered.lower()
 
 
 @pytest.mark.asyncio
@@ -323,7 +319,7 @@ async def test_same_generation_resolve_rejects_a_different_repository_response()
 
     assert "other/repository · model-q4.gguf" not in rendered
     assert candidate_buttons == []
-    assert view._selected_catalog is None
+    assert view._operation_reference is None
     assert search_disabled is False
 
 
@@ -372,7 +368,7 @@ async def test_same_generation_resolve_rejects_when_repository_input_changes() -
 
     assert "owner/repository · model-q4.gguf" not in rendered
     assert candidate_buttons == []
-    assert view._selected_catalog is None
+    assert view._operation_reference is None
     assert search_disabled is False
 
 
@@ -421,7 +417,6 @@ async def test_resolution_mismatch_removes_stale_rendered_candidate_controls() -
         query_disabled = query.disabled
 
     assert stale_controls == []
-    assert view._selected_catalog is None
     assert view._operation_reference is None
     assert "Inspecting repository" not in status
     assert "Press Search" in status
@@ -600,46 +595,109 @@ async def test_candidate_cap_discloses_deterministic_first_hundred() -> None:
     assert "First 100 of 137, sorted by upstream path" in rendered
 
 
+# ---------------------------------------------------------------------------
+# Install-request flow: this view posts the intent and stops (TASK-1914).
+# ---------------------------------------------------------------------------
+
+
+def _capturing_app(view) -> App:
+    """Build an App that captures ``RemoteView.InstallRequested`` events."""
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    class _App(App):
+        def __init__(self) -> None:
+            self.view = view
+            self.requests: list = []
+            super().__init__()
+
+        def compose(self) -> ComposeResult:
+            yield self.view
+
+        @on(RemoteView.InstallRequested)
+        def _capture(self, event: RemoteView.InstallRequested) -> None:
+            self.requests.append(event)
+
+    return _App()
+
+
 @pytest.mark.asyncio
-async def test_candidate_selection_freezes_catalog_and_disables_all_replacement_controls() -> (
+async def test_candidate_press_posts_install_requested_with_the_resolved_service_and_resolver() -> (
     None
 ):
-    """A pending plan must remain bound to the selected candidate."""
+    """A real candidate click -- not a direct call to an internal method --
+    posts ``RemoteView.InstallRequested`` carrying the exact catalog,
+    candidate, service, and credential resolver the host screen needs to
+    resolve a plan itself (TASK-1914: this view no longer performs that
+    resolution; ``LLMScreen`` does). See
+    ``test_llm_screen_lab_adoption.py``'s remote-install tests for the
+    end-to-end coverage of what happens once ``LLMScreen`` receives this
+    message.
+    """
     resolved = _resolved()
-    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
-    app = _RemoteApp(view)
-    view._preflight_model = MagicMock()
+    service = object()
+    # A working `.resolve()` stand-in, not a bare `object()`: this same
+    # factory also backs the metadata search/resolve this test drives
+    # through `_submit` first, so it must behave like a real resolver, not
+    # just be identity-comparable.
+    resolver = _Resolver([])
+    adapter = _Adapter(resolved=resolved)
+    view = _view(
+        adapter_factory=lambda: adapter,
+        resolver_factory=lambda: resolver,
+        service_factory=lambda: service,
+    )
+    app = _capturing_app(view)
 
     async with app.run_test() as pilot:
-        view.query_one("#remote-model-query", Input).value = "owner/repository"
-        view._resolve_generation = 1
-        view._apply_resolve_result(
-            1,
-            "owner/repository",
-            "owner/repository",
-            resolved,
-            None,
-        )
+        await _submit(app, pilot, "owner/repository")
+
+        button = view.query_one(".remote-candidate", Button)
+        await pilot.click(button)
         await pilot.pause()
+
+        assert len(app.requests) == 1
+        event = app.requests[0]
+        expected_catalog = build_remote_catalog(resolved, resolved.candidates[0])
+        assert event.catalog == expected_catalog
+        assert event.candidate == resolved.candidates[0]
+        assert event.service is service
+        assert event.credential_resolver is resolver
+
+        # The clicked candidate's own row re-disables immediately (the
+        # long-standing "cannot double-click install" contract, unrelated
+        # to whether LLMScreen has even received the message yet).
+        assert view.query_one(".remote-candidate", Button).disabled is True
+        assert view.query_one("#remote-model-search", Button).disabled is True
+
+
+@pytest.mark.asyncio
+async def test_default_credential_resolver_factory_builds_env_config_resolver_for_the_posted_intent() -> (
+    None
+):
+    """The production path must not silently fall back to no credential resolver at all."""
+    from tldw_chatbook.Model_Artifacts.acquisition import EnvConfigCredentialResolver
+
+    resolved = _resolved()
+    adapter = _Adapter(resolved=resolved)
+    view = _view(adapter_factory=lambda: adapter, service_factory=lambda: object())
+    app = _capturing_app(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
         await pilot.click(".remote-candidate")
         await pilot.pause()
 
-        expected = build_remote_catalog(resolved, resolved.candidates[0])
-        assert view._selected_catalog == expected
-        assert view._operation_reference == expected.artifact.reference
-        assert view.query_one("#remote-model-query", Input).disabled is True
-        assert view.query_one("#remote-model-search", Button).disabled is True
-        assert view.query_one(".remote-candidate", Button).disabled is True
+    assert len(app.requests) == 1
+    assert isinstance(app.requests[0].credential_resolver, EnvConfigCredentialResolver)
 
 
 @pytest.mark.asyncio
 async def test_stale_candidate_press_is_rejected_at_the_ui_boundary() -> None:
-    """A queued button event from an old resolution must not start preflight."""
+    """A queued button event from an old resolution must not post an intent."""
     old_resolved = _resolved("old/repository")
     current_resolved = _resolved("current/repository")
     view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
-    view._preflight_model = MagicMock()
-    app = _RemoteApp(view)
+    app = _capturing_app(view)
 
     async with app.run_test() as pilot:
         view._resolved = old_resolved
@@ -653,326 +711,241 @@ async def test_stale_candidate_press_is_rejected_at_the_ui_boundary() -> None:
         view._candidate_pressed(Button.Pressed(stale_button))
         await pilot.pause()
 
-    view._preflight_model.assert_not_called()
-    assert view._selected_catalog is None
+    assert app.requests == []
     assert view._operation_reference is None
 
 
 @pytest.mark.asyncio
-async def test_preflight_receives_exact_catalog_sources_and_fresh_resolver(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """Changing the catalog, source map, or credential seam must fail this boundary."""
-    from tldw_chatbook.UI.Screens import model_remote_view as module
-
-    catalog = _catalog()
-    report = _report_for(catalog, tmp_path / "managed")
-    core = object()
-    resolver = object()
-    captured: dict[str, object] = {}
-
-    class _Acquisition:
-        def __init__(self, received_core, *, credential_resolver) -> None:
-            captured["core"] = received_core
-            captured["resolver"] = credential_resolver
-
-        async def preflight(self, root, received_catalog, *, sources):
-            captured["preflight"] = (root, received_catalog, sources)
-            return report
-
-    monkeypatch.setattr(module, "ArtifactAcquisitionService", _Acquisition)
-    resolver_factory = MagicMock(return_value=resolver)
-    view = _view(
-        adapter_factory=MagicMock(),
-        resolver_factory=resolver_factory,
-        service_factory=lambda: core,
-    )
-
-    actual = await view._preflight(catalog)
-
-    assert actual is report
-    assert captured == {
-        "core": core,
-        "resolver": resolver,
-        "preflight": (
-            catalog.artifact.reference,
-            catalog,
-            catalog.sources,
-        ),
-    }
-    resolver_factory.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_default_preflight_uses_env_config_credential_resolver(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """The production path must not silently fall back to anonymous acquisition."""
-    from tldw_chatbook.Model_Artifacts.acquisition import EnvConfigCredentialResolver
-    from tldw_chatbook.UI.Screens import model_remote_view as module
-
-    catalog = _catalog()
-    report = _report_for(catalog, tmp_path / "managed")
-    captured: list[object] = []
-
-    class _Acquisition:
-        def __init__(self, _core, *, credential_resolver) -> None:
-            captured.append(credential_resolver)
-
-        async def preflight(self, _root, _catalog, *, sources):
-            return report
-
-    monkeypatch.setattr(module, "ArtifactAcquisitionService", _Acquisition)
-    view = module.RemoteView(service_factory=lambda: object())
-
-    await view._preflight(catalog)
-
-    assert len(captured) == 1
-    assert isinstance(captured[0], EnvConfigCredentialResolver)
-
-
-@pytest.mark.parametrize(
-    ("license_id", "expected_acknowledgment"),
-    (
-        (
-            "NOASSERTION",
-            "No license was declared. I reviewed the source and want to continue.",
-        ),
-        ("apache-2.0", None),
-    ),
-)
-def test_preflight_modal_requires_acknowledgment_only_for_unknown_license(
-    license_id: str,
-    expected_acknowledgment: str | None,
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """Known licenses must not be gated and unknown licenses must be explicit."""
-    from tldw_chatbook.UI.Screens import model_remote_view as module
-    from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallModal
-
-    resolved = _resolved(license_id=license_id)
-    candidate = resolved.candidates[0]
-    catalog = build_remote_catalog(resolved, candidate)
-    report = _report_for(catalog, tmp_path / "managed")
-    fake_app = MagicMock()
-    monkeypatch.setattr(module.RemoteView, "app", property(lambda self: fake_app))
-    view = module.RemoteView()
-    view._selected_catalog = catalog
-    view._operation_reference = report.root
-
-    view._apply_preflight_result(report, None, candidate)
-
-    modal, callback = fake_app.push_screen.call_args.args
-    assert isinstance(modal, ModelInstallModal)
-    assert modal.required_acknowledgment == expected_acknowledgment
-    assert modal.selected_file_details == (
-        (
-            "model-q4.gguf",
-            1024,
-            _DIGEST,
-            f"https://huggingface.co/owner/repository/resolve/{_COMMIT}/model-q4.gguf",
-        ),
-    )
-    assert callback == view._confirm_install
-
-
-@pytest.mark.asyncio
-async def test_provision_reuses_exact_preflight_values_without_activation(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """Any catalog/source substitution or activation would violate reviewed consent."""
-    from tldw_chatbook.UI.Screens import model_remote_view as module
-
-    catalog = _catalog()
-    report = _report_for(catalog, tmp_path / "managed")
-    core = object()
-    resolver = object()
-    captured: dict[str, object] = {}
-
-    class _Acquisition:
-        def __init__(self, received_core, *, credential_resolver) -> None:
-            captured["core"] = received_core
-            captured["resolver"] = credential_resolver
-
-        async def provision(
-            self,
-            root,
-            consent,
-            received_catalog,
-            *,
-            sources,
-            progress,
-            activate,
-        ):
-            captured["provision"] = (
-                root,
-                consent,
-                received_catalog,
-                sources,
-                progress,
-                activate,
-            )
-
-    monkeypatch.setattr(module, "ArtifactAcquisitionService", _Acquisition)
-    resolver_factory = MagicMock(return_value=resolver)
-    view = _view(
-        adapter_factory=MagicMock(),
-        resolver_factory=resolver_factory,
-        service_factory=lambda: core,
-    )
-    view.post_message = MagicMock()
-
-    await view._provision(report, catalog)
-
-    root, consent, actual_catalog, sources, progress, activate = captured["provision"]
-    assert captured["core"] is core
-    assert captured["resolver"] is resolver
-    assert root == report.root
-    assert consent == report.grant()
-    assert actual_catalog is catalog
-    assert sources is catalog.sources
-    assert callable(progress)
-    assert activate is False
-    resolver_factory.assert_called_once_with()
-
-
-@pytest.mark.parametrize("operation", ("preflight", "installation"))
-def test_install_failures_log_safe_classification_without_exception_details(
-    operation: str,
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """Worker diagnostics classify failures without logging exception details."""
-    from tldw_chatbook.UI.Screens import model_remote_view as module
-
-    marker = "PRIVATE-REMOTE-INSTALL-DETAIL"
+async def test_candidate_press_notifies_and_does_not_post_when_the_catalog_cannot_be_built() -> (
+    None
+):
+    """A candidate that fails ``build_remote_catalog`` must never reach the host screen."""
     resolved = _resolved()
-    candidate = resolved.candidates[0]
-    catalog = build_remote_catalog(resolved, candidate)
-    report = _report_for(catalog, tmp_path / "managed")
-    fake_app = MagicMock()
-    fake_logger = MagicMock()
-    monkeypatch.setattr(module.RemoteView, "app", property(lambda self: fake_app))
-    monkeypatch.setattr(module, "logger", fake_logger)
-    view = module.RemoteView()
-
-    if operation == "preflight":
-
-        async def fail_preflight(_catalog):
-            raise TransferError(marker, retryable=True)
-
-        view._preflight = fail_preflight
-        module.RemoteView._preflight_model.__wrapped__(
-            view,
-            catalog,
-            candidate,
-        )
-    else:
-        view._pending_report = report
-        view._selected_catalog = catalog
-
-        async def fail_provision(_report, _catalog):
-            raise TransferError(marker, retryable=True)
-
-        view._provision = fail_provision
-        module.RemoteView._provision_model.__wrapped__(view)
-
-    logged = " ".join(str(value) for value in fake_logger.error.call_args.args)
-    assert "TransferError" in logged
-    assert "retryable" in logged.casefold()
-    assert "True" in logged
-    assert marker not in logged
-    assert marker not in str(fake_app.call_from_thread.call_args)
-
-
-@pytest.mark.asyncio
-async def test_controls_stay_disabled_through_consent_and_reenable_after_failure(
-    tmp_path: Path,
-) -> None:
-    """Consent must not create a window where Search can replace the plan."""
-    catalog = _catalog()
-    report = _report_for(catalog, tmp_path / "managed")
-    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
-    app = _RemoteApp(view)
-    view._preflight_model = MagicMock()
-    view._provision_model = MagicMock()
-
-    async with app.run_test() as pilot:
-        view._resolved = _resolved()
-        view._refresh_with_status("Select one GGUF candidate.")
-        await pilot.pause()
-        await pilot.click(".remote-candidate")
-        await pilot.pause()
-        view._apply_preflight_result(report, None)
-        await pilot.pause()
-
-        assert view.query_one("#remote-model-search", Button).disabled is True
-        assert view.query_one(".remote-candidate", Button).disabled is True
-
-        await pilot.click("#model-install-confirm")
-        await pilot.pause()
-        assert view.query_one("#remote-model-search", Button).disabled is True
-        assert view.query_one(".remote-candidate", Button).disabled is True
-
-        view._apply_provision_result("Managed download failed. Retry.")
-        await pilot.pause()
-
-        assert view.query_one("#remote-model-search", Button).disabled is False
-        assert view.query_one(".remote-candidate", Button).disabled is False
-
-
-@pytest.mark.asyncio
-async def test_progress_and_completion_publish_shared_lifecycle_and_success_copy(
-    tmp_path: Path,
-) -> None:
-    """Removing progress/completion messages must desynchronize Installed and Lab."""
-    from tldw_chatbook.Widgets.ModelArtifacts import (
-        InstallProgressed,
-        InstallStatusChanged,
+    bad_candidate = RemoteGGUFCandidate(label="bad", files=(), total_bytes=0)
+    tampered = ResolvedRemoteModel(
+        repository=resolved.repository,
+        commit=resolved.commit,
+        license_id=resolved.license_id,
+        review_url=resolved.review_url,
+        candidates=(bad_candidate,),
+        total_candidate_count=1,
+        warnings=(),
     )
-
-    catalog = _catalog()
-    report = _report_for(catalog, tmp_path / "managed")
     view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
-    app = _RemoteApp(view)
+    app = _capturing_app(view)
     notifications: list[tuple[str, str]] = []
-    view._selected_catalog = catalog
-    view._pending_report = report
-    view._operation_reference = report.root
-    view._provision_model = MagicMock()
 
     async with app.run_test() as pilot:
         view.notify = lambda message, *, severity: notifications.append(
             (message, severity)
         )
-        view._confirm_install(True)
-        progress = AcquisitionProgress("fetch", report.root, "model.gguf", 1, 2)
-        view._install_progressed(InstallProgressed(progress))
+        view._resolved = tampered
+        view._refresh_with_status("Select one GGUF candidate.")
         await pilot.pause()
-        assert "Downloading" in _text(view)
-
-        view._apply_provision_result(None)
+        await pilot.click(".remote-candidate")
         await pilot.pause()
 
-    statuses = [
-        message
-        for message in app.install_statuses
-        if isinstance(message, InstallStatusChanged)
-    ]
-    assert [(item.active, item.succeeded) for item in statuses] == [
-        (True, None),
-        (False, True),
-    ]
-    assert notifications == [
-        (
-            "Model downloaded and managed. Runtime compatibility has not been verified.",
-            "information",
-        )
-    ]
-    assert view._pending_report is None
+    assert app.requests == []
     assert view._operation_reference is None
-    assert view._selected_catalog is None
+    assert notifications and notifications[0][1] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Render-only outcomes: apply_progress() / cancel_pending_install() /
+# finish_install().
+#
+# TASK-1914: the host screen (LLMScreen) is the only caller of any of
+# these -- apply_progress for a live tick, cancel_pending_install after a
+# preflight failure or an explicit consent-modal decline, finish_install
+# once provisioning completes, successfully or not.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_progress_renders_and_retains_the_tick() -> None:
+    """A live tick updates the progress widget and is retained for hydration."""
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.Widgets.ModelArtifacts.install_progress import (
+        ModelInstallProgress,
+    )
+
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+    reference = ArtifactRef("owner-repository", "a" * 40, "q4_k_m")
+    progress = AcquisitionProgress("fetch", reference, "model-q4.gguf", 512, 1024)
+
+    async with app.run_test() as pilot:
+        view.apply_progress(progress)
+        await pilot.pause()
+
+        widget = view.query_one(
+            "#remote-model-install-progress", ModelInstallProgress
+        )
+        assert widget.display is True
+        assert view._progress == progress
+
+
+def test_apply_progress_tolerates_a_recompose_gap() -> None:
+    """A progress event is retained while its widget is temporarily absent."""
+    from tldw_chatbook.UI.Screens.model_remote_view import RemoteView
+
+    view = RemoteView(adapter_factory=MagicMock(), service_factory=MagicMock())
+    view.query_one = MagicMock(side_effect=NoMatches)
+    view.refresh = MagicMock()
+    progress = object()
+
+    view.apply_progress(progress)
+
+    assert view._progress is progress
+    view.refresh.assert_called_once_with(recompose=True)
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_install_clears_the_indicator_and_reenables_controls() -> (
+    None
+):
+    """A preflight failure or a decline releases the indicator without reloading."""
+    resolved = _resolved()
+    adapter = _Adapter(resolved=resolved)
+    view = _view(adapter_factory=lambda: adapter, resolver_factory=lambda: _Resolver([]))
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
+        await pilot.click(".remote-candidate")
+        await pilot.pause()
+        assert view._operation_reference is not None
+        assert view.query_one("#remote-model-search", Button).disabled is True
+
+        view.cancel_pending_install("Sanitized failure.")
+        await pilot.pause()
+
+        assert view._operation_reference is None
+        assert view.query_one("#remote-model-search", Button).disabled is False
+        assert view.query_one(".remote-candidate", Button).disabled is False
+        status = str(view.query_one("#remote-model-status", Static).renderable)
+
+    assert status == "Sanitized failure."
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_install_with_no_message_restores_the_default_status() -> (
+    None
+):
+    """An explicit consent-modal decline restores ordinary status copy."""
+    resolved = _resolved()
+    adapter = _Adapter(resolved=resolved)
+    view = _view(adapter_factory=lambda: adapter, resolver_factory=lambda: _Resolver([]))
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
+        await pilot.click(".remote-candidate")
+        await pilot.pause()
+
+        view.cancel_pending_install()
+        await pilot.pause()
+        status = str(view.query_one("#remote-model-status", Static).renderable)
+
+    assert "Select one GGUF candidate." in status
+
+
+@pytest.mark.asyncio
+async def test_finish_install_clears_the_indicator_progress_and_shows_the_given_message() -> (
+    None
+):
+    """``finish_install`` always hides progress, even mid-recompose."""
+    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+    from tldw_chatbook.Widgets.ModelArtifacts.install_progress import (
+        ModelInstallProgress,
+    )
+
+    resolved = _resolved()
+    adapter = _Adapter(resolved=resolved)
+    view = _view(adapter_factory=lambda: adapter, resolver_factory=lambda: _Resolver([]))
+    app = _RemoteApp(view)
+    reference = ArtifactRef("owner-repository", "a" * 40, "q4_k_m")
+
+    async with app.run_test() as pilot:
+        await _submit(app, pilot, "owner/repository")
+        await pilot.click(".remote-candidate")
+        await pilot.pause()
+        view.apply_progress(
+            AcquisitionProgress("fetch", reference, "model-q4.gguf", 512, 1024)
+        )
+        await pilot.pause()
+
+        view.finish_install("Model downloaded and managed.")
+        await pilot.pause()
+
+        assert view._operation_reference is None
+        assert view._progress is None
+        progress_widget = view.query_one(
+            "#remote-model-install-progress", ModelInstallProgress
+        )
+        assert progress_widget.display is False
+        status = str(view.query_one("#remote-model-status", Static).renderable)
+
+    assert status == "Model downloaded and managed."
+
+
+@pytest.mark.asyncio
+async def test_finish_install_tolerates_a_missing_progress_widget() -> None:
+    """Missing progress markup mid-recompose must not skip indicator cleanup
+    or the status update -- only the progress widget lookup is tolerated
+    (mirroring ``apply_progress``'s own tolerance for the same underlying
+    reason: ``ModelInstallProgress`` may not have finished composing its
+    own children yet), not every widget on the view.
+    """
+    from tldw_chatbook.Model_Artifacts.service import ArtifactRef
+
+    view = _view(adapter_factory=MagicMock(), resolver_factory=MagicMock())
+    app = _RemoteApp(view)
+
+    async with app.run_test() as pilot:
+        view._operation_reference = ArtifactRef("model-a", "a" * 40, "q4_k_m")
+        view._progress = object()
+        original_query_one = view.query_one
+
+        def _flaky_query_one(selector, *args, **kwargs):
+            if selector == "#remote-model-install-progress":
+                raise NoMatches("missing widget")
+            return original_query_one(selector, *args, **kwargs)
+
+        view.query_one = _flaky_query_one
+
+        view.finish_install("Model downloaded and managed.")
+        await pilot.pause()
+
+        assert view._operation_reference is None
+        assert view._progress is None
+        status = str(view.query_one("#remote-model-status", Static).renderable)
+
+    assert status == "Model downloaded and managed."
+
+
+# ---------------------------------------------------------------------------
+# Module-scope import boundary (TASK-1914, AC #3).
+# ---------------------------------------------------------------------------
+
+
+def test_remote_view_does_not_import_acquisition_at_module_scope() -> None:
+    """``RemoteView`` posts intents; only ``LLMScreen``'s worker methods
+    (and this module's own lazily-invoked ``_default_credential_resolver``)
+    import ``Model_Artifacts.acquisition``.
+    """
+    import inspect
+
+    from tldw_chatbook.UI.Screens import model_remote_view as module
+
+    source = inspect.getsource(module)
+    before_type_checking = source.split("if TYPE_CHECKING:")[0]
+    assert "class RemoteView(Widget):" in source
+    assert (
+        "from tldw_chatbook.Model_Artifacts.acquisition import"
+        not in before_type_checking
+    )
+    assert "from .acquisition import" not in before_type_checking
+    assert "import tldw_chatbook.Model_Artifacts.acquisition" not in before_type_checking

--- a/Tests/UI/test_model_remote_view.py
+++ b/Tests/UI/test_model_remote_view.py
@@ -21,6 +21,7 @@ the outcome, calls ``cancel_pending_install()``/``finish_install()``/
 
 from __future__ import annotations
 
+import ast
 from collections.abc import Callable
 from threading import Event
 from unittest.mock import MagicMock
@@ -45,6 +46,121 @@ from tldw_chatbook.Model_Artifacts.remote_huggingface import (
 
 _COMMIT = "a" * 40
 _DIGEST = "b" * 64
+
+
+# ---------------------------------------------------------------------------
+# Shared AST-based module-scope import check (TASK-1914 fix round 1).
+#
+# The original version of this check (see git history) scanned for three
+# literal substrings in the module's source text. That missed the
+# package-then-attribute bypass -- `from tldw_chatbook.Model_Artifacts
+# import acquisition` is a real, eager, module-scope import of the
+# acquisition runtime, but contains none of the three forbidden substrings
+# (no ".acquisition import", no "from .acquisition import", no "import
+# tldw_chatbook.Model_Artifacts.acquisition"). This is the exact class of
+# gap this workstream's own Task 2 no-subclass test caught and fixed with
+# an MRO check instead of a substring scan; the fix here is the same shape
+# of fix, applied to imports instead of subclassing.
+#
+# ``test_model_curated_view.py`` imports this helper rather than
+# duplicating it -- both modules are held to the identical rule, and one
+# AST walker gets to be the single implementation both tests exercise.
+# ---------------------------------------------------------------------------
+
+
+def _is_type_checking_test(test: ast.expr) -> bool:
+    """True for an ``if`` test that is (or ends in) ``TYPE_CHECKING``.
+
+    Covers both ``if TYPE_CHECKING:`` (a bare ``Name``) and
+    ``if typing.TYPE_CHECKING:`` (an ``Attribute``) -- this codebase only
+    ever uses the former, but the check is cheap to make either way.
+    """
+    return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+        isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+    )
+
+
+def _module_dotted_suffix_is(module: str | None, suffix: str) -> bool:
+    """True if ``module`` (an import's dotted path, absolute or relative)
+    ends in ``suffix`` as its own final component -- e.g. both
+    ``"tldw_chatbook.Model_Artifacts.acquisition"`` and
+    ``"Model_Artifacts.acquisition"`` (a relative import's ``module``,
+    which never includes the leading dots ``ast`` strips into ``level``)
+    end in ``"acquisition"``, but ``"acquisition_helpers"`` does not.
+    """
+    if not module:
+        return False
+    return module.rsplit(".", 1)[-1] == suffix
+
+
+def module_scope_forbidden_acquisition_imports(source: str) -> list[str]:
+    """Find real, module-scope imports of ``Model_Artifacts.acquisition``/``.fetch``.
+
+    "Module scope" here means reachable by simply importing the module --
+    NOT nested inside any function/method body (those run lazily, on
+    demand, which is exactly what the "acquisition/fetch only inside
+    functions" rule requires) and NOT inside an ``if TYPE_CHECKING:``
+    guard (``False`` at runtime, so that branch never executes).
+
+    Catches both import forms a violation could take:
+
+    - ``from tldw_chatbook.Model_Artifacts.acquisition import X`` (or the
+      relative ``from ...Model_Artifacts.acquisition import X``) -- the
+      import's own ``module`` ends in ``"acquisition"``/``"fetch"``.
+    - ``from tldw_chatbook.Model_Artifacts import acquisition`` -- the
+      package-then-attribute bypass a plain substring scan on import text
+      misses entirely: ``module`` ends in ``"Model_Artifacts"``, but one
+      of the imported *names* is ``"acquisition"``/``"fetch"``.
+
+    Args:
+        source: The module's full source text (e.g. from
+            ``inspect.getsource``).
+
+    Returns:
+        Human-readable descriptions of every forbidden import found, one
+        per finding; empty when the module is clean.
+    """
+    tree = ast.parse(source)
+    findings: list[str] = []
+
+    def visit(node: ast.AST, in_function: bool, in_type_checking: bool) -> None:
+        for child in ast.iter_child_nodes(node):
+            child_in_function = in_function or isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef)
+            )
+            child_in_type_checking = in_type_checking or (
+                isinstance(child, ast.If) and _is_type_checking_test(child.test)
+            )
+            if (
+                isinstance(child, (ast.Import, ast.ImportFrom))
+                and not in_function
+                and not in_type_checking
+            ):
+                if isinstance(child, ast.Import):
+                    for alias in child.names:
+                        if _module_dotted_suffix_is(
+                            alias.name, "acquisition"
+                        ) or _module_dotted_suffix_is(alias.name, "fetch"):
+                            findings.append(f"line {child.lineno}: import {alias.name}")
+                else:
+                    module = child.module
+                    if _module_dotted_suffix_is(
+                        module, "acquisition"
+                    ) or _module_dotted_suffix_is(module, "fetch"):
+                        findings.append(
+                            f"line {child.lineno}: from {module!r} import ..."
+                        )
+                    elif _module_dotted_suffix_is(module, "Model_Artifacts"):
+                        for alias in child.names:
+                            if alias.name in {"acquisition", "fetch"}:
+                                findings.append(
+                                    f"line {child.lineno}: from {module!r} "
+                                    f"import {alias.name}"
+                                )
+            visit(child, child_in_function, child_in_type_checking)
+
+    visit(tree, False, False)
+    return findings
 
 
 class _Resolver:
@@ -935,17 +1051,22 @@ def test_remote_view_does_not_import_acquisition_at_module_scope() -> None:
     """``RemoteView`` posts intents; only ``LLMScreen``'s worker methods
     (and this module's own lazily-invoked ``_default_credential_resolver``)
     import ``Model_Artifacts.acquisition``.
+
+    Uses the AST-based :func:`module_scope_forbidden_acquisition_imports`
+    (TASK-1914 fix round 1) rather than a text/substring scan: a substring
+    scan for ``"from tldw_chatbook.Model_Artifacts.acquisition import"``
+    (etc.) passes right over ``from tldw_chatbook.Model_Artifacts import
+    acquisition`` -- a real, eager, module-scope import of the acquisition
+    runtime via the package-then-attribute form -- because that exact
+    substring never appears in it.
     """
     import inspect
 
     from tldw_chatbook.UI.Screens import model_remote_view as module
 
     source = inspect.getsource(module)
-    before_type_checking = source.split("if TYPE_CHECKING:")[0]
     assert "class RemoteView(Widget):" in source
-    assert (
-        "from tldw_chatbook.Model_Artifacts.acquisition import"
-        not in before_type_checking
+    findings = module_scope_forbidden_acquisition_imports(source)
+    assert findings == [], (
+        f"model_remote_view.py imports acquisition/fetch at module scope: {findings}"
     )
-    assert "from .acquisition import" not in before_type_checking
-    assert "import tldw_chatbook.Model_Artifacts.acquisition" not in before_type_checking

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -506,6 +506,24 @@ class LLMScreen(LabScreen):
         error: str | None,
     ) -> None:
         """Show the shared consent modal, or a sanitized preflight failure."""
+        # NOTE (pre-existing since TASK-1803, annotated not fixed here):
+        # _model_install_worker is None from this line until
+        # _confirm_curated_install's own _run_curated_provision() call --
+        # i.e. for as long as the shared consent modal is up. A second,
+        # non-UI-originated InstallRequested landing in that window would
+        # pass _curated_install_requested's/_remote_install_requested's
+        # worker-in-flight guard (which only checks _model_install_worker),
+        # and -- if that second request were invalid -- reach
+        # _clear_curated_install_state()/_clear_remote_install_state(),
+        # which unconditionally zeroes _model_install_kind, clobbering
+        # whichever flow (curated or remote) is the one actually still
+        # awaiting consent. Currently unreachable via the UI: the consent
+        # modal is a ModalScreen and captures input, so neither view's own
+        # Install/candidate button can be pressed again -- and therefore
+        # no second InstallRequested can be posted -- while it is showing.
+        # A future refactor that lets something else post InstallRequested
+        # (a command palette action, a test harness driving the message
+        # bus directly, etc.) would need to close this gap for real.
         self._model_install_worker = None
         if error is not None or report is None:
             self.notify(error or "Model preflight failed.", severity="error")
@@ -822,6 +840,13 @@ class LLMScreen(LabScreen):
         error: str | None,
     ) -> None:
         """Show the shared consent modal, or a sanitized preflight failure."""
+        # NOTE (pre-existing since TASK-1803, annotated not fixed here): see
+        # the identical note in _apply_curated_preflight_result -- the same
+        # narrow pending-consent window (_model_install_worker is None
+        # until _confirm_remote_install's own _run_remote_provision() call)
+        # applies here, and for the same reason (the consent modal is a
+        # ModalScreen that captures input, so no second InstallRequested,
+        # curated or remote, can be posted through the UI while it is up).
         self._model_install_worker = None
         catalog = self._model_install_catalog
         candidate = self._model_install_candidate

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -13,6 +13,10 @@ from textual.widget import Widget
 from textual.widgets import Button, Static
 from textual.worker import Worker
 
+from ...Model_Artifacts.remote_huggingface import (
+    RemoteGGUFCandidate,
+    ResolvedRemoteCatalog,
+)
 from ...Model_Artifacts.service import ArtifactRef, ModelArtifactService
 from ...Widgets.ModelArtifacts import (
     InstallProgressed,
@@ -33,10 +37,15 @@ from .lab_frame import LabInspectorRow, LabScreen, LabStatusChip
 from .model_browser_state import install_failure_message
 from .model_curated_view import CuratedView
 from .model_installed_view import InstalledView
+from .model_remote_view import RemoteView
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
-    from tldw_chatbook.Model_Artifacts.acquisition import AcquisitionProgress, PreflightReport
+    from tldw_chatbook.Model_Artifacts.acquisition import (
+        AcquisitionProgress,
+        CredentialResolver,
+        PreflightReport,
+    )
     from tldw_chatbook.Model_Artifacts.curated_registry import CuratedRegistry
 
 #: (section title, ((view key, label), ...)) in rail order. The view keys are
@@ -95,40 +104,75 @@ class LLMScreen(LabScreen):
         self._model_install_active = False
         self._model_install_phase: str | None = None
         self._model_install_succeeded: bool | None = None
+        #: Which flow currently owns ``_model_install_worker``/the fields
+        #: below -- ``"curated"`` or ``"remote"``, or ``None`` when idle.
+        #: TASK-1914: curated and remote installs share this screen's one
+        #: set of retained state and one worker slot (see
+        #: ``_model_install_worker``'s own docstring for why one shared
+        #: lock is correct here, not two independent ones), so this is the
+        #: only way to know which mounted view (``_curated_view()`` or
+        #: ``_remote_view()``) the currently in-flight operation belongs
+        #: to -- both views can be mounted at once (``LLMManagementWindow``
+        #: composes every rail view eagerly; only ``active_view`` picks
+        #: which is visible), so a progress tick must be routed to the
+        #: right one, not applied to both. See ``_active_install_view``.
+        self._model_install_kind: str | None = None
         #: The last ``AcquisitionProgress`` this screen has seen for the
-        #: active curated install, retained so a freshly (re)mounted
-        #: ``CuratedView`` -- a screen-level ``LabScreen.recompose()``
-        #: tears down and rebuilds the whole ``LLMManagementWindow``,
-        #: ``CuratedView`` included, mid-download -- can be hydrated back
-        #: to it immediately instead of starting blank (TASK-596 delta
-        #: port). Mirrors ``LibraryScreen``'s own retained
+        #: active install (curated or remote), retained so a freshly
+        #: (re)mounted ``CuratedView``/``RemoteView`` -- a screen-level
+        #: ``LabScreen.recompose()`` tears down and rebuilds the whole
+        #: ``LLMManagementWindow`` mid-download -- can be hydrated back to
+        #: it immediately instead of starting blank (TASK-596 delta port).
+        #: Mirrors ``LibraryScreen``'s own retained
         #: ``_parakeet_v2_install_progress``. Cleared whenever the install
         #: stops (see ``_model_install_status_changed``).
         self._model_install_last_progress: "AcquisitionProgress | None" = None
-        #: The curated-install worker currently running (preflight OR
-        #: provision -- reassigned when the second phase starts, mirroring
-        #: ``LibraryScreen``'s single ``_parakeet_v2_install_worker``
-        #: field across its own two phases). Guards
-        #: ``_curated_install_requested`` against starting a second,
-        #: concurrent install while this one is still in flight -- this
-        #: screen owns exactly one ``WorkerManager``, unlike the
-        #: view-owned workers TASK-1803 replaced, so this guard now holds
-        #: across a screen-level recompose instead of only within one
-        #: ``CuratedView`` instance's lifetime.
+        #: The install worker currently running (preflight OR provision --
+        #: reassigned when the second phase starts, mirroring
+        #: ``LibraryScreen``'s single ``_parakeet_v2_install_worker`` field
+        #: across its own two phases). Guards ``_curated_install_requested``
+        #: AND ``_remote_install_requested`` against starting a second,
+        #: concurrent install while this one is still in flight -- a
+        #: SINGLE lock shared by both flows (TASK-1914), not one each,
+        #: because the managed store's own ``ArtifactAcquisitionService.
+        #: provision`` already serializes concurrent installs behind one
+        #: in-process lease regardless of which view started them (see
+        #: that class's own docstring): a curated install and a remote
+        #: install running "at the same time" would already queue against
+        #: each other at that layer, so tracking two independently here
+        #: would only mean paying for a wasted preflight before the second
+        #: one blocked anyway, while doubling every field below for no
+        #: operational benefit. This screen owns exactly one
+        #: ``WorkerManager``, unlike the view-owned workers TASK-1803/
+        #: TASK-1914 replaced, so this guard now holds across a
+        #: screen-level recompose instead of only within one view
+        #: instance's lifetime.
         self._model_install_worker: Worker | None = None
-        #: The reference, service, registry, and source map the currently
-        #: running (or about-to-run) curated install needs -- captured
-        #: once from the posted ``CuratedView.InstallRequested`` (or, for
-        #: ``_model_install_pending_report``, once preflight resolves) and
-        #: read back by this screen's own worker methods for as long as
-        #: the operation runs, so nothing here depends on the posting
-        #: ``CuratedView`` instance still existing by the time provisioning
-        #: finishes.
+        #: The reference, service, and (curated-only) registry/source map
+        #: the currently running (or about-to-run) curated install needs
+        #: -- captured once from the posted ``CuratedView.InstallRequested``
+        #: (or, for ``_model_install_pending_report``, once preflight
+        #: resolves) and read back by this screen's own worker methods for
+        #: as long as the operation runs, so nothing here depends on the
+        #: posting ``CuratedView`` instance still existing by the time
+        #: provisioning finishes. ``_model_install_reference`` and
+        #: ``_model_install_service``/``_model_install_pending_report`` are
+        #: shared with the remote flow below; ``_model_install_registry``/
+        #: ``_model_install_sources`` are curated-only (left ``None``
+        #: while a remote install runs).
         self._model_install_reference: ArtifactRef | None = None
         self._model_install_service: ModelArtifactService | None = None
         self._model_install_registry: "CuratedRegistry | None" = None
         self._model_install_sources: dict[ArtifactRef, dict[str, str]] | None = None
         self._model_install_pending_report: "PreflightReport | None" = None
+        #: The frozen catalog, exact candidate, and credential resolver a
+        #: running (or about-to-run) REMOTE install needs -- captured once
+        #: from the posted ``RemoteView.InstallRequested``, mirroring the
+        #: curated fields above. Remote-only; left ``None`` while a
+        #: curated install runs.
+        self._model_install_catalog: "ResolvedRemoteCatalog | None" = None
+        self._model_install_candidate: "RemoteGGUFCandidate | None" = None
+        self._model_install_credential_resolver: "CredentialResolver | None" = None
         #: Server rows snapshotted for the duration of one
         #: ``refresh_lab_status`` pass; None outside one. See
         #: :meth:`_current_server_rows`.
@@ -210,24 +254,25 @@ class LLMScreen(LabScreen):
     def _model_install_progressed(self, event: InstallProgressed) -> None:
         """Keep the Lab chip current, and re-render live progress (TASK-596).
 
-        Forwards the event into whichever ``CuratedView`` is currently
-        mounted -- not only the instance mounted when the install started.
-        This screen itself is the sole poster of ``InstallProgressed`` for
-        a curated install (TASK-1803: see ``_run_curated_provision`` and
-        ``_deliver_curated``, which post at ``self.llm_window`` so the
-        message bubbles through ``LLMManagementWindow``'s own mirroring
-        handler on its way here) -- unlike before, when ``CuratedView``
-        posted it and needed a durable fallback path to survive a
-        screen-level recompose tearing it down mid-install. This screen
-        is never what a recompose tears down, so no such fallback is
-        needed any more.
+        Forwards the event into whichever view owns the currently in-
+        flight install (``_active_install_view()``) -- not only the
+        instance mounted when the install started. This screen itself is
+        the sole poster of ``InstallProgressed`` for BOTH a curated and a
+        remote install (TASK-1803/TASK-1914: see ``_run_curated_provision``/
+        ``_run_remote_provision`` and ``_deliver_curated``, which post at
+        ``self.llm_window`` so the message bubbles through
+        ``LLMManagementWindow``'s own mirroring handler on its way here) --
+        unlike before, when the view posted it directly and needed a
+        durable fallback path to survive a screen-level recompose tearing
+        it down mid-install. This screen is never what a recompose tears
+        down, so no such fallback is needed any more.
         """
         self._model_install_active = True
         self._model_install_phase = event.progress.phase
         self._model_install_succeeded = None
         self._model_install_last_progress = event.progress
         self.refresh_lab_status()
-        view = self._curated_view()
+        view = self._active_install_view()
         if view is not None:
             view.apply_progress(event.progress)
 
@@ -273,6 +318,45 @@ class LLMScreen(LabScreen):
         except NoMatches:
             return None
 
+    def _remote_view(self) -> "RemoteView | None":
+        """Return the mounted ``RemoteView``, or None if it cannot be found.
+
+        Returns:
+            The view, or None when the window has not mounted yet, or a
+            screen-level recompose has torn down the previous instance and
+            the fresh one is not mounted yet either (see
+            ``LabScreen.recompose()``).
+        """
+        if self.llm_window is None:
+            return None
+        try:
+            return self.llm_window.query_one(RemoteView)
+        except NoMatches:
+            return None
+
+    def _active_install_view(self) -> "CuratedView | RemoteView | None":
+        """Return the view rendering the currently in-flight install, if any.
+
+        ``LLMManagementWindow`` composes every rail view eagerly (only
+        ``active_view`` picks which one is visible), so both
+        ``CuratedView`` and ``RemoteView`` are mounted at once regardless
+        of which install (if either) is running -- routing by
+        ``_model_install_kind`` (set once, when ``_curated_install_
+        requested``/``_remote_install_requested`` accepts a request) is
+        what keeps a remote install's progress from also being rendered
+        into the unrelated, currently-idle ``CuratedView``, and vice
+        versa.
+
+        Returns:
+            ``_curated_view()``/``_remote_view()`` matching the in-flight
+            install's kind, or ``None`` while idle.
+        """
+        if self._model_install_kind == "curated":
+            return self._curated_view()
+        if self._model_install_kind == "remote":
+            return self._remote_view()
+        return None
+
     # -- Curated model install: this screen owns preflight/provision -----
     #
     # TASK-1803: CuratedView posts CuratedView.InstallRequested and renders
@@ -293,13 +377,16 @@ class LLMScreen(LabScreen):
 
         Refuses a second concurrent install outright (mirroring
         ``LibraryScreen.handle_parakeet_v2_install_requested``'s own
-        worker-in-flight guard): the requesting ``CuratedView`` already
-        disabled its own row before posting this, but only a screen-level
-        recompose can hand a *different*, freshly (re)mounted instance a
-        chance to post a second request while the first is still running
-        -- ``cancel_pending_install()`` releases only that fresh
-        instance's own indicator, leaving the still-running install's
-        retained state (below) untouched.
+        worker-in-flight guard) -- including a concurrent REMOTE install
+        (TASK-1914: both flows share this screen's one
+        ``_model_install_worker`` lock, see its own docstring for why one
+        shared lock is correct here): the requesting ``CuratedView``
+        already disabled its own row before posting this, but only a
+        screen-level recompose can hand a *different*, freshly (re)mounted
+        instance a chance to post a second request while the first is
+        still running -- ``cancel_pending_install()`` releases only that
+        fresh instance's own indicator, leaving the still-running
+        install's retained state (below) untouched.
 
         Also validates the event's payload before storing any of it
         (TASK-1803 review round 2, Critical): ``CuratedView`` only ever
@@ -342,6 +429,7 @@ class LLMScreen(LabScreen):
             )
             self._clear_curated_install_state()
             return
+        self._model_install_kind = "curated"
         self._model_install_reference = event.reference
         self._model_install_service = event.service
         self._model_install_registry = event.registry
@@ -518,6 +606,7 @@ class LLMScreen(LabScreen):
         self._model_install_service = None
         self._model_install_registry = None
         self._model_install_sources = None
+        self._model_install_kind = None
         view = self._curated_view()
         if view is not None:
             view.finish_install()
@@ -536,26 +625,37 @@ class LLMScreen(LabScreen):
         self._model_install_registry = None
         self._model_install_sources = None
         self._model_install_pending_report = None
+        self._model_install_kind = None
         view = self._curated_view()
         if view is not None:
             view.cancel_pending_install()
 
     def _deliver_curated(self, message: InstallProgressed | InstallStatusChanged) -> None:
-        """Post one curated-install message so it bubbles through ``LLMManagementWindow``.
+        """Post one install-lifecycle message so it bubbles through ``LLMManagementWindow``.
+
+        Despite the name (kept for the existing call sites and tests that
+        already depend on it), this is the single delivery path for BOTH
+        the curated and the remote install flow (TASK-1914): each worker
+        pair (``_run_curated_provision``/``_run_remote_provision``, and
+        their ``_confirm_*_install`` counterparts for the leading
+        ``InstallStatusChanged(active=True)``) calls this exact method --
+        there is nothing curated-specific left in its own body, only in
+        its history.
 
         Tried first at ``self.llm_window`` -- read fresh on every call, so
         it already points at whichever ``LLMManagementWindow`` instance is
         currently mounted once a screen-level recompose has finished
         replacing it (``build_lab_body`` reassigns this attribute every
-        time it runs). Posting there lets the message bubble CuratedView-
-        less straight through ``LLMManagementWindow``'s own mirroring
-        handlers (``_managed_install_progressed``/``_managed_install_
-        status_changed``, which keep ``InstalledView`` in sync) and on up
-        to this screen's own ``@on(InstallProgressed)``/
-        ``@on(InstallStatusChanged)`` handlers -- the exact same single
-        bubble path ``CuratedView`` used to originate (``CuratedView`` ->
-        ``LLMManagementWindow`` -> ``LLMScreen``), except this screen is
-        now the origin, not an orphanable view.
+        time it runs). Posting there lets the message bubble view-less
+        straight through ``LLMManagementWindow``'s own mirroring handlers
+        (``_managed_install_progressed``/``_managed_install_status_
+        changed``, which keep ``InstalledView`` in sync) and on up to this
+        screen's own ``@on(InstallProgressed)``/``@on(InstallStatusChanged)``
+        handlers -- the exact same single bubble path ``CuratedView`` used
+        to originate (``CuratedView`` -> ``LLMManagementWindow`` ->
+        ``LLMScreen``) before TASK-1803, and ``RemoteView`` before
+        TASK-1914, except this screen is now the origin, not an orphanable
+        view.
 
         ``self.llm_window`` is a plain attribute, not a live query:
         ``LabScreen.recompose()`` tears down and closes the old
@@ -584,6 +684,329 @@ class LLMScreen(LabScreen):
         if target.post_message(message):
             return
         self.post_message(message)
+
+    # -- Remote model install: this screen owns preflight/provision -------
+    #
+    # TASK-1914: mirrors the curated block above exactly. RemoteView posts
+    # RemoteView.InstallRequested and renders what it is told
+    # (apply_progress/cancel_pending_install/finish_install); resolving the
+    # plan, showing the consent modal, and provisioning all run here. Both
+    # flows share this screen's single _model_install_worker lock (see that
+    # field's own docstring) and the InstallProgressed/InstallStatusChanged
+    # delivery path (_deliver_curated, despite its name -- see its own
+    # docstring) and hydration path (_hydrate_model_install_progress);
+    # only the curated-vs-remote-specific plan-resolution/consent/
+    # provisioning steps below are duplicated, exactly as the curated
+    # block duplicates LibraryScreen's own Parakeet v2 shape.
+
+    @on(RemoteView.InstallRequested)
+    def _remote_install_requested(self, event: RemoteView.InstallRequested) -> None:
+        """Resolve an install plan for a reviewed remote candidate, off the Textual event loop.
+
+        Shares ``_curated_install_requested``'s worker-in-flight guard
+        (the same ``_model_install_worker`` field -- see its own docstring
+        for why one screen-level lock, not two, is the correct shape now
+        that both flows live on this screen) and the same validate-before-
+        store discipline (TASK-1803 review round 2, Critical, applied here
+        from the start rather than rediscovered): an invalid payload
+        notifies, releases the clicking view's own indicator, and clears
+        state via ``_clear_remote_install_state`` without ever starting a
+        worker.
+        """
+        event.stop()
+        worker = self._model_install_worker
+        if worker is not None and not worker.is_finished:
+            self.notify(
+                "A model install is already running.",
+                severity="information",
+            )
+            view = self._remote_view()
+            if view is not None:
+                view.cancel_pending_install()
+            return
+        if (
+            not isinstance(event.catalog, ResolvedRemoteCatalog)
+            or not isinstance(event.candidate, RemoteGGUFCandidate)
+            or event.service is None
+            or event.credential_resolver is None
+        ):
+            logger.error(
+                "Remote install request carried an invalid catalog, "
+                "candidate, service, or credential resolver; refusing to "
+                "start."
+            )
+            self.notify(
+                "Could not start the model install: invalid request.",
+                severity="error",
+            )
+            self._clear_remote_install_state()
+            return
+        self._model_install_kind = "remote"
+        self._model_install_reference = event.catalog.artifact.reference
+        self._model_install_service = event.service
+        self._model_install_catalog = event.catalog
+        self._model_install_candidate = event.candidate
+        self._model_install_credential_resolver = event.credential_resolver
+        self._model_install_worker = self._run_remote_preflight()
+
+    async def _preflight_remote(self, catalog: "ResolvedRemoteCatalog"):
+        """Resolve a remote acquisition plan on the worker's event loop.
+
+        Args:
+            catalog: The frozen one-item catalog to preflight.
+
+        Returns:
+            The immutable ``PreflightReport`` describing the download.
+        """
+        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
+
+        acquisition = ArtifactAcquisitionService(
+            self._model_install_service,
+            credential_resolver=self._model_install_credential_resolver,
+        )
+        return await acquisition.preflight(
+            catalog.artifact.reference,
+            catalog,
+            sources=catalog.sources,
+        )
+
+    @work(thread=True, group="llm_remote_preflight", exit_on_error=False)
+    def _run_remote_preflight(self) -> None:
+        """Resolve the remote install plan off the Textual event loop.
+
+        Same defense-in-depth as ``_run_curated_preflight``: a missing
+        ``_model_install_catalog`` schedules ``_apply_remote_preflight_
+        result`` directly instead of ever reaching the ``try`` block, and
+        the ``except`` clause walks ``catalog.artifact.reference``
+        defensively (``getattr(..., "unknown")`` at each hop) rather than
+        assuming attribute access succeeds, so every path ends in exactly
+        one ``call_from_thread(self._apply_remote_preflight_result, ...)``.
+        """
+        catalog = self._model_install_catalog
+        if catalog is None:
+            self.app.call_from_thread(
+                self._apply_remote_preflight_result,
+                None,
+                "No install request is available; search and review the model again.",
+            )
+            return
+        try:
+            report = asyncio.run(  # policy-exception: worker-thread loop
+                self._preflight_remote(catalog)
+            )
+        except Exception as exc:
+            from tldw_chatbook.Model_Artifacts.acquisition import TransferError
+
+            artifact = getattr(catalog, "artifact", None)
+            reference = getattr(artifact, "reference", None)
+            artifact_id = getattr(reference, "artifact_id", "unknown")
+            model_label = getattr(artifact, "model_id", "unknown")
+            logger.error(
+                "Remote model preflight failed for managed artifact {}; "
+                "error_type={}, retryable={}",
+                artifact_id,
+                type(exc).__name__,
+                isinstance(exc, TransferError) and getattr(exc, "retryable", False),
+            )
+            self.app.call_from_thread(
+                self._apply_remote_preflight_result,
+                None,
+                install_failure_message(exc, model_label=model_label),
+            )
+            return
+        self.app.call_from_thread(self._apply_remote_preflight_result, report, None)
+
+    def _apply_remote_preflight_result(
+        self,
+        report: "PreflightReport | None",
+        error: str | None,
+    ) -> None:
+        """Show the shared consent modal, or a sanitized preflight failure."""
+        self._model_install_worker = None
+        catalog = self._model_install_catalog
+        candidate = self._model_install_candidate
+        if (
+            error is not None
+            or report is None
+            or catalog is None
+            or report.root != catalog.artifact.reference
+        ):
+            message = error or "The install plan changed. Search and review it again."
+            self.notify(message, severity="error")
+            self._clear_remote_install_state(message)
+            return
+        self._model_install_pending_report = report
+        acknowledgment = (
+            "No license was declared. I reviewed the source and want to continue."
+            if catalog.artifact.license_id == "NOASSERTION"
+            else None
+        )
+        selected_file_details: tuple[tuple[str, int, str, str], ...] = ()
+        if candidate is not None:
+            remote_files = tuple(
+                sorted(candidate.files, key=lambda item: item.upstream_path)
+            )
+            selected_file_details = tuple(
+                (
+                    remote_file.upstream_path,
+                    remote_file.size_bytes,
+                    remote_file.sha256,
+                    catalog.sources[catalog.artifact.reference][artifact_file.path],
+                )
+                for remote_file, artifact_file in zip(
+                    remote_files,
+                    catalog.artifact.files,
+                    strict=True,
+                )
+            )
+        self.app.push_screen(
+            ModelInstallModal(
+                report,
+                model_label=catalog.artifact.model_id,
+                required_acknowledgment=acknowledgment,
+                selected_file_details=selected_file_details,
+            ),
+            self._confirm_remote_install,
+        )
+
+    def _confirm_remote_install(self, confirmed: bool) -> None:
+        """Start provisioning only after explicit consent."""
+        if not confirmed:
+            self._clear_remote_install_state()
+            return
+        reference = self._model_install_reference
+        if reference is not None:
+            self._deliver_curated(InstallStatusChanged(reference, active=True))
+        self._model_install_worker = self._run_remote_provision()
+
+    async def _provision_remote(
+        self,
+        report: "PreflightReport",
+        catalog: "ResolvedRemoteCatalog",
+    ):
+        """Provision the consented report on the worker's event loop, without activating.
+
+        Args:
+            report: The plan ``_confirm_remote_install`` obtained consent
+                for.
+            catalog: The frozen catalog the report was resolved against.
+
+        Returns:
+            The root ``ArtifactRef`` provisioned but left inactive, exactly
+            as the pre-TASK-1914 ``RemoteView._provision`` behaved --
+            reviewing and downloading a remote GGUF file never implicitly
+            switches the active provider/model.
+        """
+        from tldw_chatbook.Model_Artifacts.acquisition import ArtifactAcquisitionService
+
+        acquisition = ArtifactAcquisitionService(
+            self._model_install_service,
+            credential_resolver=self._model_install_credential_resolver,
+        )
+
+        def deliver(progress: "AcquisitionProgress") -> None:
+            self._deliver_curated(InstallProgressed(progress))
+
+        return await acquisition.provision(
+            report.root,
+            report.grant(),
+            catalog,
+            sources=catalog.sources,
+            progress=deliver,
+            activate=False,
+        )
+
+    @work(thread=True, group="llm_remote_install", exit_on_error=False)
+    def _run_remote_provision(self) -> None:
+        """Provision the consented plan off the Textual event loop.
+
+        Same defense-in-depth as ``_run_remote_preflight``: the ``except``
+        clause formats ``report.root``/``catalog.artifact`` defensively
+        rather than assuming attribute access succeeds.
+        """
+        report = self._model_install_pending_report
+        catalog = self._model_install_catalog
+        if report is None or catalog is None:
+            self.app.call_from_thread(
+                self._apply_remote_provision_result,
+                "No install plan is available; search and review the model again.",
+            )
+            return
+        try:
+            asyncio.run(self._provision_remote(report, catalog))  # policy-exception: worker-thread loop
+        except Exception as exc:
+            from tldw_chatbook.Model_Artifacts.acquisition import TransferError
+
+            artifact = getattr(catalog, "artifact", None)
+            root = getattr(report, "root", None)
+            artifact_id = getattr(root, "artifact_id", "unknown")
+            model_label = getattr(artifact, "model_id", "unknown")
+            logger.error(
+                "Remote model installation failed for managed artifact {}; "
+                "error_type={}, retryable={}",
+                artifact_id,
+                type(exc).__name__,
+                isinstance(exc, TransferError) and getattr(exc, "retryable", False),
+            )
+            self.app.call_from_thread(
+                self._apply_remote_provision_result,
+                install_failure_message(exc, model_label=model_label),
+            )
+            return
+        self.app.call_from_thread(self._apply_remote_provision_result, None)
+
+    def _apply_remote_provision_result(self, error: str | None) -> None:
+        """Finish an installation: notify, mirror lifecycle, and reset state."""
+        reference = self._model_install_reference
+        self._model_install_worker = None
+        self._model_install_pending_report = None
+        if error is not None:
+            message = error
+            self.notify(message, severity="error")
+        else:
+            message = (
+                "Model downloaded and managed. Runtime compatibility has "
+                "not been verified."
+            )
+            self.notify(message, severity="information")
+        if reference is not None:
+            self._deliver_curated(
+                InstallStatusChanged(reference, active=False, succeeded=error is None)
+            )
+        self._model_install_reference = None
+        self._model_install_service = None
+        self._model_install_catalog = None
+        self._model_install_candidate = None
+        self._model_install_credential_resolver = None
+        self._model_install_kind = None
+        view = self._remote_view()
+        if view is not None:
+            view.finish_install(message)
+
+    def _clear_remote_install_state(self, message: str | None = None) -> None:
+        """Reset this screen's own bookkeeping after a request that never
+        started provisioning (a preflight failure or an explicit decline
+        at the consent modal) -- neither ever posted
+        ``InstallStatusChanged(active=True)``, so neither mirrors into
+        ``InstalledView``; the visible ``RemoteView`` (if still mounted)
+        only needs its own in-flight indicator released.
+
+        Args:
+            message: Status copy to hand to ``RemoteView.cancel_pending_
+                install`` in place of the in-flight indicator (e.g. a
+                sanitized preflight failure); ``None`` for an explicit
+                decline, which restores the view's default status.
+        """
+        self._model_install_reference = None
+        self._model_install_service = None
+        self._model_install_catalog = None
+        self._model_install_candidate = None
+        self._model_install_credential_resolver = None
+        self._model_install_pending_report = None
+        self._model_install_kind = None
+        view = self._remote_view()
+        if view is not None:
+            view.cancel_pending_install(message)
 
     def compose_lab_rail(self) -> ComposeResult:
         """Yield the two rail sections and their nine provider rows."""
@@ -659,29 +1082,33 @@ class LLMScreen(LabScreen):
             self.set_interval(LAB_SERVER_POLL_SECONDS, self.refresh_lab_status)
         # This fires on every (re)mount of the body -- first mount AND every
         # later screen-level recompose (see this method's own docstring) --
-        # which is exactly when a fresh CuratedView instance, with no
-        # memory of an install this screen already knows is running, can
-        # appear mid-download (TASK-596 delta port). call_after_refresh
-        # (rather than calling directly) gives the freshly (re)mounted
-        # LLMManagementWindow's own children -- CuratedView included -- a
-        # chance to finish composing before _hydrate_curated_progress
-        # queries for it.
+        # which is exactly when a fresh CuratedView/RemoteView instance,
+        # with no memory of an install this screen already knows is
+        # running, can appear mid-download (TASK-596 delta port).
+        # call_after_refresh (rather than calling directly) gives the
+        # freshly (re)mounted LLMManagementWindow's own children a chance
+        # to finish composing before _hydrate_model_install_progress
+        # queries for them.
         if self._model_install_active:
-            self.call_after_refresh(self._hydrate_curated_progress)
+            self.call_after_refresh(self._hydrate_model_install_progress)
 
-    def _hydrate_curated_progress(self) -> None:
-        """Re-apply the last known curated-install progress after a recompose.
+    def _hydrate_model_install_progress(self) -> None:
+        """Re-apply the last known install progress after a recompose.
 
-        Without this, a freshly (re)mounted ``CuratedView``'s progress
-        widget -- composed hidden every time a new instance is built, see
-        ``CuratedView.compose`` -- would stay hidden for the rest of an
-        install that outlived a screen-level ``LabScreen.recompose()``,
-        even though ``CuratedView`` itself keeps rendering live updates
-        that reach it (see ``_model_install_progressed``). Scheduled via
-        ``call_after_refresh`` from ``on_lab_body_ready`` (which reruns on
-        every recompose, not only first mount) -- mirroring
-        ``LibraryScreen``'s own ``_hydrate_parakeet_v2_progress`` -- so the
-        fresh ``CuratedView`` has actually finished mounting first.
+        Covers both flows (TASK-1914): whichever view owns the in-flight
+        install (``_active_install_view()``, keyed by
+        ``_model_install_kind``) is hydrated the same way.
+
+        Without this, a freshly (re)mounted ``CuratedView``/``RemoteView``'s
+        progress widget -- composed hidden every time a new instance is
+        built -- would stay hidden for the rest of an install that
+        outlived a screen-level ``LabScreen.recompose()``, even though the
+        view itself keeps rendering live updates that reach it (see
+        ``_model_install_progressed``). Scheduled via ``call_after_refresh``
+        from ``on_lab_body_ready`` (which reruns on every recompose, not
+        only first mount) -- mirroring ``LibraryScreen``'s own
+        ``_hydrate_parakeet_v2_progress`` -- so the fresh view has actually
+        finished mounting first.
 
         Also mirrors the same retained state directly into the freshly
         (re)mounted ``LLMManagementWindow``'s own ``InstalledView`` (TASK-
@@ -708,7 +1135,7 @@ class LLMScreen(LabScreen):
             return
         if self._model_install_last_progress is None:
             return
-        view = self._curated_view()
+        view = self._active_install_view()
         if view is not None:
             view.apply_progress(self._model_install_last_progress)
         installed = self._installed_view()

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -104,18 +104,26 @@ class LLMScreen(LabScreen):
         self._model_install_active = False
         self._model_install_phase: str | None = None
         self._model_install_succeeded: bool | None = None
-        #: Which flow currently owns ``_model_install_worker``/the fields
-        #: below -- ``"curated"`` or ``"remote"``, or ``None`` when idle.
-        #: TASK-1914: curated and remote installs share this screen's one
-        #: set of retained state and one worker slot (see
-        #: ``_model_install_worker``'s own docstring for why one shared
-        #: lock is correct here, not two independent ones), so this is the
-        #: only way to know which mounted view (``_curated_view()`` or
-        #: ``_remote_view()``) the currently in-flight operation belongs
-        #: to -- both views can be mounted at once (``LLMManagementWindow``
-        #: composes every rail view eagerly; only ``active_view`` picks
-        #: which is visible), so a progress tick must be routed to the
-        #: right one, not applied to both. See ``_active_install_view``.
+        #: Which flow currently owns the fields below -- ``"curated"`` or
+        #: ``"remote"``, or ``None`` when idle. TASK-1914: curated and
+        #: remote installs share this screen's one set of retained state
+        #: (see this field's own role below for why one shared lock is
+        #: correct here, not two independent ones). Serves two purposes:
+        #: (1) routing -- the only way to know which mounted view
+        #: (``_curated_view()`` or ``_remote_view()``) the currently
+        #: in-flight operation belongs to, since both views can be mounted
+        #: at once (``LLMManagementWindow`` composes every rail view
+        #: eagerly; only ``active_view`` picks which is visible), so a
+        #: progress tick must be routed to the right one, not applied to
+        #: both -- see ``_active_install_view``; and (2), since TASK-1914
+        #: fix round 2, THE concurrency guard itself: set once, when
+        #: ``_curated_install_requested``/``_remote_install_requested``
+        #: accepts a request, and cleared ONLY in the terminal
+        #: apply-provision-result/clear-state paths, so it stays non-
+        #: ``None`` for an accepted request's entire lifecycle -- preflight
+        #: running, pending consent, and provisioning -- unlike
+        #: ``_model_install_worker`` below, which is briefly ``None``
+        #: during the pending-consent window. See ``_install_in_progress``.
         self._model_install_kind: str | None = None
         #: The last ``AcquisitionProgress`` this screen has seen for the
         #: active install (curated or remote), retained so a freshly
@@ -130,23 +138,25 @@ class LLMScreen(LabScreen):
         #: The install worker currently running (preflight OR provision --
         #: reassigned when the second phase starts, mirroring
         #: ``LibraryScreen``'s single ``_parakeet_v2_install_worker`` field
-        #: across its own two phases). Guards ``_curated_install_requested``
-        #: AND ``_remote_install_requested`` against starting a second,
-        #: concurrent install while this one is still in flight -- a
-        #: SINGLE lock shared by both flows (TASK-1914), not one each,
-        #: because the managed store's own ``ArtifactAcquisitionService.
-        #: provision`` already serializes concurrent installs behind one
-        #: in-process lease regardless of which view started them (see
-        #: that class's own docstring): a curated install and a remote
-        #: install running "at the same time" would already queue against
-        #: each other at that layer, so tracking two independently here
-        #: would only mean paying for a wasted preflight before the second
-        #: one blocked anyway, while doubling every field below for no
-        #: operational benefit. This screen owns exactly one
-        #: ``WorkerManager``, unlike the view-owned workers TASK-1803/
-        #: TASK-1914 replaced, so this guard now holds across a
-        #: screen-level recompose instead of only within one view
-        #: instance's lifetime.
+        #: across its own two phases), and briefly ``None`` BETWEEN those
+        #: two phases while the shared consent modal awaits the user's
+        #: decision. NOT the concurrency guard (TASK-1914 fix round 2 --
+        #: it was, before this fix, and that was the bug: a worker-handle
+        #: check is blind to the pending-consent window). ``_model_install_
+        #: kind`` is the guard now (see ``_install_in_progress``); this
+        #: field exists purely so the actual ``Worker`` handle is
+        #: retained/inspectable across the two phases, mirroring
+        #: ``LibraryScreen``'s equivalent field. Both flows still share
+        #: this one slot (TASK-1914), not one each, because the managed
+        #: store's own ``ArtifactAcquisitionService.provision`` already
+        #: serializes concurrent installs behind one in-process lease
+        #: regardless of which view started them (see that class's own
+        #: docstring): a curated install and a remote install running "at
+        #: the same time" would already queue against each other at that
+        #: layer, so tracking two independently here would only mean
+        #: paying for a wasted preflight before the second one blocked
+        #: anyway, while doubling every field below for no operational
+        #: benefit.
         self._model_install_worker: Worker | None = None
         #: The reference, service, and (curated-only) registry/source map
         #: the currently running (or about-to-run) curated install needs
@@ -357,6 +367,38 @@ class LLMScreen(LabScreen):
             return self._remote_view()
         return None
 
+    def _install_in_progress(self) -> bool:
+        """Return whether a curated or remote install is in ANY phase.
+
+        TASK-1914 fix round 2: the concurrency guard in ``_curated_
+        install_requested``/``_remote_install_requested`` used to check
+        only ``_model_install_worker is not None and not worker.is_
+        finished`` -- true while a preflight/provision thread is actually
+        running, but ``_model_install_worker`` is deliberately set back to
+        ``None`` by ``_apply_curated_preflight_result``/``_apply_remote_
+        preflight_result`` the moment preflight succeeds, before the
+        shared consent modal is even pushed (see those methods' own
+        docstrings). A second ``InstallRequested`` landing during that
+        pending-consent window -- no worker running, but an install very
+        much still in progress, awaiting the user's decision -- passed the
+        old guard and could overwrite ``_model_install_kind``/the pending
+        report/reference for the install actually awaiting consent.
+
+        ``_model_install_kind`` is the fix: set once, when a request is
+        accepted (``_curated_install_requested``/``_remote_install_
+        requested``), and cleared ONLY in the terminal paths -- the
+        provision-result methods (success or failure) and the cancel/
+        clear-state helpers (invalid payload, preflight failure, explicit
+        decline) -- so it is non-``None`` for the ENTIRE lifecycle of an
+        accepted request: preflight running, pending consent, and
+        provisioning, not merely "a worker happens to be running right
+        now".
+
+        Returns:
+            Whether an install (either kind) is currently in progress.
+        """
+        return self._model_install_kind is not None
+
     # -- Curated model install: this screen owns preflight/provision -----
     #
     # TASK-1803: CuratedView posts CuratedView.InstallRequested and renders
@@ -377,16 +419,21 @@ class LLMScreen(LabScreen):
 
         Refuses a second concurrent install outright (mirroring
         ``LibraryScreen.handle_parakeet_v2_install_requested``'s own
-        worker-in-flight guard) -- including a concurrent REMOTE install
-        (TASK-1914: both flows share this screen's one
-        ``_model_install_worker`` lock, see its own docstring for why one
-        shared lock is correct here): the requesting ``CuratedView``
-        already disabled its own row before posting this, but only a
-        screen-level recompose can hand a *different*, freshly (re)mounted
-        instance a chance to post a second request while the first is
-        still running -- ``cancel_pending_install()`` releases only that
-        fresh instance's own indicator, leaving the still-running
-        install's retained state (below) untouched.
+        worker-in-flight guard, generalized -- see ``_install_in_progress``)
+        -- including a concurrent REMOTE install (TASK-1914: both flows
+        share this screen's one ``_model_install_kind`` lifecycle guard) --
+        for as long as ANY phase of another install is in progress:
+        preflight running, pending consent (the shared modal is up, no
+        worker running), or provisioning (TASK-1914 fix round 2 -- see
+        ``_install_in_progress``'s own docstring for why checking the
+        worker handle alone left the pending-consent window unguarded).
+        The requesting ``CuratedView`` already disabled its own row before
+        posting this, but only a screen-level recompose can hand a
+        *different*, freshly (re)mounted instance a chance to post a
+        second request while the first is still in progress --
+        ``cancel_pending_install()`` releases only that fresh instance's
+        own indicator, leaving the still-in-progress install's retained
+        state (below) untouched.
 
         Also validates the event's payload before storing any of it
         (TASK-1803 review round 2, Critical): ``CuratedView`` only ever
@@ -403,8 +450,7 @@ class LLMScreen(LabScreen):
         formatting are the defense-in-depth backstop.
         """
         event.stop()
-        worker = self._model_install_worker
-        if worker is not None and not worker.is_finished:
+        if self._install_in_progress():
             self.notify(
                 "A curated model install is already running.",
                 severity="information",
@@ -506,24 +552,15 @@ class LLMScreen(LabScreen):
         error: str | None,
     ) -> None:
         """Show the shared consent modal, or a sanitized preflight failure."""
-        # NOTE (pre-existing since TASK-1803, annotated not fixed here):
         # _model_install_worker is None from this line until
         # _confirm_curated_install's own _run_curated_provision() call --
-        # i.e. for as long as the shared consent modal is up. A second,
-        # non-UI-originated InstallRequested landing in that window would
-        # pass _curated_install_requested's/_remote_install_requested's
-        # worker-in-flight guard (which only checks _model_install_worker),
-        # and -- if that second request were invalid -- reach
-        # _clear_curated_install_state()/_clear_remote_install_state(),
-        # which unconditionally zeroes _model_install_kind, clobbering
-        # whichever flow (curated or remote) is the one actually still
-        # awaiting consent. Currently unreachable via the UI: the consent
-        # modal is a ModalScreen and captures input, so neither view's own
-        # Install/candidate button can be pressed again -- and therefore
-        # no second InstallRequested can be posted -- while it is showing.
-        # A future refactor that lets something else post InstallRequested
-        # (a command palette action, a test harness driving the message
-        # bus directly, etc.) would need to close this gap for real.
+        # i.e. for as long as the shared consent modal is up -- but that no
+        # longer matters for concurrency safety: _curated_install_
+        # requested/_remote_install_requested guard on _install_in_
+        # progress() (_model_install_kind is not None), and _model_install_
+        # kind stays set through this entire pending-consent window (TASK-
+        # 1914 fix round 2). A second InstallRequested landing here is
+        # refused before it can touch any of this screen's retained state.
         self._model_install_worker = None
         if error is not None or report is None:
             self.notify(error or "Model preflight failed.", severity="error")
@@ -709,31 +746,33 @@ class LLMScreen(LabScreen):
     # RemoteView.InstallRequested and renders what it is told
     # (apply_progress/cancel_pending_install/finish_install); resolving the
     # plan, showing the consent modal, and provisioning all run here. Both
-    # flows share this screen's single _model_install_worker lock (see that
-    # field's own docstring) and the InstallProgressed/InstallStatusChanged
-    # delivery path (_deliver_curated, despite its name -- see its own
-    # docstring) and hydration path (_hydrate_model_install_progress);
-    # only the curated-vs-remote-specific plan-resolution/consent/
-    # provisioning steps below are duplicated, exactly as the curated
-    # block duplicates LibraryScreen's own Parakeet v2 shape.
+    # flows share this screen's single _install_in_progress()/
+    # _model_install_kind concurrency guard (see that method's own
+    # docstring) and the InstallProgressed/InstallStatusChanged delivery
+    # path (_deliver_curated, despite its name -- see its own docstring)
+    # and hydration path (_hydrate_model_install_progress); only the
+    # curated-vs-remote-specific plan-resolution/consent/provisioning
+    # steps below are duplicated, exactly as the curated block duplicates
+    # LibraryScreen's own Parakeet v2 shape.
 
     @on(RemoteView.InstallRequested)
     def _remote_install_requested(self, event: RemoteView.InstallRequested) -> None:
         """Resolve an install plan for a reviewed remote candidate, off the Textual event loop.
 
-        Shares ``_curated_install_requested``'s worker-in-flight guard
-        (the same ``_model_install_worker`` field -- see its own docstring
-        for why one screen-level lock, not two, is the correct shape now
-        that both flows live on this screen) and the same validate-before-
-        store discipline (TASK-1803 review round 2, Critical, applied here
-        from the start rather than rediscovered): an invalid payload
-        notifies, releases the clicking view's own indicator, and clears
-        state via ``_clear_remote_install_state`` without ever starting a
-        worker.
+        Shares ``_curated_install_requested``'s guard (``_install_in_
+        progress()``, checking ``_model_install_kind`` rather than the
+        worker handle -- see that method's own docstring for why one
+        screen-level lock, not two, is the correct shape now that both
+        flows live on this screen, AND why the guard must span the whole
+        install lifecycle, not just "a worker happens to be running")
+        and the same validate-before-store discipline (TASK-1803 review
+        round 2, Critical, applied here from the start rather than
+        rediscovered): an invalid payload notifies, releases the clicking
+        view's own indicator, and clears state via ``_clear_remote_
+        install_state`` without ever starting a worker.
         """
         event.stop()
-        worker = self._model_install_worker
-        if worker is not None and not worker.is_finished:
+        if self._install_in_progress():
             self.notify(
                 "A model install is already running.",
                 severity="information",
@@ -840,13 +879,10 @@ class LLMScreen(LabScreen):
         error: str | None,
     ) -> None:
         """Show the shared consent modal, or a sanitized preflight failure."""
-        # NOTE (pre-existing since TASK-1803, annotated not fixed here): see
-        # the identical note in _apply_curated_preflight_result -- the same
-        # narrow pending-consent window (_model_install_worker is None
-        # until _confirm_remote_install's own _run_remote_provision() call)
-        # applies here, and for the same reason (the consent modal is a
-        # ModalScreen that captures input, so no second InstallRequested,
-        # curated or remote, can be posted through the UI while it is up).
+        # See the identical note in _apply_curated_preflight_result: this
+        # window is safe now because _install_in_progress() guards on
+        # _model_install_kind, not on _model_install_worker (TASK-1914 fix
+        # round 2).
         self._model_install_worker = None
         catalog = self._model_install_catalog
         candidate = self._model_install_candidate

--- a/tldw_chatbook/UI/Screens/model_remote_view.py
+++ b/tldw_chatbook/UI/Screens/model_remote_view.py
@@ -6,19 +6,14 @@ import asyncio
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from loguru import logger
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
+from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Button, Input, Static
 
-from tldw_chatbook.Model_Artifacts.acquisition import (
-    ArtifactAcquisitionService,
-    EnvConfigCredentialResolver,
-    TransferError,
-)
 from tldw_chatbook.Model_Artifacts.remote_huggingface import (
     HuggingFaceRemoteAdapter,
     RemoteDiscoveryError,
@@ -34,21 +29,110 @@ from tldw_chatbook.Model_Artifacts.service import (
     ModelArtifactService,
 )
 from tldw_chatbook.Model_Artifacts.store import managed_service
-from tldw_chatbook.UI.Screens.model_browser_state import install_failure_message
-from tldw_chatbook.Widgets.ModelArtifacts import (
-    InstallProgressed,
-    InstallStatusChanged,
-    ModelInstallModal,
-    ModelInstallProgress,
-    make_progress_callback,
-)
+from tldw_chatbook.Widgets.ModelArtifacts import ModelInstallProgress
 
 if TYPE_CHECKING:
-    from tldw_chatbook.Model_Artifacts.acquisition import CredentialResolver
+    from tldw_chatbook.Model_Artifacts.acquisition import (
+        AcquisitionProgress,
+        CredentialResolver,
+    )
+
+
+def _default_credential_resolver() -> "CredentialResolver":
+    """Lazily construct the production env/config credential resolver.
+
+    A plain function, not ``EnvConfigCredentialResolver`` itself, as the
+    ``credential_resolver_factory`` constructor default: evaluating a
+    default parameter value happens once, at class-definition (i.e.
+    module-import) time, so binding the class itself there would import
+    ``Model_Artifacts.acquisition`` at module scope. This function defers
+    that import to its own body, run only when a ``RemoteView`` is actually
+    constructed (or a test calls the factory directly) -- the same
+    module-scope boundary this module's own docstring, and
+    ``model_curated_view.py`` before it, both hold to.
+
+    Returns:
+        A fresh ``EnvConfigCredentialResolver``.
+    """
+    from tldw_chatbook.Model_Artifacts.acquisition import EnvConfigCredentialResolver
+
+    return EnvConfigCredentialResolver()
 
 
 class RemoteView(Widget):
-    """Search and explicitly install pinned remote GGUF artifacts."""
+    """Search remote GGUF repositories and request their installation.
+
+    Metadata discovery -- ``Search``/repository inspection, driven by
+    :meth:`_search_remote`/:meth:`_resolve_remote` -- stays owned by this
+    view (TASK-1914): it is a read-only listing concern, exactly like
+    ``CuratedView._load_curated`` and ``InstalledView``'s own inventory
+    load, neither of which TASK-1803 moved either. Only acquisition --
+    preflight, provision, and the consent modal in between -- crosses the
+    browser's screen-owns-worker boundary: reviewing a candidate posts
+    :class:`InstallRequested` and waits to be told what happened via
+    :meth:`apply_progress`, :meth:`cancel_pending_install`, or
+    :meth:`finish_install`. ``LLMScreen`` owns the actual preflight/
+    provision workers (mirroring ``LibraryScreen``'s Parakeet v2 flow and
+    ``CuratedView``'s own TASK-1803 fix) precisely so a several-hundred-
+    megabyte download survives both the consent modal being dismissed and
+    a screen-level recompose that tears down and rebuilds this exact view
+    mid-install.
+
+    Before this change, this view owned that worker directly (added by
+    PR #1190, TASK-596.1) and had no compensating delivery logic at all: a
+    screen-level recompose mid-install orphaned the worker, whose own
+    ``post_message`` became a silent no-op once this instance was torn
+    down, so progress stopped reaching the UI with nothing to catch it.
+    Moving the worker to ``LLMScreen`` -- which already survives that same
+    recompose for the equivalent curated install -- removes the need for
+    any durable-delivery fallback here: ``LLMScreen`` is never the thing
+    being torn down, so there is no orphaned poster left to compensate for.
+
+    This module deliberately never imports ``ArtifactAcquisitionService``
+    nor calls ``preflight()``/``provision()`` itself; ``Model_Artifacts.
+    acquisition``/``fetch`` are only ever imported inside ``LLMScreen``'s
+    own worker methods (and, lazily, inside :func:`_default_credential_
+    resolver`, for the resolver this view's metadata search still performs
+    itself).
+    """
+
+    class InstallRequested(Message):
+        """Posted when a reviewed remote GGUF candidate is selected for install."""
+
+        def __init__(
+            self,
+            catalog: ResolvedRemoteCatalog,
+            candidate: RemoteGGUFCandidate,
+            *,
+            service: ModelArtifactService,
+            credential_resolver: "CredentialResolver",
+        ) -> None:
+            """Carry everything the host screen needs to preflight/provision.
+
+            Args:
+                catalog: The one-item remote catalog this view already
+                    froze via ``build_remote_catalog`` -- a pure, local
+                    computation, not itself an acquisition call -- naming
+                    the exact selected candidate as its root artifact.
+                candidate: The exact GGUF candidate the catalog was built
+                    from, carried alongside it so the host screen can
+                    describe the selected files (size/digest/source URL)
+                    on the shared consent modal without re-deriving them.
+                service: The managed-store service resolved by this view's
+                    own (possibly test-injected) ``service_factory`` --
+                    captured here so ``LLMScreen``'s worker uses the exact
+                    same instance a test constructed this view with.
+                credential_resolver: The credential resolver resolved the
+                    same way, via ``credential_resolver_factory`` -- the
+                    same seam this view's own metadata search already uses,
+                    so a gated repository's preflight/provision requests
+                    carry the same credential its search did.
+            """
+            super().__init__()
+            self.catalog = catalog
+            self.candidate = candidate
+            self.service = service
+            self.credential_resolver = credential_resolver
 
     DEFAULT_CSS = """
     RemoteView {
@@ -91,8 +175,8 @@ class RemoteView(Widget):
             HuggingFaceRemoteAdapter
         ),
         service_factory: Callable[[], ModelArtifactService] = managed_service,
-        credential_resolver_factory: Callable[[], CredentialResolver] = (
-            EnvConfigCredentialResolver
+        credential_resolver_factory: Callable[[], "CredentialResolver"] = (
+            _default_credential_resolver
         ),
         id: str | None = None,
     ) -> None:
@@ -111,9 +195,8 @@ class RemoteView(Widget):
         self._resolve_generation = 0
         self._results: tuple[RemoteModelSummary, ...] = ()
         self._resolved: ResolvedRemoteModel | None = None
-        self._selected_catalog: ResolvedRemoteCatalog | None = None
-        self._pending_report = None
         self._operation_reference: ArtifactRef | None = None
+        self._progress: "AcquisitionProgress | None" = None
         super().__init__(id=id)
 
     def compose(self) -> ComposeResult:
@@ -131,8 +214,11 @@ class RemoteView(Widget):
                 variant="primary",
                 disabled=disabled,
             )
-        progress = ModelInstallProgress(None, id="remote-model-install-progress")
-        progress.display = False
+        progress = ModelInstallProgress(
+            self._progress,
+            id="remote-model-install-progress",
+        )
+        progress.display = self._progress is not None
         yield progress
         yield Static(self._default_status(), id="remote-model-status", markup=False)
 
@@ -250,7 +336,6 @@ class RemoteView(Widget):
         self._resolve_generation += 1
         self._results = ()
         self._resolved = None
-        self._selected_catalog = None
         self._set_metadata_controls_disabled(True)
         if is_exact_repository(query):
             self._set_status("Inspecting repository…")
@@ -269,7 +354,6 @@ class RemoteView(Widget):
             return
         self._resolve_generation += 1
         self._resolved = None
-        self._selected_catalog = None
         self._set_metadata_controls_disabled(True)
         self._set_status("Inspecting repository…")
         relevant_input = self.query_one("#remote-model-query", Input).value.strip()
@@ -277,7 +361,7 @@ class RemoteView(Widget):
 
     @on(Button.Pressed, ".remote-candidate")
     def _candidate_pressed(self, event: Button.Pressed) -> None:
-        """Freeze one resolved candidate and begin managed preflight."""
+        """Post an install intent for one reviewed candidate; never preflight/provision here."""
         event.stop()
         candidate = getattr(event.button, "candidate", None)
         if (
@@ -295,11 +379,17 @@ class RemoteView(Widget):
                 severity="error",
             )
             return
-        self._selected_catalog = catalog
         self._operation_reference = catalog.artifact.reference
         self._set_metadata_controls_disabled(True)
         self._set_status("Preparing the managed install plan…")
-        self._preflight_model(catalog, candidate)
+        self.post_message(
+            self.InstallRequested(
+                catalog,
+                candidate,
+                service=self._service_factory(),
+                credential_resolver=self._credential_resolver_factory(),
+            )
+        )
 
     @work(thread=True, group="remote_model_search", exit_on_error=False)
     def _search_remote(self, query: str, generation: int) -> None:
@@ -413,7 +503,6 @@ class RemoteView(Widget):
         ):
             self._results = ()
             self._resolved = None
-            self._selected_catalog = None
             self._set_metadata_controls_disabled(False)
             self._refresh_with_status(
                 "Repository selection changed. Press Search to inspect the current ID."
@@ -433,194 +522,71 @@ class RemoteView(Widget):
             "Select one GGUF candidate."
         )
 
-    async def _preflight(self, catalog: ResolvedRemoteCatalog):
-        """Resolve the selected catalog's managed plan on a worker event loop."""
-        resolver = self._credential_resolver_factory()
-        acquisition = ArtifactAcquisitionService(
-            self._service_factory(),
-            credential_resolver=resolver,
-        )
-        return await acquisition.preflight(
-            catalog.artifact.reference,
-            catalog,
-            sources=catalog.sources,
-        )
+    def apply_progress(self, progress: "AcquisitionProgress") -> None:
+        """Render one acquisition progress event, retaining it for later.
 
-    @work(
-        thread=True, group="remote_model_install", exclusive=True, exit_on_error=False
-    )
-    def _preflight_model(
-        self,
-        catalog: ResolvedRemoteCatalog,
-        candidate: RemoteGGUFCandidate,
-    ) -> None:
-        """Resolve the frozen candidate plan off the Textual event loop."""
+        Called ONLY by the host screen (``LLMScreen``) -- via its own
+        ``InstallProgressed`` handler for a live tick, and to re-apply the
+        last known progress to a freshly (re)mounted instance after a
+        screen-level recompose. This view has no ``@on(InstallProgressed)``
+        handler of its own and never posts that message itself (TASK-1914
+        moved the worker that used to post it to ``LLMScreen``); ``LLMScreen``
+        is the sole caller, giving exactly one render per tick.
+
+        ``self._progress`` is retained before either branch below runs, so
+        a fallback ``refresh(recompose=True)`` still picks up the correct
+        value on this view's next (complete) compose pass -- mirroring
+        ``CuratedView.apply_progress``'s own tolerance for the same
+        momentary mid-recompose gap.
+
+        Args:
+            progress: The acquisition progress event to render.
+        """
+        self._progress = progress
         try:
-            report = asyncio.run(self._preflight(catalog))
-        except Exception as exc:
-            logger.error(
-                "Remote model preflight failed for managed artifact {}; "
-                "error_type={}, retryable={}",
-                catalog.artifact.reference.artifact_id,
-                type(exc).__name__,
-                isinstance(exc, TransferError) and exc.retryable,
-            )
-            self.app.call_from_thread(
-                self._apply_preflight_result,
-                None,
-                install_failure_message(
-                    exc,
-                    model_label=catalog.artifact.model_id,
-                ),
-                candidate,
-            )
-            return
-        self.app.call_from_thread(
-            self._apply_preflight_result,
-            report,
-            None,
-            candidate,
-        )
-
-    def _apply_preflight_result(
-        self,
-        report,
-        error: str | None,
-        candidate: RemoteGGUFCandidate | None = None,
-    ) -> None:
-        """Show the shared consent modal or release the frozen selection."""
-        catalog = self._selected_catalog
-        if (
-            error is not None
-            or report is None
-            or catalog is None
-            or report.root != catalog.artifact.reference
-        ):
-            self._pending_report = None
-            self._operation_reference = None
-            self._selected_catalog = None
-            self._set_metadata_controls_disabled(False)
-            message = error or "The install plan changed. Search and review it again."
-            self._set_status(message)
-            self.notify(message, severity="error")
-            return
-        self._pending_report = report
-        acknowledgment = (
-            "No license was declared. I reviewed the source and want to continue."
-            if catalog.artifact.license_id == "NOASSERTION"
-            else None
-        )
-        selected_file_details: tuple[tuple[str, int, str, str], ...] = ()
-        if candidate is not None:
-            remote_files = tuple(
-                sorted(candidate.files, key=lambda item: item.upstream_path)
-            )
-            selected_file_details = tuple(
-                (
-                    remote_file.upstream_path,
-                    remote_file.size_bytes,
-                    remote_file.sha256,
-                    catalog.sources[catalog.artifact.reference][artifact_file.path],
-                )
-                for remote_file, artifact_file in zip(
-                    remote_files,
-                    catalog.artifact.files,
-                    strict=True,
-                )
-            )
-        self.app.push_screen(
-            ModelInstallModal(
-                report,
-                model_label=catalog.artifact.model_id,
-                required_acknowledgment=acknowledgment,
-                selected_file_details=selected_file_details,
-            ),
-            self._confirm_install,
-        )
-
-    def _confirm_install(self, confirmed: bool) -> None:
-        """Provision only after consent while preserving the frozen catalog."""
-        if not confirmed:
-            self._pending_report = None
-            self._operation_reference = None
-            self._selected_catalog = None
-            self._set_metadata_controls_disabled(False)
-            self._set_status(self._default_status())
-            return
-        if self._operation_reference is not None:
-            self.post_message(
-                InstallStatusChanged(self._operation_reference, active=True)
-            )
-        self._provision_model()
-
-    async def _provision(self, report, catalog: ResolvedRemoteCatalog):
-        """Install the reviewed catalog without activating it."""
-        resolver = self._credential_resolver_factory()
-        acquisition = ArtifactAcquisitionService(
-            self._service_factory(),
-            credential_resolver=resolver,
-        )
-        return await acquisition.provision(
-            report.root,
-            report.grant(),
-            catalog,
-            sources=catalog.sources,
-            progress=make_progress_callback(self.post_message),
-            activate=False,
-        )
-
-    @work(
-        thread=True, group="remote_model_install", exclusive=True, exit_on_error=False
-    )
-    def _provision_model(self) -> None:
-        """Provision the frozen plan and catalog off the Textual event loop."""
-        report = self._pending_report
-        catalog = self._selected_catalog
-        if report is None or catalog is None:
-            self.app.call_from_thread(
-                self._apply_provision_result,
-                "No install plan is available; search and review the model again.",
-            )
-            return
-        try:
-            asyncio.run(self._provision(report, catalog))
-        except Exception as exc:
-            logger.error(
-                "Remote model installation failed for managed artifact {}; "
-                "error_type={}, retryable={}",
-                report.root.artifact_id,
-                type(exc).__name__,
-                isinstance(exc, TransferError) and exc.retryable,
-            )
-            self.app.call_from_thread(
-                self._apply_provision_result,
-                install_failure_message(
-                    exc,
-                    model_label=catalog.artifact.model_id,
-                ),
-            )
-            return
-        self.app.call_from_thread(self._apply_provision_result, None)
-
-    @on(InstallProgressed)
-    def _install_progressed(self, event: InstallProgressed) -> None:
-        """Render shared acquisition progress in the Remote view."""
-        try:
-            progress = self.query_one(
+            widget = self.query_one(
                 "#remote-model-install-progress",
                 ModelInstallProgress,
             )
+            widget.display = True
+            widget.update_progress(progress)
         except NoMatches:
-            return
-        progress.display = True
-        progress.update_progress(event.progress)
+            self.refresh(recompose=True)
 
-    def _apply_provision_result(self, error: str | None) -> None:
-        """Finish install-only provisioning and publish inventory refresh state."""
-        reference = self._operation_reference
-        self._pending_report = None
+    def cancel_pending_install(self, message: str | None = None) -> None:
+        """Clear the in-flight indicator without disturbing search/resolve state.
+
+        Called by the host screen (``LLMScreen``) when a request this view
+        posted did not lead to an install actually starting: a preflight
+        failure, an explicit decline at the consent modal, or a request
+        refused outright because a different install (curated or remote --
+        both now share one screen-level lock, see ``LLMScreen``) is already
+        running -- in which case this is the freshly (re)mounted view that
+        just clicked install, not the instance whose install is still in
+        flight.
+
+        Args:
+            message: Status copy to show in place of the in-flight
+                indicator, e.g. a sanitized preflight failure. ``None``
+                (an explicit decline) restores the default status derived
+                from current search/resolve state.
+        """
         self._operation_reference = None
-        self._selected_catalog = None
+        self._set_metadata_controls_disabled(False)
+        self._set_status(message or self._default_status())
+
+    def finish_install(self, message: str | None = None) -> None:
+        """Clear the in-flight indicator and hide progress after a completed install.
+
+        Called by the host screen (``LLMScreen``) once provisioning
+        finishes, successfully or not.
+
+        Args:
+            message: The outcome copy to show (success or sanitized
+                failure); ``None`` restores the default status.
+        """
+        self._operation_reference = None
+        self._progress = None
         try:
             progress = self.query_one(
                 "#remote-model-install-progress",
@@ -631,24 +597,7 @@ class RemoteView(Widget):
         if progress is not None:
             progress.display = False
         self._set_metadata_controls_disabled(False)
-        if error is not None:
-            self._set_status(error)
-            self.notify(error, severity="error")
-        else:
-            message = (
-                "Model downloaded and managed. Runtime compatibility has not "
-                "been verified."
-            )
-            self._set_status(message)
-            self.notify(message, severity="information")
-        if reference is not None:
-            self.post_message(
-                InstallStatusChanged(
-                    reference,
-                    active=False,
-                    succeeded=error is None,
-                )
-            )
+        self._set_status(message or self._default_status())
 
 
 def _discovery_error_message(error: BaseException) -> str:


### PR DESCRIPTION
Closes TASK-1914. Completes what #1210 (TASK-1803) started: the last view driving acquisition itself now posts intents instead.

## The defect

`RemoteView` (Phase 2, #1190) carried the same worker-ownership violation TASK-1803 fixed in `CuratedView` — it drove `preflight`/`provision` itself and imported `ArtifactAcquisitionService` at module scope — but **worse**: it had no compensating delivery logic at all, so a screen recompose mid-install orphaned the worker and progress was simply lost.

## What changes

`LLMScreen` owns the remote preflight/provision workers, mirroring the merged 1803 shape. `RemoteView` posts intents and renders. Remote *search* (`_search_remote`/`_resolve_remote`) stays on the view — it is read-only metadata listing, the same precedent as `_load_curated` and `_load_inventory`.

**One install lock, not two.** Curated and remote installs now share `_model_install_worker`: the acquisition service already serializes concurrent installs behind one in-process lease regardless of origin, so a second lock would only waste a preflight. `_model_install_kind` routes progress to the correct one of the two simultaneously-mounted views — proven in both directions by a concurrent-install refusal test (which also asserts the refusal leaves the *first* install's state untouched) and a cross-view exactly-once test.

All three of 1803's hard-won behaviours carry over and are tested for the remote flow: the closed-target `post_message` fallback during the recompose teardown→remount gap, hydration of the fresh window including `InstalledView` state, and crash-proof error paths that always schedule exactly one apply-result call.

## Review finding, fixed

The first cut enforced AC 3 ("no module-scope `acquisition` import") with a substring scan — which the review proved circumventable by `from tldw_chatbook.Model_Artifacts import acquisition`, a real eager import that passed all three assertions. Third appearance of this test-design flaw in the workstream. Replaced with an AST walk over `Import`/`ImportFrom` nodes outside `TYPE_CHECKING`, applied to `model_curated_view.py` as well (same gap, previously unenforced), and sabotage-verified against exactly that bypass form on both modules — red, then reverted.

## Verification

826 passed, 1 skipped (pre-existing, unrelated) across the model browser, Lab rail, `Model_Artifacts`, and STT boundary suites. Sabotage evidence recorded per finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves remote model preflight/provision workers to `LLMScreen` and unifies curated/remote installs behind one screen-level flow (TASK-1914). Prevents orphaned installs on recompose, routes progress to the correct view, and closes a pending-consent concurrency race.

- **Bug Fixes**
  - `RemoteView` no longer owns install workers or imports `ArtifactAcquisitionService` at module scope; it posts intents and renders only.
  - One install flow is shared for curated and remote; `_model_install_kind` now routes progress and guards concurrency across the whole lifecycle (preflight → consent → provision).
  - Second install requests are refused during both worker-running and pending-consent phases; existing install state stays intact and scoped to the right view.
  - Reuses curated delivery fallback and hydration so progress survives unmount/remount and results apply exactly once.
  - Remote discovery (search/resolve) remains read-only on `RemoteView`.

- **Tests**
  - Added AST-based checks blocking module-scope imports of `Model_Artifacts.acquisition`/`fetch` in both `model_remote_view.py` and `model_curated_view.py`.
  - Added coverage for the new lifecycle-wide guard (same-flow and cross-flow, worker and consent phases), plus exactly-once updates, cross-view isolation, and `InstalledView` hydration via `LLMScreen`.

<sup>Written for commit 1966a478d919d91d54de1752c4c83fb6c84b7e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

