### PR TITLE
chore: file task-2200 (Watchlists recompose root cause, from task-1960)

### DIFF
--- a/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
+++ b/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
@@ -1,0 +1,63 @@
+---
+id: TASK-2200
+title: Watchlists screen stops full-screen recomposing from background loaders
+status: To Do
+assignee: []
+created_date: '2026-08-04'
+labels:
+  - watchlists
+  - ui
+  - tech-debt
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+The Watchlists screen's background loaders request full-screen recomposes:
+`_apply_local_wc_snapshot` (watchlists_collections_screen.py:983) and
+`_load_tree_data` (:912) call `refresh(recompose=True)` at screen level, tearing
+down and rebuilding the entire centre — including panes that are mid-recompose
+of their own.
+
+This is the architectural root cause behind TASK-1960's crash class, confirmed
+empirically during that investigation: `App._prune` stamps `_pruning` over a
+`walk_children` snapshot, `Widget.mount` silently mounts nothing on a pruned
+widget, and `MessagePump._pre_process`'s `finally` marks it mounted anyway — so
+any widget whose `_on_mount` queries its own children can crash when a screen
+recompose lands mid-mount. TASK-1960 shipped `PruneSafeSelect` as the
+mechanism-level guard for `Select`, but the guard covers one widget class, not
+the hazard: any other composite widget mounted by these rebuilds is exposed the
+same way.
+
+A second latent defect is masked by the same behaviour: `SourcesPane`'s
+form-close recompose silently mounts *nothing* when the screen prunes it
+mid-flight — invisible today only because the screen's own recompose immediately
+rebuilds the pane. If a future change stops the screen rebuilding the pane on
+that path, form-close visibly breaks.
+
+This is also TASK-1541's standing recommendation (recorded there as "open rec,
+documented, not filed"): replace recompose-the-world refresh paths with the
+targeted in-place update discipline the screen already uses elsewhere
+(`update_item_status_cell`, `refresh_header_content`).
+
+## Acceptance Criteria (the what)
+
+- [ ] Completing a background load (`_load_tree_data`) or applying a local
+      watchlists snapshot (`_apply_local_wc_snapshot`) no longer rebuilds the
+      whole screen: the affected panes/regions are updated in place, and
+      unrelated in-flight pane recomposes (e.g. the Sources create-form
+      open/close) are not torn down by it.
+- [ ] The rendered result after a background refresh is equivalent to what the
+      full recompose produced today, covering the overview/first-run/loading
+      states (the TASK-1347-strengthened tests stay green).
+- [ ] The TASK-1960 e2e reproduction
+      (`test_a_source_can_be_created_end_to_end_through_the_form`) stays green
+      10/10 in isolation and in the poisoned order after
+      `Tests/UI/test_watchlists_content_pane.py` — now with the destroyer
+      removed rather than merely guarded against.
+- [ ] The masked SourcesPane defect is addressed or made impossible: closing the
+      create form yields a correctly-populated pane without depending on a
+      screen-level rebuild to paper over an empty recompose.
+- [ ] `PruneSafeSelect` remains in place as defense-in-depth (this task removes
+      the known destroyer; it does not un-fix TASK-1960).


### PR DESCRIPTION
Files the architectural follow-up that task-1960's investigation, whole-branch review, and Qodo's assessment each independently recommended. Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog task TASK-2200 to stop full-screen recomposes on the Watchlists screen triggered by background loaders. Documents the root cause from TASK-1960, and sets acceptance criteria for targeted in-place updates, preserving e2e coverage and keeping `PruneSafeSelect` as defense-in-depth.

<sup>Written for commit a8c99af9a4527d9c3b29de8e09c1564b4e789fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

