### PR TITLE
Change review: root budgets, oversize excludes, retention/GC (TASK-1975)

### DIFF
--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -46,6 +46,7 @@ def _record_turn(db, tracker, root, run_id: str, mutate) -> None:
             adds=rec.adds,
             dels=rec.dels,
             tracking_error=rec.tracking_error,
+            untracked_oversize=rec.untracked_oversize,
         )
 
 
@@ -434,4 +435,64 @@ async def test_revert_refusal_during_active_run_reaches_the_user(review_fixture)
         await pilot.pause()
         assert (root / "edit.txt").read_text() == "after\n", (
             "the revert ran under an active run"
+        )
+
+
+@pytest.mark.asyncio
+async def test_oversize_disclosure_banner_renders(tmp_path, monkeypatch):
+    """TASK-1975 AC#2: the untracked-oversize count is disclosed in review."""
+    monkeypatch.setenv("TLDW_CHANGE_REVIEW_MAX_FILE_BYTES", "100")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "small.txt").write_text("hello\n")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+
+    def mutate():
+        (root / "big.bin").write_bytes(b"x" * 500)
+        (root / "small.txt").write_text("edited\n")
+
+    _record_turn(db, tracker, root, run, mutate)
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="conv-1"
+    )
+    app = _Harness(provider)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        await _wait_for(
+            pilot, lambda: screen.query("#change-review-banner"), "banner"
+        )
+        banner = screen.query_one("#change-review-banner", Static)
+        text = str(banner.renderable)
+        assert "1 oversized" in text, text
+        assert banner.display is True
+
+
+@pytest.mark.asyncio
+async def test_pruned_snapshots_render_pruned_by_retention(review_fixture, tmp_path):
+    """TASK-1975 AC#7: a history row whose snapshots were pruned renders
+    'pruned by retention' instead of erroring."""
+    import shutil as _shutil
+
+    provider, root, run1, run2 = review_fixture
+    # Retention reset the shadow store; the DB rows remain.
+    _shutil.rmtree(tmp_path / "appdata")
+    app = _Harness(provider)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        await _wait_for(
+            pilot,
+            lambda: "pruned by retention"
+            in str(screen.query_one("#change-review-banner", Static).renderable),
+            "pruned banner",
         )

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -1,0 +1,426 @@
+"""TASK-1975: cost bounds — knobs, root budget scan, oversize detection."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Workspaces.change_bounds import (
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_MAX_FILES,
+    DEFAULT_MAX_TOTAL_BYTES,
+    DEFAULT_RETENTION_DAYS,
+    RootScan,
+    change_review_setting,
+    scan_root,
+)
+
+
+class TestKnobs:
+    def test_defaults_come_back_untouched(self):
+        assert change_review_setting("max_files", DEFAULT_MAX_FILES) == (
+            DEFAULT_MAX_FILES
+        )
+        assert change_review_setting(
+            "retention_days", DEFAULT_RETENTION_DAYS
+        ) == DEFAULT_RETENTION_DAYS
+
+    def test_env_var_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("TLDW_CHANGE_REVIEW_MAX_FILES", "123")
+        assert change_review_setting("max_files", DEFAULT_MAX_FILES) == 123
+
+    def test_garbage_env_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("TLDW_CHANGE_REVIEW_MAX_FILES", "not-a-number")
+        assert change_review_setting("max_files", DEFAULT_MAX_FILES) == (
+            DEFAULT_MAX_FILES
+        )
+
+    def test_flat_config_section_is_read(self, monkeypatch):
+        # The FLAT section is the spec's contract (dotted get_cli_setting
+        # has dropped defaults before — task 1754).
+        import tldw_chatbook.Workspaces.change_bounds as cb
+
+        monkeypatch.setattr(
+            cb,
+            "_config_setting",
+            lambda key, default: 77 if key == "max_files" else default,
+        )
+        assert change_review_setting("max_files", DEFAULT_MAX_FILES) == 77
+
+
+@pytest.fixture()
+def scanroot(tmp_path):
+    # The project conftest materializes an isolated config tree inside
+    # tmp_path — scan a dedicated subdir so only OUR files count.
+    d = tmp_path / "scanroot"
+    d.mkdir()
+    return d
+
+
+class TestRootScan:
+    def test_counts_files_and_bytes(self, scanroot):
+        (scanroot / "a.txt").write_bytes(b"x" * 10)
+        (scanroot / "b.txt").write_bytes(b"y" * 20)
+        scan = scan_root(scanroot)
+        assert scan.files == 2
+        assert scan.total_bytes == 30
+        assert scan.over_budget is False
+        assert scan.oversized == ()
+
+    def test_forced_exclude_dirs_do_not_count(self, scanroot):
+        (scanroot / "a.txt").write_bytes(b"x")
+        (scanroot / ".venv").mkdir()
+        (scanroot / ".venv" / "huge.bin").write_bytes(b"z" * 1000)
+        (scanroot / "node_modules").mkdir()
+        (scanroot / "node_modules" / "dep.js").write_bytes(b"z" * 1000)
+        (scanroot / ".git").mkdir()
+        (scanroot / ".git" / "objects").mkdir()
+        scan = scan_root(scanroot)
+        assert scan.files == 1
+        assert scan.total_bytes == 1
+
+    def test_over_file_budget_flags_and_aborts_early(self, scanroot):
+        for i in range(10):
+            (scanroot / f"f{i}.txt").write_bytes(b"x")
+        scan = scan_root(scanroot, max_files=5)
+        assert scan.over_budget is True
+
+    def test_over_total_bytes_budget_flags(self, scanroot):
+        (scanroot / "big.bin").write_bytes(b"x" * 100)
+        scan = scan_root(scanroot, max_total_bytes=50)
+        assert scan.over_budget is True
+
+    def test_oversized_files_listed_root_relative(self, scanroot):
+        (scanroot / "sub").mkdir()
+        (scanroot / "sub" / "fat [v2].bin").write_bytes(b"x" * 100)
+        (scanroot / "slim.txt").write_bytes(b"x")
+        scan = scan_root(scanroot, max_file_bytes=50)
+        assert scan.over_budget is False
+        assert scan.oversized == ("sub/fat [v2].bin",)
+
+    def test_symlinks_are_not_followed(self, tmp_path):
+        outside = tmp_path / "outside-tree"
+        outside.mkdir(exist_ok=True)
+        (outside / "huge.bin").write_bytes(b"x" * 10_000)
+        root = tmp_path / "scanroot2"
+        root.mkdir()
+        (root / "a.txt").write_bytes(b"x")
+        (root / "link").symlink_to(outside)
+        scan = scan_root(root)
+        assert scan.files == 1, "symlinked trees must not count against the root"
+
+
+# -- enforcement (real git) --------------------------------------------------
+
+
+@pytest.fixture()
+def tracked(tmp_path, monkeypatch):
+    """A tracker + in-budget root, with a small oversize cap via env."""
+    from tldw_chatbook.Workspaces.change_tracking import ShadowRepoService
+    from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
+
+    monkeypatch.setenv("TLDW_CHANGE_REVIEW_MAX_FILE_BYTES", "100")
+    root = tmp_path / "workroot"
+    root.mkdir()
+    (root / "small.txt").write_text("hello\n")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    return ChangeTurnTracker(service=service), service, root
+
+
+class TestBudgetEnforcement:
+    def test_over_budget_root_disables_tracking_with_honest_copy(
+        self, tracked, monkeypatch
+    ):
+        tracker, service, root = tracked
+        for i in range(8):
+            (root / f"f{i}.txt").write_text("x")
+        monkeypatch.setenv("TLDW_CHANGE_REVIEW_MAX_FILES", "5")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        assert len(records) == 1
+        assert "narrow the root or add excludes" in records[0].tracking_error
+        assert records[0].baseline_sha == "", "over-budget must not snapshot"
+
+    def test_in_budget_root_tracks_normally(self, tracked):
+        tracker, service, root = tracked
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+        assert len(records) == 1
+        assert records[0].tracking_error == ""
+        assert records[0].files_changed == 1
+
+
+class TestOversizeExcludes:
+    def test_mid_turn_oversized_creation_excluded_and_disclosed(self, tracked):
+        tracker, service, root = tracked
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "big.bin").write_bytes(b"x" * 500)
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.files_changed == 1, "only the small edit is a change"
+        assert rec.untracked_oversize == 1
+        repo = service.repo_for_root(root)
+        assert repo.file_bytes(rec.end_sha, "big.bin") is None, (
+            "the oversized file must never be committed to the shadow store"
+        )
+
+    def test_preexisting_oversize_disclosed_on_changed_turns(self, tracked):
+        tracker, service, root = tracked
+        (root / "old-big.bin").write_bytes(b"x" * 500)
+        service.repo_for_root(root).snapshot("registration")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        assert len(records) == 1
+        assert records[0].untracked_oversize == 1
+
+    def test_oversize_only_turn_emits_a_zero_change_record(self, tracked):
+        tracker, service, root = tracked
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "big.bin").write_bytes(b"x" * 500)
+        records = tracker.end_turn(handle)
+
+        assert len(records) == 1
+        assert records[0].files_changed == 0
+        assert records[0].untracked_oversize == 1
+
+    def test_stable_oversize_set_with_no_changes_emits_no_record(self, tracked):
+        tracker, service, root = tracked
+        (root / "big.bin").write_bytes(b"x" * 500)
+        service.repo_for_root(root).snapshot("registration")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        records = tracker.end_turn(handle)
+        assert records == [], "an unchanged root must stay cardless"
+
+    def test_tool_touched_oversized_path_is_not_force_added(self, tracked):
+        tracker, service, root = tracked
+        (root / ".gitignore").write_text("secret.bin\n")
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "secret.bin").write_bytes(b"x" * 500)
+        records = tracker.end_turn(
+            handle, touched_paths=[str(root / "secret.bin")]
+        )
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.untracked_oversize == 1
+        if rec.end_sha:
+            repo = service.repo_for_root(root)
+            assert repo.file_bytes(rec.end_sha, "secret.bin") is None, (
+                "force-add must not defeat the size cap"
+            )
+
+
+# -- retention (AC#3/#4) -----------------------------------------------------
+
+
+class TestRetention:
+    def _turn_row(self, tracked, db):
+        tracker, service, root = tracked
+        run = db.create_run(conversation_id="c", agent_kind="primary")
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited by turn\n")
+        rec = tracker.end_turn(handle)[0]
+        db.record_change_snapshot(
+            run_id=run,
+            root=rec.root,
+            baseline_sha=rec.baseline_sha,
+            end_sha=rec.end_sha,
+            files_changed=rec.files_changed,
+            adds=rec.adds,
+            dels=rec.dels,
+        )
+        return run
+
+    def test_prune_drops_old_rows_and_resets_rowless_repos(
+        self, tracked, tmp_path
+    ):
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            prune_change_history,
+        )
+
+        tracker, service, root = tracked
+        db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+        run = self._turn_row(tracked, db)
+        repo = service.repo_for_root(root)
+        objects_before = sum(
+            1 for _ in (repo.git_dir / "objects").rglob("*") if _.is_file()
+        )
+        assert objects_before > 0
+        with db.transaction() as conn:
+            conn.execute(
+                "UPDATE change_snapshots SET created_at = '2020-01-01T00:00:00.000000Z'"
+            )
+
+        report = prune_change_history(db, service)
+
+        assert report.rows_pruned == 1
+        assert db.change_snapshots_for_run(run) == []
+        assert not repo.git_dir.exists(), (
+            "a rowless shadow repo must be reset (object count -> 0)"
+        )
+
+    def test_recent_rows_and_their_repo_survive(self, tracked, tmp_path):
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            prune_change_history,
+        )
+
+        tracker, service, root = tracked
+        db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+        run = self._turn_row(tracked, db)
+
+        report = prune_change_history(db, service)
+
+        assert report.rows_pruned == 0
+        assert len(db.change_snapshots_for_run(run)) == 1
+        assert service.repo_for_root(root).git_dir.exists()
+
+    def test_orphaned_repo_dir_removed_by_age(self, tracked, tmp_path):
+        import os as _os
+        import time as _time
+
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            prune_change_history,
+        )
+
+        tracker, service, root = tracked
+        db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+        repo = service.repo_for_root(root)
+        repo.snapshot("registration")
+        git_dir = repo.git_dir
+        import shutil as _shutil
+
+        _shutil.rmtree(root)  # the ROOT vanishes; the shadow repo is orphaned
+        old = _time.time() - 90 * 86400
+        _os.utime(git_dir, (old, old))
+
+        report = prune_change_history(db, service)
+
+        assert report.orphans_removed == 1
+        assert not git_dir.exists()
+
+    def test_fresh_orphan_is_left_alone(self, tracked, tmp_path):
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            prune_change_history,
+        )
+        import shutil as _shutil
+
+        tracker, service, root = tracked
+        db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+        repo = service.repo_for_root(root)
+        repo.snapshot("registration")
+        _shutil.rmtree(root)
+
+        report = prune_change_history(db, service)
+
+        assert report.orphans_removed == 0
+        assert repo.git_dir.exists(), "a fresh orphan may still be re-bound"
+
+
+class TestAppRetentionRunner:
+    def test_runs_a_pass_against_the_sibling_runs_db(self, tracked, tmp_path):
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            run_retention_for_app,
+        )
+
+        tracker, service, root = tracked
+        db = AgentRunsDB(tmp_path / "agent_runs.db", client_id="t")
+        run = db.create_run(conversation_id="c", agent_kind="primary")
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        rec = tracker.end_turn(handle)[0]
+        db.record_change_snapshot(
+            run_id=run,
+            root=rec.root,
+            baseline_sha=rec.baseline_sha,
+            end_sha=rec.end_sha,
+        )
+        with db.transaction() as conn:
+            conn.execute(
+                "UPDATE change_snapshots SET created_at = '2020-01-01T00:00:00.000000Z'"
+            )
+
+        report = run_retention_for_app(
+            tmp_path / "chachanotes.db", service=service
+        )
+
+        assert report is not None and report.rows_pruned == 1
+
+    def test_never_raises_on_a_broken_path(self, tmp_path):
+        from tldw_chatbook.Workspaces.change_retention import (
+            run_retention_for_app,
+        )
+
+        assert (
+            run_retention_for_app(tmp_path / "nodir" / "x.db") is None
+            or True
+        )
+
+
+def test_old_schema_file_gains_the_oversize_column_on_open(tmp_path):
+    """v3->v4: a change_snapshots table created before untracked_oversize
+    existed picks the column up via the idempotent-ALTER-on-open mechanism."""
+    import sqlite3
+
+    from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+    db_file = tmp_path / "old.db"
+    conn = sqlite3.connect(db_file)
+    conn.executescript(
+        """
+        CREATE TABLE change_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            root TEXT NOT NULL,
+            baseline_sha TEXT NOT NULL,
+            end_sha TEXT NOT NULL,
+            files_changed INTEGER NOT NULL DEFAULT 0,
+            adds INTEGER NOT NULL DEFAULT 0,
+            dels INTEGER NOT NULL DEFAULT 0,
+            reverted TEXT NOT NULL DEFAULT '',
+            tracking_error TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL
+        );
+        INSERT INTO change_snapshots
+            (run_id, root, baseline_sha, end_sha, created_at)
+        VALUES ('r', '/tmp/x', 'a', 'b', '2026-01-01T00:00:00.000000Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    db = AgentRunsDB(db_file, client_id="t")
+    db.record_change_snapshot(
+        run_id="r2",
+        root="/tmp/x",
+        baseline_sha="c",
+        end_sha="d",
+        untracked_oversize=3,
+    )
+    rows = db.change_snapshots_for_run("r2")
+    assert rows[0]["untracked_oversize"] == 3
+    old_rows = db.change_snapshots_for_run("r")
+    assert old_rows[0]["untracked_oversize"] == 0

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -384,12 +384,13 @@ def test_old_schema_file_gains_the_oversize_column_on_open(tmp_path):
     """v3->v4: a change_snapshots table created before untracked_oversize
     existed picks the column up via the idempotent-ALTER-on-open mechanism."""
     import sqlite3
+    from contextlib import closing
 
     from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
     db_file = tmp_path / "old.db"
-    conn = sqlite3.connect(db_file)
-    conn.executescript(
+    with closing(sqlite3.connect(db_file)) as conn:
+        conn.executescript(
         """
         CREATE TABLE change_snapshots (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -408,9 +409,8 @@ def test_old_schema_file_gains_the_oversize_column_on_open(tmp_path):
             (run_id, root, baseline_sha, end_sha, created_at)
         VALUES ('r', '/tmp/x', 'a', 'b', '2026-01-01T00:00:00.000000Z');
         """
-    )
-    conn.commit()
-    conn.close()
+        )
+        conn.commit()
 
     db = AgentRunsDB(db_file, client_id="t")
     db.record_change_snapshot(
@@ -424,3 +424,98 @@ def test_old_schema_file_gains_the_oversize_column_on_open(tmp_path):
     assert rows[0]["untracked_oversize"] == 3
     old_rows = db.change_snapshots_for_run("r")
     assert old_rows[0]["untracked_oversize"] == 0
+
+
+class TestReviewRoundHardening:
+    """PR #1251 Qodo round: newline injection, git path, sweep locking."""
+
+    def test_newline_named_oversize_file_neither_committed_nor_injected(
+        self, tracked
+    ):
+        tracker, service, root = tracked
+        evil = "evil\nsecond-line.bin"
+        (root / evil).write_bytes(b"x" * 500)
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.untracked_oversize == 1
+        repo = service.repo_for_root(root)
+        assert repo.file_bytes(rec.end_sha, evil) is None, (
+            "an unexcludable oversized file must still never be committed"
+        )
+        exclude = (repo.git_dir / "info" / "exclude").read_text()
+        assert "second-line.bin" not in exclude, (
+            "a newline in a filename injected an exclude pattern"
+        )
+
+    def test_retention_uses_the_services_git_not_PATH(
+        self, tracked, tmp_path, monkeypatch
+    ):
+        import shutil as _shutil
+
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            prune_change_history,
+        )
+        from tldw_chatbook.Workspaces.change_tracking import ShadowRepoService
+
+        real_git = _shutil.which("git")
+        tracker, service, root = tracked
+        db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+        run = db.create_run(conversation_id="c", agent_kind="primary")
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        rec = tracker.end_turn(handle)[0]
+        db.record_change_snapshot(
+            run_id=run,
+            root=rec.root,
+            baseline_sha=rec.baseline_sha,
+            end_sha=rec.end_sha,
+        )
+        # A service configured with an explicit git path, on a machine
+        # where PATH has no git: the sweep must still classify the repo
+        # as live (a PATH-only spawn would fail -> misclassified orphan).
+        pathless = ShadowRepoService(
+            data_dir=service._data_dir, git_executable=real_git
+        )
+        monkeypatch.setenv("PATH", str(tmp_path / "no-binaries-here"))
+        # Backdate the repo: a misclassified "orphan" would be aged out --
+        # the strengthened assertion a fresh repo cannot make.
+        import os as _os
+        import time as _time
+
+        repo = service.repo_for_root(root)
+        old_ts = _time.time() - 90 * 86400
+        _os.utime(repo.git_dir, (old_ts, old_ts))
+
+        report = prune_change_history(db, pathless)
+
+        assert report.orphans_removed == 0
+        assert report.repos_reset == 0
+        assert service.repo_for_root(root).git_dir.exists()
+
+    def test_sweep_skips_a_container_another_process_holds(self, tracked, tmp_path):
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            prune_change_history,
+        )
+
+        tracker, service, root = tracked
+        db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+        repo = service.repo_for_root(root)
+        repo.snapshot("registration")
+        # No rows -> the sweep would RESET this container; a held lock
+        # (concurrent snapshot in another process) must make it skip.
+        repo.lock_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            report = prune_change_history(db, service)
+        finally:
+            repo.lock_dir.rmdir()
+
+        assert report.repos_reset == 0
+        assert repo.git_dir.exists(), "the sweep deleted a LOCKED repo"

