### PR TITLE
feat: per-rule appeared/disappeared/anywhere scope for content alerts (task-1363)

### DIFF
--- a/Tests/Subscriptions/test_watchlist_content_alert_service.py
+++ b/Tests/Subscriptions/test_watchlist_content_alert_service.py
@@ -43,6 +43,37 @@ def _change_item(**overrides):
     return item
 
 
+def test_appeared_scope_ignores_the_synthetic_change_title_and_metadata(service):
+    """task-1363 review: "appeared" matches ONLY the added page text, never the
+    change item's own metadata. A site change's title is the synthetic
+    "Change detected: <source name>", present on every check, so a pattern that
+    sits in the source name (here "Test source") must NOT fire under "appeared"
+    -- otherwise the scope that exists to cut page-wide noise would itself fire
+    on every change. Reds if "appeared" folds title/summary/author back into
+    the haystack.
+    """
+    item = _change_item()  # title = "Change detected: Test source"
+
+    source_name_rule = [{
+        "id": 9,
+        "name": "Matches the source name in the synthetic title",
+        "conditions": {"type": "keyword", "pattern": "Test source", "scope": "appeared"},
+    }]
+    assert service.evaluate(item, source_name_rule) == [], (
+        "the synthetic change title is not text that appeared on the page; an "
+        "'appeared' rule must not match it"
+    )
+    # Sanity: the same pattern DOES match under "anywhere" (it is in the title),
+    # proving the item genuinely carries it and the appeared-scope miss is the
+    # scoping, not a missing field.
+    source_name_anywhere = [{
+        "id": 10,
+        "name": "Same pattern, anywhere scope",
+        "conditions": {"type": "keyword", "pattern": "Test source", "scope": "anywhere"},
+    }]
+    assert [m["rule_id"] for m in service.evaluate(item, source_name_anywhere)] == [10]
+
+
 def test_appeared_scope_matches_added_text_but_not_an_unchanged_old_phrase(service):
     """AC#1/#3: "appeared" matches text a change introduced, not text that was
     already on the page before the change -- even though the old phrase is

--- a/Tests/Subscriptions/test_watchlist_content_alert_service.py
+++ b/Tests/Subscriptions/test_watchlist_content_alert_service.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tldw_chatbook.Subscriptions.watchlist_content_alert_service import WatchlistContentAlertService
 from tldw_chatbook.Subscriptions.watchlist_rule_matching import (
     RULE_MATCH_ADDED_TEXT_KEY,
@@ -106,6 +107,52 @@ def test_appeared_scope_matches_added_text_but_not_an_unchanged_old_phrase(servi
     assert [m["rule_id"] for m in service.evaluate(item, old_phrase_anywhere)] == [3], (
         "the same phrase must still match under scope=anywhere -- it is a "
         "genuine part of the current page"
+    )
+
+
+def test_mixed_scopes_in_one_evaluate_do_not_cross_contaminate(service):
+    """Qodo perf refactor: `evaluate` caches the haystack per scope so a
+    page-wide join is not rebuilt for every rule. The cache must be keyed by
+    scope -- a rule of one scope must never receive another scope's haystack.
+    Drive three rules of three different scopes through ONE call and confirm
+    each sees its own slice. Reds if the cache serves the wrong haystack (e.g.
+    a single shared key).
+    """
+    item = _change_item(**{
+        RULE_MATCH_ADDED_TEXT_KEY: "brand new phrase just landed.",
+        RULE_MATCH_REMOVED_TEXT_KEY: "gone phrase used to be here.",
+    })
+    rules = [
+        {  # appeared: matches added text, not removed, not the old page text
+            "id": 1,
+            "name": "appeared",
+            "conditions": {"type": "keyword", "pattern": "brand new phrase", "scope": "appeared"},
+        },
+        {  # disappeared: matches removed text only
+            "id": 2,
+            "name": "disappeared",
+            "conditions": {"type": "keyword", "pattern": "gone phrase", "scope": "disappeared"},
+        },
+        {  # anywhere: matches the old page phrase (present in RULE_MATCH_TEXT_KEY)
+            "id": 3,
+            "name": "anywhere",
+            "conditions": {"type": "keyword", "pattern": "an old phrase", "scope": "anywhere"},
+        },
+        {  # appeared rule for the GONE phrase -> must NOT match (it's removed, not added)
+            "id": 4,
+            "name": "appeared-for-removed",
+            "conditions": {"type": "keyword", "pattern": "gone phrase", "scope": "appeared"},
+        },
+        {  # disappeared rule for the NEW phrase -> must NOT match (it's added, not removed)
+            "id": 5,
+            "name": "disappeared-for-added",
+            "conditions": {"type": "keyword", "pattern": "brand new phrase", "scope": "disappeared"},
+        },
+    ]
+    matched_ids = sorted(m["rule_id"] for m in service.evaluate(item, rules))
+    assert matched_ids == [1, 2, 3], (
+        "each scope must see only its own text: appeared->added, "
+        "disappeared->removed, anywhere->page; the cross rules (4, 5) must miss"
     )
 
 

--- a/Tests/Subscriptions/test_watchlist_content_alert_service.py
+++ b/Tests/Subscriptions/test_watchlist_content_alert_service.py
@@ -1,5 +1,11 @@
 import pytest
 from tldw_chatbook.Subscriptions.watchlist_content_alert_service import WatchlistContentAlertService
+from tldw_chatbook.Subscriptions.watchlist_rule_matching import (
+    RULE_MATCH_ADDED_TEXT_KEY,
+    RULE_MATCH_REMOVED_TEXT_KEY,
+    RULE_MATCH_TEXT_KEY,
+    build_rule_haystack,
+)
 
 
 @pytest.fixture
@@ -15,3 +21,133 @@ def test_keyword_match(service):
     assert len(matches) == 1
     assert matches[0]["rule_id"] == 1
     assert matches[0]["severity"] == "warning"
+
+
+# --- TASK-1363: per-rule appeared/disappeared/anywhere scope ----------------
+
+
+def _change_item(**overrides):
+    """A site-change item carrying the page-wide text plus a diff's added and
+    removed segments, the shape `URLMonitor.check_url` produces.
+    """
+    item = {
+        "title": "Change detected: Test source",
+        "content": "the diff body itself, never matched against directly",
+        RULE_MATCH_TEXT_KEY: (
+            "an old phrase that was always here. brand new phrase just landed."
+        ),
+        RULE_MATCH_ADDED_TEXT_KEY: "brand new phrase just landed.",
+        RULE_MATCH_REMOVED_TEXT_KEY: "",
+    }
+    item.update(overrides)
+    return item
+
+
+def test_appeared_scope_matches_added_text_but_not_an_unchanged_old_phrase(service):
+    """AC#1/#3: "appeared" matches text a change introduced, not text that was
+    already on the page before the change -- even though the old phrase is
+    still on the page (and would match under "anywhere").
+    """
+    item = _change_item()
+
+    new_phrase_rule = [{
+        "id": 1,
+        "name": "New phrase",
+        "conditions": {"type": "keyword", "pattern": "brand new phrase", "scope": "appeared"},
+    }]
+    assert [m["rule_id"] for m in service.evaluate(item, new_phrase_rule)] == [1]
+
+    old_phrase_appeared = [{
+        "id": 2,
+        "name": "Old phrase, appeared scope",
+        "conditions": {"type": "keyword", "pattern": "an old phrase", "scope": "appeared"},
+    }]
+    assert service.evaluate(item, old_phrase_appeared) == [], (
+        "the old phrase did not appear in this change -- it must not match "
+        "under scope=appeared even though it is still on the page"
+    )
+
+    old_phrase_anywhere = [{
+        "id": 3,
+        "name": "Old phrase, anywhere scope",
+        "conditions": {"type": "keyword", "pattern": "an old phrase", "scope": "anywhere"},
+    }]
+    assert [m["rule_id"] for m in service.evaluate(item, old_phrase_anywhere)] == [3], (
+        "the same phrase must still match under scope=anywhere -- it is a "
+        "genuine part of the current page"
+    )
+
+
+def test_disappeared_scope_matches_removed_text_only(service):
+    """AC#1/#3: "disappeared" matches text a change removed, and that rule
+    must not also match under "appeared" -- the two scopes are disjoint.
+    """
+    item = _change_item(**{
+        RULE_MATCH_ADDED_TEXT_KEY: "",
+        RULE_MATCH_REMOVED_TEXT_KEY: "gone phrase used to be here.",
+    })
+
+    disappeared_rule = [{
+        "id": 1,
+        "name": "Gone phrase",
+        "conditions": {"type": "keyword", "pattern": "gone phrase", "scope": "disappeared"},
+    }]
+    assert [m["rule_id"] for m in service.evaluate(item, disappeared_rule)] == [1]
+
+    appeared_rule = [{
+        "id": 2,
+        "name": "Gone phrase, appeared scope",
+        "conditions": {"type": "keyword", "pattern": "gone phrase", "scope": "appeared"},
+    }]
+    assert service.evaluate(item, appeared_rule) == [], (
+        "removed text must not match under scope=appeared"
+    )
+
+
+def test_absent_or_anywhere_scope_keeps_page_wide_behaviour(service):
+    """AC#3 regression: a rule with no `scope` key at all -- every rule that
+    existed before this task -- keeps matching the whole page, identically to
+    an explicit scope="anywhere".
+    """
+    item = _change_item()
+
+    no_scope_rule = [{
+        "id": 1,
+        "name": "Old phrase, no scope key",
+        "conditions": {"type": "keyword", "pattern": "an old phrase"},
+    }]
+    explicit_anywhere_rule = [{
+        "id": 2,
+        "name": "Old phrase, explicit anywhere",
+        "conditions": {"type": "keyword", "pattern": "an old phrase", "scope": "anywhere"},
+    }]
+
+    no_scope_matches = service.evaluate(item, no_scope_rule)
+    anywhere_matches = service.evaluate(item, explicit_anywhere_rule)
+    assert [m["rule_id"] for m in no_scope_matches] == [1]
+    assert [m["rule_id"] for m in anywhere_matches] == [2]
+
+
+def test_unrecognized_scope_value_falls_back_to_anywhere(service):
+    """`build_rule_haystack` treats an unknown scope as "anywhere" (a safe
+    default), and the service must pass whatever string the rule holds
+    straight through rather than validating it first.
+    """
+    item = _change_item()
+    rules = [{
+        "id": 1,
+        "name": "Typo'd scope",
+        "conditions": {"type": "keyword", "pattern": "an old phrase", "scope": "evrywhere"},
+    }]
+    assert [m["rule_id"] for m in service.evaluate(item, rules)] == [1]
+
+
+def test_build_rule_haystack_no_scope_argument_matches_the_anywhere_default():
+    """AC#2's free half, pinned directly: the default `scope` parameter value
+    produces byte-identical output to calling with no `scope` argument at all
+    -- which is what `WatchlistFilterService` does, since it never passes one.
+    """
+    item = _change_item()
+    assert build_rule_haystack(item) == build_rule_haystack(item, scope="anywhere")
+    assert "an old phrase" in build_rule_haystack(item)
+    assert "brand new phrase" in build_rule_haystack(item)

--- a/Tests/Subscriptions/test_watchlist_content_kind_producer.py
+++ b/Tests/Subscriptions/test_watchlist_content_kind_producer.py
@@ -869,6 +869,128 @@ def test_the_rule_match_text_is_not_persisted_as_a_column():
     assert RULE_MATCH_TEXT_KEY not in columns
 
 
+# --- TASK-1363: appeared/disappeared scope, the producer half --------------
+
+
+def test_added_and_removed_text_helper_isolates_each_side_of_a_change():
+    """`added_and_removed_text`, the module helper `check_url` calls, in
+    isolation. Sharp assertions: each side must carry what changed on its own
+    side and nothing from the other, which is exactly what a scope-narrowed
+    rule relies on.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import added_and_removed_text
+
+    added, removed = added_and_removed_text(
+        "Alpha stays. Opus 4.1 is available. Gamma end.",
+        "Alpha stays. Opus 4.5 is available. Delta arrives. Gamma end.",
+    )
+
+    assert "Opus 4.5 is available" in added
+    assert "Delta arrives" in added
+    assert "Opus 4.1" not in added, "the added side must not carry the old text"
+
+    assert "Opus 4.1 is available" in removed
+    assert "Opus 4.5" not in removed, "the removed side must not carry the new text"
+    assert "Delta arrives" not in removed
+
+    # Nothing removed / nothing added are legitimate, common shapes (a pure
+    # addition, a pure deletion) -- both sides must be the empty string, not
+    # None or a KeyError-prone shape.
+    added_only, removed_none = added_and_removed_text("", "brand new page")
+    assert added_only.strip() == "brand new page"
+    assert removed_none == ""
+
+    added_none, removed_only = added_and_removed_text("old page gone", "")
+    assert added_none == ""
+    assert removed_only.strip() == "old page gone"
+
+
+async def _direct_check(db: SubscriptionsDB, source_id: int) -> tuple[dict | None, dict]:
+    """Call the real `check_url` directly, bypassing persistence.
+
+    `_check`/`_stored_items` only ever see what survives `persist_subscription_item`,
+    which drops any key outside its fixed column set -- exactly the thing
+    `RULE_MATCH_ADDED_TEXT_KEY`/`RULE_MATCH_REMOVED_TEXT_KEY` rely on staying
+    matching-only. This is the only way to see them on the raw change_info dict.
+    """
+    from tldw_chatbook.Subscriptions.local_watchlists_service import (
+        LocalWatchlistsService,
+    )
+    from tldw_chatbook.Subscriptions.monitoring_engine import URLMonitor
+
+    config = LocalWatchlistsService._subscription_execution_config(
+        db.get_subscription(source_id)
+    )
+    return await URLMonitor(db).check_url(config)
+
+
+@pytest.mark.asyncio
+async def test_check_url_attaches_added_and_removed_text_to_a_real_change(monkeypatch):
+    """The producer wiring, end to end: a real site change's `change_info`
+    carries both new keys, with content matching the real before/after pages
+    -- not merely present, but correctly split.
+    """
+    from tldw_chatbook.Subscriptions.watchlist_rule_matching import (
+        RULE_MATCH_ADDED_TEXT_KEY,
+        RULE_MATCH_REMOVED_TEXT_KEY,
+    )
+
+    db, service, source_id = await _site_source(
+        monkeypatch, [_PAGE_BEFORE, _PAGE_AFTER], change_threshold=0.0
+    )
+    await _check(service, source_id)  # baseline; check_url's own return is unused
+
+    item, disposition = await _direct_check(db, source_id)
+    assert disposition["kind"] == "changed", disposition
+    assert item is not None
+
+    added = item[RULE_MATCH_ADDED_TEXT_KEY]
+    removed = item[RULE_MATCH_REMOVED_TEXT_KEY]
+
+    assert "Opus 4.5 is available" in added
+    assert "Scheduled maintenance on Friday" in added
+    assert "Opus 4.1" not in added, "the added text must not carry the old version"
+
+    assert "Opus 4.1 is available" in removed
+    assert "Opus 4.5" not in removed
+    assert "Scheduled maintenance" not in removed, (
+        "the removed text must not carry a line the change only added"
+    )
+
+
+def test_feed_and_api_items_carry_neither_key_so_scope_falls_back_safely():
+    """AC#1: a feed/API item was never diffed against a previous version, so
+    it has neither `RULE_MATCH_ADDED_TEXT_KEY` nor `RULE_MATCH_REMOVED_TEXT_KEY`
+    -- only site changes go through `check_url`'s diff. `build_rule_haystack`
+    must handle their absence deliberately: "appeared" falls back to the whole
+    (wholly new) item rather than matching nothing, and "disappeared" matches
+    nothing at all, since nothing is known to have disappeared from an item
+    that was never compared against anything.
+    """
+    from tldw_chatbook.Subscriptions.watchlist_rule_matching import (
+        RULE_MATCH_ADDED_TEXT_KEY,
+        RULE_MATCH_REMOVED_TEXT_KEY,
+        build_rule_haystack,
+    )
+
+    feed_item = {
+        "title": "Opus 4.5",
+        "content": "The model is available in the API today.",
+    }
+    assert RULE_MATCH_ADDED_TEXT_KEY not in feed_item
+    assert RULE_MATCH_REMOVED_TEXT_KEY not in feed_item
+
+    assert "the model is available" in build_rule_haystack(feed_item, scope="appeared"), (
+        "a wholly new item has no diff to narrow against -- it all just appeared"
+    )
+    assert build_rule_haystack(feed_item, scope="disappeared") == "", (
+        "nothing is known to have disappeared from an item with no previous "
+        "version to compare against"
+    )
+    # And "anywhere" is exactly as before: unaffected by either new key.
+    assert "the model is available" in build_rule_haystack(feed_item)
+
+
 # --- no path may emit an invalid pairing -----------------------------------
 
 

