### PR TITLE
Change review: tree selection loads the file's diff (TASK-2032)

### DIFF
--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -545,3 +545,51 @@ async def test_nested_repo_banner_names_the_holes(tmp_path, monkeypatch):
         assert not any("inner.txt" in l for l in labels), (
             "the nested edit leaked into the tree"
         )
+
+
+@pytest.mark.asyncio
+async def test_selecting_a_tree_node_loads_that_files_diff(review_fixture):
+    """TASK-2032 (live-UAT defect): clicking a file row must load its diff.
+
+    Driven through Tree's own cursor-select action — the same NodeSelected
+    event a mouse click produces — so the mouse path is what's pinned.
+    """
+    provider, root, run1, run2 = review_fixture
+    app = _Harness(provider)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        tree = screen.query_one("#change-review-tree", Tree)
+        await _wait_for(pilot, lambda: screen._leaves, "leaves loaded")
+        assert len(screen._leaves) >= 2, "fixture must offer multiple files"
+
+        target_row, target_change = screen._leaves[-1]
+        first_row, first_change = screen._leaves[0]
+        assert target_change.path != first_change.path
+
+        # Walk the tree cursor to the target leaf and select it — the event
+        # path a mouse click takes (click -> cursor + NodeSelected).
+        chosen = None
+        for line in range(tree.last_line + 1):
+            tree.cursor_line = line
+            node = tree.cursor_node
+            if node is not None and target_change.path in str(node.label):
+                chosen = line
+                break
+        assert chosen is not None, "target leaf not found in the tree"
+        tree.action_select_cursor()
+        await pilot.pause()
+
+        def diff_text() -> str:
+            body = screen.query(".change-review-diff-body")
+            return str(body.first().renderable) if body else ""
+
+        await _wait_for(
+            pilot,
+            lambda: target_change.path in diff_text(),
+            f"diff to switch to {target_change.path} (still showing "
+            f"{first_change.path})",
+        )

--- a/backlog/tasks/task-2032 - Change-review-tree-click-does-not-load-the-file-diff.md
+++ b/backlog/tasks/task-2032 - Change-review-tree-click-does-not-load-the-file-diff.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2032
 title: 'Change review: tree click does not load the file diff'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 00:45'
 labels:
@@ -25,6 +25,32 @@ gating in `_load_file`).
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Clicking a file row loads that file's diff (parity with j/k)
-- [ ] #2 A test pins the mouse-selection path
+- [x] #1 Clicking a file row loads that file's diff (parity with j/k)
+- [x] #2 A test pins the mouse-selection path
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED test: move the tree cursor to a second file and select it (the same
+   NodeSelected path a mouse click takes) — the diff pane must switch
+2. Fix: leaf nodes carry their leaf index as node.data; a Tree.NodeSelected
+   handler calls _focus_leaf(index); group nodes (data None) ignored
+3. Sabotage-verify
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: the screen had NO Tree.NodeSelected handler — j/k
+(`action_next_file`/`action_previous_file` → `_focus_leaf`) was the only
+diff loader, so a mouse click selected the row visually and loaded nothing.
+
+Fix: leaf nodes carry their `_leaves` index as `node.data` at add time;
+an `@on(Tree.NodeSelected, "#change-review-tree")` handler calls
+`_focus_leaf(index)`; group nodes (data None) keep their expand/collapse
+click untouched. Test drives Tree's own cursor-select action — the same
+NodeSelected event a mouse click produces — and watched the exact live
+failure first (diff pinned to the first file). 14 screen tests +
+change-review regression green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -442,7 +442,12 @@ class ChangeReviewScreen(Screen):
                 continue
             branch = tree.root.add(f"{label} ({len(entries)})", expand=True)
             for row, change in entries:
-                branch.add_leaf(self._leaf_label(row, change, multi_root))
+                # TASK-2032: the node carries its leaf index so a MOUSE
+                # selection can load the diff (j/k was the only loader).
+                branch.add_leaf(
+                    self._leaf_label(row, change, multi_root),
+                    data=len(self._leaves),
+                )
                 self._leaves.append((row, change))
         other = [
             entry
@@ -453,7 +458,12 @@ class ChangeReviewScreen(Screen):
         if other:
             branch = tree.root.add(f"{_OTHER_GROUP} ({len(other)})", expand=True)
             for row, change in other:
-                branch.add_leaf(self._leaf_label(row, change, multi_root))
+                # TASK-2032: the node carries its leaf index so a MOUSE
+                # selection can load the diff (j/k was the only loader).
+                branch.add_leaf(
+                    self._leaf_label(row, change, multi_root),
+                    data=len(self._leaves),
+                )
                 self._leaves.append((row, change))
 
         banner = self.query_one("#change-review-banner", Static)
@@ -514,6 +524,17 @@ class ChangeReviewScreen(Screen):
         self._focused_leaf = max(0, min(index, len(self._leaves) - 1))
         row, change = self._leaves[self._focused_leaf]
         self._render_diff(row, change)
+
+    @on(Tree.NodeSelected, "#change-review-tree")
+    def _on_tree_node_selected(self, event: "Tree.NodeSelected") -> None:
+        """Load the selected file's diff — the mouse-click path (TASK-2032).
+
+        Group nodes carry no index and are ignored (their click just
+        expands/collapses).
+        """
+        index = getattr(event.node, "data", None)
+        if isinstance(index, int):
+            self._focus_leaf(index)
 
     def action_next_file(self) -> None:
         self._focus_leaf(self._focused_leaf + 1)


### PR DESCRIPTION
## Summary
- Fixes the TASK-1980 live-UAT defect: clicking a file row in the Review tree selected it visually but never loaded its diff — j/k was the only loader (no `Tree.NodeSelected` handler existed)
- Leaf nodes now carry their leaf index as `node.data`; a `NodeSelected` handler (the same event a mouse click produces) calls `_focus_leaf`; group nodes keep their expand/collapse behavior

## Testing
- New test drives Tree's cursor-select action and watched the exact live failure first; 14 screen tests + full change-review regression green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a file row in the review tree now loads that file’s diff. Addresses TASK-2032 by wiring mouse selection to the same loader as j/k; group rows still only expand/collapse.

- **Bug Fixes**
  - Leaf nodes store their `_leaves` index in `node.data`; group nodes keep `None`.
  - Added `@on(Tree.NodeSelected, "#change-review-tree")` to call `_focus_leaf(index)`.
  - New UI test drives `Tree` cursor-select to pin the mouse-click path.

<sup>Written for commit ebd7bacaac4aa1ec946920b31bac91ba1ea117a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

