### PR TITLE
Change review: Settings surface, per-workspace toggle, git-absent gating (TASK-1979)

### DIFF
--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -467,3 +467,29 @@ async def test_change_review_git_absent_shows_honest_copy(monkeypatch) -> None:
             in _visible_text(screen)
         )
         assert not screen.query("#settings-workspace-change-review-toggle")
+
+
+@pytest.mark.asyncio
+async def test_change_review_global_kill_disclosed_in_settings(
+    monkeypatch,
+) -> None:
+    """Qodo #1264: with the global knob off, the card must say so instead
+    of claiming per-workspace tracking is enabled."""
+    from textual.widgets import Button
+
+    monkeypatch.setenv("TLDW_CHANGE_REVIEW_ENABLED", "0")
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    registry.create_workspace(workspace_id="ws-gk", name="GK WS")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.query_one("#settings-workspace-row-ws-gk", Button).press()
+        await pilot.pause(0.2)
+
+        text = _visible_text(screen)
+        assert "disabled globally" in text, text
+        assert "Tracking enabled" not in text
+        assert not screen.query("#settings-workspace-change-review-toggle")

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -406,3 +406,64 @@ async def test_overview_pins_workspaces_recovery_copy() -> None:
             "Settings > Workspaces; switch in Console (Alt+W); run "
             "sync from the owning sync surfaces." in text
         )
+
+
+@pytest.mark.asyncio
+async def test_change_review_toggle_flips_and_persists(tmp_path) -> None:
+    """TASK-1979: the per-workspace change-review toggle round-trips."""
+    from textual.widgets import Button
+
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    registry.create_workspace(workspace_id="ws-cr", name="CR WS")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.query_one("#settings-workspace-row-ws-cr", Button).press()
+        await pilot.pause(0.2)
+
+        assert registry.change_review_enabled("ws-cr") is True
+        assert "Tracking enabled" in _visible_text(screen)
+        screen.query_one(
+            "#settings-workspace-change-review-toggle", Button
+        ).press()
+        await pilot.pause(0.3)
+        assert registry.change_review_enabled("ws-cr") is False
+        assert "Tracking disabled" in _visible_text(screen)
+        screen.query_one(
+            "#settings-workspace-change-review-toggle", Button
+        ).press()
+        await pilot.pause(0.3)
+        assert registry.change_review_enabled("ws-cr") is True
+
+
+@pytest.mark.asyncio
+async def test_change_review_git_absent_shows_honest_copy(monkeypatch) -> None:
+    """TASK-1979 AC#2: no git — the row states the reason, no dead toggle."""
+    from textual.widgets import Button
+
+    import tldw_chatbook.Workspaces.change_tracking as ct
+
+    # Narrow seam: shutil is a shared module object — patching its `which`
+    # breaks unrelated services (file-notes git calls it with path=).
+    monkeypatch.setattr(
+        ct.ShadowRepoService, "available", property(lambda self: False)
+    )
+    app = _build_test_app()
+    registry = app.workspace_registry_service
+    registry.create_workspace(workspace_id="ws-nogit", name="NoGit WS")
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _open_settings_category(pilot, "#settings-category-workspaces")
+        screen.query_one("#settings-workspace-row-ws-nogit", Button).press()
+        await pilot.pause(0.2)
+
+        assert (
+            "Change review needs git — install git to enable."
+            in _visible_text(screen)
+        )
+        assert not screen.query("#settings-workspace-change-review-toggle")

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -890,3 +890,77 @@ class TestChangeReviewGating:
         assert wfr.folder_binding_roots("ws-1") == ()
         registry.set_change_review_enabled("ws-1", True)
         assert wfr.folder_binding_roots("ws-1") == (root.resolve(),)
