### PR TITLE
Change review: nested-repo detection + honest disclosure (TASK-1976)

### DIFF
--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -47,6 +47,7 @@ def _record_turn(db, tracker, root, run_id: str, mutate) -> None:
             dels=rec.dels,
             tracking_error=rec.tracking_error,
             untracked_oversize=rec.untracked_oversize,
+            nested_repos=rec.nested_repos,
         )
 
 
@@ -495,4 +496,49 @@ async def test_pruned_snapshots_render_pruned_by_retention(review_fixture, tmp_p
             lambda: "pruned by retention"
             in str(screen.query_one("#change-review-banner", Static).renderable),
             "pruned banner",
+        )
+
+
+@pytest.mark.asyncio
+async def test_nested_repo_banner_names_the_holes(tmp_path):
+    """TASK-1976 AC#1: nested repos are named in the Review banner."""
+    import subprocess as _sp
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "small.txt").write_text("hello\n")
+    child = root / "childrepo"
+    child.mkdir()
+    _sp.run(["git", "init", "--quiet", str(child)], check=True)
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+
+    def mutate():
+        (root / "small.txt").write_text("edited\n")
+        (child / "inner.txt").write_text("invisible\n")
+
+    _record_turn(db, tracker, root, run, mutate)
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="conv-1"
+    )
+    app = _Harness(provider)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        await _wait_for(
+            pilot,
+            lambda: "childrepo"
+            in str(screen.query_one("#change-review-banner", Static).renderable),
+            "nested banner",
+        )
+        text = str(screen.query_one("#change-review-banner", Static).renderable)
+        assert "1 nested repository" in text
+        labels = _tree_labels(screen.query_one("#change-review-tree", Tree))
+        assert not any("inner.txt" in l for l in labels), (
+            "the nested edit leaked into the tree"
         )

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -519,3 +519,74 @@ class TestReviewRoundHardening:
 
         assert report.repos_reset == 0
         assert repo.git_dir.exists(), "the sweep deleted a LOCKED repo"
+
+
+# -- nested repos (TASK-1976) ------------------------------------------------
+
+
+class TestNestedRepoDetection:
+    def test_scan_lists_nested_repos_root_relative(self, scanroot):
+        (scanroot / "projects" / "childrepo" / ".git").mkdir(parents=True)
+        (scanroot / "projects" / "childrepo" / "code.py").write_text("x\n")
+        (scanroot / "worktree-child").mkdir()
+        (scanroot / "worktree-child" / ".git").write_text("gitdir: /elsewhere\n")
+        (scanroot / "plain").mkdir()
+        (scanroot / "plain" / "note.md").write_text("x\n")
+        scan = scan_root(scanroot)
+        assert sorted(scan.nested_repos) == [
+            "projects/childrepo",
+            "worktree-child",
+        ]
+
+    def test_roots_own_git_is_not_nested(self, scanroot):
+        (scanroot / ".git").mkdir()
+        (scanroot / "a.txt").write_text("x\n")
+        scan = scan_root(scanroot)
+        assert scan.nested_repos == ()
+
+    def test_nested_edit_is_invisible_and_disclosed(self, tracked):
+        """AC#2: the hole exists (git gitlink semantics) and is DISCLOSED."""
+        import subprocess as _sp
+
+        tracker, service, root = tracked
+        child = root / "childrepo"
+        child.mkdir()
+        _sp.run(["git", "init", "--quiet", str(child)], check=True)
+        (child / "inner.txt").write_text("original\n")
+        service.repo_for_root(root).snapshot("registration")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (child / "inner.txt").write_text("EDITED INSIDE CHILD\n")
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.nested_repos == ("childrepo",)
+        repo = service.repo_for_root(root)
+        changed = {c.path for c in repo.changed_files(rec.baseline_sha, rec.end_sha)}
+        assert "small.txt" in changed
+        assert not any("inner.txt" in p for p in changed), (
+            "the nested edit must NOT appear as a diff row (the disclosed hole)"
+        )
+
+    def test_new_nested_repo_mid_turn_emits_disclosure_record(self, tracked):
+        tracker, service, root = tracked
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        child = root / "cloned-mid-turn"
+        (child / ".git").mkdir(parents=True)
+        (child / "inner.txt").write_text("x\n")
+        records = tracker.end_turn(handle)
+        assert len(records) == 1
+        assert records[0].nested_repos == ("cloned-mid-turn",)
+
+    def test_repo_root_with_no_children_stays_bannerless(self, tracked):
+        """AC#3: tracking a root normally — nested_repos stays empty."""
+        tracker, service, root = tracked
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+        assert records[0].nested_repos == ()

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -590,3 +590,57 @@ class TestNestedRepoDetection:
         (root / "small.txt").write_text("edited\n")
         records = tracker.end_turn(handle)
         assert records[0].nested_repos == ()
