### PR TITLE
feat(console): add System Prompt chip to status strip

### DIFF
--- a/Docs/superpowers/specs/2026-08-03-console-system-prompt-chip-design.md
+++ b/Docs/superpowers/specs/2026-08-03-console-system-prompt-chip-design.md
@@ -1,0 +1,107 @@
+# Console System Prompt Chip — Design
+
+Date: 2026-08-03
+Status: Implemented
+
+## Goal
+
+Give users a one-click way to view and edit the current chat's system prompt from the
+Console screen, via a clickable "System Prompt" chip in the control bar, placed between
+the "Model: …" chip and the "Persona: …" chip.
+
+## Background
+
+> **Rebase note (2026-08-03):** this spec was first written against a checkout
+> where the chips lived in `console_control_bar.py` and the persona chip read
+> "Persona: …". Current `dev` extracted the chips into
+> `tldw_chatbook/Widgets/Console/console_status_chips.py` (`ConsoleStatusChips`)
+> and renamed the persona chip to the **Assistant/Character** chip
+> (`ConsoleAssistantChip`, `assistant_label`). The implementation below follows
+> the current-dev structure; sibling action chips there
+> (`ConsoleModelChip`/`ConsoleAssistantChip`) post a nested `OpenRequested`
+> message handled on `ChatScreen`, and this chip follows that contract.
+
+The backend for this feature already exists:
+
+- `ConsoleSystemPromptModal` (`tldw_chatbook/Widgets/Console/console_system_prompt_modal.py`)
+  — modal editor with TextArea, Apply / Clear / Cancel, Escape binding. Dismisses with
+  `str` (new prompt), `""` (clear), or `None` (cancel).
+- `ChatScreen._open_console_system_prompt_editor()` (`tldw_chatbook/UI/Screens/chat_screen.py:9497`)
+  — pushes the modal and applies the result.
+- `ChatScreen._apply_console_session_system_prompt()` (`chat_screen.py:9468`) →
+  `ConsoleChatStore.set_session_system_prompt()` (`tldw_chatbook/Chat/console_chat_store.py:892`)
+  — normalizes blank → `None`, updates session settings, persists via
+  `persistence.update_conversation_system_prompt` (DB column `conversations.system_prompt`).
+- Existing entry points: command palette action and the `/system` slash command.
+
+What is missing: a visible, clickable control in the console control bar.
+
+## Design
+
+### Components
+
+1. **`ConsoleControlState.system_prompt_label`** (`tldw_chatbook/Chat/console_display_state.py`)
+   - New derived label field, computed in `from_values()` (`console_display_state.py:300-327`):
+     `"System Prompt"` when no prompt is set, `"System Prompt: set"` when one is active.
+   - `from_values()` gains a parameter carrying the prompt-set state; its caller
+     `_build_console_control_state` (`chat_screen.py:3088-3103`) already fetches the
+     session settings and must stop discarding them (`provider, model, _settings = ...`)
+     so it can pass the prompt-set state through.
+
+2. **`ConsoleSystemPromptChip`** (`tldw_chatbook/Widgets/Console/console_status_chips.py`)
+   - Focusable, clickable chip modeled on the sibling action chips
+     (`ConsoleModelChip` / `ConsoleAssistantChip`).
+   - Nested message class named `OpenRequested` (matching the sibling action-chip
+     convention), posted from both the Enter/Space key bindings and `_on_click`.
+   - Inserted in `ConsoleStatusChips.compose()` between the model chip and the
+     assistant chip, id `console-system-prompt-chip`.
+   - Add `"#console-system-prompt-chip": state.system_prompt_label` to the hardcoded
+     selector→field `label_values` dict in `ConsoleStatusChips.sync_state`
+     — without this entry the label never refreshes (the `NoMatches` guard fails
+     silently).
+
+3. **`ChatScreen` handler** (`tldw_chatbook/UI/Screens/chat_screen.py`)
+   - One `@on(ConsoleSystemPromptChip.OpenRequested)` handler on `ChatScreen`,
+     next to `_console_assistant_chip_activated`, delegating to
+     `action_open_console_system_prompt_editor()` (which wraps the async editor
+     opener in `run_worker`, like the `/system` and command-palette entry points).
+   - `_apply_console_session_system_prompt` currently only calls
+     `_sync_console_chat_core_state()` and `_sync_console_settings_summary()`, neither of
+     which reaches `_sync_console_control_bar()` (which pushes the new state into
+     `ConsoleStatusChips.sync_state`). Add a control-bar sync there so the chip
+     label updates immediately after Apply/Clear instead of going stale until an unrelated
+     sync fires.
+
+### Behavior
+
+- Click chip → `ConsoleSystemPromptModal` opens showing the current system prompt.
+- Apply → saves to session state + persists per conversation; used in the next LLM request.
+- Clear → removes the prompt (blank → `None`).
+- Cancel / Escape → no change.
+- Chip label reflects state after Apply/Clear.
+
+### Rejected alternatives
+
+- **Workbench action button** (`.console-control-action` / `WorkbenchActionRequested`):
+  different styling and location in the bar; breaks the chip grouping.
+- **Widget self-contained modal**: would duplicate apply/persist logic already in
+  `ChatScreen`/`ConsoleChatStore`.
+
+## Error handling
+
+No new failure modes: the modal and apply path already exist and are in use. The chip
+handler is a thin delegate; if no conversation is active the existing editor path's
+behavior applies unchanged.
+
+## Testing
+
+- Extend existing console display-state tests: label derivation (set vs unset).
+- Extend console control-bar tests: chip renders between model and persona chips;
+  click posts the expected message.
+- If a handler-level test pattern exists for `ChatScreen`, assert the handler invokes
+  the editor entry point.
+
+## ADR
+
+ADR required: **no**. No schema, sync, persistence-policy, or boundary changes — this
+wires a new UI trigger to an existing, already-persisted feature.