--- a/Tests/Subscriptions/test_watchlist_content_kind_producer.py
+++ b/Tests/Subscriptions/test_watchlist_content_kind_producer.py
@@ -905,6 +905,33 @@ def test_added_and_removed_text_helper_isolates_each_side_of_a_change():
     assert removed_only.strip() == "old page gone"
 
 
+def test_pre_segmented_diff_helpers_match_the_self_segmenting_path():
+    """Qodo perf refactor: `check_url` segments each side once and hands the
+    segments to BOTH `build_change_diff` and `added_and_removed_text`, instead
+    of each re-segmenting. That optimization must be behaviour-preserving --
+    passing pre-computed segments must yield byte-identical output to letting
+    each helper segment the text itself. Reds if the shared-segment path ever
+    diverges from the self-segmenting path.
+    """
+    from tldw_chatbook.Subscriptions.monitoring_engine import (
+        _segment_for_diff,
+        added_and_removed_text,
+        build_change_diff,
+    )
+
+    previous = "Alpha stays. Opus 4.1 is available. Gamma end."
+    current = "Alpha stays. Opus 4.5 is available. Delta arrives. Gamma end."
+    old_segments = _segment_for_diff(previous)
+    new_segments = _segment_for_diff(current)
+
+    assert build_change_diff(previous, current) == build_change_diff(
+        previous, current, old_segments=old_segments, new_segments=new_segments
+    )
+    assert added_and_removed_text(previous, current) == added_and_removed_text(
+        previous, current, old_segments=old_segments, new_segments=new_segments
+    )
+
+
 async def _direct_check(db: SubscriptionsDB, source_id: int) -> tuple[dict | None, dict]:
     """Call the real `check_url` directly, bypassing persistence.
 

--- a/Tests/Subscriptions/test_watchlist_filter_service.py
+++ b/Tests/Subscriptions/test_watchlist_filter_service.py
@@ -25,3 +25,44 @@ def test_exclude_wins_over_include(service):
     result = service.evaluate(items, filters)
     # Lower priority number evaluated first; exclude wins.
     assert result[0]["filter_decision"] == "exclude"
+
+
+def test_exclude_filter_matches_whole_page_even_if_conditions_carry_a_scope_key(service):
+    """TASK-1363, AC#2: a per-rule scope is a content-alert-rule concept only.
+    `WatchlistFilterService._matches` never reads `conditions["scope"]` -- it
+    calls `build_rule_haystack(item)` with no `scope` argument at all, so it
+    always gets the "anywhere" default -- so even a filter whose conditions
+    happen to carry a scope key (e.g. copied from a content-alert rule, or a
+    future editor that shares one schema for both) must still match anywhere
+    on the page. A narrowed exclude filter could otherwise admit an item the
+    user told the app to drop, which is exactly the regression TASK-1343
+    already fixed once.
+
+    The pattern here is deliberately present ONLY in the page-wide text
+    (`rule_match_text`), not in the "added" text a scope would narrow to, so
+    this could not pass by accident if scope narrowing leaked into the
+    filter path.
+    """
+    from tldw_chatbook.Subscriptions.watchlist_rule_matching import (
+        RULE_MATCH_ADDED_TEXT_KEY,
+        RULE_MATCH_TEXT_KEY,
+    )
+
+    items = [{
+        "title": "",
+        "content": "",
+        RULE_MATCH_TEXT_KEY: "sponsored placement sits deep in the unchanged part of this page",
+        RULE_MATCH_ADDED_TEXT_KEY: "totally unrelated new text",
+    }]
+    filters = [{
+        "id": 1,
+        "priority": 0,
+        "action": "exclude",
+        "conditions": {"type": "keyword", "pattern": "sponsored placement", "scope": "appeared"},
+        "is_include_required": False,
+    }]
+    result = service.evaluate(items, filters)
+    assert result[0]["filter_decision"] == "exclude", (
+        "the filter must still match the whole page even though its "
+        "conditions carry a scope key -- WatchlistFilterService never reads it"
+    )

--- a/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
+++ b/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1363
 title: Offer appeared/disappeared semantics for content alerts
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-29 23:55'
 labels:
@@ -33,3 +33,20 @@ the capability arrived as a side effect of TASK-1343's diff and would otherwise 
 - [ ] #2 Exclude filters continue to match the whole page regardless of the setting, so a narrowed scope can never admit an excluded item
 - [ ] #3 Tests cover each scope, including that an existing rule with no explicit scope keeps its current page-wide behaviour
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Backend/service capability (no create-UI exists for pattern notify rules today; the scope lives in
+the rule's `conditions` JSON and the service honors it — a future rule editor sets it).
+1. `watchlist_rule_matching.py`: add `RULE_MATCH_ADDED_TEXT_KEY`/`RULE_MATCH_REMOVED_TEXT_KEY`; give
+   `build_rule_haystack(item, scope="anywhere")` a scope param. Default "anywhere" = current behavior
+   → `WatchlistFilterService` (exclude filters) never passes scope, so it stays whole-page (AC#2, free).
+2. `monitoring_engine.check_url`: compute added/removed text from previous/current (reuse
+   `_segment_for_diff` + SequenceMatcher for consistency with the shown diff); attach under the two
+   new keys on the url_change item (matching-only, non-persisted, like RULE_MATCH_TEXT_KEY).
+3. `WatchlistContentAlertService.evaluate`: read `conditions.get("scope")` (default/unknown →
+   "anywhere"), pass to the haystack. Feed/API items (no added/removed keys): "appeared" → whole
+   item (it all just appeared, fall back to anywhere); "disappeared" → empty (never matches).
+4. Tests (AC#3): each scope; absent-scope == page-wide (regression); exclude filter stays whole-page.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
+++ b/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
@@ -93,3 +93,15 @@ Followed the plan exactly; no UI (none exists for these rules today — see plan
 - Left status `In Progress` per dispatch instructions (no UI exists to close AC#1 end-to-end for a
   human user — the capability is proven at the rule-data/service layer the tests exercise directly, as
   the plan's preamble anticipated).
+
+## Review refinement (2026-08-03)
+
+Whole-branch review (CLEAN — "anywhere" default proven byte-identical by md5, both mutations
+reproduced, non-persistence confirmed) flagged one non-blocking note: under "appeared" on a SITE
+change, the haystack originally included the synthetic change title ("Change detected: <source
+name>") + summary + author alongside the added text, so an "appeared" pattern that sat in the source
+name would fire on EVERY change — page-wide noise, the opposite of what "appeared" is for. Refined so
+"appeared" matches ONLY the added text when the delta key is present (symmetric with "disappeared");
+the feed/API whole-item fallback (delta key absent) is unchanged. Pinned by
+`test_appeared_scope_ignores_the_synthetic_change_title_and_metadata` (a "Test source" pattern misses
+under "appeared" but hits under "anywhere"), mutation-verified.

--- a/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
+++ b/backlog/tasks/task-1363 - Offer-appeared-disappeared-semantics-for-content-alerts.md
@@ -29,9 +29,9 @@ the capability arrived as a side effect of TASK-1343's diff and would otherwise 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A content alert rule can be set to match on newly-added text, on removed text, or anywhere on the page, with anywhere remaining the default
-- [ ] #2 Exclude filters continue to match the whole page regardless of the setting, so a narrowed scope can never admit an excluded item
-- [ ] #3 Tests cover each scope, including that an existing rule with no explicit scope keeps its current page-wide behaviour
+- [x] #1 A content alert rule can be set to match on newly-added text, on removed text, or anywhere on the page, with anywhere remaining the default
+- [x] #2 Exclude filters continue to match the whole page regardless of the setting, so a narrowed scope can never admit an excluded item
+- [x] #3 Tests cover each scope, including that an existing rule with no explicit scope keeps its current page-wide behaviour
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -50,3 +50,46 @@ the rule's `conditions` JSON and the service honors it — a future rule editor 
    item (it all just appeared, fall back to anywhere); "disappeared" → empty (never matches).
 4. Tests (AC#3): each scope; absent-scope == page-wide (regression); exclude filter stays whole-page.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Followed the plan exactly; no UI (none exists for these rules today — see plan preamble).
+
+- `watchlist_rule_matching.py`: `RULE_MATCH_ADDED_TEXT_KEY` / `RULE_MATCH_REMOVED_TEXT_KEY` added,
+  documented as matching-only/non-persisted like `RULE_MATCH_TEXT_KEY`. `build_rule_haystack` gained
+  a `scope="anywhere"` param, with the original title/summary/body/author logic pulled into
+  `_page_wide_haystack` so `"anywhere"` and the "appeared" fallback for a wholly-new item share one
+  implementation instead of two copies that could drift. `"appeared"` narrows to the added text (plus
+  title/summary/author) when `RULE_MATCH_ADDED_TEXT_KEY` is present, else falls back to page-wide (a
+  feed/API item was never diffed — the whole item just appeared). `"disappeared"` uses ONLY the
+  removed text when `RULE_MATCH_REMOVED_TEXT_KEY` is present (not title/summary/author — those
+  describe the item as it stands now, not what left), else empty (never matches — nothing is known to
+  have disappeared). Any unrecognized scope value falls back to `"anywhere"`.
+- `monitoring_engine.py`: new `added_and_removed_text(previous_text, current_text)` helper, next to
+  `build_change_diff`, reuses `_segment_for_diff` + `SequenceMatcher(...).get_opcodes()` so
+  added/removed segments line up with what the reader's diff pane already shows. `check_url` calls it
+  alongside the existing `build_change_diff` call and attaches both keys on `change_info` — a second
+  segmentation pass rather than reusing `build_change_diff`'s internal one, per the plan, since the two
+  helpers serve different consumers (rendering vs. matching) and diverging later must not require
+  threading state between them. Confirmed `persist_subscription_item` reads a fixed key set via
+  `.get(...)` for named columns only, so both new keys are silently ignored at persistence — same
+  non-persistence guarantee `RULE_MATCH_TEXT_KEY` already relies on.
+- `WatchlistContentAlertService.evaluate`: haystack is now built per-rule (was once per-item) reading
+  `conditions.get("scope")`, defaulting to `"anywhere"`. `WatchlistFilterService` is untouched — it
+  still calls `build_rule_haystack(item)` with no `scope` argument, so it always gets the `"anywhere"`
+  default regardless of what a filter's `conditions` happen to contain, which is what makes AC#2 true
+  without any code in the filter path referencing scope at all.
+- Tests: `Tests/Subscriptions/test_watchlist_content_alert_service.py` (appeared/disappeared/anywhere/
+  absent-scope/unrecognized-scope through the real service, plus a direct `build_rule_haystack`
+  no-scope-arg pin), `Tests/Subscriptions/test_watchlist_filter_service.py` (AC#2: an exclude filter
+  whose conditions carry a `scope` key still matches whole-page), and
+  `Tests/Subscriptions/test_watchlist_content_kind_producer.py` (the producer half: `added_and_removed_text`
+  unit tests including pure-addition/pure-removal shapes, an end-to-end `check_url` test asserting the
+  real before/after split, and a feed/API-item test proving the no-key fallback behaviour). 59/59 green
+  in the targeted run; `--collect-only Tests/Subscriptions` unchanged at 633 tests, no collection
+  errors. Two mutations applied and reverted (Edit-revert, `git status --short` clean after): dropping
+  the scope passthrough in the service reddened 2 tests; swapping added/removed in the producer helper
+  reddened 2 tests.
+- Left status `In Progress` per dispatch instructions (no UI exists to close AC#1 end-to-end for a
+  human user — the capability is proven at the rule-data/service layer the tests exercise directly, as
+  the plan's preamble anticipated).

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -382,7 +382,13 @@ def _segment_for_diff(text: str) -> List[str]:
     return segments
 
 
-def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
+def build_change_diff(
+    previous_text: str,
+    current_text: str,
+    *,
+    old_segments: List[str] | None = None,
+    new_segments: List[str] | None = None,
+) -> tuple[str, str]:
     """Produce the stored diff body and its one-line summary for a site change.
 
     Before TASK-1343 the site-change path stored the *entire new page text* as
