### PR TITLE
Redact URLs in egress exception strings; add the leak tests the redaction never had (TASK-1722)

### DIFF
--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -226,6 +226,91 @@ def test_disabled_egress_log_redacts_url_credentials(monkeypatch):
         assert sensitive_value not in messages[0]
 
 
+# ---------------------------------------------------------------------------
+# _log_origin: credential-free URL label for transport logs (TASK-1722)
+# ---------------------------------------------------------------------------
+
+def test_log_origin_strips_userinfo_query_and_fragment():
+    """_log_origin renders scheme://host[:port] only -- no userinfo/path/query/fragment."""
+    label = egress._log_origin(
+        "https://user:SECRET-TOKEN-MARKER@example.test:8443"
+        "/path?token=SECRET-TOKEN-MARKER#frag"
+    )
+    assert label == "https://example.test:8443"
+    assert "SECRET-TOKEN-MARKER" not in label
+
+
+def test_log_origin_omits_port_when_absent():
+    assert egress._log_origin("https://example.test/path?x=1") == "https://example.test"
+
+
+def test_log_origin_ipv6_host_is_bracketed():
+    assert (
+        egress._log_origin("https://[2001:db8::1]:9443/x?y=SECRET-TOKEN-MARKER")
+        == "https://[2001:db8::1]:9443"
+    )
+    assert egress._log_origin("http://[::1]/") == "http://[::1]"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.test/file?token=SECRET-TOKEN-MARKER",
+        "file:///etc/passwd",
+        "mailto:user@example.test",
+        "data:text/html,hi",
+        "https:///nohost",
+        "",
+        "not a url at all",
+        "http://[::1/x",  # malformed IPv6 -- urlparse.hostname raises ValueError
+        "http://",
+        "://bad",
+    ],
+)
+def test_log_origin_never_raises_for_non_http_or_unparseable_input(url):
+    """Non-http(s) scheme, hostless, and unparseable input all redact to a fixed
+    sentinel and never raise -- a logging helper that can throw would turn a
+    blocked request into a crash."""
+    assert egress._log_origin(url) == "<invalid-url>"
+
+
+def test_egress_block_log_omits_injected_query_marker(monkeypatch):
+    """AC2: a blocked fetch of a URL with a token in the query string must not
+    leak that token into the log line -- assert the marker's ABSENCE, not
+    merely the presence of a redacted form."""
+    marker = "SECRET-TOKEN-MARKER"
+    messages = []
+    monkeypatch.setattr(egress.logger, "warning", messages.append)
+    monkeypatch.setattr(egress, "_resolve", lambda host: ["10.0.0.1"])
+
+    decision = evaluate_url_policy(f"https://example.test/download?sig={marker}")
+
+    assert decision.allowed is False
+    assert len(messages) == 1
+    assert marker not in messages[0]
+    assert "https://example.test" in messages[0]  # host stays visible to operators
+
+
+def test_disabled_egress_log_omits_injected_query_marker(monkeypatch):
+    """Same as above for the disabled-check DEBUG log site (AC3: every site,
+    not just the block path)."""
+    marker = "SECRET-TOKEN-MARKER"
+    messages = []
+    monkeypatch.setattr(egress.logger, "debug", messages.append)
+    monkeypatch.setattr(
+        egress,
+        "get_cli_setting",
+        lambda section, key=None, default=None: False if key == "enabled" else default,
+    )
+
+    decision = evaluate_url_policy(f"https://example.test/download?sig={marker}")
+
+    assert decision.allowed is True
+    assert len(messages) == 1
+    assert marker not in messages[0]
+    assert "https://example.test" in messages[0]
+
+
 def test_check_url_or_raise_raises_with_remedy(monkeypatch):
     _resolve_to(monkeypatch, ["127.0.0.1"])
     with pytest.raises(EgressBlockedError) as exc:

--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -270,14 +270,22 @@ def test_log_origin_ipv6_host_is_bracketed():
 def test_log_origin_never_raises_for_non_http_or_unparseable_input(url):
     """Non-http(s) scheme, hostless, and unparseable input all redact to a fixed
     sentinel and never raise -- a logging helper that can throw would turn a
-    blocked request into a crash."""
+    blocked request into a crash.
+
+    Args:
+        url: Parametrized non-http(s) or unparseable input.
+    """
     assert egress._log_origin(url) == "<invalid-url>"
 
 
 def test_egress_block_log_omits_injected_query_marker(monkeypatch):
     """AC2: a blocked fetch of a URL with a token in the query string must not
     leak that token into the log line -- assert the marker's ABSENCE, not
