### PR TITLE
docs: spec adopts the shipped seven-section watchlists tab strip (task-1346)

### DIFF
--- a/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
+++ b/Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md
@@ -326,20 +326,34 @@ rather than `SubscriptionsDB`.
 
 ### Tabs
 
-`1`–`5` select Read / Sources / Runs / Rules / Artifacts, preserving the digit muscle memory of the
-current screen. Only **Read** uses the three-pane split. Sources, Runs, Rules, and Artifacts take
-the full centre width — they have no collection→feed→item relationship.
+> **Decision (task-1346, owner ruling 2026-08-03): the spec adopts the shipped strip.** Phase C
+> deliberately kept the pre-existing section strip rather than this section's original five-tab
+> layout, and that divergence was never recorded — it was rediscovered in Phase D when a task went
+> looking for the original "Artifacts tab names the next slice" empty state. Rather than reshape
+> the shipped UI to match an earlier sketch, this section now describes what ships; the original
+> five-tab text is preserved in git history.
 
-**Artifacts is empty-state-only in spec #1**, stating plainly that generation arrives in the next
-slice. It lists artifacts produced by the selected watchlist and navigates to the Artifacts screen;
-it never stores or renders artifacts itself.
+`1`–`7` select **Overview / Sources / Items / Runs / Rules / Notifications / Artifacts** — the
+seven sections of `watchlists_tab_strip.SECTIONS`, one digit per tab in strip order. "Read" in
+prose and code comments refers to the **Items** section (the reader lives there). Only Items uses
+the three-pane split; every other section takes the full centre width — they have no
+collection→feed→item relationship. That rule is enforced, not aspirational (task-1344): FEEDS and
+CONTENT are unmounted off the Items tab, and every centre-region layout gesture (`z`/`Z`/chevron)
+off Items is refused with a notify rather than silently persisting a layout for panes that are not
+on screen.
 
-Deep-linking needs care. `NavigateToScreen` does accept a `screen_context` dict
-(`main_navigation.py:47`), but the Artifacts screen does not read it — it consumes an app attribute,
-`pending_artifacts_chatbook_target_id` (`artifacts_screen.py:72-85`), and that attribute is
-**chatbook-specific**. Selecting a watchlist artifact therefore requires a parallel pending
-attribute and a consumer on the Artifacts screen. That work belongs to spec #2, since spec #1 has no
-artifacts to link to; it is recorded here so spec #2 does not discover it late.
+Beyond the original five: **Overview** is the landing section (health cards, failed runs, and the
+first-run guidance that replaces empty chrome — TASK-998), and **Notifications** hosts the
+notification rules and log the original sketch had no home for.
+
+**Artifacts is a fully built section, not the empty-state placeholder spec #1 planned.** Spec #2
+shipped in full: the section generates and lists text briefings, casts scripts, synthesizes
+per-speaker audio, exports the podcast feed directory (with an opt-in localhost server,
+task-1760), persists kept briefings/scripts to ChaChaNotes (task-1780), and schedules generation.
+Artifacts render **in this screen** — the original plan to navigate out to the chatbook Artifacts
+screen, and the `pending_artifacts_chatbook_target_id` deep-linking concern that came with it, are
+both moot; section deep-linking into this screen goes through the shell's validated
+`screen_context` (`_apply_navigation_context`, which accepts any of the seven section ids).
 
 ### Action scopes
 
@@ -423,7 +437,8 @@ throughout the workflow while showing what was honestly captured.
 
 ### Key bindings
 
-Preserved from today: `1`–`5`, `?`, `n`, `d`, `c`, `p`.
+Preserved from today: the section digits (shipped as `1`–`7`, one per tab — see Tabs), `?`, `n`,
+`d`, `c`, `p`.
 Added: `e` edit, `s` stage, `i` ingest, `P` pause, `z` collapse, `Z` solo, `/` search, `j`/`k`
 next/previous item, `[` / `]` rail toggles.
 
@@ -433,9 +448,11 @@ bindings are weakly discoverable — the footer hint bar carries them.
 
 ### Empty states
 
-First run has no watchlists. The tree shows **All sources** with an inline "Add your first feed"
-affordance rather than an empty box. Items with no captured body explain why and how to fix it.
-The Artifacts tab names the next slice instead of showing a bare empty table.
+First run has no watchlists. The Overview section carries the first-run guidance (what a watchlist
+is and the two steps to a working one — TASK-998/TASK-1347), and the tree shows **All sources**
+rather than an empty box. Items with no captured body explain why and how to fix it. The Artifacts
+tab's empty state is actionable, not a bare table: "No briefings yet. Press Generate to write one."
+(The original "names the next slice" wording is superseded — the slice shipped; see Tabs above.)
 
 ## Data flow
 

--- a/backlog/tasks/task-1346 - Watchlists-tab-strip-diverges-from-the-approved-spec.md
+++ b/backlog/tasks/task-1346 - Watchlists-tab-strip-diverges-from-the-approved-spec.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1346
 title: Watchlists tab strip diverges from the approved spec
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-29 05:30'
 labels:
@@ -31,7 +31,36 @@ link needs a parallel pending attribute and consumer.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A decision is recorded on whether the spec adopts the six-section strip or the implementation adopts the spec's five tabs
-- [ ] #2 Whichever is chosen, the spec and the implementation agree, and the spec's Empty states section no longer references a tab that does not exist
-- [ ] #3 If Artifacts is added, its empty state names the next slice rather than showing a bare table
+- [x] #1 A decision is recorded on whether the spec adopts the six-section strip or the implementation adopts the spec's five tabs
+- [x] #2 Whichever is chosen, the spec and the implementation agree, and the spec's Empty states section no longer references a tab that does not exist
+- [x] #3 (moot in its original form — see notes) If Artifacts is added, its empty state names the next slice rather than showing a bare table
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Decision (AC#1, owner ruling 2026-08-03): the spec adopts the shipped strip.** Recorded as a
+dated decision block at the top of the spec's `### Tabs` section
+(`Docs/superpowers/specs/2026-07-25-watchlists-console-rebuild-design.md`).
+
+Reality had moved past BOTH this task's premises and the spec's: the shipped strip is now **seven**
+sections (Overview / Sources / Items / Runs / Rules / Notifications / Artifacts, digits `1`-`7`) —
+this task was filed when it was six with no Artifacts, and spec #2's briefings work has since added
+a fully built Artifacts section (generation, casts, audio, kept briefings, feed export + serve).
+
+**AC#2:** the spec's Tabs section now describes the shipped seven tabs, records that only
+Items/"Read" uses the three-pane split and that the rule is ENFORCED (task-1344's
+unmount-plus-refusal), and notes where Overview and Notifications came from. The Empty-states
+section no longer references a tab that does not exist — and its Artifacts line now quotes the
+shipped actionable empty state. The stale five-tab keybinding line (`1`-`5`) was corrected to
+`1`-`7`. The chatbook-Artifacts-screen deep-linking concern is recorded as moot (artifacts render
+in-screen; section deep-links go through the shell's validated `screen_context`).
+
+**AC#3 ("If Artifacts is added, its empty state names the next slice"):** moot in its original
+form — Artifacts was added AND the "next slice" it was supposed to name has shipped. The section's
+empty state is actionable rather than a bare table ("No briefings yet. Press Generate to write
+one.", `artifacts_pane.py::_NO_BRIEFINGS`), which satisfies the AC's intent (an empty state that
+tells the user what comes next) in the post-ship world; the spec records the supersession.
+
+Docs-only change; no code touched.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Why

The approved spec said five tabs (Read / Sources / Runs / Rules / Artifacts); Phase C deliberately kept the pre-existing section strip instead, and that decision was never recorded — Phase D rediscovered the divergence when a task went looking for the spec's Artifacts empty state and found no such tab. Task-1346 asks for a recorded decision and spec/implementation agreement. **Owner ruling: the spec adopts what shipped.**

## What (docs-only)

Reality had moved past both the spec *and* the task's own premises: the shipped strip is now **seven** sections — Overview / Sources / Items / Runs / Rules / Notifications / Artifacts, digits `1`–`7` — because spec #2's briefings work added a fully built Artifacts section since the task was filed.

- **Tabs section** rewritten around a dated decision block: the seven shipped tabs; "Read" = the Items section; only Items uses the three-pane split and the rule is *enforced* (task-1344's unmount + gesture refusal), not aspirational; where Overview and Notifications came from; and Artifacts as a fully built in-screen section (generation, casts, audio, kept briefings, feed export + opt-in serve) — superseding the "empty-state-only, navigates to the Artifacts screen" plan and the now-moot `pending_artifacts_chatbook_target_id` deep-linking concern (section deep-links go through the shell's validated `screen_context`).
- **Empty states** no longer references a nonexistent tab; the Artifacts line now quotes the shipped actionable empty state ("No briefings yet. Press Generate to write one.") and records the supersession of "names the next slice" — the slice shipped.
- **Key bindings** line corrected from `1`–`5` to the shipped `1`–`7`.
- Task file: AC#1 decision recorded; AC#2 spec/impl agree; AC#3 moot in its original form (Artifacts was added *and* the slice it was to name has shipped — the intent, an empty state that tells the user what comes next, is satisfied).

Original five-tab text preserved in git history, as the decision block notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the watchlists spec to adopt the shipped seven‑tab strip and record the decision for TASK‑1346. Docs now list Overview/Sources/Items/Runs/Rules/Notifications/Artifacts with digits 1–7, clarify Items is the only enforced three‑pane section, note in‑screen Artifacts and deep‑links via `screen_context`, fix the Artifacts empty‑state copy, correct key bindings to 1–7, and sync the task file ACs.

<sup>Written for commit 6068df7200db5af4ca7655dcbf1531254c81b67d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

