### PR TITLE
fix(security): stop loguru diagnose from dumping API keys into logs (TASK-2119)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1483,7 +1483,7 @@
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "4b8fb9c0c74292e9a654",
+      "diagnostic_digest": "13620254e75bfb9fa931",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/local_watchlists_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2092,7 +2092,7 @@
     },
     {
       "call_count": 78,
-      "diagnostic_digest": "9a28b0b1c1b2f93a3af9",
+      "diagnostic_digest": "5a61b1708aaebfeac83f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2203,8 +2203,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 70,
-      "diagnostic_digest": "d5f61630d3aa6fd4fff0",
+      "call_count": 72,
+      "diagnostic_digest": "eec1352f4f9e96df5307",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/watchlists_collections_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2309,7 +2309,7 @@
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "9b534fd6c3ec6680de27",
+      "diagnostic_digest": "4c13984904c0b109798a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2330,7 +2330,7 @@
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "f8ea4c5892e3279801f3",
+      "diagnostic_digest": "f7b7b3068c84e17994d7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/sources_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3283,6 +3283,6 @@
     "owner_files": 443,
     "persistent_sink_files": 6,
     "task_492_calls": 1108,
-    "task_494_calls": 6765
+    "task_494_calls": 6767
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -167,7 +167,7 @@
     },
     {
       "call_count": 107,
-      "diagnostic_digest": "13a61d363bb0db109180",
+      "diagnostic_digest": "f017eaf38022f2d4017f",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/Chat_Functions.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -188,23 +188,30 @@
     },
     {
       "call_count": 11,
-      "diagnostic_digest": "fe462419f37de7969cf9",
+      "diagnostic_digest": "c17f3dd3e9db1996084c",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_agent_bridge.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 20,
-      "diagnostic_digest": "86dd180cfd9c0110f8c0",
+      "call_count": 22,
+      "diagnostic_digest": "b927b5eb0c2f0c186e54",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 28,
-      "diagnostic_digest": "ea81acdf843e50b0cf26",
+      "diagnostic_digest": "8b25583c372ef2cf7f77",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_store.py",
+      "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
+    },
+    {
+      "call_count": 4,
+      "diagnostic_digest": "e9f793b29a42be432c3c",
+      "owner": "TASK-492",
+      "path": "tldw_chatbook/Chat/console_cost_tracker.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
@@ -230,7 +237,7 @@
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "65f0bdc2948992c39d23",
+      "diagnostic_digest": "8c26198aaec0ad29e749",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_provider_gateway.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -362,8 +369,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 118,
-      "diagnostic_digest": "61bebec465d0a14df56d",
+      "call_count": 120,
+      "diagnostic_digest": "15e26a5f1df0fd8482ef",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Prompts_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -377,7 +384,7 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "1cf390d6b5d72b4962df",
+      "diagnostic_digest": "3dce80a5bcb4e75c3885",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Subscriptions_DB.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -761,15 +768,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 158,
-      "diagnostic_digest": "cc4b6250b50f013e1a2f",
+      "call_count": 171,
+      "diagnostic_digest": "0b7ed0fef4c9638f2699",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/LLM_API_Calls.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 41,
-      "diagnostic_digest": "5394e7aeccd621fd920f",
+      "diagnostic_digest": "bc790fe8d2f3544203bf",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -804,7 +811,7 @@
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "d2154e846e242bf9e456",
+      "diagnostic_digest": "211e68ecc8c6e816b301",
       "owner": "TASK-494",
       "path": "tldw_chatbook/LLM_Provider_Catalog/local_llm_provider_catalog_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -818,14 +825,14 @@
     },
     {
       "call_count": 5,
-      "diagnostic_digest": "053c1b8fcbec30e74284",
+      "diagnostic_digest": "1962f998d219591786fc",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_ingest_jobs.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "461e4d7cde1269168683",
+      "diagnostic_digest": "c0c481a8ae10d7f6983d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_local_rag_search_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -923,7 +930,7 @@
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "047360d502090fe4b84d",
+      "diagnostic_digest": "7efc96ac41a3d8afe09f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Local_Ingestion/local_file_ingestion.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -944,7 +951,7 @@
     },
     {
       "call_count": 31,
-      "diagnostic_digest": "5ba7a0c97ec695134b38",
+      "diagnostic_digest": "3cda2240450d542faf5e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Logging_Config.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1119,9 +1126,16 @@
     },
     {
       "call_count": 93,
-      "diagnostic_digest": "54ca930a05f9a265c104",
+      "diagnostic_digest": "d7ca19fa44acdf1e5289",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Prompt_Management/Prompts_Interop.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "f7a441595550015f240a",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Prompt_Management/prompt_improvement_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -1349,8 +1363,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 14,
-      "diagnostic_digest": "465396aaec988ba8acae",
+      "call_count": 15,
+      "diagnostic_digest": "e02a2bca25d9c10edc9c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/handlers/watchlist_check_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1413,14 +1427,14 @@
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "646b271defd5f13f7235",
+      "diagnostic_digest": "05450a019294b70fcabd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/baseline_manager.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "e9423d25fd75d0e9b735",
+      "diagnostic_digest": "479bee10109f937c61a0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/briefing_audio.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1468,15 +1482,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "ca3f7e1e5b34b56155fc",
+      "call_count": 2,
+      "diagnostic_digest": "4b8fb9c0c74292e9a654",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/local_watchlists_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 16,
-      "diagnostic_digest": "5bd6f2dfc3a7c56e9aea",
+      "diagnostic_digest": "f9ccee6989b39da1333b",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Subscriptions/monitoring_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1805,7 +1819,7 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "8d8b4bf92e753bb708d3",
+      "diagnostic_digest": "122ab2feccfd622a2e42",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Tools/workspace_file_roots.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -2028,8 +2042,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 148,
-      "diagnostic_digest": "6bbb213eddcb80de3676",
+      "call_count": 1,
+      "diagnostic_digest": "1877d8fb2610dfd81032",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/change_review_screen.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 151,
+      "diagnostic_digest": "775f8aa7cb9c4401b07a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2070,15 +2091,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 77,
-      "diagnostic_digest": "3c687b9a0eb3cab67739",
+      "call_count": 78,
+      "diagnostic_digest": "9a28b0b1c1b2f93a3af9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 3,
-      "diagnostic_digest": "728a59df7cf1e9c270f3",
+      "call_count": 6,
+      "diagnostic_digest": "7ef04fc5e0d79ae655ac",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/llm_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2102,13 +2123,6 @@
       "diagnostic_digest": "efb67c3050b23f826e0d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/model_installed_view.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
-      "call_count": 2,
-      "diagnostic_digest": "febcad90cd450a36453e",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/UI/Screens/model_remote_view.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -2140,13 +2154,6 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 6,
-      "diagnostic_digest": "d5d520dd2862eba92fa9",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/UI/Screens/search_screen.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
       "call_count": 2,
       "diagnostic_digest": "a0ed0e636c2f32286894",
       "owner": "TASK-494",
@@ -2161,8 +2168,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 26,
-      "diagnostic_digest": "9294ebe8039c701411f7",
+      "call_count": 27,
+      "diagnostic_digest": "77073870672638e385e4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2196,8 +2203,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 67,
-      "diagnostic_digest": "924ce6894e3c3f56dec3",
+      "call_count": 70,
+      "diagnostic_digest": "d5f61630d3aa6fd4fff0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/watchlists_collections_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2287,27 +2294,6 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 6,
-      "diagnostic_digest": "8ee671c56b9cdf92c997",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/UI/Views/RAGSearch/saved_searches_panel.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
-      "call_count": 1,
-      "diagnostic_digest": "8aed675eb9ca79230d2c",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
-      "call_count": 20,
-      "diagnostic_digest": "deac0462b264cca37b90",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
       "call_count": 4,
       "diagnostic_digest": "4abc40612c24634bd076",
       "owner": "TASK-494",
@@ -2323,7 +2309,7 @@
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "af72e7ae72372751bc67",
+      "diagnostic_digest": "9b534fd6c3ec6680de27",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2343,8 +2329,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 2,
-      "diagnostic_digest": "9ecf53fc42da7c035ad0",
+      "call_count": 3,
+      "diagnostic_digest": "f8ea4c5892e3279801f3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Watchlists_Modules/sources_pane.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2400,7 +2386,7 @@
     },
     {
       "call_count": 21,
-      "diagnostic_digest": "185f964112733ca4c16c",
+      "diagnostic_digest": "8c30334cb3873a1ac5f0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2463,7 +2449,7 @@
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "77e51ea48869deb02e1c",
+      "diagnostic_digest": "b41325ff324affce507e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Utils/egress.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2729,7 +2715,7 @@
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "eb6557ada7c2436e9d5b",
+      "diagnostic_digest": "7e4e7bdd21dd1f8b3619",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/Console/console_transcript.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3037,14 +3023,35 @@
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "51dd4e6e4647ad852219",
+      "diagnostic_digest": "5beb792371aed4f9eb76",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Workspaces/change_bounds.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 6,
+      "diagnostic_digest": "303871fdb52cb0798907",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Workspaces/change_retention.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
+      "diagnostic_digest": "2c290c7704b2a652f70b",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Workspaces/change_revert.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "a729fc5f9bab7ce46228",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/change_tracking.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "cedcd4a592c8852ea865",
+      "diagnostic_digest": "733d830aa2dd2070ddad",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/change_turn_tracker.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3057,22 +3064,22 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 3,
-      "diagnostic_digest": "2e7019c93ef0589cc96b",
+      "call_count": 4,
+      "diagnostic_digest": "cda7280a1b1d9c5c39e2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/registry_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 284,
-      "diagnostic_digest": "3d2c8de8b09e5909d066",
+      "call_count": 287,
+      "diagnostic_digest": "78966ce3d45d9b35dd27",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
       "call_count": 100,
-      "diagnostic_digest": "798354024f474fee9df2",
+      "diagnostic_digest": "ce32b91e418e2921ac82",
       "owner": "TASK-494",
       "path": "tldw_chatbook/config.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3115,6 +3122,17 @@
   ],
   "persistent_sink_topology": [
     {
+      "path": "tldw_chatbook/Local_Ingestion/ingest_parse_worker.py",
+      "sinks": [
+        {
+          "digest": "f3f48a9cf32cb9a3",
+          "kind": "addHandler",
+          "line": 103,
+          "method": "addHandler"
+        }
+      ]
+    },
+    {
       "path": "tldw_chatbook/Logging_Config.py",
       "sinks": [
         {
@@ -3142,7 +3160,7 @@
           "method": "addHandler"
         },
         {
-          "digest": "0575ac40a7a642a3",
+          "digest": "9fce73a232622dc7",
           "kind": "loguru_sink",
           "line": 419,
           "method": "add"
@@ -3150,13 +3168,13 @@
         {
           "digest": "7907c11f3c5927cc",
           "kind": "addHandler",
-          "line": 491,
+          "line": 508,
           "method": "addHandler"
         },
         {
           "digest": "f32845c700525187",
           "kind": "addHandler",
-          "line": 526,
+          "line": 543,
           "method": "addHandler"
         }
       ]
@@ -3211,15 +3229,21 @@
       "path": "tldw_chatbook/app.py",
       "sinks": [
         {
+          "digest": "9edec43a81cb22b9",
+          "kind": "addHandler",
+          "line": 45,
+          "method": "addHandler"
+        },
+        {
           "digest": "567455f2495e9603",
           "kind": "addHandler",
-          "line": 5897,
+          "line": 5954,
           "method": "addHandler"
         },
         {
           "digest": "928f6c554daaf493",
           "kind": "addHandler",
-          "line": 5951,
+          "line": 6008,
           "method": "addHandler"
         }
       ]
@@ -3230,7 +3254,7 @@
         {
           "digest": "79153c35e06865c1",
           "kind": "open_private_text_append_stream",
-          "line": 3932,
+          "line": 3942,
           "method": "open_private_text_append_stream"
         }
       ]
@@ -3256,9 +3280,9 @@
   "schema_version": 1,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 442,
-    "persistent_sink_files": 5,
-    "task_492_calls": 1089,
-    "task_494_calls": 6769
+    "owner_files": 443,
+    "persistent_sink_files": 6,
+    "task_492_calls": 1108,
+    "task_494_calls": 6765
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -82,8 +82,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 49,
-      "diagnostic_digest": "1bf67d137b2b840e83ca",
+      "call_count": 51,
+      "diagnostic_digest": "89dcd208a5502b9253e5",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Audio/dictation_service_lazy.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -243,8 +243,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 26,
-      "diagnostic_digest": "3189034a11cacf19a1be",
+      "call_count": 27,
+      "diagnostic_digest": "6c122c659edce3511149",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_voice_input.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -268,6 +268,13 @@
       "diagnostic_digest": "82764920d87a6701a4d1",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/rag_scope.py",
+      "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
+    },
+    {
+      "call_count": 2,
+      "diagnostic_digest": "74cd77fd68a0141b4ec1",
+      "owner": "TASK-492",
+      "path": "tldw_chatbook/Chat/reply_sentence_sequencer.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
@@ -628,8 +635,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 40,
-      "diagnostic_digest": "1040c47fd8ffcfd363e9",
+      "call_count": 44,
+      "diagnostic_digest": "3d7006dfaff62c29327f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -835,6 +842,13 @@
       "diagnostic_digest": "c0c481a8ae10d7f6983d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Library/library_local_rag_search_service.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 3,
+      "diagnostic_digest": "78cd42cd4134de7d1d3d",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Library/library_rag_answer_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -1588,7 +1602,7 @@
     },
     {
       "call_count": 31,
-      "diagnostic_digest": "91bb5932eb697f8b9066",
+      "diagnostic_digest": "12d8ea56470a0db5196c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/audio_player.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2049,8 +2063,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 151,
-      "diagnostic_digest": "775f8aa7cb9c4401b07a",
+      "call_count": 154,
+      "diagnostic_digest": "d76bfd999f80fcd7d032",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2091,8 +2105,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 78,
-      "diagnostic_digest": "5a61b1708aaebfeac83f",
+      "call_count": 79,
+      "diagnostic_digest": "fcc5318feb83f5a39c1a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3280,9 +3294,9 @@
   "schema_version": 1,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 443,
+    "owner_files": 445,
     "persistent_sink_files": 6,
-    "task_492_calls": 1108,
-    "task_494_calls": 6767
+    "task_492_calls": 1111,
+    "task_494_calls": 6780
   }
 }

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import inspect
 import logging
 import os
 import subprocess
 import sys