-    merely the presence of a redacted form."""
+    merely the presence of a redacted form.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     marker = "SECRET-TOKEN-MARKER"
     messages = []
     monkeypatch.setattr(egress.logger, "warning", messages.append)
@@ -293,7 +301,11 @@ def test_egress_block_log_omits_injected_query_marker(monkeypatch):
 
 def test_disabled_egress_log_omits_injected_query_marker(monkeypatch):
     """Same as above for the disabled-check DEBUG log site (AC3: every site,
-    not just the block path)."""
+    not just the block path).
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     marker = "SECRET-TOKEN-MARKER"
     messages = []
     monkeypatch.setattr(egress.logger, "debug", messages.append)

--- a/Tests/Utils/test_egress.py
+++ b/Tests/Utils/test_egress.py
@@ -320,6 +320,49 @@ def test_check_url_or_raise_raises_with_remedy(monkeypatch):
     assert exc.value.reason == "private"
 
 
+# ---------------------------------------------------------------------------
+# Exception message redaction (TASK-1722 fix round 1): EgressBlockedError and
+# EgressFetchError are caught and logged verbatim by many callers (e.g.
+# Article_Extractor_Lib.py, monitoring_engine.py, audio_processing.py) --
+# their str()/repr() is as much a "log site" as a direct logger.* call. The
+# ``.url`` attribute keeps the full URL for programmatic use; only the
+# message is redacted.
+# ---------------------------------------------------------------------------
+
+def test_egress_blocked_error_message_omits_query_marker():
+    marker = "SECRET-TOKEN-MARKER"
+    url = f"https://user:pw@example.test:8443/models/f.gguf?sig={marker}#frag"
+
+    exc = EgressBlockedError(url, "private", "resolves to private IP")
+
+    assert marker not in str(exc)
+    assert marker not in repr(exc)
+    assert "user:pw@" not in str(exc)
+    assert "example.test:8443" in str(exc)  # host stays visible to operators
+    assert "allowed_hosts" in str(exc)  # remedy text preserved
+    assert exc.url == url  # full URL still available to programmatic consumers
+
+
+def test_egress_fetch_error_message_omits_query_marker():
+    marker = "SECRET-TOKEN-MARKER"
+    url = f"https://user:pw@example.test:8443/models/f.gguf?sig={marker}#frag"
+
+    exc = EgressFetchError("too many redirects", url=url)
+
+    assert marker not in str(exc)
+    assert marker not in repr(exc)
+    assert "user:pw@" not in str(exc)
+    assert "example.test:8443" in str(exc)
+    assert exc.url == url
+
+
+def test_egress_fetch_error_no_url_omits_bracket():
+    """No url given -> no bracketed suffix at all (unchanged behavior)."""
+    exc = EgressFetchError("HTTP 500")
+    assert str(exc) == "HTTP 500"
+    assert exc.url == ""
+
+
 @pytest.mark.asyncio
 async def test_async_variant_same_policy(monkeypatch):
     async def _fake(host):

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -52,11 +52,15 @@ class EgressBlockedError(Exception):
     """URL blocked by the egress policy (SSRF guard)."""
 
     def __init__(self, url: str, reason: str, detail: str = ""):
+        # ``self.url`` keeps the full URL for programmatic consumers (retry
+        # logic, callers that need the real target); the redaction boundary
+        # is str()/repr() -- what actually reaches logs and end users -- so
+        # the exception MESSAGE gets the credential-free origin label only.
         self.url = url
         self.reason = reason
         self.detail = detail
         super().__init__(
-            f"Egress blocked ({reason}) for {url}"
+            f"Egress blocked ({reason}) for {_log_origin(url)}"
             + (f": {detail}" if detail else "")
             + " [remedy: add the host to [web_security] allowed_hosts in"
             " config.toml, or set [web_security] enabled = false]"
@@ -268,8 +272,10 @@ class EgressFetchError(Exception):
     """Guarded-fetch transport failure: size cap, hop cap, missing Location."""
 
     def __init__(self, message: str, url: str = ""):
+        # Same redaction boundary as EgressBlockedError: ``self.url`` keeps
+        # the full URL, the message gets the origin label only.
         self.url = url
-        super().__init__(f"{message}" + (f" [{url}]" if url else ""))
+        super().__init__(f"{message}" + (f" [{_log_origin(url)}]" if url else ""))
 
 
 @dataclass

--- a/tldw_chatbook/Utils/egress.py
+++ b/tldw_chatbook/Utils/egress.py
@@ -52,10 +52,20 @@ class EgressBlockedError(Exception):
     """URL blocked by the egress policy (SSRF guard)."""
 
     def __init__(self, url: str, reason: str, detail: str = ""):
-        # ``self.url`` keeps the full URL for programmatic consumers (retry
-        # logic, callers that need the real target); the redaction boundary
-        # is str()/repr() -- what actually reaches logs and end users -- so
-        # the exception MESSAGE gets the credential-free origin label only.
+        """Build the blocked-egress error with a credential-free message.
+
+        ``self.url`` keeps the full URL for programmatic consumers (retry
+        logic, callers that need the real target); the redaction boundary
+        is ``str()``/``repr()`` -- what actually reaches logs and end
+        users -- so the exception MESSAGE gets the credential-free origin
+        label only.
+
+        Args:
+            url: The full request URL, retained verbatim on ``self.url``
+                but rendered in the message via ``_log_origin``.
+            reason: Short policy-reason slug (e.g. ``"private-ip"``).
+            detail: Optional extra context appended to the message.
+        """
         self.url = url
         self.reason = reason
         self.detail = detail
@@ -272,8 +282,17 @@ class EgressFetchError(Exception):
     """Guarded-fetch transport failure: size cap, hop cap, missing Location."""
 
     def __init__(self, message: str, url: str = ""):
-        # Same redaction boundary as EgressBlockedError: ``self.url`` keeps
-        # the full URL, the message gets the origin label only.
+        """Build the fetch-failure error with a credential-free message.
+
+        Same redaction boundary as ``EgressBlockedError``: ``self.url``
+        keeps the full URL, the message gets the origin label only.
+
+        Args:
+            message: Human-readable failure description.
+            url: Optional full request URL, retained verbatim on
+                ``self.url`` but rendered in the message via
+                ``_log_origin``.
+        """
         self.url = url
         super().__init__(f"{message}" + (f" [{_log_origin(url)}]" if url else ""))
 


### PR DESCRIPTION
Closes TASK-1722. Egress credential redaction: the log sites were already fixed (PR #1173 adopted `_log_origin()`); this PR closes the leak that remained and adds the test coverage the fix never had.

## The remaining leak: exception strings

`str(EgressBlockedError)` embedded the full URL (`"Egress blocked (reason) for {url}"`), and `EgressFetchError` appended ` [{url}]`. Callers log these verbatim — `Article_Extractor_Lib.py:344` does `logging.warning(f"...: {e}")`, and `acquisition.py` and `monitoring_engine.py` have equivalent sites — so a blocked presigned URL still landed its token in the log, one frame above the redacted module.

Both messages now render through `_log_origin(url)`. The **`.url` attribute keeps the full URL**: the redaction boundary is `str()`/`repr()` — what reaches logs and users — not what programmatic consumers can access, and a test pins that attribute contract so it cannot silently regress either way.

## Test coverage added (none of this existed)

- Marker-absence tests (`SECRET-TOKEN-MARKER` in the query string) on **both log sites and both exceptions' `str()` and `repr()`** — asserting the token absent while the host remains visible, since operators need to know which host was blocked.
- Direct `_log_origin()` edge coverage: userinfo/query/fragment stripping, IPv6 bracketing, and a 10-case never-raises parametrization over non-http(s) and garbage input — a logging helper that can throw turns a blocked request into a crash.
- Sweep confirmed the module's third log site (`warn_insecure_ssl`) takes a bare host by construction, and no test pinned the old exception-string form.

Both fixes sabotage-verified independently (raw URL restored → marker test red → reverted), one exception per verifier so each test's load-bearing status was proven separately.

## Verification

`test_egress.py` 94/94; full caller sweep (egress tests + `Tests/Model_Artifacts/` + every file matching `Utils.egress|check_url`) 1155 passed, 1 pre-existing unrelated failure (missing `playwright`, reproduces with zero egress changes).

Out of scope, noted for a future sweep: `Article_Extractor_Lib.py:344` also logs its own raw `url` variable in the same line — caller-side logging of caller input, not fixable from `egress.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts URLs in egress exception messages and expands tests to prevent credential leaks, satisfying TASK-1722. Messages show only scheme+host via `_log_origin`, and `.url` still holds the full URL for programmatic use.

- **Bug Fixes**
  - `EgressBlockedError` and `EgressFetchError` now build messages with `_log_origin(url)`; host stays visible, secrets do not.
  - Tests assert no secret markers in logs and in both exceptions’ `str()`/`repr()`; cover `_log_origin` edge cases (userinfo/query/fragment stripping, IPv6, non-http/invalid input => "<invalid-url>") and the no-URL case for `EgressFetchError`.

- **Refactors**
  - Added concise Google-style docstrings to clarify the redaction boundary and arguments.

<sup>Written for commit 7c859ed4e00d96ad4b4301e2d0dbadeee56aa7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

