### PR TITLE
fix(library): ingest round-5 critique batch — reliable commit summary, honest failure details, durable Dismiss (task-2140)

### DIFF
--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -1524,7 +1524,9 @@ def test_expanded_details_render_unwrapped_lines_and_retry_hint():
     assert not any(
         line.startswith("Details:") for line in row.detail_lines
     ), "a Details line that repeats the summary is the round-4 P1"
-    assert any("retry can succeed" in line for line in row.detail_lines)
+    # (task-2140) Parse errors get corrupt-file advice, never network talk.
+    assert any("repair or re-export" in line for line in row.detail_lines)
+    assert not any("network" in line for line in row.detail_lines)
     assert not any("missing tooling" in line for line in row.detail_lines)
 
 
@@ -1811,3 +1813,34 @@ def test_option_errors_skip_hidden_groups_and_gated_fields():
     form.type_options["generic"] = {"chunk": False, "chunk_size": "abc"}
     gated_off = build_library_ingest_state((), form=form)
     assert gated_off.option_errors == ()
+
+
+def test_underlying_lines_skip_prefixed_restatements_of_the_row_error():
+    """(task-2140) A chain entry that merely restates the row's error
+    behind a "ClassName: " prefix must not render -- round 5 saw
+    "Underlying: FileIngestionError: <row error>" as the only detail."""
+    job = _job(
+        state=IngestJobState.FAILED,
+        source_path="/tmp/broken.pdf",
+        error="Failed to process pdf file: PDF Extraction Error.",
+        error_detail={
+            "category": "parse_error",
+            "exception_type": "FileIngestionError",
+            "message": "Failed to process pdf file: PDF Extraction Error.",
+            "chain": [
+                "FileIngestionError: Failed to process pdf file: PDF Extraction Error.",
+                "ValueError: startxref not found",
+            ],
+        },
+    )
+    state = build_library_ingest_state(
+        (job,),
+        form=LibraryIngestFormState(),
+        expanded_details={"ingest-job-1"},
+    )
+    row = state.queue_rows[0]
+    assert not any(
+        "FileIngestionError: Failed to process" in line
+        for line in row.detail_lines
+    ), "prefixed restatement of the row error leaked into the details"
+    assert "Underlying: ValueError: startxref not found" in row.detail_lines

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -13316,3 +13316,126 @@ async def test_clear_finished_keeps_recent_ledger_and_scrolls_confirm(tmp_path):
         assert state.queue_empty_line == "Queue is empty."
         recent = list(screen.query("#library-ingest-recent"))
         assert recent, "Recent ingests vanished after the clear"
