### PR TITLE
feat: paused watchlist sources visible + one-press Resume (task-2050)

### DIFF
--- a/Tests/Subscriptions/test_watchlist_normalizers.py
+++ b/Tests/Subscriptions/test_watchlist_normalizers.py
@@ -73,3 +73,132 @@ def test_normalize_tolerates_a_row_with_no_body():
 
     assert item["content"] is None
     assert item["content_kind"] is None
+
+
+def test_normalize_marks_a_paused_source_paused_and_says_so_in_status(
+) -> None:
+    """task-2050 AC#1: a paused source must be distinguishable from
+    inactive/healthy -- both `paused` and `status_summary` carry it."""
+    from tldw_chatbook.Subscriptions.watchlist_normalizers import (
+        normalize_local_subscription_row,
+    )
+
+    source = normalize_local_subscription_row(
+        {
+            "id": 1,
+            "name": "Dead feed",
+            "type": "rss",
+            "source": "https://dead.example/feed",
+            "is_active": 1,
+            "is_paused": 1,
+        }
+    )
+
+    assert source["paused"] is True
+    assert source["status_summary"] == "paused"
+    assert source["active"] is False, (
+        "a paused source must not also read as active in the Active column"
+    )
+
+
+def test_normalize_a_paused_source_with_a_last_error_still_says_paused(
+) -> None:
+    """task-2050: precedence is paused > error, not error > paused.
+
+    A source auto-paused by repeated failures (task-1410) always still
+    carries the `last_error` that caused the pause. An error-first
+    precedence would render "error (N)" -- indistinguishable from a source
+    that is merely having a bad day but is STILL being retried on schedule.
+    Paused has to win so the Status column's headline does not lie about
+    that; the error detail itself is not lost, it stays on the entity's own
+    `last_error`/`error_count` keys for the Inspector to show.
+    """
+    from tldw_chatbook.Subscriptions.watchlist_normalizers import (
+        normalize_local_subscription_row,
+    )
+
+    source = normalize_local_subscription_row(
+        {
+            "id": 2,
+            "name": "Flaky feed",
+            "type": "rss",
+            "source": "https://flaky.example/feed",
+            "is_active": 1,
+            "is_paused": 1,
+            "last_error": "connection refused",
+            "error_count": 5,
+        }
+    )
+
+    assert source["paused"] is True
+    assert source["status_summary"] == "paused", (
+        "paused must win over error in the status headline"
+    )
+    assert "error" not in source["status_summary"]
+
+
+def test_normalize_a_healthy_or_merely_inactive_source_is_unchanged(
+) -> None:
+    """Regression: task-2050 must not touch the two pre-existing statuses."""
+    from tldw_chatbook.Subscriptions.watchlist_normalizers import (
+        normalize_local_subscription_row,
+    )
+
+    healthy = normalize_local_subscription_row(
+        {
+            "id": 3,
+            "name": "Healthy feed",
+            "type": "rss",
+            "source": "https://ok.example/feed",
+            "is_active": 1,
+        }
+    )
+    assert healthy["paused"] is False
+    assert healthy["status_summary"] == "active"
+    assert healthy["active"] is True
+
+    inactive = normalize_local_subscription_row(
+        {
+            "id": 4,
+            "name": "Disabled feed",
+            "type": "rss",
+            "source": "https://off.example/feed",
+            "is_active": 0,
+        }
+    )
+    assert inactive["paused"] is False
+    assert inactive["status_summary"] == "inactive"
+    assert inactive["active"] is False
+
+    errored = normalize_local_subscription_row(
+        {
+            "id": 5,
+            "name": "Errored feed",
+            "type": "rss",
+            "source": "https://err.example/feed",
+            "is_active": 1,
+            "last_error": "timeout",
+            "error_count": 2,
+        }
+    )
+    assert errored["paused"] is False
+    assert errored["status_summary"] == "error (2)"
+
+
+def test_normalize_server_watchlist_source_never_reports_paused() -> None:
+    """task-2050: the server watchlist source model has no pause concept
+    yet -- `paused` must always be False, never sourced from `active`."""
+    from tldw_chatbook.Subscriptions.watchlist_normalizers import (
+        normalize_server_watchlist_source,
+    )
+
+    source = normalize_server_watchlist_source(
+        {
+            "id": 9,
+            "name": "Server source",
+            "url": "https://example.test/feed",
+            "active": False,
+        }
+    )
+
+    assert source["paused"] is False

--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -27,6 +27,7 @@ from Tests.UI.full_app_destination_context import (
     StaticWatchlistsScopeService,
 )
 from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_watchlists_check_now_failure import Notified
 from Tests.UI.test_watchlists_item_actions import OTHER_ENTITIES, REAL_ITEM
 from tldw_chatbook.Subscriptions.item_persist import persist_subscription_item
 from tldw_chatbook.Subscriptions.noise_defaults import DEFAULT_IGNORE_SELECTORS
@@ -37,6 +38,7 @@ from tldw_chatbook.UI.Watchlists_Modules import inspector_pane as inspector_pane
 from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import (
     BreadcrumbScopeSelected,
     InspectorPane,
+    ResumeSourceRequested,
     SaveNoiseSelectorsRequested,
 )
 from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemSelected, ItemsPane
@@ -1752,3 +1754,319 @@ async def test_the_queued_indicator_renders_from_the_normalized_flag_on_load():
         assert table.get_row(row_key)[4] == ItemsPane._QUEUED_GLYPH, (
             "a pre-queued item must show the glyph as soon as it loads"
         )
