### PR TITLE
chore: mark task-1394 Done (PR #1263 merged)

### DIFF
--- a/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
+++ b/backlog/tasks/task-1394 - One-failing-URL-fails-a-whole-url_list-run-and-discards-collected-items.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1394
 title: One failing URL fails a whole url_list run and discards collected items
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 05:20'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked TASK-1394 (One failing URL fails a whole url_list run and discards collected items) as Done to sync the backlog with the resolved fix. Backlog status update only; no code changes.

<sup>Written for commit f509f55ef3995b29b0ee7a9bb655eaf7e08b29ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

