### PR TITLE
TASK-1980: Change-review live UAT complete; defects 2030-2033 filed

### DIFF
--- a/backlog/tasks/task-1980 - Change-review-live-UAT.md
+++ b/backlog/tasks/task-1980 - Change-review-live-UAT.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1980
 title: 'Change review: live end-to-end verification (real app, real agent run)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -24,8 +24,54 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The full journey above completes on the live app at both sizes, evidenced by captured panes
-- [ ] #2 The script-side-effect file appears in the review (with its TASK-1978 badge if merged)
-- [ ] #3 Reverted files verified on DISK, not just in the UI
-- [ ] #4 Any defect found is filed as a backlog task and linked here
+- [x] #1 The full journey above completes on the live app at both sizes, evidenced by captured panes
+- [x] #2 The script-side-effect file appears in the review (with its TASK-1978 badge if merged)
+- [x] #3 Reverted files verified on DISK, not just in the UI
+- [x] #4 Any defect found is filed as a backlog task and linked here
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Isolated profile (TLDW_CONFIG_PATH scratch config, users_name verify_1980) + seeded scratch root
+2. Register workspace + writable folder binding through the Settings UI; agent turn via a deterministic local OpenAI-compatible stub on the Custom provider (config's Anthropic key is dead — 401 straight from the API)
+3. Drive the full journey at 212×64 and 80×24; verify every revert on disk; file defects
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Full journey completed on the LIVE app, both sizes, panes captured throughout.
+
+**What verified clean:** ✎ summary row appears with correct counts for agent
+writes (+2 −1) AND for changes made outside file tools (+1 −1 from a mid-turn
+external delete+create injected while the run was paused on approval — AC #2's
+substance; no badge, TASK-1978 unmerged). Failed runs (provider 401) produce no
+phantom rows; pre/post-turn external changes correctly excluded from B..E.
+Review screen: turn selector with totals, A/M/D grouping, correct unified
+diffs (create/modify/delete), j/k navigation, 80×24 layout with wrapped diff
+and key footer. Reverts verified ON DISK three times: per-file un-create
+(summary.md removed), Undo-all at 212×64 (notes.md restored to baseline),
+Undo-all at 80×24 (sidecar.log restored byte-identical from B, script_output.txt
+un-created). Approval card keys duplicate tools as write_file ×2.
+
+**Defects filed (AC #4):** TASK-2030 (HIGH — the ✎ row's own `v`/Review action
+always toasts "target no longer exists": recompute-synthesized marker rows are
+not store messages; the inspector route works and is how the UAT proceeded),
+TASK-2031 (chips stale after session-model Apply until session switch),
+TASK-2032 (Review tree click doesn't load the diff; only j/k), TASK-2033
+(Console boots on Default despite registry-active workspace — owner decision).
+
+**Observations not filed:** workspace-create name input has no Enter-submit
+(button only); turn selector lists a pickable "No turns" placeholder row;
+Console at 80×24 shows only the context rail (pre-existing layout, not
+change-review scope). The tool_sandbox is where RELATIVE write_file paths
+land — invisible to change review by design (sandbox excluded from roots);
+agents must use absolute paths under a bound root for tracked writes.
+
+**Method note:** agent turns used a deterministic local OpenAI-compatible stub
+(scripted write_file×2 → final text) behind the Custom provider — the config's
+real Anthropic key is dead (401 from the API directly), and a scripted model
+makes the tool sequence reproducible. Everything from the gateway inward
+(tool dispatch, approvals, gate, tracking, DB, UI) was the real app.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2030 - Change-review-transcript-row-Review-action-cannot-resolve-its-message.md
+++ b/backlog/tasks/task-2030 - Change-review-transcript-row-Review-action-cannot-resolve-its-message.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2030
+title: 'Change review: transcript ✎ row''s Review action cannot resolve its message'
+status: To Do
+assignee: []
+created_date: '2026-08-03 00:45'
+labels:
+  - change-review
+  - console
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in TASK-1980 live UAT (the headline finding). The ✎ change-summary row
+says "review with `v`", but on the live app BOTH the `v` binding and the
+row's own Review action button toast "Console message action target no
+longer exists" — every time, including seconds after the run on the very
+turn that produced the row.
+
+Root cause: the transcript renders TOOL marker rows through the
+resume/recompute pipeline (`console_agent_bridge.py` `_console_historical_blocks`
+area, ~line 2300), which synthesizes fresh `ConsoleChatMessage` objects that
+are never placed in the store. Their auto-generated ids end up in the action
+button id, and `handle_console_message_action` (`chat_screen.py` ~18079)
+resolves `store.get_message(message_id)` BEFORE dispatching `review-changes`
+— KeyError → toast. The run id the action actually needs is already ON the
+row (`change_review_run_id`); the store lookup is only how the handler reads
+it back.
+
+The inspector route (`Run` panel → Review changes) works and is how the UAT
+proceeded. 24 change-tracking tests pass because they drive the handler with
+store message ids — the fixture-invented-shape trap, fifth occurrence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selecting a ✎ row and pressing `v` (or clicking its Review action) opens the Review screen on that turn, on the live app, including after a session switch or resume
+- [ ] #2 A test drives the real transcript render path (synthesized marker rows, not store ids) and pins the fix
+- [ ] #3 The failure toast still appears for genuinely-deleted targets (no blanket bypass of the store lookup for other actions)
+<!-- AC:END -->

--- a/backlog/tasks/task-2031 - Console-provider-model-chips-stale-after-session-model-Apply.md
+++ b/backlog/tasks/task-2031 - Console-provider-model-chips-stale-after-session-model-Apply.md
@@ -1,0 +1,32 @@
+---
+id: TASK-2031
+title: 'Console provider/model chips stale after session model Apply'
+status: To Do
+assignee: []
+created_date: '2026-08-03 00:45'
+labels:
+  - console
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in TASK-1980 live UAT. Changing provider/model via the Provider chip's
+session model modal and pressing Apply updates the SESSION (the next run
+uses the new provider — verified against a local stub endpoint) but the
+status chips keep showing the old provider/model until a session/tab switch
+forces a refresh. The user watches "Provider: Anthropic" while the run is
+actually served by Custom — the chips' whole purpose (PR #1153) inverted.
+
+The left-rail Model section DOES show the new values immediately; only the
+status chip row misses the poke after Apply.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After Apply in the session model modal, the Provider/Model chips reflect the new values without switching sessions
+- [ ] #2 A test pins the chip refresh on the Apply path
+<!-- AC:END -->

--- a/backlog/tasks/task-2032 - Change-review-tree-click-does-not-load-the-file-diff.md
+++ b/backlog/tasks/task-2032 - Change-review-tree-click-does-not-load-the-file-diff.md
@@ -1,0 +1,30 @@
+---
+id: TASK-2032
+title: 'Change review: tree click does not load the file diff'
+status: To Do
+assignee: []
+created_date: '2026-08-03 00:45'
+labels:
+  - change-review
+  - bug
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in TASK-1980 live UAT. On the Review screen, clicking a file row in
+the changed-file tree does not load that file's diff into the right pane —
+only keyboard navigation (j/k) switches the diff. A mouse user clicks
+summary.md, keeps reading notes.md's diff, and has no signal anything is
+wrong. Likely the diff loader listens to a Tree event the mouse path does
+not emit (NodeHighlighted-via-key vs NodeSelected-on-click, or focus
+gating in `_load_file`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Clicking a file row loads that file's diff (parity with j/k)
+- [ ] #2 A test pins the mouse-selection path
+<!-- AC:END -->

--- a/backlog/tasks/task-2033 - Console-boot-ignores-registry-active-workspace.md
+++ b/backlog/tasks/task-2033 - Console-boot-ignores-registry-active-workspace.md
@@ -1,0 +1,33 @@
+---
+id: TASK-2033
+title: 'Console boot lands on Default workspace even when another is registry-active'
+status: To Do
+assignee: []
+created_date: '2026-08-03 00:45'
+labels:
+  - console
+  - workspaces
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in TASK-1980 live UAT. Settings → Workspaces "Set active" marks a
+workspace active in the registry (list shows "UAT Review (active)"), but
+after an app restart the Console workspace switcher shows "Default
+(everyday chats) (current)" — the Console context does not start on the
+registry-active workspace, and the startup session is created tool-less
+under Default. May be deliberate ("Switching changes Console context only")
+but it surprises: the one thing "Set active" visibly promises is where you
+land next. Owner decision wanted: either boot Console on the registry-active
+workspace, or rename/re-copy the Settings affordance so it stops implying
+that.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Decision recorded: Console boot honors registry-active workspace, or the Settings "Set active" copy/behavior is changed to match reality
+- [ ] #2 The chosen behavior is implemented and tested
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- TASK-1980 (change-review live end-to-end verification) → Done, all four ACs checked
- Full journey driven on the LIVE app from an isolated profile at 212×64 and 80×24: workspace + writable folder binding registered through the Settings UI, real agent turn (deterministic local OpenAI-compatible stub behind the Custom provider; everything from the gateway inward real), approval card (write_file ×2 keying), ✎ summary rows, Review screen (turn selector, A/M/D tree, unified diffs), per-file revert and Undo-all — every revert verified ON DISK, including a byte-identical restore from B
- Side-effect coverage: mid-turn external delete+create (injected during the approval pause) appears in review as D/A rows — the "changed outside direct file tools" path proven live
- Four defects filed: **TASK-2030 (high)** — the ✎ row's own `v`/Review action always toasts "target no longer exists" (recompute-synthesized marker rows aren't store messages; inspector route works), TASK-2031 (chips stale after session-model Apply), TASK-2032 (review tree click doesn't load diff), TASK-2033 (Console boots on Default despite registry-active workspace)

Backlog-only change: task files (1980 → Done with notes; 2030-2033 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completed live end-to-end UAT for change review (TASK-1980) and marked it Done with all ACs met on the live app at both sizes. Filed follow-up defects TASK-2030–TASK-2033 covering the transcript Review action not resolving, stale provider/model chips after Apply, tree click not loading diffs, and Console boot ignoring the registry-active workspace.

<sup>Written for commit ac8f5b3a797b27fa7421fc8aaa31cf5ab8f10e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

