### PR TITLE
Console: fix the ✎ row's Review action — resolve via transcript display model (TASK-2030)

### DIFF
--- a/Tests/Chat/test_change_turn_tracking.py
+++ b/Tests/Chat/test_change_turn_tracking.py
@@ -726,6 +726,127 @@ async def test_the_opener_pushes_the_screen_and_selects_the_turn(
         assert [t.run_id for t in turns] == [run_id]
 
 
+@pytest.mark.asyncio
+async def test_the_summary_rows_own_review_action_opens_the_screen(
+    tmp_path, root, tracker
+):
+    """TASK-2030 (live-UAT headline defect): selecting the rendered ✎ row
+    and invoking its review action must open the Review screen.
+
+    The defect class: TOOL markers are display-only rows, deliberately NOT
+    tree nodes, so `store.get_message(marker_id)` ALWAYS raises -- and the
+    action handler resolved the store row before dispatching, killing the
+    row's own advertised affordance ("review with `v`") on the live app
+    while the direct-call opener test stayed green. This test goes through
+    the REAL chain the user does: transcript render -> row selection ->
+    `invoke_selected_action("review-changes")` -> button dispatch ->
+    handler -> pushed screen.
+    """
+    from Tests.UI.app_factory import _build_test_app
+    from textual.app import App
+
+    from tldw_chatbook.UI.Screens.change_review_screen import ChangeReviewScreen
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+    from tldw_chatbook.Widgets.Console.console_transcript import (
+        ConsoleTranscript,
+    )
+
+    gateway = _SideEffectGateway(
+        [[_calc_fence()], ["done."]],
+        side_effect_on_call=2,
+        side_effect=lambda: (root / "made.txt").write_text("x\n"),
+    )
+    bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
+    import asyncio as _asyncio
+
+    run_id, outcome = await _asyncio.to_thread(_run, bridge, session, aid, root)
+    assert outcome.status not in ("error",), outcome.steps
+    marker = next(
+        m for m in _tool_rows(store, session) if m.content.startswith("✎")
+    )
+    assert marker.change_review_run_id == run_id
+
+    class _ConsoleHarness(App):
+        def __init__(self, app_instance):
+            super().__init__()
+            self.app_instance = app_instance
+
+        async def on_mount(self) -> None:
+            await self.push_screen(ChatScreen(self.app_instance))
+
+    app = _build_test_app()
+    app.app_config = {
+        "chat_defaults": {"provider": "llama_cpp", "model": "local-model"},
+        "api_settings": {
+            "llama_cpp": {
+                "api_url": "http://127.0.0.1:9099",
+                "model": "local-model",
+            },
+        },
+    }
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "local-model"
+    harness = _ConsoleHarness(app)
+    async with harness.run_test(size=(160, 48)) as pilot:
+        await pilot.pause()
+        chat_screen = harness.screen_stack[-1]
+        assert isinstance(chat_screen, ChatScreen)
+        # The run's rows live in THIS test's store -- make it the screen's
+        # store before the lazy controller builds, then render it for real.
+        chat_screen._console_chat_store = store
+        chat_screen._ensure_console_agent_bridge = lambda: bridge
+        chat_screen._ensure_console_chat_controller()
+        controller = chat_screen._console_chat_controller
+        assert controller is not None
+        chat_screen._console_chat_controller._agent_conversation_id = (
+            lambda _sid: "conv-1"
+        )
+        await chat_screen._sync_native_console_transcript()
+        await pilot.pause()
+
+        transcript = chat_screen.query_one(
+            "#console-native-transcript", ConsoleTranscript
+        )
+        rendered = [
+            m
+            for m in transcript._messages
+            if str(getattr(m, "content", "")).startswith("✎")
+        ]
+        assert rendered, "precondition: the ✎ row rendered in the transcript"
+        transcript.select_message(rendered[0].id)
+        await pilot.pause()
+        transcript.action_invoke_selected_action("review-changes")
+        await pilot.pause()
+
+        review = await _wait_for_screen(harness, pilot, ChangeReviewScreen)
+        assert review is not None, (
+            "the ✎ row's own review action never opened the Review screen"
+        )
+        turns = review._provider.turns()
+        assert [t.run_id for t in turns] == [run_id]
+
+        # AC#3: a genuinely-unknown target still gets the failure toast --
+        # the display-model path is not a blanket bypass of resolution.
+        harness.pop_screen()
+        await pilot.pause()
+        toasts: list[str] = []
+        app.notify = lambda msg, **kw: toasts.append(str(msg))
+
+        class _Btn:
+            id = "console-message-action-review-changes-not-a-row"
+
+        class _Ev:
+            button = _Btn()
+
+            def stop(self) -> None:
+                pass
+
+        handled = await chat_screen.handle_console_message_action(_Ev())
+        assert handled is True
+        assert any("no longer exists" in t for t in toasts), toasts
+        assert not isinstance(harness.screen, ChangeReviewScreen)
+
+
 async def _wait_for_screen(harness, pilot, screen_type, timeout: float = 8.0):
     import time as _t
 

--- a/backlog/tasks/task-2030 - Change-review-transcript-row-Review-action-cannot-resolve-its-message.md
+++ b/backlog/tasks/task-2030 - Change-review-transcript-row-Review-action-cannot-resolve-its-message.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2030
 title: 'Change review: transcript ✎ row''s Review action cannot resolve its message'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 00:45'
 labels:
@@ -38,7 +38,45 @@ store message ids — the fixture-invented-shape trap, fifth occurrence.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Selecting a ✎ row and pressing `v` (or clicking its Review action) opens the Review screen on that turn, on the live app, including after a session switch or resume
-- [ ] #2 A test drives the real transcript render path (synthesized marker rows, not store ids) and pins the fix
-- [ ] #3 The failure toast still appears for genuinely-deleted targets (no blanket bypass of the store lookup for other actions)
+- [x] #1 Selecting a ✎ row and pressing `v` (or clicking its Review action) opens the Review screen on that turn, on the live app, including after a session switch or resume
+- [x] #2 A test drives the real transcript render path (synthesized marker rows, not store ids) and pins the fix
+- [x] #3 The failure toast still appears for genuinely-deleted targets (no blanket bypass of the store lookup for other actions)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing test that drives the REAL render path: transcript built from the historical/recompute pipeline (synthesized ✎ marker rows not in the store), invoke the row's review-changes action, assert the Review screen opens on the right run — watch it fail with the "target no longer exists" shape
+2. Fix: carry the run id in the review-changes dispatch at render time (it is display data already on the row) so the handler's review-changes branch never needs the store lookup; every other action keeps the store resolution and its failure toast
+3. Sabotage-verify, run the change-tracking/transcript/screen suites
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause was sharper than filed: `ConsoleChatStore._message_or_raise`
+resolves from the session's TREE NODES, and display-only TOOL markers are
+deliberately never tree nodes (its own comment says so) — so
+`store.get_message(<marker id>)` ALWAYS raises, live-appended or resumed.
+No resume needed; every ✎ row action died at the handler's pre-dispatch
+lookup.
+
+Fix: `ConsoleTranscript.display_message(id)` (public display-model lookup
+over the rendered rows) + the `review-changes` branch in
+`handle_console_message_action` hoisted ABOVE the store lookup, resolving
+the run id via `_console_change_review_run_id` (display model first, store
+fallback for tree-node rows, toast on neither). Every other action keeps
+the store resolution and failure toast byte-identical.
+
+Test drives the REAL chain the live UAT exercised: bridge run → store rows
+→ `_sync_native_console_transcript` → rendered ✎ row → `select_message` →
+`action_invoke_selected_action("review-changes")` → button dispatch →
+handler → pushed ChangeReviewScreen with the right turn. Watched it fail
+with the exact live shape first. AC#3 pinned: unknown target still toasts,
+no screen. Both directions sabotage-verified (None-branch removed; display
+lookup blinded — each caught).
+
+Files: `Widgets/Console/console_transcript.py`, `UI/Screens/chat_screen.py`,
+`Tests/Chat/test_change_turn_tracking.py`. 361 tests green across
+change-review + transcript + message-action suites.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -17969,6 +17969,46 @@ class ChatScreen(BaseAppScreen):
             )
         )
 
