### PR TITLE
chore: mark task-1960 Done (PR #1315 merged)

### DIFF
--- a/backlog/tasks/task-1960 - SelectCurrent-label-mount-race-on-watchlists-form-close.md
+++ b/backlog/tasks/task-1960 - SelectCurrent-label-mount-race-on-watchlists-form-close.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1960
 title: SelectCurrent #label mount race on the Watchlists Sources form-close recompose
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-02 17:20'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark TASK-1960 (SelectCurrent label mount race on Watchlists Sources form close) as Done in the backlog to reflect that the fix shipped in PR #1315.

<sup>Written for commit ffa19dd7c933a65dbc31c8f8da06724901361793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

