### PR TITLE
chore: mark task-1346 Done (PR #1297 merged)

### DIFF
--- a/backlog/tasks/task-1346 - Watchlists-tab-strip-diverges-from-the-approved-spec.md
+++ b/backlog/tasks/task-1346 - Watchlists-tab-strip-diverges-from-the-approved-spec.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1346
 title: Watchlists tab strip diverges from the approved spec
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-29 05:30'
 labels:


### PR DESCRIPTION
Bookkeeping only: spec adopts the shipped seven-section strip per owner ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked TASK-1346 as Done to reflect that the Watchlists tab strip now matches the approved spec (seven-section strip).

<sup>Written for commit a29bfc75bda4381a6ae8f122645adf105b2df368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