--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -9,6 +9,8 @@ from tldw_chatbook.Chat.console_display_state import (
     CONSOLE_INSPECTOR_REVIEW_APPROVAL_ID,
     CONSOLE_INSPECTOR_REVIEW_TOOL_CALL_ID,
     CONSOLE_INSPECTOR_SAVE_CHATBOOK_ID,
+    CONSOLE_SYSTEM_PROMPT_LABEL_SET,
+    CONSOLE_SYSTEM_PROMPT_LABEL_UNSET,
     ConsoleControlState,
     ConsoleInspectorState,
     ConsoleStagedContextState,
@@ -66,13 +68,13 @@ def test_console_control_state_counter_activity_flags():
 def test_console_control_state_system_prompt_label_defaults_to_unset():
     state = ConsoleControlState.from_values()
 
-    assert state.system_prompt_label == "System Prompt"
+    assert state.system_prompt_label == CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
 
 
 def test_console_control_state_system_prompt_label_reflects_set_prompt():
     state = ConsoleControlState.from_values(system_prompt_set=True)
 
-    assert state.system_prompt_label == "System Prompt: set"
+    assert state.system_prompt_label == CONSOLE_SYSTEM_PROMPT_LABEL_SET
 
 
 def test_console_control_state_tools_chip_includes_mcp_tools():

--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -63,6 +63,18 @@ def test_console_control_state_counter_activity_flags():
     )
 
 
