### PR TITLE
fix(console): cost-ticker live-verification findings (TASK-2114/2115/2116)

### DIFF
--- a/Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md
+++ b/Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md
@@ -353,6 +353,24 @@ estimator and set `has_estimated_entries`.
   from last-send ground truth plus fingerprint break alerts, no countdown.
 - App restart: warm-until is in-memory → shows cold even if the provider
   cache is still warm. Under-promises, never lies. Accepted.
+- **Revert of a break, TTL remaining (task-2115, real-provider live
+  verification, 2026-08-03):** editing then reverting the system prompt
+  (or any other break source) never touches `warm_until`/`had_activity` —
+  only a real send does (see the ground-truth bullet above) — so the chip
+  correctly returns to plain warm `●` with the ORIGINAL deadline, byte-
+  identical to before the edit, confirmed by a scripted repro with zero
+  clock manipulation
+  (`Tests/UI/test_console_cost_chip_screen.py::test_reverting_system_prompt_edit_with_ttl_remaining_returns_to_warm`).
+  A live-verification pass once observed the chip land on cold `○`
+  immediately after such a revert despite believing TTL time remained;
+  investigation found no code path that could produce that from the
+  mechanism above — the far more likely explanation is that the manual,
+  multi-step round trip (reopening the editor modal, clicking, capturing
+  the pane) took long enough in real wall-clock time to genuinely cross
+  the 5-minute deadline between the last fresh tooltip read and the
+  revert completing, i.e. the chip was reporting truthfully. This is not
+  a distinct "unverified since your edit" state; the existing "expired"
+  copy already covers it.
 
 ### Projection math (always shown with `~`)
 

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2846,13 +2846,7 @@ def test_chat_api_kwargs_system_message_is_byte_stable_across_turns() -> None:
 
 
 def test_chat_api_kwargs_forwards_configured_anthropic_base_url() -> None:
-    """task-2114: a configured `[api_settings.anthropic].api_base_url` must
-    reach the PRIMARY Console send path's kwargs, mirroring what
-    `_auxiliary_chat_api_kwargs` already did for the auxiliary/one-shot
-    path -- `resolve_for_send` resolves the effective endpoint into
-    `resolution.base_url`; before this fix `_chat_api_kwargs` never
-    forwarded it, so a configured proxy/relay was a silent no-op on the
-    sends that matter most."""
+    """Confirm a configured Anthropic api_base_url reaches the primary send path's kwargs."""
     resolution = ConsoleProviderResolution(
         provider="anthropic",
         base_url="https://proxy.example.test/v1",
@@ -2871,11 +2865,7 @@ def test_chat_api_kwargs_forwards_configured_anthropic_base_url() -> None:
 
 
 def test_chat_api_kwargs_omits_api_base_url_for_non_anthropic() -> None:
-    """task-2114 AC#4: the fix is scoped to Anthropic only -- other
-    provider adapters sharing the same auxiliary-honors/primary-ignores
-    split are identified but not fixed here (see task-2114's
-    Implementation Notes), so their `_chat_api_kwargs` output must stay
-    exactly what it was before this change."""
+    """Confirm the api_base_url forwarding fix is scoped to Anthropic only."""
     resolution = ConsoleProviderResolution(
         provider="openai",
         base_url="https://proxy.example.test/v1",
@@ -3077,11 +3067,15 @@ class _FakeAnthropicPostResponse:
 
 @pytest.mark.asyncio
 async def test_console_send_honors_configured_anthropic_base_url(monkeypatch) -> None:
-    """task-2114 end-to-end: drives the REAL gateway -> `chat_api_call` ->
-    `chat_with_anthropic` chain (no `chat_api_call_fn` stand-in) and proves
-    the actual HTTP URL posted honors a configured
-    `[api_settings.anthropic].api_base_url` on the PRIMARY Console send
-    path, not just the auxiliary/one-shot path."""
+    """Confirm the real gateway-to-adapter chain posts to a configured Anthropic api_base_url.
+
+    Drives the real gateway -> ``chat_api_call`` -> ``chat_with_anthropic``
+    chain (no ``chat_api_call_fn`` stand-in) on the primary Console send
+    path, not just the auxiliary/one-shot path.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub the outgoing HTTP session.
+    """
     from tldw_chatbook.LLM_Calls import LLM_API_Calls
 
     captured: dict = {}
@@ -3122,9 +3116,11 @@ async def test_console_send_honors_configured_anthropic_base_url(monkeypatch) ->
 async def test_console_send_default_anthropic_url_unchanged_when_unconfigured(
     monkeypatch,
 ) -> None:
-    """task-2114 AC#2: with no `api_base_url` configured, the posted URL on
-    the primary Console send path is byte-identical to today's default
-    endpoint -- no behavior change for the common case."""
+    """Confirm the default Anthropic endpoint is unchanged when api_base_url is not configured.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub the outgoing HTTP session.
+    """
     from tldw_chatbook.LLM_Calls import LLM_API_Calls
 
     captured: dict = {}

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2845,6 +2845,54 @@ def test_chat_api_kwargs_system_message_is_byte_stable_across_turns() -> None:
 # ---- per-turn cache_control opt-in (Console-only) ----
 
 
+def test_chat_api_kwargs_forwards_configured_anthropic_base_url() -> None:
+    """task-2114: a configured `[api_settings.anthropic].api_base_url` must
+    reach the PRIMARY Console send path's kwargs, mirroring what
+    `_auxiliary_chat_api_kwargs` already did for the auxiliary/one-shot
+    path -- `resolve_for_send` resolves the effective endpoint into
+    `resolution.base_url`; before this fix `_chat_api_kwargs` never
+    forwarded it, so a configured proxy/relay was a silent no-op on the
+    sends that matter most."""
+    resolution = ConsoleProviderResolution(
+        provider="anthropic",
+        base_url="https://proxy.example.test/v1",
+        model="claude-x",
+        ready=True,
+        execution_key="anthropic",
+        api_key="k",
+        streaming=False,
+    )
+
+    kwargs = ConsoleProviderGateway._chat_api_kwargs(
+        resolution, [{"role": "user", "content": "hi"}]
+    )
+
+    assert kwargs["api_base_url"] == "https://proxy.example.test/v1"
+
+
+def test_chat_api_kwargs_omits_api_base_url_for_non_anthropic() -> None:
+    """task-2114 AC#4: the fix is scoped to Anthropic only -- other
+    provider adapters sharing the same auxiliary-honors/primary-ignores
+    split are identified but not fixed here (see task-2114's
+    Implementation Notes), so their `_chat_api_kwargs` output must stay
+    exactly what it was before this change."""
+    resolution = ConsoleProviderResolution(
+        provider="openai",
+        base_url="https://proxy.example.test/v1",
+        model="gpt-4.1",
+        ready=True,
+        execution_key="openai",
+        api_key="k",
+        streaming=False,
+    )
+
+    kwargs = ConsoleProviderGateway._chat_api_kwargs(
+        resolution, [{"role": "user", "content": "hi"}]
+    )
+
+    assert "api_base_url" not in kwargs
+
+
 def test_chat_api_kwargs_omits_prompt_caching_for_non_anthropic() -> None:
     """`prompt_caching=None` is stripped, so non-Anthropic kwargs are
     unchanged from before prompt caching existed."""
@@ -2978,6 +3026,131 @@ async def test_non_anthropic_resolution_has_no_prompt_caching_flag() -> None:
     )
 
     assert resolution.prompt_caching is None
+
+
+# ---- task-2114: configured api_base_url reaches the real posted URL ----
+
+
+def _fake_anthropic_message_response() -> dict:
+    return {
+        "id": "msg_test",
+        "model": "claude-sonnet-4-6",
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+
+class _CapturedURLSession:
+    """Minimal `requests.Session` stand-in recording only the posted URL --
+    a narrower cousin of `Tests/Chat/test_chat_functions.py::_CapturedSession`
+    (that file already owns the full request-capture fixture; this one only
+    needs the URL for the assertion below)."""
+
+    def __init__(self, captured: dict) -> None:
+        self._captured = captured
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info):
+        return False
+
+    def mount(self, *_args, **_kwargs) -> None:
+        return None
+
+    def post(self, url, *, headers=None, json=None, stream=False, timeout=None):
+        self._captured["url"] = url
+        return _FakeAnthropicPostResponse()
+
+
+class _FakeAnthropicPostResponse:
+    status_code = 200
+    text = "{}"
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return _fake_anthropic_message_response()
+
+
+@pytest.mark.asyncio
+async def test_console_send_honors_configured_anthropic_base_url(monkeypatch) -> None:
+    """task-2114 end-to-end: drives the REAL gateway -> `chat_api_call` ->
+    `chat_with_anthropic` chain (no `chat_api_call_fn` stand-in) and proves
+    the actual HTTP URL posted honors a configured
+    `[api_settings.anthropic].api_base_url` on the PRIMARY Console send
+    path, not just the auxiliary/one-shot path."""
+    from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        LLM_API_Calls.requests, "Session", lambda: _CapturedURLSession(captured)
+    )
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {
+                "anthropic": {
+                    "api_key": "k",
+                    "api_base_url": "https://proxy.example.test/v1",
+                }
+            }
+        },
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="anthropic",
+            explicit_model="claude-sonnet-4-6",
+            streaming=False,
+        )
+    )
+    assert resolution.base_url == "https://proxy.example.test/v1"
+
+    _ = [
+        chunk
+        async for chunk in gateway.stream_chat(
+            resolution, [{"role": "user", "content": "hi"}]
+        )
+    ]
+
+    assert captured["url"] == "https://proxy.example.test/v1/messages"
+
+
+@pytest.mark.asyncio
+async def test_console_send_default_anthropic_url_unchanged_when_unconfigured(
+    monkeypatch,
+) -> None:
+    """task-2114 AC#2: with no `api_base_url` configured, the posted URL on
+    the primary Console send path is byte-identical to today's default
+    endpoint -- no behavior change for the common case."""
+    from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        LLM_API_Calls.requests, "Session", lambda: _CapturedURLSession(captured)
+    )
+
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {"api_settings": {"anthropic": {"api_key": "k"}}},
+    )
+    resolution = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="anthropic",
+            explicit_model="claude-sonnet-4-6",
+            streaming=False,
+        )
+    )
+
+    _ = [
+        chunk
+        async for chunk in gateway.stream_chat(
+            resolution, [{"role": "user", "content": "hi"}]
+        )
+    ]
+
+    assert captured["url"] == "https://api.anthropic.com/v1/messages"
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import threading
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 import httpx
 import pytest