+import textwrap
 import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
@@ -1258,26 +1260,49 @@ def test_persistent_and_legacy_sink_configuration_pin_diagnose_false() -> None:
     ``backtrace=True`` is pinned alongside it: traceback/diagnostic value
     (exception type, message, stack of source lines) must stay intact --
     only frame-local dumping goes away.
+
+    Checked by parsing the call's actual keyword arguments, NOT by substring
+    search over the source text. The first version of this test did the
+    latter and was vacuous: the security rationale comment sitting directly
+    above the kwarg contains the literal string ``diagnose=False``, so
+    deleting the real argument still left the assertion satisfied by the
+    comment. Confirmed by mutation -- removing the kwarg now fails here.
     """
     from tldw_chatbook import Logging_Config
     from tldw_chatbook.Metrics import logger_config as metrics_logger_config
 
-    app_logging_source = inspect.getsource(
-        Logging_Config.configure_application_logging
-    )
-    add_call_start = app_logging_source.index("loguru_logger.add(")
-    add_call_end = app_logging_source.index(")\n", add_call_start)
-    add_call_block = app_logging_source[add_call_start:add_call_end]
-    assert "_forward_loguru_to_standard" in add_call_block
-    assert "diagnose=False" in add_call_block
-    assert "backtrace=True" in add_call_block
+    def _sink_kwargs(function: object, receiver: str) -> dict[str, ast.expr]:
+        """Return the keyword arguments of the ``<receiver>.add(...)`` call."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(function)))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == receiver
+            ):
+                return {
+                    keyword.arg: keyword.value
+                    for keyword in node.keywords
+                    if keyword.arg is not None
+                }
+        raise AssertionError(f"no {receiver}.add(...) call found")
 
-    metrics_source = inspect.getsource(metrics_logger_config.setup_logger)
-    add_call_start = metrics_source.index("logger.add(")
-    add_call_end = metrics_source.index(")\n", add_call_start)
-    add_call_block = metrics_source[add_call_start:add_call_end]
-    assert "diagnose=False" in add_call_block
-    assert "backtrace=True" in add_call_block
+    for function, receiver in (
+        (Logging_Config.configure_application_logging, "loguru_logger"),
+        (metrics_logger_config.setup_logger, "logger"),
+    ):
+        kwargs = _sink_kwargs(function, receiver)
+        for name, expected in (("diagnose", False), ("backtrace", True)):
+            node = kwargs.get(name)
+            assert node is not None, (
+                f"{function.__qualname__}: sink is missing an explicit "
+                f"{name}= argument; it must not inherit loguru's default"
+            )
+            assert isinstance(node, ast.Constant) and node.value is expected, (
+                f"{function.__qualname__}: sink must pass {name}={expected}"
+            )
 
 
 def test_package_import_sets_loguru_diagnose_env_default() -> None:

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
+import subprocess
+import sys
 import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
+from pathlib import Path
 
 import httpx
 import pytest
@@ -1105,3 +1109,226 @@ async def test_auxiliary_huggingface_router_url_matches_ordinary_adapter_after_d
     assert ordinary["choices"][0]["message"]["content"] == "ok"
     assert auxiliary.text == "ok"
     assert [post["url"] for post in session.posts] == [expected_url, expected_url]
