### PR TITLE
Change review: 'changed outside direct file tools' badge (TASK-1978)

### DIFF
--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -700,3 +700,51 @@ def test_badge_span_is_monochrome():
     assert badge_spans and all(s.style == "dim" for s in badge_spans), (
         f"badge must be monochrome dim: {label.spans}"
     )
+
+
+@pytest.mark.asyncio
+async def test_deleted_and_renamed_rows_badge_even_when_path_was_tool_touched(
+    tmp_path,
+):
+    """Qodo #1262: no file tool can delete or rename, so D/R rows badge
+    even when the path itself appears in the run's write_file steps."""
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "doomed.txt").write_text("tool wrote me\n")
+    (root / "old.txt").write_text("stable rename content\n" * 5)
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+
+    def mutate():
+        (root / "doomed.txt").unlink()
+        (root / "old.txt").rename(root / "new.txt")
+
+    _record_turn(db, tracker, root, run, mutate)
+    # The run DID write these paths earlier — membership alone would
+    # wrongly suppress the badge on their D/R rows.
+    _append_real_write_step(db, run, str(root / "doomed.txt"))
+    _append_real_write_step(db, run, str(root / "new.txt"))
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="conv-1"
+    )
+    app = _Harness(provider)
+    async with app.run_test(size=(140, 40)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        tree = screen.query_one("#change-review-tree", Tree)
+        labels = await _wait_for(
+            pilot,
+            lambda: (lambda ls: ls if any("doomed.txt" in l for l in ls) else None)(
+                _tree_labels(tree)
+            ),
+            "turn files",
+        )
+        doomed = next(l for l in labels if "doomed.txt" in l)
+        renamed = next(l for l in labels if "new.txt" in l)
+        assert BADGE_COPY in doomed, f"deletion unbadged: {doomed}"
+        assert BADGE_COPY in renamed, f"rename unbadged: {renamed}"

--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -593,3 +593,110 @@ async def test_selecting_a_tree_node_loads_that_files_diff(review_fixture):
             f"diff to switch to {target_change.path} (still showing "
             f"{first_change.path})",
         )