+def test_console_control_state_system_prompt_label_defaults_to_unset():
+    state = ConsoleControlState.from_values()
+
+    assert state.system_prompt_label == "System Prompt"
+
+
+def test_console_control_state_system_prompt_label_reflects_set_prompt():
+    state = ConsoleControlState.from_values(system_prompt_set=True)
+
+    assert state.system_prompt_label == "System Prompt: set"
+
+
 def test_console_control_state_tools_chip_includes_mcp_tools():
     """TASK-350: the header Tools chip must count the tools that can actually run
     — built-in AND MCP — not just built-in. It read 'Tools: 0 ready' while the

--- a/Tests/UI/test_console_system_prompt.py
+++ b/Tests/UI/test_console_system_prompt.py
@@ -28,6 +28,10 @@ from tldw_chatbook.Prompt_Management.prompt_scope_service import (
     LocalPromptService as ScopeLocalPromptService,
     PromptScopeService,
 )
+from tldw_chatbook.Chat.console_display_state import (
+    CONSOLE_SYSTEM_PROMPT_LABEL_SET,
+    CONSOLE_SYSTEM_PROMPT_LABEL_UNSET,
+)
 from tldw_chatbook.UI.console_command_provider import ConsoleCommandProvider
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
 from tldw_chatbook.Widgets.Console.console_prompt_picker_modal import (
@@ -204,15 +208,15 @@ async def test_console_system_prompt_chip_label_reflects_applied_prompt():
     async with host.run_test(size=(180, 48)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-system-prompt-chip")
-        assert _system_prompt_chip_text(console) == "System Prompt"
+        assert _system_prompt_chip_text(console) == CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
 
         console._apply_console_session_system_prompt("Be concise.")
         await pilot.pause(0.2)
-        assert _system_prompt_chip_text(console) == "System Prompt: set"
+        assert _system_prompt_chip_text(console) == CONSOLE_SYSTEM_PROMPT_LABEL_SET
 
         console._apply_console_session_system_prompt(None)
         await pilot.pause(0.2)
-        assert _system_prompt_chip_text(console) == "System Prompt"
+        assert _system_prompt_chip_text(console) == CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_system_prompt.py
+++ b/Tests/UI/test_console_system_prompt.py
@@ -165,6 +165,57 @@ async def test_console_rail_system_line_click_opens_editor_modal():
 
 
 # ---------------------------------------------------------------------------
+# Status-strip System Prompt chip.
+# ---------------------------------------------------------------------------
+
+
+def _system_prompt_chip_text(console) -> str:
+    return _static_plain_text(console.query_one("#console-system-prompt-chip", Static))
+
+
+@pytest.mark.asyncio
+async def test_console_system_prompt_chip_activation_opens_editor_modal():
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(180, 48)) as pilot:
+        console = host.screen_stack[-1]
+        baseline_depth = len(host.screen_stack)
+        await _wait_for_selector(console, pilot, "#console-system-prompt-chip")
+
+        # Activate via keyboard: the test harness loads no stylesheet, so the
+        # chip strip overflows the screen and a mouse click lands out of bounds.
+        console.query_one("#console-system-prompt-chip").focus()
+        await pilot.press("enter")
+        await pilot.pause(0.2)
+
+        assert len(host.screen_stack) == baseline_depth + 1
+        modal = host.screen_stack[-1]
+        assert modal.query_one(f"#{TEXT_AREA_ID}", TextArea).text == ""
+
+
+@pytest.mark.asyncio
+async def test_console_system_prompt_chip_label_reflects_applied_prompt():
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(180, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-system-prompt-chip")
+        assert _system_prompt_chip_text(console) == "System Prompt"
+
+        console._apply_console_session_system_prompt("Be concise.")
+        await pilot.pause(0.2)
+        assert _system_prompt_chip_text(console) == "System Prompt: set"
+
+        console._apply_console_session_system_prompt(None)
+        await pilot.pause(0.2)
+        assert _system_prompt_chip_text(console) == "System Prompt"
+
+
+# ---------------------------------------------------------------------------
 # Bare `/system` opens the editor modal.
 # ---------------------------------------------------------------------------
 

--- a/Tests/UI/test_console_system_prompt_chip.py
+++ b/Tests/UI/test_console_system_prompt_chip.py
@@ -1,0 +1,90 @@
+"""Tests for the Console system-prompt chip in the status-chips strip.
+
+The chip sits between the Model and Assistant (Character) chips and opens the
+existing system-prompt editor modal via ``ConsoleSystemPromptChip.OpenRequested``.
+"""
+
+import pytest
+from textual import on
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_display_state import ConsoleControlState
+from tldw_chatbook.Widgets.Console.console_status_chips import (
+    ConsoleStatusChips,
+    ConsoleSystemPromptChip,
+)
+
+
+class StatusChipsHarness(App):
+    # Mirror the app stylesheet's chip sizing (tldw_cli_modular.tcss) so the
+    # whole chip strip fits on screen without the full app chrome.
+    CSS = """
+    .console-control-chip {
+        width: auto;
+        min-width: 7;
+        max-width: 22;
+        height: 1;
+        margin: 0 1 0 0;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, state: ConsoleControlState):
+        super().__init__()
+        self._state = state
+        self.open_requests = 0
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleStatusChips(self._state, id="console-status-chips")
+
+    @on(ConsoleSystemPromptChip.OpenRequested)
+    def _record_open_request(
+        self, event: ConsoleSystemPromptChip.OpenRequested
+    ) -> None:
+        self.open_requests += 1
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_chip_mounted_between_model_and_assistant_chips():
+    app = StatusChipsHarness(ConsoleControlState.from_values())
+    async with app.run_test():
+        strip = app.query_one(ConsoleStatusChips)
+        chip_ids = [child.id for child in strip.children]
+
+        model_index = chip_ids.index("console-model-chip")
+        assistant_index = chip_ids.index("console-assistant-chip")
+        assert chip_ids.index("console-system-prompt-chip") == model_index + 1
+        assert assistant_index == model_index + 2
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_chip_click_posts_open_requested():
+    app = StatusChipsHarness(ConsoleControlState.from_values())
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.click("#console-system-prompt-chip")
+
+        assert app.open_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_chip_keyboard_activation_posts_open_requested():
+    app = StatusChipsHarness(ConsoleControlState.from_values())
+    async with app.run_test() as pilot:
+        app.query_one("#console-system-prompt-chip").focus()
+        await pilot.press("enter")
+
+        assert app.open_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_state_updates_system_prompt_chip_label():
+    app = StatusChipsHarness(ConsoleControlState.from_values())
+    async with app.run_test():
+        strip = app.query_one(ConsoleStatusChips)
+        chip = app.query_one("#console-system-prompt-chip")
+        assert str(chip.renderable) == "System Prompt"
+
+        strip.sync_state(ConsoleControlState.from_values(system_prompt_set=True))
+
+        assert str(chip.renderable) == "System Prompt: set"
+        assert str(chip.tooltip) == "System Prompt: set"

