### PR TITLE
chore: mark task-1395 Done (PR #1280 merged)

### DIFF
--- a/backlog/tasks/task-1395 - Inspector-noise-editor-shows-stale-selectors-on-a-bare-shape-entity.md
+++ b/backlog/tasks/task-1395 - Inspector-noise-editor-shows-stale-selectors-on-a-bare-shape-entity.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1395
 title: Inspector noise editor shows stale selectors on a bare-shape entity
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-30 05:20'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark TASK-1395 as Done in the backlog after the fix for the Inspector noise editor showing stale selectors on a bare-shape entity was merged. This closes the task and reflects the shipped change.

<sup>Written for commit c69427929272b46de39088db68e5e8abd7b69dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