+
+
+class TestNestedRepoBudgetIsolation:
+    """PR #1254 Qodo round: nested content must not distort budgets."""
+
+    def test_nested_content_does_not_count_against_the_budget(self, scanroot):
+        (scanroot / "a.txt").write_bytes(b"x")
+        child = scanroot / "bigchild"
+        (child / ".git").mkdir(parents=True)
+        for i in range(50):
+            (child / f"f{i}.bin").write_bytes(b"z" * 100)
+        scan = scan_root(scanroot, max_files=10, max_total_bytes=1000)
+        assert scan.over_budget is False, (
+            "a large NESTED repo tripped the whole root's budget"
+        )
+        assert scan.files == 1
+        assert scan.nested_repos == ("bigchild",)
+
+    def test_oversized_inside_nested_is_not_disclosed(self, scanroot):
+        (scanroot / "a.txt").write_bytes(b"x")
+        child = scanroot / "child"
+        (child / ".git").mkdir(parents=True)
+        (child / "fat.bin").write_bytes(b"z" * 500)
+        scan = scan_root(scanroot, max_file_bytes=100)
+        assert scan.oversized == (), (
+            "never-trackable nested files polluted the oversize disclosure"
+        )
+
+    def test_newline_named_commitless_child_does_not_kill_tracking(
+        self, tracked
+    ):
+        import subprocess as _sp
+
+        tracker, service, root = tracked
+        evil = root / "evil\nrepo"
+        evil.mkdir()
+        _sp.run(["git", "init", "--quiet", str(evil)], check=True)
+        (evil / "inner.txt").write_text("x\n")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.tracking_error == "", (
+            "an unexcludable commitless child killed tracking for the root"
+        )
+        assert "evil\nrepo" in rec.nested_repos
+        repo = service.repo_for_root(root)
+        changed = {c.path for c in repo.changed_files(rec.baseline_sha, rec.end_sha)}
+        assert "small.txt" in changed
+        assert not any("inner.txt" in p for p in changed)

--- a/backlog/tasks/task-1976 - Change-review-nested-repo-detection.md
+++ b/backlog/tasks/task-1976 - Change-review-nested-repo-detection.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1976
 title: 'Change review: detect nested repos and disclose the tracking hole'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -22,8 +22,48 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A root containing a child repo reports the child by path in the Review screen banner
