### PR TITLE
fix: inspector reads the single settings shape for ignore_selectors (task-1395)

### DIFF
--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -1108,6 +1108,32 @@ async def test_saving_selectors_does_not_recompose_the_screen():
         )
 
 
+def test_cleared_selectors_stay_cleared_on_a_dual_shape_entity():
+    """TASK-1395: the reader and the post-save patch agree on ONE shape.
+
+    An entity can in principle carry BOTH the published
+    `settings["ignore_selectors"]` list AND a stale bare top-level
+    `ignore_selectors` key. `_patch_entity_ignore_selectors` only ever
+    touches the `settings` shape, so a reader that fell back to the bare key
+    would re-display the stale bare value after the field was cleared (the
+    patch pops the settings entry but never the bare key). The reader now
+    reads ONLY the settings shape, so a clear stays cleared. Reds under the
+    old bare-key fallback: the cleared entity would read back the stale
+    ".stale-bare-value".
+    """
+    dual = {
+        "id": 1,
+        "settings": {"ignore_selectors": [".ad", ".promo"]},
+        "ignore_selectors": ".stale-bare-value",
+    }
+    assert InspectorPane._ignore_selectors_text(dual) == ".ad\n.promo"
+
+    # The post-clear state the patcher produces: settings entry gone, stale
+    # bare key still present. The reader must ignore the bare key.
+    cleared = {"id": 1, "settings": {}, "ignore_selectors": ".stale-bare-value"}
+    assert InspectorPane._ignore_selectors_text(cleared) == ""
+
+
 @pytest.mark.asyncio
 async def test_a_save_that_cannot_write_says_so():
     """Fix round 1 (Minor 4): no silent no-op behind the Save button.

--- a/backlog/tasks/task-1395 - Inspector-noise-editor-shows-stale-selectors-on-a-bare-shape-entity.md
+++ b/backlog/tasks/task-1395 - Inspector-noise-editor-shows-stale-selectors-on-a-bare-shape-entity.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1395
 title: Inspector noise editor shows stale selectors on a bare-shape entity
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-30 05:20'
 labels:
@@ -26,6 +26,25 @@ to make the reader and the patcher agree on one shape (drop the bare-key fallbac
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The editor's read path and the post-save patch use the same single shape
-- [ ] #2 A test constructs the dual-shape entity and proves a cleared field stays cleared on re-render
+- [x] #1 The editor's read path and the post-save patch use the same single shape
+- [x] #2 A test constructs the dual-shape entity and proves a cleared field stays cleared on re-render
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC#1: dropped the bare-key fallback from `InspectorPane._ignore_selectors_text` (the reader), so it
+reads ONLY the `settings["ignore_selectors"]` shape -- the single shape `normalize_local_subscription_row`
+publishes AND the one `_patch_entity_ignore_selectors` (the post-save patch) writes. Reader and patcher
+now agree. Verified the bare-key fallback was dead for real entities: every bare `entity["ignore_selectors"]`
+reference in tests reads the DB COLUMN (`db.get_subscription(...)["ignore_selectors"]`) or the create-source
+API, never a bare-key entity fed to the reader; the one direct reader test (`test_watchlists_inspector.py:1106`)
+passes a normalized settings-shape entity.
+
+AC#2: `test_cleared_selectors_stay_cleared_on_a_dual_shape_entity` constructs a dual-shape entity
+(settings list + a stale bare key), confirms the settings shape wins when populated, then asserts the
+post-clear state (settings entry popped, stale bare key still present) reads back "" -- not the stale
+bare value. Mutation-verified: restoring the bare-key fallback reds it.
+
+Files: `tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py`, `Tests/UI/test_watchlists_inspector.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
@@ -265,8 +265,16 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
         `normalize_local_subscription_row` publishes them under
         `settings["ignore_selectors"]` as a **list** (and omits the key
         entirely when the column is empty), so the stored newline text has to
-        be reassembled here. The bare `ignore_selectors` key is the fallback
-        shape a hand-built dict uses.
+        be reassembled here.
+
+        Reads ONLY the `settings` shape -- the single shape the backend
+        publishes AND the one the post-save patch
+        (`_patch_entity_ignore_selectors`) writes. TASK-1395: an earlier
+        version also fell back to a bare `entity["ignore_selectors"]` key,
+        but the patcher never cleared that key, so on an entity carrying both
+        shapes a cleared field would re-display the stale bare value on
+        reopen. Reader and patcher now agree on one shape, so a clear stays
+        cleared.
 
         Args:
             entity: A normalized source entity.
@@ -274,18 +282,12 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
         Returns:
             One rule per line, or "" when the source has none.
         """
-        candidates = []
         settings = entity.get("settings")
-        if isinstance(settings, dict):
-            candidates.append(settings.get("ignore_selectors"))
-        candidates.append(entity.get("ignore_selectors"))
-        for stored in candidates:
-            if isinstance(stored, (list, tuple)):
-                joined = "\n".join(str(selector) for selector in stored)
-                if joined:
-                    return joined
-            elif stored:
-                return str(stored)
+        stored = settings.get("ignore_selectors") if isinstance(settings, dict) else None
+        if isinstance(stored, (list, tuple)):
+            return "\n".join(str(selector) for selector in stored)
+        if stored:
+            return str(stored)
         return ""
 
     def _noise_selectors_editor(self, entity: dict[str, Any]):


### PR DESCRIPTION
## Why

`InspectorPane._ignore_selectors_text` (the noise-editor read path) fell back to a bare `entity["ignore_selectors"]` key, but the post-save patch (`_patch_entity_ignore_selectors`) only ever touches the `settings["ignore_selectors"]` shape. On an entity carrying both shapes, clearing the field pops the settings entry while the stale bare key survives — so reopening re-displayed the stale value. Unreachable today (`normalize_local_subscription_row` publishes only the settings shape), so a latent trap rather than a live bug (task-1395).

## What

- **AC#1:** dropped the bare-key fallback from the reader, so it reads only the `settings` shape — the single shape the backend publishes and the patcher writes. Reader and patcher now agree, so a clear stays cleared. Verified the fallback was dead for real entities: every bare-key reference in tests reads the DB *column* or the create-source API, never a bare-key entity fed to the reader.
- **AC#2:** `test_cleared_selectors_stay_cleared_on_a_dual_shape_entity` builds the dual-shape entity, confirms the settings shape wins when populated, and asserts the post-clear state (settings popped, stale bare key present) reads back `""` — not the stale value. Mutation-verified: restoring the fallback reds it.

## Testing

`test_watchlists_inspector.py` + `test_watchlists_sources_pane.py`: 61 passed. Zero behavior change for real (settings-shape) entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The inspector now reads ignore selectors only from the `settings` shape, preventing stale values from reappearing after clearing the field. Aligns the reader with the post-save patch and addresses TASK-1395.

- **Bug Fixes**
  - Removed the bare `ignore_selectors` fallback in `InspectorPane._ignore_selectors_text`; now reads only `settings["ignore_selectors"]`.
  - Added `test_cleared_selectors_stay_cleared_on_a_dual_shape_entity` to confirm a cleared field stays empty even if a stale bare key exists.
  - No behavior change for normalized entities; related tests pass.

<sup>Written for commit 12282e15f5886f2c226d1266334a0006c1bdaf08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