+
+
+def _append_real_write_step(db, run_id: str, path: str) -> None:
+    """Record a write_file step through the PRODUCTION serialization:
+    a real AgentStep dataclass via dataclasses.asdict — the exact shape
+    `AgentService._persist` stores (TASK-1978 AC#4)."""
+    import dataclasses
+
+    from tldw_chatbook.Agents.agent_models import AgentStep
+
+    step = AgentStep(
+        index=0,
+        kind="tool",
+        tool_name="write_file",
+        args={"file_path": path, "content": "x"},
+        result="ok",
+        created_at="2026-08-03T00:00:00.000000Z",
+    )
+    db.append_steps(run_id, [dataclasses.asdict(step)])
+
+
+BADGE_COPY = "⚠ changed outside direct file tools"
+
+
+@pytest.mark.asyncio
+async def test_badge_marks_files_no_write_tool_touched(tmp_path):
+    """TASK-1978 AC#1/#2/#4: tool-written files carry no badge; everything
+    else in the turn does — with the exact spec copy, monochrome."""
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "tooled.txt").write_text("before\n")
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+
+    def mutate():
+        (root / "tooled.txt").write_text("after\n")
+        (root / "scripted.txt").write_text("a script wrote this\n")
+
+    _record_turn(db, tracker, root, run, mutate)
+    _append_real_write_step(db, run, str(root / "tooled.txt"))
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id="conv-1"
+    )
+    app = _Harness(provider)
+    async with app.run_test(size=(140, 40)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        tree = screen.query_one("#change-review-tree", Tree)
+        labels = await _wait_for(
+            pilot,
+            lambda: (lambda ls: ls if any("scripted.txt" in l for l in ls) else None)(
+                _tree_labels(tree)
+            ),
+            "turn files",
+        )
+        scripted = next(l for l in labels if "scripted.txt" in l)
+        tooled = next(l for l in labels if "tooled.txt" in l)
+        assert BADGE_COPY in scripted, scripted
+        assert BADGE_COPY not in tooled, (
+            "a write_file-touched file must NOT be badged"
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_with_no_recorded_steps_renders_no_badges(review_fixture):
+    """TASK-1978 AC#3: older data without steps must not badge everything."""
+    provider, root, run1, run2 = review_fixture
+    app = _Harness(provider)
+    async with app.run_test(size=(140, 40)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        tree = screen.query_one("#change-review-tree", Tree)
+        labels = await _wait_for(
+            pilot,
+            lambda: (lambda ls: ls if any("new.txt" in l for l in ls) else None)(
+                _tree_labels(tree)
+            ),
+            "turn files",
+        )
+        assert not any(BADGE_COPY in l for l in labels), (
+            "a stepless run badged its files"
+        )
+
+
+def test_badge_span_is_monochrome():
+    """TASK-1978 AC#2: the badge renders dim, never colored."""
+    from tldw_chatbook.Workspaces.change_tracking import ChangedFile
+
+    label = ChangeReviewScreen._leaf_label(
+        {"root": "/r"},
+        ChangedFile(path="a.txt", status="M", adds=1, dels=0),
+        multi_root=False,
+        badge=True,
+    )
+    assert BADGE_COPY in str(label)
+    badge_spans = [s for s in label.spans if s.style]
+    assert badge_spans and all(s.style == "dim" for s in badge_spans), (
+        f"badge must be monochrome dim: {label.spans}"
+    )

--- a/backlog/tasks/task-1978 - Change-review-tool-log-badge.md
+++ b/backlog/tasks/task-1978 - Change-review-tool-log-badge.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1978
 title: 'Change review: ''changed outside direct file tools'' badge'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -24,8 +24,46 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A write_file-modified file carries no badge; a file created by a script the agent ran carries the badge
-- [ ] #2 Badge text matches the spec copy exactly and renders in monochrome
-- [ ] #3 A run with no recorded steps (older data) renders without badges rather than badging everything
-- [ ] #4 Badge derivation is tested against real recorded step shapes, not hand-built dicts
+- [x] #1 A write_file-modified file carries no badge; a file created by a script the agent ran carries the badge
+- [x] #2 Badge text matches the spec copy exactly and renders in monochrome
+- [x] #3 A run with no recorded steps (older data) renders without badges rather than badging everything
+- [x] #4 Badge derivation is tested against real recorded step shapes, not hand-built dicts
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Provider `tool_touched_relpaths(row)`: run's persisted steps (real
+   asdict(AgentStep) shape) through the SAME `tool_touched_paths` extractor
+   the force-add carve-out uses, relativized to the row's root; None when
+   the run has no recorded steps (older data -> no badges, AC#3)
+2. `_leaf_label` appends the exact spec copy as a dim (monochrome) Text span
+   for changed files absent from the touched set
+3. RED tests: badged vs unbadged rows against a real fixture turn with
+   steps appended via the production serializer; no-steps run bannerless;
+   exact copy + dim style pinned
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Provider gains `tool_touched_relpaths(row)`: the run's persisted steps
+(the real `asdict(AgentStep)` shape `AgentService._persist` stores) run
+through the SAME `ChangeTurnTracker.tool_touched_paths` extractor the
+force-add carve-out uses — badge and carve-out can never disagree about
+provenance. Paths relativize to the row's root; `None` when the run has
+no recorded steps, and the screen then renders NO badges (AC#3,
+sabotage-verified: badging-everything failed the guard test).
+
+`_leaf_label` appends the exact spec copy "⚠ changed outside direct file
+tools" as a dim (monochrome) Text span for changed files absent from the
+touched set; deletions and renames badge honestly (no file tool can
+delete or rename — a true 'outside direct file tools' change). Derivation
+is memoized per row and exception-guarded — a badge must never break the
+review.
+
+Tests: badged-vs-unbadged against a real fixture turn with a step
+appended via the production serializer (real AgentStep dataclass through
+dataclasses.asdict — AC#4), stepless-run guard, exact-copy + dim-span
+pin. 261 green across all change-review suites before push.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         RevertPreflight,
     )
 
+from loguru import logger
 from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
@@ -485,9 +486,20 @@ class ChangeReviewScreen(Screen):
                         row
                     )
                 except Exception:  # noqa: BLE001 -- a badge must never break review
+                    logger.opt(exception=True).warning(
+                        "change_review: badge derivation failed for "
+                        f"{row.get('root')!r}; rendering without badges"
+                    )
                     touched_by_row[rid] = None
             touched = touched_by_row[rid]
-            return touched is not None and change.path not in touched
+            if touched is None:
+                return False
+            # Qodo #1262: no file tool can DELETE or RENAME — those rows
+            # badge regardless of path membership (a write_file-created
+            # path later script-deleted must not launder the deletion).
+            if change.status in ("D", "R"):
+                return True
+            return change.path not in touched
 
         known = {code for code, _label in _GROUPS}
         for code, label in _GROUPS:

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -163,6 +163,46 @@ class AgentRunsChangeReviewProvider:
             )
         return turns
 
+    def tool_touched_relpaths(self, row: dict) -> "set[str] | None":
+        """Root-relative paths the run's recorded WRITE tools touched.
+
+        TASK-1978: the badge derivation. Uses the SAME extractor the
+        force-add carve-out runs over the SAME persisted step shape, so
+        the badge and the carve-out can never disagree about provenance.
+
+        Args:
+            row: One ``change_snapshots`` row.
+
+        Returns:
+            The touched set, or ``None`` when the run has no recorded
+            steps (older data) — callers must then render NO badges
+            rather than badging everything.
+        """
+        run = self._db.get_run(str(row.get("run_id") or ""))
+        steps = (run or {}).get("steps") or []
+        if not steps:
+            return None
+        from pathlib import Path as _P
+
+        from tldw_chatbook.Workspaces.change_turn_tracker import (
+            ChangeTurnTracker,
+        )
+
+        root = _P(str(row["root"]))
+        rel: set[str] = set()
+        for raw in ChangeTurnTracker.tool_touched_paths(steps):
+            try:
+                rel.add(
+                    _P(raw)
+                    .expanduser()
+                    .resolve()
+                    .relative_to(root)
+                    .as_posix()
+                )
+            except (ValueError, OSError):
+                continue
+        return rel
+
     def snapshots_pruned(self, row: dict) -> bool:
         """Whether a row's snapshots no longer exist (retention reset).
 
@@ -435,6 +475,20 @@ class ChangeReviewScreen(Screen):
                         f"⚠ diff unavailable for {row['root']}: {exc}"
                     )
 
+        touched_by_row: dict[int, "set[str] | None"] = {}
+
+        def _badged(row: dict, change: ChangedFile) -> bool:
+            rid = id(row)
+            if rid not in touched_by_row:
+                try:
+                    touched_by_row[rid] = self._provider.tool_touched_relpaths(
+                        row
+                    )
+                except Exception:  # noqa: BLE001 -- a badge must never break review
+                    touched_by_row[rid] = None
+            touched = touched_by_row[rid]
+            return touched is not None and change.path not in touched
+
         known = {code for code, _label in _GROUPS}
         for code, label in _GROUPS:
             entries = grouped.get(code, [])
@@ -445,7 +499,9 @@ class ChangeReviewScreen(Screen):
                 # TASK-2032: the node carries its leaf index so a MOUSE
                 # selection can load the diff (j/k was the only loader).
                 branch.add_leaf(
-                    self._leaf_label(row, change, multi_root),
+                    self._leaf_label(
+                        row, change, multi_root, badge=_badged(row, change)
+                    ),
                     data=len(self._leaves),
                 )
                 self._leaves.append((row, change))
@@ -461,7 +517,9 @@ class ChangeReviewScreen(Screen):
                 # TASK-2032: the node carries its leaf index so a MOUSE
                 # selection can load the diff (j/k was the only loader).
                 branch.add_leaf(
-                    self._leaf_label(row, change, multi_root),
+                    self._leaf_label(
+                        row, change, multi_root, badge=_badged(row, change)
+                    ),
                     data=len(self._leaves),
                 )
                 self._leaves.append((row, change))
@@ -481,7 +539,12 @@ class ChangeReviewScreen(Screen):
             self._show_empty("No file changes in this turn.")
 
     @staticmethod
-    def _leaf_label(row: dict, change: ChangedFile, multi_root: bool) -> Text:
+    def _leaf_label(
+        row: dict,
+        change: ChangedFile,
+        multi_root: bool,
+        badge: bool = False,
+    ) -> Text:
         """Build one leaf label as a PLAIN rich Text.
 
         Tree labels are markup-PARSED when given as strings — "[binary]"
@@ -500,7 +563,16 @@ class ChangeReviewScreen(Screen):
             from pathlib import Path as _P
 
             parts.append(f"· {_P(str(row['root'])).name}")
-        return Text("  ".join(parts))
+        label = Text("  ".join(parts))
+        if badge:
+            # TASK-1978: exact spec copy — 'outside direct file tools',
+            # never 'not by the agent' (script writes are agent work too,
+            # and badge absence is not proof of tool provenance). Dim,
+            # monochrome.
+            label.append(
+                "  ⚠ changed outside direct file tools", style="dim"
+            )
+        return label
 
     def _show_empty(self, copy: str) -> None:
         self.query_one("#change-review-diff-content", Static).update(copy)


### PR DESCRIPTION
## Summary
- The B..E attribution limit becomes signal: files no recorded WRITE tool touched get a `⚠ changed outside direct file tools` badge in the Review tree — script side effects and external writers become visible AS SUCH
- Derivation reuses the exact extractor and persisted step shape the force-add carve-out uses (`ChangeTurnTracker.tool_touched_paths` over `asdict(AgentStep)`), so badge and carve-out can never disagree; memoized per row and exception-guarded
- Copy is exact per spec ("outside direct file tools", never "not by the agent") and renders as a dim monochrome span; runs with no recorded steps (older data) render without badges rather than badging everything — sabotage-verified

## Testing
- Badged-vs-unbadged against a real fixture turn with a write_file step appended via the production serializer; stepless-run guard; exact-copy + dim-span pin; 261 green across all change-review suites before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dim "⚠ changed outside direct file tools" badge in Change Review for files not touched by recorded WRITE tools, making script/external changes visible. Uses the same extractor and persisted step shape as the force-add carve-out; stepless runs show no badges, and derivation failures log and degrade to no badges (TASK-1978).

- **New Features**
  - Cross-references changed files with recorded WRITE-tool steps (same extractor and persisted `asdict(AgentStep)` as the force-add carve-out); unmatched files get the dim, monochrome badge.

- **Bug Fixes**
  - Deletions and renames always badge, even if the path appears in write steps (Qodo #1262).
  - Badge derivation errors are logged and fall back to no badges.

<sup>Written for commit 1c6ea9cb2d05a79eb8a0ab040a3a617eb4fc6918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

