### PR TITLE
docs(readme): surface Console voice conversation + hands-free quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,19 @@ All chat features listed here work with the core installation:
 - **Notification system**: Alert on new content
 - **Flexible scheduling**: Configure update frequencies
 
+### Voice Conversation in the Console (Hands-Free)
+Talk to the Console instead of typing. Three layers, each usable on its own:
+- **Dictation**: press the mic button in the Console composer and speak; the transcript lands in your draft.
+- **Spoken commands**: "Console, send.", "Console, stop.", "Console, discard.", and more — drive the capture by voice.
+- **Hands-free loop** (`Ctrl+Shift+H` or "Console, hands free."): speak, pause, it sends; the reply is spoken back sentence by sentence; the microphone reopens for your next turn. Any key interrupts the reply; `Esc`, the mic button, or `Ctrl+Shift+H` exit.
+
+Quickstart:
+1. **Microphone + STT**: `pip install -e ".[speech_recording,transcription_parakeet]"` (macOS; use `transcription_faster_whisper` elsewhere). The first-run wizard's Speech step can also set this up.
+2. **A voice for replies** (needed for spoken feedback and the hands-free loop): configure any TTS provider under `[app_tts]` — an OpenAI API key is the fastest start; a local [audio.cpp](https://github.com/0xShug0/audio.cpp) server is the recommended local option.
+3. Open the Console, press the mic (or `Ctrl+Shift+H`), and talk.
+
+Full walkthrough — including every spoken command, hands-free timing, barge-in modes, and local TTS server setup — in the [Speech Services User Guide](Docs/Features/Speech-Services-Guide.md).
+
 ### Text-to-Speech System
 Comprehensive TTS support with multiple backends:
 - **OpenAI TTS**: High-quality cloud-based synthesis


### PR DESCRIPTION
Adds a 'Voice Conversation in the Console (Hands-Free)' section to the README feature list: the three layers (dictation, spoken commands, hands-free loop), a three-step quickstart with the correct pip extras (`speech_recording` + `transcription_parakeet`/`transcription_faster_whisper`), the up-front note that reply speech needs a TTS provider under `[app_tts]`, and a link to the full Speech Services User Guide.

Follows up #1296, which shipped the hands-free loop and its guide documentation but left no README-level pointer — a new user had no way to discover the feature existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Voice Conversation in the Console (Hands‑Free)” quickstart to the README so new users can discover voice features and set them up correctly. This surfaces dictation, spoken commands, and the hands‑free loop, and calls out the TTS requirement to avoid silent replies.

- **New Features**
  - New README section describing dictation, spoken commands, and the hands‑free loop (toggle with Ctrl+Shift+H).
  - Quickstart install paths using `speech_recording` with `transcription_parakeet` (macOS) or `transcription_faster_whisper` (others).
  - Clear note that spoken replies require a TTS provider configured under `[app_tts]`.
  - Link to the Speech Services User Guide for full setup and commands.

<sup>Written for commit f9e6487abe6dd239e577efd55857404bb0c66548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