--- a/Tests/UI/test_console_system_prompt_chip.py
+++ b/Tests/UI/test_console_system_prompt_chip.py
@@ -8,7 +8,11 @@ import pytest
 from textual import on
 from textual.app import App, ComposeResult
 
-from tldw_chatbook.Chat.console_display_state import ConsoleControlState
+from tldw_chatbook.Chat.console_display_state import (
+    CONSOLE_SYSTEM_PROMPT_LABEL_SET,
+    CONSOLE_SYSTEM_PROMPT_LABEL_UNSET,
+    ConsoleControlState,
+)
 from tldw_chatbook.Widgets.Console.console_status_chips import (
     ConsoleStatusChips,
     ConsoleSystemPromptChip,
@@ -16,6 +20,8 @@ from tldw_chatbook.Widgets.Console.console_status_chips import (
 
 
 class StatusChipsHarness(App):
+    """Minimal app harness mounting only the ConsoleStatusChips strip."""
+
     # Mirror the app stylesheet's chip sizing (tldw_cli_modular.tcss) so the
     # whole chip strip fits on screen without the full app chrome.
     CSS = """
@@ -82,9 +88,9 @@ async def test_sync_state_updates_system_prompt_chip_label():
     async with app.run_test():
         strip = app.query_one(ConsoleStatusChips)
         chip = app.query_one("#console-system-prompt-chip")
-        assert str(chip.renderable) == "System Prompt"
+        assert str(chip.renderable) == CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
 
         strip.sync_state(ConsoleControlState.from_values(system_prompt_set=True))
 
-        assert str(chip.renderable) == "System Prompt: set"
-        assert str(chip.tooltip) == "System Prompt: set"
+        assert str(chip.renderable) == CONSOLE_SYSTEM_PROMPT_LABEL_SET
+        assert str(chip.tooltip) == CONSOLE_SYSTEM_PROMPT_LABEL_SET

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -354,6 +354,7 @@ class ConsoleControlState:
     sources_label: str
     tools_label: str
     approvals_label: str
+    system_prompt_label: str = "System Prompt"
     sources_active: bool = False
     tools_active: bool = False
     approvals_active: bool = False
@@ -373,6 +374,7 @@ class ConsoleControlState:
         tool_count: int = 0,
         mcp_tool_count: int | None = None,
         approval_count: int = 0,
+        system_prompt_set: bool = False,
     ) -> "ConsoleControlState":
         """Build the Console control-bar chip state from raw run values.
 
@@ -432,6 +434,9 @@ class ConsoleControlState:
             sources_label=f"Sources: {staged_source_count} staged",
             tools_label=tools_label,
             approvals_label=f"Approvals: {approval_count} pending",
+            system_prompt_label=(
+                "System Prompt: set" if system_prompt_set else "System Prompt"
+            ),
             sources_active=staged_source_count > 0,
             tools_active=effective_tool_count > 0,
             approvals_active=approval_count > 0,

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -343,6 +343,10 @@ class ConsoleInspectorAction:
         return "" if self.enabled else self.disabled_reason
 
 
+CONSOLE_SYSTEM_PROMPT_LABEL_UNSET = "System Prompt"
+CONSOLE_SYSTEM_PROMPT_LABEL_SET = "System Prompt: set"
+
+
 @dataclass(frozen=True)
 class ConsoleControlState:
     """Header/control labels for the Console-native workbench chrome."""
@@ -354,7 +358,7 @@ class ConsoleControlState:
     sources_label: str
     tools_label: str
     approvals_label: str
-    system_prompt_label: str = "System Prompt"
+    system_prompt_label: str = CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
     sources_active: bool = False
     tools_active: bool = False
     approvals_active: bool = False
@@ -392,6 +396,8 @@ class ConsoleControlState:
             mcp_tool_count: MCP catalog size that can run, or ``None`` when no MCP
                 seam is wired (chip then reflects built-in tools only).
             approval_count: Pending MCP approvals.
+            system_prompt_set: Whether the active session has a system prompt;
+                the chip then reads ``System Prompt: set``.
 
         Returns:
             A ``ConsoleControlState`` whose ``tools_label`` counts the tools that
@@ -435,7 +441,9 @@ class ConsoleControlState:
             tools_label=tools_label,
             approvals_label=f"Approvals: {approval_count} pending",
             system_prompt_label=(
-                "System Prompt: set" if system_prompt_set else "System Prompt"
+                CONSOLE_SYSTEM_PROMPT_LABEL_SET
+                if system_prompt_set
+                else CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
             ),
             sources_active=staged_source_count > 0,
             tools_active=effective_tool_count > 0,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -389,6 +389,7 @@ from ...Widgets.Console.console_status_chips import (
     ConsoleRagChip,
     ConsoleScopeChip,
     ConsoleStatusChips,
+    ConsoleSystemPromptChip,
     ConsoleTemporaryChip,
 )
 from ...Widgets.Console.console_retrieval_scope_row import (
@@ -7079,6 +7080,7 @@ class ChatScreen(BaseAppScreen):
             tool_count=self._console_tool_count(),
             mcp_tool_count=self._console_mcp_tool_count(),
             approval_count=self._console_pending_approval_count(),
+            system_prompt_set=bool(settings.system_prompt),
         )
 
     def _build_console_cost_state(self) -> ConsoleCostState | None:
@@ -7762,6 +7764,18 @@ class ChatScreen(BaseAppScreen):
         """Open the character picker from the Character/Assistant chip."""
         event.stop()
         await self._open_console_character_picker()
+
+    @on(ConsoleSystemPromptChip.OpenRequested)
+    def _console_system_prompt_chip_activated(
+        self, event: ConsoleSystemPromptChip.OpenRequested
+    ) -> None:
+        """Open the system prompt editor from the System Prompt chip.
+
+        A third entry point into the same opener ``/system`` and the
+        command palette use, following the model/assistant-chip precedent.
+        """
+        event.stop()
+        self.action_open_console_system_prompt_editor()
 
     @on(ConsoleRagChip.OpenRequested)
     def _console_rag_chip_activated(
@@ -17523,6 +17537,7 @@ class ChatScreen(BaseAppScreen):
             )
         self._sync_console_chat_core_state()
         self._sync_console_settings_summary()
+        self._sync_console_control_bar()
 
     async def _open_console_system_prompt_editor(self) -> None:
         """Open the system prompt editor modal for the active Console session."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -7080,7 +7080,7 @@ class ChatScreen(BaseAppScreen):
             tool_count=self._console_tool_count(),
             mcp_tool_count=self._console_mcp_tool_count(),
             approval_count=self._console_pending_approval_count(),
-            system_prompt_set=bool(settings.system_prompt),
+            system_prompt_set=bool(getattr(settings, "system_prompt", None)),
         )
 
     def _build_console_cost_state(self) -> ConsoleCostState | None:

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -132,6 +132,7 @@ class ConsoleSystemPromptChip(ConsoleChip):
         """Posted when the system-prompt chip is activated."""
 
     def action_edit_system_prompt(self) -> None:
+        """Post ``OpenRequested`` when the chip is activated from the keyboard."""
         self.post_message(self.OpenRequested())
 
     def _on_click(self, event: events.Click) -> None:

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -115,6 +115,29 @@ class ConsoleAssistantChip(ConsoleChip):
         self.post_message(self.OpenRequested())
 
 
+class ConsoleSystemPromptChip(ConsoleChip):
+    """System-prompt chip that opens the system-prompt editor when activated.
+
+    Same activation contract as the sibling action chips: Enter/Space while
+    focused, or a click, opens the same editor modal ``/system`` and the
+    command palette open (``ChatScreen._open_console_system_prompt_editor``).
+    """
+
+    BINDINGS = [
+        Binding("enter", "edit_system_prompt", "Edit system prompt", show=False),
+        Binding("space", "edit_system_prompt", "Edit system prompt", show=False),
+    ]
+
+    class OpenRequested(Message):
+        """Posted when the system-prompt chip is activated."""
+
+    def action_edit_system_prompt(self) -> None:
+        self.post_message(self.OpenRequested())
+
+    def _on_click(self, event: events.Click) -> None:
+        self.post_message(self.OpenRequested())
+
+
 class ConsoleScopeChip(ConsoleChip):
     """Retrieval-scope chip that opens the scope picker when activated.
 
@@ -312,6 +335,11 @@ class ConsoleStatusChips(Horizontal):
             self.state.model_label,
             id="console-model-chip",
             chip_class=ConsoleModelChip,
+        )
+        yield self._chip(
+            self.state.system_prompt_label,
+            id="console-system-prompt-chip",
+            chip_class=ConsoleSystemPromptChip,
         )
         yield self._chip(
             self.state.assistant_label,
@@ -577,6 +605,7 @@ class ConsoleStatusChips(Horizontal):
         label_values = {
             "#console-provider-chip": state.provider_label,
             "#console-model-chip": state.model_label,
+            "#console-system-prompt-chip": state.system_prompt_label,
             "#console-assistant-chip": state.assistant_label,
             "#console-rag-chip": state.rag_label,
             "#console-sources-chip": state.sources_label,


### PR DESCRIPTION
## What

Adds a clickable **System Prompt** chip to the Console status strip, between the **Model** and **Assistant (Character)** chips. Activating it (click, or Enter/Space while focused) opens the existing system-prompt editor modal — the same `ConsoleSystemPromptModal` already reachable via `/system` and the command palette — so users can view and modify the current chat's system prompt directly from the console page.

The chip label reflects state: `System Prompt` when unset, `System Prompt: set` when a prompt is active, updating immediately after Apply/Clear.

## How

- `console_status_chips.py` — new `ConsoleSystemPromptChip` following the sibling action-chip contract (`OpenRequested` message, Enter/Space + click), mounted between the model and assistant chips; label synced in `sync_state`.
- `console_display_state.py` — new derived `ConsoleControlState.system_prompt_label` (`system_prompt_set` param on `from_values`).
- `chat_screen.py` — `_build_console_control_state` passes prompt-set state; `@on(OpenRequested)` handler delegates to `action_open_console_system_prompt_editor()`; `_apply_console_session_system_prompt` now also calls `_sync_console_control_bar()` so the label never goes stale.

No new backend logic: apply/persist/LLM-injection all pre-exist. No ADR required (no schema/boundary changes — wires a UI trigger to an existing persisted feature).

Spec: `Docs/superpowers/specs/2026-08-03-console-system-prompt-chip-design.md`

## Tests

- 2 label-derivation tests (`Tests/Chat/test_console_display_state.py`)
- 4 new widget tests (`Tests/UI/test_console_system_prompt_chip.py`): placement, click, keyboard activation, label sync
- 2 integration tests (`Tests/UI/test_console_system_prompt.py`): chip opens the modal with current text; label reflects apply/clear
- Regression: `test_console_status_chips.py`, `test_console_shell_chip_actions.py`, `test_console_workbench_contract.py` — 78 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clickable System Prompt chip to the Console status strip (between Model and Assistant) that opens the existing system-prompt editor. The chip shows “System Prompt” or “System Prompt: set” and updates immediately after Apply/Clear.

- **New Features**
  - Introduced `ConsoleSystemPromptChip` in `console_status_chips.py` with click and Enter/Space activation, posting `OpenRequested`.
  - Added `ConsoleControlState.system_prompt_label` and passed `system_prompt_set` from `_build_console_control_state` in `chat_screen.py`.
  - Handled `ConsoleSystemPromptChip.OpenRequested` on `ChatScreen` by delegating to `action_open_console_system_prompt_editor()`.
  - Synced the control bar in `_apply_console_session_system_prompt` so the chip label updates right after Apply/Clear.

- **Refactors**
  - Extracted label strings into `CONSOLE_SYSTEM_PROMPT_LABEL_UNSET` and `CONSOLE_SYSTEM_PROMPT_LABEL_SET`; updated tests to use them.
  - Guarded `system_prompt_set` against missing `settings` with `getattr` in `_build_console_control_state`.
  - Clarified docs: added arg docs for `system_prompt_set` and chip method docstrings.

<sup>Written for commit ed4e48e849a044fe34cb334594287bf9a2bc14fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