+
+
+class TestGatingCoversRegistrationHook:
+    """Qodo #1264: the opt-out must gate the registration-time snapshot too."""
+
+    def test_disabled_workspace_add_binding_takes_no_snapshot(
+        self, tmp_path, monkeypatch
+    ):
+        import time
+
+        from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+        from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.db", client_id="t")
+        )
+        registry.create_workspace(workspace_id="ws-off", name="Off WS")
+        registry.set_change_review_enabled("ws-off", False)
+        root = tmp_path / "offroot"
+        root.mkdir()
+        appdata = tmp_path / "appdata-gate"
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+        registry.add_folder_binding("ws-off", root)
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            time.sleep(0.1)
+
+        from tldw_chatbook.Utils.paths import get_user_data_dir
+
+        change_dir = get_user_data_dir() / "change_review"
+        containers = (
+            [d for d in change_dir.iterdir() if d.is_dir()]
+            if change_dir.is_dir()
+            else []
+        )
+        assert containers == [], (
+            "a change-review-disabled workspace still snapshotted on "
+            f"binding add: {containers}"
+        )
+
+    def test_global_kill_gates_the_registration_hook(
+        self, tmp_path, monkeypatch
+    ):
+        import time
+
+        from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+        from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+        monkeypatch.setenv("TLDW_CHANGE_REVIEW_ENABLED", "0")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg2"))
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces2.db", client_id="t")
+        )
+        registry.create_workspace(workspace_id="ws-g", name="G WS")
+        root = tmp_path / "groot"
+        root.mkdir()
+
+        registry.add_folder_binding("ws-g", root)
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            time.sleep(0.1)
+
+        from tldw_chatbook.Utils.paths import get_user_data_dir
+
+        change_dir = get_user_data_dir() / "change_review"
+        containers = (
+            [d for d in change_dir.iterdir() if d.is_dir()]
+            if change_dir.is_dir()
+            else []
+        )
+        assert containers == [], (
+            f"globally-disabled change review still snapshotted: {containers}"
+        )

--- a/Tests/Workspaces/test_change_bounds.py
+++ b/Tests/Workspaces/test_change_bounds.py
@@ -819,3 +819,74 @@ def test_end_turn_survives_a_still_running_discovery_thread(tracked):
     assert len(mine) == 1, (
         f"churned roots produced {len(mine)} records for one root"
     )
+
+
+# -- settings + gating (TASK-1979) -------------------------------------------
+
+
+class TestChangeReviewGating:
+    def _registry(self, tmp_path):
+        from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+        from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+        return LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.db", client_id="t")
+        )
+
+    def _bound_workspace(self, registry, tmp_path):
+        root = tmp_path / "wsroot"
+        root.mkdir()
+        registry.create_workspace(workspace_id="ws-1", name="WS")
+        registry.add_folder_binding("ws-1", root)
+        return root
+
+    def test_global_kill_knob_empties_the_root_list(
+        self, tmp_path, monkeypatch
+    ):
+        import tldw_chatbook.Tools.workspace_file_roots as wfr
+
+        registry = self._registry(tmp_path)
+        root = self._bound_workspace(registry, tmp_path)
+        monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+
+        assert wfr.folder_binding_roots("ws-1") == (root.resolve(),)
+        monkeypatch.setenv("TLDW_CHANGE_REVIEW_ENABLED", "0")
+        assert wfr.folder_binding_roots("ws-1") == (), (
+            "the global knob must stop tracking on the NEXT read"
+        )
+
+    def test_workspace_toggle_gates_only_that_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        import tldw_chatbook.Tools.workspace_file_roots as wfr
+
+        registry = self._registry(tmp_path)
+        root = self._bound_workspace(registry, tmp_path)
+        other_root = tmp_path / "other"
+        other_root.mkdir()
+        registry.create_workspace(workspace_id="ws-2", name="Other")
+        registry.add_folder_binding("ws-2", other_root)
+        monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+
+        registry.set_change_review_enabled("ws-1", False)
+
+        assert registry.change_review_enabled("ws-1") is False
+        assert registry.change_review_enabled("ws-2") is True, (
+            "absent row must read as enabled"
+        )
+        assert wfr.folder_binding_roots("ws-1") == ()
+        assert wfr.folder_binding_roots("ws-2") == (other_root.resolve(),)
+
+    def test_reenabling_restores_tracking_without_restart(
+        self, tmp_path, monkeypatch
+    ):
+        import tldw_chatbook.Tools.workspace_file_roots as wfr
+
+        registry = self._registry(tmp_path)
+        root = self._bound_workspace(registry, tmp_path)
+        monkeypatch.setattr(wfr, "_registry_factory", lambda: registry)
+
+        registry.set_change_review_enabled("ws-1", False)
+        assert wfr.folder_binding_roots("ws-1") == ()
+        registry.set_change_review_enabled("ws-1", True)
+        assert wfr.folder_binding_roots("ws-1") == (root.resolve(),)

