### PR TITLE
docs: record baseline_manager keep-as-future-component decision (task-1360)

### DIFF
--- a/backlog/tasks/task-1360 - Decide-the-fate-of-baseline_manager-a-697-line-change-detector-nothing-imports.md
+++ b/backlog/tasks/task-1360 - Decide-the-fate-of-baseline_manager-a-697-line-change-detector-nothing-imports.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1360
 title: Decide the fate of baseline_manager, a 697-line change detector nothing imports
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-29 23:10'
 labels:
@@ -39,9 +39,44 @@ as the producers of `change_percentage`. Half of that is false and is corrected 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A decision is recorded on whether baseline_manager is adopted into the live change-detection path, kept as a documented future component, or deleted
-- [ ] #2 If adopted, it has test coverage before it enters the fetch path, and monitoring_engine's duplicate detection is retired rather than left as a second implementation
-- [ ] #3 If deleted, the change_type vocabulary and structural comparison worth keeping are named in the task notes so the capability is not silently lost
-- [ ] #4 A liveness check is run from both ends (what imports it, and what it imports) rather than a single outward grep
-- [ ] #5 If its pruning is adopted, it is re-keyed per (subscription, url) first: as written it prunes per subscription, which under the per-URL baselines shipped by TASK-1361/1362 would evict other URLs' baselines on multi-URL sources and cause endless re-baselining (see TASK-1393)
+- [x] #1 A decision is recorded on whether baseline_manager is adopted into the live change-detection path, kept as a documented future component, or deleted
+- [x] #2 (moot — not adopted) If adopted, it has test coverage before it enters the fetch path, and monitoring_engine's duplicate detection is retired rather than left as a second implementation
+- [x] #3 (moot — not deleted; capability named in the decision) If deleted, the change_type vocabulary and structural comparison worth keeping are named in the task notes so the capability is not silently lost
+- [x] #4 A liveness check is run from both ends (what imports it, and what it imports) rather than a single outward grep
+- [x] #5 (moot — not adopted; the re-keying prerequisite is recorded in the module header for any future adoption) If its pruning is adopted, it is re-keyed per (subscription, url) first: as written it prunes per subscription, which under the per-URL baselines shipped by TASK-1361/1362 would evict other URLs' baselines on multi-URL sources and cause endless re-baselining (see TASK-1393)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Decision (AC#1): KEEP as a documented future component** — neither adopted into the live fetch
+path nor deleted. Recorded as a prominent NOT-WIRED header at the top of
+`tldw_chatbook/Subscriptions/baseline_manager.py`.
+
+Rationale: (a) I did not author this 697-line subsystem and deletion is hard to reverse; (b) it
+implements a genuinely better change-detection approach the spec mockup references (`structural`
+change_type, structural element comparison, a `summary` field for `diff_summary`) — deleting loses
+that; (c) adopting it is a substantial, deliberate effort with hard prerequisites (AC#5's
+per-(subscription,url) re-keying, AC#2's test coverage + retiring monitoring_engine's duplicate
+detection) that "deserves its own decision", not a drive-by; (d) the *actual* harm the task names —
+reading as live to a grep, the 6th orphaned-but-grep-live instance — is fully neutralized by the
+NOT-WIRED header, which tells any future reader/grep-er immediately that nothing imports it and why.
+
+**AC#4 (liveness from both ends):** OUTWARD — no `import` of `baseline_manager`/`BaselineManager`
+anywhere in `tldw_chatbook/` or `Tests/`; the only references are docstring mentions in
+`monitoring_engine.py:477` and `test_watchlist_snapshot_pruning.py` (which tests the LIVE
+`monitoring_engine`/`URLMonitor._store_snapshot` pruning, not this module — it merely cites it as
+context). INWARD — the module imports stdlib + `bs4` + loguru; it is functional code but nothing is
+wired INTO it. Confirmed dead in both directions, correcting the single-outward-grep the task warned
+against.
+
+**AC#3 (capability worth keeping, per the "if deleted" arm — recorded even though NOT deleted):** the
+`ChangeReport.change_type` vocabulary (`content`/`structural`/`semantic`/`new`/`removed`), the
+`summary` field, and the structural (key-element) comparison rather than pure text-ratio. All named
+in the module header so the capability is preserved as a design record regardless of the code's fate.
+
+Note: the false comment the task cites (`content_pane.py:160-161` naming baseline_manager as a
+`change_percentage` producer) was ALREADY corrected on dev by TASK-1343 — verified; no change needed.
+
+File: `tldw_chatbook/Subscriptions/baseline_manager.py` (module header only; no logic change).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Subscriptions/baseline_manager.py
+++ b/tldw_chatbook/Subscriptions/baseline_manager.py
@@ -1,6 +1,35 @@
 # baseline_manager.py
 # Description: Baseline management system for content change detection
 #
