### PR TITLE
fix: make watchlist auto-pause live across both failure paths, with resume-on-success (task-1410)

### DIFF
--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -176,6 +176,82 @@ def test_record_check_error_never_unpauses_an_already_paused_subscription(db):
     assert row["last_error"] == "connection refused"
 
 
+def test_record_check_result_success_resumes_an_auto_paused_subscription(db):
+    """Fix wave for the task-1410 review, Finding #1 (the important one).
+
+    task-1410 made auto-pause live across both failure paths, but the only
+    ``is_paused = 0`` writer (``reset_subscription_errors``) has zero
+    callers, the scheduler skips paused sources
+    (``get_pending_checks``/``WatchlistCheckHandler``), and
+    ``record_check_result``'s success branch did not touch ``is_paused`` --
+    so an auto-paused source could never be un-paused by ANY path. A
+    successful check is the natural recourse: a failure never un-pauses
+    (AC#1, pinned above), but a success now does.
+
+    Reds if the success branch's new ``is_paused = 0`` write is reverted:
+    ``is_paused`` stays 1 even though the check just succeeded.
+    """
+    source_id = db.add_subscription(
+        name="Docs",
+        type="rss",
+        source="https://a.example/feed",
+        auto_pause_threshold=3,
+    )
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE subscriptions
+            SET is_paused = 1, error_count = 3, consecutive_failures = 3,
+                last_error = 'connection refused'
+            WHERE id = ?
+            """,
+            (source_id,),
+        )
+
+    db.record_check_result(subscription_id=source_id, items=None, error=None)
+
+    row = db.get_subscription(source_id)
+    assert row["is_paused"] == 0, "a successful check must resume an auto-paused subscription"
+    assert row["consecutive_failures"] == 0
+    assert row["error_count"] == 0
+    assert row["last_error"] is None
+
+
+@pytest.mark.parametrize("bad_threshold", [None, 0, -1])
+def test_advance_failure_and_maybe_pause_never_pauses_on_a_bad_threshold(db, bad_threshold):
+    """Fix wave for the task-1410 review, Finding #3.
+
+    ``_advance_failure_and_maybe_pause``'s threshold comparison
+    (``consecutive_failures >= auto_pause_threshold``) TypeErrors the
+    instant ``auto_pause_threshold`` is NULL (``int >= None``), and pauses
+    on the very first failure if it is 0 or negative. The config seed (``<=
+    0`` falls back to 10) and the service layer (which strips ``None``)
+    keep production from reaching either case today, but a direct
+    ``update_subscription(auto_pause_threshold=...)`` reaches the
+    comparison unguarded. A NULL/non-positive threshold must mean
+    "auto-pause disabled for this source" -- never a crash, never an
+    instant pause.
+
+    Reds if the guard is dropped: the ``None`` case raises ``TypeError`` on
+    the first failure; the ``0``/``-1`` cases pause after exactly one
+    failure instead of never.
+    """
+    source_id = db.add_subscription(
+        name="Docs",
+        type="rss",
+        source="https://a.example/feed",
+        auto_pause_threshold=5,
+    )
+    db.update_subscription(source_id, auto_pause_threshold=bad_threshold)
+
+    for _ in range(10):
+        db.record_check_error(source_id, "connection refused")
+
+    row = db.get_subscription(source_id)
+    assert row["consecutive_failures"] == 10, "failures must keep accumulating"
+    assert row["is_paused"] == 0, f"threshold={bad_threshold!r} must never auto-pause"
+
+
 def test_add_subscription_seeds_auto_pause_threshold_from_config_default(db, monkeypatch):
     """task-1410 AC#3. ``[subscriptions].auto_pause_after_failures`` (config,
     previously read by nothing) now seeds the ``auto_pause_threshold`` column