-- [ ] #2 An edit inside the child repo produces NO diff rows AND the banner is present (the hole is disclosed, not hidden)
-- [ ] #3 A root that IS a repo (no children) shows no banner and tracks normally
-- [ ] #4 Detection runs in the registration scan, not per-turn
+- [x] #1 A root containing a child repo reports the child by path in the Review screen banner
+- [x] #2 An edit inside the child repo produces NO diff rows AND the banner is present (the hole is disclosed, not hidden)
+- [x] #3 A root that IS a repo (no children) shows no banner and tracks normally
+- [x] #4 Detection runs in the registration scan, not per-turn
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. `scan_root` detects nested repos during the SAME walk budgets already use
+   (zero additional per-turn cost — AC#4's substance); root's own .git is
+   not "nested"
+2. TurnChangeRecord.nested_repos; rows carry them (JSON column, ALTER-on-open);
+   bridge threads through; Review banner names them
+3. Oversize precedent for cardless turns: NEW nested repo since B -> zero-change
+   disclosure record; stable set stays cardless, disclosed on changed turns
+4. TDD against real git; sabotage first-try passes
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Detection rides the SAME walk the TASK-1975 budget gate already runs
+(`scan_root` gains `nested_repos`; zero additional per-turn cost — AC#4's
+substance), collected BEFORE directory pruning so both `.git` spellings
+(dir and worktree file) register; the root's own `.git` is not nested.
+
+**The test found a real production bug beyond the spec's framing:** `git
+add -A` HARD-FAILS (exit 128, "does not have a commit checked out") on a
+commitless nested repo — tracking would have died for the whole root, not
+merely missed the child. Nested repos are therefore EXCLUDED from tracking
+entirely (written to info/exclude alongside the oversize entries, trailing
+slash, newline-named dirs unexcludable-but-skipped like oversize), making
+the semantics uniform: excluded + disclosed.
+
+Disclosure follows the oversize precedent: `TurnChangeRecord.nested_repos`
+→ `change_snapshots.nested_repos` JSON column (idempotent-ALTER-on-open)
+→ bridge pass-through → Review banner "N nested repositor(y/ies) inside
+<root> not tracked: a, b" (first 5 named). A repo CLONED mid-turn emits a
+zero-change disclosure record; a stable nested set stays cardless and is
+disclosed on every changed turn's banner.
+
+5 scan/tracker tests + 1 screen test (banner sabotage-verified); 249 green
+across all change-review suites.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1958,6 +1958,7 @@ class ConsoleAgentBridge:
                                 dels=_rec.dels,
                                 tracking_error=_rec.tracking_error,
                                 untracked_oversize=_rec.untracked_oversize,
+                                nested_repos=_rec.nested_repos,
                             )
                         self._append_change_markers(
                             session_id, run_id, _records

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -12,7 +12,7 @@ import uuid
 from contextlib import closing, contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator, Union
+from typing import Sequence, Iterator, Union
 
 from loguru import logger
 
@@ -149,6 +149,7 @@ class AgentRunsDB(BaseDB):
                     reverted TEXT NOT NULL DEFAULT '',
                     tracking_error TEXT NOT NULL DEFAULT '',
                     untracked_oversize INTEGER NOT NULL DEFAULT 0,
+                    nested_repos TEXT NOT NULL DEFAULT '[]',
                     created_at TEXT NOT NULL
                 );
                 CREATE INDEX IF NOT EXISTS idx_change_snapshots_run
@@ -181,6 +182,11 @@ class AgentRunsDB(BaseDB):
                     "ALTER TABLE change_snapshots ADD COLUMN "
                     "untracked_oversize INTEGER NOT NULL DEFAULT 0"
                 )
+            if "nested_repos" not in snapshot_columns:
+                conn.execute(
+                    "ALTER TABLE change_snapshots ADD COLUMN "
+                    "nested_repos TEXT NOT NULL DEFAULT '[]'"
+                )
             # Keep the (write-only, audit) version table in step with the
             # DDL -- append-per-version, matching the INSERT OR IGNORE
             # convention above (UPDATE would collide on the UNIQUE column
@@ -201,6 +207,7 @@ class AgentRunsDB(BaseDB):
         dels: int = 0,
         tracking_error: str = "",
         untracked_oversize: int = 0,
+        nested_repos: "Sequence[str]" = (),
     ) -> None:
         """Record one root's turn snapshot pair (TASK-1971).
 
@@ -215,6 +222,8 @@ class AgentRunsDB(BaseDB):
             tracking_error: Non-empty when tracking failed for this root.
             untracked_oversize: Files over the size cap left untracked at
                 the turn's end (TASK-1975 disclosure).
+            nested_repos: Root-relative nested repos excluded from tracking
+                (TASK-1976 disclosure).
         """
         with self.transaction() as conn:
             conn.execute(
@@ -222,8 +231,8 @@ class AgentRunsDB(BaseDB):
                 INSERT INTO change_snapshots
                     (run_id, root, baseline_sha, end_sha, files_changed,
                      adds, dels, tracking_error, untracked_oversize,
-                     created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     nested_repos, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     run_id,
@@ -235,6 +244,7 @@ class AgentRunsDB(BaseDB):
                     dels,
                     tracking_error,
                     untracked_oversize,
+                    json.dumps(list(nested_repos)),
                     _now_iso(),
                 ),
             )

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -43,6 +43,10 @@ from tldw_chatbook.Workspaces.change_tracking import (
 #: but the flat section name is the spec's (dotted sections drop defaults).
 DEFAULT_DIFF_DISPLAY_MAX_LINES = 2000
 
+#: How many nested-repo paths the disclosure banner names before "+N more"
+#: (TASK-1976; Qodo #1254 asked for the limit to be discoverable).
+NESTED_BANNER_NAMED_LIMIT = 5
+
 #: Group headings in display order. "Other" carries the rare git letters
 #: (T typechange, C copy) that pass through verbatim rather than being
 #: coerced — see ``ChangedFile.status``.
@@ -399,8 +403,11 @@ class ChangeReviewScreen(Screen):
             if nested:
                 # TASK-1976: name the holes — changes inside these repos
                 # are not tracked at all.
-                shown = ", ".join(nested[:5]) + (
-                    f" (+{len(nested) - 5} more)" if len(nested) > 5 else ""
+                limit = NESTED_BANNER_NAMED_LIMIT
+                shown = ", ".join(nested[:limit]) + (
+                    f" (+{len(nested) - limit} more)"
+                    if len(nested) > limit
+                    else ""
                 )
                 plural = "ies" if len(nested) != 1 else "y"
                 banners.append(

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -389,6 +389,24 @@ class ChangeReviewScreen(Screen):
             if error:
                 banners.append(f"⚠ tracking failed for {row['root']}: {error}")
                 continue
+            nested_raw = row.get("nested_repos") or "[]"
+            try:
+                import json as _json
+
+                nested = [str(p) for p in _json.loads(nested_raw)]
+            except (ValueError, TypeError):
+                nested = []
+            if nested:
+                # TASK-1976: name the holes — changes inside these repos
+                # are not tracked at all.
+                shown = ", ".join(nested[:5]) + (
+                    f" (+{len(nested) - 5} more)" if len(nested) > 5 else ""
+                )
+                plural = "ies" if len(nested) != 1 else "y"
+                banners.append(
+                    f"⚠ {len(nested)} nested repositor{plural} inside "
+                    f"{row['root']} not tracked: {shown}"
+                )
             oversize = int(row.get("untracked_oversize") or 0)
             if oversize:
                 # TASK-1975 AC#2: cost bounds are honest, not silent.

--- a/tldw_chatbook/Workspaces/change_bounds.py
+++ b/tldw_chatbook/Workspaces/change_bounds.py
@@ -96,12 +96,18 @@ class RootScan:
             already knows is too big).
         oversized: Root-relative paths of files over ``max_file_bytes``,
             in walk order.
+        nested_repos: Root-relative paths of NESTED git repos (a child
+            directory carrying ``.git`` as dir or file — TASK-1976: git
+            records these as gitlinks, so changes inside are invisible to
+            snapshots; the hole must be disclosed). The root's own
+            ``.git`` is not nested.
     """
 
     files: int
     total_bytes: int
     over_budget: bool
     oversized: tuple[str, ...] = ()
+    nested_repos: tuple[str, ...] = ()
 
 
 def scan_root(
@@ -138,7 +144,16 @@ def scan_root(
     files = 0
     total = 0
     oversized: list[str] = []
+    nested: list[str] = []
     for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        # Nested-repo detection (TASK-1976) BEFORE pruning: a child dir
+        # carrying `.git` (dir or worktree FILE) is a disclosed hole. The
+        # root's own `.git` is the root being a repo, not a nested one.
+        if Path(dirpath) != root and (".git" in dirnames or ".git" in filenames):
+            try:
+                nested.append(Path(dirpath).relative_to(root).as_posix())
+            except ValueError:  # pragma: no cover -- walk stays inside
+                pass
         dirnames[:] = [d for d in dirnames if d not in _SKIP_DIR_NAMES]
         for name in filenames:
             path = Path(dirpath) / name
@@ -161,10 +176,12 @@ def scan_root(
                     total_bytes=total,
                     over_budget=True,
                     oversized=tuple(oversized),
+                    nested_repos=tuple(nested),
                 )
     return RootScan(
         files=files,
         total_bytes=total,
         over_budget=False,
         oversized=tuple(oversized),
+        nested_repos=tuple(nested),
     )

--- a/tldw_chatbook/Workspaces/change_bounds.py
+++ b/tldw_chatbook/Workspaces/change_bounds.py
@@ -154,6 +154,12 @@ def scan_root(
                 nested.append(Path(dirpath).relative_to(root).as_posix())
             except ValueError:  # pragma: no cover -- walk stays inside
                 pass
+            # Qodo #1254 finding 4: nothing under a nested repo is ever
+            # trackable, so none of it may count against the root's budget
+            # or pollute the oversize disclosure -- do not descend, do not
+            # count its files.
+            dirnames[:] = []
+            continue
         dirnames[:] = [d for d in dirnames if d not in _SKIP_DIR_NAMES]
         for name in filenames:
             path = Path(dirpath) / name

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -464,6 +464,13 @@ class ShadowRepo:
                 for rel in scan.nested_repos
                 if "\n" not in rel and "\r" not in rel
             ]
+            # Qodo #1254 finding 5: a newline-named nested repo cannot go
+            # into info/exclude, and a commitless child makes `add -A`
+            # FATAL -- exclude it at add time via pathspec magic instead
+            # (argv is newline-safe; `literal` disables glob semantics).
+            nested_unexcludable = [
+                rel for rel in scan.nested_repos if rel not in nested_excludable
+            ]
             if excludable or nested_excludable:
                 exclude = self.git_dir / "info" / "exclude"
                 with exclude.open("a", encoding="utf-8") as fh:
@@ -475,7 +482,11 @@ class ShadowRepo:
                         fh.write(_exclude_pattern(rel) + "\n")
                     for rel in nested_excludable:
                         fh.write(_exclude_pattern(rel) + "/\n")
-            self._run("add", "-A", "--", ".")
+            add_args = ["add", "-A", "--", "."]
+            add_args.extend(
+                f":(literal,exclude){rel}" for rel in nested_unexcludable
+            )
+            self._run(*add_args)
             for rel in unexcludable:
                 self._run(
                     "rm", "--cached", "--ignore-unmatch", "--quiet", "--", rel,

--- a/tldw_chatbook/Workspaces/change_tracking.py
+++ b/tldw_chatbook/Workspaces/change_tracking.py
@@ -239,6 +239,8 @@ class ShadowRepo:
         #: Root-relative paths excluded as oversized by the LAST snapshot
         #: on this instance (TASK-1975 disclosure).
         self.last_oversize_excluded: tuple[str, ...] = ()
+        #: Nested repos seen by the LAST snapshot's scan (TASK-1976).
+        self.last_nested_repos: tuple[str, ...] = ()
 
     # -- plumbing ----------------------------------------------------------
 
@@ -437,6 +439,7 @@ class ShadowRepo:
                 max_total_bytes=_sys.maxsize,
             )
             self.last_oversize_excluded = scan.oversized
+            self.last_nested_repos = scan.nested_repos
             # info/exclude is line-oriented and has NO newline escaping --
             # a filename carrying \n would INJECT extra patterns (Qodo
             # #1251 finding 5). Such paths are unexcludable; they are
@@ -449,12 +452,29 @@ class ShadowRepo:
             unexcludable = [
                 rel for rel in scan.oversized if rel not in excludable
             ]
-            if excludable:
+            # TASK-1976: nested repos are excluded from tracking entirely.
+            # This is not merely hygiene -- `git add -A` HARD-FAILS (128,
+            # "does not have a commit checked out") on a commitless child
+            # repo, which would kill tracking for the whole root; and a
+            # committed child would land as a gitlink whose inner changes
+            # are invisible anyway. Excluded + disclosed is the honest,
+            # uniform behavior (test: nested-edit-invisible).
+            nested_excludable = [
+                rel
+                for rel in scan.nested_repos
+                if "\n" not in rel and "\r" not in rel
+            ]
+            if excludable or nested_excludable:
                 exclude = self.git_dir / "info" / "exclude"
                 with exclude.open("a", encoding="utf-8") as fh:
-                    fh.write("# oversize (TASK-1975), rewritten per snapshot\n")
+                    fh.write(
+                        "# oversize + nested (TASK-1975/1976), "
+                        "rewritten per snapshot\n"
+                    )
                     for rel in excludable:
                         fh.write(_exclude_pattern(rel) + "\n")
+                    for rel in nested_excludable:
+                        fh.write(_exclude_pattern(rel) + "/\n")
             self._run("add", "-A", "--", ".")
             for rel in unexcludable:
                 self._run(

--- a/tldw_chatbook/Workspaces/change_turn_tracker.py
+++ b/tldw_chatbook/Workspaces/change_turn_tracker.py
@@ -87,6 +87,7 @@ class TurnChangeRecord:
     dels: int = 0
     tracking_error: str = ""
     untracked_oversize: int = 0
+    nested_repos: tuple[str, ...] = ()
 
 
 class TurnHandle:
@@ -99,6 +100,9 @@ class TurnHandle:
         #: TASK-1975: each root's oversize-excluded set at B, so end_turn
         #: can tell NEW oversize (disclose even changeless) from stable.
         self.baseline_oversize: dict[str, tuple[str, ...]] = {}
+        #: TASK-1976: each root's nested-repo set at B, from the SAME walk
+        #: the budget gate already runs — new holes disclose even cardless.
+        self.baseline_nested: dict[str, tuple[str, ...]] = {}
         self._thread: threading.Thread | None = None
 
     def await_baseline(self, timeout: float = _BASELINE_TIMEOUT_SECONDS) -> None:
@@ -178,6 +182,7 @@ class ChangeTurnTracker:
                             "tracking disabled for this turn"
                         )
                         continue
+                    handle.baseline_nested[key] = scan.nested_repos
                     repo = self.service.repo_for_root(root)
                     handle.baselines[key] = repo.snapshot("turn baseline")
                     handle.baseline_oversize[key] = repo.last_oversize_excluded
@@ -249,6 +254,7 @@ class ChangeTurnTracker:
                     repo.force_add(in_root)
                 end = repo.snapshot("turn end")
                 oversize = repo.last_oversize_excluded
+                nested = repo.last_nested_repos
                 if end == baseline:
                     # TASK-1975 (AC#6): an oversized file CREATED during
                     # the turn is the turn's only event -- disclose it with
@@ -257,13 +263,19 @@ class ChangeTurnTracker:
                     new_oversize = set(oversize) - set(
                         handle.baseline_oversize.get(key, ())
                     )
-                    if new_oversize:
+                    # TASK-1976: a repo cloned mid-turn is a NEW hole —
+                    # same disclosure rule as new oversize.
+                    new_nested = set(nested) - set(
+                        handle.baseline_nested.get(key, ())
+                    )
+                    if new_oversize or new_nested:
                         records.append(
                             TurnChangeRecord(
                                 root=key,
                                 baseline_sha=baseline,
                                 end_sha=end,
                                 untracked_oversize=len(oversize),
+                                nested_repos=nested,
                             )
                         )
                     continue
@@ -277,6 +289,7 @@ class ChangeTurnTracker:
                         adds=sum(c.adds for c in changed),
                         dels=sum(c.dels for c in changed),
                         untracked_oversize=len(oversize),
+                        nested_repos=nested,
                     )
                 )
             except Exception as exc:  # noqa: BLE001 -- disclosed, never raised


### PR DESCRIPTION
## Summary
- Detects nested git repos (dir or worktree-file `.git`) during the same walk the TASK-1975 budget gate already runs — zero additional per-turn cost; the root's own `.git` is not "nested"
- **Excludes nested repos from tracking entirely** — the test surfaced that `git add -A` hard-fails (128, "does not have a commit checked out") on a commitless child repo, which would have killed tracking for the whole root; excluded + disclosed is the uniform honest behavior
- Disclosure: `TurnChangeRecord.nested_repos` → JSON column on `change_snapshots` (idempotent-ALTER-on-open) → bridge → Review banner "N nested repositor(y/ies) inside <root> not tracked: …" naming up to 5; a repo cloned mid-turn emits a zero-change disclosure record, a stable set stays cardless
- An edit inside a child produces no diff rows AND the banner is present (AC#2 verified against a real `git init` child)

## Testing
- 6 new tests (scan, tracker, screen banner — banner sabotage-verified); full change-review regression 249 passed BEFORE push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and disclose nested git repositories inside tracked roots, exclude them from tracking, and show a clear banner in Change Review. Also isolates budgets so nested content never counts toward file/byte limits. (TASK-1976)

- **New Features**
  - Detects nested repos during the existing registration scan; the root’s own `.git` is not nested.
  - Skips descending into nested repos so their files don’t count toward budgets or oversize disclosure.
  - Excludes nested repos via `info/exclude`; falls back to `:(literal,exclude)` pathspecs for newline-named dirs to prevent `git add -A` failures.
  - Persists paths in `change_snapshots.nested_repos` (JSON) via `TurnChangeRecord` and the console bridge.
  - Shows a banner per root: “N nested repositor(y/ies) inside <root> not tracked: …” (names up to 5).
  - Emits a zero-change disclosure when a nested repo appears mid-turn; stable sets stay cardless. Tests cover detection, budget isolation, and the banner.

<sup>Written for commit e34ba3580abfc6466efe52fd7fadf63a97ba75e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

