### PR TITLE
fix(library): dev is broken — SyntaxError in library_screen.py (constant merged into decorator slot)

### DIFF
--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -14298,11 +14298,11 @@ class LibraryScreen(BaseAppScreen):
             self._library_ingest_expanded_details.add(job_id)
         self._update_library_ingest_dynamic_regions()
 
-    @on(Button.Pressed, "#library-ingest-clear-finished")
     #: Presses landing this soon after the arming press are the same
     #: physical gesture (a double-click), not a decision (task-2160).
     _CLEAR_FINISHED_DEAD_ZONE_SECONDS = 0.3
 
+    @on(Button.Pressed, "#library-ingest-clear-finished")
     def handle_library_ingest_clear_finished(self, event: Button.Pressed) -> None:
         """Clear every done+failed ingest job in one shot (L3b AB wave, B2).
 


### PR DESCRIPTION
Current dev tip cannot import `library_screen` at all: a merge placed `_CLEAR_FINISHED_DEAD_ZONE_SECONDS = 0.3` (with its `#:` comments) between `@on(Button.Pressed, "#library-ingest-clear-finished")` and its function def — `SyntaxError` at line 14304, every Library/Console suite fails at collection.

Fix: constant moved above the decorator (class-body level, where its `#:` doc comments belong); handler untouched. `ast.parse` clean; the handler's owning suite (`test_library_shell.py`, 305 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a SyntaxError in `library_screen.py` that broke imports on dev. Moved `_CLEAR_FINISHED_DEAD_ZONE_SECONDS` out of the decorator slot so the file loads and tests run again.

- **Bug Fixes**
  - Relocated the constant above `@on(Button.Pressed, "#library-ingest-clear-finished")`.
  - Handler unchanged; no behavior change.

<sup>Written for commit 36a6b3ec55d9c5621ff226bce18c66fb4883d5a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