@@ -32,6 +32,7 @@ from tldw_chatbook.Utils.sensitive_llm_logging import (
     llm_retry_count,
     safe_llm_error_detail,
     safe_llm_log_value,
+    safe_llm_request_payload_summary,
     safe_llm_url_host,
     sensitive_llm_request,
 )
@@ -50,6 +51,13 @@ CANARIES = (
     "ENDPOINT-PATH-CANARY",
     "ENDPOINT-USER-CANARY",
     "ENDPOINT-PASSWORD-CANARY",
+    # task-2117 Qodo round: prompt-bearing fields the old messages/contents
+    # denylist never accounted for.
+    "OPENAI-RESPONSES-INPUT-CANARY",
+    "ANTHROPIC-SYSTEM-FIELD-CANARY",
+    "GOOGLE-SYSTEM-INSTRUCTION-CANARY",
+    "UNKNOWN-PAYLOAD-FIELD-CANARY",
+    "TOOL-SCHEMA-DESCRIPTION-CANARY",
 )
 
 
@@ -484,6 +492,235 @@ def test_sensitive_google_request_content_and_error_body_are_not_logged(
             )
 
     _assert_canaries_absent(logs, exc_info.value)
+
+
+# ---- task-2117 Qodo round: allowlist, not denylist -------------------------
+#
+# TASK-2116 made the "Request Payload" debug logs above actually
+# interpolate. The redaction added alongside them only stripped
+# `messages`/`contents` -- a denylist that has now failed twice: it never
+# accounted for OTHER prompt-bearing fields providers carry outside those
+# two keys (OpenAI Responses API `input`, Anthropic `system`, Google
+# `system_instruction`). These tests pin the allowlist that replaced it:
+# only known-safe scalar metadata is logged, everything else -- including a
+# payload key nobody has seen yet -- is dropped by default.
+
+
+@pytest.mark.parametrize("sensitive", [False, True])
+def test_openai_responses_api_input_field_is_never_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    sensitive: bool,
+) -> None:
+    """Confirm the Responses API's input field never reaches debug logs.
+
+    The Responses API (used whenever ``reasoning_effort`` is set) carries
+    the whole conversation -- system message included -- under ``input``,
+    not ``messages``. The old messages-only denylist never accounted for
+    this field.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub config loading and the
+            outgoing HTTP session.
+        sensitive: Whether to also exercise the sensitive-auxiliary logging
+            path alongside the ordinary path.
+    """
+    # The response body deliberately avoids any CANARIES entry: this test's
+    # concern is the request-payload allowlist, not error-detail redaction
+    # (already covered elsewhere) -- an ordinary, non-sensitive request is
+    # expected to surface a real HTTP error detail.
+    session = _FakeSession(
+        _FakeResponse({}, status_code=500, text="non-sensitive-path-http-failure")
+    )
+    monkeypatch.setattr(
+        cloud_adapters,
+        "load_settings",
+        lambda: {
+            "openai_api": {
+                "api_base_url": "https://api.openai.test/v1",
+                "api_retries": 0,
+            }
+        },
+    )
+    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+
+    def _invoke() -> None:
+        with pytest.raises(Exception):
+            cloud_adapters.chat_with_openai(
+                input_data=[
+                    {"role": "user", "content": "OPENAI-RESPONSES-INPUT-CANARY"}
+                ],
+                api_key="key",
+                system_message="SYSTEM-CANARY OPTIMIZER-CANARY",
+                model="gpt-test",
+                streaming=False,
+                reasoning_effort="medium",
+            )
+
+    context = sensitive_llm_request() if sensitive else nullcontext()
+    with _captured_logs() as logs, context:
+        _invoke()
+
+    _assert_canaries_absent(logs)
+
+
+@pytest.mark.parametrize("sensitive", [False, True])
+def test_anthropic_system_field_is_never_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    sensitive: bool,
+) -> None:
+    """Confirm Anthropic's top-level system field never reaches debug logs.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub config loading and the
+            outgoing HTTP session.
+        sensitive: Whether to also exercise the sensitive-auxiliary logging
+            path alongside the ordinary path.
+    """
+    # See the OpenAI test above for why the response body avoids CANARIES.
+    session = _FakeSession(
+        _FakeResponse({}, status_code=500, text="non-sensitive-path-http-failure")
+    )
+    monkeypatch.setattr(
+        cloud_adapters,
+        "load_settings",
+        lambda: {
+            "anthropic_api": {
+                "api_key": "key",
+                "api_base_url": "https://anthropic.test/v1",
+                "api_retries": 0,
+            }
+        },
+    )
+    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+
+    def _invoke() -> None:
+        with pytest.raises(Exception):
+            cloud_adapters.chat_with_anthropic(
+                input_data=[{"role": "user", "content": "USER-CANARY"}],
+                api_key="key",
+                system_prompt="ANTHROPIC-SYSTEM-FIELD-CANARY",
+                model="claude-test",
+                streaming=False,
+            )
+
+    context = sensitive_llm_request() if sensitive else nullcontext()
+    with _captured_logs() as logs, context:
+        _invoke()
+
+    _assert_canaries_absent(logs)
+
+
+@pytest.mark.parametrize("sensitive", [False, True])
+def test_google_system_instruction_field_is_never_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    sensitive: bool,
+) -> None:
+    """Confirm Google's system_instruction field never reaches debug logs.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub config loading and the
+            outgoing HTTP session.
+        sensitive: Whether to also exercise the sensitive-auxiliary logging
+            path alongside the ordinary path.
+    """
+    # See the OpenAI test above for why the response body avoids CANARIES.
+    session = _FakeSession(
+        _FakeResponse({}, status_code=500, text="non-sensitive-path-http-failure")
+    )
+    monkeypatch.setattr(
+        cloud_adapters,
+        "get_runtime_config_snapshot",
+        lambda: _runtime_config("google", {"api_key": "key", "api_retries": 0}),
+    )
+    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+
+    def _invoke() -> None:
+        with pytest.raises(Exception):
+            cloud_adapters.chat_with_google(
+                input_data=[{"role": "user", "content": "USER-CANARY"}],
+                api_key="key",
+                system_message="GOOGLE-SYSTEM-INSTRUCTION-CANARY",
+                model="gemini-test",
+                streaming=False,
+            )
+
+    context = sensitive_llm_request() if sensitive else nullcontext()
+    with _captured_logs() as logs, context:
+        _invoke()
+
+    _assert_canaries_absent(logs)
+
+
+def test_safe_llm_request_payload_summary_drops_unrecognized_payload_keys() -> None:
+    """Confirm the allowlist drops any payload key it does not explicitly recognize.
+
+    This is the property that stops a third recurrence of this bug class: a
+    provider payload growing a brand-new field must be safe by default, not
+    exposed by default, even before anyone updates the allowlist.
+    """
+    payload = {
+        "model": "gpt-test",
+        "stream": False,
+        "messages": [{"role": "user", "content": "hi"}],
+        "a_field_no_provider_has_shipped_yet": "UNKNOWN-PAYLOAD-FIELD-CANARY",
+    }
+
+    summary = safe_llm_request_payload_summary(payload)
+
+    assert "a_field_no_provider_has_shipped_yet" not in summary
+    assert "UNKNOWN-PAYLOAD-FIELD-CANARY" not in str(summary)
+    assert summary["model"] == "gpt-test"
+    assert summary["message_count"] == 1
+
+
+def test_tool_definitions_log_names_only_never_schema_or_description(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirm tool debug logs carry only names, never descriptions or JSON-schema parameters.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub config loading and the
+            outgoing HTTP session.
+    """
+    # See test_openai_responses_api_input_field_is_never_logged for why the
+    # response body avoids CANARIES.
+    session = _FakeSession(
+        _FakeResponse({}, status_code=500, text="non-sensitive-path-http-failure")
+    )
+    monkeypatch.setattr(
+        cloud_adapters,
+        "load_settings",
+        lambda: {
+            "openai_api": {
+                "api_base_url": "https://api.openai.test/v1",
+                "api_retries": 0,
+            }
+        },
+    )
+    monkeypatch.setattr(cloud_adapters.requests, "Session", lambda: session)
+
+    with _captured_logs() as logs:
+        with pytest.raises(Exception):
+            cloud_adapters.chat_with_openai(
+                input_data=[{"role": "user", "content": "hello"}],
+                api_key="key",
+                model="gpt-test",
+                streaming=False,
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_weather",
+                            "description": "TOOL-SCHEMA-DESCRIPTION-CANARY",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+    rendered = "\n".join(logs)
+    _assert_canaries_absent(logs)
+    assert "lookup_weather" in rendered
 
 
 def test_sensitive_huggingface_error_body_endpoint_and_exception_are_not_logged(

--- a/Tests/LLM_Calls/test_debug_log_fstring_hygiene.py
+++ b/Tests/LLM_Calls/test_debug_log_fstring_hygiene.py
@@ -94,10 +94,12 @@ def test_no_logging_call_has_an_unevaluated_brace_placeholder():
 
 
 def test_anthropic_debug_log_interpolates_payload_values(monkeypatch):
-    """task-2116 AC#1: the fixed line must show REAL payload values (and
-    never the source text of the dict comprehension that used to be
-    printed literally), while still honoring its own "(excluding messages)"
-    promise -- user message content must never appear in the log."""
+    """Confirm the request-payload log shows real values, not comprehension source text or message content.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub config loading, the debug
+            logger, and the outgoing HTTP session.
+    """
     from tldw_chatbook.LLM_Calls import LLM_API_Calls
 
     debug_messages: list[str] = []

--- a/Tests/LLM_Calls/test_debug_log_fstring_hygiene.py
+++ b/Tests/LLM_Calls/test_debug_log_fstring_hygiene.py
@@ -1,0 +1,168 @@
+"""task-2116: a debug log missing its `f` prefix logs literal template text
+instead of the values it was written to show.
+
+Found in ``chat_with_anthropic`` (LLM_API_Calls.py): the log statement meant
+to show the outgoing request payload (minus ``messages``) was a plain string
+containing an unevaluated dict-comprehension -- ``logger.debug("... {k: v
+for k, v in data.items() ...}")`` instead of an f-string. It printed the
+literal source text on every call, never the actual payload, which cost real
+diagnostic time during the cost-ticker live-provider verification (see the
+task file). Sweeping the module found the SAME copy-pasted bug repeated for
+every other cloud provider's "Request Payload" debug log (OpenAI, DeepSeek,
+Google, Groq, Mistral, OpenRouter, Moonshot, Z.AI) -- nine hits total, all
+fixed together.
+
+Two tests:
+    ``test_no_logging_call_has_an_unevaluated_brace_placeholder``: a static
+        AST sweep of every module under ``tldw_chatbook/LLM_Calls/`` that
+        would have caught all nine original hits (verified against the
+        pre-fix source during development) and stays as a permanent
+        regression guard against the same class of bug creeping back in via
+        copy-paste.
+    ``test_anthropic_debug_log_interpolates_payload_values``: a runtime
+        check that ``chat_with_anthropic``'s specific log line now emits
+        real payload values (AC#1), not the dict-comprehension source text,
+        and that ``messages`` content -- the one thing the log's own name
+        promises to exclude -- never leaks into it.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+LLM_CALLS_ROOT = pathlib.Path(__file__).resolve().parents[2] / "tldw_chatbook" / "LLM_Calls"
+
+_LOG_METHODS = {"debug", "info", "warning", "error", "critical", "trace", "success"}
+
+
+def _logger_call_method(node: ast.Call) -> str | None:
+    """Return the log-level method name for a ``logger.<method>(...)`` or
+    ``logger.opt(...).<method>(...)`` call node, else ``None``."""
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr not in _LOG_METHODS:
+        return None
+    base = func.value
+    if isinstance(base, ast.Name) and base.id == "logger":
+        return func.attr
+    if (
+        isinstance(base, ast.Call)
+        and isinstance(base.func, ast.Attribute)
+        and isinstance(base.func.value, ast.Name)
+        and base.func.value.id == "logger"
+    ):
+        return func.attr
+    return None
+
+
+def _brace_placeholder_hits(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, text)`` for every logger call whose first argument
+    is a plain (non-f) string literal containing a ``{...}`` placeholder --
+    the exact shape of the missing-`f`-prefix bug this task fixes."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if _logger_call_method(node) is None:
+            continue
+        first = node.args[0]
+        # A real f-string parses as ast.JoinedStr, not ast.Constant -- only
+        # a plain (mistakenly non-f) string literal reaches this branch.
+        if (
+            isinstance(first, ast.Constant)
+            and isinstance(first.value, str)
+            and "{" in first.value
+            and "}" in first.value
+        ):
+            hits.append((node.lineno, first.value[:120]))
+    return hits
+
+
+def test_no_logging_call_has_an_unevaluated_brace_placeholder():
+    all_hits: list[str] = []
+    for path in sorted(LLM_CALLS_ROOT.rglob("*.py")):
+        for lineno, text in _brace_placeholder_hits(path):
+            all_hits.append(f"{path.relative_to(LLM_CALLS_ROOT)}:{lineno}: {text!r}")
+    assert not all_hits, (
+        "Logging call(s) with a '{...}' placeholder but no f-prefix -- these "
+        "log literal template text instead of interpolated values:\n"
+        + "\n".join(all_hits)
+    )
+
+
+def test_anthropic_debug_log_interpolates_payload_values(monkeypatch):
+    """task-2116 AC#1: the fixed line must show REAL payload values (and
+    never the source text of the dict comprehension that used to be
+    printed literally), while still honoring its own "(excluding messages)"
+    promise -- user message content must never appear in the log."""
+    from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+    debug_messages: list[str] = []
+    monkeypatch.setattr(
+        LLM_API_Calls,
+        "load_settings",
+        lambda: {"anthropic_api": {"api_base_url": "https://api.anthropic.test/v1"}},
+    )
+    monkeypatch.setattr(
+        LLM_API_Calls.logger,
+        "debug",
+        lambda message, *args, **kwargs: debug_messages.append(str(message)),
+    )
+
+    class _CapturedSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc_info):
+            return False
+
+        def mount(self, *_args, **_kwargs):
+            return None
+
+        def post(self, url, *, headers=None, json=None, stream=False, timeout=None):
+            return _FakeResponse()
+
+    class _FakeResponse:
+        status_code = 200
+        text = "{}"
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "id": "msg_test",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "hi back"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 4, "output_tokens": 5},
+            }
+
+    monkeypatch.setattr(LLM_API_Calls.requests, "Session", lambda: _CapturedSession())
+
+    secret_user_text = "MY-VERY-PRIVATE-MESSAGE-CONTENT"
+    LLM_API_Calls.chat_with_anthropic(
+        input_data=[{"role": "user", "content": secret_user_text}],
+        api_key="test-anthropic-key",
+        model="claude-sonnet-4-6",
+        streaming=False,
+        max_tokens=64,
+    )
+
+    payload_lines = [
+        message for message in debug_messages if "Request Payload" in message
+    ]
+    assert payload_lines, "expected the Anthropic request-payload debug log to fire"
+    payload_line = payload_lines[0]
+
+    # Real values, not the old literal template text.
+    assert "claude-sonnet-4-6" in payload_line
+    assert "for k, v in data.items()" not in payload_line
+    assert "{k: v" not in payload_line
+
+    # The log's own name promises "(excluding messages)" -- still true now
+    # that it actually interpolates the dict.
+    assert secret_user_text not in payload_line

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -365,18 +365,11 @@ async def _mount_and_send_warm_system_prompt(console, pilot):
 
 @pytest.mark.asyncio
 async def test_reverting_system_prompt_edit_with_ttl_remaining_returns_to_warm():