--- a/backlog/tasks/task-1979 - Change-review-settings-and-gating.md
+++ b/backlog/tasks/task-1979 - Change-review-settings-and-gating.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1979
 title: 'Change review: Settings surface, per-workspace toggle, git-absent gating'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-02 21:00'
 labels:
@@ -23,8 +23,54 @@ Spec: `Docs/superpowers/specs/2026-08-02-agent-change-review-design.md`.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Disabling per-workspace stops snapshots for that workspace's roots on the NEXT run without restart
-- [ ] #2 git absent -> Settings and card copy state the reason; runs behave exactly as with the feature off
-- [ ] #3 Every knob is read live from config with the documented env-var override
-- [ ] #4 Settings copy passes the monochrome/persistence-badge conventions of the Settings screen
+- [x] #1 Disabling per-workspace stops snapshots for that workspace's roots on the NEXT run without restart
+- [x] #2 git absent -> Settings and card copy state the reason; runs behave exactly as with the feature off
+- [x] #3 Every knob is read live from config with the documented env-var override
+- [x] #4 Settings copy passes the monochrome/persistence-badge conventions of the Settings screen
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Gating choke point: `folder_binding_roots` (exists solely for tracking)
+   returns () when the flat `[change_review] enabled` knob (env-overridable,
+   read live per call) is off OR the workspace's toggle is off — AC#1 falls
+   out with zero controller changes
+2. Per-workspace toggle: `workspace_change_review` side table mirroring the
+   workspace_rag_scopes pattern (absent row = enabled); registry get/set
+3. Settings workspace card: Change review row — toggle button when git is
+   present, the honest 'Change review needs git — install git to enable'
+   copy when absent (monochrome, matching the pane's conventions)
+4. TDD; sabotage first-try passes; regression before push
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Gating** lives at the ONE choke point: `folder_binding_roots` (which
+exists solely as the tracker's root source) returns () when the flat
+`[change_review] enabled` knob is off (env `TLDW_CHANGE_REVIEW_ENABLED`
+beats config, read live per call — AC#3) or the workspace's toggle is off.
+AC#1 (next-run effect, no restart) falls out with zero controller changes;
+the registration hook's initial snapshot gates identically for free.
+
+**Per-workspace toggle**: `workspace_change_review` side table mirroring
+the `workspace_rag_scopes` pattern (absent row = enabled, opt-out; a
+storage READ error also reads enabled — availability must not flip off on
+a failed read); `LocalWorkspaceRegistryService.change_review_enabled` /
+`set_change_review_enabled` (upsert, service clock seam).
+
+**Settings surface**: the workspace card gains a "Change review (post-run
+diffs)" section — state copy + Enable/Disable toggle button in the pane's
+existing monochrome idiom (AC#4); with no git binary the row shows the
+exact honest copy 'Change review needs git — install git to enable.' and
+no dead toggle (AC#2; runs already behave feature-off via the bridge's
+tracker=None gating from TASK-1971).
+
+Tests: 3 gating round-trips (global knob, per-workspace isolation,
+re-enable without restart) + 2 UI tests (toggle round-trip persisting to
+the registry; git-absent copy — patched at the `ShadowRepoService.available`
+seam, NOT `shutil.which`, which is a shared module object that broke the
+file-notes git service mid-test). Settings section sabotage-verified
+(blinded render failed both UI tests). 273 green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -120,6 +120,18 @@ class WorkspaceDB(BaseDB):
                         REFERENCES workspace_records(workspace_id)
                         ON DELETE CASCADE
                 );
+
+                -- TASK-1979: per-workspace change-review toggle. Absent
+                -- row = enabled (opt-out), mirroring the scopes table's
+                -- co-location rationale.
+                CREATE TABLE IF NOT EXISTS workspace_change_review (
+                    workspace_id TEXT PRIMARY KEY,
+                    enabled INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY(workspace_id)
+                        REFERENCES workspace_records(workspace_id)
+                        ON DELETE CASCADE
+                );
                 """
             )
             conn.commit()

--- a/tldw_chatbook/Tools/workspace_file_roots.py
+++ b/tldw_chatbook/Tools/workspace_file_roots.py
@@ -88,9 +88,20 @@ def folder_binding_roots(workspace_id: str | None) -> tuple[Path, ...]:
     """
     if not workspace_id:
         return ()
+    # TASK-1979: this function exists solely as the change-review tracker's
+    # root source, so the enable gates live HERE — one choke point, read
+    # fresh per turn, no restart needed.
+    from tldw_chatbook.Workspaces.change_bounds import (
+        change_review_enabled_globally,
+    )
+
+    if not change_review_enabled_globally():
+        return ()
     roots: list[Path] = []
     try:
         registry = _registry_factory()
+        if not registry.change_review_enabled(workspace_id):
+            return ()
         for binding in registry.list_folder_bindings(workspace_id):
             folder = Path(binding.locator)
             if not folder.is_dir():

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -11156,6 +11156,48 @@ class SettingsScreen(BaseAppScreen):
             yield from self._render_workspace_folder_bindings(
                 registry, record.workspace_id
             )
+            yield from self._render_workspace_change_review(
+                registry, record.workspace_id
+            )
+
+    def _render_workspace_change_review(
+        self,
+        registry: LocalWorkspaceRegistryService,
+        workspace_id: str,
+    ) -> ComposeResult:
+        """Render the per-workspace change-review toggle (TASK-1979).
+
+        Honest availability: without a git binary the feature is absent,
+        so the row states the reason instead of offering a dead toggle.
+        Copy stays monochrome per the pane's conventions.
+        """
+        yield Static(
+            "Change review (post-run diffs)", classes="destination-section"
+        )
+        from tldw_chatbook.Workspaces.change_tracking import ShadowRepoService
+
+        if not ShadowRepoService().available:
+            yield Static(
+                "Change review needs git — install git to enable.",
+                id="settings-workspace-change-review-unavailable",
+                classes="settings-detail-row",
+            )
+            return
+        enabled = registry.change_review_enabled(workspace_id)
+        yield Static(
+            "Tracking enabled: agent runs record per-turn diffs for this "
+            "workspace's folders."
+            if enabled
+            else "Tracking disabled for this workspace: runs record no "
+            "diffs and offer no review.",
+            id="settings-workspace-change-review-state",
+            classes="settings-detail-row",
+        )
+        yield Button(
+            "Disable change review" if enabled else "Enable change review",
+            id="settings-workspace-change-review-toggle",
+            compact=True,
+        )
 
     def _render_workspace_folder_bindings(
         self,
@@ -13333,6 +13375,29 @@ class SettingsScreen(BaseAppScreen):
             return
         try:
             registry.unarchive_workspace(workspace_id)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_settings_workspaces_result(str(exc))
+            return
+        self._settings_workspaces_result = ""
+        self._refresh_settings_workspaces_pane()
+
+    @on(Button.Pressed, "#settings-workspace-change-review-toggle")
+    def _settings_workspace_toggle_change_review(self, event: Button.Pressed) -> None:
+        """Flip the selected workspace's change-review toggle (TASK-1979).
+
+        Takes effect on the NEXT run without restart — the tracker's root
+        source reads the registry fresh per turn.
+        """
+        event.stop()
+        workspace_id = self._settings_selected_workspace_id
+        if not workspace_id:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        try:
+            enabled = registry.change_review_enabled(workspace_id)
+            registry.set_change_review_enabled(workspace_id, not enabled)
         except WorkspaceRegistryServiceError as exc:
             self._set_settings_workspaces_result(str(exc))
             return

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -11183,6 +11183,20 @@ class SettingsScreen(BaseAppScreen):
                 classes="settings-detail-row",
             )
             return
+        from tldw_chatbook.Workspaces.change_bounds import (
+            change_review_enabled_globally,
+        )
+
+        if not change_review_enabled_globally():
+            # Qodo #1264: the per-workspace toggle is moot under the
+            # global kill switch — say so instead of claiming tracking.
+            yield Static(
+                "Change review is disabled globally "
+                "([change_review] enabled = false).",
+                id="settings-workspace-change-review-global-off",
+                classes="settings-detail-row",
+            )
+            return
         enabled = registry.change_review_enabled(workspace_id)
         yield Static(
             "Tracking enabled: agent runs record per-turn diffs for this "

--- a/tldw_chatbook/Workspaces/change_bounds.py
+++ b/tldw_chatbook/Workspaces/change_bounds.py
@@ -31,6 +31,27 @@ DEFAULT_MAX_FILE_BYTES = 10 * 1024**2
 DEFAULT_RETENTION_DAYS = 30
 DEFAULT_MAX_SUB_ROOTS = 20
 
+
+def change_review_enabled_globally() -> bool:
+    """The flat ``[change_review] enabled`` knob, env-overridable, read live.
+
+    Returns:
+        False only when the knob is explicitly 0/false — the feature is
+        opt-out (TASK-1979).
+    """
+    env = os.environ.get("TLDW_CHANGE_REVIEW_ENABLED")
+    if env is not None:
+        return env.strip().lower() not in {"0", "false", "no", "off"}
+    try:
+        from tldw_chatbook.config import get_cli_setting
+
+        value = get_cli_setting("change_review", "enabled", True)
+    except Exception:  # noqa: BLE001 -- a broken config never disables review
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off"}
+    return bool(value)
+
 #: Directory names the scan prunes — mirrors the shadow repo's
 #: ``FORCED_EXCLUDES`` (change_tracking.py): untracked trees must not count.
 _SKIP_DIR_NAMES = frozenset(

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -739,11 +739,20 @@ class LocalWorkspaceRegistryService:
         # first agent send must never absorb the cost of hashing a whole
         # tree. Best-effort: failures log and are disclosed on first use.
         try:
+            from tldw_chatbook.Workspaces.change_bounds import (
+                change_review_enabled_globally,
+            )
             from tldw_chatbook.Workspaces.change_turn_tracker import (
                 initial_snapshot_in_background,
             )
 
-            initial_snapshot_in_background(resolved)
+            # TASK-1979 (Qodo #1264): the opt-out gates registration too —
+            # a disabled workspace (or a global kill) must not grow shadow
+            # state when a binding is added.
+            if change_review_enabled_globally() and self.change_review_enabled(
+                workspace_id
+            ):
+                initial_snapshot_in_background(resolved)
         except Exception:  # noqa: BLE001 -- registration must never fail on this
             logger.opt(exception=True).debug(
                 "change_review: initial-snapshot hook failed at registration"

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -869,6 +869,69 @@ class LocalWorkspaceRegistryService:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         return tuple(_runtime_binding_from_row(row) for row in rows)
 
+    def change_review_enabled(self, workspace_id: str) -> bool:
+        """Whether change review tracks this workspace's roots (TASK-1979).
+
+        Absent row reads as ENABLED (the toggle is an opt-out); a storage
+        error also reads as enabled — tracking availability must not flip
+        off because a read failed.
+
+        Args:
+            workspace_id: Workspace identifier.
+
+        Returns:
+            The stored toggle, default True.
+        """
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
+        try:
+            with self.db.connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT enabled FROM workspace_change_review
+                    WHERE workspace_id = ?
+                    """,
+                    (safe_workspace_id,),
+                ).fetchone()
+        except sqlite3.Error:
+            logger.opt(exception=True).debug(
+                "change_review toggle read failed; treating as enabled"
+            )
+            return True
+        if row is None:
+            return True
+        return bool(row["enabled"])
+
+    def set_change_review_enabled(self, workspace_id: str, enabled: bool) -> None:
+        """Persist the per-workspace change-review toggle (TASK-1979).
+
+        Args:
+            workspace_id: Workspace identifier.
+            enabled: Whether the workspace's roots are tracked.
+
+        Raises:
+            WorkspaceRegistryServiceError: If the write fails.
+        """
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
+        try:
+            with self.db.transaction() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO workspace_change_review
+                        (workspace_id, enabled, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(workspace_id) DO UPDATE SET
+                        enabled = excluded.enabled,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        safe_workspace_id,
+                        1 if enabled else 0,
+                        self._now_factory(),
+                    ),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+
     def get_workspace_scope(self, workspace_id: str) -> RagScope | None:
         """Return a workspace's stored RAG retrieval scope, guarded.
 


### PR DESCRIPTION
## Summary
- Completes the Agent Change Review programme's final task: user control + honest availability
- **Gating at one choke point**: `folder_binding_roots` (the tracker's sole root source) returns nothing when the flat `[change_review] enabled` knob is off (env `TLDW_CHANGE_REVIEW_ENABLED` beats config, read live per call) or the workspace's toggle is off — next-run effect with zero controller changes and no restart
- **Per-workspace toggle**: `workspace_change_review` side table mirroring the `workspace_rag_scopes` pattern (absent row = enabled; a failed read also reads enabled); registry get/set with upsert
- **Settings surface**: the workspace card gains a "Change review (post-run diffs)" section — monochrome state copy + Enable/Disable toggle; with no git binary it shows 'Change review needs git — install git to enable.' and no dead toggle

## Testing
- 3 gating round-trips (global knob, per-workspace isolation, re-enable without restart) + 2 UI tests (toggle persistence; git-absent copy via the `ShadowRepoService.available` seam — patching shared `shutil.which` broke unrelated services); Settings section sabotage-verified; 273 green across change-review + settings suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-workspace Change Review toggle and a Settings UI row, with honest availability. Gating now also covers the registration snapshot and shows a clear global-off message; changes take effect on the next run without restart — meets TASK-1979 ACs.

- **New Features**
  - Gate at `folder_binding_roots`: returns no roots when the global `[change_review] enabled` knob (env `TLDW_CHANGE_REVIEW_ENABLED`, read live) is off or the workspace toggle is off; no restart needed.
  - Per-workspace toggle persisted in `workspace_change_review` (absent row = enabled); registry `change_review_enabled` / `set_change_review_enabled`.
  - Settings: "Change review (post-run diffs)" row with Enable/Disable. If git is missing (`ShadowRepoService.available` false), show "Change review needs git — install git to enable." and hide the toggle; when globally disabled, show "disabled globally" and hide the toggle.

- **Bug Fixes**
  - The registration-time initial snapshot now respects both gates, preventing shadow state creation when the feature is disabled.

<sup>Written for commit 8d0ecc2aa51fd1a3bd102bace6a3dc866f4a3f01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

