### PR TITLE
Hotfix: schema_version append (broken v2-era DB open from #1251)

### DIFF
--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -181,8 +181,13 @@ class AgentRunsDB(BaseDB):
                     "ALTER TABLE change_snapshots ADD COLUMN "
                     "untracked_oversize INTEGER NOT NULL DEFAULT 0"
                 )
-            # Keep the (write-only, audit) version row in step with the DDL.
-            conn.execute("UPDATE schema_version SET version = 4 WHERE version < 4")
+            # Keep the (write-only, audit) version table in step with the
+            # DDL -- append-per-version, matching the INSERT OR IGNORE
+            # convention above (UPDATE would collide on the UNIQUE column
+            # when older version rows exist).
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (4)"
+            )
 
     def record_change_snapshot(
         self,


### PR DESCRIPTION
## Summary
- #1251's schema_version bump used UPDATE, which collides on the UNIQUE version column for DBs that carry older version rows (any v2-era agent_runs.db) — every open of such a file crashes with IntegrityError
- The post-rebase regression caught it (`test_v2_database_gains_the_change_snapshots_table_on_open`), but #1251 was merged before the run finished — this is the fix-forward
- INSERT OR IGNORE matches the table's existing append-per-version convention

## Testing
- Both migration tests green (v2-era file + pre-column file); 243 passed across all change-review suites with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DB open crashes on v2-era `agent_runs.db` introduced by #1251 by switching the schema audit to append. We now use `INSERT OR IGNORE` to add version 4 to `schema_version`, matching the append-per-version convention.

- **Bug Fixes**
  - Prevent UNIQUE constraint collisions by appending the version row instead of updating.
  - Verified with migration tests (v2-era + pre-column); all 243 change-review tests pass.

<sup>Written for commit c836e8d124fc34a0d2f26a7e5b19442ed45f5087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