-    """task-2115 (real-provider live verification, 2026-08-03): a warm cache,
-    a system-prompt edit (alert), then a revert of that exact edit -- with
-    NO clock manipulation, so the 300s TTL recorded by the original send is
-    still comfortably in the future the whole time (mirrors the spec's own
-    TTL model: "reverting an edit is not a send, so the deadline itself
-    should be untouched by step 3").
+    """Confirm reverting a system-prompt edit with TTL time remaining returns the chip to warm, not cold.
 
-    This is the scripted reproduction that settled task-2115: it pins that
-    the chip returns to plain warm ``●`` (not cold ``○``) with a correct
-    remaining countdown, proving the live-verify's observed "lands on
-    expired" was not caused by the revert path itself -- see the task's
-    Implementation Notes for the full determination.
+    No clock manipulation happens here, so the 300s TTL recorded by the
+    original send is still comfortably in the future throughout -- the
+    scripted reproduction that settled task-2115.
     """
     gateway = _AnthropicCostGateway(WARM_USAGE, reply="warm reply")
     app = _build_test_app()
@@ -429,14 +422,12 @@ async def test_reverting_system_prompt_edit_with_ttl_remaining_returns_to_warm()
 
 @pytest.mark.asyncio
 async def test_system_prompt_revert_after_genuine_ttl_lapse_still_reports_expired():
-    """task-2115, AC#5: the companion case to the test above -- once the
-    recorded deadline has GENUINELY passed (simulated the same way
-    ``test_ttl_timer_expires_the_chip_and_stops_itself`` does: pushing the
-    controller's own ``_cache_warm_until`` entry into the past, never by
-    freezing/jumping the real monotonic clock a running app also depends
-    on), a break -> revert sequence must still report the chip as expired/
-    cold, not warm -- proving the fix for the "revert restores warm" case
-    above did not also make the chip forget a real TTL lapse.
+    """Confirm a break-then-revert sequence still reports expired once the TTL deadline has genuinely passed.
+
+    The companion case to the test above: the deadline lapse is simulated
+    by pushing the controller's own ``_cache_warm_until`` entry into the
+    past (never by freezing or jumping the real monotonic clock a running
+    app also depends on).
     """
     gateway = _AnthropicCostGateway(WARM_USAGE, reply="warm reply")
     app = _build_test_app()

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -330,9 +330,148 @@ async def test_reverting_the_edit_clears_the_alert():
         state = console._last_console_cost_state
         assert state is not None
         assert state.alert is False
+        # task-2115: the alert clearing was never in question -- what the
+        # live-provider verification flagged is whether the cache-state
+        # READOUT underneath it also comes back to plain warm, rather than
+        # landing on cold/expired despite real TTL time remaining (no clock
+        # manipulation happened between the edit and the revert here, so
+        # the deadline recorded by the original send is still comfortably
+        # in the future).
+        assert state.cold is False
+        assert console._console_cost_cache_state == ConsoleCacheState.WARM
 
         chip = console.query_one("#console-cost-chip")
         assert not chip.has_class("console-chip-alert")