+# ============================================================================
+# NOT WIRED — this module is imported by nothing in the repository (TASK-1360).
+# A grep for `baseline_manager`/`BaselineManager` returns only docstring
+# mentions (this file, `monitoring_engine.py`, `test_watchlist_snapshot_
+# pruning.py`); there is no `import`. Nothing calls any of its 20 methods, and
+# it has no tests. It reads as live to a search but carries nothing — the
+# recurring "orphaned-but-grep-live" trap this codebase has hit before
+# (TASK-1220 `content_processor`, TASK-1221 gated-on-nothing packages).
+#
+# DECISION (TASK-1360): KEPT as a documented future component, not adopted and
+# not deleted. It is deliberately NOT pulled into the live fetch path:
+#   * The live change detector is `monitoring_engine.URLMonitor.check_url`,
+#     which computes `change_percentage` from `difflib.SequenceMatcher` and
+#     hardcodes `change_type: "content"`.
+#   * This module is genuinely BETTER — `ChangeReport.change_type` carries the
+#     `'content'/'structural'/'semantic'/'new'/'removed'` vocabulary the spec
+#     site mockup shows, plus a `summary` field that is exactly what the
+#     `diff_summary` column wants, and it compares key elements STRUCTURALLY
+#     rather than only by text ratio. That capability is the reason to keep it.
+#   * But adopting it is a deliberate, separate effort, NOT a drive-by: it must
+#     first be re-keyed per (subscription, url) — its `_cleanup_old_baselines`
+#     prunes per SUBSCRIPTION, which under the per-URL baselines shipped by
+#     TASK-1361/1362 would evict OTHER urls' baselines on a multi-url source
+#     and cause endless re-baselining (TASK-1393) — AND gain test coverage
+#     before it enters the fetch path, AND `monitoring_engine`'s duplicate
+#     text-ratio detection must be retired rather than left as a second
+#     implementation. Those are the conditions any future adoption task owns.
+# ============================================================================
+#
 # This module provides intelligent change detection by maintaining baselines
 # and comparing new content against them using multiple strategies:
 # - Content hashing for exact matches


### PR DESCRIPTION
## Why

`Subscriptions/baseline_manager.py` is 697 lines and 20 methods of change-detection machinery with **no importers and no tests** — the only references are docstring mentions. It reads as live to a grep but carries nothing (the 6th orphaned-but-grep-live instance this codebase has hit, after TASK-1220/1221). It also happens to be *better* than the live detector (`monitoring_engine`'s text-ratio `change_percentage`): it carries the `structural`/`semantic`/`new`/`removed` `change_type` vocabulary the spec mockup shows and compares elements structurally. Task-1360 asks for a recorded decision on its fate.

## Decision: KEEP as a documented future component

Neither adopted into the live fetch path nor deleted — recorded as a prominent NOT-WIRED header at the top of the module. Rationale:

- I did not author this subsystem and deletion is hard to reverse; it implements a genuinely better approach the spec references, so deleting loses that capability.
- Adopting it is a substantial, deliberate effort with hard prerequisites (per-`(subscription, url)` re-keying — its pruning is per-subscription, which under the shipped per-URL baselines would evict other URLs' baselines and cause endless re-baselining, TASK-1393; plus test coverage and retiring monitoring_engine's duplicate detection) that "deserves its own decision", not a drive-by.
- The actual harm — reading as live to a grep — is fully neutralized by the header, which states plainly that nothing imports it, why it isn't adopted, and the conditions any future adoption owns.

**AC#4 (liveness both ends):** outward — no `import` anywhere in `tldw_chatbook/` or `Tests/`; the only references are docstring citations (`monitoring_engine.py`, and `test_watchlist_snapshot_pruning.py`, which tests the *live* pruning, not this module). Inward — it imports stdlib + bs4 + loguru but nothing wires into it. Confirmed dead both directions, correcting the single-outward-grep the task warned against.

**AC#3** (capability worth keeping, recorded even though not deleted): the `change_type` vocabulary, the `summary` field for `diff_summary`, and the structural comparison — all named in the header so the design is preserved regardless of the code's fate.

The false `content_pane.py` comment the task cites was already corrected on dev by TASK-1343 (verified; no change needed).

## Testing

Docs/comment only — no logic change (module header + task notes). `import ast` parse confirms syntax; the module remains unimported so nothing exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `tldw_chatbook/Subscriptions/baseline_manager.py` as a future component and mark it NOT WIRED to avoid grep confusion and accidental use. Adds a module header with rationale and adoption prerequisites, confirms liveness from both ends, and updates TASK-1360 notes to check off ACs; no logic changes.

<sup>Written for commit 1d19e04893ca8ddb330f7022b3bfaad78adb05e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