+    def _console_change_review_run_id(
+        self, store: ConsoleChatStore, message_id: str
+    ) -> str | None:
+        """Resolve the run id a review-changes action should open (TASK-2030).
+
+        The transcript's display model is checked FIRST: the ✎ summary row
+        is a display-only TOOL marker that the store's tree lookup can never
+        resolve. The store remains the fallback for tree-node rows.
+
+        Args:
+            store: The native Console chat store.
+            message_id: The action button's message id.
+
+        Returns:
+            The run id to review, or ``None`` when no rendered or stored
+            row with that id carries one.
+        """
+        try:
+            transcript = self.query_one(
+                "#console-native-transcript", ConsoleTranscript
+            )
+        except QueryError:
+            transcript = None
+        if transcript is not None:
+            row = transcript.display_message(message_id)
+            run_id = (
+                getattr(row, "change_review_run_id", None)
+                if row is not None
+                else None
+            )
+            if run_id:
+                return str(run_id)
+        try:
+            run_id = getattr(
+                store.get_message(message_id), "change_review_run_id", None
+            )
+        except KeyError:
+            return None
+        return str(run_id) if run_id else None
+
     def _open_change_review(self, run_id: str | None = None) -> None:
         """Push the Change Review screen for the active conversation.
 
@@ -18077,6 +18117,28 @@ class ChatScreen(BaseAppScreen):
 
         event.stop()
         store = self._ensure_console_chat_store()
+
+        if action_id == "review-changes":
+            # TASK-2030 (live-UAT headline defect): the ✎ summary row is a
+            # display-only TOOL marker — deliberately NOT a tree node — so
+            # `store.get_message` can NEVER resolve it, and the pre-dispatch
+            # lookup below killed the row's own advertised affordance
+            # ("review with `v`") with the not-found toast on every press.
+            # The run id is display data already ON the rendered row:
+            # resolve it from the transcript's display model, falling back
+            # to the store for tree-node rows. Every other action keeps the
+            # store resolution (and its failure toast) untouched.
+            self._pending_console_delete_message_id = None
+            run_id = self._console_change_review_run_id(store, message_id)
+            if run_id is None:
+                self.app_instance.notify(
+                    "Console message action target no longer exists.",
+                    severity="warning",
+                )
+                return True
+            self._open_change_review(run_id)
+            return True
+
         try:
             message = store.get_message(message_id)
         except KeyError:
@@ -18087,11 +18149,6 @@ class ChatScreen(BaseAppScreen):
 
         if action_id != "delete":
             self._pending_console_delete_message_id = None
-
-        if action_id == "review-changes":
-            run_id = getattr(message, "change_review_run_id", None)
-            self._open_change_review(run_id)
-            return True
 
         if action_id == "save-as":
             destinations = self._console_save_as_destinations(message)

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -955,6 +955,22 @@ class ConsoleTranscript(VerticalScroll):
         """
         return tuple(self._message_signature_cache)
 