+        assert not chip.has_class("console-chip-cold")
+
+
+# --- task-2115: revert-with-TTL-remaining vs. genuine TTL lapse -------------
+
+
+async def _mount_and_send_warm_system_prompt(console, pilot):
+    """Send one turn that warms the cache, matching
+    ``_mount_and_send_warm_reply`` but returning the store/session id the
+    same way for the system-prompt-edit tests below."""
+    await _send_and_settle(console, pilot, "hello", "warm reply")
+    store = console._ensure_console_chat_store()
+    session_id = store.active_session_id
+    controller = console._ensure_console_chat_controller()
+    warm_until, had_activity = controller.cache_ttl_snapshot(session_id)
+    assert had_activity is True and warm_until is not None, (
+        "test setup: the stub usage must actually warm the cache"
+    )
+    return store, session_id, controller
+
+
+@pytest.mark.asyncio
+async def test_reverting_system_prompt_edit_with_ttl_remaining_returns_to_warm():
+    """task-2115 (real-provider live verification, 2026-08-03): a warm cache,
+    a system-prompt edit (alert), then a revert of that exact edit -- with
+    NO clock manipulation, so the 300s TTL recorded by the original send is
+    still comfortably in the future the whole time (mirrors the spec's own
+    TTL model: "reverting an edit is not a send, so the deadline itself
+    should be untouched by step 3").
+
+    This is the scripted reproduction that settled task-2115: it pins that
+    the chip returns to plain warm ``●`` (not cold ``○``) with a correct
+    remaining countdown, proving the live-verify's observed "lands on
+    expired" was not caused by the revert path itself -- see the task's
+    Implementation Notes for the full determination.
+    """
+    gateway = _AnthropicCostGateway(WARM_USAGE, reply="warm reply")
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        store, session_id, controller = await _mount_and_send_warm_system_prompt(
+            console, pilot
+        )
+        warm_until_before, _ = controller.cache_ttl_snapshot(session_id)
+
+        console._apply_console_session_system_prompt("You are a pirate.")
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        edited_state = console._last_console_cost_state
+        assert edited_state is not None
+        assert edited_state.alert is True
+        assert "system prompt changed" in edited_state.tooltip
+
+        # Revert to no override -- same session, no new send, no elapsed
+        # clock beyond real test-execution time (well under the 300s TTL).
+        console._apply_console_session_system_prompt(None)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        reverted_state = console._last_console_cost_state
+        assert reverted_state is not None
+        assert reverted_state.alert is False
+        assert reverted_state.cold is False
+        assert "Cache: warm" in reverted_state.tooltip
+        assert "expired" not in reverted_state.tooltip
+        assert console._console_cost_cache_state == ConsoleCacheState.WARM
+
+        # The deadline itself is untouched by the edit/revert round trip --
+        # not just "still warm" but the SAME deadline the original send set.
+        warm_until_after, had_activity_after = controller.cache_ttl_snapshot(
+            session_id
+        )
+        assert had_activity_after is True
+        assert warm_until_after == warm_until_before
+
+        chip = console.query_one("#console-cost-chip")
+        assert not chip.has_class("console-chip-alert")
+        assert not chip.has_class("console-chip-cold")
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_revert_after_genuine_ttl_lapse_still_reports_expired():
+    """task-2115, AC#5: the companion case to the test above -- once the
+    recorded deadline has GENUINELY passed (simulated the same way
+    ``test_ttl_timer_expires_the_chip_and_stops_itself`` does: pushing the
+    controller's own ``_cache_warm_until`` entry into the past, never by
+    freezing/jumping the real monotonic clock a running app also depends
+    on), a break -> revert sequence must still report the chip as expired/
+    cold, not warm -- proving the fix for the "revert restores warm" case
+    above did not also make the chip forget a real TTL lapse.
+    """
+    gateway = _AnthropicCostGateway(WARM_USAGE, reply="warm reply")
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        store, session_id, controller = await _mount_and_send_warm_system_prompt(
+            console, pilot
+        )
+
+        console._apply_console_session_system_prompt("You are a pirate.")
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+        assert console._last_console_cost_state.alert is True
+
+        console._apply_console_session_system_prompt(None)
+        # The deadline has genuinely lapsed by the time the revert is
+        # observed -- e.g. a slow manual round trip through the editor
+        # modal, exactly the real-world scenario the live verification hit.
+        controller._cache_warm_until[session_id] = time.monotonic() - 1.0
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        state = console._last_console_cost_state
+        assert state is not None
+        assert state.alert is False
+        assert state.cold is True
+        assert "Cache: expired" in state.tooltip
+        assert console._console_cost_cache_state == ConsoleCacheState.EXPIRED
+
+        chip = console.query_one("#console-cost-chip")
+        assert chip.has_class("console-chip-cold")
 
 
 # --- (d) no active native session -> None / hidden --------------------------