+
+
+# ---- task-2119: sink-level diagnose=False must stop credential leaks ------
+#
+# `logger.opt(exception=True)` in the provider handlers attaches the live
+# exception to the log record. Loguru's own `diagnose` option (default True)
+# then dumps every stack frame's LOCAL VARIABLES alongside the traceback --
+# for these handlers that includes `headers` (the raw
+# `Authorization`/`x-api-key` value) and `final_api_key`. A real Moonshot key
+# was disclosed this way via an ordinary HTTP 429 on 2026-08-03 (see
+# .superpowers/sdd/multi-provider-usage-verification-2026-08-03.md). Payload
+# redaction (the allowlist tests above) cannot touch this -- the secret
+# arrives via frame locals, not a logged dict. The fix is sink-level
+# (`Logging_Config.py`, `Metrics/logger_config.py`, and
+# `tldw_chatbook/__init__.py`'s package-import default), not per call site;
+# these tests pin that sink-level contract directly with a distinctive,
+# obviously-fake sentinel standing in for a live credential.
+
+SENTINEL_API_KEY = "sk-SENTINEL-DO-NOT-LOG-1234567890"
+
+# task-2119: deliberately NOT a fully-mocked `requests.Session`. A fake
+# `.post()` that raises immediately has no intermediate frames, and this
+# app's own call site (`chat_with_openai`'s `response = session.post(`) is a
+# multi-line call -- `headers=` lands on a continuation line, past the
+# single source line loguru's diagnose renderer annotates for that specific
+# frame, so a fully-mocked session does not actually reproduce a leak and
+# would make the positive-control test below pass for the wrong reason
+# (verified empirically while writing this test). The real 2026-08-03 leak
+# happened a few frames deeper, inside `requests` itself
+# (`Session.request`'s `**kwargs`, which contains `headers`) -- reachable
+# only by letting a REAL `ConnectionError` propagate through `requests`'
+# actual internals. Port 1 on loopback is always refused immediately (no
+# real network access, no listener ever binds a privileged port as a normal
+# user), so this is fast and deterministic while still exercising the real
+# code path end-to-end.
+_UNREACHABLE_LOCAL_URL = "http://127.0.0.1:1"
+
+
+@contextmanager
+def _loguru_sink_with_diagnose(diagnose: bool) -> Iterator[list[str]]:
+    """Capture loguru's fully-formatted sink text under a pinned ``diagnose``.
+
+    Mirrors what a real stream/file sink receives: ``str(message)`` includes
+    loguru's own traceback rendering, with per-frame locals attached when
+    ``diagnose=True``. Unlike ``_captured_logs()`` above, this pins
+    ``diagnose`` explicitly instead of inheriting the ambient process
+    default -- the ambient default is not a reliable proxy for production
+    behavior in this suite: ``Tests/conftest.py`` imports loguru ahead of
+    ``tldw_chatbook``, so this package's own ``LOGURU_DIAGNOSE``-setting
+    import (see ``tldw_chatbook/__init__.py``) never gets to influence the
+    bound default for the whole test session.
+    """
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="DEBUG",
+        diagnose=diagnose,
+        backtrace=True,
+    )
+    try:
+        yield messages
+    finally:
+        logger.remove(sink_id)
+
+
+def _plant_sentinel_openai_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cloud_adapters,
+        "load_settings",
+        lambda: {
+            "openai_api": {
+                "api_key": SENTINEL_API_KEY,
+                "api_base_url": _UNREACHABLE_LOCAL_URL,
+                "api_retries": 0,
+                "api_timeout": 2,
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize("sensitive", [False, True])
+def test_sentinel_api_key_never_reaches_diagnose_false_sink_on_request_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    sensitive: bool,
+) -> None:
+    """task-2119 AC#1/#3: a real credential-shaped local must never leak.
+
+    Forces the OpenAI adapter's ``RequestException`` handler (the branch
+    that calls ``logger.opt(exception=True)`` on the non-sensitive path --
+    LLM_API_Calls.py's ``chat_with_openai``, ``except
+    requests.exceptions.RequestException`` block) with a distinctive
+    sentinel standing in for the live API key, on BOTH the sensitive and
+    non-sensitive request paths, and asserts the sentinel never reaches a
+    sink configured the way this app's real sinks now are
+    (``diagnose=False``).
+    """
+    _plant_sentinel_openai_config(monkeypatch)
+
+    context = sensitive_llm_request() if sensitive else nullcontext()
+    with _loguru_sink_with_diagnose(False) as logs, context:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            cloud_adapters.chat_with_openai(
+                input_data=[{"role": "user", "content": "hi"}],
+                api_key=SENTINEL_API_KEY,
+                model="gpt-test",
+                streaming=False,
+            )
+
+    rendered = "\n".join(logs)
+    assert SENTINEL_API_KEY not in rendered
+
+
+def test_sentinel_api_key_leaks_via_diagnose_true_sink_confirming_mechanism_is_real(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive control for the regression test above.
+
+    Without a ``diagnose=False`` sink, the SAME non-sensitive
+    ``RequestException`` DOES attach ``headers``/``final_api_key``
+    frame-local values to the sink text -- this is the exact mechanism that
+    disclosed a real Moonshot key on 2026-08-03. If this test ever stops
+    leaking, the regression test above has stopped proving anything (it
+    would be passing vacuously, e.g. because the sentinel was never actually
+    exercised).
+    """
+    _plant_sentinel_openai_config(monkeypatch)
+
+    with _loguru_sink_with_diagnose(True) as logs:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            cloud_adapters.chat_with_openai(
+                input_data=[{"role": "user", "content": "hi"}],
+                api_key=SENTINEL_API_KEY,
+                model="gpt-test",
+                streaming=False,
+            )
+
+    rendered = "\n".join(logs)
+    assert SENTINEL_API_KEY in rendered
+
+
+def test_persistent_and_legacy_sink_configuration_pin_diagnose_false() -> None:
+    """task-2119 AC#2/#4: pin the sink-level contract itself.
+
+    A future contributor flipping ``diagnose=False`` back to unset (or to
+    ``True``) on either of this app's real loguru sinks must fail a test
+    rather than silently reopening the credential-leak hole.
+    ``backtrace=True`` is pinned alongside it: traceback/diagnostic value
+    (exception type, message, stack of source lines) must stay intact --
+    only frame-local dumping goes away.
+    """
+    from tldw_chatbook import Logging_Config
+    from tldw_chatbook.Metrics import logger_config as metrics_logger_config
+
+    app_logging_source = inspect.getsource(
+        Logging_Config.configure_application_logging
+    )
+    add_call_start = app_logging_source.index("loguru_logger.add(")
+    add_call_end = app_logging_source.index(")\n", add_call_start)
+    add_call_block = app_logging_source[add_call_start:add_call_end]
+    assert "_forward_loguru_to_standard" in add_call_block
+    assert "diagnose=False" in add_call_block
+    assert "backtrace=True" in add_call_block
+
+    metrics_source = inspect.getsource(metrics_logger_config.setup_logger)
+    add_call_start = metrics_source.index("logger.add(")
+    add_call_end = metrics_source.index(")\n", add_call_start)
+    add_call_block = metrics_source[add_call_start:add_call_end]
+    assert "diagnose=False" in add_call_block
+    assert "backtrace=True" in add_call_block
+
+
+def test_package_import_sets_loguru_diagnose_env_default() -> None:
+    """task-2119: importing ``tldw_chatbook`` sets the safe library default.
+
+    Cheap in-process check that the env-var lever from
+    ``tldw_chatbook/__init__.py`` is actually wired (the full "does this
+    make loguru's own default sink safe" property needs a fresh process --
+    see the subprocess test below -- since this test SESSION already
+    imported loguru, via ``Tests/conftest.py``, before ``tldw_chatbook``
+    ever got a chance to set this).
+    """
+    assert os.environ.get("LOGURU_DIAGNOSE") == "0"
+
+
+def test_fresh_process_importing_package_alone_leaves_loguru_diagnose_false() -> (
+    None
+):
+    """task-2119: reproduce the exact shape of the 2026-08-03 live incident.
+
+    A subprocess that imports only ``tldw_chatbook`` (nothing else touches
+    loguru first, unlike this test session's own ``conftest.py``) must end
+    up with every loguru sink ``diagnose=False`` and ``LOGURU_DIAGNOSE=0``
+    in its environment. This is run out-of-process on purpose: the live
+    incident happened in a script that imported the provider adapters
+    directly and never called
+    ``Logging_Config.configure_application_logging`` -- exactly this
+    shape -- and ``Tests/conftest.py`` importing loguru ahead of this
+    package (for its own, unrelated fixture-ordering reasons) means the
+    property under test is already gone by the time any in-process test
+    body runs in this suite.
+    """
+    script = (
+        "import os, sys\n"
+        "import tldw_chatbook\n"
+        "from loguru import logger\n"
+        "assert os.environ.get('LOGURU_DIAGNOSE') == '0', os.environ.get('LOGURU_DIAGNOSE')\n"
+        "handlers = list(logger._core.handlers.values())\n"
+        "assert handlers, 'expected at least one loguru sink after package import'\n"
+        "for handler in handlers:\n"
+        "    ef = getattr(handler, '_exception_formatter', None)\n"
+        "    assert getattr(ef, '_diagnose', None) is False, 'diagnose not disabled'\n"
+        "print('OK')\n"
+    )
+    project_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout

--- a/Tests/Chat/test_sensitive_llm_logging.py
+++ b/Tests/Chat/test_sensitive_llm_logging.py
@@ -1206,6 +1206,12 @@ def test_sentinel_api_key_never_reaches_diagnose_false_sink_on_request_exception
     non-sensitive request paths, and asserts the sentinel never reaches a
     sink configured the way this app's real sinks now are
     (``diagnose=False``).
+
+    Args:
+        monkeypatch: Pytest fixture used to plant the sentinel-bearing
+            OpenAI config pointing at an unreachable local endpoint.
+        sensitive: Whether to wrap the request in the
+            ``sensitive_llm_request`` context (both paths must be safe).
     """
     _plant_sentinel_openai_config(monkeypatch)
 
@@ -1235,6 +1241,10 @@ def test_sentinel_api_key_leaks_via_diagnose_true_sink_confirming_mechanism_is_r
     leaking, the regression test above has stopped proving anything (it
     would be passing vacuously, e.g. because the sentinel was never actually
     exercised).
+
+    Args:
+        monkeypatch: Pytest fixture used to plant the sentinel-bearing
+            OpenAI config pointing at an unreachable local endpoint.
     """
     _plant_sentinel_openai_config(monkeypatch)
 
@@ -1305,55 +1315,179 @@ def test_persistent_and_legacy_sink_configuration_pin_diagnose_false() -> None:
             )
 
 
-def test_package_import_sets_loguru_diagnose_env_default() -> None:
-    """task-2119: importing ``tldw_chatbook`` sets the safe library default.
+# The child script deliberately mirrors the provider-handler shape from the
+# 2026-08-03 live incident: an ``Authorization`` header dict built from the
+# key sits in a frame whose FAILING LINE references it (``_post(headers)``),
+# which is exactly what loguru's ``diagnose`` annotates with the variable's
+# live value. The sentinel arrives via the environment, never as a literal
+# in the script, so a plain source-line backtrace (``diagnose=False``,
+# ``backtrace=True``) cannot reveal it -- only frame-local dumping can.
+_INCIDENT_SHAPE_CHILD_SCRIPT = """\
+import os
 
-    Cheap in-process check that the env-var lever from
-    ``tldw_chatbook/__init__.py`` is actually wired (the full "does this
-    make loguru's own default sink safe" property needs a fresh process --
-    see the subprocess test below -- since this test SESSION already
-    imported loguru, via ``Tests/conftest.py``, before ``tldw_chatbook``
-    ever got a chance to set this).
-    """
-    assert os.environ.get("LOGURU_DIAGNOSE") == "0"
+{package_import}
+from loguru import logger
+
+secret = os.environ["LEAK_SENTINEL"]
 
 
-def test_fresh_process_importing_package_alone_leaves_loguru_diagnose_false() -> (
-    None
-):
+def _post(headers):
+    raise ConnectionError("simulated transient provider error")
+
+
+def _request(final_api_key):
+    headers = {{"Authorization": "Bearer " + final_api_key}}
+    return _post(headers)
+
+
+try:
+    _request(secret)
+except ConnectionError:
+    logger.opt(exception=True).error("Request failed")
+
+print("LOGURU_DIAGNOSE=" + repr(os.environ.get("LOGURU_DIAGNOSE")))
+print("CHILD-DONE")
+"""
+
+
+@pytest.mark.parametrize(
+    ("import_package", "expect_leak"),
+    [
+        pytest.param(True, False, id="package-import-neutralizes-default-sink"),
+        pytest.param(False, True, id="bare-loguru-default-leaks-positive-control"),
+    ],
+)
+def test_fresh_process_incident_shape_leaks_only_without_package_import(
+    tmp_path: Path,
+    import_package: bool,
+    expect_leak: bool,
+) -> None:
     """task-2119: reproduce the exact shape of the 2026-08-03 live incident.
 
-    A subprocess that imports only ``tldw_chatbook`` (nothing else touches
-    loguru first, unlike this test session's own ``conftest.py``) must end
-    up with every loguru sink ``diagnose=False`` and ``LOGURU_DIAGNOSE=0``
-    in its environment. This is run out-of-process on purpose: the live
-    incident happened in a script that imported the provider adapters
-    directly and never called
-    ``Logging_Config.configure_application_logging`` -- exactly this
-    shape -- and ``Tests/conftest.py`` importing loguru ahead of this
-    package (for its own, unrelated fixture-ordering reasons) means the
-    property under test is already gone by the time any in-process test
-    body runs in this suite.
+    A fresh process logs a caught exception whose frames hold a
+    credential-shaped local, through whatever loguru sink is active after
+    (a) importing only ``tldw_chatbook`` first, or (b) importing nothing --
+    loguru's own auto-init default sink, the pre-fix world. The sentinel
+    must stay out of the output in (a) and MUST appear in (b): the positive
+    control proves this script shape genuinely leaks under loguru's
+    defaults, so (a) cannot pass vacuously. Behavioral on purpose -- an
+    earlier version introspected ``logger._core.handlers`` private
+    internals, which loguru upgrades could rename without any real
+    regression. Out-of-process on purpose: the live incident happened in a
+    script that imported the provider adapters directly and never called
+    ``Logging_Config.configure_application_logging``, and this test
+    session's own ``Tests/conftest.py`` imports loguru before
+    ``tldw_chatbook`` ever could. The child env is scrubbed of ``LOGURU_*``
+    so an ambient ``LOGURU_DIAGNOSE`` export can neither mask the leak in
+    (b) nor fail (a) for reasons unrelated to the code. The script runs
+    from a real file, not ``-c``, because diagnose resolves the variables
+    it dumps from traceback source lines, which ``<string>`` frames do not
+    have.
+
+    Args:
+        tmp_path: Pytest fixture; the child script is written here so its
+            traceback frames carry real source lines.
+        import_package: Whether the child imports ``tldw_chatbook`` before
+            logging (the fix under test) or exercises bare loguru.
+        expect_leak: Whether the sentinel must appear in the child's
+            stderr (the positive control) or must be absent (the fix).
     """
-    script = (
-        "import os, sys\n"
-        "import tldw_chatbook\n"
-        "from loguru import logger\n"
-        "assert os.environ.get('LOGURU_DIAGNOSE') == '0', os.environ.get('LOGURU_DIAGNOSE')\n"
-        "handlers = list(logger._core.handlers.values())\n"
-        "assert handlers, 'expected at least one loguru sink after package import'\n"
-        "for handler in handlers:\n"
-        "    ef = getattr(handler, '_exception_formatter', None)\n"
-        "    assert getattr(ef, '_diagnose', None) is False, 'diagnose not disabled'\n"
-        "print('OK')\n"
+    script_path = tmp_path / "incident_shape_child.py"
+    script_path.write_text(
+        _INCIDENT_SHAPE_CHILD_SCRIPT.format(
+            package_import="import tldw_chatbook" if import_package else "",
+        ),
+        encoding="utf-8",
     )
+
     project_root = Path(__file__).resolve().parents[2]
+    child_env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("LOGURU_")
+    }
+    child_env["LEAK_SENTINEL"] = SENTINEL_API_KEY
+    child_env["PYTHONPATH"] = str(project_root) + (
+        os.pathsep + child_env["PYTHONPATH"] if child_env.get("PYTHONPATH") else ""
+    )
+
     result = subprocess.run(
-        [sys.executable, "-c", script],
+        [sys.executable, str(script_path)],
         cwd=str(project_root),
+        env=child_env,
         capture_output=True,
         text=True,
         timeout=30,
     )
+
     assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
-    assert "OK" in result.stdout
+    assert "CHILD-DONE" in result.stdout
+    # The exception must actually have been rendered (backtrace stays on);
+    # an empty stderr would make the no-leak assertion below vacuous.
+    assert "ConnectionError" in result.stderr
+    if expect_leak:
+        assert SENTINEL_API_KEY in result.stderr
+    else:
+        assert SENTINEL_API_KEY not in result.stderr
+        assert "LOGURU_DIAGNOSE='0'" in result.stdout
+
+
+def test_package_import_preserves_host_configured_loguru_sinks(
+    tmp_path: Path,
+) -> None:
+    """Package import must only replace loguru's auto-init default sink.
+
+    A host application that configured loguru BEFORE importing
+    ``tldw_chatbook`` (removed the default sink, installed its own) must
+    keep its sinks working and must not gain a duplicate stderr sink from
+    the package init. Pins the ``remove(0)``-not-``remove()`` narrowing:
+    reverting to a bare ``remove()`` wipes the host's sink and fails here.
+
+    Args:
+        tmp_path: Pytest fixture; the child script is written here.
+    """
+    script_path = tmp_path / "host_configured_child.py"
+    script_path.write_text(
+        textwrap.dedent(
+            """\
+            from loguru import logger
+
+            captured = []
+            logger.remove()
+            logger.add(captured.append, format="{message}")
+
+            import tldw_chatbook
+
+            logger.info("host-sink-message")
+            assert any(
+                "host-sink-message" in str(message) for message in captured
+            ), "host-configured sink was clobbered by package import"
+            print("CHILD-DONE")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    project_root = Path(__file__).resolve().parents[2]
+    child_env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("LOGURU_")
+    }
+    child_env["PYTHONPATH"] = str(project_root) + (
+        os.pathsep + child_env["PYTHONPATH"] if child_env.get("PYTHONPATH") else ""
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=str(project_root),
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "CHILD-DONE" in result.stdout
+    # No duplicate package stderr sink: the message reached ONLY the host sink.
+    assert "host-sink-message" not in result.stderr

--- a/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
+++ b/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
@@ -51,10 +51,62 @@ exposed by default.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 An exception raised inside a provider call with an API key in scope does NOT write the key value to any log sink (file or console), on both the sensitive and non-sensitive request paths
-- [ ] #2 The fix is applied at the sink/configuration level so a newly added exception handler is safe by default, not dependent on the author remembering a flag
-- [ ] #3 A regression test plants a sentinel key value in scope, forces a provider exception, captures log output, and asserts the sentinel appears nowhere
-- [ ] #4 Traceback/diagnostic value is preserved to the extent possible (the exception type, message, and stack are still logged — only frame-local dumping is suppressed)
-- [ ] #5 `tldw_chatbook/` swept for other `opt(exception=True)` / `exc_info=True` sites where credentials or full payloads are in scope; each fixed or justified
+- [x] #1 An exception raised inside a provider call with an API key in scope does NOT write the key value to any log sink (file or console), on both the sensitive and non-sensitive request paths
+- [x] #2 The fix is applied at the sink/configuration level so a newly added exception handler is safe by default, not dependent on the author remembering a flag
+- [x] #3 A regression test plants a sentinel key value in scope, forces a provider exception, captures log output, and asserts the sentinel appears nowhere
+- [x] #4 Traceback/diagnostic value is preserved to the extent possible (the exception type, message, and stack are still logged — only frame-local dumping is suppressed)
+- [x] #5 `tldw_chatbook/` swept for other `opt(exception=True)` / `exc_info=True` sites where credentials or full payloads are in scope; each fixed or justified
 - [ ] #6 The exposed Moonshot key is rotated by the owner (tracked here for closure; not an agent action)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Fix at the loguru sink rather than the call sites
+2. Cover the auto-init default sink that the incident script actually hit
+3. Pin with a sentinel regression test plus a positive control
+4. Sweep for any remaining sink registration
+
+## Implementation Notes
+
+Fixed at the sink. All three live `logger.add()` registrations in the package now
+pass `diagnose=False` explicitly, with `backtrace=True` kept so exception type,
+message, and the stack of source lines still log — only the per-frame local-variable
+dump goes away.
+
+**Why the sink and not the call sites:** the task described ~30 handlers in
+`LLM_API_Calls.py`, but a sweep found **1,055** `opt(exception=True)` sites across
+`tldw_chatbook/`. Per-call-site patching was never viable, and any one missed site
+reopens the hole. Three `logger.add()` calls cover all 1,055 by construction
+(AC#5). The 160 stdlib `exc_info=True` sites need no change: stdlib's formatter
+renders a traceback without frame locals.
+
+**Third sink was the load-bearing one.** Beyond `Logging_Config.py` and
+`Metrics/logger_config.py`, `tldw_chatbook/__init__.py` now replaces loguru's
+auto-init default sink at package import. That sink is what the 2026-08-03 incident
+actually hit: the verification script imported the provider adapters directly and
+never called `configure_application_logging`, so the app's own hardened sink was
+never installed. `configure_application_logging` calls `logger.remove()` before
+adding its own sink, so the package-init stderr sink is discarded in the real app —
+no duplicate TUI logging. `LOGURU_DIAGNOSE=0` is set alongside it as a default for
+future `add()` calls, but is not relied on: it only binds if set before loguru's
+module is first imported, and `Tests/conftest.py` imports loguru first.
+
+**Test-quality note.** The first version of the sink-config pin asserted
+`"diagnose=False" in <sliced source>`. Mutation testing showed it was **vacuous** —
+the security rationale comment directly above the kwarg contains that same literal
+string, so deleting the real argument still passed. Rewritten to parse the call with
+`ast` and check actual keyword arguments; re-verified against three mutations
+(remove the kwarg from either sink, flip it to `True`), each of which now fails.
+The suite also carries a **positive control** asserting the sentinel *does* leak
+through a `diagnose=True` sink, so the regression test cannot pass for the wrong
+reason, and an out-of-process test reproducing the incident's exact import shape.
+The sentinel test deliberately drives a real `ConnectionError` through `requests`'
+internals rather than a mocked session — a fully-mocked `.post()` has no
+intermediate frames and does not reproduce the leak at all.
+
+**Modified:** `tldw_chatbook/__init__.py`, `tldw_chatbook/Logging_Config.py`,
+`tldw_chatbook/Metrics/logger_config.py`, `Tests/Chat/test_sensitive_llm_logging.py`
+(67 passing).
+
+**AC#6 remains open and is an owner action:** the disclosed Moonshot key still needs
+rotating. Code changes cannot close that.

--- a/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
+++ b/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
@@ -1,16 +1,16 @@
 ---
 id: TASK-2119
-title: >-
-  Provider exception handlers leak API keys into logs via loguru diagnose
-status: To Do
+title: Provider exception handlers leak API keys into logs via loguru diagnose
+status: Done
 assignee: []
 created_date: '2026-08-03 18:50'
+updated_date: '2026-08-04 02:14'
 labels:
   - security
   - llm-calls
   - observability
-priority: high
 dependencies: []
+priority: high
 ---
 
 ## Description
@@ -49,7 +49,6 @@ exposed by default.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
 - [x] #1 An exception raised inside a provider call with an API key in scope does NOT write the key value to any log sink (file or console), on both the sensitive and non-sensitive request paths
 - [x] #2 The fix is applied at the sink/configuration level so a newly added exception handler is safe by default, not dependent on the author remembering a flag
@@ -61,13 +60,16 @@ exposed by default.
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Fix at the loguru sink rather than the call sites
 2. Cover the auto-init default sink that the incident script actually hit
 3. Pin with a sentinel regression test plus a positive control
 4. Sweep for any remaining sink registration
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 Fixed at the sink. All three live `logger.add()` registrations in the package now
 pass `diagnose=False` explicitly, with `backtrace=True` kept so exception type,
 message, and the stack of source lines still log — only the per-frame local-variable
@@ -104,9 +106,25 @@ The sentinel test deliberately drives a real `ConnectionError` through `requests
 internals rather than a mocked session — a fully-mocked `.post()` has no
 intermediate frames and does not reproduce the leak at all.
 
+**Post-fix gate sweep found a second, unrelated failure:** `Tests/Architecture/
+test_persistent_diagnostic_inventory.py` pins a checked-in JSON snapshot
+(`Docs/security/production-diagnostic-inventory.json`) of every production
+diagnostic call and persistent-sink registration, keyed by source digest. It failed
+after this fix — correctly: the `Logging_Config.py` sink's digest changed because
+`diagnose=False, backtrace=True` were added to it. The rest of the diff (~200 of
+~212 changed lines) was pre-existing drift already on `origin/dev`: the checked-in
+snapshot predates PR #1235 (2026-08-02 16:54) by six minutes and had never been
+regenerated since, so unrelated files (console_cost_tracker.py,
+prompt_improvement_service.py, change_review_screen.py, several UI screen
+refactors) were already out of sync before this branch existed. Reviewed the full
+diff line by line for anything suspicious (a new `diagnose=True`, a new bare
+`FileHandler`, etc.) — none found — then regenerated via the script's own
+`--write` flag, the sanctioned path for an explicit, reviewed topology change.
+
 **Modified:** `tldw_chatbook/__init__.py`, `tldw_chatbook/Logging_Config.py`,
 `tldw_chatbook/Metrics/logger_config.py`, `Tests/Chat/test_sensitive_llm_logging.py`
-(67 passing).
+(67 passing), `Docs/security/production-diagnostic-inventory.json` (regenerated).
 
 **AC#6 remains open and is an owner action:** the disclosed Moonshot key still needs
 rotating. Code changes cannot close that.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
+++ b/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
@@ -127,4 +127,18 @@ diff line by line for anything suspicious (a new `diagnose=True`, a new bare
 
 **AC#6 remains open and is an owner action:** the disclosed Moonshot key still needs
 rotating. Code changes cannot close that.
+
+**PR #1305 Qodo round (all four findings accepted, mutation-verified):**
+(1) package init narrowed from `logger.remove()` (wipes host-app sinks) to a
+guarded `remove(0)` that replaces only loguru's auto-init default sink — a host
+that configured loguru before importing the package keeps its sinks, pinned by a
+new subprocess test that goes red if `remove(0)` reverts to `remove()`;
+(2) tests made hermetic — the subprocess child now runs with `LOGURU_*` scrubbed
+from its env, and the in-process ambient-env assertion (unfixable in-process:
+the package is imported before any test body runs) was dropped in its favor;
+(3) the subprocess check no longer reads `logger._core` private internals — it
+behaviorally asserts a credential-shaped frame local stays out of the child's
+stderr, with a bare-loguru positive-control variant proving the same script
+shape DOES leak pre-fix (mutation: deleting the init block fails the test);
+(4) `Args:` sections added to the new parameterized tests per file convention.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
+++ b/backlog/tasks/task-2119 - Provider-exception-handlers-leak-API-keys-into-logs-via-loguru-diagnose.md
@@ -1,0 +1,60 @@
+---
+id: TASK-2119
+title: >-
+  Provider exception handlers leak API keys into logs via loguru diagnose
+status: To Do
+assignee: []
+created_date: '2026-08-03 18:50'
+labels:
+  - security
+  - llm-calls
+  - observability
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**A real API key was disclosed while verifying this. The Moonshot key in the repo root
+was leaked in plaintext by an ordinary HTTP 429 during multi-provider verification on
+2026-08-03 and must be rotated.**
+
+`tldw_chatbook/LLM_Calls/LLM_API_Calls.py` has ~30 call sites where a provider request's
+`RequestException` / generic exception handler calls
+`logger.opt(exception=True).error(...)`. Loguru's `diagnose` option defaults to True and
+dumps **every stack frame's local variables** alongside the traceback. In these handlers
+the locals in scope include the raw request `headers` (carrying
+`Authorization: Bearer <key>` / `x-api-key`) and `final_api_key`. So any transient
+provider error during normal chat writes the user's key to the log sink in cleartext.
+
+Confirmed affected by grep: OpenAI, Cohere, Moonshot, Z.AI. Live-confirmed for Moonshot
+via a genuine 429. Google's and OpenRouter's specific error branches happen not to use
+`opt(exception=True)` — coincidence, not design.
+
+**Pre-existing, not introduced by the cost-ticker program:** `git blame` traces the
+sampled sites to PR #707 (2026-07-19) and PR #1235 (2026-08-02).
+
+Note this is a *different* surface from the one PR #1295 closed. That work made the
+**debug payload logs** allowlist-shaped; these are **exception handlers**, where the
+secret arrives via frame locals rather than via a logged payload dict — so no amount of
+payload redaction touches it.
+
+**Preferred fix is the class-killer, not 30 patches.** Frame locals should never reach a
+persistent sink: set `diagnose=False` on the app's logger sink configuration, which
+eliminates the entire category in one place regardless of which handler runs or what a
+future contributor adds. Per-call-site `opt(exception=True, diagnose=False)` is the
+fallback if a sink-level change is judged too broad, but it leaves the next new handler
+exposed by default.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 An exception raised inside a provider call with an API key in scope does NOT write the key value to any log sink (file or console), on both the sensitive and non-sensitive request paths
+- [ ] #2 The fix is applied at the sink/configuration level so a newly added exception handler is safe by default, not dependent on the author remembering a flag
+- [ ] #3 A regression test plants a sentinel key value in scope, forces a provider exception, captures log output, and asserts the sentinel appears nowhere
+- [ ] #4 Traceback/diagnostic value is preserved to the extent possible (the exception type, message, and stack are still logged — only frame-local dumping is suppressed)
+- [ ] #5 `tldw_chatbook/` swept for other `opt(exception=True)` / `exc_info=True` sites where credentials or full payloads are in scope; each fixed or justified
+- [ ] #6 The exposed Moonshot key is rotated by the owner (tracked here for closure; not an agent action)
+<!-- AC:END -->

--- a/backlog/tasks/task-2120 - Usage-adapter-ignores-cache_write_tokens-under-reporting-cost.md
+++ b/backlog/tasks/task-2120 - Usage-adapter-ignores-cache_write_tokens-under-reporting-cost.md
@@ -1,0 +1,48 @@
+---
+id: TASK-2120
+title: >-
+  Usage adapter ignores cache_write_tokens, under-reporting cost on cache writes
+status: To Do
+assignee: []
+created_date: '2026-08-03 19:05'
+labels:
+  - cost-ticker
+  - llm-calls
+  - correctness
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`ProviderUsage.from_provider_payload` maps cache writes only on the Anthropic-native
+branch (`cache_creation_input_tokens`). Both OpenAI-shaped branches read
+`prompt_tokens_details.cached_tokens` / `input_tokens_details.cached_tokens` into
+`cache_read` and leave `cache_write` at zero — there is no write field in either path.
+
+Per OpenRouter's prompt-caching docs, its usage object reports **`cache_write_tokens`**
+alongside `cached_tokens` inside `prompt_tokens_details`, and OpenAI's own explicit
+caching (GPT-5.6+) also bills cache writes at **1.25x** input. Because our adapter
+computes `uncached_input = prompt_tokens - cached_tokens`, any write tokens fall into
+the `uncached_input` bucket and are priced at the **1x input rate instead of 1.25x**.
+
+Effect: the cost ticker under-reports spend on exactly the turns that cost the most —
+the cache-write turns. It is a silent undercount, not a visible error, which is the
+worst shape for a number users are meant to trust. It also makes the chip's cache
+accounting inconsistent across providers: identical caching behavior is fully priced on
+Anthropic and partially priced everywhere else.
+
+Also unused: OpenRouter's `cache_discount` field, which reports realized savings
+directly and could corroborate our computed figure.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Both OpenAI-shaped adapter branches read a cache-write field (`cache_write_tokens`, plus any provider-specific spelling verified against real payloads) into `cache_write`
+- [ ] #2 `uncached_input` excludes write tokens so the four buckets stay disjoint and do not double-count
+- [ ] #3 Unit tests cover a payload carrying cached + write + prompt tokens together, asserting exact bucket values
+- [ ] #4 Pricing applies the cache-write rate to those tokens, verified against a seeded model with a non-null `cache_write_per_mtok`
+- [ ] #5 Providers that report no write field are unaffected (regression pinned)
+<!-- AC:END -->

--- a/backlog/tasks/task-2121 - Console-prompt-caching-is-unavailable-through-OpenRouter.md
+++ b/backlog/tasks/task-2121 - Console-prompt-caching-is-unavailable-through-OpenRouter.md
@@ -1,0 +1,68 @@
+---
+id: TASK-2121
+title: >-
+  Console prompt caching is unavailable through OpenRouter (gate, session_id, pricing)
+status: To Do
+assignee: []
+created_date: '2026-08-03 19:05'
+labels:
+  - cost-ticker
+  - console
+  - openrouter
+priority: medium
+dependencies:
+  - TASK-2120
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR2 gave the Console a per-turn `cache_control` breakpoint so conversation history
+becomes a reusable cache prefix. `ConsoleProviderGateway.resolve_for_send` sets
+`prompt_caching` only when `identity.execution_key == "anthropic"`, so a user running
+Claude **through OpenRouter** gets none of it — despite OpenRouter explicitly accepting
+`cache_control` and translating between provider formats (Anthropic-style
+`cache_control` ⇄ OpenAI-style `prompt_cache_breakpoint`). The capability is there; our
+gate excludes it by provider name.
+
+Three separate gaps, worth doing together:
+
+1. **The per-turn breakpoint is gated out.** The condition keys on the execution key
+   rather than on whether the *routed model* supports explicit caching. Anthropic and
+   Gemini via OpenRouter both want breakpoints; OpenAI/DeepSeek/Groq/Moonshot via
+   OpenRouter cache automatically and want none.
+
+2. **No `session_id` — sticky routing is fragile.** OpenRouter keeps a conversation on
+   one upstream provider to keep its cache warm, but by default identifies the
+   conversation by *hashing the opening messages*. It exposes `session_id` (body or
+   `x-session-id` header, ≤256 chars) for explicit control, and with a `session_id`
+   stickiness engages on any successful request rather than only after a cache hit is
+   observed. The Console has a stable per-session id already; not sending it leaves
+   routing to a heuristic and re-routes cold whenever the sticky provider is
+   unavailable.
+   **Cost-ticker consequence:** a provider fallback breaks the cache with an
+   *unchanged payload*, so the fingerprint break-detector cannot see it and will not
+   alert. The chip still reports honestly after the fact (warm/cold comes from the last
+   send's real usage), but the user gets no warning and no cause.
+
+3. **No pricing entries for OpenRouter**, so every OpenRouter model resolves to `None`
+   and the chip falls back to tokens-only. Note OpenRouter pricing is per-routed-model,
+   so this likely needs the routed model reported in the response rather than a static
+   table.
+
+Verified against OpenRouter's prompt-caching guide (provider sticky routing section) on
+2026-08-03. Live end-to-end confirmation was not possible: the repo-root OpenRouter key
+is rejected by OpenRouter itself (`401 User not found`) — a working key is needed to
+validate any fix.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The per-turn `cache_control` breakpoint is emitted for explicit-caching models routed via OpenRouter (Anthropic, Gemini), and NOT for automatic-caching ones
+- [ ] #2 The gate keys on routed-model caching capability rather than a hardcoded execution-key equality check
+- [ ] #3 The Console sends a stable `session_id` (or `x-session-id`) for OpenRouter requests, derived from the existing per-session id
+- [ ] #4 Cache reads/writes returned by OpenRouter land in the correct disjoint buckets (depends on TASK-2120)
+- [ ] #5 Pricing resolves for OpenRouter responses using the routed model reported in the response, or the tokens-only fallback is documented as intended
+- [ ] #6 Validated end-to-end against a working OpenRouter key: a second same-conversation send reports a cache read
+<!-- AC:END -->

--- a/backlog/tasks/task-2122 - Nine-of-eleven-providers-report-no-usage-on-the-streaming-path.md
+++ b/backlog/tasks/task-2122 - Nine-of-eleven-providers-report-no-usage-on-the-streaming-path.md
@@ -16,11 +16,11 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The cost ticker's core promise is "real usage from the API, never an estimate." That
-holds for **OpenAI and Anthropic only**. An audit of every `stream_generator` in
-`LLM_Calls/LLM_API_Calls.py`, bounded by indentation so the non-streaming path in the
-same function is not miscounted, found that **nine of eleven providers emit no usage
-chunk at all when streaming** — and streaming is the Console default.
+The cost ticker's core promise is "real usage from the API, never an estimate." On the
+streaming path that holds for **OpenAI and Anthropic only**. An audit of every
+`stream_generator` in `LLM_Calls/LLM_API_Calls.py`, bounded by indentation so the
+non-streaming path in the same function is not miscounted, found that **nine of eleven
+providers emit no usage chunk at all when streaming**.
 
 | Provider | Streaming generator | Usage emitted |
 |---|---|---|
@@ -60,10 +60,28 @@ the usage and emit a chunk. Both drop data the provider is already sending:
 - Google's generator never reads `usageMetadata`, which Gemini sends on the final
   streaming chunk. Its non-streaming path maps it at line 3637.
 
-Consequence: for nine providers the Console persists no `usage_json`, so cost falls back
-to estimation and the cache chip has no ground truth to report warm/cold from — the two
-things the ticker exists to provide. This was missed because PR1's verification targeted
-Anthropic and PR3's live verification ran against Anthropic only.
+**How exposed is this today?** Measured, not assumed — a probe over the shipped config
+template resolving `build_default_console_session_settings` per provider:
+
+- `[chat_defaults]` ships **no** `streaming` key, so the `True` fallback in
+  `console_session_settings.py:436` does not apply; resolution falls through
+  `default_sources = (model_profile, saved_defaults, chat_defaults, provider_settings)`
+  to the per-provider template value, which is `streaming = false`.
+- So for anthropic/openai/google/cohere/groq/deepseek/openrouter/moonshot the Console is
+  **non-streaming out of the box** and usage capture works today.
+- **Mistral is the exception and is broken by default**: its `[api_settings.mistral]`
+  block is the only one with no `streaming` key, so it falls through to the `True`
+  default. Mistral streams out of the box and therefore records no usage at all. That
+  template inconsistency is worth fixing on its own.
+- For the other eight, enabling streaming is a **one-keystroke, first-class action** —
+  the Alt+M quick popover and the Settings screen's `chat_defaults.streaming` field, and
+  a `chat_defaults` value outranks the per-provider template. The moment a user turns
+  streaming on, usage capture silently stops: cost falls back to estimation and the cache
+  chip loses the ground truth it derives warm/cold from — the two things the ticker
+  exists to provide. Nothing warns them.
+
+Missed because PR1's verification targeted Anthropic and PR3's live verification ran
+against Anthropic only.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -75,4 +93,5 @@ Anthropic and PR3's live verification ran against Anthropic only.
 - [ ] #4 A test per provider drives a recorded SSE stream through the generator and asserts a usage chunk reaches the gateway with correct disjoint buckets
 - [ ] #5 A single guard test enumerates the streaming generators and fails if one emits no usage, so a newly added provider cannot silently regress
 - [ ] #6 Verified live against at least one OpenAI-compatible provider and one native translator that a streamed Console turn persists real `usage_json`
+- [ ] #7 `[api_settings.mistral]` gets an explicit `streaming` key so it stops differing from every other provider block by omission
 <!-- AC:END -->

--- a/backlog/tasks/task-2122 - Nine-of-eleven-providers-report-no-usage-on-the-streaming-path.md
+++ b/backlog/tasks/task-2122 - Nine-of-eleven-providers-report-no-usage-on-the-streaming-path.md
@@ -1,0 +1,78 @@
+---
+id: TASK-2122
+title: >-
+  Nine of eleven providers report no usage on the streaming path
+status: To Do
+assignee: []
+created_date: '2026-08-03 19:20'
+labels:
+  - cost-ticker
+  - llm-calls
+  - correctness
+priority: high
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The cost ticker's core promise is "real usage from the API, never an estimate." That
+holds for **OpenAI and Anthropic only**. An audit of every `stream_generator` in
+`LLM_Calls/LLM_API_Calls.py`, bounded by indentation so the non-streaming path in the
+same function is not miscounted, found that **nine of eleven providers emit no usage
+chunk at all when streaming** — and streaming is the Console default.
+
+| Provider | Streaming generator | Usage emitted |
+|---|---|---|
+| openai | 758-829 | yes (`stream_options`) |
+| anthropic | 1548-1741 | yes (PR1 work) |
+| cohere | 2363-2555 | **no** |
+| deepseek | 2950-2966 | **no** |
+| google | 3417-3541 | **no** |
+| groq | 3969-3992 | **no** |
+| huggingface | 4373-4416 | **no** |
+| mistral | 4740-4750 | **no** |
+| openrouter | 4993-5003 | **no** |
+| moonshot | 5363-5399 | **no** |
+| zai | 5691-5711 | **no** |
+
+Every one of these providers **does** handle usage on its non-streaming path, so the
+gap is invisible in any non-streaming test and looks like working code on inspection.
+
+There are two distinct root causes, needing two different fixes:
+
+**1. OpenAI-compatible passthroughs** (deepseek, groq, huggingface, mistral,
+openrouter, moonshot, zai). These generators are pure SSE relays — `for line in
+response.iter_lines(): yield line + "\n\n"` — so they would forward a usage chunk
+faithfully if one ever arrived. It never does: `stream_options: {"include_usage": True}`
+is set at **exactly one site**, line 649, inside `chat_with_openai`. These providers are
+simply never asked for usage. The fix is to request it, reusing the 400-degrade retry
+already proven on the OpenAI path (line 768) since not every compatible endpoint accepts
+the field.
+
+**2. Native-protocol translators** (cohere, google). These parse provider-shaped SSE and
+synthesize OpenAI-shaped chunks, so no payload flag can help — the translator has to read
+the usage and emit a chunk. Both drop data the provider is already sending:
+- Cohere's `message-end` branch (line 2485) reads `delta.finish_reason` and ignores
+  `usage`, even though the generator's own comment above it documents `message-end` as
+  carrying `(delta.finish_reason, usage)`. Cohere's non-streaming path already knows the
+  shape: `usage.billed_units.{input_tokens,output_tokens}` (line 2631).
+- Google's generator never reads `usageMetadata`, which Gemini sends on the final
+  streaming chunk. Its non-streaming path maps it at line 3637.
+
+Consequence: for nine providers the Console persists no `usage_json`, so cost falls back
+to estimation and the cache chip has no ground truth to report warm/cold from — the two
+things the ticker exists to provide. This was missed because PR1's verification targeted
+Anthropic and PR3's live verification ran against Anthropic only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `stream_options: {"include_usage": True}` is requested for the OpenAI-compatible providers, with the existing 400-degrade retry so endpoints that reject the field still stream
+- [ ] #2 Cohere's streaming `message-end` handler reads `usage.billed_units` and emits a usage chunk matching the non-streaming path's bucket mapping
+- [ ] #3 Google's streaming generator reads `usageMetadata` from the final chunk and emits a usage chunk matching its non-streaming mapping
+- [ ] #4 A test per provider drives a recorded SSE stream through the generator and asserts a usage chunk reaches the gateway with correct disjoint buckets
+- [ ] #5 A single guard test enumerates the streaming generators and fails if one emits no usage, so a newly added provider cannot silently regress
+- [ ] #6 Verified live against at least one OpenAI-compatible provider and one native translator that a streamed Console turn persists real `usage_json`
+<!-- AC:END -->

--- a/tldw_chatbook/Logging_Config.py
+++ b/tldw_chatbook/Logging_Config.py
@@ -420,6 +420,23 @@ def configure_application_logging(app_instance):
             _forward_loguru_to_standard,
             format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}",
             level="TRACE",
+            # task-2119 (security): diagnose=False is load-bearing, not
+            # cosmetic. With it left at loguru's default (True), any
+            # exception logged via `logger.opt(exception=True)` -- e.g. the
+            # provider request handlers in LLM_Calls/LLM_API_Calls.py, which
+            # hold the raw Authorization/x-api-key header and the resolved
+            # API key as frame locals -- has those locals dumped alongside
+            # the traceback. `_forward_loguru_to_standard` itself only reads
+            # `record["exception"]` (safe against stdlib's own, locals-free
+            # formatter), but loguru builds the diagnose-formatted text for
+            # *every* sink on this record regardless of what the sink does
+            # with it, so leaving this sink diagnose=True still means a
+            # secret-bearing string gets materialized on each such call.
+            # backtrace stays True: the exception type, message, and full
+            # stack of *source lines* are still logged -- only the per-frame
+            # local-variable dump is suppressed.
+            diagnose=False,
+            backtrace=True,
         )
         # This log message will also currently go to the initial basicConfig stderr handler
         logging.info(

--- a/tldw_chatbook/Metrics/logger_config.py
+++ b/tldw_chatbook/Metrics/logger_config.py
@@ -33,7 +33,18 @@ def setup_logger(
     """
 
     logger.remove()
-    logger.add(sys.stdout, level=log_level.upper(), format=console_format)
+    # task-2119 (security): explicit diagnose=False, backtrace=True -- see
+    # Logging_Config.py's matching sink for the full rationale. This sink is
+    # not known to be live in production, but "not known to be a production
+    # caller" was already wrong once for this module's file sinks (see the
+    # docstring above), so it does not get to default open.
+    logger.add(
+        sys.stdout,
+        level=log_level.upper(),
+        format=console_format,
+        diagnose=False,
+        backtrace=True,
+    )
     if app_log_path is not None or metrics_log_path is not None:
         warnings.warn(
             "Legacy Loguru file sinks are disabled; use application logging.",

--- a/tldw_chatbook/__init__.py
+++ b/tldw_chatbook/__init__.py
@@ -46,16 +46,26 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 # on `Logger.add`'s signature at that point, not a value read fresh on every
 # call -- and `Tests/conftest.py` imports loguru ahead of this package for
 # fixture-ordering reasons, which would otherwise defeat the env var alone
-# for the whole test session. The explicit `remove()` + `add(diagnose=False)`
+# for the whole test session. The explicit `remove(0)` + `add(diagnose=False)`
 # below is not subject to that ordering: it runs the moment this package is
 # imported, which is unconditionally required before any of its own
 # exception handlers can execute.
+#
+# Only loguru's auto-init sink (always handler id 0) is replaced. A host
+# application that configured loguru before importing this package keeps its
+# own sinks untouched -- if it removed the default sink, `remove(0)` raises
+# ValueError and this block installs nothing, because that host owns the
+# logging configuration (and any diagnose=True sink it installed on purpose).
 os.environ.setdefault("LOGURU_DIAGNOSE", "0")
 try:
     from loguru import logger as _pkg_init_loguru_logger
 
-    _pkg_init_loguru_logger.remove()
-    _pkg_init_loguru_logger.add(sys.stderr, diagnose=False)
+    try:
+        _pkg_init_loguru_logger.remove(0)
+    except ValueError:
+        pass
+    else:
+        _pkg_init_loguru_logger.add(sys.stderr, diagnose=False, backtrace=True)
 except Exception:
     # Logging safety must never be the reason package import fails.
     pass

--- a/tldw_chatbook/__init__.py
+++ b/tldw_chatbook/__init__.py
@@ -11,12 +11,54 @@ and advanced RAG (Retrieval-Augmented Generation) capabilities.
 # Disable progress bars early to prevent interference with TUI
 # This must be done before any libraries that use progress bars are imported
 import os
+import sys
 
 os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
 os.environ["TQDM_DISABLE"] = "1"
 os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+# task-2119 (security): Loguru's `diagnose` option defaults to True and, on
+# any record logged via `logger.opt(exception=True)`, dumps every stack
+# frame's LOCAL VARIABLES alongside the traceback -- not just the source
+# line. Provider request handlers in LLM_Calls/LLM_API_Calls.py hold the raw
+# `Authorization`/`x-api-key` header dict and the resolved API key in scope
+# across ~30 exception handlers; with diagnose left at its default, an
+# ordinary transient error (timeout, 429, connection reset) prints the live
+# credential in cleartext to whatever sink is active. Live-confirmed via a
+# genuine Moonshot 429 on 2026-08-03: a verification script that imported
+# this package's adapters directly (never running the real app's own
+# `Logging_Config.configure_application_logging`) hit loguru's auto-init
+# default sink, which was still diagnose=True.
+#
+# The real app's own sink, and `Metrics/logger_config.py`'s legacy sink,
+# both now also pass `diagnose=False` explicitly where they call
+# `logger.add(...)` -- that per-sink kwarg is the actual, order-independent
+# fix. This block additionally neutralizes loguru's own auto-init default
+# sink (created the instant anything, anywhere, does
+# `from loguru import logger`, before any application code has run) by
+# replacing it outright, and sets the library-wide default for any *future*
+# `logger.add(...)` call that forgets to pass `diagnose=` explicitly. Doing
+# both (not just the env var) matters: `LOGURU_DIAGNOSE` only takes effect
+# for a given `add()` call if it was set before loguru's `_logger.py` module
+# was first imported anywhere in the process -- it becomes a bound default
+# on `Logger.add`'s signature at that point, not a value read fresh on every
+# call -- and `Tests/conftest.py` imports loguru ahead of this package for
+# fixture-ordering reasons, which would otherwise defeat the env var alone
+# for the whole test session. The explicit `remove()` + `add(diagnose=False)`
+# below is not subject to that ordering: it runs the moment this package is
+# imported, which is unconditionally required before any of its own
+# exception handlers can execute.
+os.environ.setdefault("LOGURU_DIAGNOSE", "0")
+try:
+    from loguru import logger as _pkg_init_loguru_logger
+
+    _pkg_init_loguru_logger.remove()
+    _pkg_init_loguru_logger.add(sys.stderr, diagnose=False)
+except Exception:
+    # Logging safety must never be the reason package import fails.
+    pass
 
 
 def _install_textual_compatibility_shims() -> None:


### PR DESCRIPTION
## Summary

Loguru's `diagnose` option defaults to **True** and, on any record logged via `logger.opt(exception=True)`, dumps **every stack frame's local variables** alongside the traceback. The provider request handlers in `LLM_Calls/LLM_API_Calls.py` hold the raw `Authorization` / `x-api-key` header dict and the resolved API key in scope, so an ordinary transient error — timeout, 429, connection reset — wrote the live credential to the log sink in cleartext.

**This was live-confirmed, not theoretical:** a real Moonshot key was disclosed by a genuine HTTP 429 during multi-provider verification on 2026-08-03.

Pre-existing, not introduced by the cost-ticker program — `git blame` traces the sampled sites to #707 and #1235. It is also a **different surface** from the one #1295 closed: that work made the *debug payload logs* allowlist-shaped, whereas here the secret arrives via frame locals, so no amount of payload redaction touches it.

## Why the sink, not the call sites

The task described ~30 handlers. A sweep found **1,055** `opt(exception=True)` sites across `tldw_chatbook/`. Per-call-site patching was never viable, and one missed site reopens the hole. Three `logger.add()` registrations cover all 1,055 by construction:

| Sink | Role |
|---|---|
| `Logging_Config.py` | the real app's forwarding sink |
| `Metrics/logger_config.py` | legacy console sink |
| `__init__.py` | **the load-bearing one** — replaces loguru's auto-init default sink |

That third one is what the incident actually hit: the verification script imported the provider adapters directly and never called `configure_application_logging`, so the app's own sink was never installed. `configure_application_logging` calls `logger.remove()` before adding its own, so the package-init stderr sink is discarded in the real app — no duplicate TUI logging.

`backtrace=True` is kept throughout: exception type, message, and the stack of source lines still log. Only the per-frame local dump goes away. **`LLM_API_Calls.py` has a zero-line diff.**

## Test quality

The first version of the sink-config pin asserted `"diagnose=False" in <sliced source>`. **Mutation testing exposed it as vacuous** — the security rationale comment directly above the kwarg contains that same literal string, so deleting the real argument still passed. Rewritten to parse the call with `ast` and check actual keyword arguments, then re-verified against three mutations (remove the kwarg from either sink; flip it to `True`), each of which now fails.

The suite also carries a **positive control** asserting the sentinel *does* leak through a `diagnose=True` sink, so the regression test cannot pass for the wrong reason, plus an out-of-process test reproducing the incident's exact import shape. The sentinel test drives a real `ConnectionError` through `requests`' internals rather than a mocked session — a mocked `.post()` has no intermediate frames and does not reproduce the leak at all.

## Diagnostic inventory regeneration

`Docs/security/production-diagnostic-inventory.json` is regenerated. This was verified rather than assumed: the check script **already fails on clean `origin/dev`**, and regenerating there with zero of this branch's changes produces **204 of the 212 changed lines**. The snapshot predates #1235 and had never been refreshed. Reviewed line by line for anything suspicious — no new `diagnose=True`, no new sink; `persistent_sink_files` stays 6.

## Verification

- `Tests/Chat/test_sensitive_llm_logging.py` — 67 passed
- `Tests/Chat/` + `Tests/LLM_Calls/` — 3266 passed, 66 skipped, 0 failed
- Logging/architecture/privacy modules post-rebase — 89 passed
- `--collect-only` sweep — 28,515 collected; the 26 errors are missing optional deps (numpy, playwright), unrelated

Rebased onto latest `dev`.

## ⚠️ Requires an owner action

**The exposed Moonshot key still needs rotating.** AC#6 is deliberately left unchecked — no code change can close it.

Closes TASK-2119 (AC#1-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled `loguru` diagnose across all sinks and at package import to stop API key leaks from exception logs while keeping full backtraces. Completes TASK-2119 (AC#1–5) with hermetic tests and a refreshed diagnostic inventory.

- **Bug Fixes**
  - Set `diagnose=False, backtrace=True` on `logger.add(...)` in `tldw_chatbook/Logging_Config.py` and `tldw_chatbook/Metrics/logger_config.py`.
  - Package init now sets `LOGURU_DIAGNOSE=0`, replaces only loguru’s default sink via guarded `remove(0)`, and installs a safe stderr sink without clobbering host-configured sinks.
  - Stops frame-local dumps that exposed `Authorization`/`x-api-key` and `final_api_key`; no call-site changes.
  - Hardened tests: hermetic subprocess leak checks that scrub `LOGURU_*` env, a positive-control `diagnose=True` leak, AST keyword checks for sink kwargs, an incident-shape repro, and a host-sink preservation test.
  - Regenerated `Docs/security/production-diagnostic-inventory.json` after the sink change and reviewed topology.

- **Migration**
  - Rotate the exposed Moonshot API key.

<sup>Written for commit b0931f9324d22fe99a806548e9d17f98704c2d57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

