### PR TITLE
Change review: auto-register nested repos as tracked sub-roots (TASK-1977)

### DIFF
--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -500,10 +500,13 @@ async def test_pruned_snapshots_render_pruned_by_retention(review_fixture, tmp_p
 
 
 @pytest.mark.asyncio
-async def test_nested_repo_banner_names_the_holes(tmp_path):
-    """TASK-1976 AC#1: nested repos are named in the Review banner."""
+async def test_nested_repo_banner_names_the_holes(tmp_path, monkeypatch):
+    """TASK-1976 AC#1: UNREGISTERED nested repos are named in the Review
+    banner. Under TASK-1977 children are auto-registered as sub-roots, so
+    the disclosure path is pinned with the sub-root bound at zero."""
     import subprocess as _sp
 
+    monkeypatch.setenv("TLDW_CHANGE_REVIEW_MAX_SUB_ROOTS", "0")
     root = tmp_path / "root"
     root.mkdir()
     (root / "small.txt").write_text("hello\n")

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -786,3 +786,36 @@ class TestAutoSubRoots:
 
         assert report.orphans_removed >= 1
         assert not child_repo.git_dir.exists()
+
+
+def test_end_turn_survives_a_still_running_discovery_thread(tracked):
+    """Qodo #1256: a timed-out baseline thread may still be appending
+    sub-roots while end_turn runs — iteration must be over a snapshot,
+    yielding one record per root, never churn-driven duplicates."""
+    import threading
+    import time
+
+    tracker, service, root = tracked
+    handle = tracker.begin_turn([root])
+    handle.await_baseline()
+    (root / "small.txt").write_text("edited\n")
+
+    stop = threading.Event()
+
+    def churn() -> None:
+        while not stop.is_set():
+            handle.roots.append(root)
+            time.sleep(0.0005)
+
+    thread = threading.Thread(target=churn, daemon=True)
+    thread.start()
+    try:
+        records = tracker.end_turn(handle)
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+
+    mine = [r for r in records if r.root == str(root.resolve())]
+    assert len(mine) == 1, (
+        f"churned roots produced {len(mine)} records for one root"
+    )

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -544,8 +544,10 @@ class TestNestedRepoDetection:
         scan = scan_root(scanroot)
         assert scan.nested_repos == ()
 
-    def test_nested_edit_is_invisible_and_disclosed(self, tracked):
-        """AC#2: the hole exists (git gitlink semantics) and is DISCLOSED."""
+    def test_nested_edit_never_pollutes_the_parents_diff(self, tracked):
+        """1976 AC#2's surviving core under TASK-1977: the PARENT's diff
+        never carries nested content — the edit is tracked via the child's
+        own sub-root instead of being disclosed as a hole."""
         import subprocess as _sp
 
         tracker, service, root = tracked
@@ -561,15 +563,19 @@ class TestNestedRepoDetection:
         (root / "small.txt").write_text("edited\n")
         records = tracker.end_turn(handle)
 
-        assert len(records) == 1
-        rec = records[0]
-        assert rec.nested_repos == ("childrepo",)
+        by_root = {r.root: r for r in records}
+        parent = by_root[str(root.resolve())]
+        assert parent.nested_repos == (), "tracked sub-root wrongly disclosed"
         repo = service.repo_for_root(root)
-        changed = {c.path for c in repo.changed_files(rec.baseline_sha, rec.end_sha)}
+        changed = {
+            c.path
+            for c in repo.changed_files(parent.baseline_sha, parent.end_sha)
+        }
         assert "small.txt" in changed
         assert not any("inner.txt" in p for p in changed), (
-            "the nested edit must NOT appear as a diff row (the disclosed hole)"
+            "nested content leaked into the PARENT's diff"
         )
+        assert str(child.resolve()) in by_root, "the hole did not close"
 
     def test_new_nested_repo_mid_turn_emits_disclosure_record(self, tracked):
         tracker, service, root = tracked
@@ -632,15 +638,151 @@ class TestNestedRepoBudgetIsolation:
         handle = tracker.begin_turn([root])
         handle.await_baseline()
         (root / "small.txt").write_text("edited\n")
+        (evil / "inner.txt").write_text("EDITED\n")
         records = tracker.end_turn(handle)
 
-        assert len(records) == 1
-        rec = records[0]
-        assert rec.tracking_error == "", (
+        by_root = {r.root: r for r in records}
+        parent = by_root[str(root.resolve())]
+        assert parent.tracking_error == "", (
             "an unexcludable commitless child killed tracking for the root"
         )
-        assert "evil\nrepo" in rec.nested_repos
         repo = service.repo_for_root(root)
-        changed = {c.path for c in repo.changed_files(rec.baseline_sha, rec.end_sha)}
+        changed = {
+            c.path
+            for c in repo.changed_files(parent.baseline_sha, parent.end_sha)
+        }
         assert "small.txt" in changed
         assert not any("inner.txt" in p for p in changed)
+        # Under TASK-1977 the child is auto-registered (tracked), so it is
+        # neither disclosed as a hole nor able to hurt the parent.
+        assert str((root / "evil\nrepo").resolve()) in by_root
+
+
+# -- auto sub-roots (TASK-1977) ----------------------------------------------
+
+
+def _real_child(root, name: str):
+    """A real nested git repo with one committed file."""
+    import subprocess as _sp
+
+    child = root / name
+    child.mkdir()
+    _sp.run(["git", "init", "--quiet", str(child)], check=True)
+    (child / "inner.txt").write_text("original\n")
+    _sp.run(
+        ["git", "-C", str(child), "-c", "user.email=t@t", "-c", "user.name=t",
+         "add", "-A"],
+        check=True, capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(child), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "--quiet", "-m", "init"],
+        check=True, capture_output=True,
+    )
+    return child
+
+
+class TestAutoSubRoots:
+    def test_nested_edit_appears_attributed_to_the_sub_root(self, tracked):
+        """AC#1: the 1976 hole closes — the child's edit is reviewable."""
+        tracker, service, root = tracked
+        child = _real_child(root, "childrepo")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (child / "inner.txt").write_text("EDITED\n")
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        by_root = {r.root: r for r in records}
+        child_key = str(child.resolve())
+        assert child_key in by_root, f"no sub-root record: {list(by_root)}"
+        child_rec = by_root[child_key]
+        assert child_rec.files_changed == 1
+        repo = service.repo_for_root(child)
+        changed = {
+            c.path
+            for c in repo.changed_files(
+                child_rec.baseline_sha, child_rec.end_sha
+            )
+        }
+        assert changed == {"inner.txt"}
+
+    def test_registered_child_leaves_the_disclosure_banner(self, tracked):
+        tracker, service, root = tracked
+        _real_child(root, "childrepo")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        records = tracker.end_turn(handle)
+
+        parent = next(r for r in records if r.root == str(root.resolve()))
+        assert parent.nested_repos == (), (
+            "a TRACKED sub-root must not be disclosed as an untracked hole"
+        )
+
+    def test_sub_root_count_bound_truncates_with_disclosure(
+        self, tracked, monkeypatch
+    ):
+        """AC#3: beyond max_sub_roots, children stay DISCLOSED untracked."""
+        monkeypatch.setenv("TLDW_CHANGE_REVIEW_MAX_SUB_ROOTS", "1")
+        tracker, service, root = tracked
+        _real_child(root, "alpha")
+        _real_child(root, "beta")
+
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (root / "small.txt").write_text("edited\n")
+        (root / "alpha" / "inner.txt").write_text("EDITED\n")
+        (root / "beta" / "inner.txt").write_text("EDITED\n")
+        records = tracker.end_turn(handle)
+
+        parent = next(r for r in records if r.root == str(root.resolve()))
+        registered = {
+            Path(r.root).name
+            for r in records
+            if r.root != str(root.resolve())
+        }
+        assert len(registered) == 1, (
+            "exactly one child is within the bound; only ITS edit is "
+            f"reviewable — got {registered}"
+        )
+        disclosed = set(parent.nested_repos)
+        assert len(disclosed) == 1, "the beyond-bound child must stay disclosed"
+        assert registered | disclosed == {"alpha", "beta"}
+        assert registered.isdisjoint(disclosed), (
+            "a child is both registered and disclosed"
+        )
+
+    def test_deleted_child_unregisters_via_orphan_gc(self, tracked, tmp_path):
+        """AC#4: the existing orphan GC covers sub-root shadow repos."""
+        import os as _os
+        import shutil as _shutil
+        import time as _time
+
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+        from tldw_chatbook.Workspaces.change_retention import (
+            prune_change_history,
+        )
+
+        tracker, service, root = tracked
+        child = _real_child(root, "childrepo")
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        (child / "inner.txt").write_text("EDITED\n")
+        tracker.end_turn(handle)
+        child_repo = service.repo_for_root(child)
+        container = child_repo.git_dir.parent
+        assert child_repo.git_dir.exists()
+
+        _shutil.rmtree(child)
+        old = _time.time() - 90 * 86400
+        _os.utime(container, (old, old))
+        _os.utime(child_repo.git_dir, (old, old))
+        db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+
+        report = prune_change_history(db, service)
+
+        assert report.orphans_removed >= 1
+        assert not child_repo.git_dir.exists()

--- a/backlog/tasks/task-1977 - Change-review-nested-repo-sub-roots.md
+++ b/backlog/tasks/task-1977 - Change-review-nested-repo-sub-roots.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1977
 title: 'Change review: auto-register nested repos as tracked sub-roots (fast-follow)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -22,8 +22,55 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An edit inside a nested repo now appears in the turn's review, attributed to the sub-root
-- [ ] #2 The parent's shadow repo excludes the child (no gitlink churn rows)
-- [ ] #3 Sub-root discovery is bounded (depth/count) with disclosure when the bound truncates
-- [ ] #4 Removing the child repo un-registers its sub-root via existing GC
+- [x] #1 An edit inside a nested repo now appears in the turn's review, attributed to the sub-root
+- [x] #2 The parent's shadow repo excludes the child (no gitlink churn rows)
+- [x] #3 Sub-root discovery is bounded (depth/count) with disclosure when the bound truncates
+- [x] #4 Removing the child repo un-registers its sub-root via existing GC
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. begin_turn expands each root's scan.nested_repos (first max_sub_roots,
+   knob default 20) into additional tracked roots — each gets its own budget
+   gate, B snapshot, and shadow repo; depth bound = 1 by construction (the
+   scan stops descending at a nested repo; grandchildren stay disclosed via
+   the CHILD's own banner when it scans as a root)
+2. end_turn: parent's nested_repos disclosure = E-scan nested MINUS the
+   auto-registered children (disclosure covers exactly the untracked);
+   beyond-bound children remain disclosed (AC#3 truncation honesty)
+3. Attribution (AC#1) falls out of per-(run,root) rows + the screen's
+   existing multi-root labels; parent excludes child already (1976, AC#2);
+   deleted child un-registers via the existing orphan GC (AC#4)
+4. TDD against real git; sabotage first-try passes
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`ChangeTurnTracker._baseline` now expands each ORIGINAL root's detected
+nested repos (first `max_sub_roots`, knob default 20, flat-section +
+env-overridable) into tracked roots of their own: each gets the same budget
+gate, B snapshot, and its own shadow repo keyed by canonical path. Depth is
+1 by construction — only the caller's original roots expand, so a
+grandchild repo stays DISCLOSED via its parent's banner instead of
+recursing; a cycle/dedupe guard (`seen`, resolved paths) protects the queue.
+
+Disclosure now covers exactly what is untracked: a registered child leaves
+`nested_repos` (both the baseline set and the E-scan set are filtered), a
+beyond-bound child stays in it (AC#3 truncation honesty — asserted
+order-agnostically since walk order isn't guaranteed), and a repo cloned
+mid-turn is disclosed this turn and auto-registered the next. Attribution
+(AC#1) falls out of per-(run,root) rows plus the screen's existing
+multi-root labels; parent exclusion (AC#2) was already TASK-1976's exclude
++ pathspec work; a deleted child's shadow container goes through the
+existing TASK-1975 orphan GC (AC#4, tested).
+
+Contract updates to three TASK-1976 tests whose premises 1977 supersedes
+(hole closed, not just disclosed): parent-diff purity is the surviving
+core; the screen's banner test pins the disclosure path with the bound at
+zero. Key test subtlety: a CLEAN sub-root correctly yields no record —
+assertions must mutate the child to observe registration. Sabotage
+(auto-registration disabled) failed 6 tests. 256 green across all
+change-review suites before push.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Workspaces/change_bounds.py
+++ b/tldw_chatbook/Workspaces/change_bounds.py
@@ -29,6 +29,7 @@ DEFAULT_MAX_FILES = 20_000
 DEFAULT_MAX_TOTAL_BYTES = 2 * 1024**3
 DEFAULT_MAX_FILE_BYTES = 10 * 1024**2
 DEFAULT_RETENTION_DAYS = 30
+DEFAULT_MAX_SUB_ROOTS = 20
 
 #: Directory names the scan prunes — mirrors the shadow repo's
 #: ``FORCED_EXCLUDES`` (change_tracking.py): untracked trees must not count.

--- a/tldw_chatbook/Workspaces/change_turn_tracker.py
+++ b/tldw_chatbook/Workspaces/change_turn_tracker.py
@@ -103,6 +103,9 @@ class TurnHandle:
         #: TASK-1976: each root's nested-repo set at B, from the SAME walk
         #: the budget gate already runs — new holes disclose even cardless.
         self.baseline_nested: dict[str, tuple[str, ...]] = {}
+        #: TASK-1977: per-root REL paths auto-registered as sub-roots this
+        #: turn — excluded from that root's nested-repo disclosure.
+        self.auto_registered: dict[str, tuple[str, ...]] = {}
         self._thread: threading.Thread | None = None
 
     def await_baseline(self, timeout: float = _BASELINE_TIMEOUT_SECONDS) -> None:
@@ -165,9 +168,21 @@ class ChangeTurnTracker:
         )
 
         def _baseline() -> None:
-            from tldw_chatbook.Workspaces.change_bounds import scan_root
+            from tldw_chatbook.Workspaces.change_bounds import (
+                DEFAULT_MAX_SUB_ROOTS,
+                scan_root,
+            )
 
-            for root in handle.roots:
+            # TASK-1977: nested repos found inside a GIVEN root become
+            # tracked sub-roots of their own (bounded by max_sub_roots).
+            # Depth is 1 by construction: only the caller's original roots
+            # expand — a grandchild repo stays disclosed via ITS parent's
+            # banner rather than recursing unbounded.
+            original_keys = {str(root) for root in handle.roots}
+            seen = set(original_keys)
+            queue = list(handle.roots)
+            while queue:
+                root = queue.pop(0)
                 key = str(root)
                 try:
                     # TASK-1975: budget gate BEFORE any snapshot work. Over
@@ -182,7 +197,29 @@ class ChangeTurnTracker:
                             "tracking disabled for this turn"
                         )
                         continue
-                    handle.baseline_nested[key] = scan.nested_repos
+                    registered: tuple[str, ...] = ()
+                    if key in original_keys:
+                        max_subs = change_review_setting(
+                            "max_sub_roots", DEFAULT_MAX_SUB_ROOTS
+                        )
+                        candidates = scan.nested_repos[: max(0, max_subs)]
+                        kept: list[str] = []
+                        for rel in candidates:
+                            child = (root / rel).resolve()
+                            ckey = str(child)
+                            if ckey in seen or not child.is_dir():
+                                continue
+                            seen.add(ckey)
+                            kept.append(rel)
+                            handle.roots.append(child)
+                            queue.append(child)
+                        registered = tuple(kept)
+                    handle.auto_registered[key] = registered
+                    handle.baseline_nested[key] = tuple(
+                        rel
+                        for rel in scan.nested_repos
+                        if rel not in registered
+                    )
                     repo = self.service.repo_for_root(root)
                     handle.baselines[key] = repo.snapshot("turn baseline")
                     handle.baseline_oversize[key] = repo.last_oversize_excluded
@@ -254,7 +291,14 @@ class ChangeTurnTracker:
                     repo.force_add(in_root)
                 end = repo.snapshot("turn end")
                 oversize = repo.last_oversize_excluded
-                nested = repo.last_nested_repos
+                # TASK-1977: a TRACKED sub-root is not an untracked hole —
+                # disclosure covers exactly what is not tracked.
+                registered = handle.auto_registered.get(key, ())
+                nested = tuple(
+                    rel
+                    for rel in repo.last_nested_repos
+                    if rel not in registered
+                )
                 if end == baseline:
                     # TASK-1975 (AC#6): an oversized file CREATED during
                     # the turn is the turn's only event -- disclose it with

--- a/tldw_chatbook/Workspaces/change_turn_tracker.py
+++ b/tldw_chatbook/Workspaces/change_turn_tracker.py
@@ -120,7 +120,9 @@ class TurnHandle:
             return
         thread.join(timeout=timeout)
         if thread.is_alive():
-            for root in self.roots:
+            # Qodo #1256: the discovery thread may still be APPENDING
+            # sub-roots — iterate a snapshot, never the live list.
+            for root in tuple(self.roots):
                 key = str(root)
                 if key not in self.baselines and key not in self.errors:
                     self.errors[key] = (
@@ -256,8 +258,16 @@ class ChangeTurnTracker:
         """
         handle.await_baseline()
         records: list[TurnChangeRecord] = []
-        for root in handle.roots:
+        # Snapshot + dedupe: a timed-out baseline thread may still be
+        # appending discovered sub-roots (Qodo #1256) — a live-list
+        # iteration could loop on churn, and a duplicate entry would yield
+        # duplicate records for one root.
+        seen_roots: set[str] = set()
+        for root in tuple(handle.roots):
             key = str(root)
+            if key in seen_roots:
+                continue
+            seen_roots.add(key)
             if key in handle.errors:
                 records.append(
                     TurnChangeRecord(root=key, tracking_error=handle.errors[key])


### PR DESCRIPTION
## Summary
- Closes the TASK-1976 hole: nested repos inside a turn's roots become tracked sub-roots with their own shadow repos — an edit inside a child now appears in the review attributed to that sub-root
- Bounded: first `max_sub_roots` (knob, default 20) per original root; depth 1 by construction (grandchildren stay disclosed via their parent's banner); cycle/dedupe guard on resolved paths
- Disclosure covers exactly what is untracked: registered children leave the banner, beyond-bound children stay in it, a mid-turn clone is disclosed this turn and auto-registered next turn
- Deleted children un-register via the existing TASK-1975 orphan GC (tested); parent exclusion is TASK-1976's exclude/pathspec work, unchanged
- Three 1976 tests updated to the superseding contract (hole closed, not just disclosed) — parent-diff purity is the surviving invariant; the banner path stays pinned with the bound at zero

## Testing
- 4 new sub-root tests (attribution, banner suppression, order-agnostic truncation, orphan GC), sabotage run failed 6 tests with auto-registration disabled; 256 green across all change-review suites before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-register nested git repos found under a tracked root as their own sub-roots so their edits appear in the review and never leak into the parent’s diff. Implements TASK-1977 with a per-root bound (default 20, depth=1) and updates the banner to disclose only untracked children.

- **New Features**
  - Automatically tracks the first `max_sub_roots` children per root (default 20), depth limited to 1 with cycle/dedupe guard.
  - Attributes child edits to the child’s sub-root; parent diffs stay clean.
  - Banner omits registered children; beyond-bound children stay disclosed; mid-turn clones are disclosed this turn and tracked next turn.
  - Deleted children are cleaned up by the existing orphan GC.

- **Bug Fixes**
  - `end_turn` now iterates a deduped snapshot of roots (and the timeout path does too) to prevent churn and duplicate records if discovery is still appending sub-roots.

<sup>Written for commit fdcf61548201a6ccfb9754fbcbc5e0a9bb0d6516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

