### PR TITLE
refactor: rename side-effecting Watchlists predicate to an action name (task-1349)

### DIFF
--- a/Tests/Watchlists/test_no_side_effecting_predicates.py
+++ b/Tests/Watchlists/test_no_side_effecting_predicates.py
@@ -46,7 +46,9 @@ _SIDE_EFFECTS = {
 def _python_files():
     for target in _WATCHLISTS_DIRS:
         if target.is_dir():
-            yield from target.glob("*.py")
+            # Recursive: a predicate in a future nested subpackage must be
+            # covered too (Qodo, TASK-1349).
+            yield from target.rglob("*.py")
         elif target.is_file():
             yield target
 
@@ -69,7 +71,10 @@ def _side_effects_in(node: ast.AST) -> set[str]:
 def test_no_predicate_named_function_in_watchlists_has_a_side_effect():
     offenders = []
     for path in _python_files():
-        tree = ast.parse(path.read_text())
+        # Explicit UTF-8: these sources carry non-ASCII glyphs (e.g. the
+        # `▸` collapsed-region marker), so a default-locale read could
+        # UnicodeDecodeError or mis-decode on some runners (Qodo, TASK-1349).
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue

--- a/Tests/Watchlists/test_no_side_effecting_predicates.py
+++ b/Tests/Watchlists/test_no_side_effecting_predicates.py
@@ -1,0 +1,87 @@
+"""TASK-1349 AC#2: no predicate-named function in the Watchlists modules
+may have a side effect.
+
+The bug this guards against: a function named like a pure query
+(`_is_*`/`_has_*`/`_can_*`/`*_is_blocked`) that actually calls `self.notify`,
+posts a message, or writes the DB. Such a function is safe until someone wires
+it into a render path -- this codebase already shipped `provider_is_configured()`
+writing an `eval_models` row from `compose()`, so opening the Evals screen
+mutated the DB on every fresh install. The name gave no warning.
+
+`_content_toggle_is_blocked` (a predicate that notified) was renamed to the
+action `_refuse_content_toggle_off_read_tab` to fix exactly this; this test
+keeps the whole module family clean going forward -- a new side-effecting
+predicate fails here rather than waiting to be discovered from a render path.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# A repo-root-relative walk so the test is independent of the CWD pytest runs in.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WATCHLISTS_DIRS = [
+    _REPO_ROOT / "tldw_chatbook" / "UI" / "Watchlists_Modules",
+    _REPO_ROOT / "tldw_chatbook" / "UI" / "Screens" / "watchlists_collections_screen.py",
+]
+
+# Names that read as a pure boolean query.
+_PREDICATE_PREFIXES = ("_is_", "_has_", "_can_", "_should_", "is_", "has_", "can_")
+_PREDICATE_SUFFIXES = ("_is_blocked", "_is_allowed", "_is_open", "_is_active")
+
+# Attribute/call names that mutate observable state.
+_SIDE_EFFECTS = {
+    "notify",
+    "post_message",
+    "execute",
+    "executemany",
+    "commit",
+    "_schedule_layout_persist",
+}
+
+
+def _python_files():
+    for target in _WATCHLISTS_DIRS:
+        if target.is_dir():
+            yield from target.glob("*.py")
+        elif target.is_file():
+            yield target
+
+
+def _is_predicate_name(name: str) -> bool:
+    return name.startswith(_PREDICATE_PREFIXES) or any(
+        name.endswith(s) for s in _PREDICATE_SUFFIXES
+    )
+
+
+def _side_effects_in(node: ast.AST) -> set[str]:
+    hits: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+            if sub.func.attr in _SIDE_EFFECTS:
+                hits.add(sub.func.attr)
+    return hits
+
+
+def test_no_predicate_named_function_in_watchlists_has_a_side_effect():
+    offenders = []
+    for path in _python_files():
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _is_predicate_name(node.name):
+                continue
+            effects = _side_effects_in(node)
+            if effects:
+                offenders.append(
+                    f"{path.name}:{node.lineno} {node.name} -> {sorted(effects)}"
+                )
+    assert not offenders, (
+        "predicate-named functions must be pure; rename to an action (verb) or "
+        "move the side effect to the caller (TASK-1349):\n  "
+        + "\n  ".join(offenders)
+    )

--- a/backlog/tasks/task-1349 - _content_toggle_is_blocked-is-a-predicate-that-notifies.md
+++ b/backlog/tasks/task-1349 - _content_toggle_is_blocked-is-a-predicate-that-notifies.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1349
 title: _content_toggle_is_blocked is a predicate that notifies
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-29 05:30'
 labels:
@@ -26,6 +26,26 @@ render path, and the name gives no warning.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The predicate is pure, with the notify moved to its callers, or renamed to state that it acts
-- [ ] #2 A grep confirms no other predicate-named function in the Watchlists modules has side effects
+- [x] #1 The predicate is pure, with the notify moved to its callers, or renamed to state that it acts
+- [x] #2 A grep confirms no other predicate-named function in the Watchlists modules has side effects
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC#1 (rename arm): `_content_toggle_is_blocked` -> `_refuse_content_toggle_off_read_tab`. The
+notify stays in the helper (three call sites all want the same toast; moving it would duplicate the
+string 3x), so the fix is to name it as the ACTION it is — a verb signals the side effect that the
+innocent predicate name hid. Docstring states the naming rule and cites the `provider_is_configured()`
+render-path incident. All 5 call sites + the doc cross-reference renamed.
+
+AC#2: an AST scan (`Tests/Watchlists/test_no_side_effecting_predicates.py`) confirms
+`_content_toggle_is_blocked` was the ONLY predicate-named function with a side effect across
+`UI/Watchlists_Modules/` + `watchlists_collections_screen.py`; the other five (`_is_url_family_source`,
+`_is_sole_expanded_centre_region`, `_is_markdown`, `_has_local_wc_context`, `_can_generate_briefing`)
+are pure. Kept as a permanent regression: a new side-effecting predicate now fails this test rather
+than waiting to be found from a render path. Mutation-verified (rename back -> guard reds).
+
+Files: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
+`Tests/Watchlists/test_no_side_effecting_predicates.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1995,7 +1995,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _refuse_content_toggle_off_read_tab(self, region: Region) -> bool:
         """Refuse a CONTENT layout change off the Read tab, telling the user why.
 
-        Named as an ACTION, not a predicate (`_refuse_content_toggle_off_read_tab`
+        Named as an ACTION, not a predicate (it was `_content_toggle_is_blocked`
         before TASK-1349), because it is NOT pure: when it refuses it calls
         `self.notify(...)`. A side-effecting predicate is safe only until
         someone wires it into a render path -- this codebase already shipped

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1992,8 +1992,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 return
             save_region_layout(layout)
 
-    def _content_toggle_is_blocked(self, region: Region) -> bool:
-        """Whether a CONTENT layout change must be refused right now.
+    def _refuse_content_toggle_off_read_tab(self, region: Region) -> bool:
+        """Refuse a CONTENT layout change off the Read tab, telling the user why.
+
+        Named as an ACTION, not a predicate (`_refuse_content_toggle_off_read_tab`
+        before TASK-1349), because it is NOT pure: when it refuses it calls
+        `self.notify(...)`. A side-effecting predicate is safe only until
+        someone wires it into a render path -- this codebase already shipped
+        `provider_is_configured()` writing an `eval_models` row from
+        `compose()`, so opening the Evals screen mutated the DB on every fresh
+        install. The verb in the name is the warning that innocent name never
+        gave; keep it a verb if the notify stays here.
 
         Whole-branch review (Important): off the Read (Items) tab,
         `_visible_region_layout` force-collapses CONTENT, which renders a
@@ -2035,7 +2044,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def action_toggle_region(self) -> None:
         """Collapse or expand whichever region currently has focus."""
         region = self.focused_region
-        if self._content_toggle_is_blocked(region):
+        if self._refuse_content_toggle_off_read_tab(region):
             return
         self._apply_layout(self.region_layout.toggle(region))
 
@@ -2043,12 +2052,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         """Isolate the focused centre pane; press again to restore.
 
         Refused for CONTENT off the Read tab, exactly as the chevron and `z`
-        already are -- see `_content_toggle_is_blocked`.
+        already are -- see `_refuse_content_toggle_off_read_tab`.
         """
         if self.focused_region not in CENTRE_REGIONS:
             self.notify("Solo applies to the Feeds, Items, or Content panes.")
             return
-        if self._content_toggle_is_blocked(self.focused_region):
+        if self._refuse_content_toggle_off_read_tab(self.focused_region):
             return
         self._apply_layout(self.region_layout.solo(self.focused_region))
 
@@ -2061,7 +2070,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @on(RegionToggled)
     def _on_region_toggled(self, event: RegionToggled) -> None:
         event.stop()
-        if self._content_toggle_is_blocked(event.region):
+        if self._refuse_content_toggle_off_read_tab(event.region):
             return
         self._apply_layout(self.region_layout.toggle(event.region))
 


### PR DESCRIPTION
## Why

`_content_toggle_is_blocked` reads as a pure query but calls `self.notify(...)` before returning `True`. Harmless at its three call sites (all user gestures where the toast is wanted), but the name gives no warning — and this codebase has already been bitten by exactly this shape: `provider_is_configured()`, a predicate, wrote an `eval_models` row from `compose()`, so opening the Evals screen mutated the DB on every fresh install. A side-effecting predicate is safe only until someone wires it into a render path (task-1349).

## What

- **AC#1 (rename arm):** `_content_toggle_is_blocked` → `_refuse_content_toggle_off_read_tab`. The notify stays in the helper (three call sites all want the same toast; moving it would duplicate the string), so the fix is to name it as the action it is — the verb is the warning the innocent name never gave. The docstring now states the naming rule and cites the `provider_is_configured()` incident. All five call sites and the doc cross-reference updated.
- **AC#2:** an AST scan confirms this was the *only* predicate-named function with a side effect across `UI/Watchlists_Modules/` and `watchlists_collections_screen.py`; the other five predicates are pure. Kept as a permanent regression test (`test_no_side_effecting_predicates.py`) so a new side-effecting predicate fails there rather than being discovered from a render path.

## Testing

The refusal-behavior tests (`test_watchlists_content_pane.py`, 40) pass unchanged — they exercise the toast through the public gesture, not the private name. The new guard test passes and is mutation-verified: renaming back to the predicate form reds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed a side‑effecting predicate in Watchlists to a clear action and added a guard test to block future side‑effecting predicates. Satisfies TASK-1349 by making side effects explicit and preventing regressions.

- **Refactors**
  - `_content_toggle_is_blocked` → `_refuse_content_toggle_off_read_tab`; keeps `self.notify(...)`; updated three call sites and expanded docstring with rename history and the naming rule.
  - Added `Tests/Watchlists/test_no_side_effecting_predicates.py`: AST-scan runs recursively over `UI/Watchlists_Modules` and `watchlists_collections_screen.py` with explicit UTF‑8 reads; fails if predicate‑named functions call side‑effect methods.

<sup>Written for commit 85a6c6e142e8f943ee5a54b3eff7df8fe7c678e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