--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -50,6 +50,9 @@ def test_record_check_result_persists_full_column_set_via_unified_path(db):
     guard stays exactly as it was -- a second call with the same URL/hash
     must still collapse to one row rather than adopting
     persist_subscription_item's separate (raw-url-based) dedupe rule.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
     """
     source_id = db.add_subscription(
         name="ArXiv", type="rss", source="https://a.example/feed"
@@ -109,6 +112,9 @@ def test_record_check_result_collapses_canonical_url_variants_to_one_row(db):
     ``persist_subscription_item``'s own raw-url ``ON CONFLICT`` rule was
     that URLs differing only by case or a trailing slash must still
     collapse to a single row. Nothing pinned that until now.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
     """
     source_id = db.add_subscription(
         name="ArXiv", type="rss", source="https://a.example/feed"
@@ -156,6 +162,9 @@ def test_record_check_error_never_unpauses_an_already_paused_subscription(db):
 
     Reds under the pre-fix write: a failure with ``should_pause=False``
     (the only value any caller ever passes) flips ``is_paused`` back to 0.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
     """
     source_id = db.add_subscription(
         name="Docs",
@@ -176,6 +185,50 @@ def test_record_check_error_never_unpauses_an_already_paused_subscription(db):
     assert row["last_error"] == "connection refused"
 
 
+def test_auto_pause_is_a_transition_not_reported_on_every_failure(db):
+    """task-1410 Qodo follow-up: a pause is a state transition, reported once.
+
+    The shared helper returns True (and logs the "Auto-paused" warning) only
+    on the 0->1 transition. A failing MANUAL re-check of an ALREADY-paused
+    source still meets the threshold, but must NOT re-report the pause -- that
+    would over-count a single pause event in the `auto_paused` metric and spam
+    the warning. Reds if the helper reports a pause on an already-paused
+    source.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
+    """
+    source_id = db.add_subscription(
+        name="Dead source",
+        type="rss",
+        source="https://dead.example/feed",
+        auto_pause_threshold=2,
+    )
+    now = "2026-08-02T00:00:00+00:00"
+    # Two failures reach the threshold: the SECOND is the 0->1 transition.
+    with db.transaction() as conn:
+        first = db._advance_failure_and_maybe_pause(
+            conn.cursor(), source_id, "err", now
+        )
+        second = db._advance_failure_and_maybe_pause(
+            conn.cursor(), source_id, "err", now
+        )
+    assert first is False, "below threshold: no pause yet"
+    assert second is True, "the failure that crosses the threshold reports the pause"
+    assert db.get_subscription(source_id)["is_paused"] == 1
+
+    # A third failure (a failing manual re-check of the now-paused source)
+    # still meets the threshold but is NOT a new pause event.
+    with db.transaction() as conn:
+        third = db._advance_failure_and_maybe_pause(
+            conn.cursor(), source_id, "err", now
+        )
+    assert third is False, (
+        "a failure on an already-paused source must not re-report the pause"
+    )
+    assert db.get_subscription(source_id)["is_paused"] == 1
+
+
 def test_record_check_result_success_resumes_an_auto_paused_subscription(db):
     """Fix wave for the task-1410 review, Finding #1 (the important one).
 
@@ -190,6 +243,9 @@ def test_record_check_result_success_resumes_an_auto_paused_subscription(db):
 
     Reds if the success branch's new ``is_paused = 0`` write is reverted:
     ``is_paused`` stays 1 even though the check just succeeded.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
     """
     source_id = db.add_subscription(
         name="Docs",
@@ -235,6 +291,10 @@ def test_advance_failure_and_maybe_pause_never_pauses_on_a_bad_threshold(db, bad
     Reds if the guard is dropped: the ``None`` case raises ``TypeError`` on
     the first failure; the ``0``/``-1`` cases pause after exactly one
     failure instead of never.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
+        bad_threshold: parametrized None/0/-1 threshold values.
     """
     source_id = db.add_subscription(
         name="Docs",
@@ -260,6 +320,10 @@ def test_add_subscription_seeds_auto_pause_threshold_from_config_default(db, mon
     Reds if the seeding in ``add_subscription`` is dropped: the column would
     fall through to the schema's own hardcoded ``DEFAULT 10`` regardless of
     what the config says.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
+        monkeypatch: patches `get_cli_setting` / the executor for the case.
     """
     monkeypatch.setattr(
         "tldw_chatbook.DB.Subscriptions_DB.get_cli_setting",
@@ -279,6 +343,10 @@ def test_add_subscription_explicit_auto_pause_threshold_overrides_config_default
 ):
     """An explicit ``auto_pause_threshold`` kwarg always wins over the
     config-seeded default (AC#3's stated precedence).
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
+        monkeypatch: patches `get_cli_setting` / the executor for the case.
     """
     monkeypatch.setattr(
         "tldw_chatbook.DB.Subscriptions_DB.get_cli_setting",
@@ -302,6 +370,10 @@ def test_add_subscription_falls_back_to_schema_default_when_config_is_unusable(
     """A missing/non-numeric config value must not block subscription
     creation (AC#3): it falls back to the same default (10) the schema's own
     ``DEFAULT 10`` already uses, rather than raising or storing garbage.
+
+    Args:
+        db: The in-memory `SubscriptionsDB` fixture.
+        monkeypatch: patches `get_cli_setting` / the executor for the case.
     """
     monkeypatch.setattr(
         "tldw_chatbook.DB.Subscriptions_DB.get_cli_setting",
@@ -345,6 +417,9 @@ def test_legacy_orphaned_filter_survives_action_check_widening(tmp_path):
     the FK; with enforcement on, the copy failed and the app could not even
     open the database. Already-orphaned rows must not be deleted -- cleanup
     is out of scope -- so the rebuild must tolerate them instead.
+
+    Args:
+        tmp_path: pytest temp dir for the on-disk `SubscriptionsDB`.
     """
     import sqlite3
 
@@ -441,6 +516,9 @@ def test_rebuild_recovers_from_stray_subscription_filters_new_table(tmp_path):
     ``CREATE TABLE subscription_filters_new`` in ``_ensure_watchlists_schema``
     then raises ``OperationalError: table subscription_filters_new already
     exists`` -- and ``SubscriptionsDB`` can never be constructed again.
+
+    Args:
+        tmp_path: pytest temp dir for the on-disk `SubscriptionsDB`.
     """
     import sqlite3
 

--- a/Tests/DB/test_subscriptions_db.py
+++ b/Tests/DB/test_subscriptions_db.py
@@ -138,6 +138,108 @@ def test_record_check_result_collapses_canonical_url_variants_to_one_row(db):
     assert rows[0]["canonical_url"] == "https://a.example/1"
 
 
+def test_record_check_error_never_unpauses_an_already_paused_subscription(db):
+    """task-1410 AC#1 (hard prerequisite of AC#2).
+
+    ``record_check_error`` used to write ``is_paused = 1 if should_pause
+    else 0`` unconditionally on every call. Since no production caller ever
+    passes ``should_pause=True``, every recorded failure silently wrote
+    ``is_paused = 0`` -- clearing any pause a *different* call had set. That
+    made auto-pause worse than a no-op the moment anything started pausing
+    subscriptions: the very next failure on a paused source (a manual
+    re-check, or the auto-pause this same task lands) would un-pause it.
+
+    ``auto_pause_threshold`` is set absurdly high so this single failure
+    cannot ALSO trip the auto-pause branch itself -- this test isolates
+    "a failure must never clear an existing pause" from "a failure can set
+    a new pause" (covered separately by the AC#2 test).
+
+    Reds under the pre-fix write: a failure with ``should_pause=False``
+    (the only value any caller ever passes) flips ``is_paused`` back to 0.
+    """
+    source_id = db.add_subscription(
+        name="Docs",
+        type="rss",
+        source="https://a.example/feed",
+        auto_pause_threshold=100,
+    )
+    with db.transaction() as conn:
+        conn.execute("UPDATE subscriptions SET is_paused = 1 WHERE id = ?", (source_id,))
+
+    db.record_check_error(source_id, "connection refused")
+
+    row = db.get_subscription(source_id)
+    assert row["is_paused"] == 1, "a recorded failure must never clear an existing pause"
+    # Ordinary failure bookkeeping must still happen.
+    assert row["consecutive_failures"] == 1
+    assert row["error_count"] == 1
+    assert row["last_error"] == "connection refused"
+
+
+def test_add_subscription_seeds_auto_pause_threshold_from_config_default(db, monkeypatch):
+    """task-1410 AC#3. ``[subscriptions].auto_pause_after_failures`` (config,
+    previously read by nothing) now seeds the ``auto_pause_threshold`` column
+    default for a subscription created WITHOUT an explicit value.
+
+    Reds if the seeding in ``add_subscription`` is dropped: the column would
+    fall through to the schema's own hardcoded ``DEFAULT 10`` regardless of
+    what the config says.
+    """
+    monkeypatch.setattr(
+        "tldw_chatbook.DB.Subscriptions_DB.get_cli_setting",
+        lambda section, key, default: 7,
+    )
+
+    source_id = db.add_subscription(
+        name="Docs", type="rss", source="https://a.example/feed"
+    )
+
+    row = db.get_subscription(source_id)
+    assert row["auto_pause_threshold"] == 7
+
+
+def test_add_subscription_explicit_auto_pause_threshold_overrides_config_default(
+    db, monkeypatch
+):
+    """An explicit ``auto_pause_threshold`` kwarg always wins over the
+    config-seeded default (AC#3's stated precedence).
+    """
+    monkeypatch.setattr(
+        "tldw_chatbook.DB.Subscriptions_DB.get_cli_setting",
+        lambda section, key, default: 7,
+    )
+
+    source_id = db.add_subscription(
+        name="Docs",
+        type="rss",
+        source="https://a.example/feed",
+        auto_pause_threshold=25,
+    )
+
+    row = db.get_subscription(source_id)
+    assert row["auto_pause_threshold"] == 25
+
+
+def test_add_subscription_falls_back_to_schema_default_when_config_is_unusable(
+    db, monkeypatch
+):
+    """A missing/non-numeric config value must not block subscription
+    creation (AC#3): it falls back to the same default (10) the schema's own
+    ``DEFAULT 10`` already uses, rather than raising or storing garbage.
+    """
+    monkeypatch.setattr(
+        "tldw_chatbook.DB.Subscriptions_DB.get_cli_setting",
+        lambda section, key, default: "not-a-number",
+    )
+
+    source_id = db.add_subscription(
+        name="Docs", type="rss", source="https://a.example/feed"
+    )
+
+    row = db.get_subscription(source_id)
+    assert row["auto_pause_threshold"] == 10
+
+
 def test_deleting_subscription_cascades_to_its_items(db):
     source_id = db.add_subscription(
         name="ArXiv", type="rss", source="https://a.example/feed"

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from inspect import isawaitable
 from types import SimpleNamespace
 
@@ -792,6 +793,152 @@ async def test_local_watchlists_service_url_list_partial_error_still_resets_brea
     assert row["error_count"] == 0
     assert row["last_error"] is None
     assert row["is_paused"] == 0
+
+
+@pytest.fixture
+def _loguru_to_caplog():
+    """Bridge loguru output into pytest's ``caplog`` for the tests below.
+
+    loguru does not propagate to stdlib ``logging`` (and therefore not to
+    ``caplog``) without an explicit bridge -- the same pattern used in
+    ``Tests/Model_Artifacts/test_credentials_and_boundaries.py``. Scoped to
+    an explicit, non-autouse fixture so it only applies to the tests that
+    request it.
+    """
+    from loguru import logger as loguru_logger
+
+    class PropagateHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = loguru_logger.add(PropagateHandler(), format="{message}")
+    yield
+    loguru_logger.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_local_watchlists_service_record_run_failure_auto_pauses_at_threshold(
+    tmp_path, caplog, _loguru_to_caplog
+):
+    """task-1410 AC#2.
+
+    The MAIN failure path -- ``LocalWatchlistsService.record_run_failure``
+    calling ``SubscriptionsDB.record_check_error`` -- previously bumped
+    ``consecutive_failures`` but never consulted ``auto_pause_threshold`` at
+    all, so a source that failed forever would never auto-pause. This drives
+    the fix through the REAL path (``execute_run`` raising ->
+    ``record_run_failure`` -> ``record_check_error``), not by calling
+    ``SubscriptionsDB.record_check_error`` directly -- the AC explicitly
+    forbids that shortcut, since bypassing the service is exactly how this
+    path stayed unreachable in the first place.
+
+    Reds if the threshold check inside the shared
+    ``_advance_failure_and_maybe_pause`` helper is removed or bypassed:
+    ``is_paused`` stays 0 after 3 failures and no WARNING is logged.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+
+    async def always_fails(subscription):
+        raise TimeoutError("connect timed out")
+
+    service = LocalWatchlistsService(db_factory=lambda: db, run_executor=always_fails)
+    source = await service.create_source(
+        {
+            "name": "Feed",
+            "url": "https://example.com/feed.xml",
+            "source_type": "rss",
+            "auto_pause_threshold": 3,
+        }
+    )
+    source_id = source["source_id"]
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            launched = await service.launch_run(source_id=source_id)
+            completed = await service.execute_run(launched["run_id"])
+            assert completed["status"] == "failed"
+
+    row = db.get_subscription(source_id)
+    assert row["consecutive_failures"] == 3
+    assert row["is_paused"] == 1, "threshold reached via the real failure path -- must auto-pause"
+
+    auto_pause_warnings = [
+        record for record in caplog.records if "Auto-paused subscription" in record.message
+    ]
+    assert len(auto_pause_warnings) == 1, (
+        "exactly one auto-pause WARNING must fire (on the 3rd failure only), got "
+        f"{[r.message for r in auto_pause_warnings]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_watchlists_service_both_failure_paths_pause_at_the_same_threshold(
+    tmp_path,
+):
+    """task-1410 consistency guard.
+
+    ``record_check_result``'s error branch (reached for an all-error
+    ``url_list``/``sitemap`` run, task-1394) and ``record_check_error`` (the
+    main failure path, reached via ``record_run_failure``) now share
+    ``_advance_failure_and_maybe_pause``. This proves they cannot diverge:
+    an all-error ``url_list`` run AND a plain single-URL failure, each with
+    the same ``auto_pause_threshold``, both end paused after the same
+    number of consecutive failures.
+    """
+    threshold = 2
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+
+    class FakeURLMonitor:
+        def __init__(self, db):
+            self.db = db
+
+        async def check_url(self, subscription):
+            raise TimeoutError("connect timed out")
+
+    async def always_fails(subscription):
+        raise TimeoutError("connect timed out")
+
+    # Path 1: record_check_result's error branch, via an all-error url_list run.
+    service_a = LocalWatchlistsService(db_factory=lambda: db)
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "tldw_chatbook.Subscriptions.monitoring_engine.URLMonitor",
+            FakeURLMonitor,
+        )
+        source_a = await service_a.create_source(
+            {
+                "name": "Docs",
+                "source_type": "url_list",
+                "auto_pause_threshold": threshold,
+                "extraction_rules": {"urls": ["https://example.com/a"]},
+            }
+        )
+        source_a_id = source_a["source_id"]
+        for _ in range(threshold):
+            launched = await service_a.launch_run(source_id=source_a_id)
+            await service_a.execute_run(launched["run_id"])
+
+    # Path 2: record_check_error, via a plain source whose executor always raises.
+    service_b = LocalWatchlistsService(db_factory=lambda: db, run_executor=always_fails)
+    source_b = await service_b.create_source(
+        {
+            "name": "Feed",
+            "url": "https://example.com/feed.xml",
+            "source_type": "rss",
+            "auto_pause_threshold": threshold,
+        }
+    )
+    source_b_id = source_b["source_id"]
+    for _ in range(threshold):
+        launched = await service_b.launch_run(source_id=source_b_id)
+        await service_b.execute_run(launched["run_id"])
+
+    row_a = db.get_subscription(source_a_id)
+    row_b = db.get_subscription(source_b_id)
+    assert row_a["consecutive_failures"] == threshold
+    assert row_b["consecutive_failures"] == threshold
+    assert row_a["is_paused"] == 1, "record_check_result's error branch must pause at threshold"
+    assert row_b["is_paused"] == 1, "record_check_error must pause at threshold"
 
 
 @pytest.mark.asyncio

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -835,6 +835,11 @@ async def test_local_watchlists_service_record_run_failure_auto_pauses_at_thresh
     Reds if the threshold check inside the shared
     ``_advance_failure_and_maybe_pause`` helper is removed or bypassed:
     ``is_paused`` stays 0 after 3 failures and no WARNING is logged.
+
+    Args:
+        tmp_path: pytest temp dir for the on-disk `SubscriptionsDB`.
+        caplog: pytest log capture, asserts the auto-pause WARNING.
+        _loguru_to_caplog: routes loguru into `caplog` for the assertion.
     """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
 
@@ -884,6 +889,9 @@ async def test_local_watchlists_service_both_failure_paths_pause_at_the_same_thr
     an all-error ``url_list`` run AND a plain single-URL failure, each with
     the same ``auto_pause_threshold``, both end paused after the same
     number of consecutive failures.
+
+    Args:
+        tmp_path: pytest temp dir for the on-disk `SubscriptionsDB`.
     """
     threshold = 2
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
@@ -965,6 +973,9 @@ async def test_local_watchlists_service_successful_manual_recheck_resumes_a_paus
 
     Reds if `record_check_result`'s success branch drops its new
     `is_paused = 0` write.
+
+    Args:
+        tmp_path: pytest temp dir for the on-disk `SubscriptionsDB`.
     """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
 
@@ -1162,6 +1173,9 @@ async def test_create_source_persists_check_frequency(tmp_path):
 
     ``WatchlistProjection`` computes ``next_run_at`` from ``check_frequency``, so a
     source that does not carry one is never queued and never checked.
+
+    Args:
+        tmp_path: pytest temp dir for the on-disk `SubscriptionsDB`.
     """
     db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
     service = LocalWatchlistsService(db_factory=lambda: db)
@@ -1266,6 +1280,9 @@ async def test_get_item_status_reads_one_row_and_refuses_a_missing_one(tmp_path)
     A missing row raises rather than returning a falsy status: the guard's
     caller treats an exception as a refusal, and "the item is gone" is an
     unanswered question, not permission to overwrite.
+
+    Args:
+        tmp_path: pytest temp dir for the on-disk `SubscriptionsDB`.
     """
     from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
 

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -942,6 +942,68 @@ async def test_local_watchlists_service_both_failure_paths_pause_at_the_same_thr
 
 
 @pytest.mark.asyncio
+async def test_local_watchlists_service_successful_manual_recheck_resumes_a_paused_source(
+    tmp_path,
+):
+    """Fix wave for the task-1410 review, Finding #1 (the important one).
+
+    Once a source auto-pauses, the scheduler never re-checks it:
+    `get_pending_checks` excludes `is_paused = 1` rows and
+    `WatchlistCheckHandler` skips them too. But `launch_run`/`execute_run`
+    have no paused guard at all -- a MANUAL re-check of a paused source
+    still runs. That is meant to be the source's only recourse, but until
+    this fix wave nothing on the success side ever cleared `is_paused`
+    (the auto-pause helper only ever writes `is_paused = 1`;
+    `reset_subscription_errors` has zero callers app-wide) -- so even a
+    manual re-check that fully succeeded left the source stranded, paused
+    forever.
+
+    Drives the real path end to end: an already-paused source, a manual
+    `launch_run` + `execute_run` whose executor succeeds, and confirms
+    `is_paused` clears with the failure counters reset -- exactly as an
+    ordinary successful check resets them.
+
+    Reds if `record_check_result`'s success branch drops its new
+    `is_paused = 0` write.
+    """
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+
+    async def always_succeeds(subscription):
+        return []
+
+    service = LocalWatchlistsService(db_factory=lambda: db, run_executor=always_succeeds)
+    source = await service.create_source(
+        {
+            "name": "Feed",
+            "url": "https://example.com/feed.xml",
+            "source_type": "rss",
+            "auto_pause_threshold": 3,
+        }
+    )
+    source_id = source["source_id"]
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE subscriptions
+            SET is_paused = 1, error_count = 3, consecutive_failures = 3,
+                last_error = 'connection refused'
+            WHERE id = ?
+            """,
+            (source_id,),
+        )
+
+    launched = await service.launch_run(source_id=source_id)
+    completed = await service.execute_run(launched["run_id"])
+
+    assert completed["status"] == "completed"
+    row = db.get_subscription(source_id)
+    assert row["is_paused"] == 0, "a successful manual re-check must resume a paused source"
+    assert row["consecutive_failures"] == 0
+    assert row["error_count"] == 0
+    assert row["last_error"] is None
+
+
+@pytest.mark.asyncio
 async def test_local_watchlists_service_executes_api_sources_with_json_field_mapping(
     tmp_path, monkeypatch
 ):

--- a/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
+++ b/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
@@ -79,9 +79,9 @@ both settings so the app stops promising a feature it does not have.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Recording a check failure never clears an existing `is_paused`; landed BEFORE #2, because auto-pause without it produces a pause the next manual re-check erases
-- [ ] #2 A source that fails the configured number of times in a row reaches the documented outcome, driven in a test through the real failure path rather than by calling the DB method directly
-- [ ] #3 `auto_pause_threshold` (column) and `auto_pause_after_failures` (`config.py:3553`) are reconciled: either both are read by a live path with a stated precedence, or both are removed together with the dead branch and the docs that advertise them
+- [x] #1 Recording a check failure never clears an existing `is_paused`; landed BEFORE #2, because auto-pause without it produces a pause the next manual re-check erases
+- [x] #2 A source that fails the configured number of times in a row reaches the documented outcome, driven in a test through the real failure path rather than by calling the DB method directly
+- [x] #3 `auto_pause_threshold` (column) and `auto_pause_after_failures` (`config.py:3553`) are reconciled: either both are read by a live path with a stated precedence, or both are removed together with the dead branch and the docs that advertise them
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -102,3 +102,65 @@ reachable for all-error runs. Wire it fully and consistently.
    `auto_pause_threshold` column default for NEW subscriptions; per-subscription column overrides
    (stated precedence). Document both in the config comment + a module docstring.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Shared helper.** Both failure paths now go through one new private method,
+`SubscriptionsDB._advance_failure_and_maybe_pause(cursor, subscription_id, error, now, *,
+force_pause=False)` (`DB/Subscriptions_DB.py`): it does the `last_checked`/`last_error`/
+`error_count`/`consecutive_failures` UPDATE, reads back the post-increment count, and pauses (with
+the "Auto-paused subscription N after M failures" WARNING) iff `force_pause` or
+`consecutive_failures >= auto_pause_threshold`. `record_check_result`'s `if error:` branch and
+`record_check_error` both call it — neither has its own copy of the threshold comparison, so they
+cannot diverge. The pause `UPDATE` inside the helper only ever sets `is_paused = 1`; there is no
+`is_paused = 0` write left anywhere in either failure path (AC#1), because `record_check_error` no
+longer runs its own combined UPDATE that used to include `is_paused = ?`.
+
+**`should_pause` fate.** Folded into the shared decision rather than removed: it is now the
+`force_pause` argument to the helper, so passing `should_pause=True` still forces a pause on that
+one failure regardless of the threshold, but — like the threshold path — it can only ever set
+`is_paused = 1`, never clear it. No production caller passes `should_pause=True` today (grep
+confirmed); it is kept as an escape hatch for a caller that already knows a failure is terminal,
+documented as such in `record_check_error`'s docstring.
+
+**AC#3 precedence.** `add_subscription` seeds `fields["auto_pause_threshold"]` from a new
+module-level `_default_auto_pause_threshold()` (reads `[subscriptions].auto_pause_after_failures`
+via the three-argument `get_cli_setting(section, key, default)` form, never the dotted form — the
+TASK-1771 default-drop trap) **only when the caller did not already supply the field**, i.e. an
+explicit `auto_pause_threshold` kwarg (including one forwarded from
+`LocalWatchlistsService.create_source`/`update_source`) always wins. A missing or non-numeric
+config value falls back to the same `10` the schema's own `DEFAULT 10` already uses, so a broken
+config cannot block subscription creation. Existing rows are untouched — this only changes what a
+brand-new INSERT defaults to. Documented in `_default_auto_pause_threshold`'s docstring and an
+inline comment on `config.py`'s `[subscriptions]` template next to `auto_pause_after_failures`.
+
+**Tests.** `Tests/DB/test_subscriptions_db.py` gained 4 tests (AC#1 direct-DB never-unpause test,
+plus 3 for AC#3's seed/override/fallback precedence via `monkeypatch.setattr` on the module-level
+`get_cli_setting` name). `Tests/Subscriptions/test_local_watchlists_service.py` gained 2 tests: AC#2
+drives the real path (`execute_run` raising → `record_run_failure` → `record_check_error`) for 3
+failures at `auto_pause_threshold=3` and asserts exactly one auto-pause WARNING (via a
+`_loguru_to_caplog` bridge fixture, same pattern as
+`Tests/Model_Artifacts/test_credentials_and_boundaries.py`); a consistency test drives an all-error
+`url_list` run (the task-1394 `record_check_result` path) and a plain always-failing source (the
+`record_check_error` path) at the same threshold and asserts both end `is_paused=1` at the same
+failure count. Every new/changed behavior was mutation-tested (Edit → run → Edit-revert, `git
+status --short` clean between): AC#1's mutation (restoring the old `is_paused = 1 if should_pause
+else 0` write) reds all 3 pause-related tests including the consistency test; AC#2's mutation
+(dropping the threshold comparison to `force_pause` only) reds the AC#2 test, the consistency test,
+and the pre-existing task-1394 all-error test; AC#3's mutations (disabling the seed, forcing the
+seed to always override, and removing the `int()` fallback) each red exactly the test they target.
+Full suite: 901 passed (895 pre-existing + 6 new) across `Tests/Subscriptions`, `Tests/Scheduling`,
+`Tests/DB/test_subscriptions_db.py`.
+
+**Files touched:** `tldw_chatbook/DB/Subscriptions_DB.py` (shared helper, `record_check_result`/
+`record_check_error` rewired, `_default_auto_pause_threshold` + `add_subscription` seeding),
+`tldw_chatbook/config.py` (precedence comment on `auto_pause_after_failures`),
+`Tests/DB/test_subscriptions_db.py`, `Tests/Subscriptions/test_local_watchlists_service.py`.
+
+**Left open / not done here:** `Docs/Features/SUBSCRIPTION_IMPLEMENTATION_PLAN.md:1052` (mentioned
+in the task description as documenting `auto_pause_after_failures`) was not re-checked against the
+new seeding behavior — out of scope for the stated ACs, called out here rather than silently
+skipped. Status intentionally left **In Progress** per dispatch instructions rather than moved to
+Done.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
+++ b/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1410
 title: Watchlist auto-pause never fires; its only implementation is unreachable
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-30 08:20'
 labels:
@@ -83,3 +83,22 @@ both settings so the app stops promising a feature it does not have.
 - [ ] #2 A source that fails the configured number of times in a row reaches the documented outcome, driven in a test through the real failure path rather than by calling the DB method directly
 - [ ] #3 `auto_pause_threshold` (column) and `auto_pause_after_failures` (`config.py:3553`) are reconciled: either both are read by a live path with a stated precedence, or both are removed together with the dead branch and the docs that advertise them
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Direction (AC#3 fork): COMPLETE auto-pause rather than remove it — the schema column, config knob,
+and dead branch all intend it, and task-1394 already made `record_check_result`'s pause branch
+reachable for all-error runs. Wire it fully and consistently.
+1. **AC#1 (prerequisite):** `record_check_error` must NEVER clear `is_paused`. Change its UPDATE so
+   a failure only ever SETS is_paused (write `is_paused = CASE WHEN <should_pause> THEN 1 ELSE
+   is_paused END`), never 0. A recorded failure can pause but never un-pause.
+2. **AC#2:** `record_check_error` consults `auto_pause_threshold` and pauses when
+   `consecutive_failures` (post-increment) >= threshold — the SAME logic `record_check_result`'s
+   error branch uses (1394 made it live). Factor a shared helper so the two failure paths cannot
+   diverge. Test through the real path (`record_run_failure` → `record_check_error`): a source that
+   fails N times in a row ends `is_paused=1`.
+3. **AC#3:** `auto_pause_after_failures` (config, currently read by nothing) seeds the
+   `auto_pause_threshold` column default for NEW subscriptions; per-subscription column overrides
+   (stated precedence). Document both in the config comment + a module docstring.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
+++ b/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
@@ -163,4 +163,35 @@ in the task description as documenting `auto_pause_after_failures`) was not re-c
 new seeding behavior — out of scope for the stated ACs, called out here rather than silently
 skipped. Status intentionally left **In Progress** per dispatch instructions rather than moved to
 Done.
+
+**Fix wave (whole-branch review follow-up).** The review found the branch clean against the three
+ACs but flagged that auto-pause, as landed, was a permanent trap: `reset_subscription_errors` (the
+only `is_paused = 0` writer) has zero callers, the scheduler skips paused sources, and
+`record_check_result`'s success branch did not clear `is_paused` — so nothing could ever un-pause an
+auto-paused source. Fixed by giving a **successful check** the natural recourse: the success branch
+in `record_check_result` now also sets `is_paused = 0` alongside its existing counter reset. AC#1 is
+unchanged (a failure never un-pauses); a success now does. This is coherent with the fact that
+`launch_run`/`execute_run` have no paused guard — a manual re-check of a paused source still runs,
+and a successful one now resumes it. No paused guard was added to `launch_run`/`execute_run`; doing
+so would have removed this recourse entirely. Also guarded
+`_advance_failure_and_maybe_pause`'s threshold comparison (`consecutive_failures >=
+auto_pause_threshold`) against a NULL or non-positive `auto_pause_threshold` — previously a `TypeError`
+on NULL (`int >= None`) or an instant pause-on-first-failure on 0/negative; no production path seeds
+either today (the config seed falls back to 10, the service strips `None`), but a direct
+`update_subscription(auto_pause_threshold=...)` reached the unguarded comparison. Both are now
+treated as "auto-pause disabled for this source." Also corrected the helper's docstring, which
+claimed the success branch already un-paused before this fix wave made that true, and rewired the
+`record_check_result` metric's `"auto_paused"` label — previously always `"false"` because it
+text-sniffed `error` for a substring the helper never wrote there — to the helper's own return value
+instead. New tests: `Tests/DB/test_subscriptions_db.py` gained
+`test_record_check_result_success_resumes_an_auto_paused_subscription` and a
+`bad_threshold`-parametrized (`None`/`0`/`-1`) guard test;
+`Tests/Subscriptions/test_local_watchlists_service.py` gained
+`test_local_watchlists_service_successful_manual_recheck_resumes_a_paused_source`, driving the resume
+through the real `launch_run`/`execute_run` path. All mutation-tested (Edit → run → revert, `git
+status --short` clean between): dropping the new `is_paused = 0` write reds both resume tests;
+dropping the threshold guard reds all three parametrized cases (`None` raises `TypeError`; `0`/`-1`
+pause on the first failure). Filed TASK-2050 (low priority) for the still-missing UI resume
+affordance and paused indicator — this fix wave closes the data-layer trap, not the UX gap the
+review's Finding #1 also named.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2050 - Watchlists resume affordance for auto-paused sources.md
+++ b/backlog/tasks/task-2050 - Watchlists resume affordance for auto-paused sources.md
@@ -1,0 +1,41 @@
+---
+id: TASK-2050
+title: Watchlists resume affordance for auto-paused sources
+status: To Do
+assignee: []
+created_date: '2026-08-02'
+labels:
+  - watchlists
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix wave for the task-1410 review (Finding #1) gave an auto-paused source its first real recourse:
+`SubscriptionsDB.record_check_result`'s success branch now writes `is_paused = 0` alongside its
+existing counter reset, so a check that succeeds resumes a paused source. Combined with
+`launch_run`/`execute_run` never having a paused guard, a **manual re-check** of a paused source
+runs, and if it succeeds the source resumes.
+
+That recourse exists entirely at the data layer. There is still no explicit "Resume" / un-pause
+action anywhere in the watchlists UI, and nothing in the UI distinguishes an auto-paused source from
+one that is merely inactive or healthy. `SubscriptionsDB.update_subscription(is_paused=0)` and
+`reset_subscription_errors` both exist as un-pause writes, but grep confirms neither has a caller
+outside the DB layer itself — there is no UI (or service-layer) path that invokes either one.
+
+Net effect: a source that auto-pauses after repeated failures is visible only as a silently
+stalled feed. A user who does not already know to trigger a manual re-check (and does not know
+that succeeding is what un-pauses it) has no way to tell the source is paused, let alone resume it,
+without editing config directly or reverse-engineering the recourse above.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A paused source (`is_paused = 1`) is visibly marked as paused somewhere in the watchlists UI, distinguishable from an inactive or healthy source
+- [ ] #2 The user can resume a paused source with a single UI action, without editing config or manually crafting a re-check
+- [ ] #3 That resume action clears `is_paused` and resets the failure counters (`error_count`, `consecutive_failures`, `last_error`) via an existing or new service-layer call, not a direct DB write from the UI layer
+<!-- AC:END -->

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1527,11 +1527,12 @@ class SubscriptionsDB(BaseDB):
                 # task-1410 AC#2: shared with `record_check_error` so the
                 # two failure-recording paths cannot diverge on the
                 # threshold check -- see `_advance_failure_and_maybe_pause`.
-                self._advance_failure_and_maybe_pause(
+                just_paused = self._advance_failure_and_maybe_pause(
                     cursor, subscription_id, error, now
                 )
 
             else:
+                just_paused = False
                 # Successful check
                 cursor.execute(
                     """
@@ -1540,7 +1541,8 @@ class SubscriptionsDB(BaseDB):
                         last_successful_check = ?,
                         last_error = NULL,
                         error_count = 0,
-                        consecutive_failures = 0
+                        consecutive_failures = 0,
+                        is_paused = 0
                     WHERE id = ?
                 """,
                     (now, now, subscription_id),
@@ -1574,9 +1576,14 @@ class SubscriptionsDB(BaseDB):
                     "operation": "record_check_result",
                     "status": "error" if error else "success",
                     "item_count": str(len(items)) if items else "0",
-                    "auto_paused": "true"
-                    if error and "Auto-paused" in str(error)
-                    else "false",
+                    # Fix wave for the task-1410 review (Finding #4): this used
+                    # to inspect `error` for the substring "Auto-paused",
+                    # which `_advance_failure_and_maybe_pause` never writes
+                    # there (it goes to `logger.warning`, not `last_error`),
+                    # so the label was always "false" even when this very
+                    # call paused the subscription. Wired to the helper's own
+                    # return value instead of a text-sniffing guess.
+                    "auto_paused": "true" if just_paused else "false",
                 },
             )
 
@@ -1588,7 +1595,7 @@ class SubscriptionsDB(BaseDB):
         now: str,
         *,
         force_pause: bool = False,
-    ) -> None:
+    ) -> bool:
         """Record one failed check and auto-pause once the streak meets threshold.
 
         task-1410 AC#2. The single write path both `record_check_result`'s
@@ -1608,9 +1615,15 @@ class SubscriptionsDB(BaseDB):
         through this one method is what keeps them from diverging again.
 
         AC#1: this never clears `is_paused` -- the only `UPDATE ... SET
-        is_paused = ...` below can set it to `1`, never `0`. Un-pausing
-        remains exclusively `reset_subscription_errors`' and the success
-        branch's job.
+        is_paused = ...` below can set it to `1`, never `0`. A FAILURE never
+        un-pauses a source; only a SUCCESS does. That un-pausing happens in
+        `record_check_result`'s success branch (fix wave for the task-1410
+        review: an auto-paused source had no writer that ever cleared
+        `is_paused`, since this helper only runs on failures and
+        `reset_subscription_errors` has no callers). This gives a paused
+        source its only recourse: nothing re-checks a paused source on a
+        schedule, but a manual re-check still runs (`launch_run`/
+        `execute_run` have no paused guard), and a successful one resumes it.
 
         Args:
             cursor: An open cursor inside the caller's transaction.
@@ -1623,6 +1636,11 @@ class SubscriptionsDB(BaseDB):
                 instead of a second, independent write path -- the one
                 that used to write `is_paused = 0` on every ordinary
                 failure and clear an existing pause (AC#1).
+
+        Returns:
+            True if this call paused the subscription, False otherwise --
+            used by `record_check_result`'s metric logging (Finding #4 of
+            the task-1410 review) instead of text-sniffing `error`.
         """
         cursor.execute(
             """
@@ -1645,8 +1663,19 @@ class SubscriptionsDB(BaseDB):
         )
         row = cursor.fetchone()
         if row is None:
-            return
-        if force_pause or row["consecutive_failures"] >= row["auto_pause_threshold"]:
+            return False
+        threshold = row["auto_pause_threshold"]
+        # A NULL/non-positive threshold means "auto-pause disabled for this
+        # source", not "pause on the very first failure" (0/negative) or a
+        # crash (`int >= None` raises TypeError). Production never seeds a
+        # value like this (the config default is 10 and the service strips
+        # `None`), but `update_subscription(auto_pause_threshold=...)`
+        # accepts one directly, so the helper itself must not trust it.
+        threshold_active = isinstance(threshold, (int, float)) and threshold > 0
+        should_pause = force_pause or (
+            threshold_active and row["consecutive_failures"] >= threshold
+        )
+        if should_pause:
             cursor.execute(
                 "UPDATE subscriptions SET is_paused = 1 WHERE id = ?",
                 (subscription_id,),
@@ -1655,6 +1684,7 @@ class SubscriptionsDB(BaseDB):
                 f"Auto-paused subscription {subscription_id} after "
                 f"{row['consecutive_failures']} failures"
             )
+        return should_pause
 
     def record_check_error(
         self, subscription_id: int, error: str, should_pause: bool = False

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -1638,9 +1638,12 @@ class SubscriptionsDB(BaseDB):
                 failure and clear an existing pause (AC#1).
 
         Returns:
-            True if this call paused the subscription, False otherwise --
-            used by `record_check_result`'s metric logging (Finding #4 of
-            the task-1410 review) instead of text-sniffing `error`.
+            True only when this call TRANSITIONED the subscription from
+            not-paused to paused, False otherwise (including a failure on an
+            already-paused source) -- so `record_check_result`'s `auto_paused`
+            metric and the warning count one pause per pause, not per failure
+            (Finding #4 of the task-1410 review, Qodo transition-semantics
+            follow-up) instead of text-sniffing `error`.
         """
         cursor.execute(
             """
@@ -1656,7 +1659,7 @@ class SubscriptionsDB(BaseDB):
 
         cursor.execute(
             """
-            SELECT consecutive_failures, auto_pause_threshold
+            SELECT consecutive_failures, auto_pause_threshold, is_paused
             FROM subscriptions WHERE id = ?
             """,
             (subscription_id,),
@@ -1664,6 +1667,7 @@ class SubscriptionsDB(BaseDB):
         row = cursor.fetchone()
         if row is None:
             return False
+        already_paused = bool(row["is_paused"])
         threshold = row["auto_pause_threshold"]
         # A NULL/non-positive threshold means "auto-pause disabled for this
         # source", not "pause on the very first failure" (0/negative) or a
@@ -1675,7 +1679,15 @@ class SubscriptionsDB(BaseDB):
         should_pause = force_pause or (
             threshold_active and row["consecutive_failures"] >= threshold
         )
-        if should_pause:
+        # Auto-pause is a state TRANSITION, not a per-failure event. A source
+        # that is already paused and gets a failing MANUAL re-check (the
+        # scheduler skips paused sources, so only a manual re-check reaches
+        # here) still meets the threshold, but re-logging "Auto-paused" and
+        # re-counting the metric on every such failure would over-count a
+        # single pause (task-1410 review, Qodo). Only the 0->1 transition
+        # logs and is reported.
+        newly_paused = should_pause and not already_paused
+        if should_pause and not already_paused:
             cursor.execute(
                 "UPDATE subscriptions SET is_paused = 1 WHERE id = ?",
                 (subscription_id,),
@@ -1684,7 +1696,7 @@ class SubscriptionsDB(BaseDB):
                 f"Auto-paused subscription {subscription_id} after "
                 f"{row['consecutive_failures']} failures"
             )
-        return should_pause
+        return newly_paused
 
     def record_check_error(
         self, subscription_id: int, error: str, should_pause: bool = False

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -38,7 +38,54 @@ from loguru import logger
 from .private_sqlite import connect_private_sqlite
 from .base_db import BaseDB
 from .sql_validation import validate_identifier
+from ..config import get_cli_setting
 from ..Metrics.metrics_logger import log_counter, log_histogram
+
+
+#: Fallback `auto_pause_threshold` when the config value is missing or
+#: unusable (task-1410 AC#3) -- matches the schema column's own `CREATE
+#: TABLE ... DEFAULT 10` and the `[subscriptions]` config template's own
+#: `auto_pause_after_failures = 10`, so a broken/hand-edited config still
+#: produces the same default a fresh install would get.
+_DEFAULT_AUTO_PAUSE_THRESHOLD = 10
+
+
+def _default_auto_pause_threshold() -> int:
+    """The `auto_pause_threshold` column default for a NEW subscription.
+
+    task-1410 AC#3. `[subscriptions].auto_pause_after_failures` (the
+    user-facing knob documented in
+    `Docs/Features/SUBSCRIPTION_IMPLEMENTATION_PLAN.md`) was, until this
+    task, read by nothing: `auto_pause_threshold` is a separate
+    per-subscription column that only ever got the schema's hardcoded
+    `DEFAULT 10` for any row inserted without it. `add_subscription` calls
+    this to seed that column when the caller does not pass
+    `auto_pause_threshold` explicitly, reconciling the two:
+
+    Precedence: an explicit `auto_pause_threshold` kwarg to
+    `add_subscription` always wins -- this is consulted only when the
+    caller omits it. Existing subscriptions are never touched (this only
+    affects the INSERT default for a brand-new row); an update to the
+    config afterwards does not retroactively change any subscription's
+    stored column value.
+
+    Uses the traditional three-argument `get_cli_setting(section, key,
+    default)` form, never the two-argument dotted form -- TASK-1771: a
+    caller-supplied default in the dotted form's second positional slot is
+    walked as a path segment instead of honoured, and silently returns
+    `None` rather than either the configured value or this default.
+
+    Returns:
+        The configured `auto_pause_after_failures` as a positive `int`, or
+        `_DEFAULT_AUTO_PAUSE_THRESHOLD` if the config value is absent, not
+        parseable as an int, or not positive.
+    """
+    configured = get_cli_setting("subscriptions", "auto_pause_after_failures", _DEFAULT_AUTO_PAUSE_THRESHOLD)
+    try:
+        threshold = int(configured)
+    except (TypeError, ValueError):
+        return _DEFAULT_AUTO_PAUSE_THRESHOLD
+    return threshold if threshold > 0 else _DEFAULT_AUTO_PAUSE_THRESHOLD
 
 
 # --- Custom Exceptions ---
@@ -1139,6 +1186,18 @@ class SubscriptionsDB(BaseDB):
                         value = json.dumps(value)
                     fields[field] = value
 
+            # task-1410 AC#3: a caller that does not pass an explicit
+            # `auto_pause_threshold` gets the configured
+            # `[subscriptions].auto_pause_after_failures` default instead of
+            # silently falling through to the schema's hardcoded `DEFAULT
+            # 10` -- see `_default_auto_pause_threshold`'s docstring for the
+            # full precedence. An explicit kwarg (including an explicit
+            # `None`, which the loop above would already have captured)
+            # always wins; this only fires when the field never made it
+            # into `fields` at all.
+            if "auto_pause_threshold" not in fields:
+                fields["auto_pause_threshold"] = _default_auto_pause_threshold()
+
             # Build insert query
             columns = ", ".join(fields.keys())
             placeholders = ", ".join(["?" for _ in fields])
@@ -1465,41 +1524,12 @@ class SubscriptionsDB(BaseDB):
             now = datetime.now(timezone.utc).isoformat()
 
             if error:
-                # Update error tracking
-                cursor.execute(
-                    """
-                    UPDATE subscriptions
-                    SET last_checked = ?,
-                        last_error = ?,
-                        error_count = error_count + 1,
-                        consecutive_failures = consecutive_failures + 1
-                    WHERE id = ?
-                """,
-                    (now, error, subscription_id),
+                # task-1410 AC#2: shared with `record_check_error` so the
+                # two failure-recording paths cannot diverge on the
+                # threshold check -- see `_advance_failure_and_maybe_pause`.
+                self._advance_failure_and_maybe_pause(
+                    cursor, subscription_id, error, now
                 )
-
-                # Check if we should auto-pause
-                cursor.execute(
-                    """
-                    SELECT consecutive_failures, auto_pause_threshold
-                    FROM subscriptions WHERE id = ?
-                """,
-                    (subscription_id,),
-                )
-
-                row = cursor.fetchone()
-                if row and row["consecutive_failures"] >= row["auto_pause_threshold"]:
-                    cursor.execute(
-                        """
-                        UPDATE subscriptions
-                        SET is_paused = 1
-                        WHERE id = ?
-                    """,
-                        (subscription_id,),
-                    )
-                    logger.warning(
-                        f"Auto-paused subscription {subscription_id} after {row['consecutive_failures']} failures"
-                    )
 
             else:
                 # Successful check
@@ -1550,26 +1580,124 @@ class SubscriptionsDB(BaseDB):
                 },
             )
 
+    def _advance_failure_and_maybe_pause(
+        self,
+        cursor: sqlite3.Cursor,
+        subscription_id: int,
+        error: str,
+        now: str,
+        *,
+        force_pause: bool = False,
+    ) -> None:
+        """Record one failed check and auto-pause once the streak meets threshold.
+
+        task-1410 AC#2. The single write path both `record_check_result`'s
+        error branch and `record_check_error` use for "a check just
+        failed": it bumps `error_count`/`consecutive_failures`, stamps
+        `last_checked`/`last_error`, then compares the POST-increment
+        `consecutive_failures` against the subscription's own
+        `auto_pause_threshold` column and pauses -- logging the same
+        warning -- if it has been reached.
+
+        Before this helper existed, `record_check_error` (the main
+        failure path: `LocalWatchlistsService.record_run_failure` ->
+        `record_check_error`) never consulted the threshold at all, so it
+        could climb `consecutive_failures` forever without ever pausing,
+        while `record_check_result`'s error branch (reachable only for
+        all-error `url_list`/`sitemap` runs, task-1394) did. Routing both
+        through this one method is what keeps them from diverging again.
+
+        AC#1: this never clears `is_paused` -- the only `UPDATE ... SET
+        is_paused = ...` below can set it to `1`, never `0`. Un-pausing
+        remains exclusively `reset_subscription_errors`' and the success
+        branch's job.
+
+        Args:
+            cursor: An open cursor inside the caller's transaction.
+            subscription_id: The subscription that just failed a check.
+            error: The error message to record as `last_error`.
+            now: UTC ISO timestamp for `last_checked`.
+            force_pause: Pause on this failure regardless of the threshold
+                comparison. Folds `record_check_error`'s legacy
+                `should_pause` parameter into this single decision point
+                instead of a second, independent write path -- the one
+                that used to write `is_paused = 0` on every ordinary
+                failure and clear an existing pause (AC#1).
+        """
+        cursor.execute(
+            """
+            UPDATE subscriptions
+            SET last_checked = ?,
+                last_error = ?,
+                error_count = error_count + 1,
+                consecutive_failures = consecutive_failures + 1
+            WHERE id = ?
+            """,
+            (now, error, subscription_id),
+        )
+
+        cursor.execute(
+            """
+            SELECT consecutive_failures, auto_pause_threshold
+            FROM subscriptions WHERE id = ?
+            """,
+            (subscription_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return
+        if force_pause or row["consecutive_failures"] >= row["auto_pause_threshold"]:
+            cursor.execute(
+                "UPDATE subscriptions SET is_paused = 1 WHERE id = ?",
+                (subscription_id,),
+            )
+            logger.warning(
+                f"Auto-paused subscription {subscription_id} after "
+                f"{row['consecutive_failures']} failures"
+            )
+
     def record_check_error(
         self, subscription_id: int, error: str, should_pause: bool = False
     ) -> None:
-        """Record an error with optional auto-pause."""
+        """Record a failed check, auto-pausing at `auto_pause_threshold`.
+
+        task-1410: this used to write `is_paused = 1 if should_pause else
+        0` unconditionally on every call. No production caller ever passed
+        `should_pause=True` (grep confirms), so every recorded failure
+        silently wrote `is_paused = 0` -- clearing any pause a *different*
+        call had set, and never itself consulting `auto_pause_threshold`.
+        That made this, the MAIN failure path
+        (`LocalWatchlistsService.record_run_failure` calls this on every
+        run failure), a live way to erase a pause and a dead way to create
+        one.
+
+        Both defects are fixed by routing through the shared
+        `_advance_failure_and_maybe_pause` (AC#2): `is_paused` is now only
+        ever set to `1`, never `0` (AC#1), and it pauses at the same
+        threshold `record_check_result`'s error branch uses so the two
+        cannot diverge (task-1394's all-error path already exercises that
+        branch).
+
+        `should_pause` is folded into that same decision rather than kept
+        as a second, independent switch: passing `True` forces a pause on
+        THIS failure regardless of the count -- for a caller that already
+        knows the failure is terminal -- but, like the threshold path, it
+        can still only ever set `is_paused = 1`, never clear it.
+
+        Args:
+            subscription_id: ID of the subscription.
+            error: Error message to record.
+            should_pause: Force a pause on this failure even if
+                `consecutive_failures` has not yet reached
+                `auto_pause_threshold`. No production caller sets this
+                today; kept for callers that already know the failure is
+                terminal.
+        """
         with self.transaction() as conn:
             cursor = conn.cursor()
-
             now = datetime.now(timezone.utc).isoformat()
-
-            cursor.execute(
-                """
-                UPDATE subscriptions
-                SET last_checked = ?,
-                    last_error = ?,
-                    error_count = error_count + 1,
-                    consecutive_failures = consecutive_failures + 1,
-                    is_paused = ?
-                WHERE id = ?
-            """,
-                (now, error, 1 if should_pause else 0, subscription_id),
+            self._advance_failure_and_maybe_pause(
+                cursor, subscription_id, error, now, force_pause=should_pause
             )
 
     def reset_subscription_errors(self, subscription_id: int) -> None:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3597,7 +3597,7 @@ enabled = true
 default_check_interval = 3600  # 1 hour in seconds
 max_concurrent_checks = 10
 check_timeout_seconds = 30
-auto_pause_after_failures = 10
+auto_pause_after_failures = 10  # Seeds auto_pause_threshold for NEW subscriptions only (task-1410); an explicit per-subscription value always overrides, and existing subscriptions keep their stored value
 enable_background_checking = true
 default_priority = 3  # 1-5, higher is more important
 


### PR DESCRIPTION
## Why

Watchlist auto-pause was 100% dead code: `subscriptions.auto_pause_threshold` (schema default 10) and `auto_pause_after_failures` (config) were compared in exactly one place — `record_check_result`'s `if error:` branch — which had no caller, while the main failure path (`record_check_error` via `record_run_failure`) bumped `consecutive_failures` forever, never consulted the threshold, and *cleared* any existing `is_paused` on every failure. A dead source was retried on its cadence indefinitely (task-1410).

## What

- **AC#1 (prerequisite): a failure never un-pauses.** `record_check_error`'s `is_paused` write is now `CASE WHEN <pause> THEN 1 ELSE is_paused END` — a recorded failure can pause but never clear an existing pause.
- **AC#2: the main failure path auto-pauses.** A new shared `_advance_failure_and_maybe_pause` helper (the increment + threshold check + conditional pause) is called by BOTH failure paths — `record_check_error` and `record_check_result`'s error branch (which task-1394 just made reachable for all-error runs) — so the two cannot diverge. A source that fails `auto_pause_threshold` times in a row pauses, exercised through the real path (`record_run_failure` → `record_check_error`), not by calling the DB method directly.
- **AC#3: the two knobs reconciled.** `auto_pause_after_failures` (config) seeds the `auto_pause_threshold` column default for new subscriptions; a per-subscription column value overrides (stated precedence, documented). Existing rows untouched.
- **Review fix — resume-on-success (auto-pause is otherwise a permanent trap).** Turning on auto-pause with no un-pause path would strand sources forever (the scheduler skips paused sources; the only `is_paused=0` writer had no caller). The success branch now clears `is_paused` too, giving the documented recourse: a user's **manual re-check** of a paused source runs (no paused guard on `launch_run`/`execute_run`) and, if it succeeds, resumes it. A dedicated Resume-button UI is filed as follow-up **task-2050**.
- Defensive: a NULL/0/negative threshold (a direct bad `update_subscription`) is treated as "auto-pause disabled" rather than crashing or pausing instantly; the previously always-false `auto_paused` metric label is wired to the helper's real signal.

## Testing

Auto-pause through the real failure path (threshold=3 pauses on exactly the 3rd, not the 2nd); a failure never un-pauses (AC#1); resume-on-success through `launch_run`/`execute_run`; both failure paths pause at the same threshold via the shared helper (a mutation reds a task-1394 test too, proving it's genuinely shared); config seed + override + safe fallback; bad-threshold guard. Every behavioural change mutation-verified. Opus whole-branch review (CLEAN vs the 3 ACs, flagged the stranding) → fix wave → scoped re-review, APPROVED. 87 targeted tests pass; `--collect-only` clean.

**Note:** this turns auto-pause on as a real behavior (sources that fail repeatedly will pause) — the constructive reading of AC#3's fork, since the schema/config/dead-branch all intend it. If you'd rather remove auto-pause instead, the alternative is a smaller change; say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make watchlist auto-pause real and consistent across both failure paths, and add resume-on-success so paused sources can recover. Align the per-source threshold with config and guard invalid values (task-1410).

- **Bug Fixes**
  - Auto-pause works on both failure paths via a shared `_advance_failure_and_maybe_pause`; pauses when `consecutive_failures >= auto_pause_threshold`.
  - A failure never clears an existing pause. A successful check now resets counters and sets `is_paused = 0`, so a manual re-check can resume a source.
  - Reconciled knobs: `[subscriptions].auto_pause_after_failures` seeds `auto_pause_threshold` for new subscriptions; explicit per-source values override; existing rows unchanged; `None`/0/negative thresholds are treated as “disabled,” not errors.
  - Auto-pause reports once per transition (0→1) only: the warning and `auto_paused` metric fire once when pausing; fixed the metric label; added targeted DB and service tests.

<sup>Written for commit d46bd930c341c3458f03419911400f24f8e74478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

