### PR TITLE
fix: atomic failed-audio-row creation for the preflight failure paths (task-1718)

### DIFF
--- a/Tests/Subscriptions/test_briefing_audio_db.py
+++ b/Tests/Subscriptions/test_briefing_audio_db.py
@@ -65,6 +65,30 @@ def test_create_briefing_audio_accepts_an_explicit_status():
     assert db.get_briefing_audio(audio_id)["status"] == "complete"
 
 
+def test_create_briefing_audio_writes_status_and_error_in_one_insert():
+    """TASK-1718: a create-and-immediately-fail preflight writes the finished
+    `failed` row atomically -- status AND error in a single insert -- so there
+    is no create-then-separate-update window a crash could leave a stuck
+    `generating` row in. Reds if `create_briefing_audio` drops the `error`
+    argument (the row would come back with `error is None`)."""
+    db = SubscriptionsDB(":memory:", "test")
+    script_id = _make_script(db)
+
+    audio_id = db.create_briefing_audio(
+        script_id,
+        voice_snapshot_json="[]",
+        status="failed",
+        error="voice 'Host' could not be resolved",
+    )
+
+    row = db.get_briefing_audio(audio_id)
+    assert row["status"] == "failed"
+    assert row["error"] == "voice 'Host' could not be resolved"
+    # A plain create still leaves error NULL -- the param is opt-in.
+    plain = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
+    assert db.get_briefing_audio(plain)["error"] is None
+
+
 def test_get_briefing_audio_returns_none_for_missing_id():
     db = SubscriptionsDB(":memory:", "test")
     assert db.get_briefing_audio(999999) is None

--- a/Tests/Subscriptions/test_briefing_audio_db.py
+++ b/Tests/Subscriptions/test_briefing_audio_db.py
@@ -66,11 +66,13 @@ def test_create_briefing_audio_accepts_an_explicit_status():
 
 
 def test_create_briefing_audio_writes_status_and_error_in_one_insert():
-    """TASK-1718: a create-and-immediately-fail preflight writes the finished
-    `failed` row atomically -- status AND error in a single insert -- so there
-    is no create-then-separate-update window a crash could leave a stuck
+    """A create-and-immediately-fail preflight writes the finished row atomically.
+
+    TASK-1718: status AND error land in a single insert, so there is no
+    create-then-separate-update window a crash could leave a stuck
     `generating` row in. Reds if `create_briefing_audio` drops the `error`
-    argument (the row would come back with `error is None`)."""
+    argument (the row would come back with `error is None`).
+    """
     db = SubscriptionsDB(":memory:", "test")
     script_id = _make_script(db)
 

--- a/backlog/tasks/task-1718 - Briefings-audio-pipeline-row-creation-is-not-transactional.md
+++ b/backlog/tasks/task-1718 - Briefings-audio-pipeline-row-creation-is-not-transactional.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1718
 title: 'Briefings audio: pipeline row creation is not transactional'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-31 23:59'
 labels:
@@ -36,8 +36,28 @@ other failure mode.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Either `create_briefing_audio` and the row's first `update_briefing_audio` share one
+- [x] #1 Either `create_briefing_audio` and the row's first `update_briefing_audio` share one
       transaction (so a crash between them can no longer happen), or the non-atomicity is
       documented as an accepted trade-off in `briefing_audio.py`'s module docstring, naming
       `fail_interrupted_audio` as the self-healing path that recovers from it
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both arms of AC#1, applied where each is correct. `create_briefing_audio` gained an optional `error`
+param written in the SAME insert, so the two create-and-immediately-fail preflights
+(`_record_voice_resolution_failure`, `_record_missing_pydub_failure`) now write their finished
+`failed` row ATOMICALLY in one transaction — the create-then-separate-update window is gone for them
+(they refuse before any synthesis, so there is nothing to do between the two writes). The MAIN
+pipeline's create-`generating` → synthesize → update-`complete`/`failed` sequence is INHERENTLY two
+transactions — a DB transaction cannot be held across the multi-second TTS synthesis, and the
+`generating` row must be visible during it — so that non-atomicity is documented as the accepted
+trade-off in the module docstring, naming `fail_interrupted_audio` (row-scoped per TASK-1890) as the
+self-healing sweep that recovers an orphaned `generating` row. New DB test pins the atomic
+create-with-error; mutation (drop `error` from the insert) reds both it AND the existing
+voice-resolution helper test, proving the helpers now depend on the atomic path.
+
+Files: `tldw_chatbook/DB/Subscriptions_DB.py`, `tldw_chatbook/Subscriptions/briefing_audio.py`,
+`Tests/Subscriptions/test_briefing_audio_db.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -2394,6 +2394,7 @@ class SubscriptionsDB(BaseDB):
         *,
         voice_snapshot_json: str,
         status: str = "generating",
+        error: str | None = None,
     ) -> int:
         """Create a new `briefing_audio` row for a cast script.
 
@@ -2410,15 +2411,25 @@ class SubscriptionsDB(BaseDB):
                 `insert_briefing_script`'s reasoning -- the row exists
                 before the synthesis call is even made, so a crash before
                 the first write still leaves a `generating` row behind.
+            error: Optional terminal error text, written in the SAME insert.
+                For a create-and-immediately-fail path (a preflight that
+                refuses before any synthesis happens, e.g. an unresolvable
+                voice or a missing pydub), passing `status="failed"` +
+                `error=...` here writes the finished row atomically, so
+                there is no create-then-separate-update window a crash could
+                land in (TASK-1718). The long-running synthesis path leaves
+                this `None` and finalizes later via `update_briefing_audio` --
+                that separation is inherent (see the module docstring).
 
         Returns:
             The new row's `id`.
         """
         with self.transaction() as conn:
             cursor = conn.execute(
-                "INSERT INTO briefing_audio (script_id, voice_snapshot_json, status) "
-                "VALUES (?, ?, ?)",
-                (script_id, voice_snapshot_json, status),
+                "INSERT INTO briefing_audio "
+                "(script_id, voice_snapshot_json, status, error) "
+                "VALUES (?, ?, ?, ?)",
+                (script_id, voice_snapshot_json, status, error),
             )
             return cursor.lastrowid
 

--- a/tldw_chatbook/Subscriptions/briefing_audio.py
+++ b/tldw_chatbook/Subscriptions/briefing_audio.py
@@ -152,17 +152,18 @@ to `complete`/`failed`. Those two writes are deliberately separate DB
 transactions: a transaction cannot be held open across the long-running
 synthesis between them, and the `generating` row must be visible during it
 (it is what a claim protects and what the UI shows in flight). A hard
-crash in that window leaves a `generating` row with no worker to finish
-it. That is an ACCEPTED trade-off, not a latent wedge: `fail_interrupted_
-audio` sweeps orphaned `generating` rows (row-scoped by
+crash in that window leaves a `generating` row with no worker to finish it.
+That is an ACCEPTED trade-off, not a latent wedge:
+`fail_interrupted_audio` sweeps orphaned `generating` rows (row-scoped by
 `active_audio_claim_row_ids`, TASK-1890) on both the Artifacts-load path
 and the next Synthesize attempt, flipping them to `failed`/`"interrupted"`
 so the row surfaces honestly rather than staying invisible forever. The
-two create-and-immediately-fail preflights (`_record_voice_resolution_
-failure`, `_record_missing_pydub_failure`) have NO synthesis between create
-and finalize, so they DO write their finished `failed` row atomically in a
-single insert (`create_briefing_audio(status="failed", error=...)`) --
-closing that window everywhere it can be closed.
+two create-and-immediately-fail preflights
+(`_record_voice_resolution_failure`, `_record_missing_pydub_failure`) have
+NO synthesis between create and finalize, so they DO write their finished
+`failed` row atomically in a single insert
+(`create_briefing_audio(status="failed", error=...)`) -- closing that
+window everywhere it can be closed.
 
 **Storage is buffer-then-write-once, not streaming.** A correct
 decode-and-concat (`concat_wav_segments`) must hold every turn's decoded

--- a/tldw_chatbook/Subscriptions/briefing_audio.py
+++ b/tldw_chatbook/Subscriptions/briefing_audio.py
@@ -144,6 +144,26 @@ worker wraps it, matching the spec's "Error handling ethos". The parent
 failure -- exactly as a briefing is never touched by a script's own
 outcome.
 
+**Row creation is not one transaction with its completion, and cannot be
+(TASK-1718).** The main pipeline inserts a `generating` `briefing_audio`
+row (`db.create_briefing_audio`), then synthesizes and stitches every turn
+-- seconds to minutes of real provider calls -- then updates that same row
+to `complete`/`failed`. Those two writes are deliberately separate DB
+transactions: a transaction cannot be held open across the long-running
+synthesis between them, and the `generating` row must be visible during it
+(it is what a claim protects and what the UI shows in flight). A hard
+crash in that window leaves a `generating` row with no worker to finish
+it. That is an ACCEPTED trade-off, not a latent wedge: `fail_interrupted_
+audio` sweeps orphaned `generating` rows (row-scoped by
+`active_audio_claim_row_ids`, TASK-1890) on both the Artifacts-load path
+and the next Synthesize attempt, flipping them to `failed`/`"interrupted"`
+so the row surfaces honestly rather than staying invisible forever. The
+two create-and-immediately-fail preflights (`_record_voice_resolution_
+failure`, `_record_missing_pydub_failure`) have NO synthesis between create
+and finalize, so they DO write their finished `failed` row atomically in a
+single insert (`create_briefing_audio(status="failed", error=...)`) --
+closing that window everywhere it can be closed.
+
 **Storage is buffer-then-write-once, not streaming.** A correct
 decode-and-concat (`concat_wav_segments`) must hold every turn's decoded
 audio in memory to join them, so by the time there is anything to write,
@@ -956,8 +976,14 @@ def _record_voice_resolution_failure(db: Any, script_id: int, message: str) -> d
     Returns:
         The finished (`failed`) `briefing_audio` row as a dict.
     """
-    audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
-    db.update_briefing_audio(audio_id, status=STATUS_FAILED, error=message)
+    # Atomic (TASK-1718): the row is born `failed` with its error in ONE
+    # insert. This path refuses before any synthesis happens, so unlike the
+    # main pipeline there is no work to do between creating the row and
+    # finalizing it -- and therefore no create-then-update window a crash
+    # could leave a stuck `generating` row in.
+    audio_id = db.create_briefing_audio(
+        script_id, voice_snapshot_json="[]", status=STATUS_FAILED, error=message
+    )
     return db.get_briefing_audio(audio_id)
 
 
@@ -985,8 +1011,15 @@ def _record_missing_pydub_failure(db: Any, script_id: int) -> dict[str, Any]:
     Returns:
         The finished (`failed`) `briefing_audio` row as a dict.
     """
-    audio_id = db.create_briefing_audio(script_id, voice_snapshot_json="[]")
-    db.update_briefing_audio(audio_id, status=STATUS_FAILED, error=PYDUB_MISSING_MESSAGE)
+    # Atomic (TASK-1718): born `failed` in one insert -- this preflight
+    # refuses before any synthesis, so there is nothing to do between create
+    # and finalize and thus no crashable create-then-update window.
+    audio_id = db.create_briefing_audio(
+        script_id,
+        voice_snapshot_json="[]",
+        status=STATUS_FAILED,
+        error=PYDUB_MISSING_MESSAGE,
+    )
     return db.get_briefing_audio(audio_id)
 
 


### PR DESCRIPTION
## Why

`generate_script_audio`'s two create-and-immediately-fail preflights (`_record_voice_resolution_failure`, `_record_missing_pydub_failure`) each did `create_briefing_audio` (one transaction) then `update_briefing_audio` to `failed` (a second transaction). A crash between the two left a `briefing_audio` row stuck in `generating` (task-1718).

## What

Both arms of AC#1, applied where each is correct:

- **Atomic where it's closeable.** `create_briefing_audio` gained an optional `error` written in the *same* insert, so the two preflights now write their finished `failed` row in one transaction. They refuse before any synthesis happens, so there is nothing to do between create and finalize — the crashable window is simply gone.
- **Documented where it's inherent.** The main pipeline (create `generating` → synthesize/stitch every turn → update `complete`/`failed`) *cannot* be one transaction: a DB transaction can't be held across the multi-second TTS synthesis, and the `generating` row must be visible during it (a claim protects it; the UI shows it in flight). That non-atomicity is now stated in the module docstring as the accepted trade-off, naming `fail_interrupted_audio` (row-scoped per task-1890) as the self-healing sweep that flips an orphaned `generating` row to `failed`/`interrupted`.

## Testing

New DB test pins the atomic create-with-error (status + error in one insert; a plain create still leaves `error` NULL). Mutation — dropping `error` from the insert — reds both the new test *and* the existing voice-resolution helper test, proving the preflights now genuinely depend on the atomic path. `test_briefing_audio_{db,pipeline,synthesis}.py`: 67 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make preflight audio failures atomic by inserting `status="failed"` and `error` in a single write, removing the crash window that left `briefing_audio` rows stuck in `generating`. Also document why the main synthesis path stays non-atomic and how `fail_interrupted_audio` heals orphaned rows (TASK-1718).

- **Bug Fixes**
  - `create_briefing_audio` now accepts optional `error` and writes `status` + `error` in the same insert.
  - `_record_voice_resolution_failure` and `_record_missing_pydub_failure` now create the finished `failed` row atomically.
  - Added a DB test to pin the atomic insert; plain creates still leave `error` as NULL.
  - Documented the inherent two-transaction main pipeline and the recovery via `fail_interrupted_audio`.
  - Polished docs: unsplit docstring identifiers; test docstring updated to Google style.

<sup>Written for commit d2d631dd1c4e1013c62316fe39eebe2ca30a9523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