@@ -393,6 +399,13 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
     Args:
         previous_text: The previous snapshot's ``extracted_content``.
         current_text: The freshly fetched extracted text.
+        old_segments: ``previous_text`` already run through ``_segment_for_diff``.
+            Optional: ``check_url`` also feeds the same segments to
+            ``added_and_removed_text`` for the "appeared"/"disappeared" scopes
+            (TASK-1363), so segmenting each side once and passing the result to
+            both avoids a redundant pass over pages up to 10 MB (Qodo). Segmented
+            here when omitted, so every other caller is unchanged.
+        new_segments: ``current_text`` likewise.
 
     Returns:
         ``(diff_body, diff_summary)``. ``diff_body`` is a bounded unified-diff
@@ -402,8 +415,10 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
         *whole* diff so it stays true even when the body is truncated, and
         saying so when it was.
     """
-    old_segments = _segment_for_diff(previous_text)
-    new_segments = _segment_for_diff(current_text)
+    if old_segments is None:
+        old_segments = _segment_for_diff(previous_text)
+    if new_segments is None:
+        new_segments = _segment_for_diff(current_text)
 
     # The generator is consumed ONCE and never materialized (PR #1092 review,
     # Bug #1): `list(unified_diff(...))` bounded what was *stored* but left peak
@@ -473,7 +488,13 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
     return "\n".join(kept), summary
 
 
-def added_and_removed_text(previous_text: str, current_text: str) -> tuple[str, str]:
+def added_and_removed_text(
+    previous_text: str,
+    current_text: str,
+    *,
+    old_segments: List[str] | None = None,
+    new_segments: List[str] | None = None,
+) -> tuple[str, str]:
     """Split a site change into its added and removed text (TASK-1363).
 
     Feeds a content-alert rule scoped to "appeared" or "disappeared" (see
@@ -487,6 +508,12 @@ def added_and_removed_text(previous_text: str, current_text: str) -> tuple[str, 
     Args:
         previous_text: The previous snapshot's ``extracted_content``.
         current_text: The freshly fetched extracted text.
+        old_segments: ``previous_text`` already segmented; ``new_segments``
+            likewise. Optional, and shared with ``build_change_diff`` by
+            ``check_url`` so the same page is segmented once, not twice (Qodo).
+            Segmented here when omitted, so callers passing only the texts are
+            unchanged.
+        new_segments: See ``old_segments``.
 
     Returns:
         ``(added, removed)``: the new-side segments of every ``insert`` and
@@ -495,8 +522,10 @@ def added_and_removed_text(previous_text: str, current_text: str) -> tuple[str, 
         joining `build_rule_haystack` already uses). Either half is the empty
         string when nothing was added, or nothing was removed, respectively.
     """
-    old_segments = _segment_for_diff(previous_text)
-    new_segments = _segment_for_diff(current_text)
+    if old_segments is None:
+        old_segments = _segment_for_diff(previous_text)
+    if new_segments is None:
+        new_segments = _segment_for_diff(current_text)
     matcher = SequenceMatcher(None, old_segments, new_segments)
 
     added: List[str] = []
@@ -1313,11 +1342,23 @@ class URLMonitor:
             # reader's `[full page]` / `[previous snapshot]` affordances read
             # from; storing it a second time here bought nothing and left the
             # reader unable to see what had actually changed.
+            # Segment each side ONCE and share it with both consumers: the
+            # reader's diff body and the "appeared"/"disappeared" added/removed
+            # text (TASK-1363) are different outputs of the same segmentation,
+            # and a page can be up to 10 MB (Qodo -- do not segment it twice).
+            _old_segments = _segment_for_diff(previous_text)
+            _new_segments = _segment_for_diff(current_content["text"])
             diff_body, diff_summary = build_change_diff(
-                previous_text, current_content["text"]
+                previous_text,
+                current_content["text"],
+                old_segments=_old_segments,
+                new_segments=_new_segments,
             )
             added_text, removed_text = added_and_removed_text(
-                previous_text, current_content["text"]
+                previous_text,
+                current_content["text"],
+                old_segments=_old_segments,
+                new_segments=_new_segments,
             )
             change_info = {
                 "type": "url_change",

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -51,7 +51,11 @@ from .item_persist import (
     CONTENT_KIND_CHANGE,
 )
 from .noise_defaults import extraction_fingerprint, selector_parse_errors
-from .watchlist_rule_matching import RULE_MATCH_TEXT_KEY
+from .watchlist_rule_matching import (
+    RULE_MATCH_ADDED_TEXT_KEY,
+    RULE_MATCH_REMOVED_TEXT_KEY,
+    RULE_MATCH_TEXT_KEY,
+)
 from ..Utils.egress import (
     EgressBlockedError,
     EgressFetchError,
@@ -467,6 +471,43 @@ def build_change_diff(previous_text: str, current_text: str) -> tuple[str, str]:
         )
         summary += _DIFF_TRUNCATION_SUMMARY_SUFFIX
     return "\n".join(kept), summary
+
+
+def added_and_removed_text(previous_text: str, current_text: str) -> tuple[str, str]:
+    """Split a site change into its added and removed text (TASK-1363).
+
+    Feeds a content-alert rule scoped to "appeared" or "disappeared" (see
+    ``watchlist_rule_matching.build_rule_haystack``) rather than the diff
+    body ``build_change_diff`` renders for the reader -- the two exist for
+    different consumers, but reuse the same ``_segment_for_diff``
+    segmentation so "added"/"removed" line up with what the reader's diff
+    pane shows, rather than a raw character-level diff that could slice a
+    matched phrase mid-word.
+
+    Args:
+        previous_text: The previous snapshot's ``extracted_content``.
+        current_text: The freshly fetched extracted text.
+
+    Returns:
+        ``(added, removed)``: the new-side segments of every ``insert`` and
+        ``replace`` opcode, and the old-side segments of every ``delete`` and
+        ``replace`` opcode, each joined by a single space (matching the
+        joining `build_rule_haystack` already uses). Either half is the empty
+        string when nothing was added, or nothing was removed, respectively.
+    """
+    old_segments = _segment_for_diff(previous_text)
+    new_segments = _segment_for_diff(current_text)
+    matcher = SequenceMatcher(None, old_segments, new_segments)
+
+    added: List[str] = []
+    removed: List[str] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag in ("insert", "replace"):
+            added.extend(new_segments[j1:j2])
+        if tag in ("delete", "replace"):
+            removed.extend(old_segments[i1:i2])
+
+    return " ".join(added), " ".join(removed)
 
 
 def classify_change_type(previous_text: str, current_text: str) -> str:
@@ -1275,6 +1316,9 @@ class URLMonitor:
             diff_body, diff_summary = build_change_diff(
                 previous_text, current_content["text"]
             )
+            added_text, removed_text = added_and_removed_text(
+                previous_text, current_content["text"]
+            )
             change_info = {
                 "type": "url_change",
                 "url": url,
@@ -1310,6 +1354,12 @@ class URLMonitor:
                 # for matching only; it is not a persisted column (see
                 # `watchlist_rule_matching`).
                 RULE_MATCH_TEXT_KEY: current_content["text"],
+                # A per-rule opt-in (TASK-1363): a rule scoped to "appeared" or
+                # "disappeared" matches against just one of these instead of
+                # the whole page above. Matching-only, like
+                # `RULE_MATCH_TEXT_KEY` -- see `watchlist_rule_matching`.
+                RULE_MATCH_ADDED_TEXT_KEY: added_text,
+                RULE_MATCH_REMOVED_TEXT_KEY: removed_text,
             }
 
             # Store new snapshot

--- a/tldw_chatbook/Subscriptions/watchlist_content_alert_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_content_alert_service.py
@@ -15,16 +15,19 @@ class WatchlistContentAlertService:
         rules: list[Mapping[str, Any]],
     ) -> list[dict[str, Any]]:
         matched: list[dict[str, Any]] = []
-        # Shared with `WatchlistFilterService` so the two cannot drift, and
-        # page-scoped rather than diff-scoped for a site change -- see
-        # `watchlist_rule_matching`.
-        haystack = build_rule_haystack(item)
         for rule in rules:
             conditions = dict(rule.get("conditions") or {})
             pattern = str(conditions.get("pattern") or "")
             if not pattern:
                 continue
             rule_type = str(conditions.get("type") or "keyword").lower()
+            # Shared with `WatchlistFilterService` so the two cannot drift.
+            # Page-scoped ("anywhere") by default for a site change -- see
+            # `watchlist_rule_matching` -- with a per-rule opt-in (TASK-1363)
+            # to narrow to just the text a change added or removed.
+            haystack = build_rule_haystack(
+                item, scope=str(conditions.get("scope") or "anywhere").lower()
+            )
             is_match = False
             if rule_type == "keyword":
                 is_match = pattern.lower() in haystack

--- a/tldw_chatbook/Subscriptions/watchlist_content_alert_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_content_alert_service.py
@@ -15,6 +15,12 @@ class WatchlistContentAlertService:
         rules: list[Mapping[str, Any]],
     ) -> list[dict[str, Any]]:
         matched: list[dict[str, Any]] = []
+        # There are only three distinct scopes, so a per-scope cache builds each
+        # haystack at most once even when many rules share a scope (Qodo, the
+        # page-wide join over a large page is not free) -- keyed by the
+        # NORMALIZED scope so the whole `str(... or "anywhere").lower()` family
+        # collapses to one key.
+        haystack_by_scope: dict[str, str] = {}
         for rule in rules:
             conditions = dict(rule.get("conditions") or {})
             pattern = str(conditions.get("pattern") or "")
@@ -25,9 +31,10 @@ class WatchlistContentAlertService:
             # Page-scoped ("anywhere") by default for a site change -- see
             # `watchlist_rule_matching` -- with a per-rule opt-in (TASK-1363)
             # to narrow to just the text a change added or removed.
-            haystack = build_rule_haystack(
-                item, scope=str(conditions.get("scope") or "anywhere").lower()
-            )
+            scope = str(conditions.get("scope") or "anywhere").lower()
+            if scope not in haystack_by_scope:
+                haystack_by_scope[scope] = build_rule_haystack(item, scope=scope)
+            haystack = haystack_by_scope[scope]
             is_match = False
             if rule_type == "keyword":
                 is_match = pattern.lower() in haystack

--- a/tldw_chatbook/Subscriptions/watchlist_rule_matching.py
+++ b/tldw_chatbook/Subscriptions/watchlist_rule_matching.py
@@ -82,12 +82,15 @@ def build_rule_haystack(item: Mapping[str, Any], scope: str = "anywhere") -> str
       filter could admit an item the user told the app to drop), keep matching
       the whole page exactly as before.
     * ``"appeared"``: only the text a site change newly introduced --
-      :data:`RULE_MATCH_ADDED_TEXT_KEY` in place of the body, alongside
-      ``title``/``summary``/``author`` (a rule can still match a phrase in the
-      title of the item that reported the change). When that key is absent --
-      a feed or API item, which has no "previous version" to diff against --
-      the *entire* new item just appeared, so this falls back to the page-wide
-      haystack rather than matching nothing.
+      :data:`RULE_MATCH_ADDED_TEXT_KEY` and nothing else, symmetric with
+      ``"disappeared"`` below. NOT ``title``/``summary``/``author``: a change
+      item's title is the synthetic ``"Change detected: <source name>"``,
+      present on every change, so a pattern that happened to sit in the source
+      name would match every check and defeat the point of scoping to what is
+      new. When that key is absent -- a feed or API item, which has no
+      "previous version" to diff against -- the *entire* new item just
+      appeared, so this falls back to the page-wide haystack rather than
+      matching nothing.
     * ``"disappeared"``: only :data:`RULE_MATCH_REMOVED_TEXT_KEY`, and nothing
       else -- not ``title``/``summary``/``author``, because those describe the
       item as it now stands, not text that disappeared. When the key is
@@ -114,13 +117,15 @@ def build_rule_haystack(item: Mapping[str, Any], scope: str = "anywhere") -> str
     if normalized_scope == "appeared":
         if RULE_MATCH_ADDED_TEXT_KEY not in item:
             return _page_wide_haystack(item)
-        parts = [
-            str(item.get("title") or ""),
-            str(item.get("summary") or ""),
-            str(item.get(RULE_MATCH_ADDED_TEXT_KEY) or ""),
-            str(item.get("author") or ""),
-        ]
-        return " ".join(parts).lower()
+        # Only the newly-added text -- symmetric with "disappeared", and NOT
+        # title/summary/author. A site change's title is the synthetic
+        # "Change detected: <source name>", which is present on every change,
+        # so including it would fire an "appeared" rule whose pattern happened
+        # to sit in the source name on EVERY check -- exactly the page-wide
+        # noise "appeared" exists to escape (task-1363 review). The item's own
+        # metadata is not "text that just appeared on the page"; the added
+        # segments are.
+        return str(item.get(RULE_MATCH_ADDED_TEXT_KEY) or "").lower()
 
     # "anywhere" and any unrecognized scope value (safe default).
     return _page_wide_haystack(item)

--- a/tldw_chatbook/Subscriptions/watchlist_rule_matching.py
+++ b/tldw_chatbook/Subscriptions/watchlist_rule_matching.py
@@ -29,19 +29,30 @@ from typing import Any, Mapping
 #: *is* the captured body -- so the fallback below is the common path.
 RULE_MATCH_TEXT_KEY = "rule_match_text"
 
+#: The segment of a site change's text that is newly present, for a rule
+#: scoped to "appeared" (TASK-1363).
+#:
+#: Set by ``URLMonitor.check_url`` (``added_and_removed_text``), from the same
+#: diff the reader's change pane already shows. Matching-only, like
+#: :data:`RULE_MATCH_TEXT_KEY`: not a persisted column (``persist_subscription_item``
+#: reads a fixed key set and ignores this one), and not set at all by the feed
+#: or API producers, whose items have no "previous version" to diff against.
+RULE_MATCH_ADDED_TEXT_KEY = "rule_match_added_text"
 
-def build_rule_haystack(item: Mapping[str, Any]) -> str:
-    """Build the lowercased text a filter or alert rule is matched against.
+#: The segment of a site change's text that is no longer present, for a rule
+#: scoped to "disappeared" (TASK-1363). Same provenance and non-persistence as
+#: :data:`RULE_MATCH_ADDED_TEXT_KEY`, above.
+RULE_MATCH_REMOVED_TEXT_KEY = "rule_match_removed_text"
 
-    Args:
-        item: A raw fetched item, before persistence.
 
-    Returns:
-        ``title``, ``summary``, the item's body and ``author`` joined by single
-        spaces and lowercased. The body is :data:`RULE_MATCH_TEXT_KEY` when the
-        producer supplied it, otherwise ``content``; it *replaces* ``content``
-        rather than adding to it, so that a phrase which was only ever in the
-        text the previous check removed does not start matching.
+def _page_wide_haystack(item: Mapping[str, Any]) -> str:
+    """The original, page-wide haystack: title/summary/body/author, lowercased.
+
+    This is the whole of ``scope="anywhere"`` and also the fallback a wholly
+    new item (no diff to narrow against) uses under ``scope="appeared"`` --
+    kept as one function so the two paths cannot drift apart, and so a rule
+    with no ``scope`` at all produces byte-identical output to before this
+    parameter existed.
     """
     body = item.get(RULE_MATCH_TEXT_KEY)
     if body is None:
@@ -53,3 +64,63 @@ def build_rule_haystack(item: Mapping[str, Any]) -> str:
         str(item.get("author") or ""),
     ]
     return " ".join(parts).lower()
+
+
+def build_rule_haystack(item: Mapping[str, Any], scope: str = "anywhere") -> str:
+    """Build the lowercased text a filter or alert rule is matched against.
+
+    Three scopes (TASK-1363), chosen per rule and passed in by the caller --
+    ``build_rule_haystack`` itself has no notion of "the rule", only of the
+    item and which slice of it to search:
+
+    * ``"anywhere"`` (the default, and what any unrecognized value falls back
+      to): the whole page -- ``title``/``summary``/body/``author``, where the
+      body is :data:`RULE_MATCH_TEXT_KEY` when the producer supplied it,
+      otherwise ``content``. Unchanged from before this parameter existed, so
+      an existing rule with no ``scope`` key, and :class:`WatchlistFilterService`
+      (which never passes ``scope`` at all, because a narrowed *exclude*
+      filter could admit an item the user told the app to drop), keep matching
+      the whole page exactly as before.
+    * ``"appeared"``: only the text a site change newly introduced --
+      :data:`RULE_MATCH_ADDED_TEXT_KEY` in place of the body, alongside
+      ``title``/``summary``/``author`` (a rule can still match a phrase in the
+      title of the item that reported the change). When that key is absent --
+      a feed or API item, which has no "previous version" to diff against --
+      the *entire* new item just appeared, so this falls back to the page-wide
+      haystack rather than matching nothing.
+    * ``"disappeared"``: only :data:`RULE_MATCH_REMOVED_TEXT_KEY`, and nothing
+      else -- not ``title``/``summary``/``author``, because those describe the
+      item as it now stands, not text that disappeared. When the key is
+      absent, nothing is known to have disappeared, so the haystack is empty
+      and the rule can never match (rather than silently falling back to the
+      whole page, which would defeat the point of scoping to what left).
+
+    Args:
+        item: A raw fetched item, before persistence.
+        scope: One of ``"anywhere"``, ``"appeared"``, ``"disappeared"``. Any
+            other value (including an absent/``None`` scope) is treated as
+            ``"anywhere"``.
+
+    Returns:
+        The scoped haystack, lowercased.
+    """
+    normalized_scope = str(scope or "anywhere").lower()
+
+    if normalized_scope == "disappeared":
+        if RULE_MATCH_REMOVED_TEXT_KEY not in item:
+            return ""
+        return str(item.get(RULE_MATCH_REMOVED_TEXT_KEY) or "").lower()
+
+    if normalized_scope == "appeared":
+        if RULE_MATCH_ADDED_TEXT_KEY not in item:
+            return _page_wide_haystack(item)
+        parts = [
+            str(item.get("title") or ""),
+            str(item.get("summary") or ""),
+            str(item.get(RULE_MATCH_ADDED_TEXT_KEY) or ""),
+            str(item.get("author") or ""),
+        ]
+        return " ".join(parts).lower()
+
+    # "anywhere" and any unrecognized scope value (safe default).
+    return _page_wide_haystack(item)


### PR DESCRIPTION
## Why

Content-alert rules match against the full page text (TASK-1343 preserved this deliberately, so a long-standing alert doesn't silently stop firing). But "tell me when this phrase **appears**" — matching only newly-added text — is a genuinely useful thing to want from a site watcher, and the diff now makes it cheap to compute. Same for "when it **disappears**". This adds it as a per-rule opt-in, not a change to the default (task-1363).

## What

- **`build_rule_haystack(item, scope="anywhere")`** gains a scope param:
  - `anywhere` (default): the whole page — **byte-identical** to before (verified by md5 in review). This is what makes AC#2 free: `WatchlistFilterService` (exclude filters) never passes a scope, so a narrowed scope can never admit an excluded item.
  - `appeared`: only the newly-added page text (a site change's added segments). Not the item's own metadata — a change item's title is the synthetic "Change detected: <source name>", so folding it in would fire on every check; `appeared` matches only what is genuinely new (review refinement, symmetric with `disappeared`).
  - `disappeared`: only the removed page text. Absent delta → empty → never matches (nothing is known to have left).
  - A feed/API item (no diff, wholly new) under `appeared` → the whole item just appeared, so it falls back to the page-wide haystack; under `disappeared` → matches nothing.
  - Unknown/None/non-string scope → `anywhere` (safe default).
- **`monitoring_engine.check_url`** attaches `rule_match_added_text`/`rule_match_removed_text`, computed by `added_and_removed_text` (SequenceMatcher opcodes over the same `_segment_for_diff` segmentation the shown diff uses) — matching-only, non-persisted, like `rule_match_text`.
- **`WatchlistContentAlertService`** reads each rule's `conditions["scope"]` and passes it. The run-level alert system (`local_watchlist_alert_rules`) is untouched.

No create-UI exists for these pattern-notify rules today; the scope lives in the rule's `conditions` JSON and the service honors it (a future rule editor is where it'd be surfaced) — AC#1 "can be set" is satisfied at the rule-data/service layer, which the tests exercise directly.

## Testing

Each scope; absent scope == page-wide (AC#3 regression); exclude filter stays whole-page (AC#2); the producer attaches the right added/removed text; the appeared-ignores-synthetic-title refinement. 60 passed across the four targeted files. Every behavioural change mutation-verified (scope-passthrough drop, added/removed swap, appeared-includes-title). Opus whole-branch review: CLEAN — the `anywhere` default proven byte-identical, non-persistence confirmed, both original mutations reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑rule scope for content alerts to match newly added text, removed text, or anywhere on the page. Default stays page‑wide; exclude filters are unchanged (TASK-1363).

- **New Features**
  - `build_rule_haystack(item, scope)` supports `anywhere` (default), `appeared`, and `disappeared`; unknown values fall back to `anywhere`. Feed/API items fall back safely (`appeared` → page‑wide, `disappeared` → empty).
  - `URLMonitor.check_url` attaches `rule_match_added_text` and `rule_match_removed_text` via `added_and_removed_text`, reusing `_segment_for_diff` so added/removed align with the shown diff; keys are matching‑only (not persisted).
  - `WatchlistContentAlertService` reads `conditions.scope` per rule and caches haystacks per scope; `WatchlistFilterService` remains page‑wide since it never supplies `scope`.

- **Bug Fixes**
  - Under `appeared`, ignore the synthetic change title/metadata; match only the added page text to prevent noisy matches.

<sup>Written for commit 2ee1d8a94ad189a1078d198d6f924399011a58cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

