### PR TITLE
chore: mark task-1410 Done (PR #1268 merged)

### DIFF
--- a/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
+++ b/backlog/tasks/task-1410 - Watchlist-auto-pause-never-fires-its-only-implementation-is-unreachable.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1410
 title: Watchlist auto-pause never fires; its only implementation is unreachable
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 08:20'
 labels:


### PR DESCRIPTION
Bookkeeping only: auto-pause live; resume UI filed as task-2050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark `TASK-1410` (Watchlist auto-pause unreachable) as Done, reflecting the fix shipped in `PR #1268`.
Resume UI work is tracked separately in `TASK-2050`.

<sup>Written for commit 723e39040592ccc48ce3a2890d4daeb3b17f3fda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

