### PR TITLE
chore: mark task-1349 Done (PR #1270 merged)

### DIFF
--- a/backlog/tasks/task-1349 - _content_toggle_is_blocked-is-a-predicate-that-notifies.md
+++ b/backlog/tasks/task-1349 - _content_toggle_is_blocked-is-a-predicate-that-notifies.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1349
 title: _content_toggle_is_blocked is a predicate that notifies
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-29 05:30'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark TASK-1349 as Done in the backlog now that "_content_toggle_is_blocked is a predicate that notifies" shipped in PR #1270. Doc-only change updating the task status from In Progress to Done.

<sup>Written for commit 6c2f158dac3b0e4fee023f4a7c568ae3809ceefc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