--- a/backlog/tasks/task-2114 - Anthropic-api_base_url-is-a-silent-no-op-on-the-main-Console-send-path.md
+++ b/backlog/tasks/task-2114 - Anthropic-api_base_url-is-a-silent-no-op-on-the-main-Console-send-path.md
@@ -1,0 +1,70 @@
+---
+id: TASK-2114
+title: Anthropic api_base_url is a silent no-op on the main Console send path
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-03 14:20'
+updated_date: '2026-08-03 21:31'
+labels:
+  - llm-calls
+  - anthropic
+  - config
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`[api_settings.anthropic].api_base_url` is honored only on the auxiliary/one-shot
+completion path, not on the main Console chat send. A user who sets it to redirect
+traffic through a proxy, gateway, or self-hosted relay sees the setting silently
+ignored for the calls that matter most — no error, no warning, no visible difference,
+while every primary chat request still goes to the default Anthropic endpoint.
+
+Found during the real-provider live verification of the cost-ticker program
+(2026-08-03), while configuring a scratch profile against the live Anthropic API.
+Pre-existing; not introduced by the cost-ticker PRs.
+
+The failure mode is silence, which is what makes it worth fixing: a proxy that is
+configured but bypassed looks identical to one that is working, until someone
+inspects egress.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A configured `[api_settings.anthropic].api_base_url` is used for the main Console chat send (streaming and non-streaming), not just the auxiliary completion path
+- [x] #2 With no `api_base_url` configured, the request URL is byte-identical to today's default endpoint (no behavior change for the common case)
+- [x] #3 A test asserts the posted URL honors a configured base URL on the primary send path, and a second test pins the unconfigured default
+- [x] #4 Any other provider adapter sharing this split (auxiliary honors, primary ignores) is identified in the implementation notes, or explicitly confirmed as Anthropic-only
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Trace the primary Console send path (ChatScreen -> console_chat_controller -> ConsoleProviderGateway.stream_chat -> _stream_generic_chat -> _chat_api_kwargs -> chat_api_call -> chat_with_anthropic) and compare it against the auxiliary/one-shot path (_auxiliary_chat_api_kwargs) to confirm exactly where api_base_url gets dropped.
+2. Confirm chat_with_anthropic's own api_base_url parameter (and its URL-building fallback chain) already works correctly in isolation -- the bug is purely that the gateway never threads resolution.base_url into the primary kwargs dict.
+3. Fix _chat_api_kwargs to forward resolution.base_url as api_base_url, scoped to Anthropic only (execution_key == "anthropic"), preserving byte-identical default behavior when unconfigured.
+4. Add tests: unit-level _chat_api_kwargs coverage (configured + non-Anthropic no-op), gateway-level resolve_for_send+stream_chat kwargs-forwarding coverage, and true end-to-end posted-URL coverage (real chat_api_call + stubbed requests.Session) for both the configured and unconfigured cases.
+5. Survey the other cloud provider adapters for the same auxiliary-honors/primary-ignores split and report findings in Implementation Notes (AC#4) without fixing them.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Approach: traced the primary Console send path (ChatScreen -> console_chat_controller -> `ConsoleProviderGateway.stream_chat` -> `_stream_generic_chat` -> `_chat_api_kwargs` -> `chat_api_call` -> `chat_with_anthropic`) against the auxiliary/one-shot path (`_auxiliary_chat_api_kwargs`). Both ultimately reach the same `chat_api_call(**kwargs)` -> handler dispatch, and `chat_api_call` forwards `api_base_url` unconditionally to ANY provider handler whenever the top-level parameter is not `None` (`Chat_Functions.py`, outside `PROVIDER_PARAM_MAP` entirely). `_auxiliary_chat_api_kwargs` always includes `"api_base_url": resolution.base_url or None`; `_chat_api_kwargs` (the primary path, shared by every non-llama.cpp provider) never included the key at all -- so a configured `[api_settings.anthropic].api_base_url` never reached `chat_with_anthropic` on a real Console send, silently falling back to the built-in `https://api.anthropic.com/v1`.
+
+`resolution.base_url` (set by `resolve_for_send` via `effective_provider_endpoint`) already resolves to the SAME built-in default when nothing is configured, so simply forwarding it is byte-identical in the unconfigured case (AC#2) and picks up a real override when one is configured (AC#1).
+
+Fix: `_chat_api_kwargs` (`tldw_chatbook/Chat/console_provider_gateway.py`) now adds `kwargs["api_base_url"] = resolution.base_url or None` when `resolution.execution_key == "anthropic"`, scoped narrowly per this task's instructions rather than fixing every provider as a side effect.
+
+Tests added (`Tests/Chat/test_console_provider_gateway.py`): two unit-level `_chat_api_kwargs` tests (configured value forwarded for Anthropic; key absent for a non-Anthropic resolution, proving the scoping), and two full end-to-end tests that drive the REAL `chat_api_call` (no `chat_api_call_fn` stand-in) with a stubbed `requests.Session`, asserting the actual posted URL both honors a configured base URL and stays byte-identical to the default when unconfigured (`test_console_send_honors_configured_anthropic_base_url`, `test_console_send_default_anthropic_url_unchanged_when_unconfigured`).
+
+AC#4 (other providers, dispatched to a research pass, read-only, no code changes):
+- Every cloud adapter with a `_BUILTIN_PROVIDER_ENDPOINTS` entry (openai, cohere, deepseek, google, groq, huggingface, mistral/mistralai, openrouter, moonshot, zai) already accepts and honors its own `api_base_url` parameter with the identical Anthropic-style fallback chain, and `chat_api_call`'s forwarding is provider-agnostic (no `PROVIDER_PARAM_MAP` entry needed). Since `_chat_api_kwargs` is the SHARED primary-path builder for every non-llama.cpp provider, ALL of these have the structurally identical gap Anthropic had -- confirmed no per-provider bypass exists other than llama.cpp's direct `stream_llamacpp_chat`/`complete_llamacpp_chat` path (which takes `base_url` as a first-class parameter and never goes through `_chat_api_kwargs`/`chat_api_call` at all).
+- Nuance: for google, huggingface, moonshot, and mistral/mistralai, the adapter's OWN config-fallback reads a config key/section disconnected from Console's canonical `[api_settings.<provider>]` (`google_api` vs `[api_settings.google]`; legacy top-level `huggingface_api`/`moonshot_api`; `chat_with_mistral` always reads `api_settings["mistral"]` while the shipped default section is `[api_settings.mistralai]`) -- these are user-visible with the same severity as Anthropic's bug. For openai, cohere, deepseek, groq, openrouter, and zai, the adapter's fallback DOES read the same canonical section Console resolves from, and Console's "unsaved endpoint" gate (`provider_uses_endpoint` + `generic_endpoint_differs`) currently blocks sending when the session selection diverges from the saved config -- which masks the primary-path gap for those six today, though the code path is still inconsistent and worth a follow-up.
+- Not fixed here, per this task's explicit scope (Anthropic only) -- recommend a follow-up task to either generalize the `_chat_api_kwargs` fix to all providers, or fix the disconnected-config-key adapters (google/huggingface/moonshot/mistral) as the higher-severity subset.
+
+Files touched: tldw_chatbook/Chat/console_provider_gateway.py; Tests/Chat/test_console_provider_gateway.py; backlog/tasks/task-2114.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2115 - Cost-chip-shows-expired-after-a-reverted-cache-break-despite-remaining-TTL.md
+++ b/backlog/tasks/task-2115 - Cost-chip-shows-expired-after-a-reverted-cache-break-despite-remaining-TTL.md
@@ -1,0 +1,79 @@
+---
+id: TASK-2115
+title: Cost chip shows expired after a reverted cache break despite remaining TTL
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-03 14:20'
+updated_date: '2026-08-03 21:15'
+labels:
+  - console
+  - cost-ticker
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Observed in the real-provider live verification of the cost chip (2026-08-03, live
+Anthropic API, cost-ticker PR3 as merged at `414b1a86af9`):
+
+1. Cache warm, chip shows `●` with a live TTL countdown.
+2. Change the session system prompt — chip correctly flips to `⚠ ~+$0.0032`, tooltip
+   reads "system prompt changed".
+3. Revert the change — the alert correctly clears (the self-clearing property works),
+   but the chip lands on `○` / "Cache: expired" rather than returning to warm `●`,
+   **with real TTL time still remaining**.
+
+The alert behavior is right; the cache-state readout after it is suspect. Two
+possibilities, and the fix depends on which:
+
+- **Intended conservatism:** once the prefix has been disturbed we no longer trust the
+  warm claim, so we report cold until the next send proves otherwise. Defensible — the
+  chip under-promises rather than over-promises, matching the spec's stance that ground
+  truth comes from the last send. If this is the intent, the tooltip is wrong: it says
+  "expired" when it means "unverified since your edit," and that copy should change.
+- **A real defect:** the warm-until timestamp or the cache-activity flag is being
+  cleared/ignored on the revert path, so a still-valid cache is misreported as expired.
+
+Resolve which, then fix accordingly. Note the spec's own TTL model says warm-until is
+sliding and refreshes on each successful send — reverting an edit is not a send, so the
+deadline itself should be untouched by step 3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Determined and documented whether the post-revert `○` is intended conservatism or a defect, with the evidence that settles it
+- [x] #2 If a defect: reverting a break with TTL remaining returns the chip to warm `●` with the correct remaining countdown
+- [x] #3 A regression test pins the chosen behavior across the break -> revert transition with TTL deliberately left remaining
+- [x] #4 The genuine TTL-lapse path still reports expired and is not regressed by the fix
+- [x] #5 Neither hypothesis in the description holds: a scripted repro (warm send -> system-prompt edit -> revert, zero clock manipulation) proves the chip already returns to warm with the original deadline intact, so this is not a defect; and since the mechanism never reports cold while the deadline is genuinely still in the future, it is not intended conservatism either. The live-verify's cold reading was a genuine TTL lapse caused by real elapsed wall-clock time during its slow multi-step manual interaction (reopening the editor modal, typing, clicking Clear, capturing panes) exceeding the ~78s the tooltip had last shown -- not a distinct code path
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read ChatScreen._build_console_cost_state, ConsoleChatController.cache_ttl_snapshot/_cache_warm_until/_cache_last_activity, and console_cost_tracker.build_cost_state to trace exactly what drives the chip's cache_state.
+2. Write a scripted repro (screen-level harness, mirrors test_reverting_the_edit_clears_the_alert but via the system-prompt edit path used in the live-verify) that warms the cache via a real stub send, edits the system prompt, then reverts it with NO clock manipulation, and inspects cache_ttl_snapshot + the built ConsoleCostState.
+3. Based on the repro's result, determine whether this is a defect, intended conservatism, or neither, and fix/document accordingly.
+4. Add permanent regression tests pinning both the revert-with-TTL-remaining behavior and the genuine-TTL-lapse-after-revert behavior.
+5. Update the task file's AC list to match the actual determination and record evidence in Implementation Notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Approach: read `ChatScreen._build_console_cost_state`, `ConsoleChatController.cache_ttl_snapshot`/`_cache_warm_until`/`_cache_last_activity`, and `console_cost_tracker.build_cost_state` to trace what actually drives `cache_state`. Found `cache_state` derives ONLY from `(warm_until, had_activity)` plus `time.monotonic()` -- nothing in the system-prompt edit/revert path (`_apply_console_session_system_prompt` -> `store.set_session_system_prompt` -> payload-revision bump) touches either of those two maps. The only writer is `_attach_stream_usage`, gated on an actual Anthropic send.
+
+Built a scripted repro (screen-level ConsoleHarness, stub Anthropic gateway) that warms the cache via one real send, calls `_apply_console_session_system_prompt("You are a pirate.")` (alert appears, as expected), then reverts with `_apply_console_session_system_prompt(None)` -- with ZERO clock manipulation between the two calls. Result: the chip returned to plain warm `●` (`cold=False`, `console._console_cost_cache_state == WARM`, `"Cache: warm"` in the tooltip), and the recorded `warm_until` deadline was bit-for-bit unchanged across the edit+revert -- exactly the spec's own stated model ("reverting an edit is not a send, so the deadline itself should be untouched").
+
+This rules out BOTH hypotheses in the task description: not a defect (nothing clears/ignores the deadline), and not "intended conservatism" either (the mechanism never reports cold while the deadline is genuinely in the future -- there is no separate "unverified since your edit" state in the code to give a copy fix to). The remaining, evidence-backed explanation: the live-verify's own timeline shows heavy real-world latency per manual step (~141s just for the pirate edit's round trip, per its own captured TTL readings) -- the revert's "~1 minute left" claim was extrapolated from an earlier tooltip read, not a fresh measurement at the moment of revert, and a slow revert round trip (reopen modal, click Clear, capture pane) exceeding that ~78s margin would produce a genuine, correct TTL lapse. The observed `○`/"Cache: expired" was almost certainly the chip working correctly, not a bug.
+
+Changes: added two permanent regression tests to `Tests/UI/test_console_cost_chip_screen.py` mirroring the live-verify's exact system-prompt edit/revert flow -- `test_reverting_system_prompt_edit_with_ttl_remaining_returns_to_warm` (pins today's correct warm-restore behavior, including that `warm_until` is byte-identical before/after) and `test_system_prompt_revert_after_genuine_ttl_lapse_still_reports_expired` (same edit/revert flow, but with the recorded deadline pushed into the past exactly like the existing TTL test does -- confirms a genuine lapse still correctly reports cold even right after a revert, so the fix/finding above can't regress AC#5). Also strengthened the pre-existing `test_reverting_the_edit_clears_the_alert` (the earlier-history-edit variant) with `cold`/`cache_state`/CSS-class assertions it previously lacked -- it only ever checked `alert`, leaving exactly this gap unpinned.
+
+No production code changes were needed for this task -- the mechanism was already correct. Added a short note to the design spec's PR3 "Cache state & TTL" section recording this finding, since a future verifier hitting the same "cold after revert" surprise should find the explanation there rather than re-diagnosing it.
+
+Files touched: Tests/UI/test_console_cost_chip_screen.py; Docs/superpowers/specs/2026-08-01-console-cost-ticker-design.md; backlog/tasks/task-2115.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2116 - Anthropic-debug-log-missing-its-f-prefix-logs-template-text-instead-of-values.md
+++ b/backlog/tasks/task-2116 - Anthropic-debug-log-missing-its-f-prefix-logs-template-text-instead-of-values.md
@@ -1,0 +1,70 @@
+---
+id: TASK-2116
+title: Anthropic debug log missing its f prefix logs template text instead of values
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-03 14:20'
+updated_date: '2026-08-03 22:01'
+labels:
+  - llm-calls
+  - anthropic
+  - observability
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A debug log statement in `chat_with_anthropic` is missing its `f` prefix, so it emits
+the literal template text (`{...}` braces and all) instead of interpolating the payload
+values it was written to show.
+
+This is trivial to fix and easy to dismiss, but it has already cost real time: during
+the cost-ticker real-provider verification (2026-08-03) it was the log a verifier
+reached for while diagnosing why early turns were not caching. It showed template text,
+which sent the investigation sideways before the actual cause was found (the turns were
+below Anthropic's per-model cacheable minimum — see the cost-ticker spec's amended
+Reference facts). A diagnostic that lies costs more than one that is absent.
+
+Pre-existing; not introduced by the cost-ticker PRs.
+
+While fixing, sweep the module for the same class of bug — a missing-`f` logging call is
+invisible until someone reads that exact line's output.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The `chat_with_anthropic` debug log interpolates its values instead of emitting literal template text
+- [x] #2 `tldw_chatbook/LLM_Calls/` swept for other logging calls containing `{}` placeholders without an `f` prefix; each hit fixed or explicitly justified
+- [x] #3 No log statement introduced or modified by this task emits secret material (api keys, tokens, full payload bodies)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Fix the missing f-prefix on chat_with_anthropic's request-payload debug log so it interpolates real values.
+2. Sweep tldw_chatbook/LLM_Calls/ (AST-based, catching logger.<method>(...) and logger.opt(...).<method>(...) calls whose first arg is a plain string literal containing {...}) for the same class of bug.
+3. Fix every hit found, preserving each log's existing field-exclusion scope (never widen what gets logged).
+4. Verify none of the fixed/touched log lines can emit API keys, tokens, or full message/conversation content -- headers (which carry credentials) are built separately from the payload dicts these logs print, and each log already excludes the messages/contents key.
+5. Add a permanent regression test encoding the sweep (so the same copy-paste bug can't return unnoticed) plus a runtime test proving chat_with_anthropic's specific log now shows real values.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Approach: fixed the reported chat_with_anthropic line first (added the missing f-prefix), then wrote an AST-based sweep (catches logger.<method>(...) and logger.opt(...).<method>(...) calls whose first positional argument is a plain ast.Constant string -- i.e. genuinely NOT an f-string, which parses as ast.JoinedStr -- containing a '{' and '}') across every module under tldw_chatbook/LLM_Calls/. Validated the sweep against the pre-fix source via `git show HEAD:...` before trusting it: it caught exactly 9 real hits and 0 false positives, and 0/0 after fixing.
+
+Findings: the exact same copy-pasted bug existed in EVERY other cloud provider's "Request Payload (excluding messages/contents)" debug log in LLM_API_Calls.py -- OpenAI, DeepSeek, Google Gemini (excludes "contents", the Gemini-native key name), Groq, Mistral, OpenRouter, Moonshot, and Z.AI, all missing their f-prefix identically to Anthropic. No other logging call in the LLM_Calls package (huggingface_api.py, LLM_API_Calls_Local.py, Local_Summarization_Lib.py, pricing_catalog.py, Summarization_General_Lib.py) had this shape.
+
+CORRECTION caught by the mandatory full-suite gate, not by design: my first pass just added the f-prefix to all 9 lines and declared AC#3 satisfied because each log already excluded its provider's `messages`/`contents` key. That reasoning was wrong in practice -- these logs also include `system`/`systemInstruction`-shaped fields, and because the bug meant they had NEVER actually fired with real content, that exposure had never been exercised. Running the full `Tests/Chat/` sweep (the task's own gate 3) surfaced two real failures in `Tests/Chat/test_sensitive_llm_logging.py` (`test_sensitive_anthropic_error_body_and_exception_are_not_exposed`, `test_sensitive_google_request_content_and_error_body_are_not_logged`): a canary planted in `system_prompt` now leaked into the debug log precisely because the fix made it fire for the first time. Fixing the f-prefix bug had turned a silent no-op into a real secret-material leak under the app's own `sensitive_llm_request()` policy (`tldw_chatbook/Utils/sensitive_llm_logging.py`) -- exactly the class of regression AC#3 exists to catch.
+
+Fix: found `chat_with_huggingface`'s own "Final Payload" debug log already had the correct pattern (`is_sensitive_llm_request()`-gated, logging only safe metadata when sensitive, the real payload otherwise) -- it was never one of the 9 broken hits because it was already both f-prefixed and gated. Applied the same, minimal gate to all 9 fixed logs: `if not is_sensitive_llm_request(): logger.debug(...)`, so the real payload only logs OUTSIDE a sensitive/auxiliary request. `sensitive_llm_request()` is entered ONLY on the auxiliary/one-shot completion path (`console_provider_gateway.py`'s `_run_auxiliary_completion`/`_complete_sensitive_sync`) -- the primary Console send path this task's motivating incident actually used never sets it, so the diagnostic value that prompted this task is fully preserved there; the log is simply skipped (not replaced with a redacted variant) for the auxiliary path, the smallest change consistent with "no secret material," rather than inventing a new safe-metadata branch for 8 more providers, which would have gone beyond this task's scope.
+
+Verified with the FULL required gate sequence in the foreground: `Tests/Chat/test_anthropic_native_tools.py`+3 siblings (49 passed), the cost-chip trio (53 passed), and the full `Tests/Chat/ Tests/LLM_Calls/` sweep -- 3252 passed, 0 failed, 66 skipped (env-gated only) -- including `test_sensitive_llm_logging.py` now fully green (53/53).
+
+Tests added (new file `Tests/LLM_Calls/test_debug_log_fstring_hygiene.py`): a permanent AST-based regression sweep (`test_no_logging_call_has_an_unevaluated_brace_placeholder`) that fails if the same missing-f-prefix pattern is ever reintroduced anywhere under `tldw_chatbook/LLM_Calls/`, and a runtime test (`test_anthropic_debug_log_interpolates_payload_values`) that drives a real (non-sensitive) `chat_with_anthropic` call and asserts the emitted debug line shows real values, never the old template text, and never a planted "secret" user-message string. The pre-existing `Tests/Chat/test_sensitive_llm_logging.py` suite is the test that actually caught and pins the sensitive-context regression and its fix -- no new test duplicates it.
+
+Files touched: tldw_chatbook/LLM_Calls/LLM_API_Calls.py (9 log-statement fixes, each now `is_sensitive_llm_request()`-gated); Tests/LLM_Calls/test_debug_log_fstring_hygiene.py (new); backlog/tasks/task-2116.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2117 - api_base_url-is-dropped-for-every-non-llamacpp-provider-on-the-primary-send-path.md
+++ b/backlog/tasks/task-2117 - api_base_url-is-dropped-for-every-non-llamacpp-provider-on-the-primary-send-path.md
@@ -1,0 +1,55 @@
+---
+id: TASK-2117
+title: >-
+  api_base_url is dropped for every non-llamacpp provider on the primary send path
+status: To Do
+assignee: []
+created_date: '2026-08-03 15:10'
+labels:
+  - llm-calls
+  - config
+  - console
+priority: high
+dependencies:
+  - TASK-2114
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-2114 fixed the Anthropic case. Investigating it revealed the cause is not
+Anthropic-specific: `ConsoleProviderGateway._chat_api_kwargs` — the shared kwargs
+builder for the primary Console send path — structurally drops `api_base_url` for
+**every** provider except llama.cpp.
+
+Confirmed affected: openai, cohere, deepseek, google, groq, huggingface,
+mistral/mistralai, openrouter, moonshot, zai. (`llama_cpp` / `local_llamacpp` are
+exempt — they take a separate direct-base_url code path.)
+
+Severity splits in two:
+
+- **Unmasked, live defects — google, huggingface, moonshot, mistral/mistralai.** For
+  these the config key is disconnected from Console's canonical
+  `[api_settings.<provider>]` section and nothing else stops the send, so a configured
+  base URL is silently ignored while requests go to the default endpoint. Same failure
+  shape as TASK-2114: no error, no warning, indistinguishable from a working proxy.
+- **Currently masked — openai, cohere, deepseek, groq, openrouter, zai.** Console's
+  "unsaved endpoint" send-gate happens to block these before the drop matters. That is
+  a coincidence of an unrelated guard, not a fix; if the gate is ever relaxed or
+  bypassed these become live defects too.
+
+Fixing this centrally in `_chat_api_kwargs` is preferable to ten per-provider patches,
+but each provider adapter's parameter name for the base URL must be verified rather
+than assumed — the adapters are not uniform (see `PROVIDER_PARAM_MAP`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A configured `[api_settings.<provider>].api_base_url` reaches the primary Console send path for the four unmasked providers (google, huggingface, moonshot, mistral/mistralai)
+- [ ] #2 The remaining affected providers (openai, cohere, deepseek, groq, openrouter, zai) either carry the fix too, or their masking gate is documented as the deliberate reason they are excluded
+- [ ] #3 With no `api_base_url` configured, every provider's request URL is unchanged from today (no regression for the default case)
+- [ ] #4 Each adapter's actual base-URL parameter name is verified against its signature/PROVIDER_PARAM_MAP rather than assumed uniform
+- [ ] #5 Tests cover at least one unmasked provider end-to-end (configured base URL reaches the posted request) plus the unconfigured default
+- [ ] #6 llama_cpp / local_llamacpp behavior is confirmed unchanged by the fix
+<!-- AC:END -->

--- a/backlog/tasks/task-2118 - HuggingFace-tools-debug-log-dumps-full-tool-schemas.md
+++ b/backlog/tasks/task-2118 - HuggingFace-tools-debug-log-dumps-full-tool-schemas.md
@@ -1,0 +1,48 @@
+---
+id: TASK-2118
+title: >-
+  HuggingFace tools debug log dumps full tool schemas verbatim
+status: To Do
+assignee: []
+created_date: '2026-08-03 16:35'
+labels:
+  - llm-calls
+  - observability
+  - security
+priority: medium
+dependencies:
+  - TASK-2116
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`chat_with_huggingface`'s "HuggingFace Tools" debug log emits full tool definitions —
+schemas and descriptions — verbatim when the request is not classified sensitive.
+
+This is the same bug class TASK-2116 and the PR #1295 Qodo round closed for the nine
+provider request-payload logs, but this call site was outside that task's stated scope
+(it logs tools, not the request payload) so it was left untouched and flagged instead.
+
+The fix is small because the machinery now exists: `safe_llm_request_payload_summary`
+in `tldw_chatbook/Utils/sensitive_llm_logging.py` already reduces tool definitions to
+**names only**, dropping descriptions and schemas, and PR #1295 added
+`test_tool_definitions_log_names_only_never_schema_or_description` pinning that
+behavior. This site needs to route through the same helper rather than formatting the
+raw definitions.
+
+Worth stating the general lesson, since this code has now produced three leaks in one
+session: redaction here must be **allowlist-shaped**. Denylists ("strip messages",
+"strip contents") failed twice — once by missing `input`/`system`/`system_instruction`,
+once by missing tool schemas. Anything logged from a provider payload should be an
+explicitly enumerated safe field, so an unrecognized field is dropped by construction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The "HuggingFace Tools" debug log emits tool names only — never descriptions, parameter schemas, or enum values
+- [ ] #2 The site routes through the existing `safe_llm_request_payload_summary` / tool-name helper rather than reimplementing redaction
+- [ ] #3 A sentinel test proves a distinctive string planted in a tool description and in a parameter schema appears nowhere in log output, on BOTH the sensitive and non-sensitive paths
+- [ ] #4 `tldw_chatbook/LLM_Calls/` swept for any remaining log site that formats raw tool definitions or raw payload dicts; each hit fixed or justified in the notes
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -1783,6 +1783,22 @@ class ConsoleProviderGateway:
             # for byte what they were before prompt caching existed.
             "prompt_caching": resolution.prompt_caching,
         }
+        if resolution.execution_key == "anthropic":
+            # task-2114: `resolve_for_send` already resolves the effective
+            # endpoint (configured `[api_settings.anthropic].api_base_url`,
+            # or the built-in default when unset -- see
+            # `effective_provider_endpoint`) into `resolution.base_url`, but
+            # this dict never forwarded it, so a configured proxy/relay was
+            # silently a no-op on the main Console send: only the
+            # auxiliary/one-shot path's `_auxiliary_chat_api_kwargs` passed
+            # `api_base_url` through. Scoped to Anthropic only, matching
+            # this task's fix -- other adapters sharing the same gap are
+            # tracked separately (see the task's Implementation Notes).
+            # When unset, `resolution.base_url` is already the SAME
+            # built-in default `chat_with_anthropic` would fall back to on
+            # its own, so this is a byte-identical no-op for the common
+            # case, never a behavior change.
+            kwargs["api_base_url"] = resolution.base_url or None
         return {key: value for key, value in kwargs.items() if value is not None}
 
     @staticmethod

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -722,9 +722,17 @@ def chat_with_openai(
         "Authorization": f"Bearer {final_api_key}",
         "Content-Type": "application/json",
     }
-    logger.debug(
-        "OpenAI Request Payload (excluding messages): {k: v for k, v in payload.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: this now actually interpolates (it used to be a plain
+        # string missing its `f` prefix, so it silently logged literal
+        # template text). Skipped entirely for sensitive/auxiliary requests
+        # -- the payload can carry a caller-supplied system prompt or other
+        # request content that must never reach a log in that context (see
+        # Tests/Chat/test_sensitive_llm_logging.py).
+        logger.debug(
+            f"OpenAI Request Payload (excluding messages): "
+            f"{ {k: v for k, v in payload.items() if k != 'messages'} }"
+        )
 
     api_path = "/responses" if use_responses_api else "/chat/completions"
     api_url = (
@@ -1468,9 +1476,12 @@ def chat_with_anthropic(
         or anthropic_config.get("api_base_url")
         or builtin_provider_endpoint("anthropic", anthropic_config)
     ).rstrip("/") + "/messages"
-    logger.debug(
-        "Anthropic Request Payload (excluding messages): {k: v for k, v in data.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"Anthropic Request Payload (excluding messages): "
+            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+        )
 
     start_time = time.time()
     log_counter(
@@ -2896,9 +2907,12 @@ def chat_with_deepseek(
         or deepseek_config.get("api_base_url")
         or builtin_provider_endpoint("deepseek", deepseek_config)
     ).rstrip("/") + "/chat/completions"
-    logger.debug(
-        "DeepSeek Request Payload (excluding messages): {k: v for k, v in data.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"DeepSeek Request Payload (excluding messages): "
+            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+        )
 
     try:
         if current_streaming:
@@ -3308,9 +3322,12 @@ def chat_with_google(
     ).rstrip("/")
     api_url = f"{google_api_base}/models/{current_model}{stream_suffix}"
     headers = {"x-goog-api-key": final_api_key, "Content-Type": "application/json"}
-    logger.debug(
-        "Google Gemini Request Payload (excluding contents): {k: v for k,v in payload.items() if k != 'contents'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"Google Gemini Request Payload (excluding contents): "
+            f"{ {k: v for k, v in payload.items() if k != 'contents'} }"
+        )
     logger.debug(
         "Google Gemini request content metadata: "
         f"message_count={len(gemini_contents)}; "
@@ -3899,9 +3916,12 @@ def chat_with_groq(
         or groq_config.get("api_base_url")
         or builtin_provider_endpoint("groq", groq_config)
     ).rstrip("/") + "/chat/completions"
-    logger.debug(
-        "Groq Request Payload (excluding messages): {k: v for k, v in data.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"Groq Request Payload (excluding messages): "
+            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+        )
     try:
         if current_streaming:
             # ... (OpenAI-like streaming logic, ensure "Groq" in logs) ...
@@ -4664,9 +4684,12 @@ def chat_with_mistral(
         or mistral_config.get("api_base_url")
         or builtin_provider_endpoint("mistralai", mistral_config)
     ).rstrip("/") + "/chat/completions"
-    logger.debug(
-        "Mistral Request Payload (excluding messages): {k: v for k, v in data.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"Mistral Request Payload (excluding messages): "
+            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+        )
 
     try:
         if current_streaming:
@@ -4912,9 +4935,12 @@ def chat_with_openrouter(
         or openrouter_config.get("api_base_url")
         or builtin_provider_endpoint("openrouter", openrouter_config)
     ).rstrip("/") + "/chat/completions"
-    logger.debug(
-        "OpenRouter Request Payload (excluding messages): {k: v for k, v in data.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"OpenRouter Request Payload (excluding messages): "
+            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+        )
 
     try:
         if current_streaming:
@@ -5277,9 +5303,12 @@ def chat_with_moonshot(
         "Authorization": f"Bearer {final_api_key}",
         "Content-Type": "application/json",
     }
-    logger.debug(
-        "Moonshot Request Payload (excluding messages): {k: v for k, v in payload.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"Moonshot Request Payload (excluding messages): "
+            f"{ {k: v for k, v in payload.items() if k != 'messages'} }"
+        )
 
     # Determine API endpoint based on config (default to international)
     if api_base_url:
@@ -5598,9 +5627,12 @@ def chat_with_zai(
     )
     api_url = effective_api_base_url.rstrip("/") + "/chat/completions"
 
-    logger.debug(
-        "Z.AI Request Payload (excluding messages): {k: v for k, v in payload.items() if k != 'messages'}"
-    )
+    if not is_sensitive_llm_request():
+        # task-2116: see the OpenAI branch above for why this is gated.
+        logger.debug(
+            f"Z.AI Request Payload (excluding messages): "
+            f"{ {k: v for k, v in payload.items() if k != 'messages'} }"
+        )
 
     start_time = time.time()
 

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -59,6 +59,7 @@ from tldw_chatbook.Utils.sensitive_llm_logging import (
     llm_retry_count,
     safe_llm_error_detail,
     safe_llm_exception_message,
+    safe_llm_request_payload_summary,
     safe_llm_url_host,
 )
 #
@@ -729,9 +730,12 @@ def chat_with_openai(
         # -- the payload can carry a caller-supplied system prompt or other
         # request content that must never reach a log in that context (see
         # Tests/Chat/test_sensitive_llm_logging.py).
+        # task-2117 Qodo round: an allowlisted summary, not a denylist -- the
+        # Responses API puts the WHOLE conversation under "input", which the
+        # old "excluding messages" denylist never accounted for.
         logger.debug(
-            f"OpenAI Request Payload (excluding messages): "
-            f"{ {k: v for k, v in payload.items() if k != 'messages'} }"
+            "OpenAI Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(payload, content_keys=('input', 'messages'))}"
         )
 
     api_path = "/responses" if use_responses_api else "/chat/completions"
@@ -1478,9 +1482,11 @@ def chat_with_anthropic(
     ).rstrip("/") + "/messages"
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary -- "system" carries the
+        # actual system-prompt text and must never be logged verbatim.
         logger.debug(
-            f"Anthropic Request Payload (excluding messages): "
-            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+            "Anthropic Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(data, system_keys=('system',))}"
         )
 
     start_time = time.time()
@@ -2909,9 +2915,11 @@ def chat_with_deepseek(
     ).rstrip("/") + "/chat/completions"
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary, see the Anthropic
+        # branch above for why a denylist isn't safe here.
         logger.debug(
-            f"DeepSeek Request Payload (excluding messages): "
-            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+            "DeepSeek Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(data)}"
         )
 
     try:
@@ -3324,9 +3332,18 @@ def chat_with_google(
     headers = {"x-goog-api-key": final_api_key, "Content-Type": "application/json"}
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary -- "system_instruction"
+        # carries the actual system-prompt text and must never be logged
+        # verbatim. generationConfig is flattened to the top level first so
+        # its (camelCase) sampling params can be picked up by the allowlist.
+        google_log_payload = {
+            **payload,
+            **payload.get("generationConfig", {}),
+            "streaming": current_streaming,
+        }
         logger.debug(
-            f"Google Gemini Request Payload (excluding contents): "
-            f"{ {k: v for k, v in payload.items() if k != 'contents'} }"
+            "Google Gemini Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(google_log_payload, content_keys=('contents',), system_keys=('system_instruction',))}"
         )
     logger.debug(
         "Google Gemini request content metadata: "
@@ -3918,9 +3935,11 @@ def chat_with_groq(
     ).rstrip("/") + "/chat/completions"
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary, see the Anthropic
+        # branch above for why a denylist isn't safe here.
         logger.debug(
-            f"Groq Request Payload (excluding messages): "
-            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+            "Groq Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(data)}"
         )
     try:
         if current_streaming:
@@ -4686,9 +4705,11 @@ def chat_with_mistral(
     ).rstrip("/") + "/chat/completions"
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary, see the Anthropic
+        # branch above for why a denylist isn't safe here.
         logger.debug(
-            f"Mistral Request Payload (excluding messages): "
-            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+            "Mistral Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(data)}"
         )
 
     try:
@@ -4937,9 +4958,11 @@ def chat_with_openrouter(
     ).rstrip("/") + "/chat/completions"
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary, see the Anthropic
+        # branch above for why a denylist isn't safe here.
         logger.debug(
-            f"OpenRouter Request Payload (excluding messages): "
-            f"{ {k: v for k, v in data.items() if k != 'messages'} }"
+            "OpenRouter Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(data)}"
         )
 
     try:
@@ -5305,9 +5328,11 @@ def chat_with_moonshot(
     }
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary, see the Anthropic
+        # branch above for why a denylist isn't safe here.
         logger.debug(
-            f"Moonshot Request Payload (excluding messages): "
-            f"{ {k: v for k, v in payload.items() if k != 'messages'} }"
+            "Moonshot Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(payload)}"
         )
 
     # Determine API endpoint based on config (default to international)
@@ -5629,9 +5654,11 @@ def chat_with_zai(
 
     if not is_sensitive_llm_request():
         # task-2116: see the OpenAI branch above for why this is gated.
+        # task-2117 Qodo round: allowlisted summary, see the Anthropic
+        # branch above for why a denylist isn't safe here.
         logger.debug(
-            f"Z.AI Request Payload (excluding messages): "
-            f"{ {k: v for k, v in payload.items() if k != 'messages'} }"
+            "Z.AI Request Payload (safe fields only): "
+            f"{safe_llm_request_payload_summary(payload)}"
         )
 
     start_time = time.time()

--- a/tldw_chatbook/Utils/sensitive_llm_logging.py
+++ b/tldw_chatbook/Utils/sensitive_llm_logging.py
@@ -7,7 +7,7 @@ changing process-wide logger configuration or affecting concurrent chat work.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from urllib.parse import urlsplit
@@ -18,6 +18,32 @@ _SENSITIVE_LLM_REQUEST: ContextVar[bool] = ContextVar(
 )
 SENSITIVE_CONTENT_REDACTION = "<sensitive-content-redacted>"
 SENSITIVE_ERROR_REDACTION = "<sensitive-error-detail-redacted>"
+
+# task-2117 Qodo round: the fixed set of provider request-payload fields that
+# are safe to write to a debug log verbatim. This is an ALLOWLIST, not a
+# denylist -- a denylist ("everything except messages/contents") has already
+# failed twice on this exact logging path: first when only messages/contents
+# were recognized as content-bearing, then again when providers turned out
+# to carry prompt content under OTHER keys (OpenAI Responses API ``input``,
+# Anthropic ``system``, Google ``system_instruction``). Any payload key not
+# listed here is dropped by ``safe_llm_request_payload_summary`` -- an
+# unrecognized/future key is safe by default instead of exposed by default.
+SAFE_LLM_PAYLOAD_SCALAR_KEYS: tuple[str, ...] = (
+    "model",
+    "stream",
+    "streaming",
+    "max_tokens",
+    "max_completion_tokens",
+    "max_output_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    # Google Gemini's generationConfig uses camelCase field names; callers
+    # flatten generationConfig to the top level before summarizing.
+    "topP",
+    "topK",
+    "maxOutputTokens",
+)
 
 
 def is_sensitive_llm_request() -> bool:
@@ -109,3 +135,113 @@ def safe_llm_exception_message(exc: BaseException) -> str:
     if is_sensitive_llm_request():
         return type(exc).__name__
     return str(exc)
+
+
+def safe_llm_tool_names(tools: object) -> list[str]:
+    """Return only the callable tool NAMES from a request's tool definitions.
+
+    Provider tool entries also carry descriptions, JSON-schema parameters,
+    and (on tool-call messages) arguments -- none of that is safe to write
+    to a log. This understands OpenAI-style ``{"function": {"name": ...}}``
+    entries, Anthropic's converted ``{"name": ...}`` entries, and Google's
+    ``functionDeclarations``/``function_declarations`` wrapper; any other
+    shape is skipped rather than serialized.
+
+    Args:
+        tools: The raw or provider-converted ``tools`` payload value.
+
+    Returns:
+        A list of tool name strings, in payload order. Empty when ``tools``
+        is falsy or none of its entries have a recognizable name.
+    """
+
+    names: list[str] = []
+    for entry in tools or []:
+        if not isinstance(entry, Mapping):
+            continue
+        function = entry.get("function")
+        if isinstance(function, Mapping) and isinstance(function.get("name"), str):
+            names.append(function["name"])
+            continue
+        if isinstance(entry.get("name"), str):
+            names.append(entry["name"])
+            continue
+        declarations = entry.get("functionDeclarations") or entry.get(
+            "function_declarations"
+        )
+        if isinstance(declarations, list):
+            for declaration in declarations:
+                if isinstance(declaration, Mapping) and isinstance(
+                    declaration.get("name"), str
+                ):
+                    names.append(declaration["name"])
+    return names
+
+
+def safe_llm_request_payload_summary(
+    payload: Mapping[str, object],
+    *,
+    content_keys: Sequence[str] = ("messages",),
+    system_keys: Sequence[str] = (),
+    tools_key: str = "tools",
+) -> dict[str, object]:
+    """Build an allowlisted, content-free summary of an outgoing LLM request payload.
+
+    Only the fixed scalar keys in :data:`SAFE_LLM_PAYLOAD_SCALAR_KEYS` are
+    copied through verbatim. Everything else about the request is reduced to
+    non-content facts: a message COUNT (never the messages themselves),
+    whether a system prompt is PRESENT (a boolean, never its text), and tool
+    NAMES (never schemas or arguments, via :func:`safe_llm_tool_names`). Any
+    other key in ``payload`` -- including ones no current provider happens
+    to use -- is dropped. See ``Tests/Chat/test_sensitive_llm_logging.py``
+    for the regression coverage, including the "unknown payload key" property
+    test this shape exists to satisfy.
+
+    Args:
+        payload: The outgoing provider request payload, or a flattened view
+            of it. Callers whose sampling parameters live in a nested dict
+            (e.g. Google's ``generationConfig``) should merge that dict to
+            the top level before calling this.
+        content_keys: Keys to check, in order, for the conversation/messages
+            list. The first one present in ``payload`` is summarized as
+            ``message_count`` and scanned for a ``role: "system"`` entry.
+        system_keys: Keys holding a system prompt/instruction as a separate
+            top-level field (str, content-block list, or dict, depending on
+            provider). Any truthy value marks ``has_system_prompt`` True.
+        tools_key: Key holding the tool/function definitions list.
+
+    Returns:
+        A new dict containing only allowlisted scalar fields plus whichever
+        of ``message_count``, ``has_system_prompt``, and ``tool_names``
+        apply to this payload.
+    """
+
+    summary: dict[str, object] = {
+        key: payload[key] for key in SAFE_LLM_PAYLOAD_SCALAR_KEYS if key in payload
+    }
+
+    message_list: object = None
+    for content_key in content_keys:
+        if content_key in payload:
+            message_list = payload[content_key]
+            break
+
+    has_system_role = False
+    if isinstance(message_list, (list, tuple)):
+        summary["message_count"] = len(message_list)
+        has_system_role = any(
+            isinstance(entry, Mapping) and entry.get("role") == "system"
+            for entry in message_list
+        )
+
+    has_system_field = any(bool(payload.get(key)) for key in system_keys)
+    if content_keys or system_keys:
+        summary["has_system_prompt"] = bool(has_system_role or has_system_field)
+
+    tools_value = payload.get(tools_key)
+    if tools_value:
+        tool_names = safe_llm_tool_names(tools_value)
+        if tool_names:
+            summary["tool_names"] = tool_names
+
+    return summary


### PR DESCRIPTION
Three findings from the real-provider live verification of the merged cost-ticker program, filed as TASK-2114/2115/2116 and fixed here. One of them turned out to be a false alarm; the other two were real, and one nearly shipped a secret leak.

**TASK-2115 — cost chip "expired" after a reverted cache break: NOT A BUG.** A scripted reproduction (warm send → system-prompt edit → revert, zero clock manipulation) shows the chip already returns to warm `●` carrying the byte-identical original `warm_until` deadline — nothing on the edit/revert path touches the controller's cache ground truth; only a real send does. The live-verify session's own timeline shows ~141s consumed by the edit round trip alone, and its "TTL had ~1 minute left" note was extrapolated from an earlier reading rather than fresh, so the observed `○` was a genuine, correct TTL lapse. The commit adds the regression tests that pin this behavior both ways (revert-with-TTL-remaining stays warm; genuine lapse still reports expired), so the question can't be re-litigated by eyeballing a slow manual repro again.

**TASK-2114 — Anthropic `api_base_url` silently ignored on the main Console send.** Fixed for the primary path (streaming and non-streaming), default endpoint byte-identical when unset. Investigating it showed the drop lives in the shared `_chat_api_kwargs` builder rather than the Anthropic adapter, so **ten other providers are affected** — four of them (google, huggingface, moonshot, mistral) as live, unmasked defects. That's filed as **TASK-2117** (included here) rather than silently widened into this PR.

**TASK-2116 — debug log missing its `f` prefix**, emitting template text instead of values. This one cost real diagnostic time during the live verification, sending the investigation sideways while the actual cause was a per-model cache minimum. Worth flagging: fixing the f-string *alone* would have shipped a secret-material leak — interpolating those payload logs exposes request bodies. Only the mandated full-suite gate caught it (2 failures in `test_sensitive_llm_logging.py`); the fix gates all 9 logs behind `is_sensitive_llm_request()`, matching the existing `chat_with_huggingface` precedent. A narrow test selection would have merged it.

Gates: 49 passed (Anthropic native/caching/streaming/prefix), 53 passed (cost-chip trio), **3,252 passed** on the full `Tests/Chat/ + Tests/LLM_Calls/` sweep — all run in the foreground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console sends to honor Anthropic `api_base_url`, tightens provider debug logs with an allowlist and sensitive gating, and pins cost chip TTL behavior with focused tests. Addresses TASK-2114, TASK-2115, and TASK-2116; follow-ups TASK-2117 and TASK-2118 filed.

- **Bug Fixes**
  - TASK-2114: Primary Console send now forwards Anthropic `api_base_url` via `ConsoleProviderGateway._chat_api_kwargs` (streaming and non-streaming). Default endpoint is unchanged when unset. Added unit and end-to-end tests asserting the posted URL for configured and default cases. Broader provider gap tracked in TASK-2117.
  - TASK-2116: Fixed nine missing f-string “Request Payload” logs and gated them with `is_sensitive_llm_request()`. Switched to an allowlist using `safe_llm_request_payload_summary` and `safe_llm_tool_names` so only safe fields and tool names are logged; fields like OpenAI `input`, Anthropic `system`, Google `system_instruction`, unknown payload keys, and tool schemas/descriptions never appear. Added an AST hygiene guard and updated tests to pin this behavior.
  - TASK-2115: Confirmed chip behavior: reverting a system-prompt edit with TTL remaining returns to warm with the original deadline; a real TTL lapse still reports expired. Added regression tests and updated the design spec.

<sup>Written for commit 4557caf6649c769cffbf837975783567098bb431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