--- a/backlog/tasks/task-1975 - Change-review-cost-bounds-and-retention.md
+++ b/backlog/tasks/task-1975 - Change-review-cost-bounds-and-retention.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1975
 title: 'Change review: root budgets, oversize excludes, snapshot retention/GC'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -24,11 +24,72 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An over-budget root registers with tracking disabled and the stated copy; an in-budget root tracks
-- [ ] #2 A file exceeding max_file_bytes lands in info/exclude, is absent from diffs, and the untracked count is disclosed in the review
-- [ ] #3 Retention run prunes rows older than the cutoff AND shrinks the shadow repo (object count measured before/after)
-- [ ] #4 A shadow repo whose root no longer exists is removed by GC
-- [ ] #5 All knobs read from the flat [change_review] section (NOT dotted-nested -- the get_cli_setting dotted form has dropped defaults before) with env-var overrides per repo convention
-- [ ] #6 An oversized file CREATED during a turn is excluded at E-snapshot time and disclosed, never committed to the shadow store
-- [ ] #7 A history row whose snapshots were pruned renders 'pruned by retention' instead of erroring
+- [x] #1 An over-budget root registers with tracking disabled and the stated copy; an in-budget root tracks
+- [x] #2 A file exceeding max_file_bytes lands in info/exclude, is absent from diffs, and the untracked count is disclosed in the review
+- [x] #3 Retention run prunes rows older than the cutoff AND shrinks the shadow repo (object count measured before/after)
+- [x] #4 A shadow repo whose root no longer exists is removed by GC
+- [x] #5 All knobs read from the flat [change_review] section (NOT dotted-nested -- the get_cli_setting dotted form has dropped defaults before) with env-var overrides per repo convention
+- [x] #6 An oversized file CREATED during a turn is excluded at E-snapshot time and disclosed, never committed to the shadow store
+- [x] #7 A history row whose snapshots were pruned renders 'pruned by retention' instead of erroring
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. `change_bounds.py`: flat `[change_review]` knob readers (max_files, max_total_bytes, max_file_bytes, retention_days) with env overrides; root budget scan; oversize scan appending to info/exclude (idempotent, disclosed count persisted per snapshot row)
+2. Wire budgets into `ChangeTurnTracker.begin_turn` (over-budget root -> tracking_error copy 'narrow the root or add excludes') and oversize scan into every `snapshot()` call (B AND E — AC#6 mid-turn creations)
+3. AgentRunsDB: `untracked_oversize` column on change_snapshots (additive, CREATE-on-open migration discipline); provider/screen disclose 'N oversized files untracked'
+4. Retention: `prune_change_history(now)` — delete rows past retention_days, reflog expire + gc --prune on each shadow repo, rm orphaned repo dirs by age; hook onto the existing maintenance path
+5. Screen: a selected history row whose shas no longer resolve renders 'pruned by retention' not a traceback
+6. TDD throughout against real git; sabotage every first-try pass
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three new/changed layers, all against real git:
+
+**`Workspaces/change_bounds.py` (new):** flat `[change_review]` knob reader
+(`change_review_setting` — env `TLDW_CHANGE_REVIEW_*` beats config beats
+default; unparseable values fall back) and `scan_root` (walk with the same
+directory prunes as the shadow repo's forced excludes, symlinks never
+followed, early-abort once either budget cap crosses, oversize list
+root-relative).
+
+**Enforcement:** `ChangeTurnTracker._baseline` budget-gates each root BEFORE
+any snapshot ("root over change-tracking budget (N+ files / M+ bytes) —
+narrow the root or add excludes; tracking disabled for this turn").
+`ShadowRepo.snapshot` re-scans every call and appends oversized files to
+`info/exclude` (static block rewritten first by ensure_initialized, so
+entries never accumulate; `_exclude_pattern` escapes glob chars — paths are
+data), exposing the set as `last_oversize_excluded`. `end_turn` filters
+oversized paths out of the force-add carve-out (force-add defeats ignore
+rules, not the size cap), attaches `untracked_oversize` to records, and
+emits a ZERO-change record when the only turn event was a new oversized
+file (a stable oversize set stays cardless — noise control). Documented
+limit: excludes only stop untracked files; a file committed small that
+later grew stays tracked and shows in diffs.
+
+**Retention (`Workspaces/change_retention.py`, new):** `prune_change_history`
+= row prune by `retention_days` cutoff → per-container sweep of the shadow
+data dir (`<hash>/git` layout): root vanished + aged past retention → rmtree
+(orphan GC); root alive but NO remaining rows → reset the whole container
+(ancestry keeps every snapshot reachable, so gc alone can never shrink a
+live chain — reset is the shrink move, next snapshot re-inits); rows remain
+→ reflog expire + `gc --prune=now` under the repo lock. `run_retention_for_app`
+wraps the production layout (runs DB sits beside ChaChaNotes) and never
+raises. Scheduled in `app.schedule_media_cleanup` on its OWN timer BEFORE
+the media-enabled early return — disabling media cleanup must not silently
+disable snapshot retention; `retention_days <= 0` disables inside the pass.
+
+**Disclosure/pruned rendering:** `change_snapshots.untracked_oversize`
+column (idempotent-ALTER-on-open migration, tested against a pre-column
+file), bridge threads the count through, Review screen banners "N oversized
+file(s) untracked" (AC#2) and — via `ShadowRepo.has_snapshot` +
+`provider.snapshots_pruned` — renders "history … was pruned by retention"
+instead of the generic diff-unavailable copy (AC#7).
+
+24 new tests in `Tests/Workspaces/test_change_bounds.py` + 2 screen tests;
+noise-control branch and the app runner sabotage-verified; 240 green across
+all change-review suites.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1957,6 +1957,7 @@ class ConsoleAgentBridge:
                                 adds=_rec.adds,
                                 dels=_rec.dels,
                                 tracking_error=_rec.tracking_error,
+                                untracked_oversize=_rec.untracked_oversize,
                             )
                         self._append_change_markers(
                             session_id, run_id, _records

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -110,7 +110,7 @@ class AgentRunsDB(BaseDB):
                 CREATE TABLE IF NOT EXISTS schema_version (
                     version INTEGER PRIMARY KEY NOT NULL
                 );
-                INSERT OR IGNORE INTO schema_version (version) VALUES (3);
+                INSERT OR IGNORE INTO schema_version (version) VALUES (4);
 
                 CREATE TABLE IF NOT EXISTS agent_runs (
                     id TEXT PRIMARY KEY,
@@ -181,6 +181,8 @@ class AgentRunsDB(BaseDB):
                     "ALTER TABLE change_snapshots ADD COLUMN "
                     "untracked_oversize INTEGER NOT NULL DEFAULT 0"
                 )
+            # Keep the (write-only, audit) version row in step with the DDL.
+            conn.execute("UPDATE schema_version SET version = 4 WHERE version < 4")
 
     def record_change_snapshot(
         self,

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -148,6 +148,7 @@ class AgentRunsDB(BaseDB):
                     dels INTEGER NOT NULL DEFAULT 0,
                     reverted TEXT NOT NULL DEFAULT '',
                     tracking_error TEXT NOT NULL DEFAULT '',
+                    untracked_oversize INTEGER NOT NULL DEFAULT 0,
                     created_at TEXT NOT NULL
                 );
                 CREATE INDEX IF NOT EXISTS idx_change_snapshots_run
@@ -167,6 +168,19 @@ class AgentRunsDB(BaseDB):
                 conn.execute(
                     "ALTER TABLE agent_runs ADD COLUMN assistant_message_id TEXT"
                 )
+            # v3->v4 (TASK-1975): oversize disclosure count on snapshot
+            # rows -- same idempotent-ALTER migration mechanism as above.
+            snapshot_columns = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(change_snapshots)"
+                ).fetchall()
+            }
+            if "untracked_oversize" not in snapshot_columns:
+                conn.execute(
+                    "ALTER TABLE change_snapshots ADD COLUMN "
+                    "untracked_oversize INTEGER NOT NULL DEFAULT 0"
+                )
 
     def record_change_snapshot(
         self,
@@ -179,6 +193,7 @@ class AgentRunsDB(BaseDB):
         adds: int = 0,
         dels: int = 0,
         tracking_error: str = "",
+        untracked_oversize: int = 0,
     ) -> None:
         """Record one root's turn snapshot pair (TASK-1971).
 
@@ -191,14 +206,17 @@ class AgentRunsDB(BaseDB):
             adds: Total added lines.
             dels: Total deleted lines.
             tracking_error: Non-empty when tracking failed for this root.
+            untracked_oversize: Files over the size cap left untracked at
+                the turn's end (TASK-1975 disclosure).
         """
         with self.transaction() as conn:
             conn.execute(
                 """
                 INSERT INTO change_snapshots
                     (run_id, root, baseline_sha, end_sha, files_changed,
-                     adds, dels, tracking_error, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     adds, dels, tracking_error, untracked_oversize,
+                     created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     run_id,
@@ -209,9 +227,39 @@ class AgentRunsDB(BaseDB):
                     adds,
                     dels,
                     tracking_error,
+                    untracked_oversize,
                     _now_iso(),
                 ),
             )
+
+    def delete_change_snapshots_older_than(self, cutoff_iso: str) -> int:
+        """Delete snapshot rows created before ``cutoff_iso`` (TASK-1975).
+
+        Args:
+            cutoff_iso: ISO-8601 UTC timestamp in this DB's own format
+                (lexicographic compare is valid for it).
+
+        Returns:
+            Number of rows deleted.
+        """
+        with self.transaction() as conn:
+            cur = conn.execute(
+                "DELETE FROM change_snapshots WHERE created_at < ?",
+                (cutoff_iso,),
+            )
+            return int(cur.rowcount or 0)
+
+    def roots_with_change_snapshots(self) -> set[str]:
+        """Roots still referenced by at least one snapshot row (TASK-1975).
+
+        Returns:
+            The distinct ``root`` values across all remaining rows.
+        """
+        with self.connection() as conn:
+            rows = conn.execute(
+                "SELECT DISTINCT root FROM change_snapshots"
+            ).fetchall()
+        return {str(row[0]) for row in rows}
 
     def update_change_snapshot_reverted(
         self, row_id: int, reverted_paths: list[str]

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -159,6 +159,27 @@ class AgentRunsChangeReviewProvider:
             )
         return turns
 
+    def snapshots_pruned(self, row: dict) -> bool:
+        """Whether a row's snapshots no longer exist (retention reset).
+
+        Args:
+            row: One ``change_snapshots`` row.
+
+        Returns:
+            True when either recorded sha is gone from the shadow repo —
+            the row's history was pruned by retention (TASK-1975).
+        """
+        try:
+            repo = self._service.repo_for_root(row["root"])
+            return not (
+                repo.has_snapshot(str(row.get("baseline_sha") or ""))
+                and repo.has_snapshot(str(row.get("end_sha") or ""))
+            )
+        except ChangeTrackingError:
+            # The root itself vanished — the diff is equally unrenderable;
+            # the generic unavailable copy handles it.
+            return False
+
     def changed_files(self, row: dict) -> list[ChangedFile]:
         """A snapshot row's changed files (empty for tracking-error rows).
 
@@ -368,11 +389,26 @@ class ChangeReviewScreen(Screen):
             if error:
                 banners.append(f"⚠ tracking failed for {row['root']}: {error}")
                 continue
+            oversize = int(row.get("untracked_oversize") or 0)
+            if oversize:
+                # TASK-1975 AC#2: cost bounds are honest, not silent.
+                plural = "s" if oversize != 1 else ""
+                banners.append(
+                    f"⚠ {oversize} oversized file{plural} untracked for "
+                    f"{row['root']} (over the size cap)"
+                )
             try:
                 for change in self._provider.changed_files(row):
                     grouped.setdefault(change.status, []).append((row, change))
             except ChangeTrackingError as exc:
-                banners.append(f"⚠ diff unavailable for {row['root']}: {exc}")
+                if self._provider.snapshots_pruned(row):
+                    banners.append(
+                        f"history for {row['root']} was pruned by retention"
+                    )
+                else:
+                    banners.append(
+                        f"⚠ diff unavailable for {row['root']}: {exc}"
+                    )
 
         known = {code for code, _label in _GROUPS}
         for code, label in _GROUPS:

--- a/tldw_chatbook/Workspaces/change_bounds.py
+++ b/tldw_chatbook/Workspaces/change_bounds.py
@@ -1,0 +1,170 @@
+"""Cost bounds for Agent Change Review (TASK-1975).
+
+Keeps the tracking substrate bounded, per the spec's cost posture:
+
+* **Root budgets** — a root over ``max_files``/``max_total_bytes`` gets
+  tracking DISABLED with honest copy, never a silent half-track.
+* **Oversize excludes** — git cannot exclude by size, so files over
+  ``max_file_bytes`` are appended to the shadow repo's ``info/exclude``
+  dynamically at snapshot time and the review discloses the count.
+* **Knobs** — read from the FLAT ``[change_review]`` config section (the
+  dotted ``get_cli_setting`` form has dropped defaults before — task
+  1754), each overridable via ``TLDW_CHANGE_REVIEW_<KEY>`` env vars.
+
+The scan never follows symlinks (a link to a huge external tree must not
+disqualify the root) and prunes the same directories the shadow repo's
+forced excludes skip — those trees are never tracked, so they never count
+against the budget either.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+DEFAULT_MAX_FILES = 20_000
+DEFAULT_MAX_TOTAL_BYTES = 2 * 1024**3
+DEFAULT_MAX_FILE_BYTES = 10 * 1024**2
+DEFAULT_RETENTION_DAYS = 30
+
+#: Directory names the scan prunes — mirrors the shadow repo's
+#: ``FORCED_EXCLUDES`` (change_tracking.py): untracked trees must not count.
+_SKIP_DIR_NAMES = frozenset(
+    {
+        ".git",
+        "node_modules",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        "dist",
+        "build",
+    }
+)
+
+
+def _config_setting(key: str, default: int) -> int:
+    """Read one knob from the flat ``[change_review]`` config section."""
+    try:
+        from tldw_chatbook.config import get_cli_setting
+
+        return get_cli_setting("change_review", key, default)
+    except Exception:  # noqa: BLE001 -- a broken config never breaks bounds
+        return default
+
+
+def change_review_setting(key: str, default: int) -> int:
+    """Resolve a ``[change_review]`` knob: env var, then config, then default.
+
+    Args:
+        key: Flat-section key, e.g. ``"max_files"``.
+        default: Value when neither env nor config provides one.
+
+    Returns:
+        The resolved integer; unparseable values fall back to ``default``.
+    """
+    env = os.environ.get(f"TLDW_CHANGE_REVIEW_{key.upper()}")
+    if env is not None:
+        try:
+            return int(env)
+        except ValueError:
+            logger.warning(
+                "change_review: ignoring unparseable env override "
+                f"TLDW_CHANGE_REVIEW_{key.upper()}={env!r}"
+            )
+    try:
+        return int(_config_setting(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class RootScan:
+    """One root's budget scan result.
+
+    Attributes:
+        files: Files counted before finishing or aborting.
+        total_bytes: Bytes counted before finishing or aborting.
+        over_budget: True when either cap was crossed (counts are then
+            partial — the scan aborts early rather than walking a tree it
+            already knows is too big).
+        oversized: Root-relative paths of files over ``max_file_bytes``,
+            in walk order.
+    """
+
+    files: int
+    total_bytes: int
+    over_budget: bool
+    oversized: tuple[str, ...] = ()
+
+
+def scan_root(
+    root: Path | str,
+    *,
+    max_files: int | None = None,
+    max_total_bytes: int | None = None,
+    max_file_bytes: int | None = None,
+) -> RootScan:
+    """Walk a root, counting files/bytes and collecting oversize paths.
+
+    Args:
+        root: The directory to scan.
+        max_files: File-count budget; ``None`` reads the knob.
+        max_total_bytes: Byte budget; ``None`` reads the knob.
+        max_file_bytes: Per-file cap for the oversize list; ``None`` reads
+            the knob.
+
+    Returns:
+        The scan result; unreadable entries are skipped (a permission
+        error on one file must not disable tracking for the root).
+    """
+    if max_files is None:
+        max_files = change_review_setting("max_files", DEFAULT_MAX_FILES)
+    if max_total_bytes is None:
+        max_total_bytes = change_review_setting(
+            "max_total_bytes", DEFAULT_MAX_TOTAL_BYTES
+        )
+    if max_file_bytes is None:
+        max_file_bytes = change_review_setting(
+            "max_file_bytes", DEFAULT_MAX_FILE_BYTES
+        )
+    root = Path(root)
+    files = 0
+    total = 0
+    oversized: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIR_NAMES]
+        for name in filenames:
+            path = Path(dirpath) / name
+            try:
+                if path.is_symlink():
+                    continue
+                size = path.stat().st_size
+            except OSError:
+                continue
+            files += 1
+            total += size
+            if size > max_file_bytes:
+                try:
+                    oversized.append(path.relative_to(root).as_posix())
+                except ValueError:  # pragma: no cover -- walk stays inside
+                    continue
+            if files > max_files or total > max_total_bytes:
+                return RootScan(
+                    files=files,
+                    total_bytes=total,
+                    over_budget=True,
+                    oversized=tuple(oversized),
+                )
+    return RootScan(
+        files=files,
+        total_bytes=total,
+        over_budget=False,
+        oversized=tuple(oversized),
+    )

--- a/tldw_chatbook/Workspaces/change_retention.py
+++ b/tldw_chatbook/Workspaces/change_retention.py
@@ -52,11 +52,11 @@ class PruneReport:
     orphans_removed: int = 0
 
 
-def _repo_root(git_dir: Path) -> str | None:
+def _repo_root(git_dir: Path, git_exe: str = "git") -> str | None:
     """Read a shadow repo's bound root from its pinned ``core.worktree``."""
     try:
         proc = subprocess.run(
-            ["git", "--git-dir", str(git_dir), "config", "core.worktree"],
+            [git_exe, "--git-dir", str(git_dir), "config", "core.worktree"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -124,12 +124,25 @@ def prune_change_history(
     # Layout: <data_dir>/<root-hash>/git (plus hooks/ and the lockdir) --
     # each CONTAINER dir is one root's shadow state; removal takes the
     # whole container so hooks and stale locks go with it.
+    git_exe = getattr(service, "_git", None) or "git"
     for container in sorted(Path(data_dir).iterdir()):
         git_dir = container / "git"
         if not container.is_dir() or not (git_dir / "HEAD").exists():
             continue
+        # Qodo #1251 finding 4: destructive sweep moves must not race an
+        # active snapshot. Take the SAME cross-process lockdir the repo
+        # protocol uses; a held lock skips the container this pass.
+        lock_dir = container / "lock.d"
         try:
-            root = _repo_root(git_dir)
+            lock_dir.parent.mkdir(parents=True, exist_ok=True)
+            lock_dir.mkdir()
+        except OSError:
+            logger.debug(
+                f"change_review: retention skipping locked container {container}"
+            )
+            continue
+        try:
+            root = _repo_root(git_dir, git_exe)
             if root is None or not Path(root).is_dir():
                 # Orphan: the bound root vanished. Old orphans are dead
                 # weight; fresh ones may still be re-bound.
@@ -147,18 +160,25 @@ def prune_change_history(
                 repos_reset += 1
                 continue
             repo = service.repo_for_root(root)
-            with repo._locked():  # noqa: SLF001 -- retention is a peer op
-                repo._run(  # noqa: SLF001
-                    "reflog", "expire", "--expire=now", "--all", check=False
-                )
-                repo._run(  # noqa: SLF001
-                    "gc", "--prune=now", "--quiet", check=False
-                )
+            # The sweep already holds this container's cross-process
+            # lockdir (above) -- taking repo._locked() here would deadlock
+            # on the very same lock.d.
+            repo._run(  # noqa: SLF001 -- retention is a peer op
+                "reflog", "expire", "--expire=now", "--all", check=False
+            )
+            repo._run(  # noqa: SLF001
+                "gc", "--prune=now", "--quiet", check=False
+            )
             repos_gcd += 1
         except Exception:  # noqa: BLE001 -- one bad repo must not stop the sweep
             logger.opt(exception=True).warning(
                 f"change_review: retention sweep failed for {git_dir}"
             )
+        finally:
+            try:
+                lock_dir.rmdir()
+            except OSError:
+                pass  # removed with the container, or never released cleanly
     report = PruneReport(
         rows_pruned=rows_pruned,
         repos_reset=repos_reset,

--- a/tldw_chatbook/Workspaces/change_retention.py
+++ b/tldw_chatbook/Workspaces/change_retention.py
@@ -1,0 +1,207 @@
+"""Snapshot retention + shadow-repo GC for Agent Change Review (TASK-1975).
+
+Retention has three moves, run on the app's existing maintenance path:
+
+1. **Row prune** — ``change_snapshots`` rows older than ``retention_days``
+   are deleted; their history rows disappear from the Review screen's turn
+   selector.
+2. **Repo shrink** — every snapshot is an ancestor of the shadow repo's
+   HEAD, so ordinary ``gc`` can never collect referenced history; instead,
+   a repo whose root has NO remaining rows is RESET (its git dir removed —
+   the next snapshot re-initializes from scratch), and a repo that still
+   backs rows gets ``reflog expire`` + ``gc --prune=now`` to collect the
+   genuinely unreachable (superseded stage blobs, revert staging).
+3. **Orphan GC** — a shadow repo whose ROOT no longer exists is removed
+   once the repo directory itself ages past retention (a fresh orphan may
+   still be re-bound; an old one is dead weight).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from loguru import logger
+
+from tldw_chatbook.Workspaces.change_bounds import (
+    DEFAULT_RETENTION_DAYS,
+    change_review_setting,
+)
+from tldw_chatbook.Workspaces.change_tracking import ShadowRepoService
+
+
+@dataclass(frozen=True)
+class PruneReport:
+    """What one retention pass did.
+
+    Attributes:
+        rows_pruned: ``change_snapshots`` rows deleted.
+        repos_reset: Shadow repos removed because no rows reference their
+            root anymore (recreated on next use).
+        repos_gcd: Live repos that received reflog-expire + gc.
+        orphans_removed: Repo dirs removed because their root vanished and
+            the repo aged past retention.
+    """
+
+    rows_pruned: int = 0
+    repos_reset: int = 0
+    repos_gcd: int = 0
+    orphans_removed: int = 0
+
+
+def _repo_root(git_dir: Path) -> str | None:
+    """Read a shadow repo's bound root from its pinned ``core.worktree``."""
+    try:
+        proc = subprocess.run(
+            ["git", "--git-dir", str(git_dir), "config", "core.worktree"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    value = proc.stdout.strip()
+    return value or None
+
+
+def prune_change_history(
+    db,
+    service: ShadowRepoService,
+    *,
+    now: datetime | None = None,
+    retention_days: int | None = None,
+) -> PruneReport:
+    """Run one retention pass. Best-effort per repo; never raises.
+
+    Args:
+        db: The ``AgentRunsDB`` holding ``change_snapshots`` rows.
+        service: Shadow-repo service whose data dir is swept.
+        now: Injected clock for tests; defaults to UTC now.
+        retention_days: Override; ``None`` reads the flat
+            ``[change_review]`` knob (default 30).
+
+    Returns:
+        A :class:`PruneReport` of what happened.
+    """
+    if retention_days is None:
+        retention_days = change_review_setting(
+            "retention_days", DEFAULT_RETENTION_DAYS
+        )
+    if retention_days <= 0:
+        return PruneReport()
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=retention_days)
+    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    rows_pruned = 0
+    try:
+        rows_pruned = db.delete_change_snapshots_older_than(cutoff_iso)
+    except Exception:  # noqa: BLE001 -- retention must never crash the app
+        logger.opt(exception=True).warning(
+            "change_review: retention row-prune failed"
+        )
+    try:
+        live_roots = db.roots_with_change_snapshots()
+    except Exception:  # noqa: BLE001
+        logger.opt(exception=True).warning(
+            "change_review: could not list live roots; skipping repo sweep"
+        )
+        return PruneReport(rows_pruned=rows_pruned)
+
+    repos_reset = 0
+    repos_gcd = 0
+    orphans_removed = 0
+    data_dir = getattr(service, "_data_dir", None)
+    if data_dir is None or not Path(data_dir).is_dir():
+        return PruneReport(rows_pruned=rows_pruned)
+
+    # Layout: <data_dir>/<root-hash>/git (plus hooks/ and the lockdir) --
+    # each CONTAINER dir is one root's shadow state; removal takes the
+    # whole container so hooks and stale locks go with it.
+    for container in sorted(Path(data_dir).iterdir()):
+        git_dir = container / "git"
+        if not container.is_dir() or not (git_dir / "HEAD").exists():
+            continue
+        try:
+            root = _repo_root(git_dir)
+            if root is None or not Path(root).is_dir():
+                # Orphan: the bound root vanished. Old orphans are dead
+                # weight; fresh ones may still be re-bound.
+                age = now.timestamp() - git_dir.stat().st_mtime
+                if age > retention_days * 86400:
+                    shutil.rmtree(container, ignore_errors=True)
+                    orphans_removed += 1
+                continue
+            if root not in live_roots:
+                # No rows left for this root — nothing the Review screen
+                # can show needs these objects. Reset; next snapshot
+                # re-initializes. This is the shrink move: ancestry keeps
+                # every snapshot reachable, so gc alone cannot collect it.
+                shutil.rmtree(container, ignore_errors=True)
+                repos_reset += 1
+                continue
+            repo = service.repo_for_root(root)
+            with repo._locked():  # noqa: SLF001 -- retention is a peer op
+                repo._run(  # noqa: SLF001
+                    "reflog", "expire", "--expire=now", "--all", check=False
+                )
+                repo._run(  # noqa: SLF001
+                    "gc", "--prune=now", "--quiet", check=False
+                )
+            repos_gcd += 1
+        except Exception:  # noqa: BLE001 -- one bad repo must not stop the sweep
+            logger.opt(exception=True).warning(
+                f"change_review: retention sweep failed for {git_dir}"
+            )
+    report = PruneReport(
+        rows_pruned=rows_pruned,
+        repos_reset=repos_reset,
+        repos_gcd=repos_gcd,
+        orphans_removed=orphans_removed,
+    )
+    logger.info(
+        "change_review: retention pass "
+        f"rows={report.rows_pruned} reset={report.repos_reset} "
+        f"gc={report.repos_gcd} orphans={report.orphans_removed}"
+    )
+    return report
+
+
+def run_retention_for_app(
+    db_path: Path | str,
+    *,
+    service: ShadowRepoService | None = None,
+) -> PruneReport | None:
+    """One maintenance-path retention pass for the production layout.
+
+    Args:
+        db_path: The ChaChaNotes DB path — the runs DB lives beside it as
+            ``agent_runs.db`` (the same siting rule the Console bridge
+            uses).
+        service: Injection seam for tests; defaults to the app's shadow
+            service.
+
+    Returns:
+        The pass report, or ``None`` when git is unavailable or the pass
+        could not run (never raises).
+    """
+    try:
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+        if service is None:
+            service = ShadowRepoService()
+        if not service.available:
+            return None
+        runs_db = AgentRunsDB(Path(db_path).parent / "agent_runs.db")
+        return prune_change_history(runs_db, service)
+    except Exception:  # noqa: BLE001 -- maintenance must never crash the app
+        logger.opt(exception=True).warning(
+            "change_review: retention pass failed"
+        )
+        return None

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -66,6 +66,31 @@ FORCED_EXCLUDES: tuple[str, ...] = (
     "build/",
 )
 
+def _exclude_pattern(rel_path: str) -> str:
+    """Turn a root-relative path into an anchored, literal exclude pattern.
+
+    Git exclude patterns treat ``* ? [ ] \\`` as globs and a trailing
+    space as trimmable — paths are data, so each is escaped and the
+    pattern anchored with a leading ``/``.
+
+    Args:
+        rel_path: POSIX-style path relative to the root.
+
+    Returns:
+        One ``info/exclude`` line matching exactly that path.
+    """
+    escaped = (
+        rel_path.replace("\\", "\\\\")
+        .replace("*", "\\*")
+        .replace("?", "\\?")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+    )
+    if escaped.endswith(" "):
+        escaped = escaped[:-1] + "\\ "
+    return "/" + escaped
+
+
 #: A lockdir older than this is treated as abandoned by a crashed process and
 #: taken over. Snapshot operations are seconds, not minutes.
 _STALE_LOCK_SECONDS = 300.0
@@ -211,6 +236,9 @@ class ShadowRepo:
         self.hooks_dir = hooks_dir
         self.lock_dir = lock_dir
         self._git = git_executable
+        #: Root-relative paths excluded as oversized by the LAST snapshot
+        #: on this instance (TASK-1975 disclosure).
+        self.last_oversize_excluded: tuple[str, ...] = ()
 
     # -- plumbing ----------------------------------------------------------
 
@@ -355,12 +383,38 @@ class ShadowRepo:
             return None
         return str(proc.stdout).strip()
 
+    def has_snapshot(self, sha: str) -> bool:
+        """Whether a snapshot commit still exists in this shadow repo.
+
+        Retention (TASK-1975) can reset a repo whose rows were pruned; a
+        surviving history row must then render "pruned by retention"
+        rather than erroring, and this probe is how callers tell.
+
+        Args:
+            sha: A snapshot commit sha.
+
+        Returns:
+            True when the commit object is present.
+        """
+        if not sha:
+            return False
+        proc = self._run("cat-file", "-e", f"{sha}^{{commit}}", check=False)
+        return proc.returncode == 0
+
     def snapshot(self, message: str) -> str:
         """Stage everything and commit if anything changed; return the tip.
 
         A clean tree returns the existing tip without a new commit. The very
         first snapshot commits even an empty tree (``--allow-empty``) so a
         baseline tip always exists.
+
+        TASK-1975: git cannot exclude by size, so every snapshot re-scans
+        the root and appends files over ``max_file_bytes`` to
+        ``info/exclude`` (``ensure_initialized`` rewrites the static block
+        first, so entries never accumulate stale). The excluded set lands on
+        :attr:`last_oversize_excluded` for disclosure. Limit: excludes only
+        stop UNTRACKED files — a file committed while small that later grew
+        stays tracked, which shows in diffs rather than lying by omission.
 
         Args:
             message: Commit message recorded on the snapshot (turn labels).
@@ -371,8 +425,24 @@ class ShadowRepo:
         Raises:
             ChangeTrackingError: A git step failed or produced no tip.
         """
+        import sys as _sys
+
+        from tldw_chatbook.Workspaces.change_bounds import scan_root
+
         with self._locked():
             self.ensure_initialized()
+            scan = scan_root(
+                self.root,
+                max_files=_sys.maxsize,
+                max_total_bytes=_sys.maxsize,
+            )
+            self.last_oversize_excluded = scan.oversized
+            if scan.oversized:
+                exclude = self.git_dir / "info" / "exclude"
+                with exclude.open("a", encoding="utf-8") as fh:
+                    fh.write("# oversize (TASK-1975), rewritten per snapshot\n")
+                    for rel in scan.oversized:
+                        fh.write(_exclude_pattern(rel) + "\n")
             self._run("add", "-A", "--", ".")
             had_tip = self.tip() is not None
             if had_tip:

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -437,13 +437,30 @@ class ShadowRepo:
                 max_total_bytes=_sys.maxsize,
             )
             self.last_oversize_excluded = scan.oversized
-            if scan.oversized:
+            # info/exclude is line-oriented and has NO newline escaping --
+            # a filename carrying \n would INJECT extra patterns (Qodo
+            # #1251 finding 5). Such paths are unexcludable; they are
+            # unstaged after add instead (argv is newline-safe).
+            excludable = [
+                rel
+                for rel in scan.oversized
+                if "\n" not in rel and "\r" not in rel
+            ]
+            unexcludable = [
+                rel for rel in scan.oversized if rel not in excludable
+            ]
+            if excludable:
                 exclude = self.git_dir / "info" / "exclude"
                 with exclude.open("a", encoding="utf-8") as fh:
                     fh.write("# oversize (TASK-1975), rewritten per snapshot\n")
-                    for rel in scan.oversized:
+                    for rel in excludable:
                         fh.write(_exclude_pattern(rel) + "\n")
             self._run("add", "-A", "--", ".")
+            for rel in unexcludable:
+                self._run(
+                    "rm", "--cached", "--ignore-unmatch", "--quiet", "--", rel,
+                    check=False,
+                )
             had_tip = self.tip() is not None
             if had_tip:
                 staged = self._run("diff", "--cached", "--quiet", check=False)

--- a/tldw_chatbook/Workspaces/change_turn_tracker.py
+++ b/tldw_chatbook/Workspaces/change_turn_tracker.py
@@ -41,6 +41,10 @@ from typing import Any, Iterable, Sequence
 
 from loguru import logger
 
+from tldw_chatbook.Workspaces.change_bounds import (
+    DEFAULT_MAX_FILE_BYTES,
+    change_review_setting,
+)
 from tldw_chatbook.Workspaces.change_tracking import (
     ChangeTrackingError,
     ShadowRepoService,
@@ -82,6 +86,7 @@ class TurnChangeRecord:
     adds: int = 0
     dels: int = 0
     tracking_error: str = ""
+    untracked_oversize: int = 0
 
 
 class TurnHandle:
@@ -91,6 +96,9 @@ class TurnHandle:
         self.roots = roots
         self.baselines: dict[str, str] = {}
         self.errors: dict[str, str] = {}
+        #: TASK-1975: each root's oversize-excluded set at B, so end_turn
+        #: can tell NEW oversize (disclose even changeless) from stable.
+        self.baseline_oversize: dict[str, tuple[str, ...]] = {}
         self._thread: threading.Thread | None = None
 
     def await_baseline(self, timeout: float = _BASELINE_TIMEOUT_SECONDS) -> None:
@@ -153,11 +161,26 @@ class ChangeTurnTracker:
         )
 
         def _baseline() -> None:
+            from tldw_chatbook.Workspaces.change_bounds import scan_root
+
             for root in handle.roots:
                 key = str(root)
                 try:
+                    # TASK-1975: budget gate BEFORE any snapshot work. Over
+                    # budget disables tracking for this root with honest
+                    # copy -- never a silent half-track.
+                    scan = scan_root(root)
+                    if scan.over_budget:
+                        handle.errors[key] = (
+                            "root over change-tracking budget "
+                            f"({scan.files}+ files / {scan.total_bytes}+ "
+                            "bytes) — narrow the root or add excludes; "
+                            "tracking disabled for this turn"
+                        )
+                        continue
                     repo = self.service.repo_for_root(root)
                     handle.baselines[key] = repo.snapshot("turn baseline")
+                    handle.baseline_oversize[key] = repo.last_oversize_excluded
                 except Exception as exc:  # noqa: BLE001 -- disclosed, never raised
                     handle.errors[key] = str(exc)[:400]
 
@@ -211,9 +234,38 @@ class ChangeTurnTracker:
                 repo = self.service.repo_for_root(root)
                 in_root = self._paths_within(root, touched_paths)
                 if in_root:
+                    # TASK-1975: force-add exists to defeat IGNORE rules,
+                    # not the size cap -- a tool-written oversized file is
+                    # disclosed, never committed.
+                    cap = change_review_setting(
+                        "max_file_bytes", DEFAULT_MAX_FILE_BYTES
+                    )
+                    in_root = [
+                        rel
+                        for rel in in_root
+                        if not self._over_cap(root, rel, cap)
+                    ]
+                if in_root:
                     repo.force_add(in_root)
                 end = repo.snapshot("turn end")
+                oversize = repo.last_oversize_excluded
                 if end == baseline:
+                    # TASK-1975 (AC#6): an oversized file CREATED during
+                    # the turn is the turn's only event -- disclose it with
+                    # a zero-change record instead of staying silent. A
+                    # STABLE oversize set stays cardless (noise control).
+                    new_oversize = set(oversize) - set(
+                        handle.baseline_oversize.get(key, ())
+                    )
+                    if new_oversize:
+                        records.append(
+                            TurnChangeRecord(
+                                root=key,
+                                baseline_sha=baseline,
+                                end_sha=end,
+                                untracked_oversize=len(oversize),
+                            )
+                        )
                     continue
                 changed = repo.changed_files(baseline, end)
                 records.append(
@@ -224,6 +276,7 @@ class ChangeTurnTracker:
                         files_changed=len(changed),
                         adds=sum(c.adds for c in changed),
                         dels=sum(c.dels for c in changed),
+                        untracked_oversize=len(oversize),
                     )
                 )
             except Exception as exc:  # noqa: BLE001 -- disclosed, never raised
@@ -237,6 +290,14 @@ class ChangeTurnTracker:
         return records
 
     # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _over_cap(root: Path, rel: str, cap: int) -> bool:
+        """Whether a root-relative path currently exceeds the size cap."""
+        try:
+            return (root / rel).stat().st_size > cap
+        except OSError:
+            return False
 
     @staticmethod
     def _paths_within(root: Path, paths: Iterable[str]) -> list[str]:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -8739,6 +8739,22 @@ class TldwCli(
 
     def schedule_media_cleanup(self) -> None:
         """Schedule periodic media cleanup based on configuration."""
+        # TASK-1975: change-review snapshot retention rides the same
+        # maintenance path but has its OWN knob ([change_review]
+        # retention_days; <=0 disables inside the pass) -- disabling media
+        # cleanup must not silently disable snapshot retention.
+        try:
+            self._change_review_retention_startup_timer = self.set_timer(
+                DEFERRED_MEDIA_CLEANUP_DELAY_SECONDS + 60,
+                self._perform_change_review_retention,
+            )
+            self._change_review_retention_timer = self.set_interval(
+                24 * 3600, self._perform_change_review_retention
+            )
+        except Exception:  # noqa: BLE001 -- maintenance must never block boot
+            self.loguru_logger.opt(exception=True).warning(
+                "Could not schedule change-review retention"
+            )
         try:
             # Get cleanup configuration
             cleanup_config = get_cli_setting("media_cleanup", "enabled", True)
@@ -8775,6 +8791,23 @@ class TldwCli(
         except Exception as e:
             self.loguru_logger.opt(exception=True).error(
                 f"Error scheduling media cleanup: {e}"
+            )
+
+    async def _perform_change_review_retention(self) -> None:
+        """Run one change-review retention pass off the UI thread (TASK-1975)."""
+        try:
+            db = getattr(self, "chachanotes_db", None)
+            db_path = getattr(db, "db_path", None) if db is not None else None
+            if not db_path or str(db_path) == ":memory:":
+                return
+            from tldw_chatbook.Workspaces.change_retention import (
+                run_retention_for_app,
+            )
+
+            await asyncio.to_thread(run_retention_for_app, db_path)
+        except Exception:  # noqa: BLE001 -- retention must never surface to the UI
+            self.loguru_logger.opt(exception=True).warning(
+                "Change-review retention pass failed"
             )
 
     async def perform_media_cleanup(self) -> None:


### PR DESCRIPTION
## Summary
- **Budgets (AC#1):** `ChangeTurnTracker` gates each root before any snapshot — over `max_files`/`max_total_bytes` disables tracking for the turn with honest copy ("narrow the root or add excludes"), never a silent half-track
- **Oversize excludes (AC#2/#6):** git cannot exclude by size, so every `snapshot()` re-scans the root and appends over-cap files to `info/exclude` (glob chars escaped — paths are data); the force-add carve-out is filtered too (it defeats ignore rules, not the size cap); the Review screen banners "N oversized file(s) untracked". A turn whose only event is a NEW oversized file emits a zero-change record so the disclosure isn't lost; a stable oversize set stays cardless
- **Retention/GC (AC#3/#4/#7):** `prune_change_history` prunes rows past `retention_days`, resets shadow repos with no remaining rows (ancestry keeps every snapshot reachable, so reset is the real shrink move), reflog-expires + gc's live repos, and removes orphaned repos (root vanished) by age. Rides the app maintenance path on its own timer — disabling media cleanup does not disable retention. Pruned history rows render "pruned by retention" instead of erroring
- **Knobs (AC#5):** flat `[change_review]` section via `change_review_setting`, each overridable with `TLDW_CHANGE_REVIEW_*` env vars; `untracked_oversize` column added with the idempotent-ALTER-on-open migration (tested against a pre-column file)

## Testing
- 26 new tests (`Tests/Workspaces/test_change_bounds.py` + 2 screen banner tests), all RED-first or sabotage-verified; 240 green across all change-review suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements change‑review cost bounds and retention for TASK-1975: budgets gate roots before snapshots, oversized files are auto‑excluded and disclosed, and a scheduled pass prunes old history and GCs shadow repos. The Review screen shows oversize counts and “pruned by retention” when snapshots were cleaned.

- **New Features**
  - Root budgets: `ChangeTurnTracker` gates before snapshots; over `max_files`/`max_total_bytes` disables tracking with a clear message.
  - Oversize handling: each snapshot excludes files over `max_file_bytes`, filters force‑add, records `untracked_oversize`, and shows a banner; emits a zero‑change record when only a new oversized file appears.
  - Retention/GC: `prune_change_history` deletes rows older than `retention_days`, resets rowless shadow repos, runs `reflog expire` + `gc` for live repos, and removes orphaned repos by age; runs on its own timer (independent of media cleanup) and is disabled when `retention_days <= 0`.
  - Knobs/DB: flat `[change_review]` config with env overrides (`TLDW_CHANGE_REVIEW_*`); adds `untracked_oversize` to `change_snapshots` with an idempotent ALTER-on-open migration (schema version 4).

- **Bug Fixes**
  - Retention sweep takes each repo container’s `lock.d`; locked repos are skipped to avoid races.
  - Newline-safe excludes: filenames with newlines are not written to `info/exclude`; they are unstaged after add and remain disclosed.
  - Retention uses the service’s configured git executable, not `PATH`, to avoid misclassifying live repos.

<sup>Written for commit 3fd0023ad76b558f1f7718a78965cd3b72807549. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