+
+
+@pytest.mark.asyncio
+async def test_commit_summary_renders_for_text_selection_and_clears(tmp_path):
+    """(task-2140) The commit-summary Static was conditionally composed, so
+    a text-only pre-flight (non-structural apply) never mounted it and a
+    Clear left it stale ('0 will import · 1 will match' over an empty
+    field). Always-mounted + updater-owned: renders for plain text,
+    clears with the selection."""
+    db = MediaDatabase(tmp_path / "ingest-canvas.db", client_id="c5-commit")
+    harness = _LibraryIngestCanvasHarness(db)
+    staged = tmp_path / "report.txt"
+    staged.write_text("hello world")
+
+    async with harness.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = harness.screen_stack[-1]
+        await _wait_for_library_shell(screen, pilot)
+        await _open_library_ingest_canvas(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-ingest-path")
+
+        summary = screen.query_one("#library-ingest-commit-summary", Static)
+        assert summary.display is False, "no selection yet -- line must hide"
+
+        path_input = screen.query_one("#library-ingest-path", Input)
+        path_input.value = str(staged)
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if screen._library_ingest_form.preflight is not None:
+                break
+        else:
+            raise AssertionError("preflight never completed")
+        await pilot.pause()
+
+        current = screen.query_one("#library-ingest-commit-summary", Static)
+        assert current is summary, "line must be always-mounted (identity)"
+        assert current.display is True, (
+            "plain-text selection never mounted the commit summary "
+            "(the non-structural apply path)"
+        )
+        assert "1 will import" in str(current.renderable)
+
+        screen.query_one("#library-ingest-clear-path", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        cleared = screen.query_one("#library-ingest-commit-summary", Static)
+        assert cleared.display is False, (
+            "commit summary stayed visible (stale) after Clear"
+        )
+
+
+@pytest.mark.asyncio
+async def test_dismiss_preserves_failure_in_recent_ledger(tmp_path):
+    """(task-2140) Dismiss was the one destructive act that erased the
+    failure from every surface with zero friction -- the record now
+    survives in Recent ingests, marked dismissed."""
+    db = MediaDatabase(tmp_path / "ingest-canvas.db", client_id="c5-dismiss")
+    harness = _LibraryIngestCanvasHarness(db)
+    broken = tmp_path / "broken.pdf"
+    broken.write_bytes(b"%PDF-1.4\nnot really a pdf\n")
+
+    async with harness.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = harness.screen_stack[-1]
+        await _wait_for_library_shell(screen, pilot)
+
+        failing = harness.submit_library_ingest_job(source_path=str(broken))
+        for _ in range(_INGEST_POLL_ATTEMPTS):
+            jobs = {j.job_id: j.state for j in harness.library_ingest_jobs.jobs()}
+            if jobs.get(failing.job_id) == IngestJobState.FAILED:
+                break
+            await pilot.pause(_INGEST_POLL_INTERVAL)
+        else:
+            raise AssertionError("job never failed")
+
+        await _open_library_ingest_canvas(screen, pilot)
+        await _wait_for_selector(
+            screen, pilot, f"#library-ingest-dismiss-{failing.job_id}"
+        )
+        screen.query_one(
+            f"#library-ingest-dismiss-{failing.job_id}", Button
+        ).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        state = screen._build_library_ingest_state()
+        assert [job.job_id for job in state.recent_jobs] == [failing.job_id], (
+            "Dismiss erased the failure from the Recent ledger"
+        )
+        assert getattr(state.recent_jobs[0], "dismissed", False) is True
+        recent = list(screen.query("#library-ingest-recent"))
+        assert recent, "Recent ingests must render the dismissed record"
+
+
+@pytest.mark.asyncio
+async def test_start_click_immediately_after_typing_submits(tmp_path):
+    """(task-2140 pin) One live report of a dead Start click at the commit
+    moment (unreproduced) -- pin the type-then-immediately-click path so a
+    real first-click swallow can never hide as driving noise."""
+    db = MediaDatabase(tmp_path / "ingest-canvas.db", client_id="c5-deadclick")
+    harness = _LibraryIngestCanvasHarness(db)
+    staged = tmp_path / "report.txt"
+    staged.write_text("hello world")
+
+    async with harness.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = harness.screen_stack[-1]
+        await _wait_for_library_shell(screen, pilot)
+        await _open_library_ingest_canvas(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-ingest-path")
+
+        path_input = screen.query_one("#library-ingest-path", Input)
+        path_input.focus()
+        await pilot.pause()
+        path_input.value = str(staged)
+        # Immediately click Start -- within the debounce window, before
+        # any pre-flight lands.
+        await pilot.pause()
+        await pilot.click("#library-ingest-start")
+        for _ in range(_INGEST_POLL_ATTEMPTS):
+            if harness.library_ingest_jobs.jobs():
+                break
+            await pilot.pause(_INGEST_POLL_INTERVAL)
+        assert harness.library_ingest_jobs.jobs(), (
+            "first Start click after typing did not submit"
+        )

--- a/backlog/tasks/task-2140 - Library-ingest-round-5-critique-batch.md
+++ b/backlog/tasks/task-2140 - Library-ingest-round-5-critique-batch.md
@@ -1,0 +1,106 @@
+---
+id: TASK-2140
+title: >-
+  Library ingest round-5 critique batch (commit-summary regression, failure-aftermath P1s, confirm at scale)
+status: In Progress
+assignee: []
+created_date: '2026-08-04 03:00'
+labels:
+  - library
+  - ingest
+  - ux
+priority: high
+dependencies: []
+---
+
+## Description (the why)
+
+The round-5 dual-agent critique (snapshot `2026-08-04T02-23-46Z…`, 26/40 —
+trend 21 → 24 → 29 → 25 → 26; every round-4 fix verified holding by both
+agents) found the remaining defects concentrated in the failure
+aftermath, plus one self-inflicted round-4 regression. Owner: fix
+everything now.
+
+1. **[P2, regression] The commit-summary line is unreliable** — it is a
+   conditionally-composed canvas-level Static (the round-3
+   empty-Recent bug class, reintroduced by task-2130): a text-only
+   pre-flight applies via the non-structural in-place path, which never
+   mounts it (deterministic: PDF selections render "1 will import",
+   plain-text selections never do), and after Clear it goes STALE
+   ("0 will import · 1 will match" above an empty field).
+2. **[P1] "Show details" adds no substance and the advisory misleads:**
+   the "Underlying:" line repeats the row's error verbatim (the worker
+   dedups chain entries against the message STRING, but entries carry a
+   `ClassName: ` prefix, so equality never fires), and the retry
+   advisory suggests "a network hiccup" for a local parse failure.
+3. **[P1] Dismiss destroys the only record of a failure with zero
+   friction** — after Dismiss the failure is gone from the queue, the
+   summary, AND Recent ingests, while the less-destructive Clear
+   finished has a two-press confirm.
+4. **[P2] The armed clear-finished confirm can hide at queue scale:**
+   with a ~9-row queue the arming press scroll-jumped the pane leaving
+   "Press again…" below the fold (a 2-row queue passes) — the queue
+   panel recompose resets scroll before/despite the `scroll_visible`
+   call.
+5. **[P2, suspected] One unreproduced dead Start click** at the commit
+   moment — pin the type-then-immediately-click-Start path with a
+   regression test and record the investigation.
+
+## Acceptance Criteria (the what)
+
+- [x] The commit-summary line renders for ANY valid selection (plain
+      text, PDF, folder) regardless of which update path applied the
+      pre-flight, and clears when the selection clears — always-mounted,
+      display-managed, owned by the in-place updater.
+- [x] No expanded detail line repeats the row's error text (prefix
+      differences do not defeat the comparison); the retry advisory for
+      parse errors talks about corrupt files, not network hiccups —
+      network/transient copy is reserved for non-parse categories.
+- [x] Dismissing a failed row preserves it in Recent ingests (marked
+      dismissed where representable); the failure record survives on at
+      least one surface.
+- [x] The armed clear-finished confirm is visible after the arming press
+      with a tall queue (scroll ordered after layout settles).
+- [x] A Start click immediately after typing submits on the first click
+      (regression-pinned); the dead-click observation is recorded with
+      the investigation outcome.
+
+## Implementation Plan (the how)
+
+Five fixes in one pass (owner: "fix everything now"): (1) commit-summary
+Static → always-mounted/display-managed/updater-owned; (2) prefix-aware
+chain dedup + advisory-by-category; (3) dismissed failures → Recent
+ledger with "(dismissed)" suffix; (4) call_after_refresh for the armed
+confirm scroll; (5) type-then-click-Start regression pin.
+
+## Implementation Notes
+
+- **Commit summary (regression):** the conditional compose was the
+  round-3 empty-Recent bug class reintroduced — the non-structural
+  pre-flight apply path never mounts a conditionally-composed
+  canvas-level element. Now always mounted; the in-place updater owns
+  content + visibility. Live-verified: "1 will import" renders for a
+  plain-text selection (the deterministic FAIL case) and clears with
+  the field.
+- **Details substance:** chain entries are compared after stripping the
+  "ClassName: " prefix and unwrapping, against both the structured
+  message and the job's own error — a prefixed restatement never
+  renders. Parse-error advisory now: "If the file is corrupt or
+  truncated, repair or re-export it, then Retry." (network/transient
+  copy reserved for non-parse categories).
+- **Dismiss ledger:** `registry.dismiss()` returns the job; the handler
+  prepends it to `_library_ingest_recent_ledger` (dedup, cap 10) and
+  Recent renders a " (dismissed)" suffix off the job's own flag.
+- **Confirm at scale:** the arming branch defers `scroll_visible` via
+  `call_after_refresh`, querying the post-recompose button inside the
+  callback (immediate scrolls aimed at pre-refresh geometry on tall
+  queues).
+- **Dead Start click:** not reproducible in the harness; pinned by
+  `test_start_click_immediately_after_typing_submits` (click within the
+  debounce window, before any pre-flight lands → job submitted). If the
+  live observation recurs, the pin separates app defect from driving
+  noise.
+
+**Verification.** 243 core + 71 shell-subset targeted tests green;
+29,363 collect cleanly. Live on a fresh isolated profile: commit line
+for text + clears on Clear.

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -939,7 +939,19 @@ def _build_queue_row(
         if message and message != unwrap_ingest_error(str(job.error or "")):
             lines.append(f"Details: {message}")
         chain = job.error_detail.get("chain") or ()
+        # (task-2140) The worker dedups chain entries against the bare
+        # message, but entries carry a "ClassName: " prefix -- strip it
+        # before comparing, so an entry that merely restates the row's
+        # error (round 5: "Underlying: FileIngestionError: <row error>")
+        # never renders.
+        known_texts = {
+            message,
+            unwrap_ingest_error(str(job.error or "")),
+        }
         for underlying in tuple(chain)[:3]:
+            text_part = str(underlying).split(": ", 1)[-1]
+            if unwrap_ingest_error(text_part) in known_texts:
+                continue
             lines.append(f"Underlying: {underlying}")
         if row.can_retry:
             dependency = _missing_dependency_from(message, tuple(chain))
@@ -947,6 +959,14 @@ def _build_queue_row(
                 lines.append(
                     f"Missing dependency: {dependency}. Install it, then "
                     "Retry."
+                )
+            elif category == "parse_error":
+                # (task-2140) No network talk for a local parse failure --
+                # round 5 flagged "a network hiccup" advice on a corrupt
+                # local PDF as trust-eroding.
+                lines.append(
+                    "If the file is corrupt or truncated, repair or "
+                    "re-export it, then Retry."
                 )
             else:
                 lines.append(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6057,6 +6057,19 @@ class LibraryScreen(BaseAppScreen):
         # Display-managed canvas-level bits + the gate.
         for intro in canvas.query(".library-ingest-intro"):
             intro.display = bool(new_state.intro_lines)
+        # (task-2140) The commit-summary line is canvas-level and
+        # display-managed -- update content and visibility here so a
+        # non-structural pre-flight apply (or a Clear) can never leave it
+        # unmounted or stale.
+        try:
+            commit_summary = canvas.query_one(
+                "#library-ingest-commit-summary", Static
+            )
+        except (NoMatches, QueryError):
+            pass
+        else:
+            commit_summary.update(new_state.commit_summary_line)
+            commit_summary.display = bool(new_state.commit_summary_line)
         try:
             clear_button = canvas.query_one(
                 "#library-ingest-clear-path", Button
@@ -14131,7 +14144,21 @@ class LibraryScreen(BaseAppScreen):
         if callable(dismiss):
             # Same id-based no-op safety as retry above -- ``dismiss`` only
             # ever acts on a currently-FAILED, not-yet-hidden job_id.
-            dismiss(job_id)
+            dismissed_job = dismiss(job_id)
+            # (task-2140) Dismiss was the one destructive act that erased
+            # the failure from EVERY surface with zero friction -- the
+            # dismissed record now survives in the Recent-ingests ledger,
+            # marked as dismissed.
+            if dismissed_job is not None:
+                known = {
+                    job.job_id
+                    for job in self._library_ingest_recent_ledger
+                }
+                if dismissed_job.job_id not in known:
+                    self._library_ingest_recent_ledger = [
+                        dismissed_job,
+                        *self._library_ingest_recent_ledger,
+                    ][:10]
         self._library_ingest_expanded_details.discard(job_id)
         # (task-2100) In place: the registry listener already updated the
         # queue; a trailing full recompose here yanked the scroll off the
@@ -14184,17 +14211,24 @@ class LibraryScreen(BaseAppScreen):
             self._update_library_ingest_dynamic_regions()
             # (task-2130) The armed confirm must be seen to be answerable:
             # with the button at the viewport's bottom edge the relabel
-            # landed off-screen and the press read as a no-op. The update
-            # above recomposes the queue panel, so query the CURRENT
-            # button.
-            try:
-                armed_button = self.query_one(
-                    "#library-ingest-clear-finished", Button
-                )
-            except (NoMatches, QueryError):
-                pass
-            else:
+            # landed off-screen and the press read as a no-op.
+            # (task-2140) With a TALL queue the panel recompose above has
+            # not laid out yet when this runs -- an immediate
+            # scroll_visible aimed at pre-refresh geometry and the pane
+            # then jumped to the queue top with the confirm below the
+            # fold. Defer the scroll until after the refresh settles, and
+            # query the button inside the callback (the recompose replaces
+            # it).
+            def _scroll_armed_confirm_into_view() -> None:
+                try:
+                    armed_button = self.query_one(
+                        "#library-ingest-clear-finished", Button
+                    )
+                except (NoMatches, QueryError):
+                    return
                 armed_button.scroll_visible()
+
+            self.call_after_refresh(_scroll_armed_confirm_into_view)
             return
         self._library_ingest_clear_finished_armed = False
         self._library_ingest_expanded_details.clear()

--- a/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_ingest_canvas.py
@@ -316,8 +316,14 @@ class LibraryIngestQueuePanel(Vertical):
                 id="library-ingest-recent",
             ):
                 for job in state.recent_jobs:
+                    dismissed_suffix = (
+                        " (dismissed)"
+                        if getattr(job, "dismissed", False)
+                        else ""
+                    )
                     yield Static(
-                        f"{escape_markup(job.source_path)} — {job.state.value}",
+                        f"{escape_markup(job.source_path)} — "
+                        f"{job.state.value}{dismissed_suffix}",
                         classes="library-ingest-recent-item",
                         markup=False,
                     )
@@ -743,13 +749,21 @@ class LibraryIngestCanvas(VerticalScroll):
         # line's row when the text is empty (an auto-height empty Static
         # would collapse to 0); the screen's path-changed handler updates
         # the text in place instead of mounting/removing the widget.
-        if state.commit_summary_line:
-            yield Static(
-                state.commit_summary_line,
-                id="library-ingest-commit-summary",
-                classes="library-ingest-quiet-line",
-                markup=False,
-            )
+        # (task-2140) Always mounted, display-managed: the conditional
+        # compose reintroduced the round-3 empty-Recent bug class -- a
+        # text-only pre-flight applies via the NON-structural in-place
+        # path, which never mounts a conditionally-composed canvas-level
+        # element (PDF selections rendered the line, plain text never),
+        # and after Clear the stale line survived. The in-place updater
+        # owns its content and visibility.
+        commit_summary = Static(
+            state.commit_summary_line,
+            id="library-ingest-commit-summary",
+            classes="library-ingest-quiet-line",
+            markup=False,
+        )
+        commit_summary.display = bool(state.commit_summary_line)
+        yield commit_summary
         start_quiet_line = Static(
             state.start_quiet_line,
             id="library-ingest-start-quiet-line",


### PR DESCRIPTION
## Summary

Fixes the round-5 dual-agent critique findings (snapshot `2026-08-04T02-23-46Z…`, 26/40 — trend 21 → 24 → 29 → 25 → 26; both agents verified every round-4 fix holding).

- **Commit-summary regression (round-4 self-inflicted):** the line was conditionally composed at canvas level — the round-3 empty-Recent bug class reintroduced. A text-only pre-flight applies via the NON-structural in-place path, which never mounts a conditional canvas element (deterministic: PDFs rendered "1 will import", plain text never), and after Clear the stale line survived ("0 will import · 1 will match" over an empty field). Now always-mounted, display-managed, owned by `_update_library_ingest_dynamic_regions`. Live-verified both directions.
- **Failure details (P1):** chain entries dedup against the row error AFTER stripping the `ClassName: ` prefix and unwrapping — "Underlying: FileIngestionError: <row error>" can no longer render as the only 'detail'. The parse-error retry advisory now talks about corrupt/truncated files, never "a network hiccup" (transient copy reserved for non-parse categories).
- **Dismiss (P1):** the one destructive act with zero friction no longer erases the only failure record — `registry.dismiss()`'s returned job is prepended to the Recent-ingests session ledger and rendered with a " (dismissed)" suffix.
- **Confirm at scale (P2):** the armed "Press again…" scroll is deferred via `call_after_refresh` with the button queried inside the callback — immediate scrolls aimed at pre-refresh geometry on tall queues, leaving the confirm below the fold.
- **Dead Start click (P2 suspected, unreproduced):** pinned by a type-then-immediately-click-Start regression test (submits within the debounce window); recorded as investigated.

## Tests
243 core (state/canvas/runner) + 71 shell-subset targeted green; 29,363 collect cleanly. New: always-mounted commit-summary identity test (mount + clear), dismiss-ledger survival, prefixed-restatement chain dedup, advisory-category pin, dead-click pin. Live-verified on a fresh isolated profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes round‑5 critique items in the library ingest flow to make commit summaries reliable, failure details honest, and dismisses durable. Addresses Linear TASK‑2140.

- **Bug Fixes**
  - Commit summary is always mounted and display‑managed. Updates via the screen updater so it renders for plain‑text selections and clears after Clear.
  - Failure details no longer repeat the row error. Chain entries dedup after stripping the `ClassName: ` prefix. Parse errors now advise repair/re‑export, not “network hiccup.”
  - Dismiss keeps a record. The dismissed job is added to Recent ingests with a “(dismissed)” suffix.
  - Clear‑finished confirm stays visible on tall queues. Scroll is deferred with `call_after_refresh` so “Press again…” appears in view.
  - Regression pin: typing then immediately clicking Start submits on the first click.

<sup>Written for commit 5af0f415e0aed4e644d469fea5e7a2164a512987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

