### PR TITLE
fix(library): ingest UAT P3 polish batch (task-2016)

### DIFF
--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -1376,7 +1376,10 @@ def test_create_pool_redirects_to_real_stderr_when_fileno_invalid(
                 recorded["fd_during_construction"] = -1
 
     class _RecordingContext:
-        def Pool(self, processes=None):
+        def Pool(self, processes=None, initializer=None):
+            # (task-2016) The real Pool now receives the worker-noise
+            # silencer; the fake records it so the contract is pinned.
+            recorded["initializer"] = initializer
             return _RecordingPool(processes)
 
     class _RecordingMultiprocessing:
@@ -1394,6 +1397,10 @@ def test_create_pool_redirects_to_real_stderr_when_fileno_invalid(
 
     assert isinstance(pool, _RecordingPool)
     assert recorded["fd_during_construction"] >= 0
+    assert (
+        recorded["initializer"]
+        is app_module.silence_ingest_worker_import_noise
+    )
 
 
 def test_create_pool_leaves_stderr_alone_when_fileno_is_valid(
@@ -1410,7 +1417,10 @@ def test_create_pool_leaves_stderr_alone_when_fileno_is_valid(
             recorded["stderr_during_construction"] = sys.stderr
 
     class _RecordingContext:
-        def Pool(self, processes=None):
+        def Pool(self, processes=None, initializer=None):
+            # (task-2016) The real Pool now receives the worker-noise
+            # silencer; the fake records it so the contract is pinned.
+            recorded["initializer"] = initializer
             return _RecordingPool(processes)
 
     class _RecordingMultiprocessing:
@@ -1429,6 +1439,10 @@ def test_create_pool_leaves_stderr_alone_when_fileno_is_valid(
     mixin._create_ingest_parse_pool()
 
     assert recorded["stderr_during_construction"] is ambient_stderr
+    assert (
+        recorded["initializer"]
+        is app_module.silence_ingest_worker_import_noise
+    )
 
 
 @pytest.mark.asyncio
@@ -2779,3 +2793,31 @@ async def test_directory_done_rows_all_carry_media_ids(tmp_path: Path) -> None:
                 f"folder done row without media id: {done.source_path}"
             )
         await _wait_for_runner_idle(app, pilot)
+
+
+def test_worker_initializer_silences_import_noise(tmp_path: Path) -> None:
+    """(task-2016) The pool initializer must stop loguru + warnings output
+    from reaching stderr inside a worker process -- that stderr is the
+    parent's real TTY under Textual, and import noise painted over the UI
+    on every first submit."""
+    result = _run_isolated_python(
+        tmp_path,
+        """
+        import sys
+        from tldw_chatbook.Local_Ingestion.ingest_parse_worker import (
+            silence_ingest_worker_import_noise,
+        )
+
+        silence_ingest_worker_import_noise()
+
+        import warnings
+        from loguru import logger
+
+        logger.warning("should not reach stderr")
+        warnings.warn("should not reach stderr either", UserWarning)
+        print("MARKER-OK")
+        """,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "MARKER-OK" in result.stdout
+    assert "should not reach stderr" not in result.stderr

--- a/Tests/UI/test_library_ingest_canvas.py
+++ b/Tests/UI/test_library_ingest_canvas.py
@@ -354,17 +354,18 @@ async def test_type_group_panels_render_for_detected_groups():
 
 @pytest.mark.asyncio
 async def test_expand_collapse_all_buttons_render_when_type_groups_present():
-    """Bulk expand/collapse buttons render only when there are type groups."""
+    """Bulk expand/collapse buttons render only when MULTIPLE panels exist
+    (task-2016: a single panel has nothing to expand "all" of)."""
     with_groups = build_library_ingest_state(
         (),
         form=_default_form(),
         preflight=PreflightResult(
-            type_groups={"generic": ["/tmp/a.txt"]},
+            type_groups={"pdf": ["/tmp/a.pdf"], "generic": ["/tmp/a.txt"]},
             warnings=[],
             errors=[],
             total_size=0,
             truncated=False,
-            total_files=1,
+            total_files=2,
         ),
     )
     app = _CanvasHost(with_groups)
@@ -1280,3 +1281,79 @@ async def test_unsupported_files_summary_pluralizes_correctly():
             "2 unsupported files will be recorded as failures."
             == str(summary.renderable)
         )
+
+
+# --- task-2016: P3 polish ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_done_row_progress_line_has_no_state_prefix():
+    """(task-2016) The row line already says "✓ done"; prefixing the progress
+    line with "done" again read as stuttering. Terminal states render the
+    message alone; active states keep the prefix (previous test)."""
+    job = LibraryIngestJob(
+        job_id="ingest-job-1",
+        source_path="/tmp/report.txt",
+        state=IngestJobState.DONE,
+        media_id=1,
+        progress={"message": "Ingested report.txt"},
+    )
+    state = build_library_ingest_state((job,), form=_default_form())
+    app = _CanvasHost(state)
+    async with app.run_test() as pilot:
+        progress = pilot.app.query_one(
+            "#library-ingest-progress-ingest-job-1", Static
+        )
+        assert str(progress.renderable) == "Ingested report.txt"
+
+
+@pytest.mark.asyncio
+async def test_expand_collapse_all_hidden_for_single_panel():
+    """(task-2016) Bulk expand/collapse over exactly one panel is noise."""
+    single = build_library_ingest_state(
+        (),
+        form=_default_form(),
+        preflight=PreflightResult(
+            type_groups={"generic": ["/tmp/a.txt"]},
+            warnings=[],
+            errors=[],
+            total_size=0,
+            truncated=False,
+            total_files=1,
+        ),
+    )
+    app = _CanvasHost(single)
+    async with app.run_test() as pilot:
+        assert not list(pilot.app.query("#ingest-expand-all"))
+        assert not list(pilot.app.query("#ingest-collapse-all"))
+
+
+@pytest.mark.asyncio
+async def test_generic_scope_line_reworded_when_no_generic_files_staged():
+    """(task-2016) The always-present generic panel claimed "Applies to all
+    Plain text / documents / HTML in this import." even when the import
+    contained zero such files."""
+    state = build_library_ingest_state(
+        (),
+        form=_default_form(),
+        preflight=PreflightResult(
+            type_groups={"pdf": ["/tmp/a.pdf"]},
+            warnings=[],
+            errors=[],
+            total_size=100,
+            truncated=False,
+            total_files=1,
+        ),
+    )
+    # Expand the generic panel so its scope line mounts.
+    state.form.expanded_type_groups.add("generic")
+    app = _CanvasHost(state)
+    async with app.run_test() as pilot:
+        scopes = [
+            str(w.renderable)
+            for w in pilot.app.query(".type-group-scope").results(Static)
+        ]
+        generic_scope = [s for s in scopes if "Plain text" in s]
+        assert generic_scope, f"generic scope line missing: {scopes}"
+        assert "if this import contains any" in generic_scope[0]
+        assert "in this import." not in generic_scope[0]

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -9534,11 +9534,23 @@ async def test_library_shell_ingest_canvas_clear_finished_empties_done_and_faile
         await _wait_for_selector(screen, pilot, "#library-ingest-clear-finished")
 
         # (task-2015) Clearing now takes an arming press plus a confirming
-        # press -- one accidental press must not destroy the receipts.
+        # press -- one accidental press must not destroy the receipts. Poll
+        # for the armed label before the second press: the arm recompose is
+        # async (task-699 state-then-DOM lesson).
         screen.query_one("#library-ingest-clear-finished", Button).press()
-        await pilot.pause()
+        for _ in range(_INGEST_POLL_ATTEMPTS):
+            button = screen.query_one("#library-ingest-clear-finished", Button)
+            if "again" in str(button.label).lower():
+                break
+            await pilot.pause(_INGEST_POLL_INTERVAL)
+        else:
+            raise AssertionError("first press never armed the button")
         screen.query_one("#library-ingest-clear-finished", Button).press()
-        await pilot.pause()
+        for _ in range(_INGEST_POLL_ATTEMPTS):
+            counts = harness.library_ingest_jobs.counts()
+            if counts["done"] == 0 and counts["failed"] == 0:
+                break
+            await pilot.pause(_INGEST_POLL_INTERVAL)
 
         counts = harness.library_ingest_jobs.counts()
         assert counts["done"] == 0
@@ -12060,13 +12072,96 @@ async def test_library_ingest_clear_finished_requires_second_press(tmp_path):
         await _wait_for_selector(screen, pilot, "#library-ingest-clear-finished")
 
         screen.query_one("#library-ingest-clear-finished", Button).press()
-        await pilot.pause()
+        # Poll for the armed label -- the arm's context-preserving recompose
+        # is async, and a single pause under full-suite load is not enough
+        # (the task-699 state-then-DOM lesson).
+        for _ in range(_INGEST_POLL_ATTEMPTS):
+            button = screen.query_one("#library-ingest-clear-finished", Button)
+            if "again" in str(button.label).lower():
+                break
+            await pilot.pause(_INGEST_POLL_INTERVAL)
+        else:
+            raise AssertionError("first press never armed the button")
         assert harness.library_ingest_jobs.counts()["done"] == 1, (
             "first press must arm, not clear"
         )
-        armed_button = screen.query_one("#library-ingest-clear-finished", Button)
-        assert "again" in str(armed_button.label).lower()
 
-        armed_button.press()
+        screen.query_one("#library-ingest-clear-finished", Button).press()
+        for _ in range(_INGEST_POLL_ATTEMPTS):
+            if harness.library_ingest_jobs.counts()["done"] == 0:
+                break
+            await pilot.pause(_INGEST_POLL_INTERVAL)
+        else:
+            raise AssertionError("second press never cleared the queue")
+
+
+@pytest.mark.asyncio
+async def test_library_ingest_intro_lines_hide_while_typing(tmp_path):
+    """(task-2016) The state model already drops intro lines once a path is
+    typed, but the no-recompose typing handler never removed them from the
+    DOM -- they must hide (and return) live with the field's content."""
+    db = MediaDatabase(tmp_path / "ingest-canvas.db", client_id="p3-intro")
+    harness = _LibraryIngestCanvasHarness(db)
+
+    async with harness.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = harness.screen_stack[-1]
+        await _wait_for_library_shell(screen, pilot)
+        await _open_library_ingest_canvas(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-ingest-path")
+
+        intros = list(screen.query(".library-ingest-intro"))
+        assert intros, "fresh canvas must render intro lines"
+        assert all(w.display for w in intros)
+
+        path_input = screen.query_one("#library-ingest-path", Input)
+        path_input.focus()
         await pilot.pause()
-        assert harness.library_ingest_jobs.counts()["done"] == 0
+        path_input.value = "/tmp/somewhere.txt"
+        await pilot.pause()
+        assert all(
+            not w.display for w in screen.query(".library-ingest-intro")
+        ), "intro lines must hide once a path is typed"
+
+        path_input.value = ""
+        await pilot.pause()
+        assert all(w.display for w in screen.query(".library-ingest-intro")), (
+            "intro lines must return when the path is cleared"
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_search_typed_text_survives_registry_recompose(tmp_path):
+    """(task-2016) The rail search box had no Input.Changed handler, so a
+    recompose rebuilt it from the last SUBMITTED query -- typed-but-
+    unsubmitted text (including a deletion) resurrected."""
+    db = MediaDatabase(tmp_path / "ingest-canvas.db", client_id="p3-search")
+    harness = _LibraryIngestCanvasHarness(db)
+
+    async with harness.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = harness.screen_stack[-1]
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-search-input")
+
+        search = screen.query_one("#library-search-input", Input)
+        search.value = "cake"
+        await pilot.pause()
+        # The screen-side echo must track typing: it feeds both every
+        # rail rebuild (query=...) and save_state, which is where stale
+        # queries resurrected from ("cake and pie pla…" in the UAT).
+        assert screen._library_rag_query == "cake"
+
+        screen._handle_library_ingest_registry_changed()
+        await pilot.pause()
+        await _wait_for_selector(screen, pilot, "#library-search-input")
+        assert (
+            screen.query_one("#library-search-input", Input).value == "cake"
+        ), "typed search text vanished on recompose"
+
+        screen.query_one("#library-search-input", Input).value = ""
+        await pilot.pause()
+        screen._handle_library_ingest_registry_changed()
+        await pilot.pause()
+        await _wait_for_selector(screen, pilot, "#library-search-input")
+        assert (
+            screen.query_one("#library-search-input", Input).value == ""
+        ), "deleted search text resurrected on recompose"

--- a/backlog/tasks/task-2016 - Library-ingest-P3-polish-batch.md
+++ b/backlog/tasks/task-2016 - Library-ingest-P3-polish-batch.md
@@ -2,7 +2,7 @@
 id: TASK-2016
 title: >-
   Library ingest P3 polish batch
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:30'
 labels:
@@ -23,27 +23,78 @@ contaminated instance or depend on environment — reproduce before fixing.
 
 ## Acceptance Criteria (the what)
 
-- [ ] Done rows state "done" once and show the file basename (full path
+- [x] Done rows state "done" once and show the file basename (full path
       available in details), not the absolute path inline.
-- [ ] "Expand all / Collapse all" render only when more than one options
+- [x] "Expand all / Collapse all" render only when more than one options
       panel exists.
-- [ ] The generic panel's scope line no longer claims "Applies to all
+- [x] The generic panel's scope line no longer claims "Applies to all
       Plain text / documents / HTML in this import." when zero such files
       are staged (reword for the global-options case).
-- [ ] Intro lines disappear once a path is typed (state already says so;
+- [x] Intro lines disappear once a path is typed (state already says so;
       the DOM-surgery typing path never removes them).
-- [ ] The file picker opens at the last-used directory and hints which
-      extensions are ingestible.
-- [ ] Rail counts no longer flash "(0)" before the lazy count arrives
-      (defer rendering the number until known).
-- [ ] (repro) The ingest error-details modal renders fully inside the app
-      frame with a visible close affordance.
-- [ ] (repro) First submit never smears dependency warnings / loguru
-      DEBUG over the TUI — route warnings and stderr away from the TTY
-      while the TUI owns the terminal.
-- [ ] `#library-search-input` gets an `Input.Changed` handler so typed but
+- [x] The file picker opens at the last-used directory and hints which
+      extensions are ingestible. (Already implemented on dev:
+      ``_library_ingest_browse_location`` remembers
+      ``library.ingest.last_directory`` and ``FileOpen`` gets
+      ``_ingestible_file_filters()`` — evidence-closed, no change.)
+- [x] Rail counts no longer flash "(0)" before the lazy count arrives.
+      (Already correct on dev: counts pass ``None`` until known and
+      ``_count_suffix(None, …)`` renders no suffix — evidence-closed, no
+      change. The UAT sighting was the contaminated instance at older
+      code.)
+- [x] (repro) The ingest error-details modal placement: NOT REPRODUCIBLE
+      on clean instances (opened correctly in the P1 live pass at 235 cols;
+      the original sighting was on the contaminated co-driven instance).
+      No change made; reopen with a capture if seen on a clean run.
+- [x] (repro) First submit never smears dependency warnings / loguru
+      DEBUG over the TUI. REPRODUCED on a clean instance and FIXED: spawn
+      workers re-import app.py as ``__mp_main__`` with an inherited
+      real-TTY stderr; an early guard in app.py silences loguru's default
+      sink + warnings in that case, plus a pool ``initializer`` as belt.
+      Live-verified: first submit shows zero noise at five samples (was
+      7-8 lines).
+- [x] `#library-search-input` gets an `Input.Changed` handler so typed but
       unsubmitted rail-search text persists/clears the way the user left
       it instead of resurrecting from `_library_rag_query` on recompose.
-- [ ] `[first_run] setup_started/setup_completed` are only written when
-      the user actually starts/completes (or explicitly skips) the wizard,
-      not at app open.
+- [x] `[first_run] setup_started/setup_completed`: investigated —
+      ``setup_started``-at-open is DELIBERATE and load-bearing (the
+      offered-signal the auto-offer logic keys on, per
+      ``first_run_setup_state.py``'s documented rationale);
+      ``setup_completed`` is action-only (finish/skip, wizard :3009/:3090).
+      Working as designed; no change. (Bonus find while probing: the
+      first-boot wizard CRASH filed+fixed as task-2017.)
+
+## Implementation Notes
+
+Shipped on `fix/library-ingest-uat-p3-2016` (stacked on the 2015 branch):
+
+- Done rows: terminal-state progress lines drop the state prefix (the row
+  line already says it) and the writer stamps the basename, not the
+  absolute path. Live: `✓ done · report.txt · 1s` over `Ingested
+  report.txt`.
+- Expand/Collapse-all render only with >1 panel (single generic panel =
+  nothing to bulk-toggle); pinned both ways in canvas tests.
+- New state field `type_group_file_counts` words each panel's scope line
+  honestly; live: pdf-only staging renders "Applies to Plain text /
+  documents / HTML if this import contains any."
+- Intro lines hide/show in place with the typed path (new
+  `library-ingest-intro` class as the no-recompose handle); live 1→0→1.
+- `#library-search-input` gained an `Input.Changed` handler so
+  `_library_rag_query` (rail rebuilds + persisted shell state) tracks
+  typed text; recompose-survival pinned both directions.
+- stderr flood: root cause was spawn workers re-importing `app.py` as
+  `__mp_main__` onto a real-TTY stderr. Note `parent_process()` is NOT yet
+  populated during that import — the guard must key on
+  `__name__ == "__mp_main__"` (a parent_process()-only guard was
+  live-disproven first). Pool `initializer`
+  (`silence_ingest_worker_import_noise`) kept as belt; the two
+  pool-construction fakes were extended to record + pin the initializer
+  (the fake-shaped-by-assumption trap, again).
+- Items 5/6/10: evidence-closed as already-implemented / by-design (AC
+  text updated inline); item 7 not reproducible on clean instances.
+
+Verified: suites `Tests/Library` + `test_library_shell.py` +
+`test_library_ingest_canvas.py` + `Tests/Local_Ingestion` = 1331/1331.
+Live pass (isolated profile): done-row copy, intro hiding, reworded scope
+line, zero first-submit noise at five samples, "Ingest finished — 1
+failed" warning-severity toast.

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -491,6 +491,10 @@ class LibraryIngestCanvasState:
     preflight_checking: bool
     expanded_type_groups: set[str]
     type_groups: list[str]
+    #: (task-2016) Per-supported-group staged-file counts from the active
+    #: pre-flight; the canvas words each panel's scope line from this
+    #: ("Applies to all X in this import." vs the zero-file phrasing).
+    type_group_file_counts: dict[str, int]
     unsupported_files: list[str]
     recent_jobs: list[LibraryIngestJob]
     #: Which backend a new ingest will target, so the canvas can say so.
@@ -972,6 +976,9 @@ def build_library_ingest_state(
         preflight_checking=active_preflight_checking,
         expanded_type_groups=set(form.expanded_type_groups),
         type_groups=type_groups_list,
+        type_group_file_counts={
+            group: len(paths) for group, paths in type_groups.items()
+        },
         unsupported_files=unsupported_files,
         recent_jobs=recent_jobs,
         transcribe_cpp_configured=transcribe_cpp_configured,

--- a/tldw_chatbook/Local_Ingestion/ingest_parse_worker.py
+++ b/tldw_chatbook/Local_Ingestion/ingest_parse_worker.py
@@ -69,6 +69,35 @@ from __future__ import annotations
 from typing import Any, Dict
 
 
+def silence_ingest_worker_import_noise() -> None:
+    """Pool ``initializer``: keep worker import noise off the parent's TTY.
+
+    (task-2016) Spawn workers inherit a REAL-TTY stderr: the parent
+    constructs the pool under ``redirect_stderr(sys.__stderr__)`` when
+    Textual's fd-less stderr wrapper is active (see
+    ``_create_ingest_parse_pool``), so anything a worker's lazy imports
+    emit -- loguru's default stderr sink ("python-frontmatter not
+    installed…"), ``RequestsDependencyWarning`` and friends -- paints raw
+    text over the running TUI on the first submit. Runs INSIDE each worker
+    process before any job. Deliberately does NOT touch ``sys.stderr``
+    itself: a hard worker crash should still be able to reach a terminal
+    for diagnosis; only the known import-noise channels are silenced.
+    """
+    import logging
+    import warnings
+
+    try:
+        from loguru import logger as loguru_logger
+
+        loguru_logger.remove()
+    except Exception:
+        pass
+    # Route ``warnings.warn`` through logging (which has no configured
+    # handlers in a worker) instead of straight to stderr.
+    logging.captureWarnings(True)
+    warnings.simplefilter("ignore")
+
+
 def classify_parse_failure(exc: Exception) -> bool:
     """Return whether an ingest-time exception is a *permanent* failure.
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -12129,6 +12129,15 @@ class LibraryScreen(BaseAppScreen):
             self._library_ingest_path_debounce_timer = self.set_timer(
                 0.8, self._run_debounced_library_ingest_preflight
             )
+        # (task-2016) The state model drops intro lines once a path exists,
+        # but this handler deliberately never recomposes -- hide/show them
+        # in place so they track the field's content live.
+        show_intros = (
+            not event.value.strip()
+            and self._library_ingest_form.preflight is None
+        )
+        for intro in self.query(".library-ingest-intro"):
+            intro.display = show_intros
         try:
             start_button = self.query_one("#library-ingest-start", Button)
         except (NoMatches, QueryError):
@@ -14701,6 +14710,21 @@ class LibraryScreen(BaseAppScreen):
         """
         event.stop()
         self.post_message(NavigateToScreen("media"))
+
+    @on(Input.Changed, "#library-search-input")
+    def handle_library_search_changed(self, event: Input.Changed) -> None:
+        """Track rail-search text as the user types it (task-2016).
+
+        Without this the screen's ``_library_rag_query`` echo only moved on
+        SUBMIT, so every rail rebuild -- and the persisted shell state --
+        re-seeded the box from the last submitted query: text the user typed
+        (or deleted) without submitting resurrected on the next recompose or
+        visit. The mount-echo ``Input.Changed`` Textual fires for the
+        ``value=`` kwarg re-announces the same value, so storing it is
+        idempotent.
+        """
+        event.stop()
+        self._library_rag_query = event.value
 
     @on(Input.Submitted, "#library-search-input")
     async def handle_library_search_submitted(self, event: Input.Submitted) -> None:

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -16,6 +16,7 @@ from tldw_chatbook.Library.ingest_capabilities import (
     _is_installed,
     get_capabilities,
 )
+from tldw_chatbook.Library.library_ingest_jobs import IngestJobState
 from tldw_chatbook.Library.library_ingest_state import (
     QUEUE_EMPTY_COPY,
     LibraryIngestCanvasState,
@@ -108,9 +109,17 @@ class LibraryIngestCanvas(VerticalScroll):
         cap: TypeGroupCapabilities,
         values: dict[str, Any],
         expanded: bool,
+        has_files: bool = True,
     ) -> Collapsible:
         """Build a collapsible options panel for one detected type group."""
-        scope_label = f"Applies to all {cap.label} in this import."
+        # (task-2016) The generic panel is always rendered so global options
+        # stay reachable -- but claiming "Applies to all X in this import."
+        # with zero such files staged was a false statement.
+        scope_label = (
+            f"Applies to all {cap.label} in this import."
+            if has_files
+            else f"Applies to {cap.label} if this import contains any."
+        )
         children: list[Any] = [Static(scope_label, classes="type-group-scope")]
         summary_parts: list[str] = []
         cap_fields_by_name = {f.name: f for f in cap.fields}
@@ -294,10 +303,12 @@ class LibraryIngestCanvas(VerticalScroll):
                     compact=True,
                 )
         for index, line in enumerate(state.intro_lines):
+            # The extra class is the screen's no-recompose handle for hiding
+            # these live while the user types a path (task-2016).
             yield Static(
                 line,
                 id=f"library-ingest-intro-{index}",
-                classes="library-ingest-quiet-line",
+                classes="library-ingest-quiet-line library-ingest-intro",
                 markup=False,
             )
         # Pre-flight summary replaces the old always-visible supported-types
@@ -365,7 +376,10 @@ class LibraryIngestCanvas(VerticalScroll):
                     classes="library-ingest-quiet-line",
                     markup=False,
                 )
-            if state.type_groups:
+            # (task-2016) Bulk expand/collapse over exactly one panel is
+            # noise -- the generic panel is always appended, so a single
+            # entry means there is nothing to expand "all" of.
+            if len(state.type_groups) > 1:
                 with Horizontal(classes="library-ingest-options-bulk"):
                     yield Button(
                         "Expand all",
@@ -379,11 +393,18 @@ class LibraryIngestCanvas(VerticalScroll):
                         classes="library-canvas-action",
                         compact=True,
                     )
+            if state.type_groups:
                 for group in state.type_groups:
                     cap = get_capabilities(group)
                     values = state.form.type_options.get(group, {})
                     expanded = group in state.expanded_type_groups
-                    yield self._compose_type_group(group, cap, values, expanded)
+                    yield self._compose_type_group(
+                        group,
+                        cap,
+                        values,
+                        expanded,
+                        has_files=bool(state.type_group_file_counts.get(group)),
+                    )
         yield Input(
             value=state.form.title,
             placeholder="Title (optional)",
@@ -476,8 +497,19 @@ class LibraryIngestCanvas(VerticalScroll):
             )
             if row.progress:
                 progress_line = row.progress.get("message") if row.progress else ""
+                # (task-2016) The row line above already carries the terminal
+                # state ("✓ done · …"); repeating it here read as stuttering.
+                # Active states keep the prefix -- their progress message is
+                # stage detail, not an outcome.
+                terminal = row.state in (
+                    IngestJobState.DONE,
+                    IngestJobState.FAILED,
+                    IngestJobState.CANCELLED,
+                )
                 yield Static(
-                    f"{row.state.value} {progress_line}",
+                    progress_line
+                    if terminal
+                    else f"{row.state.value} {progress_line}",
                     id=f"library-ingest-progress-{row.job_id}",
                     classes="library-ingest-progress",
                     markup=False,

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -15,6 +15,34 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 if "TEXTUAL_LOG" not in os.environ:
     os.environ["TEXTUAL_LOG"] = ""  # Empty string disables logging
 
+# (task-2016) Spawn-pool workers re-import this module as ``__mp_main__``
+# with an inherited REAL-TTY stderr (see ``_create_ingest_parse_pool``'s
+# Textual-stderr workaround), so import-time noise from the chain below --
+# loguru's default stderr sink ("python-frontmatter not installed…"),
+# ``RequestsDependencyWarning`` -- painted raw text over the parent's TUI
+# on every first submit. This guard MUST run before the heavy imports:
+# the noise is emitted while they import. The pool ``initializer``
+# (``silence_ingest_worker_import_noise``) still runs afterwards as a
+# belt for post-import noise.
+import multiprocessing as _early_multiprocessing
+
+# ``__mp_main__`` is the name spawn gives this module while re-importing it
+# in a child; ``parent_process()`` alone is NOT yet populated at that point
+# (live-verified: the flood survived a parent_process()-only guard).
+if (
+    __name__ == "__mp_main__"
+    or _early_multiprocessing.parent_process() is not None
+):
+    import warnings as _early_warnings
+
+    _early_warnings.simplefilter("ignore")
+    try:
+        from loguru import logger as _early_worker_logger
+
+        _early_worker_logger.remove()
+    except Exception:
+        pass
+
 # Imports
 import concurrent.futures
 import contextlib
@@ -180,6 +208,7 @@ from tldw_chatbook.Local_Ingestion import FileIngestionError
 from tldw_chatbook.Local_Ingestion.ingest_parse_worker import (
     classify_parse_failure,
     run_parse_job,
+    silence_ingest_worker_import_noise,
 )
 from tldw_chatbook.Local_Ingestion.local_file_ingestion import (
     classify_ingest_source,
@@ -2120,10 +2149,19 @@ class LibraryIngestQueueMixin:
         """
         ctx = multiprocessing.get_context("spawn")
         processes = self._ingest_parse_worker_count()
+        # (task-2016) The initializer silences worker-side import noise
+        # (loguru default sink, dependency warnings) that would otherwise
+        # write straight over the TUI via the inherited real-TTY stderr.
         if _stream_fileno(sys.stderr) >= 0:
-            return ctx.Pool(processes=processes)
+            return ctx.Pool(
+                processes=processes,
+                initializer=silence_ingest_worker_import_noise,
+            )
         with contextlib.redirect_stderr(_ingest_pool_real_stderr()):
-            return ctx.Pool(processes=processes)
+            return ctx.Pool(
+                processes=processes,
+                initializer=silence_ingest_worker_import_noise,
+            )
 
     def _ensure_ingest_parse_pool(self):
         """Return the current parse pool, lazily creating one if needed.

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -3364,7 +3364,13 @@ class LibraryIngestQueueMixin:
                             )
                         }
                     else:
-                        progress = {"message": f"Ingested {job.source_path}"}
+                        # (task-2016) The basename, not the absolute path:
+                        # the row line already identifies the file and the
+                        # details surface carries the full path.
+                        source_name = (
+                            Path(job.source_path).name or job.source_path
+                        )
+                        progress = {"message": f"Ingested {source_name}"}
                     self.call_from_thread(
                         self.library_ingest_jobs.mark_done,
                         job.job_id,


### PR DESCRIPTION
## Summary

Stacked on #1244 (retarget to dev after it merges). The P3 polish findings from the 2026-08-02 ingest UAT (task-2016):

- **Done rows stop stuttering** — terminal-state progress lines drop the redundant state prefix and the writer stamps the basename, not the absolute path.
- **Expand/Collapse-all only with multiple panels** (the single always-present generic panel has nothing to bulk-toggle).
- **Honest scope line** — new `type_group_file_counts` state field; a pdf-only staging renders "Applies to Plain text / documents / HTML **if this import contains any**."
- **Intro lines hide/show live with the typed path** (no-recompose handle class).
- **Rail search box gets an `Input.Changed` handler** — typed-but-unsubmitted text (and deletions) feed `_library_rag_query` instead of resurrecting from the last submitted query.
- **First-submit TUI corruption fixed (reproduced live, then fixed)** — spawn workers re-import `app.py` as `__mp_main__` with an inherited real-TTY stderr; loguru's default sink + dependency warnings painted over the UI. Early `__mp_main__` guard (note: `parent_process()` is NOT populated during that import — a guard on it alone was live-disproven) + pool `initializer` as belt, pinned by the construction fakes.
- Items already-implemented / by-design, evidence-closed in the task file: picker last-dir+filters, rail count deferral, `first_run` flag semantics. Details-modal placement: not reproducible on clean instances.

## Evidence

- Suites: `Tests/Library` + `test_library_shell.py` + `test_library_ingest_canvas.py` + `Tests/Local_Ingestion` = **1331/1331**.
- Live (isolated profile): `✓ done · report.txt · 1s` / `Ingested report.txt`; intro lines 1→0→1 with typing; reworded scope line; **zero** first-submit noise at five samples (was 7–8 raw lines over the TUI).

Found while verifying (separate PR incoming): fresh-profile first boot **crashes** in the setup wizard (`SpeechSetupStep` reads `wizard.app_instance` before init) — filed as task-2017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the Library ingest UI per UAT P3 and fixes first-submit TUI corruption from worker import noise. Aligns with Linear task-2016: clearer copy, saner panel controls, live intro toggling, and stable rail search text.

- **Bug Fixes**
  - Stop first-submit TUI smear: early `__mp_main__` guard in `app.py` and pool initializer `silence_ingest_worker_import_noise` to silence `loguru` + warnings during worker imports.
  - Done rows: drop redundant state prefix; progress shows the basename.
  - Expand/Collapse-all only when multiple type-group panels exist.
  - Honest generic panel scope using `type_group_file_counts` (“if this import contains any” when zero files).
  - Intro lines hide/show live as the path field gains/clears content.
  - Rail search tracks typing via `Input.Changed`; `_library_rag_query` mirrors typed text and no longer resurrects stale text after recomposes.

<sup>Written for commit c7e3f8da63caaaba9b16db9a03e83f8aa4bec668. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

