### PR TITLE
fix: isolate per-URL failures in url_list/sitemap runs, preserving auto-pause (task-1394)

### DIFF
--- a/Tests/Scheduling/test_watchlist_check_handler.py
+++ b/Tests/Scheduling/test_watchlist_check_handler.py
@@ -129,6 +129,62 @@ async def test_every_executable_type_is_launched_as_a_run(handler, sub_type):
 
 
 @pytest.mark.asyncio
+async def test_partial_url_errors_are_visible_in_the_metric_and_a_warning(
+    handler, metrics_patch
+):
+    """TASK-1394 Qodo: a url_list/sitemap run that isolates a per-URL failure
+    still completes, so a status-only reader would metric it as a clean
+    success. The handler must surface the error count -- a `url_errors` metric
+    label and a per-run WARNING -- so a recurring dead URL is visible outside
+    the Runs pane.
+
+    Args:
+        handler: The `WatchlistCheckHandler` fixture (mock service/DB).
+        metrics_patch: `(log_counter, log_histogram)` patched to capture labels.
+    """
+    counter, _histogram = metrics_patch
+    handler.subscriptions_db.get_subscription.return_value = _subscription("url_list")
+    # A completed run whose dispositions record one isolated URL error.
+    handler.watchlists_service.execute_run.return_value = {
+        "run_id": 7,
+        "status": "completed",
+        "stats": {"new_items_found": 2, "dispositions": {"changed": 2, "error": 1}},
+    }
+
+    await handler.handle(_task())
+
+    _args, kwargs = counter.call_args
+    assert kwargs["labels"]["status"] == "success"
+    assert kwargs["labels"]["url_errors"] == "true", (
+        "a completed run with error dispositions must be distinguishable in "
+        "the metric from a clean success"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_clean_run_carries_no_url_errors_label(handler, metrics_patch):
+    """The `url_errors` label appears ONLY when a run had per-URL errors, so a
+    clean success is not tagged (TASK-1394 Qodo).
+
+    Args:
+        handler: The `WatchlistCheckHandler` fixture (mock service/DB).
+        metrics_patch: `(log_counter, log_histogram)` patched to capture labels.
+    """
+    counter, _histogram = metrics_patch
+    handler.subscriptions_db.get_subscription.return_value = _subscription("url_list")
+    handler.watchlists_service.execute_run.return_value = {
+        "run_id": 7,
+        "status": "completed",
+        "stats": {"new_items_found": 2, "dispositions": {"changed": 2, "error": 0}},
+    }
+
+    await handler.handle(_task())
+
+    _args, kwargs = counter.call_args
+    assert "url_errors" not in kwargs["labels"]
+
+
+@pytest.mark.asyncio
 async def test_failed_run_is_reported_without_a_second_error_record(handler):
     """`execute_run` handles its own fetch failures and does not re-raise."""
     handler.watchlists_service.execute_run.return_value = {

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -617,6 +617,168 @@ async def test_local_watchlists_service_sitemap_isolates_one_failing_url(
 
 
 @pytest.mark.asyncio
+async def test_local_watchlists_service_url_list_all_error_advances_breaker_and_pauses(
+    tmp_path, monkeypatch
+):
+    """Fix wave, task-1394 whole-branch review Finding #1 (MAJOR).
+
+    The per-URL isolation above (`_check_url_isolated`) correctly turns one
+    dead URL among many into a single `"error"` disposition instead of failing
+    the whole run -- but `execute_run`'s success path used to call
+    `db.record_check_result(source_id, items=None, stats=stats)` with
+    `error=None` UNCONDITIONALLY, even when every single URL in the run
+    errored. That call's success branch
+    (`DB/Subscriptions_DB.py:1504-1517`) resets `consecutive_failures` and
+    `error_count` to 0 on a run that found nothing and whose every check
+    failed -- so a permanently dead `url_list` source could never reach
+    `auto_pause_threshold` and auto-pause; its failure streak was wiped every
+    single run instead of accumulating.
+
+    Discriminator: this test REDs if `_all_error_check_message` is reverted to
+    always return `None` (the pre-fix-wave behaviour) -- the breaker resets to
+    0 instead of advancing to 2, and the source never pauses.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    class FakeURLMonitor:
+        def __init__(self, db):
+            self.db = db
+
+        async def check_url(self, subscription):
+            raise TimeoutError("connect timed out")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.URLMonitor",
+        FakeURLMonitor,
+    )
+    source = await service.create_source(
+        {
+            "name": "Docs",
+            "source_type": "url_list",
+            "auto_pause_threshold": 2,
+            "extraction_rules": {
+                "urls": [
+                    "https://example.com/a",
+                    "https://example.com/b",
+                ],
+            },
+        }
+    )
+    source_id = source["source_id"]
+    # One short of the (lowered, for this test) threshold -- the state a
+    # permanently-broken source would already be in from prior all-dead runs.
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE subscriptions SET consecutive_failures = ?, error_count = ? WHERE id = ?",
+            (1, 1, source_id),
+        )
+    launched = await service.launch_run(source_id=source_id)
+
+    completed = await service.execute_run(launched["run_id"])
+
+    # Honest run status: every URL failed, so the run itself failed -- not a
+    # clean "completed" with zero items.
+    assert completed["status"] == "failed"
+    # AC#2's error-count visibility survives the fix: the dispositions are
+    # still recorded even though the breaker also advanced.
+    assert completed["stats"]["dispositions"] == {
+        "changed": 0,
+        "unchanged": 0,
+        "withheld": 0,
+        "baseline": 0,
+        "rebaselined": 0,
+        "error": 2,
+    }
+    row = db.get_subscription(source_id)
+    assert row["consecutive_failures"] == 2, (
+        "the breaker must ADVANCE on an all-error run, not reset"
+    )
+    assert row["error_count"] == 2
+    assert row["is_paused"] == 1, "threshold reached -- the source must auto-pause"
+    assert row["last_error"], "last_error must be set on an all-error run, not cleared"
+
+
+@pytest.mark.asyncio
+async def test_local_watchlists_service_url_list_partial_error_still_resets_breaker(
+    tmp_path, monkeypatch
+):
+    """Fix wave, task-1394 review Finding #1: a PARTIAL run must not over-correct.
+
+    Companion to the all-error test above. One URL succeeds, one errors --
+    a working, reachable source should still be treated as healthy: the
+    breaker resets to 0 (exactly as a clean run would) and the successful
+    URL's item persists. This pins that the all-error fix does not regress
+    into treating ANY per-URL error as a subscription-level failure.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    class FakeURLMonitor:
+        def __init__(self, db):
+            self.db = db
+
+        async def check_url(self, subscription):
+            url = subscription["source"]
+            if url == "https://example.com/b":
+                raise TimeoutError("connect timed out")
+            return (
+                {
+                    "url": url,
+                    "title": "Changed",
+                    "content_hash": "hash-a",
+                    "published_date": "2026-04-25T00:00:00+00:00",
+                },
+                {"kind": "changed", "reason": None, "withheld_percentage": None},
+            )
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.URLMonitor",
+        FakeURLMonitor,
+    )
+    source = await service.create_source(
+        {
+            "name": "Docs",
+            "source_type": "url_list",
+            "extraction_rules": {
+                "urls": [
+                    "https://example.com/a",
+                    "https://example.com/b",
+                ],
+            },
+        }
+    )
+    source_id = source["source_id"]
+    with db.transaction() as conn:
+        conn.execute(
+            "UPDATE subscriptions SET consecutive_failures = ?, error_count = ? WHERE id = ?",
+            (5, 5, source_id),
+        )
+    launched = await service.launch_run(source_id=source_id)
+
+    completed = await service.execute_run(launched["run_id"])
+
+    assert completed["status"] == "completed", (
+        "at least one URL succeeded -- the run stays completed, not failed"
+    )
+    assert completed["stats"]["dispositions"]["error"] == 1
+    assert completed["stats"]["dispositions"]["changed"] == 1
+    stored_items = db.conn.execute(
+        "SELECT url FROM subscription_items WHERE subscription_id = ?",
+        (source_id,),
+    ).fetchall()
+    assert [row["url"] for row in stored_items] == ["https://example.com/a"]
+
+    row = db.get_subscription(source_id)
+    assert row["consecutive_failures"] == 0, (
+        "a working source is healthy -- the breaker resets on ANY successful check"
+    )
+    assert row["error_count"] == 0
+    assert row["last_error"] is None
+    assert row["is_paused"] == 0
+
+
+@pytest.mark.asyncio
 async def test_local_watchlists_service_executes_api_sources_with_json_field_mapping(
     tmp_path, monkeypatch
 ):

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -425,6 +425,10 @@ async def test_local_watchlists_service_url_list_isolates_one_failing_url(
     all-or-nothing behaviour (confirmed by reverting the
     `_check_url_isolated` try/except and re-running -- see the task's
     Implementation Notes) and passes with the per-URL isolation in place.
+
+    Args:
+        tmp_path: pytest tmp dir for the on-disk `SubscriptionsDB`.
+        monkeypatch: patches the URL monitor so one URL raises.
     """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
@@ -522,6 +526,10 @@ async def test_local_watchlists_service_sitemap_isolates_one_failing_url(
     before this loop starts, so a failure fetching the sitemap itself still
     fails the whole run. This test is only about the per-URL loop that walks
     the URLs the sitemap already produced.
+
+    Args:
+        tmp_path: pytest tmp dir for the on-disk `SubscriptionsDB`.
+        monkeypatch: patches the URL monitor so one URL raises.
     """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
@@ -637,6 +645,10 @@ async def test_local_watchlists_service_url_list_all_error_advances_breaker_and_
     Discriminator: this test REDs if `_all_error_check_message` is reverted to
     always return `None` (the pre-fix-wave behaviour) -- the breaker resets to
     0 instead of advancing to 2, and the source never pauses.
+
+    Args:
+        tmp_path: pytest tmp dir for the on-disk `SubscriptionsDB`.
+        monkeypatch: patches the URL monitor so one URL raises.
     """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
@@ -710,6 +722,10 @@ async def test_local_watchlists_service_url_list_partial_error_still_resets_brea
     breaker resets to 0 (exactly as a clean run would) and the successful
     URL's item persists. This pins that the all-error fix does not regress
     into treating ANY per-URL error as a subscription-level failure.
+
+    Args:
+        tmp_path: pytest tmp dir for the on-disk `SubscriptionsDB`.
+        monkeypatch: patches the URL monitor so one URL raises.
     """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -297,6 +297,8 @@ async def test_local_watchlists_service_executes_url_list_sources_with_default_u
         # first check discarded nothing, a settings-change re-baseline threw
         # away a real diff window.
         "rebaselined": 0,
+        # task-1394: no URL raised in this run.
+        "error": 0,
     }, "the url_list arm must aggregate one disposition per URL checked"
     assert seen_urls == ["https://example.com/a", "https://example.com/b"]
     assert [dict(row) for row in stored_items] == [
@@ -391,6 +393,8 @@ async def test_local_watchlists_service_executes_sitemap_sources_with_default_ur
         "withheld": 0,
         "baseline": 0,
         "rebaselined": 0,
+        # task-1394: no URL raised in this run.
+        "error": 0,
     }, "the sitemap arm must aggregate one disposition per URL checked"
     assert [dict(row) for row in stored_items] == [
         {
@@ -404,6 +408,212 @@ async def test_local_watchlists_service_executes_sitemap_sources_with_default_ur
             "content_hash": "sitemap-hash-2",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_local_watchlists_service_url_list_isolates_one_failing_url(
+    tmp_path, monkeypatch
+):
+    """task-1394 AC#1/#3: one bad URL must not sink the whole `url_list` run.
+
+    Before per-URL isolation, `check_url` raising for ANY url in the loop
+    propagated straight out of `_default_run_executor` uncaught; `execute_run`
+    then caught it at the top level and called `record_run_failure`, which
+    discards the items the OTHER, successful URLs in this same run already
+    collected. A 50-URL source with one dead link used to yield nothing at
+    all. This is the discriminator test: it reds under that old
+    all-or-nothing behaviour (confirmed by reverting the
+    `_check_url_isolated` try/except and re-running -- see the task's
+    Implementation Notes) and passes with the per-URL isolation in place.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    seen_urls = []
+
+    class FakeURLMonitor:
+        def __init__(self, db):
+            self.db = db
+
+        async def check_url(self, subscription):
+            url = subscription["source"]
+            seen_urls.append(url)
+            if url == "https://example.com/b":
+                # Deliberately NOT a subclass of any of the others -- proves
+                # the isolation catches an arbitrary exception, not just one
+                # anticipated type.
+                raise TimeoutError("connect timed out")
+            return (
+                {
+                    "url": url,
+                    "title": f"Changed {len(seen_urls)}",
+                    "content_hash": f"hash-{len(seen_urls)}",
+                    "published_date": "2026-04-25T00:00:00+00:00",
+                },
+                {"kind": "changed", "reason": None, "withheld_percentage": None},
+            )
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.URLMonitor",
+        FakeURLMonitor,
+    )
+    source = await service.create_source(
+        {
+            "name": "Docs",
+            "source_type": "url_list",
+            "extraction_rules": {
+                "urls": [
+                    "https://example.com/a",
+                    "https://example.com/b",
+                    "https://example.com/c",
+                ],
+            },
+        }
+    )
+    launched = await service.launch_run(source_id=source["source_id"])
+
+    completed = await service.execute_run(launched["run_id"])
+
+    stored_items = db.conn.execute(
+        "SELECT url, title, content_hash FROM subscription_items WHERE subscription_id = ? ORDER BY id ASC",
+        (source["source_id"],),
+    ).fetchall()
+    # The run completed -- it did NOT fail via `record_run_failure` merely
+    # because one of its three URLs raised.
+    assert completed["status"] == "completed"
+    # And the loop kept going past the poisoned URL to check the one after it.
+    assert seen_urls == [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+    # The two URLs that succeeded persisted their items...
+    assert [dict(row) for row in stored_items] == [
+        {
+            "url": "https://example.com/a",
+            "title": "Changed 1",
+            "content_hash": "hash-1",
+        },
+        {
+            "url": "https://example.com/c",
+            "title": "Changed 3",
+            "content_hash": "hash-3",
+        },
+    ]
+    # ...and the run's dispositions say exactly one URL errored, rather than
+    # reporting a clean run that simply found less than it should have.
+    assert completed["stats"]["dispositions"] == {
+        "changed": 2,
+        "unchanged": 0,
+        "withheld": 0,
+        "baseline": 0,
+        "rebaselined": 0,
+        "error": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_local_watchlists_service_sitemap_isolates_one_failing_url(
+    tmp_path, monkeypatch
+):
+    """task-1394: the sitemap arm gets the same per-URL isolation as url_list.
+
+    The sitemap FETCH that produces this URL list (`_urls_for_sitemap`) is a
+    separate concern that this task deliberately leaves alone: it runs once,
+    before this loop starts, so a failure fetching the sitemap itself still
+    fails the whole run. This test is only about the per-URL loop that walks
+    the URLs the sitemap already produced.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    seen_urls = []
+
+    SITEMAP_XML = """<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://example.com/page-a</loc></url>
+            <url><loc>https://example.com/page-b</loc></url>
+            <url><loc>https://example.com/page-c</loc></url>
+        </urlset>
+        """
+
+    async def fake_guarded(url, *, client, max_bytes, trusted_origins=frozenset(), headers=None, params=None, auth=None):
+        return SimpleNamespace(
+            status_code=200,
+            headers={"content-type": "application/xml"},
+            text=SITEMAP_XML,
+            final_url=url,
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.local_watchlists_service.guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+
+    class FakeURLMonitor:
+        def __init__(self, db):
+            self.db = db
+
+        async def check_url(self, subscription):
+            url = subscription["source"]
+            seen_urls.append(url)
+            if url == "https://example.com/page-b":
+                raise ConnectionError("connection refused")
+            return (
+                {
+                    "url": url,
+                    "title": f"Sitemap page {len(seen_urls)}",
+                    "content_hash": f"sitemap-hash-{len(seen_urls)}",
+                    "published_date": "2026-04-25T00:00:00+00:00",
+                },
+                {"kind": "changed", "reason": None, "withheld_percentage": None},
+            )
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.URLMonitor",
+        FakeURLMonitor,
+    )
+    source = await service.create_source(
+        {
+            "name": "Docs sitemap",
+            "url": "https://example.com/sitemap.xml",
+            "source_type": "sitemap",
+            "processing_options": {"max_urls": 3},
+        }
+    )
+    launched = await service.launch_run(source_id=source["source_id"])
+
+    completed = await service.execute_run(launched["run_id"])
+
+    stored_items = db.conn.execute(
+        "SELECT url, title, content_hash FROM subscription_items WHERE subscription_id = ? ORDER BY id ASC",
+        (source["source_id"],),
+    ).fetchall()
+    assert completed["status"] == "completed"
+    assert seen_urls == [
+        "https://example.com/page-a",
+        "https://example.com/page-b",
+        "https://example.com/page-c",
+    ]
+    assert [dict(row) for row in stored_items] == [
+        {
+            "url": "https://example.com/page-a",
+            "title": "Sitemap page 1",
+            "content_hash": "sitemap-hash-1",
+        },
+        {
+            "url": "https://example.com/page-c",
+            "title": "Sitemap page 3",
+            "content_hash": "sitemap-hash-3",
+        },
+    ]
+    assert completed["stats"]["dispositions"] == {
+        "changed": 2,
+        "unchanged": 0,
+        "withheld": 0,
+        "baseline": 0,
+        "rebaselined": 0,
+        "error": 1,
+    }
 
 
 @pytest.mark.asyncio

--- a/Tests/Subscriptions/test_watchlist_noise_not_volume.py
+++ b/Tests/Subscriptions/test_watchlist_noise_not_volume.py
@@ -496,6 +496,8 @@ _NO_DISPOSITIONS = {
     "withheld": 0,
     "baseline": 0,
     "rebaselined": 0,
+    # task-1394: a URL that raised instead of completing `check_url`.
+    "error": 0,
 }
 
 
@@ -528,6 +530,11 @@ def test_disposition_count_keys_are_bound_to_the_real_constants():
     that must not be aggregated -- and the two `REASON_*` constants are pinned
     to their own counters here for the same anti-drift reason the kinds are.
     Collapsing `baseline`/`rebaselined` back into one counter reddens this.
+
+    task-1394 added a sixth pair, `(DISPOSITION_ERROR, None)`, for a `check_url`
+    call that raised instead of returning; it is pinned here too, and by the
+    same reasoning -- a rename of `DISPOSITION_ERROR` that drifted from this
+    binding would `KeyError` on the very run it exists to keep from failing.
     """
     from tldw_chatbook.Subscriptions import monitoring_engine
     from tldw_chatbook.Subscriptions.local_watchlists_service import (
@@ -551,7 +558,11 @@ def test_disposition_count_keys_are_bound_to_the_real_constants():
             monitoring_engine.DISPOSITION_BASELINE_STORED,
             monitoring_engine.REASON_EXTRACTION_SETTINGS_CHANGED,
         ),
+        (monitoring_engine.DISPOSITION_ERROR, None),
     }
+    assert (
+        mapping[(monitoring_engine.DISPOSITION_ERROR, None)] == "error"
+    )
     assert mapping[(monitoring_engine.DISPOSITION_CHANGED, None)] == "changed"
     assert mapping[(monitoring_engine.DISPOSITION_UNCHANGED, None)] == "unchanged"
     assert (
@@ -588,6 +599,40 @@ def test_disposition_count_keys_are_bound_to_the_real_constants():
     # fills, so a run can never omit a key the Runs pane reads.
     assert set(mapping.values()) == set(_DISPOSITION_COUNTERS)
     assert set(_DISPOSITION_COUNTERS) == set(_NO_DISPOSITIONS)
+
+
+def test_removing_the_error_mapping_keyerrors_instead_of_miscounting(monkeypatch):
+    """task-1394 mutation guard: the `(DISPOSITION_ERROR, None)` pair added to
+    `_disposition_count_keys` is load-bearing, not decorative.
+
+    Proves it the same way the five pre-existing pairs are already proven
+    load-bearing (see `test_disposition_count_keys_are_bound_to_the_real_
+    constants`'s docstring): delete just that one pair from the binding and
+    show `_disposition_counts` blows up on an error disposition instead of
+    silently mis-sorting it, which is the deliberately loud behaviour its own
+    docstring promises for any unlisted `(kind, reason)` pair.
+    """
+    from tldw_chatbook.Subscriptions import local_watchlists_service as service_module
+    from tldw_chatbook.Subscriptions.monitoring_engine import DISPOSITION_ERROR
+
+    original_count_keys = service_module._disposition_count_keys
+
+    def mapping_without_error() -> dict[tuple[str, str | None], str]:
+        mapping = dict(original_count_keys())
+        del mapping[(DISPOSITION_ERROR, None)]
+        return mapping
+
+    monkeypatch.setattr(
+        service_module, "_disposition_count_keys", mapping_without_error
+    )
+
+    error_disposition = {
+        "kind": DISPOSITION_ERROR,
+        "reason": None,
+        "withheld_percentage": None,
+    }
+    with pytest.raises(KeyError):
+        service_module._disposition_counts([error_disposition])
 
 
 async def _url_source(monkeypatch, pages: list[str], **payload):

--- a/Tests/Watchlists/test_watchlists_runs_pane.py
+++ b/Tests/Watchlists/test_watchlists_runs_pane.py
@@ -224,6 +224,8 @@ def _disposition_run(**dispositions: int) -> dict[str, object]:
             "withheld": 0,
             "baseline": 0,
             "rebaselined": 0,
+            # task-1394: a URL that raised instead of completing `check_url`.
+            "error": 0,
             **dispositions,
         },
     }
@@ -244,6 +246,25 @@ def test_stats_text_shows_check_dispositions_when_present():
     assert "1 baseline" in text
     assert "0 withheld" in text
     assert "2 re-baselined" in text
+
+
+def test_stats_text_shows_the_error_count_for_a_partially_failed_run():
+    """task-1394, AC#2: a partially-failed run must say so, not read clean.
+
+    `url_list`/`sitemap` runs now isolate per-URL failures instead of
+    aborting the whole run, so a run that had one bad URL among several
+    completes normally with the OTHER urls' items intact. Without a rendered
+    error count, that run would look indistinguishable from one where every
+    URL was checked cleanly and simply had nothing to report -- the same
+    silence spec §4 was written to remove for the other four dispositions.
+    """
+    text = RunsPane._stats_text(_disposition_run(changed=2, error=1))
+    assert "1 error" in text
+
+    # And a clean run explicitly reports zero rather than omitting the count,
+    # matching every other counter on this line (`0 withheld`, `0 baseline`).
+    clean = RunsPane._stats_text(_disposition_run(changed=2))
+    assert "0 error" in clean
 
 
 def test_stats_text_distinguishes_a_first_check_from_a_settings_rebaseline():

--- a/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
+++ b/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
@@ -130,4 +130,68 @@ Modified files: `tldw_chatbook/Subscriptions/local_watchlists_service.py`,
 `tldw_chatbook/Subscriptions/monitoring_engine.py`, `tldw_chatbook/UI/Watchlists_Modules/
 runs_pane.py`, `Tests/Subscriptions/test_local_watchlists_service.py`, `Tests/Subscriptions/
 test_watchlist_noise_not_volume.py`, `Tests/Watchlists/test_watchlists_runs_pane.py`.
+
+### Fix wave (whole-branch review, Finding #1 -- MAJOR)
+
+The review caught a real regression the "whole-run posture" paragraph above missed: it reasoned
+about run-level visibility only, not the subscription's own health tracking. `execute_run`'s
+success path called `db.record_check_result(source_id, items=None, stats=stats)` with `error=None`
+UNCONDITIONALLY -- including for a run where every single URL errored. That call's success branch
+(`DB/Subscriptions_DB.py:1504-1517`) resets `consecutive_failures`/`error_count` to 0 and clears
+`last_error` on every run, so a permanently dead `url_list`/`sitemap` source (every URL down) could
+never accumulate toward `auto_pause_threshold` and auto-pause -- pre-task-1394 it would have raised
+and reached `record_run_failure` -> `record_check_error`, advancing the breaker normally. The
+isolation fix silently defeated the circuit breaker for exactly the "everything is dead" case it
+should matter most for.
+
+Fix: added `_all_error_check_message(dispositions_counts, item_count)` in
+`local_watchlists_service.py`, called from `execute_run` right before `db.record_check_result`. It
+reads the SAME `stats["dispositions"]` counters the run already produced -- returns a type-only
+synthetic message (`"all {n} checked URL(s) failed"`, counts only, no URL/exception text, matching
+`_check_url_isolated`'s own type-only logging) when `error` count > 0 AND every one of the five
+success counters (`changed`/`unchanged`/`withheld`/`baseline`/`rebaselined`) is 0 AND zero items
+were produced; `None` otherwise. Passing that message as `record_check_result`'s `error=` argument
+routes the run through the DB's error branch instead of its success branch, so the breaker
+ADVANCES and auto-pause fires at threshold exactly as pre-task-1394. The circuit-breaker semantics
+this settles on: **an all-error run advances the breaker (and can auto-pause); a partial run
+(>=1 successful check) resets it, same as a fully clean run** -- a source that made ANY real
+progress is healthy, only a source that produced nothing but errors is not. Feed/API-arm runs
+carry no `dispositions` key at all (`stats.get("dispositions")` is `None`), so they are structurally
+unaffected and keep resetting the breaker on every non-raising run, unchanged.
+
+Run status wiring: chose to compute this in `execute_run` (not inside `_default_run_executor`)
+because `execute_run` is the one place that already has `raw_items`, `stats`, and `source_id`
+together, and doing it there makes the behaviour apply to ANY executor (including a test's custom
+`run_executor=`) that produces a `dispositions` stats shape matching the pattern, not only the
+built-in `url_list`/`sitemap` arms. When `_all_error_check_message` returns non-`None` and the
+executor's own status would otherwise default to `"completed"`, `execute_run` overrides it to
+`"failed"` -- more honest than "completed" with zero items -- and folds the synthetic message into
+`error_msg` too (only when the executor didn't already supply one). A partial run's status and
+`error_msg` are untouched. The dispositions/stats payload is identical either way; only `status`,
+`error_msg`, and the DB breaker call change.
+
+Tests added (`Tests/Subscriptions/test_local_watchlists_service.py`):
+- `test_local_watchlists_service_url_list_all_error_advances_breaker_and_pauses` -- pre-sets
+  `consecutive_failures = auto_pause_threshold - 1` on a `url_list` source, both URLs raise;
+  asserts `status == "failed"`, `dispositions == {..., "error": 2}`, `consecutive_failures`
+  advanced to the threshold, `is_paused == 1`, and `last_error` set. Mutation-verified: reverted
+  `_all_error_check_message` to always `return None` and re-ran -- RED
+  (`assert 'completed' == 'failed'`, breaker would have reset instead of advancing); restored the
+  fix and confirmed green again, `git status --short` clean throughout.
+- `test_local_watchlists_service_url_list_partial_error_still_resets_breaker` -- one URL succeeds
+  (item persists), one errors, `consecutive_failures` pre-set to 5; asserts the item persisted,
+  `dispositions["error"] == 1`, `status == "completed"`, and `consecutive_failures`/`error_count`
+  reset to 0 with `last_error is None` -- pins that the fix does not over-correct into failing
+  partial runs. Stayed green under the same mutation (confirming it discriminates the two cases
+  rather than accidentally passing regardless).
+
+Verified: both new tests plus all 17 pre-existing `test_local_watchlists_service.py` tests (19
+passed); `Tests/Watchlists/test_watchlists_runs_pane.py` (16 passed, unaffected);
+`Tests/Scheduling/test_scheduled_watchlist_runs.py` (13 passed, unaffected -- its auto-pause tests
+use `type="url"`, which this fix wave does not touch); `Tests/Subscriptions/ -k "disposition or
+url_list or pause or breaker or failure"` (27 passed); `--collect-only Tests/Subscriptions
+Tests/Watchlists Tests/Scheduling` (1257 collected, no errors).
+
+Modified files (fix wave): `tldw_chatbook/Subscriptions/local_watchlists_service.py`,
+`Tests/Subscriptions/test_local_watchlists_service.py`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
+++ b/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1394
 title: One failing URL fails a whole url_list run and discards collected items
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-30 05:20'
 labels:
@@ -34,3 +34,17 @@ pane rather than reporting clean counts.
 - [ ] #2 The failure is visible per run (an error count or disposition in the Runs detail), not silently absorbed
 - [ ] #3 A test with one poisoned URL among several fails under the old all-or-nothing behaviour
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. `_default_run_executor` (`local_watchlists_service.py`): wrap each `monitor.check_url(...)` in the
+   `url_list` AND `sitemap` loops in try/except. On exception, append a NEW `error` disposition
+   (type-only, no URL/content in the recorded value) and continue — never add to `items`, never
+   raise out of the loop. Items/dispositions from the URLs that succeeded persist (AC#1).
+2. Add a 6th `error` counter to `_ALL_DISPOSITION_COUNTERS` (:68) + `_disposition_counts` mapping so
+   a partially/fully-failed run reports its error count in `run_stats["dispositions"]` (AC#2).
+3. Render the error count in `runs_pane.py`'s Checks line (~:162) alongside changed/unchanged/etc.
+4. Tests: one poisoned URL among several → succeeded items persist + error counter = 1 (AC#1/#2);
+   the same test REDs without the try/except (poisoned URL raises, whole run fails — AC#3).
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
+++ b/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
@@ -30,9 +30,9 @@ pane rather than reporting clean counts.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A url_list run with one failing URL persists the items and dispositions from the URLs that succeeded
-- [ ] #2 The failure is visible per run (an error count or disposition in the Runs detail), not silently absorbed
-- [ ] #3 A test with one poisoned URL among several fails under the old all-or-nothing behaviour
+- [x] #1 A url_list run with one failing URL persists the items and dispositions from the URLs that succeeded
+- [x] #2 The failure is visible per run (an error count or disposition in the Runs detail), not silently absorbed
+- [x] #3 A test with one poisoned URL among several fails under the old all-or-nothing behaviour
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,3 +48,86 @@ pane rather than reporting clean counts.
 4. Tests: one poisoned URL among several → succeeded items persist + error counter = 1 (AC#1/#2);
    the same test REDs without the try/except (poisoned URL raises, whole run fails — AC#3).
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extracted the per-URL `monitor.check_url(...)` call (identical in both the `url_list` and
+`sitemap` loops of `_default_run_executor`) into a new static helper,
+`LocalWatchlistsService._check_url_isolated`, so both arms share one `try/except Exception`
+instead of duplicating it. On success it returns `check_url`'s result unchanged; on any exception
+it logs `type(exc).__name__` only (never the message or the URL — both can carry fetched page
+content or a sensitive query string) and returns `(None, {"kind": DISPOSITION_ERROR, "reason":
+None, "withheld_percentage": None})`, letting the caller's loop treat it exactly like any other
+disposition and move on to the next URL. Neither loop's item list nor its dispositions list is
+touched beyond that — everything the OTHER urls collected persists (AC#1).
+
+Added `DISPOSITION_ERROR = "error"` to `monitoring_engine.py` alongside the other four
+`DISPOSITION_*` constants (with a docstring noting it's synthesized by the caller around a
+`check_url` call that never returned, not one of `check_url`'s own outcomes), appended `"error"`
+to `_DISPOSITION_COUNTERS` (last, so the five pre-existing counters keep their position for
+anything that might read the tuple positionally — nothing currently does, checked), and added
+`(DISPOSITION_ERROR, None): "error"` to `_disposition_count_keys()`. `reason` is fixed at `None`
+for this pair, deliberately: the counter answers "how many URLs errored", not "which exception",
+so one stable pair covers every exception type rather than needing one entry per type (which
+would defeat the existing "unlisted pair raises KeyError" safety net for the other five kinds).
+`_max_withheld_percentage` needed no change — it already filters on `withheld_percentage is not
+None`, and the error disposition's is `None`.
+
+Rendered the error count in `runs_pane.py`'s `_stats_text` Checks line, appended after
+`re-baselined`, unconditionally (matching how `changed`/`unchanged`/`baseline`/`rebaselined`
+already render regardless of count — only the withheld-percentage suffix is conditional on the
+existing convention, and that convention is untouched).
+
+The sitemap arm's URL-producing fetch (`_urls_for_sitemap`, an `await` evaluated once before the
+`for` loop starts) is deliberately NOT wrapped by `_check_url_isolated` or any new try/except: a
+failure fetching the sitemap itself still fails the whole run exactly as before, because there is
+no per-URL work to isolate at that point.
+
+Whole-run posture: a run with >=1 URL error and >=1 success completes normally (`record_run_result`,
+not `record_run_failure`) with the successful items/dispositions persisted and `dispositions.error`
+counting the failures. A run where every URL errors also completes normally rather than hard-
+failing -- `items` is empty and `dispositions.error` equals the URL count, which is an honest,
+visible report per AC#2 rather than a fabricated "clean, nothing found" run. No special-cased
+hard-fail path was added for the all-errors case; the task's own AC#2 treats "the failure is
+visible" as sufficient, and the run failing outright would put it back at pre-fix behaviour for a
+50-URL source whose FIRST url happens to be dead.
+
+Tests added (`Tests/Subscriptions/test_local_watchlists_service.py`):
+- `test_local_watchlists_service_url_list_isolates_one_failing_url` -- the AC#1/#3 discriminator: 3
+  URLs, the middle one raises `TimeoutError`, the other two persist their items and the run
+  completes with `dispositions == {..., "error": 1}`. Verified this REDs under the pre-fix
+  all-or-nothing behaviour by temporarily stripping the `try/except` from `_check_url_isolated`
+  and re-running (`status` came back `"failed"` instead of `"completed"`), then restored the fix.
+- `test_local_watchlists_service_sitemap_isolates_one_failing_url` -- same shape for the sitemap
+  arm, with a poisoned `ConnectionError` mid-list. Also confirmed RED under the same mutation.
+
+Tests added (`Tests/Subscriptions/test_watchlist_noise_not_volume.py`):
+- Extended `test_disposition_count_keys_are_bound_to_the_real_constants` with the sixth
+  `(DISPOSITION_ERROR, None)` pair.
+- `test_removing_the_error_mapping_keyerrors_instead_of_miscounting` -- mutation guard: monkeypatches
+  `_disposition_count_keys` to drop the error pair and asserts `_disposition_counts` raises
+  `KeyError` on an error disposition, proving the mapping is load-bearing rather than decorative.
+- `_NO_DISPOSITIONS` (the shared zero-fill fixture reused by `Tests/Subscriptions/
+  test_watchlist_snapshot_pruning.py` and `Tests/UI/test_watchlists_inspector.py` via `_counts`) now
+  includes `"error": 0`.
+
+Tests added (`Tests/Watchlists/test_watchlists_runs_pane.py`):
+- `test_stats_text_shows_the_error_count_for_a_partially_failed_run` -- asserts the rendered Checks
+  line includes `"1 error"` for a partially-failed run and `"0 error"` for a clean one.
+- `_disposition_run`'s fixture dict now includes `"error": 0` by default.
+
+Existing tests updated for the new 6-key shape (the only permitted edits to pre-existing tests,
+per the task brief): the two hardcoded 5-key `dispositions` dict literals in
+`test_local_watchlists_service.py`'s url_list/sitemap execution tests now include `"error": 0`.
+
+Verified: the new/updated tests, full `Tests/Subscriptions/` + `Tests/Watchlists/` (991 passed),
+`Tests/Scheduling/` (264 passed, unaffected -- it drives the real `check_url` through the scheduled
+handler with no failing URLs in its fixtures), and `Tests/UI/test_watchlists_inspector.py` (35
+passed, uses the same `_counts`/`_dispositions` fixtures).
+
+Modified files: `tldw_chatbook/Subscriptions/local_watchlists_service.py`,
+`tldw_chatbook/Subscriptions/monitoring_engine.py`, `tldw_chatbook/UI/Watchlists_Modules/
+runs_pane.py`, `Tests/Subscriptions/test_local_watchlists_service.py`, `Tests/Subscriptions/
+test_watchlist_noise_not_volume.py`, `Tests/Watchlists/test_watchlists_runs_pane.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py
@@ -148,6 +148,7 @@ class WatchlistCheckHandler:
         subscription_type = "unknown"
         status = _STATUS_MISSING
         run_id: Any = None
+        had_url_errors = False
 
         try:
             subscription_id = self._parse_subscription_id(task.get("id"))
@@ -217,11 +218,28 @@ class WatchlistCheckHandler:
                 )
             else:
                 status = _STATUS_SUCCESS
-                logger.info(
-                    f"Subscription check complete: '{subscription.get('name')}' - "
-                    f"run {run_id} {run_status or 'completed'}, "
-                    f"{stats.get('new_items_found', 0)} new items"
-                )
+                # A url_list/sitemap run isolates per-URL failures into an
+                # `error` disposition and still completes (TASK-1394), so a
+                # status-only reader here would metric a run with dead URLs as
+                # a clean success. Surface the count: a per-run WARNING (not
+                # per-URL -- low noise) and a low-cardinality metric label, so
+                # a recurring dead/blocked URL is visible outside the Runs
+                # pane. Count only, never the URL or the error text.
+                url_errors = int((stats.get("dispositions") or {}).get("error", 0))
+                if url_errors:
+                    had_url_errors = True
+                    logger.warning(
+                        f"Subscription check completed WITH ERRORS: "
+                        f"'{subscription.get('name')}' - run {run_id}, "
+                        f"{url_errors} URL(s) failed, "
+                        f"{stats.get('new_items_found', 0)} new items"
+                    )
+                else:
+                    logger.info(
+                        f"Subscription check complete: '{subscription.get('name')}' - "
+                        f"run {run_id} {run_status or 'completed'}, "
+                        f"{stats.get('new_items_found', 0)} new items"
+                    )
 
         except Exception as exc:
             status = _STATUS_ERROR
@@ -234,6 +252,11 @@ class WatchlistCheckHandler:
                 "status": status,
                 "subscription_type": subscription_type,
             }
+            if had_url_errors:
+                # Distinguishes a clean success from a completed-with-URL-errors
+                # run in the metric, without the cardinality of a raw count
+                # (TASK-1394).
+                labels["url_errors"] = "true"
             if self.shadow_mode:
                 labels["shadow"] = "true"
             log_counter("watchlist_checks", labels=labels)

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -174,6 +174,73 @@ def _disposition_counts(dispositions: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
+#: The `_DISPOSITION_COUNTERS` entries that mean "this URL's check_url call
+#: actually succeeded" -- every counter except `"error"`. Named as a tuple
+#: comprehension over `_DISPOSITION_COUNTERS` rather than re-spelled here so
+#: the all-error detection below cannot silently drift from the counters it
+#: is reading (same rationale as `_disposition_count_keys`'s docstring).
+_SUCCESS_DISPOSITION_COUNTERS: tuple[str, ...] = tuple(
+    counter for counter in _DISPOSITION_COUNTERS if counter != "error"
+)
+
+
+def _all_error_check_message(
+    dispositions_counts: Mapping[str, Any] | None, item_count: int
+) -> str | None:
+    """A type-only synthetic error for a `url_list`/`sitemap` run where every URL failed.
+
+    Fix wave for the task-1394 whole-branch review (Finding #1, MAJOR): the
+    per-URL isolation in `_check_url_isolated` correctly turns one dead URL
+    among many into a single `"error"` disposition rather than failing the
+    whole run -- but `execute_run`'s success path always called
+    `db.record_check_result(source_id, items=None, stats=stats)` with
+    `error=None`, which hits that method's success branch
+    (`DB/Subscriptions_DB.py:1504-1517`) and unconditionally RESETS the
+    subscription's auto-pause circuit breaker
+    (`consecutive_failures`/`error_count` -> 0), even when every single URL in
+    the run errored and nothing was found. A permanently-broken `url_list`/
+    `sitemap` source could then never reach `auto_pause_threshold`: its
+    failure streak was wiped every run instead of accumulating, exactly the
+    behaviour `record_check_error` (the pre-fix path, reached via
+    `record_run_failure`) used to provide.
+
+    This distinguishes that "every URL errored" case from the ordinary
+    partial-failure case the isolation was written for (some URLs succeed,
+    one or two do not): a partial run made genuine progress on a reachable
+    source and should keep resetting the breaker, exactly as a clean run
+    would. Only when there is not one single successful check in the whole
+    run does the source's own health tracking need to see a failure.
+
+    Args:
+        dispositions_counts: The run's `_disposition_counts()` output (the
+            `stats["dispositions"]` dict), or `None` for source types that
+            carry no dispositions at all (the feed and API arms) -- those are
+            deliberately unaffected and always return `None` here.
+        item_count: How many items the run produced overall (pre-filter), so
+            a run that somehow reported all-error dispositions yet still
+            surfaced an item is never treated as a total failure.
+
+    Returns:
+        A message counting only URLs, e.g. ``"all 2 checked URL(s) failed"``
+        -- no URL, no exception message, matching `_check_url_isolated`'s own
+        type-only logging -- when every disposition in the run was an error
+        and zero items were produced. `None` otherwise (nothing to record, or
+        this is a feed/api run with no dispositions to judge by).
+    """
+    if not isinstance(dispositions_counts, Mapping):
+        return None
+    error_count = int(dispositions_counts.get("error", 0) or 0)
+    if error_count == 0 or item_count:
+        return None
+    successful_count = sum(
+        int(dispositions_counts.get(counter, 0) or 0)
+        for counter in _SUCCESS_DISPOSITION_COUNTERS
+    )
+    if successful_count:
+        return None
+    return f"all {error_count} checked URL(s) failed"
+
+
 def _max_withheld_percentage(dispositions: list[dict[str, Any]]) -> float | None:
     """The largest change any check in this run held back, display-scaled.
 
@@ -464,12 +531,31 @@ class LocalWatchlistsService:
             stats["new_items_found"] = len(kept_items)
 
             self._upsert_subscription_items(db, source_id, int(run_id), kept_items)
-            db.record_check_result(source_id, items=None, stats=stats)
+            # task-1394 fix wave (review Finding #1): a `url_list`/`sitemap`
+            # run where every URL errored still needs its own failure to
+            # reach the subscription's auto-pause breaker, or a permanently
+            # dead source can never auto-pause. A partial run (>=1 success)
+            # is unaffected -- see `_all_error_check_message`'s docstring.
+            all_error_message = _all_error_check_message(
+                stats.get("dispositions"), len(raw_items)
+            )
+            db.record_check_result(
+                source_id, items=None, stats=stats, error=all_error_message
+            )
+
+            status = str(result.get("status") or "completed")
+            if all_error_message and status == "completed":
+                # More honest than "completed" with zero items: every URL
+                # this run checked failed, so the run itself failed, even
+                # though it did not raise (that is exactly the point of the
+                # per-URL isolation this run status is not undoing).
+                status = "failed"
+
             return await self.record_run_result(
                 run_id,
-                status=str(result.get("status") or "completed"),
+                status=status,
                 stats=stats,
-                error_msg=result.get("error_msg"),
+                error_msg=result.get("error_msg") or all_error_message,
                 log_text=result.get("log_text"),
             )
         except Exception as exc:

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -70,6 +70,10 @@ _DISPOSITION_COUNTERS: tuple[str, ...] = (
     "withheld",
     "baseline",
     "rebaselined",
+    # TASK-1394. Appended last rather than inserted in "kind order" so nothing
+    # that reads this tuple positionally (none of the current readers do, but
+    # a future one might) sees the existing five counters shift place.
+    "error",
 )
 
 
@@ -92,9 +96,13 @@ def _disposition_count_keys() -> dict[tuple[str, str | None], str]:
     them back into one leaves the `reason` with no production consumer at all,
     which is what made spec §3's "the Runs pane says why" untrue.
 
-    The five pairs below are exactly the five `_disposition` call sites in
-    `check_url`; an unlisted pair raises `KeyError` in `_disposition_counts`,
-    deliberately.
+    Five of the six pairs below are exactly the five `_disposition` call
+    sites in `check_url`; an unlisted pair raises `KeyError` in
+    `_disposition_counts`, deliberately. The sixth, `DISPOSITION_ERROR`, is
+    NOT one of `check_url`'s own outcomes -- it is synthesized by
+    `_default_run_executor`'s `url_list`/`sitemap` loops around a
+    `check_url` call that raised instead of returning (task-1394), so one
+    dead URL is counted rather than failing the whole run.
 
     The `monitoring_engine` import is deliberately local, not module-level:
     this module loads unconditionally from `Subscriptions/__init__.py`
@@ -108,6 +116,7 @@ def _disposition_count_keys() -> dict[tuple[str, str | None], str]:
     from .monitoring_engine import (
         DISPOSITION_BASELINE_STORED,
         DISPOSITION_CHANGED,
+        DISPOSITION_ERROR,
         DISPOSITION_UNCHANGED,
         DISPOSITION_WITHHELD,
         REASON_BELOW_CHANGE_THRESHOLD,
@@ -124,23 +133,33 @@ def _disposition_count_keys() -> dict[tuple[str, str | None], str]:
             DISPOSITION_BASELINE_STORED,
             REASON_EXTRACTION_SETTINGS_CHANGED,
         ): "rebaselined",
+        # task-1394: `reason` is always `None` here, unlike the exception
+        # detail logged at the catch site -- the counter answers "how many
+        # URLs errored", not "which exception", so it needs exactly one
+        # stable pair rather than one per exception type.
+        (DISPOSITION_ERROR, None): "error",
     }
 
 
 def _disposition_counts(dispositions: list[dict[str, Any]]) -> dict[str, int]:
-    """Aggregate one run's per-URL dispositions into the five counters.
+    """Aggregate one run's per-URL dispositions into the six counters.
 
     Spec §4. A run that produced no items used to be indistinguishable from a
     run that produced no items *because it withheld them*; these counters are
-    what makes the difference visible. All five keys are always present, so the
+    what makes the difference visible. All six keys are always present, so the
     reader never has to distinguish "zero" from "not recorded".
+
+    ``error`` (task-1394) is the odd one out: it does not come from
+    `check_url` completing with an outcome, it comes from `check_url` never
+    returning at all. A `url_list`/`sitemap` run with one dead URL among many
+    still reports `"error": 1` here rather than raising out of the whole run.
 
     Args:
         dispositions: One disposition dict per URL checked, in check order.
 
     Returns:
         ``{"changed": n, "unchanged": n, "withheld": n, "baseline": n,
-        "rebaselined": n}``.
+        "rebaselined": n, "error": n}``.
 
     Raises:
         KeyError: If a disposition carries a ``(kind, reason)`` pair outside
@@ -913,12 +932,8 @@ class LocalWatchlistsService:
             items = []
             dispositions = []
             for url in self._urls_for_url_list(subscription_config):
-                result, disposition = await monitor.check_url(
-                    {
-                        **subscription_config,
-                        "source": url,
-                        "type": "url",
-                    }
+                result, disposition = await self._check_url_isolated(
+                    monitor, subscription_config, url
                 )
                 dispositions.append(disposition)
                 if result:
@@ -927,13 +942,15 @@ class LocalWatchlistsService:
             monitor = URLMonitor(db)
             items = []
             dispositions = []
+            # The sitemap FETCH that produces this URL list happens above, in
+            # the `await` the `for` iterates -- it is NOT covered by
+            # `_check_url_isolated` and a failure there still fails the whole
+            # run (task-1394's isolation is only for the per-URL loop body;
+            # if the sitemap itself cannot be fetched there is no per-URL
+            # work to isolate).
             for url in await self._urls_for_sitemap(subscription_config):
-                result, disposition = await monitor.check_url(
-                    {
-                        **subscription_config,
-                        "source": url,
-                        "type": "url",
-                    }
+                result, disposition = await self._check_url_isolated(
+                    monitor, subscription_config, url
                 )
                 dispositions.append(disposition)
                 if result:
@@ -965,6 +982,58 @@ class LocalWatchlistsService:
                 run_stats["max_withheld_pct"] = max_withheld
             result_payload["stats"] = run_stats
         return result_payload
+
+    @staticmethod
+    async def _check_url_isolated(
+        monitor: Any,
+        subscription_config: Mapping[str, Any],
+        url: str,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+        """One URL of a `url_list`/`sitemap` run's `check_url`, failure-isolated.
+
+        task-1394: the `url_list`/`sitemap` loops used to call `check_url`
+        with no per-URL `try/except`, so one failing URL (timeout, SSRF
+        block, HTTP error) raised out of the whole loop, failed the entire
+        run via `record_run_failure`, and discarded the items already
+        collected from the URLs that succeeded -- a 50-URL source with one
+        dead link yielded nothing at all.
+
+        A raise here is turned into a `DISPOSITION_ERROR` disposition and a
+        `None` item instead, so the caller's loop can `continue`: the run
+        still completes, the OTHER urls' items and dispositions still
+        persist, and `_disposition_counts` reports how many URLs errored
+        rather than the run reporting clean zeros or failing outright.
+
+        Args:
+            monitor: The `URLMonitor` (or fake, in tests) to check with.
+            subscription_config: The source's execution config; only
+                ``source``/``type`` are overridden per URL, same as the
+                caller did inline before this was extracted.
+            url: The one URL this call checks.
+
+        Returns:
+            Whatever `monitor.check_url` returned, unchanged, on success.
+            ``(None, {"kind": DISPOSITION_ERROR, "reason": None,
+            "withheld_percentage": None})`` if it raised.
+        """
+        from .monitoring_engine import DISPOSITION_ERROR
+
+        try:
+            return await monitor.check_url(
+                {**subscription_config, "source": url, "type": "url"}
+            )
+        except Exception as exc:
+            # Type-only: never the exception message or the URL itself, both
+            # of which can carry fetched page content or a query string with
+            # sensitive data.
+            logger.debug(
+                f"watchlist URL check failed, isolated: {type(exc).__name__}"
+            )
+            return None, {
+                "kind": DISPOSITION_ERROR,
+                "reason": None,
+                "withheld_percentage": None,
+            }
 
     @classmethod
     def _subscription_execution_config(

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -514,6 +514,15 @@ DISPOSITION_UNCHANGED = "unchanged"
 DISPOSITION_WITHHELD = "withheld_below_threshold"
 #: A change was detected and an item produced.
 DISPOSITION_CHANGED = "changed"
+#: `check_url` itself never returned -- it raised (timeout, SSRF block, HTTP
+#: error, ...). Not one of the four outcomes above: those are `check_url`'s
+#: own dispositions for a call that COMPLETED, while this one is synthesized
+#: by the caller (`local_watchlists_service._default_run_executor`'s
+#: `url_list`/`sitemap` loops) around a call that did not (task-1394). One
+#: dead URL among many must not fail the whole run and discard what the
+#: other URLs already collected; this is how that partial failure stays
+#: visible instead of silently vanishing into "0 found".
+DISPOSITION_ERROR = "error"
 
 #: ``reason`` values for ``DISPOSITION_BASELINE_STORED``. These two are NOT
 #: interchangeable and must never be aggregated together (whole-branch review,

--- a/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
@@ -164,7 +164,13 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
                 f"{withheld_text} | "
                 f"{dispositions.get('baseline', 0)} baseline | "
                 f"{dispositions.get('rebaselined', 0)} re-baselined "
-                "(settings changed)"
+                "(settings changed) | "
+                # task-1394: a URL that raised (timeout, SSRF block, HTTP
+                # error) instead of completing `check_url` -- rendered
+                # unconditionally, same as `changed`/`baseline`/etc. above,
+                # so a partially-failed run says so rather than reading like
+                # a clean one that merely found nothing.
+                f"{dispositions.get('error', 0)} error"
             )
         return base
 


### PR DESCRIPTION
## Why

`_default_run_executor`'s `url_list`/`sitemap` arms looped URLs with no per-URL guard, so one failing URL (timeout, SSRF block, HTTP error) raised out of the loop, failed the whole run, and discarded every item already collected from the URLs that succeeded — a 50-URL source with one dead link yielded nothing (task-1394).

## What

- **Per-URL isolation:** each `check_url` in both arms now runs through a shared `_check_url_isolated` helper (try/except); a failing URL records a new `DISPOSITION_ERROR` disposition (type-only — `type(exc).__name__`, never the URL or message) and continues. Items and dispositions from the URLs that succeeded persist (AC#1).
- **Visible, not absorbed:** a 6th `"error"` counter joins the disposition vocabulary and renders in the Runs pane's Checks line, so a partially- or fully-failed run says so (AC#2).
- **Auto-pause preserved (whole-branch review, MAJOR).** The isolation initially made an all-URLs-errored run report `completed`, which reset the subscription's auto-pause circuit breaker — a source where every URL is dead would never auto-pause again (pre-fix it raised → `record_run_failure` → breaker advanced to the threshold). Fixed: an all-error run (error count > 0, zero successful checks, zero items) now passes a counts-only synthetic error to `record_check_result` so the breaker **advances** and auto-pause fires exactly as before, and its status is `failed`; a **partial-success** run (≥1 working URL) still completes and resets the breaker — a reachable source is healthy. Feed/API arms are structurally unaffected.

## Testing

Discriminating tests: one poisoned URL among several → the others' items persist + `error` counter == 1 (reds under the old all-or-nothing code); all-error run pre-set one below threshold → breaker advances and `is_paused` becomes true (reds if the all-error detection is removed); partial run → items persist AND breaker resets (pins no over-correction). The existing auto-pause suite used `type="url"`, an arm this never touched, which is why it missed the regression. `test_local_watchlists_service.py` 19, `test_watchlists_runs_pane.py` 16, `test_scheduled_watchlist_runs.py` 13. Whole-branch review → fix wave → scoped re-review, both APPROVED; every behavioural change mutation-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a single bad URL from failing `url_list`/`sitemap` runs, adds an `"error"` disposition and counter to stats/UI, and keeps auto‑pause intact by failing all‑error runs. Scheduler metrics now surface partial failures with a `url_errors` label and a per‑run WARNING. Addresses Linear task-1394.

- **Bug Fixes**
  - Isolate each per‑URL check via `_check_url_isolated`; on exception, record `DISPOSITION_ERROR` (type-only) and continue.
  - Add an `"error"` counter to run stats and render it in the Runs pane Checks line.
  - All‑error runs (zero items, zero successes) send a counts‑only error to `record_check_result`, report `failed`, and advance the breaker; partial runs still complete and reset it.
  - Scheduler: completed runs with error dispositions set `url_errors=true` on `watchlist_checks` and log a per‑run WARNING; clean runs omit the label.
  - Sitemap fetch is unchanged; only per‑URL checks are isolated.

<sup>Written for commit aa7f9e0b24032edefde271cc551d43e70701ab9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