+
+
+# -- task-2050: Resume affordance for auto-paused sources --------------------
+#
+# Auto-pause itself (task-1394/1410) and its data-layer recourse (a
+# successful manual re-check clearing `is_paused`, see the task-1410 review
+# fix wave) already exist. This is the explicit UI affordance: a paused
+# source has to be visibly distinct in the Sources table (normalizer tests,
+# `Tests/Subscriptions/test_watchlist_normalizers.py`) and offer a one-press
+# Resume here in the Inspector, wired through
+# `LocalWatchlistsService.resume_source` -> `SubscriptionsDB.
+# reset_subscription_errors`, not a direct DB write from the UI layer.
+
+_PAUSED_SUBSCRIPTION = {
+    "id": "local:subscription:1",
+    "entity_kind": "subscription",
+    "name": "Dead feed",
+    "source_type": "rss",
+    "url": "http://example.com/feed",
+    "active": False,
+    "paused": True,
+}
+
+_HEALTHY_SUBSCRIPTION = {
+    "id": "local:subscription:2",
+    "entity_kind": "subscription",
+    "name": "Healthy feed",
+    "source_type": "rss",
+    "url": "http://example.com/feed2",
+    "active": True,
+    "paused": False,
+}
+
+# A server-backed source, shaped like `normalize_server_watchlist_source`'s
+# output -- `entity_kind: "watchlist_source"`, not `"subscription"`. Carries
+# `paused: True` anyway (something no real server normalizer would ever
+# produce today, since that normalizer always stamps `False`) specifically
+# to prove the gate reads `entity_kind`, not just the `paused` flag alone.
+_PAUSED_LOOKING_SERVER_SOURCE = {
+    "id": "server:watchlist_source:3",
+    "entity_kind": "watchlist_source",
+    "name": "Server feed",
+    "source_type": "rss",
+    "url": "http://example.com/feed3",
+    "active": False,
+    "paused": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_resume_button_renders_only_for_a_paused_local_subscription():
+    """AC#1/#2: the Resume affordance is selectively visible -- present for
+    a paused local subscription, absent for a healthy one, absent for a
+    server-backed source even if its (never-real) `paused` flag were set,
+    and absent for a non-source entity kind.
+
+    Mutation (a): drop the `entity.get("paused")`/`entity_kind` gate in
+    `InspectorPane._is_paused_subscription` (e.g. always return True) --
+    reddens on the healthy-source and server-source assertions below.
+    """
+    sources = [
+        _PAUSED_SUBSCRIPTION,
+        _HEALTHY_SUBSCRIPTION,
+        _PAUSED_LOOKING_SERVER_SOURCE,
+    ]
+    app = _app_with_watchlists(sources)
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "sources"
+        await pilot.pause()
+
+        sources_pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+        sources_pane.sources = sources
+        await pilot.pause()
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+
+        sources_pane.select_source_by_id(_PAUSED_SUBSCRIPTION["id"])
+        await pilot.pause()
+        assert inspector.query_one("#inspector-resume-button", Button), (
+            "a paused local subscription must offer Resume"
+        )
+
+        sources_pane.select_source_by_id(_HEALTHY_SUBSCRIPTION["id"])
+        await pilot.pause()
+        assert not inspector.query("#inspector-resume-button"), (
+            "a healthy source must not offer Resume"
+        )
+
+        sources_pane.select_source_by_id(_PAUSED_LOOKING_SERVER_SOURCE["id"])
+        await pilot.pause()
+        assert not inspector.query("#inspector-resume-button"), (
+            "a server-backed source must never offer Resume, regardless of "
+            "its paused flag -- only a local subscription has a pause "
+            "concept at all"
+        )
+
+        # Absent for a non-source entity kind too (Task 1120's own
+        # discriminator, exercised the same way `OTHER_ENTITIES` proves the
+        # item-only queue button is item-only).
+        screen.post_message(
+            RuleSelected(
+                {"rule_id": 9, "name": "Price drop", "condition_type": "keyword"}
+            )
+        )
+        await pilot.pause()
+        assert inspector.query_one("#inspector-edit-rule-button", Button), (
+            "precondition: the rule's own action set is what is showing"
+        )
+        assert not inspector.query("#inspector-resume-button")
+
+
+@pytest.mark.asyncio
+async def test_pressing_resume_posts_resume_source_requested():
+    """The real press, the real message -- not just that the button exists."""
+    app = _app_with_watchlists([_PAUSED_SUBSCRIPTION])
+    host = DestinationHarness(app, "watchlists_collections")
+    captured = []
+
+    def capture_message(message):
+        captured.append(message)
+        return True
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "sources"
+        await pilot.pause()
+
+        sources_pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+        sources_pane.sources = [_PAUSED_SUBSCRIPTION]
+        await pilot.pause()
+        sources_pane.select_source_by_id(_PAUSED_SUBSCRIPTION["id"])
+        await pilot.pause()
+
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+        original_post_message = inspector.post_message
+        inspector.post_message = capture_message
+        try:
+            button = inspector.query_one("#inspector-resume-button", Button)
+            inspector.on_button_pressed(Button.Pressed(button))
+        finally:
+            inspector.post_message = original_post_message
+
+        assert any(
+            isinstance(msg, ResumeSourceRequested)
+            and (msg.entity or {}).get("id") == _PAUSED_SUBSCRIPTION["id"]
+            for msg in captured
+        )
+
+
+async def _seed_paused_source(app):
+    """Create one real, already auto-paused local subscription (task-2050).
+
+    Goes through the real `LocalWatchlistsService.create_source` -- the same
+    path the create form uses -- then flips `is_paused` and the failure
+    counters directly on the row, the identical shortcut task-1410's own
+    `test_record_check_result_success_resumes_an_auto_paused_subscription`
+    (`Tests/DB/test_subscriptions_db.py`) and
+    `test_local_watchlists_service_successful_manual_recheck_resumes_a_
+    paused_source` (`Tests/Subscriptions/test_local_watchlists_service.py`)
+    use to reach an already-paused state without driving three real failing
+    checks first.
+
+    Returns:
+        `(db, service, source_id)`.
+    """
+    service = app.local_watchlists_service
+    source = await service.create_source(
+        {
+            "name": "Dead feed",
+            "url": "https://dead.example/feed",
+            "source_type": "rss",
+        }
+    )
+    db = service._db()
+    source_id = int(source["source_id"])
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE subscriptions
+            SET is_paused = 1, error_count = 3, consecutive_failures = 3,
+                last_error = 'connection refused'
+            WHERE id = ?
+            """,
+            (source_id,),
+        )
+    return db, service, source_id
+
+
+@pytest.mark.asyncio
+async def test_pressing_resume_clears_the_pause_and_reloads_sources():
+    """AC#2/#3 end to end: the real button, the real service call, the real
+    row -- not a hand-built entity and not a mocked service. Same style as
+    `test_a_failed_fetch_is_reported_as_a_failure_and_leaves_a_trace`
+    (`Tests/UI/test_watchlists_check_now_failure.py`), Check now's own
+    real-DB end-to-end test for this screen.
+
+    Mutation (b): make `WatchlistsCollectionsScreen._resume_source` skip the
+    `service.resume_source(...)` call -- reddens on the `is_paused`/counter
+    assertions below, since nothing in `subscriptions` would ever change.
+    """
+    app = _build_test_app()
+    db, _service, source_id = await _seed_paused_source(app)
+    notified = Notified()
+    app.notify = notified
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "sources"
+        await pilot.pause(0.3)
+        pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+        for _ in range(40):
+            await pilot.pause()
+            if pane.sources:
+                break
+        assert pane.sources, "the seeded paused source must reach the Sources pane"
+
+        row_key = f"local:subscription:{source_id}"
+        pane.select_source_by_id(row_key)
+        await pilot.pause(0.2)
+
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+        resume_button = inspector.query_one("#inspector-resume-button", Button)
+        resume_button.press()
+
+        for _ in range(60):
+            await pilot.pause()
+            if notified.calls:
+                break
+
+        assert notified.calls, "pressing Resume must produce a toast"
+        assert not notified.errors, f"Resume must succeed, got: {notified.calls!r}"
+        assert any("resumed" in message.lower() for message, _ in notified.calls), (
+            f"the toast must say the source was resumed, got: {notified.calls!r}"
+        )
+
+        row = db.get_subscription(source_id)
+        for _ in range(60):
+            await pilot.pause()
+            row = db.get_subscription(source_id)
+            if row["is_paused"] == 0:
+                break
+
+        assert row["is_paused"] == 0, "the press must reach reset_subscription_errors"
+        assert row["error_count"] == 0
+        assert row["consecutive_failures"] == 0
+        assert row["last_error"] is None
+
+        # The Sources table's Status column must no longer say "paused"
+        # once the reload lands -- same reload Check now performs for the
+        # same reason (`_load_sources_preserving_selection`).
+        status_cell = ""
+        for _ in range(120):
+            await pilot.pause()
+            try:
+                table = screen.query_one("#sources-table", DataTable)
+                if not table.row_count:
+                    continue
+                status_cell = str(table.get_cell_at((0, 2)))
+            except Exception:
+                continue
+            if status_cell and "paused" not in status_cell.lower():
+                break
+
+        assert "paused" not in status_cell.lower(), (
+            f"Status column must clear once resumed; read {status_cell!r}"
+        )
+
+        # And the Resume button itself must disappear: the reload's
+        # `SourceSelected` refreshes `selected_entity` with the fresh,
+        # now-unpaused entity, and the Inspector's own gate stops rendering
+        # it.
+        for _ in range(40):
+            await pilot.pause()
+            if not inspector.query("#inspector-resume-button"):
+                break
+        assert not inspector.query("#inspector-resume-button"), (
+            "Resume must not still be offered once the source is resumed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resume_on_a_source_that_is_not_paused_is_a_harmless_no_op():
+    """The DB-level consistency guard: `resume_source` on a healthy source
+    must not corrupt anything -- it zeroes counters that are already zero
+    and clears an already-clear pause. The UI never offers this path for a
+    non-paused source (the button simply does not render, pinned by
+    `test_resume_button_renders_only_for_a_paused_local_subscription`), so
+    this exercises the service method directly, the way a defensive/future
+    caller might.
+    """
+    app = _build_test_app()
+    service = app.local_watchlists_service
+    source = await service.create_source(
+        {
+            "name": "Healthy feed",
+            "url": "https://ok.example/feed",
+            "source_type": "rss",
+        }
+    )
+    source_id = int(source["source_id"])
+    db = service._db()
+    before = db.get_subscription(source_id)
+    assert before["is_paused"] == 0
+
+    resumed = await service.resume_source(source_id)
+
+    after = db.get_subscription(source_id)
+    assert after["is_paused"] == 0
+    assert after["error_count"] == 0
+    assert after["consecutive_failures"] == 0
+    assert resumed["paused"] is False

--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -2070,3 +2070,42 @@ async def test_resume_on_a_source_that_is_not_paused_is_a_harmless_no_op():
     assert after["error_count"] == 0
     assert after["consecutive_failures"] == 0
     assert resumed["paused"] is False
+
+
+@pytest.mark.asyncio
+async def test_resume_refuses_a_non_local_subscription_entity():
+    """task-2050 Qodo: `_resume_source` takes a RAW local db id, so a
+    `ResumeSourceRequested` carrying some other entity kind whose numeric
+    `source_id` happens to collide (e.g. a server `watchlist_source` with
+    id 5) must be refused at the handler — otherwise it would reset the
+    counters of whatever unrelated LOCAL subscription shares that number.
+    The Inspector's render gate makes this unreachable from the UI today;
+    this pins the handler-level guard against any future caller. Reds if the
+    backend/entity_kind guard is dropped.
+    """
+    app = _build_test_app()
+    db, _service, source_id = await _seed_paused_source(app)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+
+        # A foreign entity that happens to carry the SAME numeric source_id
+        # as the seeded paused LOCAL subscription.
+        foreign = {
+            "backend": "server",
+            "entity_kind": "watchlist_source",
+            "source_id": source_id,
+            "paused": True,
+            "name": "Foreign lookalike",
+        }
+        screen.handle_resume_source_requested(ResumeSourceRequested(foreign))
+        await pilot.pause(0.3)
+
+        row = db.get_subscription(source_id)
+        assert row["is_paused"] == 1, (
+            "a non-local-subscription entity must never resume the local "
+            "subscription that shares its numeric id"
+        )
+        assert row["consecutive_failures"] > 0, "counters must be untouched"

--- a/Tests/Watchlists/test_watchlists_backend_controller.py
+++ b/Tests/Watchlists/test_watchlists_backend_controller.py
@@ -136,3 +136,38 @@ async def test_save_alert_rule_update_routes_to_scope_service():
         runtime_backend="local", payload={"id": "7", "name": "Updated Rule"}
     )
     assert result["name"] == "Updated Rule"
+
+
+@pytest.mark.asyncio
+async def test_overview_counts_paused_sources_as_in_error(monkeypatch):
+    """task-2050 Qodo: the Overview's `sources_in_error` card must not DROP
+    when a failing source finally trips auto-pause. A paused source's
+    `status_summary` reads "paused" (not "error (N)"), so a startswith("error")
+    predicate alone would exclude exactly the most-broken sources — the same
+    regression the Sources pane's Error filter bucket fixed. Reds if the
+    paused arm is removed from the count.
+    """
+    ctrl = WatchlistsBackendController(
+        app_instance=None, scope_service=FakeScopeService(), server_service=None
+    )
+
+    async def fake_list_sources(**kwargs):
+        return [
+            {"id": "s1", "status_summary": "active", "active": True},
+            {"id": "s2", "status_summary": "error (3)", "active": True},
+            {"id": "s3", "status_summary": "paused", "active": False},
+        ]
+
+    async def fake_safe_list(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(ctrl, "list_sources", fake_list_sources)
+    monkeypatch.setattr(ctrl, "_safe_list", fake_safe_list)
+
+    data = await ctrl.get_overview_data(runtime_backend="local")
+
+    assert data["sources_in_error"] == 2, (
+        "erroring + paused must both count; a paused source failed past the "
+        "threshold and is the most broken state there is"
+    )
+    assert data["total_sources"] == 3

--- a/Tests/Watchlists/test_watchlists_sources_pane.py
+++ b/Tests/Watchlists/test_watchlists_sources_pane.py
@@ -583,6 +583,46 @@ async def test_sources_pane_filters_by_status():
 
 
 @pytest.mark.asyncio
+async def test_paused_sources_stay_in_the_error_bucket_and_get_their_own():
+    """task-2050 review: an auto-paused source's `status_summary` now reads
+    "paused" (paused wins the precedence over error), so without an explicit
+    branch the Error filter -- the triage view for broken feeds -- would
+    silently skip exactly the most-broken sources. Paused sources must appear
+    under BOTH the Error bucket (broken-feed triage keeps working) and the
+    new dedicated Paused bucket. Reds if the error branch loses its paused
+    arm, or the Paused option vanishes.
+    """
+    app = SourcesPaneHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(SourcesPane)
+        pane.sources = [
+            {"id": "s1", "name": "Healthy", "source_type": "rss", "status_summary": "active", "active": True},
+            {"id": "s2", "name": "Erroring", "source_type": "rss", "status_summary": "error (3)", "active": True},
+            {"id": "s3", "name": "AutoPaused", "source_type": "rss", "status_summary": "paused", "active": False},
+        ]
+
+        pane.status_filter = "error"
+        await pilot.pause()
+        table = pane.query_one("#sources-table", DataTable)
+        names = {str(table.get_row_at(i)[0]) for i in range(table.row_count)}
+        assert any("Erroring" in n for n in names)
+        assert any("AutoPaused" in n for n in names), (
+            "the Error triage bucket must include auto-paused sources -- they "
+            "failed PAST the threshold"
+        )
+        assert not any("Healthy" in n for n in names)
+
+        pane.status_filter = "paused"
+        await pilot.pause()
+        table = pane.query_one("#sources-table", DataTable)
+        names = {str(table.get_row_at(i)[0]) for i in range(table.row_count)}
+        assert names and all("AutoPaused" in n for n in names)
+
+        # The Paused option genuinely exists in the dropdown.
+        assert ("Paused", "paused") in SourcesPane._STATUS_OPTIONS
+
+
+@pytest.mark.asyncio
 async def test_sources_pane_filters_by_active_state():
     app = SourcesPaneHarness()
     async with app.run_test(size=(120, 40)) as pilot:

--- a/backlog/tasks/task-2050 - Watchlists resume affordance for auto-paused sources.md
+++ b/backlog/tasks/task-2050 - Watchlists resume affordance for auto-paused sources.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2050
 title: Watchlists resume affordance for auto-paused sources
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-02'
 labels:
@@ -35,7 +35,64 @@ without editing config directly or reverse-engineering the recourse above.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A paused source (`is_paused = 1`) is visibly marked as paused somewhere in the watchlists UI, distinguishable from an inactive or healthy source
-- [ ] #2 The user can resume a paused source with a single UI action, without editing config or manually crafting a re-check
-- [ ] #3 That resume action clears `is_paused` and resets the failure counters (`error_count`, `consecutive_failures`, `last_error`) via an existing or new service-layer call, not a direct DB write from the UI layer
+- [x] #1 A paused source (`is_paused = 1`) is visibly marked as paused somewhere in the watchlists UI, distinguishable from an inactive or healthy source
+- [x] #2 The user can resume a paused source with a single UI action, without editing config or manually crafting a re-check
+- [x] #3 That resume action clears `is_paused` and resets the failure counters (`error_count`, `consecutive_failures`, `last_error`) via an existing or new service-layer call, not a direct DB write from the UI layer
 <!-- AC:END -->
+
+## Implementation Notes
+
+**AC#1.** `normalize_local_subscription_row` (`watchlist_normalizers.py`) now stamps a `paused`
+boolean and gives `status_summary` a `paused > error > inactive > active` precedence. **Decision:
+paused wins over error**, even though a source auto-paused by task-1410 always still carries the
+`last_error` that caused the pause. Rationale: an error-first headline ("error (10)") is
+indistinguishable from a source that is merely having a bad day but is *still being retried on
+schedule* — the one fact a paused source's status needs to lead with is that it has stopped being
+retried and needs an explicit Resume. This is a real trade-off, not a free win: today neither
+`last_error` nor `error_count` is surfaced anywhere else in the watchlists UI for a *source* (only a
+*run's* own `error_count` renders, in the Runs pane), so for the window a source is both paused and
+carrying the error that caused it, this precedence trades away the only place that error text was
+visible at all. The underlying `last_error`/`error_count` columns are untouched either way and
+remain available to a future source-detail affordance. `normalize_server_watchlist_source` always
+stamps `paused: False` — the server watchlist source model has no auto-pause concept yet.
+`SourcesPane.source_status_text`/`_source_row_cells` already render `status_summary` generically and
+apply no per-status color anywhere in this pane (only a selection-highlight style) — confirmed no
+existing status-coloring mechanism to mirror, so none was added.
+
+**AC#2/#3.** `InspectorPane` gains a `Resume` button in `#inspector-actions`, rendered only when the
+selected entity is `entity_kind == "subscription"` and `paused` is truthy
+(`InspectorPane._is_paused_subscription`) — never for a server-backed `watchlist_source` even if its
+`paused` flag were somehow set. Pressing it posts `ResumeSourceRequested`, handled by
+`WatchlistsCollectionsScreen.handle_resume_source_requested` → `_resume_source`, which calls
+`LocalWatchlistsService.resume_source(source_id)` directly (local-only, the same reason
+`_open_snapshot_view` bypasses `WatchlistsBackendController` for `url_snapshots` — there is no
+server-side pause concept for the controller to route to). `resume_source` delegates to
+`SubscriptionsDB.reset_subscription_errors`, which already performed exactly this reset for
+`record_check_result`'s success branch (task-1410) and had zero callers outside the DB layer; this
+task gives it its first external caller. On success: a `markup=False` toast ("Resumed <name>. It
+will be checked on its normal schedule.") and a reload via the existing
+`_load_sources_preserving_selection` (same reload Check now uses), which refreshes both the Sources
+table's Status column and the Inspector's own `selected_entity` — so the Resume button disappears
+once the source is actually resumed. Failures are caught, logged with `.opt(exception=True)` (type
+only), and reported with an honest error toast.
+
+**Consistency guard.** `resume_source` is a harmless no-op on an already-healthy source: the
+underlying `UPDATE` zeroes counters that are already zero and clears an already-clear pause flag. The
+UI never offers the button for a non-paused source; the method itself does not need that guard to
+stay correct (pinned by `test_resume_on_a_source_that_is_not_paused_is_a_harmless_no_op`).
+
+**Tests.** `Tests/Subscriptions/test_watchlist_normalizers.py` (paused/precedence/regression/server
+cases), `Tests/UI/test_watchlists_inspector.py` (button visibility gate across paused/healthy/server/
+non-source entities, a real button press posting `ResumeSourceRequested`, and a full real-DB
+end-to-end press → `SubscriptionsDB` row → toast → reload, plus the no-op case). Mutation-verified:
+dropping the `paused` emission reddened both the normalizer tests and the real-path Inspector
+end-to-end test; making the handler skip `service.resume_source(...)` reddened the end-to-end DB
+assertions. `Tests/DB/test_subscriptions_db.py`'s and
+`Tests/Subscriptions/test_local_watchlists_service.py`'s task-1410 pause/resume tests are untouched
+and stay green — `reset_subscription_errors` itself was not modified.
+
+**Files touched:** `tldw_chatbook/Subscriptions/watchlist_normalizers.py`,
+`tldw_chatbook/Subscriptions/local_watchlists_service.py`,
+`tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py`,
+`tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
+`Tests/Subscriptions/test_watchlist_normalizers.py`, `Tests/UI/test_watchlists_inspector.py`.

--- a/backlog/tasks/task-2050 - Watchlists resume affordance for auto-paused sources.md
+++ b/backlog/tasks/task-2050 - Watchlists resume affordance for auto-paused sources.md
@@ -96,3 +96,13 @@ and stay green — `reset_subscription_errors` itself was not modified.
 `tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py`,
 `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
 `Tests/Subscriptions/test_watchlist_normalizers.py`, `Tests/UI/test_watchlists_inspector.py`.
+
+## Review fix wave (2026-08-03)
+
+The branch review confirmed the predicted filter regression: with `paused` winning the
+status_summary precedence, an auto-paused source (which always carries the error that caused the
+pause) vanished from the Sources pane's "Error" filter bucket — the triage view for broken feeds
+silently missing the most-broken ones. Fixed: the Error bucket now includes `paused` (commented at
+the branch), and a dedicated "Paused" option was added to `_STATUS_OPTIONS` (the matcher's existing
+fallthrough handles it). Pinned by `test_paused_sources_stay_in_the_error_bucket_and_get_their_own`,
+mutation-verified (dropping the paused arm reds it).

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -503,6 +503,42 @@ class LocalWatchlistsService:
             "source_id": int(source_id),
         }
 
+    async def resume_source(self, source_id: Any) -> dict[str, Any]:
+        """Clear an auto-paused source's pause and failure counters (task-2050).
+
+        The UI's one-press recourse for a source auto-paused by repeated
+        check failures (task-1410's `_advance_failure_and_maybe_pause`).
+        Delegates to `SubscriptionsDB.reset_subscription_errors`, which
+        already performs exactly this reset (`error_count`,
+        `consecutive_failures`, `last_error`, `is_paused` all cleared) for
+        the success branch of `record_check_result` -- this method is that
+        reset's first caller reachable from outside the DB layer, giving it
+        an explicit trigger instead of only ever firing as a side effect of
+        a successful check.
+
+        Safe to call on a source that is not currently paused: the
+        underlying write zeroes counters that are already zero and clears an
+        already-clear pause flag, so it is a harmless no-op. The UI never
+        offers this action for a non-paused source (see
+        `InspectorPane._is_paused_subscription`), but this method does not
+        need that guard to stay correct on its own.
+
+        Args:
+            source_id: The subscription's raw database id.
+
+        Returns:
+            The resumed source, freshly normalized.
+
+        Raises:
+            KeyError: `source_id` does not name a subscription.
+        """
+        db = self._db()
+        db.reset_subscription_errors(int(source_id))
+        row = db.get_subscription(int(source_id))
+        if row is None:
+            raise KeyError(f"Subscription not found: {source_id}")
+        return normalize_local_subscription_row(row)
+
     async def launch_run(
         self, *, source_id: Any = None, job_id: Any = None
     ) -> dict[str, Any]:

--- a/tldw_chatbook/Subscriptions/watchlist_normalizers.py
+++ b/tldw_chatbook/Subscriptions/watchlist_normalizers.py
@@ -83,14 +83,38 @@ def _local_source_settings(row: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def normalize_local_subscription_row(row: Mapping[str, Any]) -> dict[str, Any]:
-    """Normalize a local subscriptions DB row as a watch item."""
+    """Normalize a local subscriptions DB row as a watch item.
+
+    task-2050 (AC#1): `status_summary` precedence is
+    ``paused > error > inactive > active``. A source auto-paused by repeated
+    check failures (`SubscriptionsDB._advance_failure_and_maybe_pause`,
+    task-1410) always still carries the `last_error` that caused the pause,
+    so an error-first precedence would render ``"error (10)"`` on a source
+    that has actually STOPPED being retried -- indistinguishable from one
+    that is merely having a bad day but is still being checked on schedule.
+    That is the one fact a paused source's status needs to lead with: it
+    needs an explicit Resume, not just time. Note this is a real trade-off,
+    not a free win: today NEITHER `last_error` NOR `error_count` is
+    surfaced anywhere else in the watchlists UI for a source (only a run's
+    own `error_count` renders, in the Runs pane) -- so for the window a
+    source is both paused and carrying the error that caused it, this
+    precedence trades away the only place that error text was visible at
+    all, in exchange for the Status column no longer implying the source is
+    still being retried when it is not. The underlying `last_error`/
+    `error_count` columns are untouched by this normalizer either way, and
+    remain available to a future source-detail affordance.
+    """
     source_id = row["id"]
-    active = bool(row.get("is_active", True)) and not bool(row.get("is_paused", False))
+    paused = bool(row.get("is_paused", False))
+    active = bool(row.get("is_active", True)) and not paused
     error_count = int(row.get("error_count") or 0)
     last_error = row.get("last_error")
-    status_summary = "active" if active else "inactive"
-    if last_error:
+    if paused:
+        status_summary = "paused"
+    elif last_error:
         status_summary = f"error ({error_count})" if error_count else "error"
+    else:
+        status_summary = "active" if active else "inactive"
 
     return {
         "id": build_watchlist_item_id("local", "subscription", source_id),
@@ -102,6 +126,15 @@ def normalize_local_subscription_row(row: Mapping[str, Any]) -> dict[str, Any]:
         "source_type": row.get("type"),
         "url": row.get("source"),
         "active": active,
+        # task-2050 AC#1: an inactive (is_active=0) source and an
+        # auto-paused one both read `active: False` and, before this task,
+        # both fell into the same "inactive" status text -- nothing told
+        # them apart, and a paused source's only real recourse (task-1410's
+        # data-layer resume-on-success) had no UI trigger at all. Carried
+        # as its own field, distinct from `status_summary`, so a consumer
+        # that only cares about the boolean (e.g. the Resume button's
+        # visibility gate) does not have to string-match status text.
+        "paused": paused,
         "tags": _coerce_tags(row.get("tags")),
         "group_ids": [],
         "settings": _local_source_settings(row),
@@ -129,6 +162,13 @@ def normalize_server_watchlist_source(
         "source_type": payload.get("source_type"),
         "url": payload.get("url"),
         "active": bool(payload.get("active", True)),
+        # task-2050: the server watchlist source model has no auto-pause
+        # concept (no `is_paused` equivalent on the response payload) --
+        # always False here, which is also why the Resume affordance never
+        # renders for a server-backed source
+        # (`InspectorPane._is_paused_subscription` gates on `entity_kind ==
+        # "subscription"`, the local-only kind this field is meaningful for).
+        "paused": False,
         "tags": _coerce_tags(payload.get("tags")),
         "group_ids": list(payload.get("group_ids") or []),
         "settings": dict(payload.get("settings") or {}),

--- a/tldw_chatbook/Subscriptions/watchlist_normalizers.py
+++ b/tldw_chatbook/Subscriptions/watchlist_normalizers.py
@@ -103,6 +103,15 @@ def normalize_local_subscription_row(row: Mapping[str, Any]) -> dict[str, Any]:
     still being retried when it is not. The underlying `last_error`/
     `error_count` columns are untouched by this normalizer either way, and
     remain available to a future source-detail affordance.
+
+    Args:
+        row: A `subscriptions` table row (or an equivalent mapping) as the
+            local backend reads it.
+
+    Returns:
+        The normalized watch-item dict: namespaced ``id``, ``entity_kind``
+        ``"subscription"``, the display fields, ``paused`` (task-2050), and
+        ``status_summary`` per the precedence above.
     """
     source_id = row["id"]
     paused = bool(row.get("is_paused", False))

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -3390,9 +3390,30 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
     @on(ResumeSourceRequested)
     def handle_resume_source_requested(self, event: ResumeSourceRequested) -> None:
+        """Dispatch a Resume press to `_resume_source` on a worker (task-2050).
+
+        Refuses any entity that is not a LOCAL `subscription` (task-2050
+        Qodo): `resume_source` takes a raw local db id, so a message carrying
+        some other entity kind that happens to hold a numeric `source_id`
+        (e.g. a server `watchlist_source`) would reset the counters of
+        whatever unrelated LOCAL subscription shares that number. The
+        Inspector's render gate already makes that unreachable today; this
+        guard keeps it unreachable from any future caller too. Type-only log,
+        no toast -- a refused programmatic message is not a user action.
+        """
         event.stop()
         entity = event.entity
         if entity is None:
+            return
+        if (
+            str(entity.get("backend") or "") != "local"
+            or str(entity.get("entity_kind") or "") != "subscription"
+        ):
+            logger.warning(
+                "ResumeSourceRequested for a non-local-subscription entity "
+                f"(backend={entity.get('backend')!r}, "
+                f"kind={entity.get('entity_kind')!r}); refusing."
+            )
             return
         self.run_worker(self._resume_source(entity), exclusive=True)
 

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -93,6 +93,7 @@ from ..Watchlists_Modules.inspector_pane import (
     IgnoreRequested,
     IngestRequested,
     InspectorPane,
+    ResumeSourceRequested,
     SaveNoiseSelectorsRequested,
     PreviewRequested,
     StageInConsoleRequested,
@@ -3386,6 +3387,78 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             return
         if any(str(s.get("id")) == str(keep_id) for s in (pane.sources or [])):
             pane.select_source_by_id(str(keep_id))
+
+    @on(ResumeSourceRequested)
+    def handle_resume_source_requested(self, event: ResumeSourceRequested) -> None:
+        event.stop()
+        entity = event.entity
+        if entity is None:
+            return
+        self.run_worker(self._resume_source(entity), exclusive=True)
+
+    async def _resume_source(self, source: dict[str, Any]) -> None:
+        """Clear an auto-paused source's pause via the real service (AC#2/#3).
+
+        Local-only, the same reason `_open_snapshot_view`'s `url_snapshots`
+        lookup reaches `_local_watchlists_service()` directly rather than
+        through `self._controller` (`WatchlistsBackendController`): only a
+        local subscription currently carries a pause concept at all (see
+        `normalize_server_watchlist_source`, which always stamps `paused:
+        False`), so the controller -- which exists to route a call to
+        whichever of local/server is active -- has no reason to gain a
+        method for a concept the server backend does not have.
+
+        `source["source_id"]` (the subscription's raw db id) is read rather
+        than `source["id"]` (the namespaced `local:subscription:5` form
+        `self._controller` calls take): there is no routing layer here to
+        parse that namespacing back off, so the raw id
+        `normalize_local_subscription_row` already carries under
+        `source_id` is used directly, matching how `LocalWatchlistsService`
+        itself takes ids everywhere.
+        """
+        service = self._local_watchlists_service()
+        source_id = source.get("source_id")
+        name = (
+            source.get("name")
+            or source.get("source_title")
+            or source.get("title")
+            or "the source"
+        )
+        if service is None or source_id is None:
+            self._notify_watchlists(WC_SERVICE_UNAVAILABLE_COPY, severity="error")
+            return
+        try:
+            await service.resume_source(source_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Failed to resume watchlist source {source_id!r}."
+            )
+            self._notify_watchlists(
+                "Could not resume that source. Check the logs and try again.",
+                severity="error",
+                markup=False,
+            )
+            return
+        # markup=False: the name is user-entered (Create Source's Name
+        # field), same reasoning as every other toast on this screen that
+        # embeds one -- a bracket in a source name must reach the user
+        # verbatim rather than being interpreted (or swallowed) as Rich
+        # markup.
+        self._notify_watchlists(
+            f"Resumed {name}. It will be checked on its normal schedule.",
+            severity="information",
+            markup=False,
+        )
+        self._refresh_local_wc_snapshot()
+        self._refresh_overview_data()
+        # Reload preserving selection, same as `_check_now_source`: the row
+        # stays selected, but the Sources table's Status column -- and the
+        # Inspector's own `paused` flag, which decides whether this very
+        # Resume button renders -- both pick up the cleared pause once the
+        # reload lands.
+        self.run_worker(
+            self._load_sources_preserving_selection(), exclusive=True, group="wc_sources"
+        )
 
     @on(ImportOpmlRequested)
     def handle_import_opml_requested(self, event: ImportOpmlRequested) -> None:

--- a/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
@@ -52,6 +52,22 @@ class CheckNowRequested(Message):
         super().__init__()
 
 
+class ResumeSourceRequested(Message):
+    """Posted when the user resumes an auto-paused source (task-2050).
+
+    Only ever posted for a local `subscription` entity whose `paused` flag
+    (`normalize_local_subscription_row`) is True -- see
+    `InspectorPane._is_paused_subscription`, which gates the button that
+    posts this. `WatchlistsCollectionsScreen.handle_resume_source_requested`
+    consumes it and dispatches to `LocalWatchlistsService.resume_source`,
+    the same shape `CheckNowRequested` uses for its own service call.
+    """
+
+    def __init__(self, entity: dict[str, Any] | None) -> None:
+        self.entity = entity
+        super().__init__()
+
+
 class StageInConsoleRequested(Message):
     """Posted when the user requests staging the selected entity in Console."""
 
@@ -240,6 +256,34 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
         "what churned; add a rule here to silence it."
     )
     _IGNORE_SELECTORS_MAX_LENGTH = 4000
+
+    @classmethod
+    def _is_paused_subscription(cls, entity: dict[str, Any] | None) -> bool:
+        """Whether `entity` is an auto-paused LOCAL subscription (task-2050).
+
+        Only a local subscription currently carries a pause concept at all
+        -- `normalize_server_watchlist_source` always stamps `paused: False`
+        because the server watchlist source model has no equivalent yet --
+        so this is gated on `entity_kind == "subscription"` rather than on
+        `deepest.kind == "source"` (which is also true for a server
+        `watchlist_source`). Reading `entity_kind` directly, the same field
+        `InspectorPane._entity_type` itself keys off, rather than trusting
+        `paused` alone: a hand-built dict in a test could set `paused: True`
+        on something that is not a subscription at all, and the Resume
+        action would be meaningless for it.
+
+        Args:
+            entity: A normalized watch entity, or None.
+
+        Returns:
+            True only for a subscription entity with `paused` truthy.
+        """
+        if not entity:
+            return False
+        return (
+            str(entity.get("entity_kind") or "") == "subscription"
+            and bool(entity.get("paused"))
+        )
 
     @classmethod
     def _is_url_family_source(cls, entity: dict[str, Any] | None) -> bool:
@@ -439,6 +483,25 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
             if deepest.kind == "source":
                 yield Button("Preview", id="inspector-preview-button", variant="primary")
                 yield Button("Check now", id="inspector-check-now-button", variant="primary")
+                # task-2050 (AC#1/#2): rendered ONLY for a paused local
+                # subscription -- `deepest.entity` can be None here (a
+                # scope-only "browsing this source" level with nothing
+                # selected below it), so the guard reads `deepest.entity`
+                # directly rather than the `entity` local, which this
+                # branch never assigns.
+                if deepest.entity is not None and self._is_paused_subscription(
+                    deepest.entity
+                ):
+                    yield Button(
+                        "Resume",
+                        id="inspector-resume-button",
+                        variant="success",
+                        tooltip=(
+                            "Clear the auto-pause and reset its failure "
+                            "counters. The source resumes checking on its "
+                            "normal schedule."
+                        ),
+                    )
                 yield Button("Stage in Console", id="inspector-stage-console-button")
                 yield Button("Delete", id="inspector-delete-button", variant="error")
             elif deepest.kind == "run":
@@ -629,6 +692,8 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
             self.post_message(PreviewRequested(entity))
         elif button_id == "inspector-check-now-button":
             self.post_message(CheckNowRequested(entity))
+        elif button_id == "inspector-resume-button":
+            self.post_message(ResumeSourceRequested(entity))
         elif button_id == "inspector-stage-console-button":
             self.post_message(StageInConsoleRequested(entity))
         elif button_id == "inspector-delete-button":

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -203,6 +203,7 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         ("All statuses", "all"),
         ("OK", "ok"),
         ("Error", "error"),
+        ("Paused", "paused"),
         ("Pending", "pending"),
     ]
 
@@ -482,7 +483,14 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         """
         status = SourcesPane.source_status_text(source).lower()
         if status_filter == "error":
-            return status.startswith("error")
+            # `paused` belongs in the Error bucket too (task-2050 review):
+            # an auto-paused source is one that failed PAST the threshold --
+            # the most broken feed there is -- and its `status_summary` now
+            # reads "paused" rather than "error (N)" (paused wins the
+            # precedence). A user filtering to Error to triage broken feeds
+            # must not silently miss exactly those. The dedicated Paused
+            # bucket below narrows further when wanted.
+            return status.startswith("error") or status == "paused"
         if status_filter == "ok":
             # `active` is what a healthy local source reports; `ok` is the
             # hand-built shape used by this pane's own tests.

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
@@ -338,13 +338,18 @@ class WatchlistsBackendController:
         # were failing, so the "Sources in error" card on the Overview was a
         # permanent zero. Same resolution and same fallback as
         # `SourcesPane.source_status_text`.
-        sources_in_error = sum(
-            1
-            for s in sources
-            if str(s.get("status_summary") or s.get("status") or "")
-            .lower()
-            .startswith("error")
-        )
+        # `paused` counts as in-error too (task-2050 review), for the same
+        # reason it stays in the Sources pane's Error filter bucket: an
+        # auto-paused source failed PAST the threshold -- the most broken
+        # state there is -- and its `status_summary` now reads "paused"
+        # rather than "error (N)". Excluding it would make the Overview's
+        # error card DROP the moment a failing source finally trips
+        # auto-pause.
+        sources_in_error = 0
+        for s in sources:
+            status = str(s.get("status_summary") or s.get("status") or "").lower()
+            if status.startswith("error") or status == "paused":
+                sources_in_error += 1
         total_items = len(items)
         new_items = sum(1 for item in items if str(item.get("status") or "").lower() == "new")
 


### PR DESCRIPTION
## Why

Auto-pause is live (tasks 1394/1410): a source that fails past its threshold gets `is_paused=1` and the scheduler stops retrying it. But nothing in the UI distinguished a paused source from an inactive one, and the only un-pause recourse — a manual re-check that succeeds — was undocumented data-layer behavior. A user just saw a silently stalled feed (task-2050, filed by the 1410 review).

## What

- **Paused is visible (AC#1).** `normalize_local_subscription_row` now emits `paused` and `status_summary` gains a `"paused"` state, with precedence `paused > error > inactive > active` — paused wins over error because every auto-paused source *still carries* the error that paused it, and an "error (10)" headline would hide the fact it stopped being retried (trade-off documented: the error text is not surfaced elsewhere for a source yet). The server normalizer stamps `paused: False` (no server pause concept), which structurally prevents the Resume button from ever rendering for a server source.
- **One-press Resume (AC#2/#3).** The inspector's actions block gains a Resume button, rendered only for a paused subscription entity. Press → `ResumeSourceRequested` → screen handler → new `LocalWatchlistsService.resume_source` → the previously caller-less `SubscriptionsDB.reset_subscription_errors` (clears `is_paused`, `error_count`, `consecutive_failures`, `last_error` — unmodified; this task gives it its first caller). Toast + sources reload; no SQL in the UI layer. Resuming a healthy source is a harmless no-op at the DB level; the button simply never renders for one.
- **Review fix (the 21st composition find of this sweep):** with `paused` winning the precedence, an auto-paused source vanished from the Sources pane's **"Error" filter bucket** — the broken-feed triage view silently missing the *most*-broken feeds. The Error bucket now includes paused sources (commented), and a dedicated "Paused" filter option was added.

## Testing

Normalizer precedence (paused / paused+error / healthy / inactive), button gating (only paused subscriptions; absent for items/rules/healthy/hand-built dicts), real-press end-to-end against a real `SubscriptionsDB` (all four columns cleared, toast, reload), filter buckets (paused appears under both Error and Paused, never under OK), and the task-1410 pause suite unchanged. 33+146 targeted tests green; every behavioural change mutation-verified (normalizer emission, handler service call, filter arm). Review: FIX WAVE on the filter bucket only, fixed and pinned; all else confirmed clean by independent re-reading and re-running the mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose auto-paused watchlist sources and add a one-click Resume; also count paused as errors on the Overview and gate Resume to local subscriptions. Satisfies TASK-2050 by making paused status visible and clearing pause/failure counters via the service layer.

- **New Features**
  - `normalize_local_subscription_row` now sets `paused` and `status_summary` precedence: paused > error > inactive > active; server sources always return `paused: False`.
  - Inspector shows Resume only for paused local subscriptions; press posts `ResumeSourceRequested` and calls `LocalWatchlistsService.resume_source` → `SubscriptionsDB.reset_subscription_errors`, then toasts and reloads sources. Resume on a non-paused source is a safe no-op.

- **Bug Fixes**
  - Paused sources remain in the “Error” filter and have a dedicated “Paused” option.
  - Overview’s “Sources in error” now counts paused sources.
  - Resume handler refuses non-local/non-`subscription` entities to prevent id-collision resets.

<sup>Written for commit 95354b7e613d4708e55c256da0e3efa394b15c28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