+    def display_message(self, message_id: str) -> "ConsoleChatMessage | None":
+        """Return the RENDERED row for ``message_id`` — tree node or not.
+
+        TASK-2030: display-only TOOL markers (the ✎/⚙ rows) are never tree
+        nodes, so the STORE cannot resolve them by id; the transcript's own
+        display model is the authority for what the user actually selected.
+
+        Args:
+            message_id: Identifier of a rendered transcript row.
+
+        Returns:
+            The display-model message, or ``None`` when nothing rendered
+            carries that id.
+        """
+        return self._message_by_id(message_id)
+
     def select_message(self, message_id: str) -> None:
         """Select one message and show its contextual action row."""
         if message_id not in {message.id for message in self._messages}:


### PR DESCRIPTION
## Summary
- Fixes the TASK-1980 live-UAT headline defect: selecting a ✎ change-summary row and pressing `v` (or its Review button) always toasted "Console message action target no longer exists" — the row's own advertised affordance was dead on the live app while the direct-call opener test stayed green
- Root cause: display-only TOOL markers are deliberately NOT tree nodes, so `ConsoleChatStore.get_message(<marker id>)` always raises; `handle_console_message_action` resolved the store row before dispatching `review-changes`
- Fix: new `ConsoleTranscript.display_message(id)` public lookup over the rendered rows; the `review-changes` branch is hoisted above the store lookup and resolves the run id display-model-first with a store fallback (`_console_change_review_run_id`). Every other action keeps the store resolution and its failure toast byte-identical
- New test drives the REAL chain (bridge run → transcript sync → rendered row → selection → `invoke_selected_action` → button dispatch → handler → pushed screen) and reproduced the exact live failure before the fix; unknown targets still toast (no blanket bypass). Both fix directions sabotage-verified

## Testing
- 361 passed across `Tests/Chat/test_change_turn_tracking.py`, `Tests/UI/test_change_review_screen.py`, `Tests/Workspaces/`, `Tests/UI/test_console_native_transcript.py`, `Tests/UI/test_console_transcript_selection_contract.py`, `Tests/Chat/test_console_message_actions.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Console transcript ✎ summary row so its Review action opens the Change Review screen for the correct run across session switches. Resolution now reads the run id from the transcript’s display model with a store fallback; genuinely unknown targets still toast.

- **Bug Fixes**
  - `review-changes` resolves the run id via `ConsoleTranscript.display_message(id)` (display model first) with a store fallback; the handler branch runs before any store lookup. Other actions keep store resolution and the existing failure toast.
  - Added an end-to-end test that renders the transcript, selects the ✎ row, invokes the action, and verifies the Review screen opens; includes a negative case to ensure unknown targets still toast. Meets TASK-2030 acceptance criteria.

<sup>Written for commit 3a36868b47de4c45814142ff44598fd87416d87b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

