### PR TITLE
chore: mark task-1345 Done (PR #1252 merged)

### DIFF
--- a/backlog/tasks/task-1345 - Select-Input-mount-race-makes-the-Watchlists-create-form-tests-order-dependent.md
+++ b/backlog/tasks/task-1345 - Select-Input-mount-race-makes-the-Watchlists-create-form-tests-order-dependent.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1345
 title: Select/Input mount race makes the Watchlists create-form tests order-dependent
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-29 05:30'
 labels:


### PR DESCRIPTION
Bookkeeping only: focus-drop race fixed; SelectCurrent mount race split to task-1960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks TASK-1345 as Done to reflect that the Select/Input mount race affecting Watchlists create-form tests was fixed in PR #1252. The remaining SelectCurrent mount race was moved to TASK-1960.

<sup>Written for commit 62c5fa150a42a23adba58a162b287a961c763dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

