### PR TITLE
fix(wizard): first boot on a fresh profile crashes the app (task-2040)

### DIFF
--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -1028,3 +1028,20 @@ async def test_ctrl_n_ctrl_b_do_not_crash_and_move_one_step(
             await pilot.pause(0.2)
             assert container.is_running, "ctrl+b crashed the wizard"
             assert container.steps[container.current_step].config.id == STEP_PROVIDER
+
+
+def test_setup_wizard_constructs_before_base_init_sets_app_instance():
+    """(task-2040) Step constructors read ``wizard.app_instance`` at
+    ``__init__`` time (SpeechSetupStep pulls ``app_config`` through it),
+    but the container built its steps BEFORE the base ``__init__`` that
+    assigns ``app_instance`` -- so every fresh-profile first boot crashed
+    with ``AttributeError`` inside the wizard and the whole app died."""
+    from types import SimpleNamespace
+
+    from tldw_chatbook.UI.Wizards.FirstRunSetupWizard import (
+        SetupWizardContainer,
+    )
+
+    app_instance = SimpleNamespace(app_config={})
+    wizard = SetupWizardContainer(app_instance)
+    assert wizard.app_instance is app_instance

--- a/backlog/tasks/task-2040 - First-run-wizard-crashes-every-fresh-profile-boot.md
+++ b/backlog/tasks/task-2040 - First-run-wizard-crashes-every-fresh-profile-boot.md
@@ -1,0 +1,47 @@
+---
+id: TASK-2040
+title: >-
+  First-run wizard crashes every fresh-profile boot (app_instance read before init)
+status: Done
+assignee: []
+created_date: '2026-08-03 01:30'
+labels:
+  - first-run
+  - wizard
+  - crash
+  - p0
+priority: high
+dependencies: []
+---
+
+## Description (the why)
+
+Every fresh profile's FIRST app boot crashed the entire app:
+`SetupWizardContainer.__init__` builds its steps (`_create_steps()`)
+BEFORE calling the base `WizardContainer.__init__` that assigns
+`app_instance`, and `SpeechSetupStep.__init__`
+(`FirstRunSetupWizard.py:1173`) reads
+`self.wizard.app_instance.app_config` at construction time →
+`AttributeError: 'SetupWizardContainer' object has no attribute
+'app_instance'` → app exits. The SECOND boot works because the crashed
+first boot already persisted `first_run.setup_started`, changing the
+offer path — which made the crash look like a transient. Found during the
+2026-08-02 ingest-UAT live verification (two "transient" first-launch
+deaths on fresh profiles, captured on the third).
+
+## Acceptance Criteria (the what)
+
+- [x] A fresh profile's first boot reaches the setup wizard instead of
+      crashing (live-verified: wizard renders on first launch).
+- [x] `SetupWizardContainer(app_instance)` construction is pinned by a
+      regression test that fails on the pre-fix code (verified red→green
+      via patch swap).
+
+## Implementation Notes
+
+One assignment: `self.app_instance = app_instance` at the top of
+`SetupWizardContainer.__init__`, before `_create_steps()` (the base class
+re-assigns the same value harmlessly). Regression test in
+`Tests/UI/test_first_run_wizard_live_contract.py`. Wizard suite 15/15.
+The likely origin is the recent SpeechSetupStep addition reading
+`app_config` at construction; any future step doing the same is now safe.

--- a/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
+++ b/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
@@ -2579,6 +2579,14 @@ class SetupWizardContainer(WizardContainer):
     def __init__(self, app_instance, rerun: bool = False, **kwargs):
         self.rerun = rerun
         self.key_entered = False
+        # (task-2040) MUST be set before ``_create_steps()``: step
+        # constructors read ``self.wizard.app_instance`` (SpeechSetupStep
+        # reads ``app_config`` through it at __init__ time), and the base
+        # ``WizardContainer.__init__`` that normally assigns it runs only
+        # AFTER the steps exist -- every fresh-profile first boot crashed
+        # with AttributeError before this line existed. The base class
+        # re-assigns the same value harmlessly.
+        self.app_instance = app_instance
         # TASK-1499: default to the QUICK track — it is the preselected
         # (recommended) Welcome option, so the progress row anchors at
         # "Step 1 of 4" instead of front-loading all nine steps before


### PR DESCRIPTION
## Summary

**Every new user's first launch dies.** `SetupWizardContainer.__init__` runs `_create_steps()` before the base `WizardContainer.__init__` assigns `app_instance`, and `SpeechSetupStep.__init__` (`FirstRunSetupWizard.py:1173`) reads `self.wizard.app_instance.app_config` at construction → `AttributeError` → app exits.

The crash masquerades as a transient: the dying boot has already persisted `first_run.setup_started` (written on wizard offer), so the SECOND boot skips the wizard and works. Found via two "transient" fresh-profile launch deaths during the ingest-UAT live verification; captured on the third with a held pane.

**Fix**: assign `self.app_instance = app_instance` before `_create_steps()` (the base class re-assigns the same value harmlessly) — makes any step reading `wizard.app_instance` at construction safe.

## Evidence

- Regression test verified **red on pre-fix code** (patch-swap) → green with fix.
- Wizard suite `test_first_run_wizard_live_contract.py`: 15/15.
- Live: fresh profile's first boot now renders the wizard (was: dead app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a first-boot crash on fresh profiles by initializing `SetupWizardContainer.app_instance` before building wizard steps. Fresh installs now reach the setup wizard on first launch. Fixes `TASK-2040`.

- **Bug Fixes**
  - Set `self.app_instance = app_instance` before `_create_steps()` to avoid `AttributeError` from steps that read `wizard.app_instance` (e.g., `SpeechSetupStep`).
  - Added a regression test to pin this construction order; verified the wizard renders on first boot.

<sup>Written for commit 394f0c45c987830369b92e933a85a80cab818740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

