### PR TITLE
fix(roleplay): UX review fixes — designed first paint, honest actions, reachable toolbar (12 tasks)

### DIFF
--- a/Tests/UI/test_command_palette_providers.py
+++ b/Tests/UI/test_command_palette_providers.py
@@ -353,10 +353,9 @@ class TestTabNavigationProvider:
             "Console",
             "Library",
             "Artifacts",
-            # task-435: the personas destination's palette command uses the
-            # full accessible label (destination.full_label), not the short
-            # "Roleplay" rail label -- see the dedicated assertion below.
-            "Roleplay & Chat Dictionaries",
+            # F-034: one public name everywhere - the palette command uses
+            # the same "Roleplay" label as the nav rail and screen header.
+            "Roleplay",
             "Watchlists",
             "Schedules",
             "Workflows",

--- a/Tests/UI/test_command_palette_shell_routes.py
+++ b/Tests/UI/test_command_palette_shell_routes.py
@@ -95,7 +95,9 @@ def test_legacy_routes_are_searchable_alias_terms_on_their_destination():
         "roleplay",
     } <= alias_terms["personas"]
     assert "Roleplay" in alias_terms["personas"]  # TAB_CCP display label, deduped to one command
-    assert "Roleplay & Chat Dictionaries" in alias_terms["personas"]
+    # F-034: "Roleplay" is the one public name; the retired long form no
+    # longer rents a search term either.
+    assert "Roleplay & Chat Dictionaries" not in alias_terms["personas"]
     assert "personas" in alias_terms["personas"]  # still searchable via id/primary_route
     assert {"subscriptions", "subscription", "Subscriptions"} <= alias_terms[
         "watchlists_collections"

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -4135,7 +4135,7 @@ async def test_console_settings_modal_save_as_default_writes_through_config(
     # The model is written here as well as into api_settings: chat_defaults.model
     # is what `resolve_effective_provider_model` feeds to the session builder as
     # an explicit override, so omitting it left a stale model winning in every
-    # new session (roleplay UAT: character "Start Chat" silently reverted to the
+    # new session (roleplay UAT: character "Chat now" silently reverted to the
     # model onboarding had auto-picked).
     assert sections["chat_defaults"] == {
         "streaming": False,
@@ -4693,7 +4693,7 @@ async def test_console_settings_modal_discover_rejects_invalid_endpoint_url() ->
 # [api_settings.<provider>].model, leaving [chat_defaults].model stale. Because
 # `resolve_effective_provider_model` reads chat_defaults.model and passes it as an
 # explicit override into `build_default_console_session_settings` (where it
-# outranks api_settings), every NEW session -- new tab, character "Start Chat",
+# outranks api_settings), every NEW session -- new tab, character "Chat now",
 # app relaunch -- silently reverted to the old model.
 
 

--- a/Tests/UI/test_destination_visual_parity_correction.py
+++ b/Tests/UI/test_destination_visual_parity_correction.py
@@ -1904,7 +1904,7 @@ async def test_personas_workbench_exposes_approved_three_column_ia():
         assert "Column 1:" not in visible_text
         assert "Column 2:" not in visible_text
         assert "Column 3:" not in visible_text
-        assert {"Characters", "Personas", "New", "Attach to Console"}.issubset(buttons)
+        assert {"Characters", "Personas", "New", "Chat now"}.issubset(buttons)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_personas_character_widgets.py
+++ b/Tests/UI/test_personas_character_widgets.py
@@ -76,10 +76,28 @@ class TestCharacterCard:
         async with app.run_test() as pilot:
             assert pilot.app.query_one("#personas-character-card-empty").display is True
             assert pilot.app.query_one("#personas-character-card-body").display is False
-            assert (
-                pilot.app.query_one("#personas-card-edit-character", Button).disabled
-                is True
-            )
+            edit = pilot.app.query_one("#personas-card-edit-character", Button)
+            assert edit.disabled is True
+            # F-037: the disabled Edit says why.
+            assert edit.tooltip == "Select a character to edit."
+
+    async def test_edit_tooltip_explains_unsaved_record_state(self):
+        """F-037: an id-less (never-saved) card keeps Edit disabled with a reason."""
+        app = WidgetApp()
+        async with app.run_test() as pilot:
+            card = pilot.app.query_one(PersonasCharacterCardWidget)
+            record = dict(CHARACTER)
+            record.pop("id")
+            card.load_character(record)
+            await pilot.pause()
+            edit = pilot.app.query_one("#personas-card-edit-character", Button)
+            assert edit.disabled is True
+            assert edit.tooltip == "This character has no saved record to edit."
+            # A saved record re-enables Edit and drops the reason.
+            card.load_character(dict(CHARACTER))
+            await pilot.pause()
+            assert edit.disabled is False
+            assert edit.tooltip is None
 
     async def test_load_populates_fields_and_enables_edit(self):
         app = WidgetApp()

--- a/Tests/UI/test_personas_character_world_books_screen.py
+++ b/Tests/UI/test_personas_character_world_books_screen.py
@@ -381,13 +381,23 @@ class TestCharacterAttachmentsWrapperGating:
         worldbooks_db,
         seeded_character_with_worldbook,
         stub_characters_for_worldbooks,
+        monkeypatch,
     ):
+        # F-031: a non-empty library auto-selects its first row on first
+        # paint (which shows the card and this wrapper), so the no-selection
+        # state this test pins needs an empty library.
+        monkeypatch.setattr(
+            character_handler_module, "fetch_all_characters", lambda: []
+        )
         mock_app_instance.chachanotes_db = worldbooks_db
         mock_app_instance.chat_dictionary_scope_service = None
 
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(200, 60)) as pilot:
             screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert not screen.state.selected_entity_id
             wrapper = screen.query_one("#personas-character-attachments")
             assert wrapper.display is False, (
                 "the world-books/dictionaries wrapper must not be visible "

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -174,6 +174,39 @@ async def test_non_character_selections_hide_conversations_section():
         )
 
 
+async def test_disabled_actions_carry_reason_tooltips_without_selection():
+    """F-037: every disabled inspector action explains why - even in the
+    pre-selection state (hidden on the screen, but the pane contract holds)."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        expectations = {
+            "#personas-start-chat": "Pick a character or persona to start chatting.",
+            "#personas-attach-to-console": (
+                "Pick a character or persona to start chatting."
+            ),
+            "#personas-export-json": "Select an item to export.",
+            "#personas-export-png": "Select an item to export.",
+            "#personas-delete": "Select an item to delete.",
+        }
+        for button_id, expected_tooltip in expectations.items():
+            button = pilot.app.query_one(button_id, Button)
+            assert button.disabled is True, button_id
+            assert button.tooltip == expected_tooltip, button_id
+
+
+async def test_blocked_console_tooltip_uses_intent_copy():
+    """F-037: a screen-blocked Console action explains itself in intent copy."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(name="Tutor", kind="character")
+        pane.set_console_actions_enabled(False, reason="prompts are not attachable")
+        await pilot.pause()
+        attach = pilot.app.query_one("#personas-attach-to-console", Button)
+        assert attach.disabled is True
+        assert attach.tooltip == "Chat blocked: prompts are not attachable"
+
+
 async def test_readiness_copy_is_compact_for_narrow_inspector():
     app = InspectorApp()
     async with app.run_test(size=(24, 20)) as pilot:

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -38,9 +38,85 @@ async def test_default_state_shows_no_selection_and_disabled_actions():
             "#personas-delete",
         ):
             assert pilot.app.query_one(button_id, Button).disabled is True
-        assert "Console blocked" in str(
+        assert str(
             pilot.app.query_one("#personas-readiness-console", Static).renderable
+        ) == "Pick a character or persona to start chatting."
+
+
+async def test_no_selection_shows_single_guidance_line():
+    """F-031: pre-selection the inspector is one plain guidance line - no
+    wall of disabled buttons, no dangling section headers, no false
+    "Validation: OK"."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        assert (
+            pilot.app.query_one("#personas-inspector-actions").display is False
         )
+        assert (
+            pilot.app.query_one("#personas-conversations-header", Static).display
+            is False
+        )
+        assert (
+            pilot.app.query_one("#personas-conversations-list", ListView).display
+            is False
+        )
+        assert (
+            pilot.app.query_one("#personas-readiness-header", Static).display
+            is False
+        )
+        assert (
+            pilot.app.query_one("#personas-validation-summary", Static).display
+            is False
+        )
+        guidance = pilot.app.query_one("#personas-readiness-console", Static)
+        assert guidance.display is True
+        assert (
+            str(guidance.renderable)
+            == "Pick a character or persona to start chatting."
+        )
+
+
+async def test_selection_reveals_inspector_sections():
+    """F-031: selecting an item wakes the whole inspector back up."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(name="Detective Sam", kind="character")
+        await pilot.pause()
+        assert (
+            pilot.app.query_one("#personas-inspector-actions").display is True
+        )
+        assert (
+            pilot.app.query_one("#personas-conversations-header", Static).display
+            is True
+        )
+        assert (
+            pilot.app.query_one("#personas-conversations-list", ListView).display
+            is True
+        )
+        assert (
+            pilot.app.query_one("#personas-readiness-header", Static).display
+            is True
+        )
+        assert (
+            pilot.app.query_one("#personas-validation-summary", Static).display
+            is True
+        )
+
+
+async def test_validation_line_stays_hidden_until_first_selection():
+    """F-031: a fresh inspector must not claim "Validation: OK" for nothing."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        summary = pilot.app.query_one("#personas-validation-summary", Static)
+        assert summary.display is False
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(name="Tutor", kind="character")
+        await pilot.pause()
+        assert summary.display is True
+        await pane.clear_selection()
+        await pilot.pause()
+        assert summary.display is False
 
 
 async def test_readiness_copy_is_compact_for_narrow_inspector():
@@ -50,9 +126,12 @@ async def test_readiness_copy_is_compact_for_narrow_inspector():
         readiness = pilot.app.query_one("#personas-readiness-console", Static)
 
         default_copy = str(readiness.renderable)
-        assert default_copy == "Console blocked: select an item"
+        assert default_copy == "Pick a character or persona to start chatting."
         assert " - " not in default_copy
 
+        # A screen-supplied reason renders once there is a selection for the
+        # copy to be about (pre-selection the guidance line owns the copy).
+        pane.show_selection(name="Tutor", kind="character")
         pane.set_console_actions_enabled(False, reason="prompts are not attachable")
         await pilot.pause()
 
@@ -211,9 +290,10 @@ async def test_lore_selection_hides_console_and_export_actions():
 
 async def test_clear_selection_restores_action_visibility():
     """Task-443: leaving a dictionary/lore selection (kind -> None) must not
-    leave the never-applies buttons permanently hidden - the pre-selection
-    baseline shows every action (disabled, with the "select an item"
-    reason), same as before any selection was ever made."""
+    leave the never-applies buttons permanently hidden - their per-button
+    display flags reset to the pre-selection baseline. F-031 layers on top:
+    with no selection the whole action STACK is hidden behind the guidance
+    line, so the restored flags only take effect on the next selection."""
     app = InspectorApp()
     async with app.run_test() as pilot:
         pane = pilot.app.query_one(PersonasInspectorPane)
@@ -232,6 +312,11 @@ async def test_clear_selection_restores_action_visibility():
             assert (
                 pilot.app.query_one(button_id, Button).display is True
             ), button_id
+        # ...but the stack itself is hidden again until a selection returns.
+        assert pilot.app.query_one("#personas-inspector-actions").display is False
+        pane.show_selection(name="Detective Sam", kind="character")
+        await pilot.pause()
+        assert pilot.app.query_one("#personas-inspector-actions").display is True
 
 
 async def test_console_action_enablement_is_explicitly_screen_owned():
@@ -332,6 +417,8 @@ async def test_conversations_panel_rows_post_selection():
     app = CaptureApp()
     async with app.run_test() as pilot:
         pane = pilot.app.query_one(PersonasInspectorPane)
+        # The conversations panel only renders for a selection (F-031).
+        pane.show_selection(name="Detective Sam", kind="character")
         await pane.show_conversations(
             (("conv-1", "First case"), ("conv-2", "Cold trail"))
         )
@@ -354,6 +441,7 @@ async def test_conversation_click_after_rerender_posts_new_id():
     app = CaptureApp()
     async with app.run_test() as pilot:
         pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(name="Detective Sam", kind="character")
         await pane.show_conversations((("conv-1", "First case"),))
         await pane.show_conversations((("conv-9", "New case"),))
         await pilot.pause()
@@ -375,6 +463,7 @@ async def test_conversation_list_arrow_enter():
     app = CaptureApp()
     async with app.run_test() as pilot:
         pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(name="Detective Sam", kind="character")
         await pane.show_conversations(
             (
                 ("conv-1", "First case"),

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -2,7 +2,7 @@
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, ListItem, ListView, Static
+from textual.widgets import Button, Checkbox, ListItem, ListView, Static
 
 from tldw_chatbook.Widgets.Persona_Widgets.personas_inspector_pane import (
     PersonasInspectorPane,
@@ -265,6 +265,41 @@ async def test_conversations_list_is_height_capped():
         styles = pilot.app.query_one("#personas-conversations-list").styles
         assert styles.max_height is not None
         assert styles.max_height.value <= 10
+
+
+async def test_disabled_tts_checkbox_stays_legible():
+    """F-041: the disabled voice-profile checkbox reads as a disabled
+    control - dimmed label, full opacity, visible glyph box - not a dark
+    gap (Textual's base *:disabled:can-focus dims to 0.7 and the stock
+    toggle box is panel-on-panel)."""
+    from pathlib import Path
+
+    from textual.color import Color
+
+    class StyledInspectorApp(App):
+        CSS_PATH = str(
+            Path(__file__).resolve().parents[2]
+            / "tldw_chatbook"
+            / "css"
+            / "tldw_cli_modular.tcss"
+        )
+
+        def compose(self):
+            yield PersonasInspectorPane(id="personas-inspector-pane")
+
+    app = StyledInspectorApp()
+    async with app.run_test() as pilot:
+        checkbox = pilot.app.query_one("#personas-export-include-tts", Checkbox)
+        assert checkbox.disabled is True
+        variables = app.get_css_variables()
+        # Full opacity (Textual's base disabled rule dims to 0.7)...
+        assert checkbox.styles.opacity == 1.0
+        # ...with the label dimmed per the disabled idiom (the theme's
+        # text-disabled is "auto 38%": foreground at 38% alpha).
+        assert checkbox.styles.color.a == 0.38
+        # ...and the glyph box paints a real surface, not a dark gap.
+        glyph_styles = checkbox.get_component_styles("toggle--button")
+        assert glyph_styles.background == Color.parse(variables["surface"])
 
 
 async def test_conversation_rows_carry_subdued_class():

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -136,17 +136,21 @@ async def test_readiness_copy_is_compact_for_narrow_inspector():
         await pilot.pause()
 
         blocked_copy = str(readiness.renderable)
-        assert blocked_copy == "Console blocked: prompts are not attachable"
+        assert blocked_copy == "Chat blocked: prompts are not attachable"
         assert " - " not in blocked_copy
 
 
 async def test_action_buttons_carry_shared_flat_button_classes():
     app = InspectorApp()
     async with app.run_test() as pilot:
-        for button_id in ("#personas-attach-to-console", "#personas-start-chat"):
-            assert pilot.app.query_one(button_id, Button).has_class(
-                "console-action-secondary"
-            )
+        # F-032: one primary Console CTA (Chat now), one secondary (Send to
+        # Console draft).
+        assert pilot.app.query_one("#personas-start-chat", Button).has_class(
+            "console-action-primary"
+        )
+        assert pilot.app.query_one("#personas-attach-to-console", Button).has_class(
+            "console-action-secondary"
+        )
         for button_id in ("#personas-export-json", "#personas-export-png"):
             assert pilot.app.query_one(button_id, Button).has_class(
                 "console-action-subdued"
@@ -154,6 +158,16 @@ async def test_action_buttons_carry_shared_flat_button_classes():
         delete = pilot.app.query_one("#personas-delete", Button)
         assert delete.has_class("console-action-subdued")
         assert delete.has_class("personas-destructive")
+
+
+async def test_console_ctas_speak_in_intent():
+    """F-032: the Console CTAs are one primary + one secondary, named by
+    intent, primary first."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        actions = pilot.app.query_one("#personas-inspector-actions")
+        labels = [str(button.label) for button in actions.query(Button)]
+        assert labels[:2] == ["Chat now", "Send to Console draft"]
 
 
 async def test_conversations_list_is_height_capped():
@@ -191,7 +205,7 @@ async def test_show_selection_enables_export_actions():
         assert pilot.app.query_one("#personas-start-chat", Button).disabled is True
         assert pilot.app.query_one("#personas-export-json", Button).disabled is False
         assert pilot.app.query_one("#personas-export-png", Button).disabled is False
-        assert "Console blocked: select an item" in str(
+        assert "Chat blocked: select an item" in str(
             pilot.app.query_one("#personas-readiness-console", Static).renderable
         )
 
@@ -266,6 +280,10 @@ async def test_dictionary_selection_hides_console_and_export_actions():
                 pilot.app.query_one(button_id, Button).display is False
             ), button_id
         assert pilot.app.query_one("#personas-delete", Button).display is True
+        # F-032: the readiness line says what DOES apply, in intent language.
+        assert "Console chat is for characters and personas." in str(
+            pilot.app.query_one("#personas-readiness-console", Static).renderable
+        )
 
 
 async def test_lore_selection_hides_console_and_export_actions():
@@ -334,7 +352,7 @@ async def test_console_action_enablement_is_explicitly_screen_owned():
             pilot.app.query_one("#personas-attach-to-console", Button).disabled is True
         )
         assert pilot.app.query_one("#personas-start-chat", Button).disabled is True
-        assert "Console blocked: select an item" in str(
+        assert "Chat blocked: select an item" in str(
             pilot.app.query_one("#personas-readiness-console", Static).renderable
         )
 
@@ -345,7 +363,7 @@ async def test_console_action_enablement_is_explicitly_screen_owned():
             pilot.app.query_one("#personas-attach-to-console", Button).disabled is False
         )
         assert pilot.app.query_one("#personas-start-chat", Button).disabled is False
-        assert "Console ready" in str(
+        assert "Ready to chat in Console." in str(
             pilot.app.query_one("#personas-readiness-console", Static).renderable
         )
 
@@ -358,7 +376,7 @@ async def test_console_action_enablement_is_explicitly_screen_owned():
             pilot.app.query_one("#personas-attach-to-console", Button).disabled is True
         )
         assert pilot.app.query_one("#personas-start-chat", Button).disabled is True
-        assert "Console blocked: prompts are not attachable" in str(
+        assert "Chat blocked: prompts are not attachable" in str(
             pilot.app.query_one("#personas-readiness-console", Static).renderable
         )
 
@@ -376,7 +394,7 @@ async def test_unsaved_disables_attach_and_export_with_reason():
         assert attach.disabled is True
         assert "unsaved" in str(attach.tooltip).lower()
         assert pilot.app.query_one("#personas-export-json", Button).disabled is True
-        assert "Console blocked: unsaved edits" in str(
+        assert "Save or discard your edits to chat in Console." in str(
             pilot.app.query_one("#personas-readiness-console", Static).renderable
         )
         pane.set_unsaved(False)

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -119,6 +119,61 @@ async def test_validation_line_stays_hidden_until_first_selection():
         assert summary.display is False
 
 
+async def test_character_with_no_conversations_shows_empty_copy():
+    """F-036: selected-but-no-conversations renders the empty-state copy
+    instead of a bare header over nothing."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(name="Detective Sam", kind="character")
+        await pane.show_conversations((), empty_copy="No saved conversations.")
+        await pilot.pause()
+        assert (
+            pilot.app.query_one("#personas-conversations-header", Static).display
+            is True
+        )
+        assert (
+            pilot.app.query_one("#personas-conversations-list", ListView).display
+            is True
+        )
+        texts = [
+            str(s.renderable)
+            for s in pilot.app.query_one("#personas-conversations-list").query(Static)
+        ]
+        assert any("No saved conversations." in text for text in texts)
+
+
+async def test_non_character_selections_hide_conversations_section():
+    """F-036: personas/dictionaries/lore have no saved conversations - the
+    section hides for those kinds (the task-443 inspector idiom) rather
+    than dangling a header over an empty list."""
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        for kind in ("persona", "dictionary", "lore"):
+            pane.show_selection(name="Item", kind=kind)
+            await pilot.pause()
+            assert (
+                pilot.app.query_one(
+                    "#personas-conversations-header", Static
+                ).display
+                is False
+            ), kind
+            assert (
+                pilot.app.query_one(
+                    "#personas-conversations-list", ListView
+                ).display
+                is False
+            ), kind
+        # ...and a character selection reveals it again.
+        pane.show_selection(name="Detective Sam", kind="character")
+        await pilot.pause()
+        assert (
+            pilot.app.query_one("#personas-conversations-header", Static).display
+            is True
+        )
+
+
 async def test_readiness_copy_is_compact_for_narrow_inspector():
     app = InspectorApp()
     async with app.run_test(size=(24, 20)) as pilot:

--- a/Tests/UI/test_personas_library_pane.py
+++ b/Tests/UI/test_personas_library_pane.py
@@ -71,13 +71,16 @@ async def test_update_rows_renders_rows_and_count():
                 "#personas-library-row-character-2", ListItem
             ).classes
         )
+        # F-033: the plain total moved up into the screen's merged purpose
+        # line; the pane count line only speaks for filtered states now.
         count = pilot.app.query_one("#personas-library-count", Static)
-        assert "2 characters" in str(count.renderable)
+        assert str(count.renderable) == ""
 
 
-async def test_singular_count_uses_singular_noun():
-    """task-445: a total of exactly 1 must read '1 character', not
-    '1 characters' -- the RP UX review flagged the plural-only count line."""
+async def test_unfiltered_count_line_stays_empty():
+    """F-033: the unfiltered total renders once (header purpose line), never
+    duplicated at the bottom of the library pane. Singularization of the
+    total (task-445) is still covered by the filtered-count tests."""
     app = LibraryPaneApp()
     async with app.run_test() as pilot:
         pane = pilot.app.query_one(PersonasLibraryPane)
@@ -88,7 +91,7 @@ async def test_singular_count_uses_singular_noun():
         )
         await pilot.pause()
         count = pilot.app.query_one("#personas-library-count", Static)
-        assert str(count.renderable) == "1 character"
+        assert str(count.renderable) == ""
 
 
 async def test_singular_filtered_count_uses_singular_noun():

--- a/Tests/UI/test_personas_library_pane.py
+++ b/Tests/UI/test_personas_library_pane.py
@@ -602,3 +602,32 @@ async def test_s_key_cycles_sort_only_when_sort_applies():
         assert "(s)" in str(
             pilot.app.query_one("#personas-library-sort", Button).tooltip
         )
+
+
+async def test_sync_control_layout_logs_and_keeps_state_on_failure(monkeypatch):
+    """Qodo review: a toolbar width-measurement failure must be logged (not
+    silently swallowed) and must leave the previous layout in place."""
+    from unittest.mock import Mock
+
+    from loguru import logger as loguru_logger
+
+    app = LibraryPaneApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasLibraryPane)
+        pane.set_class(True, "personas-library-stacked-controls")
+        records: list[str] = []
+        sink = loguru_logger.add(lambda m: records.append(str(m)), level="DEBUG")
+        try:
+            monkeypatch.setattr(
+                pane,
+                "_required_toolbar_row_width",
+                Mock(side_effect=RuntimeError("boom")),
+            )
+            pane._sync_control_layout()  # must not raise
+            # Fallback: the previous layout class is untouched.
+            assert pane.has_class("personas-library-stacked-controls")
+        finally:
+            loguru_logger.remove(sink)
+    assert any("toolbar" in record.lower() for record in records), (
+        f"expected a debug/warning log about the toolbar layout failure; got {records}"
+    )

--- a/Tests/UI/test_personas_library_pane.py
+++ b/Tests/UI/test_personas_library_pane.py
@@ -472,3 +472,133 @@ async def test_colliding_item_ids_render_without_crash():
             await pilot.click(f"#{button.id}")
             await pilot.pause()
     assert received == ["a.b", "a b"]
+
+
+# ===== F-040: marks (multi-select) and keyboard sort =====
+
+
+async def _two_character_rows(pane: PersonasLibraryPane) -> None:
+    await pane.update_rows(
+        (
+            LibraryRow(item_id="1", kind="character", name="Detective Sam"),
+            LibraryRow(item_id="2", kind="character", name="Lab Assistant"),
+        ),
+        total=2,
+        noun="characters",
+    )
+
+
+async def test_m_key_marks_rows_and_posts_marks_changed():
+    received = []
+
+    class CaptureApp(LibraryPaneApp):
+        def on_persona_marks_changed(self, message) -> None:
+            received.append(message.marks)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasLibraryPane)
+        await _two_character_rows(pane)
+        await pilot.pause()
+        list_view = pilot.app.query_one("#personas-library-rows", ListView)
+        list_view.focus()
+        list_view.index = 0
+        await pilot.pause()
+        await pilot.press("m")
+        await pilot.pause()
+        assert received[-1] == (("character", "1", "Detective Sam"),)
+        # The marked row carries the marker glyph and the pane reports it.
+        first = list_view.children[0]
+        assert _row_text(first).startswith("● ")
+        count = pilot.app.query_one("#personas-library-count", Static)
+        assert str(count.renderable) == "1 marked"
+        await pilot.press("m")  # toggles off
+        await pilot.pause()
+        assert received[-1] == ()
+        assert not _row_text(first).startswith("● ")
+        assert str(count.renderable) == ""
+
+
+async def test_marks_prune_when_rows_vanish_on_refresh():
+    received = []
+
+    class CaptureApp(LibraryPaneApp):
+        def on_persona_marks_changed(self, message) -> None:
+            received.append(message.marks)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasLibraryPane)
+        await _two_character_rows(pane)
+        await pilot.pause()
+        list_view = pilot.app.query_one("#personas-library-rows", ListView)
+        list_view.focus()
+        list_view.index = 0
+        await pilot.pause()
+        await pilot.press("m")
+        await pilot.pause()
+        assert received[-1] == (("character", "1", "Detective Sam"),)
+        # A refresh that no longer contains the marked row drops the mark.
+        await pane.update_rows(
+            (LibraryRow(item_id="2", kind="character", name="Lab Assistant"),),
+            total=1,
+            noun="characters",
+        )
+        await pilot.pause()
+        assert received[-1] == ()
+        count = pilot.app.query_one("#personas-library-count", Static)
+        assert str(count.renderable) == ""
+
+
+async def test_marks_clear_on_mode_switch():
+    received = []
+
+    class CaptureApp(LibraryPaneApp):
+        def on_persona_marks_changed(self, message) -> None:
+            received.append(message.marks)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasLibraryPane)
+        await _two_character_rows(pane)
+        await pilot.pause()
+        list_view = pilot.app.query_one("#personas-library-rows", ListView)
+        list_view.focus()
+        list_view.index = 1
+        await pilot.pause()
+        await pilot.press("m")
+        await pilot.pause()
+        assert received[-1] == (("character", "2", "Lab Assistant"),)
+        pane.set_mode("dictionaries")
+        await pilot.pause()
+        assert received[-1] == ()
+
+
+async def test_s_key_cycles_sort_only_when_sort_applies():
+    received = []
+
+    class CaptureApp(LibraryPaneApp):
+        def on_persona_sort_cycle_requested(self, message) -> None:
+            received.append(message)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasLibraryPane)
+        await _two_character_rows(pane)
+        await pilot.pause()
+        list_view = pilot.app.query_one("#personas-library-rows", ListView)
+        list_view.focus()
+        await pilot.pause()
+        await pilot.press("s")
+        await pilot.pause()
+        assert len(received) == 1
+        # Dictionaries mode has no sort control - the key is a no-op there.
+        pane.set_mode("dictionaries")
+        await pilot.pause()
+        await pilot.press("s")
+        await pilot.pause()
+        assert len(received) == 1
+        # The sort button discloses the key.
+        assert "(s)" in str(
+            pilot.app.query_one("#personas-library-sort", Button).tooltip
+        )

--- a/Tests/UI/test_personas_library_pane_paging.py
+++ b/Tests/UI/test_personas_library_pane_paging.py
@@ -138,6 +138,7 @@ async def test_update_rows_without_page_kwargs_keeps_plain_count():
         )
         await pilot.pause()
         count = app.query_one("#personas-library-count", Static)
-        # task-445: a total of exactly 1 reads singular ("1 dictionary").
-        assert "1 dictionary" in str(count.renderable)
+        # F-033: the plain total lives in the screen's merged purpose line;
+        # the pane count line stays empty unless a filter is active.
+        assert str(count.renderable) == ""
         assert app.query_one("#personas-library-pagebar").display is False

--- a/Tests/UI/test_personas_library_toolbar_layout.py
+++ b/Tests/UI/test_personas_library_toolbar_layout.py
@@ -1,0 +1,120 @@
+# Tests/UI/test_personas_library_toolbar_layout.py
+"""Rendered-layout regression tests for the Roleplay library toolbar (F-030).
+
+At supported terminal sizes every library toolbar action (New, Import,
+Duplicate, Sort, Tag) must stay reachable: at 100x30 the old fixed-width
+buttons clipped Import/Duplicate/Tag off the pane's right edge while the
+empty-state copy still told users to "use New or Import". The pane now slims
+its buttons to their labels and stacks the bars vertically when the pane is
+too narrow for one row.
+"""
+
+import pytest
+from textual.widgets import Button
+
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+from Tests.UI.test_personas_dictionaries import patch_character_paging
+from Tests.UI.test_personas_workbench import CHARACTERS, StyledPersonasTestApp
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def stub_characters(monkeypatch):
+    """Same character stubs as the workbench suite (kept local for lint)."""
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_all_characters",
+        lambda: [dict(c) for c in CHARACTERS],
+    )
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_character_by_id",
+        lambda character_id: next(
+            dict(c) for c in CHARACTERS if str(c["id"]) == str(character_id)
+        ),
+    )
+    patch_character_paging(monkeypatch)
+
+_TOOLBAR_BUTTON_IDS = (
+    "#personas-library-new",
+    "#personas-library-import",
+    "#personas-library-duplicate",
+    "#personas-library-sort",
+    "#personas-library-tag",
+)
+
+
+def _assert_toolbar_buttons_inside_pane(screen) -> None:
+    """Every visible toolbar button renders fully inside the library pane."""
+    pane = screen.query_one("#personas-library-pane")
+    pane_right = pane.region.x + pane.region.width
+    pane_bottom = pane.region.y + pane.region.height
+    for button_id in _TOOLBAR_BUTTON_IDS:
+        button = screen.query_one(button_id, Button)
+        assert button.display is True, f"{button_id} not rendered in characters mode"
+        region = button.region
+        assert region.width > 0 and region.height > 0, (
+            f"{button_id} has no rendered area: {region}"
+        )
+        assert region.x >= pane.region.x, (
+            f"{button_id} starts left of the pane: {region}"
+        )
+        assert region.x + region.width <= pane_right, (
+            f"{button_id} clips past the pane's right edge: "
+            f"{region} vs pane right {pane_right}"
+        )
+        assert region.y + region.height <= pane_bottom, (
+            f"{button_id} clips past the pane's bottom edge: "
+            f"{region} vs pane bottom {pane_bottom}"
+        )
+
+
+async def _mounted_screen(pilot):
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return pilot.app.screen
+
+
+async def test_toolbar_actions_reachable_at_100x30(
+    mock_app_instance, stub_characters
+):
+    """F-030 evidence size: Import/Duplicate/Tag used to clip here."""
+    app = StyledPersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await _mounted_screen(pilot)
+        pane = screen.query_one("#personas-library-pane")
+        # Too narrow for one row: the bars must wrap, not clip.
+        assert pane.has_class("personas-library-stacked-controls")
+        _assert_toolbar_buttons_inside_pane(screen)
+
+
+async def test_toolbar_actions_reachable_at_80x24(
+    mock_app_instance, stub_characters
+):
+    """Smallest supported size: all actions still reachable."""
+    app = StyledPersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(80, 24)) as pilot:
+        screen = await _mounted_screen(pilot)
+        pane = screen.query_one("#personas-library-pane")
+        assert pane.has_class("personas-library-stacked-controls")
+        _assert_toolbar_buttons_inside_pane(screen)
+
+
+async def test_toolbar_single_row_at_wide_terminal(
+    mock_app_instance, stub_characters
+):
+    """Counter-case: wide terminals keep the one-row toolbar (no stacking)."""
+    app = StyledPersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(170, 50)) as pilot:
+        screen = await _mounted_screen(pilot)
+        pane = screen.query_one("#personas-library-pane")
+        assert not pane.has_class("personas-library-stacked-controls")
+        _assert_toolbar_buttons_inside_pane(screen)
+        # Both bars stay on one row each when there is room.
+        toolbar = screen.query_one("#personas-library-toolbar")
+        new_button = screen.query_one("#personas-library-new", Button)
+        import_button = screen.query_one("#personas-library-import", Button)
+        assert new_button.region.y == toolbar.region.y
+        assert import_button.region.y == toolbar.region.y

--- a/Tests/UI/test_personas_library_toolbar_layout.py
+++ b/Tests/UI/test_personas_library_toolbar_layout.py
@@ -118,3 +118,31 @@ async def test_toolbar_single_row_at_wide_terminal(
         import_button = screen.query_one("#personas-library-import", Button)
         assert new_button.region.y == toolbar.region.y
         assert import_button.region.y == toolbar.region.y
+
+
+async def test_preview_pane_anchors_top_of_center_canvas(
+    mock_app_instance, stub_characters
+):
+    """F-039: the preview affordance is attached to the canvas it previews -
+    the toggle sits immediately above the center detail stack, not stranded
+    at the bottom of the work area."""
+    app = StyledPersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(170, 50)) as pilot:
+        screen = await _mounted_screen(pilot)
+        work_area = screen.query_one("#personas-work-area")
+        preview = screen.query_one("#personas-preview-pane")
+        stack = screen.query_one("#personas-detail-stack")
+        # Inside the center column...
+        assert preview.region.x >= work_area.region.x
+        assert preview.region.x + preview.region.width <= (
+            work_area.region.x + work_area.region.width
+        )
+        # ...and flush against the top of the detail stack (adjacent edges).
+        assert preview.region.y + preview.region.height == stack.region.y
+        # The toggle reads as an expand/collapse section header.
+        toggle = screen.query_one("#personas-preview-toggle", Button)
+        assert "▸" in str(toggle.label)
+        await pilot.click("#personas-preview-toggle")
+        await pilot.pause()
+        assert "▾" in str(toggle.label)
+        assert screen.query_one("#personas-preview-body").display is True

--- a/Tests/UI/test_personas_preview.py
+++ b/Tests/UI/test_personas_preview.py
@@ -70,6 +70,15 @@ async def test_buttons_carry_shared_flat_button_classes():
         assert pilot.app.query_one("#personas-preview-open-console", Button).has_class(
             "console-action-subdued"
         )
+        # F-032: the preview's Console handoff says what it continues.
+        assert (
+            str(
+                pilot.app.query_one(
+                    "#personas-preview-open-console", Button
+                ).label
+            )
+            == "Continue this chat in Console"
+        )
         assert pilot.app.query_one("#personas-preview-toggle", Button).has_class(
             "console-action-subdued"
         )

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -8484,8 +8484,57 @@ class TestCharactersEmptyStateGuidance:
             guidance = screen.query_one("#personas-characters-empty", Static)
             assert guidance.display is True
             body = str(guidance.renderable)
+            # F-035: the truly-empty copy names the creation actions (and no
+            # longer claims there is a list to pick from).
+            assert "No characters yet" in body
             assert "New" in body and "Import" in body
+            assert "Pick one from the list" not in body
             assert screen.query_one("#ccp-character-card-view").display is False
+
+    async def test_guidance_adapts_when_library_has_items(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """F-035: with characters in the library, a cleared selection asks
+        for a pick - the New/Import onboarding copy would be wrong here."""
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            # F-031 auto-selected row 1; a mode round-trip clears the
+            # selection while the non-empty library stays.
+            await screen._apply_mode("lore")
+            await pilot.pause()
+            await screen._apply_mode("characters")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert not screen.state.selected_entity_id
+            assert screen._character_total > 0
+            guidance = screen.query_one("#personas-characters-empty", Static)
+            assert guidance.display is True
+            body = str(guidance.renderable)
+            assert body == "Pick a character from the list to see it here."
+            assert "Import" not in body
+
+    async def test_guidance_uses_left_aligned_empty_state_convention(
+        self, mock_app_instance, stub_characters, monkeypatch
+    ):
+        """F-035: empty copy aligns like the app's other empty states
+        (left/top, cf. .chat-empty-state), not centered in a void."""
+        monkeypatch.setattr(
+            character_handler_module, "fetch_all_characters", lambda: []
+        )
+        app = StyledPersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            guidance = screen.query_one("#personas-characters-empty", Static)
+            assert guidance.display is True
+            assert str(guidance.styles.text_align) == "left"
+            assert guidance.styles.content_align_horizontal == "left"
+            assert guidance.styles.content_align_vertical == "top"
 
     async def test_guidance_hidden_after_selection(
         self, mock_app_instance, stub_characters, stub_conversations

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3763,7 +3763,7 @@ class TestConversationsPanel:
 
 
 class TestConsoleActions:
-    """Attach to Console and Start Chat from the inspector (Task 12)."""
+    """Send to Console draft and Chat now from the inspector (Task 12, F-032)."""
 
     @pytest.fixture
     def stub_conversations(self, monkeypatch):
@@ -3868,7 +3868,7 @@ class TestConsoleActions:
                 screen.query_one("#personas-attach-to-console", Button).disabled is True
             )
             assert screen.query_one("#personas-start-chat", Button).disabled is True
-            assert "Console blocked: prompts are not attachable" in str(
+            assert "Chat blocked: prompts are not attachable" in str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
 
@@ -3877,12 +3877,13 @@ class TestConsoleActions:
     ):
         """Task-440: honest readiness copy when the handoff provider is unready.
 
-        The configured chat_defaults provider (which a fresh Start-Chat
+        The configured chat_defaults provider (which a fresh Chat-now
         Console session resolves - the native Console never reads
         character_defaults) has no API key - the handoff send would fail, so
         neither readiness surface may claim things are ready. Per-intent gating
-        (task-523): Start Chat is DISABLED (it needs an immediate reply) while
-        Attach stays enabled (it stages context; the reply is deferred).
+        (task-523): Chat now is DISABLED (it needs an immediate reply) while
+        Send to Console draft stays enabled (it stages context; the reply is
+        deferred).
         """
         mock_app_instance.app_config = {
             "character_defaults": {"provider": "anthropic", "model": "claude-3-haiku"},
@@ -3895,17 +3896,17 @@ class TestConsoleActions:
             readiness_text = str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
-            assert readiness_text != "Console ready"
-            assert readiness_text.startswith("Start Chat blocked:")
+            assert readiness_text != "Ready to chat in Console."
+            assert readiness_text.startswith("Chat now blocked:")
             assert "anthropic" in readiness_text.lower()
             assert (
                 "api key" in readiness_text.lower()
                 or "api_settings" in readiness_text.lower()
             )
             # Per-intent gating (task-523): an unready handoff provider blocks
-            # Start Chat (it needs an immediate reply) but NOT Attach (it only
-            # stages context; the reply is deferred). The user can still stage
-            # the card and fix the provider before sending.
+            # Chat now (it needs an immediate reply) but NOT Send to Console
+            # draft (it only stages context; the reply is deferred). The user
+            # can still stage the card and fix the provider before sending.
             assert screen.query_one("#personas-start-chat", Button).disabled is True
             assert (
                 screen.query_one("#personas-attach-to-console", Button).disabled
@@ -3922,7 +3923,7 @@ class TestConsoleActions:
     async def test_readiness_surfaces_stay_ready_with_a_configured_provider(
         self, mock_app_instance, stub_characters, stub_conversations
     ):
-        """Provider ready -> existing "Console ready"/"Ready" copy is unchanged."""
+        """Provider ready -> "Ready to chat in Console."/"Ready" copy shows."""
         mock_app_instance.app_config = {
             "character_defaults": {"provider": "anthropic", "model": "claude-3-haiku"},
             "chat_defaults": {"provider": "anthropic", "model": "claude-3-haiku"},
@@ -3932,7 +3933,7 @@ class TestConsoleActions:
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
 
-            assert "Console ready" in str(
+            assert "Ready to chat in Console." in str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
             assert (
@@ -3954,9 +3955,10 @@ class TestConsoleActions:
     async def test_readiness_blocked_when_handoff_provider_unready_despite_ready_character_provider(
         self, mock_app_instance, stub_characters, stub_conversations
     ):
-        """Task-440 review: readiness mirrors the Start-Chat HANDOFF resolution.
+        """Task-440 review: readiness mirrors the Chat-now HANDOFF resolution.
 
-        Attach/Start Chat create a fresh native-Console session resolved from
+        Send to Console draft/Chat now create a fresh native-Console session
+        resolved from
         chat_defaults (chat_screen._start_character_console_session ->
         _default_console_session_settings); the native Console never reads
         character_defaults. Shipped-defaults failure shape: only an Anthropic
@@ -3978,8 +3980,8 @@ class TestConsoleActions:
             readiness_text = str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
-            assert readiness_text != "Console ready"
-            assert readiness_text.startswith("Start Chat blocked:")
+            assert readiness_text != "Ready to chat in Console."
+            assert readiness_text.startswith("Chat now blocked:")
             assert "openai" in readiness_text.lower()
             assert (
                 str(
@@ -3989,7 +3991,8 @@ class TestConsoleActions:
                 )
                 != "Ready"
             )
-            # Per-intent gating (task-523): Start Chat disabled, Attach enabled.
+            # Per-intent gating (task-523): Chat now disabled, Send to Console
+            # draft enabled.
             assert (
                 screen.query_one("#personas-start-chat", Button).disabled is True
             )
@@ -4010,7 +4013,7 @@ class TestConsoleActions:
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
 
-            assert "Console ready" in str(
+            assert "Ready to chat in Console." in str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
             assert (
@@ -4045,7 +4048,7 @@ class TestConsoleActions:
             readiness_text = str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
-            assert readiness_text == "Console blocked: unsaved edits"
+            assert readiness_text == "Save or discard your edits to chat in Console."
             assert "openai" not in readiness_text.lower()  # no provider copy
             header_status = str(
                 screen.query_one(
@@ -4172,14 +4175,14 @@ class TestConsoleActions:
     async def test_start_chat_uses_real_mechanism(
         self, mock_app_instance, stub_characters, stub_conversations
     ):
-        """Start Chat stages a handoff with start_chat intent metadata.
+        """Chat now stages a handoff with start_chat intent metadata.
 
         The legacy CCP route launched a blank tab directly via the main chat
         tab container (`#chat-window` lookup), which is not mounted while a
         destination screen is active; the workbench therefore uses the
         app-level ``open_chat_with_handoff`` API with an intent marker.
         """
-        # Start Chat now needs a ready handoff provider (task-523 per-intent);
+        # Chat now needs a ready handoff provider (task-523 per-intent);
         # give a keyless local provider so the button is enabled and the guard
         # passes.
         mock_app_instance.app_config = {
@@ -4406,7 +4409,7 @@ class TestConsoleActions:
             await pilot.pause()
         app.open_chat_with_handoff.assert_not_called()
         assert any(
-            msg.startswith("Start Chat blocked:") and severity == "warning"
+            msg.startswith("Chat now blocked:") and severity == "warning"
             for msg, severity in captured
         )
 
@@ -8127,7 +8130,7 @@ class TestPersonaHumanIdentityRemoval:
             get_local_authority_id=Mock(return_value="local-authority"),
             get_character_card_by_id=Mock(
                 side_effect=AssertionError(
-                    "Start Chat must use the source-aware scope service"
+                    "Chat now must use the source-aware scope service"
                 )
             ),
         )
@@ -8897,7 +8900,8 @@ class TestDirtyTracking:
             readiness = str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
-            assert "unsaved" in readiness
+            # F-032 intent copy for the unsaved gate.
+            assert readiness == "Save or discard your edits to chat in Console."
             confirms = self._bypass_confirm(screen, True)
             await pilot.click("#personas-mode-characters")
             await pilot.pause()

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -420,7 +420,10 @@ class TestWorkbenchShell:
             assert work_area.size.width >= 34
             assert inspector.size.width >= 18
             assert _right_edge(inspector) <= _right_edge(workbench)
-            assert str(readiness.renderable).startswith("Console blocked:")
+            # task-440 honesty contract: with no provider configured the
+            # readiness line never claims ready (F-031 auto-select means a
+            # selection exists, so this is the provider gate talking).
+            assert "blocked" in str(readiness.renderable).lower()
 
     async def test_library_rail_collapses_and_reopens_from_handle(
         self,
@@ -540,15 +543,19 @@ class TestWorkbenchShell:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test() as pilot:
             screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
             context = screen._shortcut_context()
             rendered = context.render()
             assert "new" in rendered.lower()
             assert "search" in rendered.lower()
-            # task-445: unavailable actions (nothing is being edited/selected
-            # at fresh mount) are dropped from the rendered hint entirely
-            # rather than shown with a literal "unavailable" suffix.
+            # task-445: unavailable actions are dropped from the rendered
+            # hint entirely rather than shown with a literal "unavailable"
+            # suffix. F-031 auto-selects the first row on first paint, so
+            # attach IS available here; "save" (no editor open) is the
+            # remaining dropped hint.
             assert "save" not in rendered.lower()
-            assert "attach" not in rendered.lower()
+            assert "attach" in rendered.lower()
             assert context.source == "personas"
             # task-264: the registration lands on the SCREEN's own footer,
             # not the harness's default-screen stand-in.
@@ -662,12 +669,17 @@ class TestWorkbenchShell:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test() as pilot:
             screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
             title = screen.query_one("#personas-header #workbench-header-title", Static)
             assert str(title.renderable).startswith("Roleplay")
             status = screen.query_one(
                 "#personas-header #workbench-header-status", Static
             )
-            assert str(status.renderable) == "Ready"
+            # F-031 auto-selects the first row on first paint, which makes
+            # the provider gate operative (task-440): the mock config has no
+            # ready provider, so the header honestly reads Blocked.
+            assert str(status.renderable) == "Blocked"
             # dynamic suffix still appends in create mode
             screen._edit_mode = "create"
             screen._update_title()
@@ -758,11 +770,14 @@ class TestCharacterSelectionAndEdit:
                 screen.query_one("#personas-selected-name", Static).renderable
             )
             assert "Detective Sam" not in selected_name
-            # Unsaved gating must survive the identity reset.
+            # Unsaved gating must survive the identity reset: no Console
+            # action is offered for a pristine create session (F-031: the
+            # readiness line falls back to the no-selection guidance).
             readiness = str(
                 screen.query_one("#personas-readiness-console", Static).renderable
             )
-            assert "blocked" in readiness
+            assert readiness == "Pick a character or persona to start chatting."
+            assert screen._console_action_allowed() is False
 
     async def test_ctrl_n_opens_editor_in_create_mode(
         self, mock_app_instance, stub_characters
@@ -3406,11 +3421,16 @@ class TestConversationsPanel:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await _mounted(pilot)
-            await pilot.pause()
-            await pilot.click("#personas-library-row-character-1")
-            await pilot.pause()
+            # F-031: first-paint auto-select already started the (gated)
+            # listing during mount - the loading placeholder is up while the
+            # worker thread waits on the gate.
             panel = screen.query_one("#personas-conversations-list")
-            texts = [str(s.renderable) for s in panel.query(Static)]
+            texts: list[str] = []
+            for _ in range(200):
+                await pilot.pause(0.05)
+                texts = [str(s.renderable) for s in panel.query(Static)]
+                if any("Loading conversations..." in text for text in texts):
+                    break
             assert any("Loading conversations..." in text for text in texts)
             release.set()
             await pilot.app.workers.wait_for_complete()
@@ -3811,12 +3831,18 @@ class TestConsoleActions:
         assert "Detective Sam" in payload.suggested_prompt
 
     async def test_attach_blocked_without_selection(
-        self, mock_app_instance, stub_characters, stub_conversations
+        self, mock_app_instance, stub_characters, stub_conversations, monkeypatch
     ):
+        # No-selection requires an empty library now: F-031 auto-selects the
+        # first row on a fresh mount when rows exist.
+        monkeypatch.setattr(
+            character_handler_module, "fetch_all_characters", lambda: []
+        )
         app = PersonasTestApp(mock_app_instance)
         app.open_chat_with_handoff = Mock()
         async with app.run_test(size=(160, 50)) as pilot:
             await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
             await pilot.pause()
             await pilot.press("ctrl+enter")
             await pilot.pause()
@@ -4280,7 +4306,14 @@ class TestConsoleActions:
 
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
             await pilot.pause()
+            # F-031: first-paint auto-select already fetched the mounted row
+            # (server detail + card render) once; reset those provenance
+            # mocks so the strict assertions below pin only the click-driven
+            # selection path they were written for.
+            scope_service.get_character.reset_mock()
+            detail_dto.model_dump.reset_mock()
             row = screen.query_one("#personas-library-row-character-1")
             assert "Remote Elara" in _row_text(row)
             assert "Local collision" not in _row_text(row)
@@ -4562,13 +4595,16 @@ class TestConsoleActions:
     async def test_footer_shortcut_attach_available(
         self, mock_app_instance, stub_characters, stub_conversations
     ):
-        """The attach action is truthful: allowed only with a saved selection."""
+        """The attach action is truthful: allowed only with a saved, clean selection."""
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
-            screen = await _mounted(pilot)
-            assert screen._console_action_allowed() is False  # nothing selected yet
-            await self._select_first_character(pilot)
+            # F-031: first paint auto-selects the first row, so attach is
+            # allowed from the start...
+            screen = await self._select_first_character(pilot)
             assert screen._console_action_allowed() is True
+            # ...but the gate still closes the moment the selection is dirty.
+            screen.state.has_unsaved_changes = True
+            assert screen._console_action_allowed() is False
 
 
 class TestServerCharacterSourceIsolation:
@@ -8280,7 +8316,13 @@ class TestPersonaHumanIdentityRemoval:
 
 class TestCharactersEmptyStateGuidance:
     """task-436: Characters mode shows onboarding guidance when nothing is
-    selected, instead of a blank center pane that reads as broken."""
+    selected, instead of a blank center pane that reads as broken.
+
+    F-031 (task-2082) layers first-paint auto-select on top: a non-empty
+    library mounts with its first row already selected (guidance hidden,
+    card shown), so the guidance state is only reachable with an empty
+    library, after a delete, or after a mode round-trip.
+    """
 
     @pytest.fixture
     def stub_conversations(self, monkeypatch):
@@ -8314,12 +8356,64 @@ class TestCharactersEmptyStateGuidance:
         await pilot.pause()
         return screen
 
-    async def test_guidance_shown_when_no_selection(
-        self, mock_app_instance, stub_characters
+    async def test_first_paint_auto_selects_first_library_row(
+        self, mock_app_instance, stub_characters, stub_conversations
     ):
+        """F-031: a non-empty library mounts with its first row selected -
+        card loaded, inspector awake - instead of a void center."""
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert screen.state.selected_entity_id == "1"
+            assert screen.state.selected_entity_kind == "character"
+            assert screen.state.selected_entity_name == "Detective Sam"
+            assert screen.query_one("#ccp-character-card-view").display is True
+            assert (
+                screen.query_one("#personas-characters-empty", Static).display
+                is False
+            )
+            assert "Selected: Detective Sam" in str(
+                screen.query_one("#personas-selected-name", Static).renderable
+            )
+            # Auto-select must not move focus (focus-steal guards, F-031).
+            search = screen.query_one("#personas-library-search", Input)
+            assert not search.has_focus
+
+    async def test_first_paint_auto_select_keeps_unsaved_guards_quiet(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """F-031: the auto-selected row is a clean selection - no unsaved
+        state, no guard dialog on a follow-up selection."""
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert screen.state.selected_entity_id == "1"
+            assert screen.state.has_unsaved_changes is False
+            # A second selection runs the clean fast path (no confirm).
+            await pilot.click("#personas-library-row-character-2")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert screen.state.selected_entity_id == "2"
+
+    async def test_guidance_shown_when_library_empty(
+        self, mock_app_instance, stub_characters, monkeypatch
+    ):
+        """With no rows there is nothing to auto-select: the no-selection
+        guidance paints (the state first-time users with no card see until
+        they New/Import one)."""
+        monkeypatch.setattr(
+            character_handler_module, "fetch_all_characters", lambda: []
+        )
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
             assert screen.state.active_mode == "characters"
             assert not screen.state.selected_entity_id
             guidance = screen.query_one("#personas-characters-empty", Static)
@@ -8329,24 +8423,26 @@ class TestCharactersEmptyStateGuidance:
             assert screen.query_one("#ccp-character-card-view").display is False
 
     async def test_guidance_hidden_after_selection(
-        self, mock_app_instance, stub_characters
+        self, mock_app_instance, stub_characters, stub_conversations
     ):
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
             await pilot.pause()
-            # Guidance is visible before any selection (pins the transition so
-            # the "hidden after" assertion below is non-vacuous).
+            # First paint already auto-selected row 1 (F-031), so the
+            # guidance is hidden from the start...
+            assert screen.state.selected_entity_id == "1"
             assert (
                 screen.query_one("#personas-characters-empty", Static).display
-                is True
+                is False
             )
-            # ... and disappears the moment a character is selected (AC#2).
-            await pilot.click("#personas-library-row-character-1")
+            # ...and stays hidden when the selection moves to another row.
+            await pilot.click("#personas-library-row-character-2")
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
-            assert screen.state.selected_entity_id
+            assert screen.state.selected_entity_id == "2"
             assert (
                 screen.query_one("#personas-characters-empty", Static).display
                 is False
@@ -8905,6 +9001,12 @@ class TestDirtyTracking:
         """UX-E2 carryover: import-selection must enable the attach action."""
         source = tmp_path / "card.json"
         source.write_bytes(b'{"name":"Detective Sam"}')
+        # F-031 auto-selects the first row on a fresh mount when rows exist;
+        # the "no prior selection" baseline this test pins needs an empty
+        # library.
+        monkeypatch.setattr(
+            character_handler_module, "fetch_all_characters", lambda: []
+        )
         monkeypatch.setattr(
             character_handler_module,
             "inspect_character_card_tts_attachment",
@@ -9663,7 +9765,13 @@ def _configure_character_tts_app(
 async def test_character_tts_population_requires_one_generation_and_observes_off_page_assignment(
     mock_app_instance,
     stub_characters,
+    monkeypatch,
 ) -> None:
+    # F-031: an empty library keeps first-paint auto-select from consuming
+    # this state machine's exact-call seams before the explicit select below.
+    monkeypatch.setattr(
+        character_handler_module, "fetch_all_characters", lambda: []
+    )
     first_page_profile = _character_tts_profile(1)
     assigned_profile = _character_tts_profile(51)
     character_ref = CharacterRef(
@@ -9755,7 +9863,12 @@ async def test_character_tts_population_rejects_mixed_repository_generations(
 async def test_character_tts_off_page_assignment_requires_matching_capability_revisions(
     mock_app_instance,
     stub_characters,
+    monkeypatch,
 ) -> None:
+    # F-031: empty library - see the population-generation test above.
+    monkeypatch.setattr(
+        character_handler_module, "fetch_all_characters", lambda: []
+    )
     first_page_profile = _character_tts_profile(1)
     assigned_profile = _character_tts_profile(51)
     character_ref = CharacterRef(
@@ -9906,7 +10019,12 @@ async def test_character_tts_server_principal_change_rejects_late_population(
 async def test_character_tts_local_authority_change_rejects_late_population(
     mock_app_instance,
     stub_characters,
+    monkeypatch,
 ) -> None:
+    # F-031: empty library - see the population-generation test above.
+    monkeypatch.setattr(
+        character_handler_module, "fetch_all_characters", lambda: []
+    )
     profile = _character_tts_profile(1)
     original_ref = CharacterRef(
         source="local",

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -14,7 +14,7 @@ from uuid import UUID
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, Checkbox, Input, Select, Static, TextArea
+from textual.widgets import Button, Checkbox, Input, ListView, Select, Static, TextArea
 
 import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
 import tldw_chatbook.UI.Persona_Modules.personas_conversations_controller as conversations_controller_module
@@ -8160,6 +8160,183 @@ def legacy_human_config(tmp_path, monkeypatch):
     finally:
         monkeypatch.setenv("TLDW_CONFIG_PATH", str(previous_config_path))
         config_module.load_cli_config_and_ensure_existence(force_reload=True)
+
+
+class TestBulkLibraryActions:
+    """F-040: the library pane's mark set drives bulk delete/export."""
+
+    @pytest.fixture
+    def stub_conversations(self, monkeypatch):
+        monkeypatch.setattr(
+            character_handler_module, "_default_character_db", lambda: object()
+        )
+        monkeypatch.setattr(
+            conversations_controller_module,
+            "list_character_conversations",
+            lambda db, character_id, limit=50, offset=0: [
+                {"id": "conv-1", "title": "First case"}
+            ],
+        )
+
+    @staticmethod
+    def _capture_notifications(app) -> list[tuple[str, str]]:
+        captured: list[tuple[str, str]] = []
+        app.notify = lambda message, severity="information", **kwargs: captured.append(
+            (str(message), severity)
+        )
+        return captured
+
+    async def _mount_with_marks(self, pilot, row_indexes=(0, 1)):
+        """Mount and mark rows through the pane's m key, like a user."""
+        screen = await _mounted(pilot)
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        list_view = screen.query_one("#personas-library-rows", ListView)
+        list_view.focus()
+        await pilot.pause()
+        for index in row_indexes:
+            list_view.index = index
+            await pilot.press("m")
+            await pilot.pause()
+        return screen
+
+    async def test_marks_retarget_delete_and_export_affordances(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._mount_with_marks(pilot, (0, 1))
+            inspector = screen.query_one(PersonasInspectorPane)
+            delete = inspector.query_one("#personas-delete", Button)
+            export_json = inspector.query_one("#personas-export-json", Button)
+            export_png = inspector.query_one("#personas-export-png", Button)
+            assert delete.disabled is False
+            assert delete.tooltip == "Delete the 2 marked items."
+            assert export_json.disabled is False
+            assert export_json.tooltip == "Export the 2 marked items as JSON."
+            assert export_png.disabled is True
+            assert export_png.tooltip == "Bulk export is JSON only."
+            # Clearing the marks restores the selection-owned gates.
+            screen.query_one("#personas-library-pane").clear_marks()
+            await pilot.pause()
+            assert export_png.disabled is False
+            assert delete.tooltip is None
+
+    async def test_bulk_delete_marked_characters(
+        self, mock_app_instance, stub_characters, stub_conversations, monkeypatch
+    ):
+        deleted: list[tuple[str, int]] = []
+
+        def _delete(character_id, expected_version):
+            deleted.append((str(character_id), expected_version))
+            return True
+
+        monkeypatch.setattr(character_handler_module, "delete_character", _delete)
+        # The live read shrinks as deletes land, so the refresh renders empty.
+        monkeypatch.setattr(
+            character_handler_module,
+            "fetch_all_characters",
+            lambda: [
+                dict(c)
+                for c in CHARACTERS
+                if str(c["id"]) not in {did for did, _ in deleted}
+            ],
+        )
+        confirm_calls: list[str] = []
+
+        async def _confirm(name: str) -> bool:
+            confirm_calls.append(name)
+            return True
+
+        app = PersonasTestApp(mock_app_instance)
+        notifications = self._capture_notifications(app)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._mount_with_marks(pilot, (0, 1))
+            screen._confirm_delete = _confirm
+            screen.query_one("#personas-delete", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            # One confirm for the whole batch; each item deleted once.
+            assert confirm_calls == ["2 characters"]
+            assert sorted(deleted) == [("1", 1), ("2", 1)]
+            assert not list(screen.query(".personas-library-row"))
+            assert screen.state.selected_entity_id is None
+            assert screen._marked_rows == ()
+        assert ("Deleted 2 characters.", "information") in notifications
+
+    async def test_bulk_delete_keeps_unmarked_selection(
+        self, mock_app_instance, stub_characters, stub_conversations, monkeypatch
+    ):
+        deleted: list[str] = []
+
+        def _delete(character_id, expected_version):
+            deleted.append(str(character_id))
+            return True
+
+        monkeypatch.setattr(character_handler_module, "delete_character", _delete)
+        monkeypatch.setattr(
+            character_handler_module,
+            "fetch_all_characters",
+            lambda: [
+                dict(c) for c in CHARACTERS if str(c["id"]) not in set(deleted)
+            ],
+        )
+
+        async def _confirm(name: str) -> bool:
+            return True
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            # F-031 auto-selected row 1; only row 2 is marked for deletion.
+            screen = await self._mount_with_marks(pilot, (1,))
+            screen._confirm_delete = _confirm
+            screen.query_one("#personas-delete", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert deleted == ["2"]
+            assert screen.state.selected_entity_id == "1"
+
+    async def test_bulk_export_marked_characters_writes_one_file_per_card(
+        self, mock_app_instance, stub_characters, stub_conversations, tmp_path
+    ):
+        exports: list[tuple[int, str]] = []
+
+        def _fake_export(character_id, target_path, portable_profile):
+            exports.append((character_id, target_path))
+
+        app = PersonasTestApp(mock_app_instance)
+        notifications = self._capture_notifications(app)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._mount_with_marks(pilot, (0, 1))
+            screen._export_character_json_sync = _fake_export
+            pilot.app.push_screen_wait = AsyncMock(return_value=str(tmp_path))
+            screen.query_one("#personas-export-json", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert [character_id for character_id, _ in exports] == [1, 2]
+            paths = sorted(target for _, target in exports)
+            assert paths[0].endswith("Detective Sam.json")
+            assert paths[1].endswith("Lab Assistant.json")
+        assert any(
+            message.startswith("Exported 2 items") and severity == "information"
+            for message, severity in notifications
+        )
+
+    async def test_footer_discloses_sort_key_in_sortable_modes(
+        self, mock_app_instance, stub_characters, stub_scope_service
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert "s sort" in screen._shortcut_context().render().lower()
+            await screen._apply_mode("dictionaries")
+            await pilot.pause()
+            assert "s sort" not in screen._shortcut_context().render().lower()
 
 
 class TestPersonaHumanIdentityRemoval:

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -4763,6 +4763,35 @@ class TestServerCharacterSourceIsolation:
             )
             assert screen.query_one("#personas-start-chat", Button).disabled is False
 
+    async def test_server_browsing_disables_actions_with_reason_tooltips(
+        self, mock_app_instance, stub_characters
+    ):
+        """F-037: every action disabled by server browsing says why."""
+        mock_app_instance.runtime_backend = "server"
+        mock_app_instance.active_server_id = "server-a"
+        mock_app_instance.character_persona_scope_service = self._server_service()
+        mock_app_instance.chat_dictionary_scope_service = None
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            # F-031 auto-selects the first server row; the local-only actions
+            # must be disabled AND explained.
+            assert screen.state.selected_entity_id == "7"
+            for control_id in (
+                "#personas-card-edit-character",
+                "#personas-export-json",
+                "#personas-export-png",
+                "#personas-delete",
+            ):
+                control = screen.query_one(control_id, Button)
+                assert control.disabled is True, control_id
+                assert control.tooltip == (
+                    "Server characters are read-only here."
+                ), control_id
+
     async def test_server_footer_does_not_advertise_local_character_creation(
         self, mock_app_instance, stub_characters
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -593,10 +593,18 @@ class TestWorkbenchShell:
             # task-445: unavailable actions are dropped from the rendered
             # hint entirely rather than shown with a literal "unavailable"
             # suffix. F-031 auto-selects the first row on first paint, so
-            # attach IS available here; "save" (no editor open) is the
+            # draft IS available here; "save" (no editor open) is the
             # remaining dropped hint.
             assert "save" not in rendered.lower()
-            assert "attach" in rendered.lower()
+            # F-032: the footer names the renamed Console draft CTA.
+            assert "attach" not in rendered.lower()
+            assert "ctrl+enter draft" in rendered.lower()
+            # F-038: the always-on accelerators are advertised, not hidden.
+            assert "f6 pane" in rendered.lower()
+            assert "ctrl+1-4 mode" in rendered.lower()
+            assert "[ ]" in rendered
+            # space toggle is dictionaries-only, so it stays hidden here.
+            assert "space" not in rendered.lower()
             assert context.source == "personas"
             # task-264: the registration lands on the SCREEN's own footer,
             # not the harness's default-screen stand-in.
@@ -614,6 +622,42 @@ class TestWorkbenchShell:
             assert footer.parent is None
             default_footer = pilot.app.query_one(AppFooterStatus)
             assert default_footer.shortcut_text == AppFooterStatus.DEFAULT_SHORTCUT_TEXT
+
+    async def test_footer_advertises_space_toggle_in_dictionaries_mode(
+        self, mock_app_instance, stub_characters, stub_scope_service
+    ):
+        """F-038: the dictionary row toggle key is disclosed only in its mode."""
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert "space" not in screen._shortcut_context().render().lower()
+            await screen._apply_mode("dictionaries")
+            await pilot.pause()
+            rendered = screen._shortcut_context().render().lower()
+            assert "space toggle" in rendered
+            await screen._apply_mode("characters")
+            await pilot.pause()
+            assert "space" not in screen._shortcut_context().render().lower()
+
+    async def test_mode_chips_advertise_their_ctrl_shortcut(
+        self, mock_app_instance, stub_characters
+    ):
+        """F-038: each mode chip tooltip carries its Ctrl+N jump key."""
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            expected = {
+                "characters": ("Characters — who the AI plays.", "(Ctrl+1)"),
+                "personas": ("Personas — who you play in the chat.", "(Ctrl+2)"),
+                "dictionaries": ("Dictionaries — text find/replace rules.", "(Ctrl+3)"),
+                "lore": ("Lore — world facts injected on keywords.", "(Ctrl+4)"),
+            }
+            for mode, (descriptor, hint) in expected.items():
+                tooltip = screen.query_one(f"#personas-mode-{mode}", Button).tooltip
+                assert descriptor in tooltip, mode
+                assert hint in tooltip, mode
 
     async def test_unmount_clear_does_not_stomp_other_screens_context(
         self, mock_app_instance, stub_characters
@@ -683,7 +727,8 @@ class TestWorkbenchShell:
         async with app.run_test() as pilot:
             screen = await _mounted(pilot)
             lore_chip = screen.query_one("#personas-mode-lore", Button)
-            assert lore_chip.tooltip == "Lore — world facts injected on keywords."
+            # F-038: chip tooltips carry their Ctrl+N jump key.
+            assert lore_chip.tooltip == "Lore — world facts injected on keywords. (Ctrl+4)"
             assert "soon" not in str(lore_chip.label).lower()
             char_chip = screen.query_one("#personas-mode-characters", Button)
             assert "soon" not in str(char_chip.label).lower()
@@ -9167,16 +9212,16 @@ class TestDirtyTracking:
             screen = await _mounted(pilot)
             await pilot.pause()
             assert screen._console_action_allowed() is False  # no prior selection
-            attach = next(
-                a for a in screen._shortcut_context().actions if a.label == "attach"
+            draft = next(
+                a for a in screen._shortcut_context().actions if a.label == "draft"
             )
-            assert attach.available is False  # no prior selection
+            assert draft.available is False  # no prior selection
             # task-264: the registration lands on the SCREEN's own footer,
             # not the harness's default-screen stand-in.
             footer = screen.query_one(AppFooterStatus)
             # task-445: unavailable hints are dropped entirely rather than
             # rendered with a literal "unavailable" suffix.
-            assert "ctrl+enter attach" not in footer.shortcut_text
+            assert "ctrl+enter draft" not in footer.shortcut_text
             await screen._import_character_from_path(str(source))
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -242,12 +242,15 @@ def _row_text(item) -> str:
 
 
 _SHARED_MODE_OWNER_CASES = (
+    # The count slot snapshots the pane's count line, which F-033 emptied for
+    # unfiltered lists (the total now lives in the merged header purpose
+    # line), so both cases expect "".
     pytest.param(
         "dictionaries",
         "dictionary",
         "New Dictionary Owner",
         "2 entries · on",
-        "1 dictionary",
+        "",
         id="dictionaries",
     ),
     pytest.param(
@@ -255,7 +258,7 @@ _SHARED_MODE_OWNER_CASES = (
         "lore",
         "New Lore Owner",
         "3 entries · on",
-        "1 lore book",
+        "",
         id="lore",
     ),
 )
@@ -424,6 +427,44 @@ class TestWorkbenchShell:
             # readiness line never claims ready (F-031 auto-select means a
             # selection exists, so this is the provider gate talking).
             assert "blocked" in str(readiness.renderable).lower()
+
+    async def test_header_band_merges_purpose_and_count(
+        self, mock_app_instance, stub_characters
+    ):
+        """F-033: purpose + count share one line; the separate status strip
+        and the library pane's duplicate count line are gone."""
+        app = StyledPersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(170, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            # The five-strip band lost the standalone count strip entirely.
+            assert not screen.query("#personas-status-row")
+            purpose = screen.query_one("#personas-purpose", Static)
+            assert str(purpose.renderable) == "Characters — who the AI plays · 2"
+            # ...so the workbench starts one row higher than the old layout.
+            assert screen.query_one("#personas-workbench").region.y == 10
+            # The count renders once (header line), not again under the list.
+            count = screen.query_one("#personas-library-count", Static)
+            assert str(count.renderable) == ""
+
+    async def test_header_purpose_count_updates_per_mode(
+        self, mock_app_instance, stub_characters, stub_scope_service
+    ):
+        """F-033: the merged line carries the live count for each mode."""
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            purpose = screen.query_one("#personas-purpose", Static)
+            assert str(purpose.renderable) == "Characters — who the AI plays · 2"
+            await pilot.click("#personas-mode-personas")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert "Personas" in str(purpose.renderable)
+            assert "· 1" in str(purpose.renderable)
 
     async def test_library_rail_collapses_and_reopens_from_handle(
         self,
@@ -595,26 +636,26 @@ class TestWorkbenchShell:
             assert "ctrl+enter send" in footer.shortcut_text
             assert footer.shortcut_text != AppFooterStatus.DEFAULT_SHORTCUT_TEXT
 
-    async def test_status_row_shows_live_counts_per_mode(
+    async def test_purpose_line_shows_live_counts_per_mode(
         self, mock_app_instance, stub_characters, stub_scope_service
     ):
+        """F-033: the merged purpose line carries each mode's live count."""
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test() as pilot:
             screen = await _mounted(pilot)
             await pilot.pause()
-            status = screen.query_one("#personas-status-row", Static)
-            assert "Characters: 2" in str(status.renderable)
-            assert str(status.renderable) == "Characters: 2"
+            purpose = screen.query_one("#personas-purpose", Static)
+            assert "· 2" in str(purpose.renderable)
+            assert "Characters" in str(purpose.renderable)
             await pilot.click("#personas-mode-personas")
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
-            assert "Personas: 1" in str(status.renderable)
-            # "prompts" is retired from the Personas mode strip (Task 7):
-            # "dictionaries" is the next still-unwired placeholder mode.
+            assert "· 1" in str(purpose.renderable)
+            assert "Personas" in str(purpose.renderable)
             await pilot.click("#personas-mode-dictionaries")
             await pilot.pause()
-            assert "Mode: Dictionaries" in str(status.renderable)
+            assert "Dictionaries" in str(purpose.renderable)
 
     async def test_placeholder_modes_show_placeholder_panel(
         self, mock_app_instance, stub_characters
@@ -703,9 +744,9 @@ class TestWorkbenchShell:
             )  # characters is the default mode
             await screen._apply_mode("personas")
             await pilot.pause()
-            assert (
-                str(screen.query_one("#personas-purpose", Static).renderable)
-                == "Personas — assistant profiles for roleplay and chat"
+            # F-033: the purpose line also carries the live count.
+            assert str(screen.query_one("#personas-purpose", Static).renderable) == (
+                "Personas — assistant profiles for roleplay and chat · 0"
             )
 
 
@@ -1076,7 +1117,7 @@ class TestPersonasMode:
 
             assert (
                 str(screen.query_one("#personas-purpose", Static).renderable)
-                == "Personas — assistant profiles for roleplay and chat"
+                == "Personas — assistant profiles for roleplay and chat · 1"
             )
             visible_copy = "\n".join(
                 [
@@ -1186,14 +1227,14 @@ class TestPersonasMode:
             assert screen._edit_mode == "edit"
             assert screen.query_one("#ccp-persona-editor-view").display is True
 
-    async def test_profile_save_refresh_failure_updates_status_row_and_recovery(
+    async def test_profile_save_refresh_failure_updates_purpose_line_and_recovery(
         self, mock_app_instance, stub_characters, stub_scope_service
     ):
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test() as pilot:
             screen = await self._enter_personas_mode(pilot)
-            assert "Personas: 1" in str(
-                screen.query_one("#personas-status-row", Static).renderable
+            assert "· 1" in str(
+                screen.query_one("#personas-purpose", Static).renderable
             )
 
             stub_scope_service.list_persona_profiles.side_effect = RuntimeError(
@@ -1208,8 +1249,8 @@ class TestPersonasMode:
 
             assert screen.query_one("#personas-service-error", Static)
             assert not list(screen.query(".personas-library-row"))
-            assert "Personas: 0" in str(
-                screen.query_one("#personas-status-row", Static).renderable
+            assert "· 0" in str(
+                screen.query_one("#personas-purpose", Static).renderable
             )
 
     async def test_profile_edit_save_calls_update(
@@ -1559,11 +1600,13 @@ class TestSearch:
             await self._wait_for_search_render(pilot)
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam"]
+            # F-033: the match count now lives in the merged header purpose
+            # line; the pane's duplicate count line stays empty.
             count = str(screen.query_one("#personas-library-count", Static).renderable)
-            # Task 4: the library pages from the DB seam, so a search reports the
-            # match count as the page total (no separate "of <library>" copy).
-            # task-445: a total of exactly 1 reads singular ("1 character").
-            assert "1 character" in count
+            assert count == ""
+            assert "· 1" in str(
+                screen.query_one("#personas-purpose", Static).renderable
+            )
 
     async def test_clearing_search_restores_all_rows(
         self, mock_app_instance, stub_characters
@@ -1582,8 +1625,11 @@ class TestSearch:
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam", "Lab Assistant"]
             count = str(screen.query_one("#personas-library-count", Static).renderable)
-            assert "2 characters" in count
-            assert "of" not in count
+            # F-033: unfiltered count renders once, in the header purpose line.
+            assert count == ""
+            assert "· 2" in str(
+                screen.query_one("#personas-purpose", Static).renderable
+            )
 
     async def test_search_is_case_insensitive(self, mock_app_instance, stub_characters):
         app = PersonasTestApp(mock_app_instance)
@@ -1618,10 +1664,13 @@ class TestSearch:
             await self._wait_for_search_render(pilot)
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Navigator"]
+            # F-033: the pane's duplicate count line stays empty; the merged
+            # header line carries the personas library total.
             count = str(screen.query_one("#personas-library-count", Static).renderable)
-            # Task 4: personas paginate in-memory; the count is the match total.
-            # task-445: a total of exactly 1 reads singular ("1 persona").
-            assert "1 persona" in count
+            assert count == ""
+            assert "· 2" in str(
+                screen.query_one("#personas-purpose", Static).renderable
+            )
 
     async def test_mode_switch_clears_search(
         self, mock_app_instance, stub_characters, stub_scope_service
@@ -5191,6 +5240,8 @@ class TestServerCharacterSourceIsolation:
             assert screen._characters == []
             assert screen._character_total == 0
             assert not list(screen.query(".personas-library-row"))
+            # F-033: the pane count line is empty for unfiltered lists; the
+            # (zero) total shows in the merged header purpose line instead.
             assert (
                 str(
                     screen.query_one(
@@ -5198,7 +5249,10 @@ class TestServerCharacterSourceIsolation:
                         Static,
                     ).renderable
                 )
-                == "0 characters"
+                == ""
+            )
+            assert "· 0" in str(
+                screen.query_one("#personas-purpose", Static).renderable
             )
             assert (
                 str(screen.query_one("#personas-library-sort", Button).label)
@@ -5218,19 +5272,22 @@ class TestServerCharacterSourceIsolation:
             "new_count",
         ),
         (
+            # F-033: the count slot snapshots the pane's count line, which is
+            # empty for unfiltered lists (the total moved to the merged
+            # header purpose line).
             (
                 "dictionaries",
                 "dictionary",
                 "New Dictionary Owner",
                 "2 entries · on",
-                "1 dictionary",
+                "",
             ),
             (
                 "lore",
                 "lore",
                 "New Lore Owner",
                 "3 entries · on",
-                "1 lore book",
+                "",
             ),
         ),
     )
@@ -5670,7 +5727,9 @@ class TestServerCharacterSourceIsolation:
                 await screen._apply_mode("prompts")
                 expected_mode = "prompts"
                 expected_rows = ()
-                expected_count = "0 prompts"
+                # F-033: unfiltered lists leave the pane count line empty;
+                # the total lives in the merged header purpose line.
+                expected_count = ""
 
             owner_sort = f"Sort: {expected_mode} current owner"
             owner_tag = f"Tag: {expected_mode} current owner"

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -746,7 +746,7 @@ class TestWorkbenchShell:
             await pilot.pause()
             # F-033: the purpose line also carries the live count.
             assert str(screen.query_one("#personas-purpose", Static).renderable) == (
-                "Personas — assistant profiles for roleplay and chat · 0"
+                "Personas — who you play in the chat · 0"
             )
 
 
@@ -1100,7 +1100,7 @@ class TestPersonasMode:
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Archivist"]
 
-    async def test_personas_mode_uses_assistant_profile_copy_without_human_actions(
+    async def test_personas_mode_copy_avoids_human_identity_actions(
         self, mock_app_instance, stub_characters, stub_scope_service
     ):
         app = PersonasTestApp(mock_app_instance)
@@ -1115,9 +1115,11 @@ class TestPersonasMode:
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
+            # F-034: the descriptor teaches the genre convention (who YOU
+            # play) - and F-033 merged the live count into the same line.
             assert (
                 str(screen.query_one("#personas-purpose", Static).renderable)
-                == "Personas — assistant profiles for roleplay and chat · 1"
+                == "Personas — who you play in the chat · 1"
             )
             visible_copy = "\n".join(
                 [
@@ -8087,7 +8089,8 @@ def legacy_human_config(tmp_path, monkeypatch):
 
 
 class TestPersonaHumanIdentityRemoval:
-    """Personas remain assistant profiles and never identify the human user."""
+    """Personas never identify the human user (F-034: "who you play" copy
+    teaches the play-identity convention without reviving that framing)."""
 
     async def _select_profile(self, pilot):
         screen = await _mounted(pilot)
@@ -9012,7 +9015,8 @@ class TestDirtyTracking:
             # now that the save cleared it).
             assert str(subtitle.renderable) == "Editing Detective Sam"
             title = screen.query_one("#personas-header #workbench-header-title", Static)
-            assert str(title.renderable) == "Roleplay & Chat Dictionaries"
+            # F-034: the screen's one public name matches the nav label.
+            assert str(title.renderable) == "Roleplay"
 
     async def test_active_row_gets_unsaved_badge(
         self, mock_app_instance, stub_characters, stub_conversations, monkeypatch

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -26,6 +26,7 @@ never mount a screen before its saved state has been seeded.
 """
 
 from unittest.mock import AsyncMock
+from types import SimpleNamespace
 
 import pytest
 from textual.app import App
@@ -376,27 +377,47 @@ class TestPendingRestoreGuards:
             assert screen._console_action_allowed() is False
 
 
-class TestNonCharacterModeRestoreGate:
-    """A saved non-Characters mode must never be restored (task-434 review).
+class TestNonCharacterModeRestore:
+    """F-040: saved non-Characters modes restore mode AND selection.
 
-    ``on_mount`` only unconditionally wires the Characters path; every other
-    mode's library rows and mode-specific widgets (Preview pane, Try-It
-    panes) are refreshed/toggled solely by ``_apply_mode``, which a restore
-    never calls. Reconstructing ``self.state`` for a saved non-Characters
-    mode would therefore restore the mode chip while leaving the library
-    empty and the wrong panes visible - a regression, not a restore. The
-    gate keeps that path on the safe, already-correct default view.
+    ``_apply_pending_restore`` runs the full ``_apply_mode`` for the saved
+    mode before re-selecting, so the mode's library rows and mode-specific
+    panes are live when the selection lands. (Before F-040 these round-trips
+    fell back to the fresh Characters default - the documented task-434
+    floor this task raised.)
     """
 
-    async def test_saved_dictionaries_mode_falls_back_to_characters_on_restore(
+    async def test_saved_dictionaries_mode_restores_mode_and_selection(
         self, mock_app_instance, stub_characters
     ):
-        mock_app_instance.chat_dictionary_scope_service = None
+        mock_app_instance.chat_dictionary_scope_service = SimpleNamespace(
+            list_dictionaries=AsyncMock(
+                return_value={
+                    "dictionaries": [
+                        {
+                            "id": 91,
+                            "name": "Some Dictionary",
+                            "entry_count": 2,
+                            "enabled": True,
+                        }
+                    ]
+                }
+            ),
+            get_dictionary=AsyncMock(
+                return_value={
+                    "id": 91,
+                    "name": "Some Dictionary",
+                    "entries": [],
+                    "version": 1,
+                }
+            ),
+            get_statistics=AsyncMock(return_value={}),
+        )
         saved = {
             "personas_workbench": {
                 "active_mode": "dictionaries",
                 "selected_entity_kind": "dictionary",
-                "selected_entity_id": "dict-1",
+                "selected_entity_id": "91",
                 "selected_entity_name": "Some Dictionary",
             },
             "personas_preview": None,
@@ -405,23 +426,37 @@ class TestNonCharacterModeRestoreGate:
         app = _RestoringPersonasTestApp(mock_app_instance, saved)
         async with app.run_test() as pilot:
             screen2 = await _mounted(pilot)
-            # Falls back to the fresh default: Characters mode, no selection.
-            assert screen2.state.active_mode == "characters"
-            assert screen2.state.selected_entity_id is None
-            assert screen2.state.selected_entity_kind is None
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert screen2.state.active_mode == "dictionaries"
+            assert screen2.state.selected_entity_id == "91"
+            assert screen2.state.selected_entity_kind == "dictionary"
+            assert screen2.state.selected_entity_name == "Some Dictionary"
             assert screen2._pending_restore is None
-            # Blank center, same as any fresh Characters-mode mount.
-            assert screen2.query_one("#ccp-character-card-view").display is False
+            assert (
+                screen2.query_one("#personas-dictionary-detail").display is True
+            )
 
-    async def test_saved_personas_mode_falls_back_to_characters(
+    async def test_saved_personas_mode_restores_mode_and_selection(
         self, mock_app_instance, stub_characters
     ):
-        """Only Characters mode is restored; saved Personas still falls back.
-
-        The terminology correction deliberately adds no migration or
-        persistence-format rewrite for this existing restore floor.
-        """
-        mock_app_instance.character_persona_scope_service = None
+        """Personas round-trips too, not just Characters (F-040)."""
+        mock_app_instance.character_persona_scope_service = SimpleNamespace(
+            list_persona_profiles=AsyncMock(
+                return_value={
+                    "items": [{"id": "persona-1", "name": "Some Persona"}],
+                    "total": 1,
+                }
+            ),
+            get_persona_profile=AsyncMock(
+                return_value={
+                    "id": "persona-1",
+                    "name": "Some Persona",
+                    "description": "Keeps notes.",
+                    "system_prompt": "You are archival.",
+                }
+            ),
+        )
         saved = {
             "personas_workbench": {
                 "active_mode": "personas",
@@ -435,8 +470,10 @@ class TestNonCharacterModeRestoreGate:
         app = _RestoringPersonasTestApp(mock_app_instance, saved)
         async with app.run_test() as pilot:
             screen2 = await _mounted(pilot)
-            # Falls back to the fresh default: Characters mode, no selection.
-            assert screen2.state.active_mode == "characters"
-            assert screen2.state.selected_entity_id is None
-            assert screen2.state.selected_entity_kind is None
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert screen2.state.active_mode == "personas"
+            assert screen2.state.selected_entity_id == "persona-1"
+            assert screen2.state.selected_entity_kind == "persona"
             assert screen2._pending_restore is None
+            assert screen2.query_one("#ccp-persona-card-view").display is True

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -477,3 +477,71 @@ class TestNonCharacterModeRestore:
             assert screen2.state.selected_entity_kind == "persona"
             assert screen2._pending_restore is None
             assert screen2.query_one("#ccp-persona-card-view").display is True
+
+
+class TestInvalidRestoreStillAutoSelects:
+    """Qodo review: an unusable saved payload must not suppress F-031.
+
+    ``restore_state`` used to set ``_restored_from_saved_state`` for ANY
+    dict-shaped payload, so a stale/invalid saved state landed the user on
+    the dead no-selection first paint instead of auto-selecting a row.
+    """
+
+    async def test_invalid_mode_saved_state_still_auto_selects_first_row(
+        self, mock_app_instance, stub_characters
+    ):
+        """A saved mode that does not resolve to a chip mode is not a real
+        restore - first-paint auto-select still fires."""
+        saved = {
+            "personas_workbench": {
+                # Not a MODE_CHIP_ORDER mode: nothing here can be restored.
+                "active_mode": "prompts",
+                "selected_entity_kind": "prompt",
+                "selected_entity_id": "p-1",
+                "selected_entity_name": "Some Prompt",
+            },
+            "personas_preview": None,
+        }
+
+        app = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert screen.state.selected_entity_id == "char-1"
+            assert screen.query_one("#ccp-character-card-view").display is True
+
+    async def test_stale_saved_selection_falls_back_to_auto_select(
+        self, mock_app_instance, stub_characters, monkeypatch
+    ):
+        """A valid payload whose entity no longer resolves: the restore
+        clears the stale selection AND the round-trip flag, so auto-select
+        still rescues the paint."""
+        saved = {
+            "personas_workbench": {
+                "active_mode": "characters",
+                "selected_entity_kind": "character",
+                "selected_entity_id": "ghost-9",
+                "selected_entity_name": "Ghost",
+            },
+            "personas_preview": None,
+        }
+
+        real_select = PersonasScreen._select_character
+
+        async def _flaky_select(self, entity_id, entity_name, **kwargs):
+            if str(entity_id) == "ghost-9":
+                raise RuntimeError("stale entity")
+            await real_select(self, entity_id, entity_name, **kwargs)
+
+        monkeypatch.setattr(PersonasScreen, "_select_character", _flaky_select)
+
+        app = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            # The stale restore failed, so the mount fell back to the
+            # first-paint behavior and selected the first real row.
+            assert screen.state.selected_entity_id == "char-1"
+            assert screen.query_one("#ccp-character-card-view").display is True

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -169,16 +169,19 @@ class TestWorkbenchSelectionRestore:
             # center shows the character card view, not blank
             assert screen2.query_one("#ccp-character-card-view").display is True
 
-    async def test_fresh_screen_without_saved_state_shows_blank_center(
+    async def test_fresh_screen_without_saved_state_auto_selects_first_row(
         self, mock_app_instance, stub_characters
     ):
-        """No prior selection: on_mount's default (blank) center is untouched."""
+        """No prior selection + a non-empty library: F-031 first-paint
+        auto-select picks the first row and shows its card, not a void."""
         mock_app_instance.chat_dictionary_scope_service = None
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test() as pilot:
             screen = await _mounted(pilot)
-            assert screen.state.selected_entity_id is None
-            assert screen.query_one("#ccp-character-card-view").display is False
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert screen.state.selected_entity_id == "char-1"
+            assert screen.query_one("#ccp-character-card-view").display is True
 
 
 class TestPreviewRestore:

--- a/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
+++ b/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
@@ -27,6 +27,8 @@ from Tests.UI.test_destination_shells import (
     _wait_for_wc_snapshot,
 )
 from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_personas_dictionaries import patch_character_paging
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
 from Tests.UI.test_library_shell import (
     LIBRARY_TEST_SIZE,
     LibraryHarness,
@@ -278,8 +280,20 @@ async def test_service_unavailable_states_disable_false_console_handoffs(
 
 
 @pytest.mark.asyncio
-async def test_personas_default_state_disables_false_console_handoff() -> None:
-    """Personas starts local-first; Console attach stays blocked until selection."""
+async def test_personas_default_state_disables_false_console_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Personas starts local-first; Console attach stays blocked until selection.
+
+    F-031 auto-selects the first library row on first paint when rows exist,
+    so the no-selection contract this test pins needs an empty library
+    (stubbed deterministically; the harness otherwise reads the ambient
+    character DB).
+    """
+    monkeypatch.setattr(
+        character_handler_module, "fetch_all_characters", lambda: []
+    )
+    patch_character_paging(monkeypatch, records=[])
     app = _build_test_app()
     host = DestinationHarness(app, "personas")
 
@@ -289,7 +303,7 @@ async def test_personas_default_state_disables_false_console_handoff() -> None:
         button = screen.query_one("#personas-attach-to-console", Button)
 
         visible_text = _visible_text(screen)
-        assert "Console blocked: select an item" in visible_text
+        assert "Pick a character or persona to start chatting." in visible_text
         assert button.disabled is True
 
 

--- a/Tests/UI/test_shell_destinations.py
+++ b/Tests/UI/test_shell_destinations.py
@@ -25,22 +25,23 @@ def test_master_shell_destination_order_matches_spec():
 
 
 def test_personas_destination_labelled_roleplay_with_aliases():
-    """The nav destination reads "Roleplay", expanding to "Roleplay & Chat Dictionaries".
+    """The nav destination reads "Roleplay" - the one public name everywhere.
 
     "Personas" stays reserved for the in-screen user-identity mode
     (``MODE_LABELS["personas"]``), which this test does not touch (task-435).
 
     The label was "RP&CD" until a roleplay UAT found that a newcomer -- whose
     whole goal is roleplay -- could not decode the abbreviation from the nav
-    bar, which is exactly where the decision to navigate gets made. The
-    expansion was only visible as the screen title, i.e. after guessing right.
-    Every legacy route alias below still resolves, so muscle memory and links
-    are unaffected.
+    bar, which is exactly where the decision to navigate gets made. F-034
+    then retired the long "Roleplay & Chat Dictionaries" expansion (palette
+    full_label) so nav, header, and palette all say the same thing. Every
+    legacy route alias below still resolves, so muscle memory and links are
+    unaffected.
     """
     dest = get_shell_destination("personas")
     assert dest.label == "Roleplay"
-    assert dest.full_label == "Roleplay & Chat Dictionaries"
-    assert dest.accessible_label == "Roleplay & Chat Dictionaries"
+    assert dest.full_label == "Roleplay"
+    assert dest.accessible_label == "Roleplay"
     assert "roleplay" in dest.legacy_routes
     for route in (
         "personas",

--- a/Tests/UI/test_uat_first_time_character_chat.py
+++ b/Tests/UI/test_uat_first_time_character_chat.py
@@ -8,10 +8,10 @@ DB) and a SillyTavern-layout (post-IDAT ``tEXt`` chunk) character card PNG:
 2. User imports a character card PNG (the layout a SillyTavern user reported
    failing to import).
 3. The character appears in the library and is selected.
-4. User presses "Start Chat" with NO provider configured -> the app blocks
+4. User presses "Chat now" with NO provider configured -> the app blocks
    gracefully with an actionable tooltip (no crash, no dead end).
 5. User configures a provider (API key in settings).
-6. User presses "Start Chat" again -> a character handoff payload is staged
+6. User presses "Chat now" again -> a character handoff payload is staged
    and the Console consumes it.
 7. User types a message and sends it -> the (mocked) provider replies, the
    reply lands in the transcript, and the conversation is persisted.
@@ -431,7 +431,7 @@ async def test_first_time_user_character_chat_journey(
         assert personas.state.selected_entity_kind == "character"
         assert personas.state.selected_entity_name
 
-        # -- 4. Start Chat with NO provider configured -> graceful block ----
+        # -- 4. Chat now with NO provider configured -> graceful block ------
         # First-run UX: the button is DISABLED with an actionable tooltip
         # (prevention, not an error toast). (No click: a disabled Textual
         # button ignores presses, and click-at-coordinates on a disabled
@@ -442,9 +442,9 @@ async def test_first_time_user_character_chat_journey(
 
         assert type(app.screen).__name__ == "PersonasScreen"
         assert start_btn.disabled, (
-            "Start Chat must be disabled when the handoff provider is not ready"
+            "Chat now must be disabled when the handoff provider is not ready"
         )
-        assert start_btn.tooltip and "Start Chat blocked:" in start_btn.tooltip, (
+        assert start_btn.tooltip and "Chat now blocked:" in start_btn.tooltip, (
             f"Expected an actionable block tooltip; got: {start_btn.tooltip!r}"
         )
 
@@ -459,7 +459,7 @@ async def test_first_time_user_character_chat_journey(
         personas._sync_title_and_console_actions()
         await pilot.pause(0.3)
         assert not start_btn.disabled, (
-            f"Start Chat must enable once the provider is ready; "
+            f"Chat now must enable once the provider is ready; "
             f"tooltip: {start_btn.tooltip!r}"
         )
 
@@ -480,7 +480,7 @@ async def test_first_time_user_character_chat_journey(
 
         monkeypatch.setattr(chat_functions_module, "chat_api_call", fake_chat_api_call)
 
-        # -- 6. Start Chat again -> handoff to the Console ------------------
+        # -- 6. Chat now again -> handoff to the Console ---------------------
         # Baseline for the persistence check: anything the handoff/send
         # persists must appear AFTER this point.
         before_conversation_ids = set(db.get_all_conversation_ids())

--- a/backlog/tasks/task-2081 - Roleplay-stop-the-library-toolbar-clipping-Import-at-supported-widths-F-030.md
+++ b/backlog/tasks/task-2081 - Roleplay-stop-the-library-toolbar-clipping-Import-at-supported-widths-F-030.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2081
 title: 'Roleplay: stop the library toolbar clipping Import at supported widths (F-030)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 07:16'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ At 100x30 only New and Sort survive; Import, Duplicate, Tag are clipped while em
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All toolbar actions are reachable at 100x30 (wrap or overflow menu with New pinned),Rendered-layout regression test at 100x30 and 80x24
+- [x] #1 All toolbar actions are reachable at 100x30 (wrap or overflow menu with New pinned),Rendered-layout regression test at 100x30 and 80x24
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing rendered-layout tests (styled app at 100x30 + 80x24) asserting all library toolbar buttons fit inside the pane. 2. Slim toolbar/filterbar buttons (min-width:0) in PersonasLibraryPane DEFAULT_CSS. 3. Pane-local responsive stacking: toggle a class from on_resize when the pane is too narrow for one row; CSS switches the two bars to vertical layout so every action wraps into view. Global 90-col compact threshold left unchanged (pane-local wrap makes it orthogonal; documented in notes). 4. Run persona UI suites + ruff. ADR required: no - UI layout/copy fix, no schema/boundary/contract change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Wrap fix in PersonasLibraryPane: toolbar/filterbar buttons now size to their labels (min-width:0 instead of Textual's 16), and the pane toggles a personas-library-stacked-controls class from on_resize when its content is narrower than the single-row width (label-derived measurement, so no oscillation); CSS then switches both bars to vertical layout so New/Import/Duplicate/Sort/Tag each wrap onto their own full-width row. Reached via set_mode/set_sort_label/set_tag_label resyncs too. The global PERSONAS_COMPACT_WORKBENCH_MAX_WIDTH=90 was reconsidered and deliberately left unchanged: pane-local wrapping fixes reachability at every width, while engaging the compact split at 91-100 cols would only shrink the center card below its designed 40-col minimum. Files: tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py, Tests/UI/test_personas_library_toolbar_layout.py (new rendered-layout regression tests at 100x30 + 80x24 + 170x50 counter-case). Verified: 3 new tests pass; Tests/UI/test_personas_library_pane.py + paging (27) pass; test_personas_workbench.py + test_personas_library_scale.py (302) pass; ruff clean. ADR: not required (UI layout fix, no schema/boundary change).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2082 - Roleplay-design-the-first-paint-auto-select-honest-inspector-F-031.md
+++ b/backlog/tasks/task-2082 - Roleplay-design-the-first-paint-auto-select-honest-inspector-F-031.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2082
 title: 'Roleplay: design the first paint (auto-select, honest inspector) (F-031)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 08:16'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ Nothing selected on mount: center void, 5 disabled buttons, disabled checkbox, a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 First library row is auto-selected on mount when the library is non-empty,With no selection the action stack and Validation line are hidden and a single guidance line shows,Tests updated
+- [x] #1 First library row is auto-selected on mount when the library is non-empty,With no selection the action stack and Validation line are hidden and a single guidance line shows,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing tests first: inspector pane hides action stack/Conversations+Readiness headers/Validation pre-selection and shows one guidance line; screen auto-selects first library row on mount (fresh mounts only - restore round-trips and empty libraries exempt). 2. PersonasInspectorPane: id the Conversations/Readiness headers, gate their display plus the action stack and Validation line on _has_selection inside _apply_action_state. 3. PersonasScreen._load_after_mount: after _apply_pending_restore, auto-select first row via the existing _select_character path (no focus moves - focus-steal guards untouched); restore_state marks saved-state mounts so they skip auto-select. 4. Update tests pinning the old no-selection first paint. ADR required: no - UI composition/copy change on existing selection flow; no schema, boundary, or contract change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented (a) mount-time auto-select of the first library row via the existing _select_character path (no focus moves; restore_state marks saved-state mounts via _restored_from_saved_state so Console round-trips keep their own selection semantics; empty libraries and non-characters modes skip), plus a _sync_title_and_console_actions after auto-select so header/footer reflect the selection on first paint; (b) inspector hides the action stack, Conversations+Readiness headers, conversations list, and Validation line when kind is None and shows one guidance line ('Pick a character or persona to start chatting.') via _apply_action_state; (c) Validation display is selection-gated so no false 'Validation: OK' pre-selection. Files: tldw_chatbook/UI/Screens/personas_screen.py, tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py; tests in Tests/UI/test_personas_{inspector_pane,workbench,workbench_state}.py + test_product_maturity_phase1_empty_setup_states.py. Unsaved-edit guards verified intact (guarded paths untouched; auto-select bypasses the guard only because first paint has no edits; test_first_paint_auto_select_keeps_unsaved_guards_quiet pins clean follow-up selection). Verified: 326 workbench/state/inspector tests pass, plus dictionary/lore/preview/library-pane/footer-hints suites (202) and ProductionApp/navigation/phase6 (86); ruff clean. ADR: not required (UI composition on existing selection flow).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2083 - Roleplay-consolidate-Console-CTAs-and-speak-in-intent-F-032.md
+++ b/backlog/tasks/task-2083 - Roleplay-consolidate-Console-CTAs-and-speak-in-intent-F-032.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2083
 title: 'Roleplay: consolidate Console CTAs and speak in intent (F-032)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 08:49'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ Attach to Console / Start Chat / Open in Console are three near-synonymous CTAs;
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One primary and at most one secondary Console action with intent names,Readiness copy uses intent language,Tests updated
+- [x] #1 One primary and at most one secondary Console action with intent names,Readiness copy uses intent language,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update failing tests first: new labels (Chat now primary / Send to Console draft secondary / Continue this chat in Console), intent readiness copy. 2. PersonasInspectorPane: reorder+rename the two Console buttons (ids/handlers/gating unchanged - per-intent gating from task-523 preserved), rewrite readiness branches in intent language (guidance no-selection line from task-2082 stays), rename provider-block tooltip/notify copy. 3. PersonasPreviewPane: rename Open in Console button. 4. Sweep stale comments/docstrings; run persona suites + UAT + parity + ruff. ADR required: no - label/copy changes only; gating logic, ids, and message flow unchanged.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Consolidated the three near-synonymous Console CTAs: inspector now has one primary 'Chat now' (console-action-primary, id personas-start-chat, intent=start_chat) and one secondary 'Send to Console draft' (id personas-attach-to-console, intent=attach - the old Attach semantics); preview button renamed 'Continue this chat in Console'. Ids, handlers, messages, and the task-523 per-intent gating are untouched - verified by probe: Send to Console draft stays enabled while Chat now disables on an unready provider. Readiness copy now speaks intent: 'Pick a character or persona to start chatting.' / 'Save or discard your edits to chat in Console.' / 'Console chat is for characters and personas.' / 'Chat now blocked: <reason>' / 'Ready to chat in Console.' Files: tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py, personas_preview_pane.py, tldw_chatbook/UI/Screens/personas_screen.py (notify + comments); tests updated in Tests/UI/test_personas_{inspector_pane,preview,workbench}.py, test_uat_first_time_character_chat.py, test_destination_visual_parity_correction.py (plus comment sweeps in test_console_session_settings.py). Verified: final gate 541 passed/0 failed across 14 roleplay-affected files (workbench, state, inspector, preview, library panes, toolbar layout, attach, world-books, UAT, parity, phase1, footer hints, root-state); console_session_settings 134 passed separately; ruff clean. ADR: not required (labels/copy only; no logic, schema, or boundary change).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2084 - Roleplay-slim-the-five-strip-header-band-F-033.md
+++ b/backlog/tasks/task-2084 - Roleplay-slim-the-five-strip-header-band-F-033.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2084
 title: 'Roleplay: slim the five-strip header band (F-033)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 09:39'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ Nav + title/subtitle/Ready + purpose + count + mode strip; 'Characters' appears 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Purpose and status merge into one line,Count is shown once,Header band loses at least 2 lines at 170x50,Tests updated
+- [x] #1 Purpose and status merge into one line,Count is shown once,Header band loses at least 2 lines at 170x50,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing tests first: merged purpose+count line, no #personas-status-row in DOM, library count empty when unfiltered, workbench top edge moves up at 170x50. 2. PersonasScreen: drop the status-row Static; new _purpose_line_text() (descriptor + count from _character_total/_profiles/_dictionaries_cache/_lore_books_cache) replacing _status_row_text/_update_status_row at all call sites. 3. PersonasLibraryPane.update_rows: unfiltered non-recovery count line renders empty (count now lives in the header line); filtered/recovery/pagebar states unchanged. 4. Update tests pinning the old strips/copy. ADR required: no - UI composition/copy consolidation; no schema, boundary, or contract change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Merged purpose+count into one line ('Characters — who the AI plays · 2') via new _purpose_line_text() (counts from _character_total / len(_profiles) / _dictionaries_cache / _lore_books_cache); removed the #personas-status-row strip from compose and replaced _status_row_text/_update_status_row with _update_purpose_line at all 12 call sites. Library pane count line now renders empty for unfiltered lists (count shown once, in the header line) and keeps filtered/recovery/pagebar states. Band loses one strip (workbench top edge moves from y=11 to y=10 at 170x50, pinned by test) and the library list gains the duplicate-count row. Files: tldw_chatbook/UI/Screens/personas_screen.py, tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py; tests in Tests/UI/test_personas_{workbench,library_pane,library_pane_paging}.py. Verified: 58 targeted workbench tests + 30 pane/layout tests + 48 server-isolation race tests pass; dict/lore/scale suites green in the pre-commit gate run (10 race-test failures found and fixed via updated count expectations). ruff clean. ADR: not required (UI strip consolidation; no schema/boundary change).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2085 - Roleplay-one-public-name-and-persona-copy-that-teaches-the-model-F-034.md
+++ b/backlog/tasks/task-2085 - Roleplay-one-public-name-and-persona-copy-that-teaches-the-model-F-034.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2085
 title: 'Roleplay: one public name and persona copy that teaches the model (F-034)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 09:50'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ Nav 'Roleplay' vs header 'Roleplay & Chat Dictionaries' vs mode 'Personas' ('ass
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Screen uses one public name consistently,Personas descriptor teaches 'who you play',Tests updated
+- [x] #1 Screen uses one public name consistently,Personas descriptor teaches 'who you play',Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update tests asserting 'Roleplay & Chat Dictionaries' / 'assistant profiles' first. 2. personas_screen.py: header title -> 'Roleplay' at both sites (compose + _update_title); personas mode descriptor -> 'Personas — who you play in the chat.' 3. shell_destinations.py full_label and app.py action descriptions -> 'Roleplay' for one consistent public name. 4. Update palette/shell-destination test assertions; run destination/palette/personas suites + ruff. ADR required: no - user-facing label/copy unification; no behavior, schema, or boundary change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Unified the public name as 'Roleplay': screen header title (both personas_screen.py sites), shell_destinations full_label, and the six app.py action descriptions; the retired 'Roleplay & Chat Dictionaries' long form also left the palette alias terms. Personas descriptor is now 'Personas — who you play in the chat.' (teaches the genre convention against Characters' 'who the AI plays') without touching the human-identity prohibition (forbidden-copy test retained, renamed). Files: tldw_chatbook/UI/Screens/personas_screen.py, tldw_chatbook/UI/Navigation/shell_destinations.py, tldw_chatbook/app.py; tests in Tests/UI/test_{shell_destinations,command_palette_providers,command_palette_shell_routes,personas_workbench}.py. Verified: 556 passed/1 skipped gate (workbench, shell destinations, palette x2, screen navigation, destination shells); ruff clean. ADR: not required (label/copy unification only).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2086 - Roleplay-adaptive-empty-state-copy-and-sane-alignment-F-035.md
+++ b/backlog/tasks/task-2086 - Roleplay-adaptive-empty-state-copy-and-sane-alignment-F-035.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2086
 title: 'Roleplay: adaptive empty-state copy and sane alignment (F-035)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 10:04'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ Empty copy renders 'use New or Import' even with characters present, centered in
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Empty copy adapts to whether the library has items,Copy alignment matches app conventions (left/centered deliberately),Tests updated
+- [x] #1 Empty copy adapts to whether the library has items,Copy alignment matches app conventions (left/centered deliberately),Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing tests first: empty library shows New/Import copy; non-empty library with cleared selection (mode round-trip) shows picker copy; styled test pins left/top alignment per .chat-empty-state convention. 2. personas_screen.py: _characters_empty_guidance_text adapts on _character_total; empty-library copy stops claiming 'pick from the list'; #personas-characters-empty CSS switches from center-middle to left-top alignment. 3. Run guidance + suites + ruff. ADR required: no - empty-state copy/CSS only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Empty-state copy now adapts on _character_total: empty library -> 'No characters yet — use New or Import to add one.' (no longer claims a list exists); non-empty library with cleared selection -> 'Pick a character from the list to see it here.' Reconciliation with task-2082 auto-select: first paint auto-selects, so the picker variant serves post-delete and mode-round-trip no-selection states, and the New/Import variant serves first-run/empty libraries. Alignment switched from center-middle-in-a-void to left/top per the app's empty-state convention (.chat-empty-state). Files: tldw_chatbook/UI/Screens/personas_screen.py (constants, _characters_empty_guidance_text, #personas-characters-empty CSS); tests in TestCharactersEmptyStateGuidance (adaptive copy both ways + styled alignment pin). Verified: guidance class 8 passed; gate 299 passed (full workbench + phase6 replay); ruff clean. ADR: not required (copy/CSS only).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2087 - Roleplay-give-Inspector-Conversations-an-empty-state-F-036.md
+++ b/backlog/tasks/task-2087 - Roleplay-give-Inspector-Conversations-an-empty-state-F-036.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2087
 title: 'Roleplay: give Inspector Conversations an empty state (F-036)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 10:12'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ show_conversations(()) is called without empty_copy, leaving a dangling 'Convers
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Conversations section shows empty copy or is hidden when empty,Tests updated
+- [x] #1 Conversations section shows empty copy or is hidden when empty,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing pane tests: character selection with zero conversations renders 'No saved conversations.' placeholder; persona/dictionary/lore selections hide the Conversations section entirely (kind-aware, matching the task-443 inspector idiom). 2. PersonasInspectorPane._apply_action_state: conversations header+list display = selected AND kind==character. 3. personas_screen._select_character server branch passes empty_copy='No saved conversations.' (the local path already does via the controller). 4. Run pane + conversations suites + ruff. ADR required: no - inspector section visibility/copy; no behavior-contract change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The Conversations section now follows the inspector's existing kind idiom (task-443): _apply_action_state shows the header+list only for character selections (personas/dictionaries/lore have no conversation linkage - hiding matches how the console/export actions are handled for those kinds), and characters with zero saved conversations render the 'No saved conversations.' placeholder in every path (local already did via the controller; the server select branch now passes the same empty_copy). Pre-selection hiding from task-2082 is unchanged. Files: tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py, tldw_chatbook/UI/Screens/personas_screen.py; tests in Tests/UI/test_personas_inspector_pane.py (kind-gate + empty-copy rendering). Verified: pane 26 passed; gate 324 passed (pane + full workbench incl. server isolation and conversations panel classes); ruff clean. ADR: not required (section visibility/copy).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2088 - Roleplay-reason-tooltips-on-disabled-Export-Delete-Edit-F-037.md
+++ b/backlog/tasks/task-2088 - Roleplay-reason-tooltips-on-disabled-Export-Delete-Edit-F-037.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2088
 title: 'Roleplay: reason tooltips on disabled Export/Delete/Edit (F-037)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 10:26'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ Export JSON/PNG, Delete, and card Edit are disabled with no reason in the no-sel
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All disabled inspector actions carry a reason tooltip,Tests updated
+- [x] #1 All disabled inspector actions carry a reason tooltip,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing tests first: pane default state asserts every disabled action carries a reason tooltip; server-browsing state asserts Edit/Export/Delete tooltips; card Edit id-less state tooltip. 2. PersonasInspectorPane._apply_action_state: no-selection reason tooltips for export/delete, intent tooltip for console actions (guidance replaces stale 'Console action blocked: select an item'). 3. personas_screen._sync_local_character_actions + server select branch: set a read-only reason tooltip when force-disabling Edit/Export/Delete in server mode (and clear on restore). 4. Card widget: Edit tooltip for the no-saved-id case. 5. Check the skipped tooltip audit at Tests/UI/test_destination_shells.py:2203 for re-enable scope. ADR required: no - tooltip/copy additions on existing gates.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Every disabled inspector action now carries a reason tooltip: no-selection -> intent guidance (console pair), 'Select an item to export.' (exports), 'Select an item to delete.' (delete); unsaved edits keep the save-first tooltip; the screen-blocked custom-reason tooltip now matches the readiness line's intent copy ('Chat blocked: <reason>'). Server browsing force-disables card Edit + inspector export/delete with 'Server characters are read-only here.' (set in _sync_local_character_actions and the server select branch; cleared on restore). Card Edit also explains its no-selection and no-saved-record states. Deferral: the test_destination_shells all-buttons tooltip audit (line ~2203) stays skipped - it audits tooltips on EVERY button incl. always-enabled editor Save/Cancel and preview controls, beyond F-037's disabled-reason scope. Files: personas_inspector_pane.py, personas_character_card_widget.py, personas_screen.py; tests in test_personas_{inspector_pane,character_widgets,workbench}.py. Verified: 60 pane+card tests, server-isolation tooltip test, gate 464 passed/1 skipped (pane, card widgets, full workbench, UAT, destination shells); ruff clean. ADR: not required (tooltips on existing gates).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2089 - Roleplay-surface-the-existing-accelerators-F-038.md
+++ b/backlog/tasks/task-2089 - Roleplay-surface-the-existing-accelerators-F-038.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2089
 title: 'Roleplay: surface the existing accelerators (F-038)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:24'
+updated_date: '2026-08-04 10:58'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ F6 pane cycle, Ctrl+1-4 mode jumps, Space dictionary toggle appear in no footer/
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Mode chips/tooltips and footer advertise the working shortcuts,Tests updated
+- [x] #1 Mode chips/tooltips and footer advertise the working shortcuts,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing tests first: footer context renders f6 pane / ctrl+1-4 mode / [ ] mode / renamed 'ctrl+enter draft' (was attach), space toggle only in dictionaries mode; mode chip tooltips carry their Ctrl+N hint. 2. personas_screen._shortcut_context: add the always-on accelerators, per-mode space toggle, rename attach->draft. 3. Mode chip tooltips gain ' (Ctrl+N)'. 4. Update footer/chip tests; run workbench + footer-hint suites + ruff. ADR required: no - shortcut disclosure copy; no binding behavior changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Footer shortcut context now advertises the working accelerators per state: f6 pane, ctrl+1-4 mode, [ ] mode always; space toggle only in dictionaries mode (the pane's space binding only acts on dictionary rows); ctrl+enter hint renamed 'attach' -> 'draft' to match the F-032 Send to Console draft CTA. Mode chip tooltips now carry their Ctrl+N jump key (mirrors MODE_CHIP_ORDER bindings). Files: tldw_chatbook/UI/Screens/personas_screen.py (_shortcut_context, mode chip compose); tests in test_personas_workbench.py (footer context content/gating, chip tooltips, import-refresh draft label). Verified: targeted 7 + gate 306 passed (full workbench + footer hints); ruff clean. ADR: not required (shortcut disclosure copy; no binding behavior changed).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2090 - Roleplay-re-anchor-the-preview-conversation-affordance-F-039.md
+++ b/backlog/tasks/task-2090 - Roleplay-re-anchor-the-preview-conversation-affordance-F-039.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2090
 title: 'Roleplay: re-anchor the preview conversation affordance (F-039)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:25'
+updated_date: '2026-08-04 11:07'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ priority: low
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Preview affordance is visually attached to the character/canvas it previews,Tests/snapshot updated
+- [x] #1 Preview affordance is visually attached to the character/canvas it previews,Tests/snapshot updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing layout test first: at 170x50 the preview pane sits immediately above the center detail stack (attached to the canvas), not stranded at the work-area bottom; expand/collapse glyph on the toggle. 2. personas_screen compose_content: move PersonasPreviewPane above #personas-detail-stack inside the work area. 3. Preview pane: toggle label gains a collapse glyph (expanded/collapsed state). 4. Visual verification via SVG text-grid capture at 170x50; run preview + layout + parity suites + ruff. ADR required: no - layout placement of an existing widget; no structure/contract change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Moved PersonasPreviewPane above #personas-detail-stack inside the work area so the preview toggle anchors the top of the center canvas (flush against the detail stack's top edge, pinned by layout test) instead of a strip stranded at the work-area bottom; toggle gained an expand/collapse glyph (▸/▾) synced across click and the expand() API. Files: tldw_chatbook/UI/Screens/personas_screen.py (compose order), tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py (glyph); test in Tests/UI/test_personas_library_toolbar_layout.py. Visual verification: headless SVG text-grid capture at 170x50 shows the expanded preview heading the center column. Verified: gate 462 passed (layout, preview, full workbench, visual parity); ruff clean. ADR: not required (widget placement).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2091 - Roleplay-bulk-operations-sort-key-and-selection-restore-across-modes-F-040.md
+++ b/backlog/tasks/task-2091 - Roleplay-bulk-operations-sort-key-and-selection-restore-across-modes-F-040.md
@@ -3,9 +3,10 @@ id: TASK-2091
 title: >-
   Roleplay: bulk operations, sort key, and selection restore across modes
   (F-040)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:25'
+updated_date: '2026-08-04 11:45'
 labels:
   - ux-review
   - roleplay
@@ -21,5 +22,17 @@ No multi-select delete/export; sort is click-cycle only; restore_state round-tri
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Multi-select delete/export exists in the library pane,Sort is keyboard-accessible,Selection survives mode round-trips for all modes,Tests updated
+- [x] #1 Multi-select delete/export exists in the library pane,Sort is keyboard-accessible,Selection survives mode round-trips for all modes,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing tests: pane m-marks rows (marker, 'N marked' count, PersonaMarksChanged message, prune on refresh, clear on mode switch); s key cycles sort only in characters/personas; screen bulk delete (one confirm, backend loop, summary notify) and bulk JSON export (SelectDirectory -> per-item files); restore round-trips personas/dictionaries selections. 2. Pane: _marked_ids + 'm'/'s' bindings + marked-row rendering. 3. Screen: PersonaMarksChanged handling, inspector.set_marked_count gating (PNG disabled with reason under marks), _begin_delete_marked + _export_marked_json workers. 4. restore_state/_apply_pending_restore: accept personas/dictionaries/lore modes via _apply_mode before selecting; update the two gate tests. 5. Suites + ruff. ADR required: no - extends existing selection/pane patterns; no schema or contract change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+(a) Bulk ops: library pane marks ('m' toggles, ● glyph, 'N marked' count summary, prune-on-refresh, clear-on-mode-switch, PersonaMarksChanged to the screen); inspector Delete/Export JSON retarget the marked set with scope-saying tooltips, Export PNG disabled with 'Bulk export is JSON only.'; bulk delete = one confirm then per-item backend delete (per-item fetch_character_by_id for versions) + one refresh + summary notify; bulk JSON export = SelectDirectory once then one <name>.json per card (plain cards - the TTS include checkbox is a per-selection decision). (b) Sort keyboard: pane 's' binding posts the same PersonaSortCycleRequested as the button (no-op where sort doesn't apply), tooltip + footer hint disclose it. (c) restore_state now accepts all chip modes and _apply_pending_restore runs _apply_mode for non-Characters modes before re-selecting - the task-434 fallback floor is raised; the two gate tests became restore tests. Files: personas_messages.py, personas_library_pane.py, personas_inspector_pane.py, personas_screen.py; tests in test_personas_{library_pane,workbench,workbench_state}.py. Verified: pane 35, bulk class 5, state 9, race/isolation included in gate 439 passed (workbench+dict+lore+scale); ruff clean. ADR: not required (extends existing selection/pane idioms; no schema/boundary change).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2092 - Roleplay-fix-the-unreadably-dim-voice-profile-checkbox-F-041.md
+++ b/backlog/tasks/task-2092 - Roleplay-fix-the-unreadably-dim-voice-profile-checkbox-F-041.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2092
 title: 'Roleplay: fix the unreadably dim voice-profile checkbox (F-041)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-03 17:25'
+updated_date: '2026-08-04 11:49'
 labels:
   - ux-review
   - roleplay
@@ -19,5 +20,17 @@ Disabled 'Include assigned voice profile' checkbox is so dim it reads as a dark 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Disabled checkbox remains legible as a disabled control,Tests/snapshot updated
+- [x] #1 Disabled checkbox remains legible as a disabled control,Tests/snapshot updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing style test first: disabled inspector checkbox computes full opacity, ds disabled label color, and a raised-surface glyph box (bundle-loaded app). 2. PersonasInspectorPane DEFAULT_CSS: scoped :disabled rules for #personas-export-include-tts (opacity 100%, label $ds-text-disabled, glyph box $ds-surface-raised with visible glyph color) - widget-level CSS, so no bundle regeneration needed (check_bundle_sync untouched). 3. Verify via computed styles + SVG capture. ADR required: no - presentational CSS only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Scoped :disabled rules in PersonasInspectorPane DEFAULT_CSS for #personas-export-include-tts: opacity 100% (Textual base rule dims to 0.7), label color via the theme's text-disabled derivation (matches the ds-text-disabled convention - widget DEFAULT_CSS cannot reference bundle-scoped ds-* names, noted in the CSS comment), glyph box on $surface with the text glyph color. No component TCSS touched, so no bundle regeneration; check_bundle_sync.py still passes. Verification: new computed-style test (opacity/alpha/component background) plus a render probe showing the glyph box + label painted ('▐X▌ Include assigned voice profile'); pane suite 29 passed; ruff clean. ADR: not required (presentational CSS).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Navigation/shell_destinations.py
+++ b/tldw_chatbook/UI/Navigation/shell_destinations.py
@@ -81,12 +81,14 @@ SHELL_DESTINATION_ORDER: tuple[ShellDestination, ...] = (
         # A roleplay-first newcomer finds characters from this label, so it has
         # to be readable cold. "RP&CD" could only be decoded after navigating
         # here and reading the screen title -- i.e. after already guessing right.
+        # F-034: "Roleplay" is the one public name everywhere (nav, header,
+        # palette); the long "Roleplay & Chat Dictionaries" form is retired.
         "Roleplay",
         "personas",
         "Characters, user profiles, dictionaries, and behavior profiles.",
         "Manage behavior profiles and user profile context.",
         ("ccp", "conversations_characters_prompts", "characters", "roleplay"),
-        full_label="Roleplay & Chat Dictionaries",
+        full_label="Roleplay",
     ),
     ShellDestination(
         "watchlists_collections",

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -244,7 +244,10 @@ MODE_CHIP_ORDER: tuple[str, ...] = ("characters", "personas", "dictionaries", "l
 #: One-line "what this mode is" copy, shown under the title and as chip tooltips.
 _MODE_DESCRIPTORS: dict[str, str] = {
     "characters": "Characters — who the AI plays.",
-    "personas": "Personas — assistant profiles for roleplay and chat",
+    # F-034: the descriptor teaches the genre convention (characters = who
+    # the AI plays, personas = who YOU play) instead of the vague "assistant
+    # profiles" - without reviving the retired human-identity framing.
+    "personas": "Personas — who you play in the chat.",
     "prompts": "Prompts — moving to the Library.",
     "dictionaries": "Dictionaries — text find/replace rules.",
     "lore": "Lore — world facts injected on keywords.",
@@ -773,7 +776,7 @@ class PersonasScreen(BaseAppScreen):
         with Vertical(id="personas-shell"):
             yield DestinationHeader(
                 WorkbenchHeaderState(
-                    title="Roleplay & Chat Dictionaries",
+                    title="Roleplay",
                     subtitle=self._header_subtitle_text(),
                     status="ready",
                 ),
@@ -3179,7 +3182,7 @@ class PersonasScreen(BaseAppScreen):
         status = "blocked" if self._provider_send_block_reason() else "ready"
         header.sync_state(
             WorkbenchHeaderState(
-                title="Roleplay & Chat Dictionaries",
+                title="Roleplay",
                 subtitle=self._header_subtitle_text(),
                 status=status,
             )

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -751,6 +751,11 @@ class PersonasScreen(BaseAppScreen):
         self._workbench_compact: bool | None = None
         self._library_rail_collapsed: bool = False
         self._inspector_rail_collapsed: bool = False
+        # Set by restore_state when the mount carries saved navigation state:
+        # a Console -> back round-trip keeps its own selection semantics
+        # (restored, or deliberately cleared), so first-paint auto-select
+        # (F-031) must not fire on those mounts.
+        self._restored_from_saved_state: bool = False
         self.character_handler = CCPCharacterHandler(self)
         self.persona_handler = CCPPersonaHandler(self)
         self.conversations = PersonasConversationsController(self)
@@ -953,8 +958,13 @@ class PersonasScreen(BaseAppScreen):
         super().restore_state(state)
         if not isinstance(state, dict):
             self._pending_restore = None
+            self._restored_from_saved_state = False
             return
         wb = state.get("personas_workbench")
+        # Any saved workbench payload - even one the Characters-only gate
+        # below falls back from - marks this as a navigation round-trip, not
+        # a first paint, so auto-select stays out of the restore semantics.
+        self._restored_from_saved_state = isinstance(wb, dict)
         if isinstance(wb, dict) and wb.get("active_mode") == "characters":
             names = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
             self.state = PersonasWorkbenchState(
@@ -1010,6 +1020,49 @@ class PersonasScreen(BaseAppScreen):
             self._show_center(None)
             self._sync_title_and_console_actions()
 
+    async def _auto_select_first_library_row(self) -> None:
+        """Select the first library row on a fresh first paint (F-031).
+
+        A non-empty library that opens with nothing selected paints a void
+        center and a disabled inspector; selecting the first row wakes the
+        card, actions, and preview instead. Skipped when a selection already
+        exists (including a successful restore) and on navigation
+        round-trips (``restore_state`` payloads keep their own selection
+        semantics, even the deliberately-cleared fallbacks). Runs the exact
+        ``_select_character`` path a row click takes, and never moves focus,
+        so the focus-steal guards are not involved. Mode switches
+        deliberately do NOT auto-select - this is a mount-time onboarding
+        behavior only.
+        """
+        if self._restored_from_saved_state:
+            return
+        if self.state.selected_entity_id:
+            return
+        if self.state.active_mode != "characters":
+            return
+        first = next(
+            (r for r in self._characters if r.get("id") is not None), None
+        )
+        if first is None:
+            return
+        try:
+            await self._select_character(
+                str(first["id"]), str(first.get("name") or "Unnamed")
+            )
+        except Exception:
+            # Auto-select is an onboarding convenience; a row that fails to
+            # load must degrade to the pre-selection guidance, never break
+            # the mount worker.
+            logger.opt(exception=True).warning(
+                "Personas first-paint auto-select failed; leaving no selection."
+            )
+            return
+        # _select_character runs outside _run_guarded here, so re-register
+        # the header/footer/console-action sync it normally gets from the
+        # guarded wrapper - the footer attach hint and header status must
+        # reflect the auto-selected row on first paint.
+        self._sync_title_and_console_actions()
+
     def on_mount(self) -> None:
         """Paint the shell now, load the library after (TASK-1320).
 
@@ -1054,6 +1107,7 @@ class PersonasScreen(BaseAppScreen):
                 await self.character_handler.refresh_character_list()
             self._sync_title_and_console_actions()
             await self._apply_pending_restore()
+            await self._auto_select_first_library_row()
         except Exception as exc:
             logger.opt(exception=True).error(
                 "Personas initial load failed "

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -970,6 +970,11 @@ class PersonasScreen(BaseAppScreen):
         ``self.state`` here and ``_apply_pending_restore`` runs the full
         ``_apply_mode`` for it before re-selecting, so the mode's library
         rows and mode-specific panes are live when the selection lands.
+
+        The round-trip flag is set only for payloads that can resolve (a
+        saved chip mode). An invalid payload, or one whose selection later
+        fails to apply, leaves the flag False so first-paint auto-select
+        (F-031) still rescues the mount instead of showing a dead paint.
         """
         super().restore_state(state)
         if not isinstance(state, dict):
@@ -977,11 +982,16 @@ class PersonasScreen(BaseAppScreen):
             self._restored_from_saved_state = False
             return
         wb = state.get("personas_workbench")
-        # Any saved workbench payload marks this as a navigation round-trip,
-        # not a first paint, so auto-select stays out of the restore
-        # semantics.
-        self._restored_from_saved_state = isinstance(wb, dict)
-        if isinstance(wb, dict) and wb.get("active_mode") in MODE_CHIP_ORDER:
+        # Only a payload that can actually resolve (a saved chip mode) counts
+        # as a navigation round-trip. An invalid/unsupported payload is not a
+        # restore at all, so first-paint auto-select (F-031) still fires -
+        # otherwise a stale saved state would land the user on the dead
+        # no-selection paint. A payload that then FAILS to apply its
+        # selection clears the flag again in _apply_pending_restore below.
+        self._restored_from_saved_state = isinstance(wb, dict) and wb.get(
+            "active_mode"
+        ) in MODE_CHIP_ORDER
+        if self._restored_from_saved_state:
             names = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
             self.state = PersonasWorkbenchState(
                 **{k: v for k, v in wb.items() if k in names}
@@ -1030,12 +1040,15 @@ class PersonasScreen(BaseAppScreen):
             # A stale/deleted entity must degrade to a fully cleared selection,
             # not just a blank center: leaving self.state's selection populated
             # would let _console_action_allowed() keep attach/Start-Chat wrongly
-            # enabled and the inspector showing a stale selection.
+            # enabled and the inspector showing a stale selection. The flag is
+            # cleared too: this restore produced nothing, so the mount falls
+            # back to first-paint auto-select (F-031) instead of a dead paint.
             logger.opt(exception=True).warning(
                 f"Could not restore Personas selection {kind}/{entity_id}; "
                 "clearing selection."
             )
             self.state.clear_selection()
+            self._restored_from_saved_state = False
             try:
                 await self.query_one(PersonasInspectorPane).clear_selection()
             except QueryError:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -779,15 +779,13 @@ class PersonasScreen(BaseAppScreen):
                 ),
                 id="personas-header",
             )
+            # F-033: one line carries both the mode descriptor and the live
+            # item count - the old standalone status strip ("Characters: N")
+            # and the library pane's duplicate count line are retired.
             yield Static(
-                self._mode_descriptor_text(self.state.active_mode),
+                self._purpose_line_text(),
                 id="personas-purpose",
                 classes="destination-purpose",
-            )
-            yield Static(
-                self._status_row_text(),
-                id="personas-status-row",
-                classes="destination-status-row",
             )
             with DestinationModeStrip(
                 id="personas-mode-strip", classes="destination-mode-strip"
@@ -1152,7 +1150,7 @@ class PersonasScreen(BaseAppScreen):
         self._count_cache_key = None
         self._characters = []
         self._character_total = 0
-        self._update_status_row()
+        self._update_purpose_line()
         self._sync_local_character_actions()
         if self.is_mounted:
             if active_mode == "characters":
@@ -1240,7 +1238,7 @@ class PersonasScreen(BaseAppScreen):
                 await self._render_library_rows()
             return
         self._characters = [dict(record) for record in (characters or [])]
-        self._update_status_row()
+        self._update_purpose_line()
         if self.state.active_mode != "characters":
             return
         try:
@@ -2272,7 +2270,7 @@ class PersonasScreen(BaseAppScreen):
                 self._count_cache_key = count_cache_key
             self._characters = records
             self._character_total = total
-            self._update_status_row()
+            self._update_purpose_line()
             try:
                 library = self.query_one(PersonasLibraryPane)
             except QueryError:
@@ -2288,7 +2286,7 @@ class PersonasScreen(BaseAppScreen):
                 self._count_cache_key = None
                 self._characters = []
                 self._character_total = 0
-                self._update_status_row()
+                self._update_purpose_line()
                 if self.state.active_mode != "characters":
                     return
                 if self.state.runtime_source == "server":
@@ -2545,7 +2543,7 @@ class PersonasScreen(BaseAppScreen):
         else:
             self._profile_lookup_recovery_state = None
         self._profiles = [dict(record) for record in (profiles or [])]
-        self._update_status_row()
+        self._update_purpose_line()
         if not self.is_mounted or self.state.active_mode != "personas":
             # A late result must not render persona rows into another mode.
             return
@@ -3071,10 +3069,7 @@ class PersonasScreen(BaseAppScreen):
             self.query_one(f"#personas-mode-{chip_mode}", Button).set_class(
                 chip_mode == mode, "is-active"
             )
-        self.query_one("#personas-status-row", Static).update(self._status_row_text())
-        self.query_one("#personas-purpose", Static).update(
-            self._mode_descriptor_text(mode)
-        )
+        self._update_purpose_line()
         library = self.query_one(PersonasLibraryPane)
         library.set_mode(mode)
         self._sync_local_character_actions()
@@ -3190,25 +3185,40 @@ class PersonasScreen(BaseAppScreen):
             )
         )
 
-    def _status_row_text(self) -> str:
+    def _purpose_line_text(self) -> str:
+        """Mode descriptor plus the live item count on one line (F-033).
+
+        The count mirrors what the retired status strip showed: the paged
+        total for characters, the loaded profile count for personas, and the
+        cached list sizes for dictionaries/lore (empty until that mode's
+        first render lands, same as the old strip's pre-load "0").
+        """
         mode = self.state.active_mode
+        descriptor = self._mode_descriptor_text(mode)
+        count: int | None = None
         if mode == "characters":
             # ``_characters`` is now one page; the full-library count lives in
             # ``_character_total``.
-            return f"Characters: {self._character_total}"
-        if mode == "personas":
-            return f"Personas: {len(self._profiles)}"
-        return f"Mode: {MODE_LABELS.get(mode, mode)}"
+            count = self._character_total
+        elif mode == "personas":
+            count = len(self._profiles)
+        elif mode == "dictionaries":
+            count = len(self._dictionaries_cache)
+        elif mode == "lore":
+            count = len(self._lore_books_cache)
+        if count is None:
+            return descriptor
+        return f"{descriptor.rstrip('.')} · {count}"
 
-    def _update_status_row(self) -> None:
-        """Refresh the status row text; tolerate refreshes racing teardown."""
+    def _update_purpose_line(self) -> None:
+        """Refresh the merged purpose/count line; tolerate teardown races."""
         try:
-            self.query_one("#personas-status-row", Static).update(
-                self._status_row_text()
+            self.query_one("#personas-purpose", Static).update(
+                self._purpose_line_text()
             )
         except Exception:
             logger.opt(exception=True).debug(
-                "Could not update the personas status row."
+                "Could not update the personas purpose line."
             )
 
     # ===== Selection =====
@@ -3426,7 +3436,7 @@ class PersonasScreen(BaseAppScreen):
         )
         self._sync_inspector_console_actions()
         self._update_title()
-        self._update_status_row()
+        self._update_purpose_line()
         await self._refresh_dictionary_versions()
         await self._refresh_dictionary_attachments()
 
@@ -3486,7 +3496,7 @@ class PersonasScreen(BaseAppScreen):
         )
         self._sync_inspector_console_actions()
         self._update_title()
-        self._update_status_row()
+        self._update_purpose_line()
         await self._refresh_lore_attachments()
 
     async def _refresh_lore_attachments(self) -> None:
@@ -8650,7 +8660,7 @@ class PersonasScreen(BaseAppScreen):
             await self.query_one(PersonasInspectorPane).clear_selection()
             await self._render_dictionary_rows(query=self.state.search_query)
             self._update_title()
-            self._update_status_row()
+            self._update_purpose_line()
             return
         elif kind == "lore":
             # No staleness re-check here (unlike _after_delete's character/
@@ -8691,7 +8701,7 @@ class PersonasScreen(BaseAppScreen):
             await self.query_one(PersonasInspectorPane).clear_selection()
             await self._render_lore_rows(query=self.state.search_query)
             self._update_title()
-            self._update_status_row()
+            self._update_purpose_line()
             return
         else:
             service = getattr(
@@ -9075,8 +9085,8 @@ class PersonasScreen(BaseAppScreen):
         else:
             self._profile_lookup_recovery_state = None
         self._profiles = [dict(record) for record in (profiles or [])]
-        self._update_status_row()
-        self._update_status_row()
+        self._update_purpose_line()
+        self._update_purpose_line()
         if not self.is_mounted or self.state.active_mode != "personas":
             # Leave the selection, inspector, and center pane alone.
             return

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -5068,12 +5068,11 @@ class PersonasScreen(BaseAppScreen):
         """
         # Precedence (Qodo #824-2): the provider question is only OPERATIVE
         # when the Console action gate itself passes — otherwise the header
-        # would claim provider-"Blocked" while the inspector says
-        # "Console blocked: unsaved edits/select an item" (two conflicting
-        # readiness stories for one staged intent). With the gate closed the
-        # inspector carries the action reason and the header keeps its
-        # pre-task-440 semantics; provider readiness surfaces the moment the
-        # action gate opens.
+        # would claim provider-"Blocked" while the inspector carries the
+        # no-selection/unsaved guidance (two conflicting readiness stories
+        # for one staged intent). With the gate closed the inspector carries
+        # the action reason and the header keeps its pre-task-440 semantics;
+        # provider readiness surfaces the moment the action gate opens.
         if not self._console_action_allowed():
             return None
         if self.state.selected_entity_kind not in ("character", "persona"):
@@ -5134,18 +5133,22 @@ class PersonasScreen(BaseAppScreen):
         return "\n".join(lines)
 
     async def _attach_selection_to_console(self, *, intent: str) -> None:
-        """Stage the selected card in Console (intent: "attach" or "start_chat")."""
+        """Stage the selected card in Console (intent: "attach" or "start_chat").
+
+        The inspector labels these by intent (F-032): "attach" is the
+        "Send to Console draft" button, "start_chat" is "Chat now".
+        """
         if not self._console_action_allowed():
             # The inspector disables these buttons without a saved selection;
             # this is a defensive re-check (and the ctrl+enter guard).
             self._notify("Select a saved item before using Console actions.", "warning")
             return
         if intent == "start_chat":
-            # Start Chat needs a ready handoff provider (task-523 per-intent);
+            # Chat now needs a ready handoff provider (task-523 per-intent);
             # defense-in-depth against a press racing a config change.
             block = self._provider_send_block_reason()
             if block:
-                self._notify(f"Start Chat blocked: {block}", "warning")
+                self._notify(f"Chat now blocked: {block}", "warning")
                 return
         kind = str(self.state.selected_entity_kind)
         name = self.state.selected_entity_name or "Unnamed"
@@ -5184,7 +5187,7 @@ class PersonasScreen(BaseAppScreen):
         # The legacy CCP route launched a blank main-chat tab directly via the
         # chat tab container, but that container is only queryable while the
         # chat screen is mounted - never true from a pushed destination
-        # screen. The workbench therefore routes Start Chat through the
+        # screen. The workbench therefore routes Chat now through the
         # app-level open_chat_with_handoff API with an explicit intent marker.
         event.stop()
         await self._attach_selection_to_console(intent="start_chat")
@@ -9340,7 +9343,7 @@ class PersonasScreen(BaseAppScreen):
             pass
 
     async def action_personas_attach(self) -> None:
-        """Ctrl+Enter: same path as the inspector Attach button.
+        """Ctrl+Enter: same path as the inspector Send-to-Console-draft button.
 
         No-ops silently when the attach buttons would be disabled (no saved
         selection, or unsaved edits) so the shortcut cannot bypass the guard.

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -851,6 +851,11 @@ class PersonasScreen(BaseAppScreen):
                 with Vertical(
                     id="personas-work-area", classes="destination-workbench-pane"
                 ):
+                    # F-039: the preview toggle anchors the TOP of the center
+                    # canvas (immediately above the detail stack) so the
+                    # affordance reads as the canvas's own section instead of
+                    # a bar stranded at the work-area bottom.
+                    yield PersonasPreviewPane(id="personas-preview-pane")
                     with Container(id="personas-detail-stack"):
                         yield PersonasCharacterCardWidget()
                         yield PersonasCharacterEditorWidget()
@@ -891,7 +896,6 @@ class PersonasScreen(BaseAppScreen):
                             id="personas-characters-empty",
                             markup=True,
                         )
-                    yield PersonasPreviewPane(id="personas-preview-pane")
                     tryit = PersonasDictionaryTryItWidget(id="personas-dict-tryit")
                     tryit.display = False
                     yield tryit

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -805,7 +805,7 @@ class PersonasScreen(BaseAppScreen):
                 yield Static(
                     "Modes:", id="personas-mode-label", classes="destination-section"
                 )
-                for mode in MODE_CHIP_ORDER:
+                for index, mode in enumerate(MODE_CHIP_ORDER):
                     classes = "personas-mode-chip"
                     if mode == self.state.active_mode:
                         classes = f"{classes} is-active"
@@ -816,7 +816,11 @@ class PersonasScreen(BaseAppScreen):
                         label,
                         id=f"personas-mode-{mode}",
                         classes=classes,
-                        tooltip=self._mode_descriptor_text(mode),
+                        # F-038: the chip tooltip discloses its Ctrl+N jump key
+                        # (the binding mirrors the strip order).
+                        tooltip=(
+                            f"{self._mode_descriptor_text(mode)} (Ctrl+{index + 1})"
+                        ),
                     )
             with Horizontal(
                 id="personas-workbench", classes="ds-panel destination-workbench"
@@ -9580,10 +9584,23 @@ class PersonasScreen(BaseAppScreen):
                 ShortcutAction("ctrl+f", "search"),
                 ShortcutAction("ctrl+s", "save", available=editing),
                 ShortcutAction("esc", "back", available=editing or transcript_open),
+                # F-032: the hint names the renamed "Send to Console draft" CTA.
                 ShortcutAction(
-                    "ctrl+enter", "attach", available=self._console_action_allowed()
+                    "ctrl+enter", "draft", available=self._console_action_allowed()
                 ),
+                # F-038: disclose the always-on accelerators that used to be
+                # invisible (show=False bindings with no footer/chip mention).
+                ShortcutAction("f6", "pane"),
+                ShortcutAction("ctrl+1-4", "mode"),
                 ShortcutAction("[ ]", "mode"),
+                # The library pane's space binding only acts on dictionary
+                # rows, so it is advertised only in that mode (never claim a
+                # key that does nothing in context).
+                ShortcutAction(
+                    "space",
+                    "toggle",
+                    available=self.state.active_mode == "dictionaries",
+                ),
             ),
         )
 

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -264,12 +264,16 @@ _MODE_PLACEHOLDER_BODY: dict[str, str] = {
 }
 _PLACEHOLDER_FALLBACK = "This mode is coming soon."
 #: Onboarding guidance shown in the Characters center pane when nothing is
-#: selected (task-436). Non-adaptive: rendered at on_mount before the character
-#: count loads, so it must read correctly whether or not characters exist.
+#: selected (task-436) and the library is TRULY empty (F-035): only then are
+#: New/Import the next action. With rows present the picker copy below is
+#: shown instead (reachable after a delete or a mode round-trip; first paint
+#: auto-selects, F-031).
 _CHARACTERS_EMPTY_GUIDANCE = (
-    "No character selected. Pick one from the list on the left, or use "
-    "[b]New[/b] or [b]Import[/b] to add a character."
+    "No characters yet — use [b]New[/b] or [b]Import[/b] to add one."
 )
+#: No-selection copy when the library HAS characters (F-035): the next
+#: action is picking one, not creating one.
+_CHARACTERS_EMPTY_PICKER_GUIDANCE = "Pick a character from the list to see it here."
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 #: Rows per library page. ``page_offset`` is always kept a multiple of this so
 #: the pane's "start-end of N" label math stays exact.
@@ -598,9 +602,11 @@ class PersonasScreen(BaseAppScreen):
     #personas-characters-empty {
         width: 1fr;
         height: 1fr;
-        content-align: center middle;
-        text-align: center;
-        padding: 2 4;
+        /* F-035: left/top like the app's other empty states (cf.
+           .chat-empty-state) - centered in the void read as broken layout. */
+        content-align: left top;
+        text-align: left;
+        padding: 1 2;
         color: $text-muted;
     }
 
@@ -9186,11 +9192,17 @@ class PersonasScreen(BaseAppScreen):
         )
 
     def _characters_empty_guidance_text(self) -> str:
-        """Return the onboarding guidance for the empty Characters center pane.
+        """Return the no-selection guidance for the Characters center pane.
+
+        F-035 adaptive: the New/Import onboarding copy only makes sense when
+        the library is truly empty; with rows present (post-delete, mode
+        round-trip) the next action is picking one.
 
         Returns:
-            Static guidance copy naming the three next actions.
+            Guidance copy for the current library state.
         """
+        if self._character_total > 0:
+            return _CHARACTERS_EMPTY_PICKER_GUIDANCE
         return _CHARACTERS_EMPTY_GUIDANCE
 
     def _show_center(self, visible_id: str | None) -> None:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -122,6 +122,7 @@ from ...Widgets.Persona_Widgets.personas_library_pane import (
 from ...Widgets.Persona_Widgets.personas_messages import (
     PersonaActionRequested,
     PersonaEntitySelected,
+    PersonaMarksChanged,
     PersonaPageChanged,
     PersonaSearchChanged,
     PersonaSortCycleRequested,
@@ -768,6 +769,10 @@ class PersonasScreen(BaseAppScreen):
         # (restored, or deliberately cleared), so first-paint auto-select
         # (F-031) must not fire on those mounts.
         self._restored_from_saved_state: bool = False
+        # F-040: the library pane's marked rows ((kind, item_id, name)
+        # triples) driving bulk Delete/Export; kept in step via
+        # PersonaMarksChanged.
+        self._marked_rows: tuple[tuple[str, str, str], ...] = ()
         self.character_handler = CCPCharacterHandler(self)
         self.persona_handler = CCPPersonaHandler(self)
         self.conversations = PersonasConversationsController(self)
@@ -961,17 +966,10 @@ class PersonasScreen(BaseAppScreen):
         the actual re-selection is applied by ``_apply_pending_restore`` once
         the screen (and its widgets) exist.
 
-        Gated to Characters mode: ``on_mount`` only unconditionally wires the
-        Characters path (character list refresh, center-view routing) -
-        every other mode's library rows and mode-specific widgets (the
-        Preview pane, the Dictionary/Lore Try-It panes) are only refreshed
-        and toggled by ``_apply_mode``, which a restore never calls.
-        Reconstructing ``self.state`` for a saved non-Characters mode here
-        would restore the mode chip while leaving the library empty and the
-        wrong panes visible/hidden - a regression, not a restore. So a
-        non-Characters round-trip is left at the fresh ``__init__`` default
-        (Characters, no selection) instead; restoring the other modes in
-        full is a filed follow-up.
+        All chip modes restore (F-040): a saved non-Characters mode seeds
+        ``self.state`` here and ``_apply_pending_restore`` runs the full
+        ``_apply_mode`` for it before re-selecting, so the mode's library
+        rows and mode-specific panes are live when the selection lands.
         """
         super().restore_state(state)
         if not isinstance(state, dict):
@@ -979,11 +977,11 @@ class PersonasScreen(BaseAppScreen):
             self._restored_from_saved_state = False
             return
         wb = state.get("personas_workbench")
-        # Any saved workbench payload - even one the Characters-only gate
-        # below falls back from - marks this as a navigation round-trip, not
-        # a first paint, so auto-select stays out of the restore semantics.
+        # Any saved workbench payload marks this as a navigation round-trip,
+        # not a first paint, so auto-select stays out of the restore
+        # semantics.
         self._restored_from_saved_state = isinstance(wb, dict)
-        if isinstance(wb, dict) and wb.get("active_mode") == "characters":
+        if isinstance(wb, dict) and wb.get("active_mode") in MODE_CHIP_ORDER:
             names = {f.name for f in dataclasses.fields(PersonasWorkbenchState)}
             self.state = PersonasWorkbenchState(
                 **{k: v for k, v in wb.items() if k in names}
@@ -1011,6 +1009,13 @@ class PersonasScreen(BaseAppScreen):
         entity_id = str(pending["id"])
         name = str(pending.get("name") or "")
         try:
+            # F-040: a saved non-Characters mode needs its full mode apply
+            # (library rows, Try-It panes, preview visibility) before the
+            # selection lands; ``switch_mode`` inside clears the seeded
+            # selection, which the dispatch below re-establishes.
+            saved_mode = self.state.active_mode
+            if saved_mode != "characters" and saved_mode in MODE_CHIP_ORDER:
+                await self._apply_mode(saved_mode)
             if kind == "character":
                 await self._select_character(
                     entity_id, name, restore_preview=pending.get("preview")
@@ -3275,6 +3280,18 @@ class PersonasScreen(BaseAppScreen):
             )
         # Prompts are not wired here: prompt management is retired from
         # Personas and lives entirely inside Library (Task 7).
+
+    @on(PersonaMarksChanged)
+    def _handle_marks_changed(self, message: PersonaMarksChanged) -> None:
+        """Track the library's marked set and re-gate bulk actions (F-040)."""
+        message.stop()
+        self._marked_rows = message.marks
+        try:
+            self.query_one(PersonasInspectorPane).set_marked_count(
+                len(message.marks)
+            )
+        except QueryError:
+            pass
 
     async def _fetch_server_character(
         self, entity_id: str
@@ -8273,7 +8290,94 @@ class PersonasScreen(BaseAppScreen):
             and not self._local_character_actions_allowed()
         ):
             return
+        # F-040: an active mark set retargets Export JSON at the marked rows.
+        if self._marked_rows:
+            if self._io_dialog_active:
+                return
+            self._io_dialog_active = True
+            self.run_worker(
+                self._export_marked_json_worker(tuple(self._marked_rows)),
+                group="personas-io",
+            )
+            return
         self._open_export_dialog("json")
+
+    async def _export_marked_json_worker(
+        self, marks: tuple[tuple[str, str, str], ...]
+    ) -> None:
+        """Export each marked character/persona as its own JSON file (F-040)."""
+        from ...Third_Party.textual_fspicker.select_directory import (
+            SelectDirectory,
+        )
+
+        try:
+            kind = marks[0][0]
+            if kind == "character" and not self._local_character_actions_allowed():
+                return
+            picker = SelectDirectory(title=f"Export {len(marks)} items as JSON")
+            try:
+                target_dir = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not show the export directory dialog."
+                )
+                return
+            if not target_dir:
+                return
+            if kind == "character" and not self._local_character_actions_allowed():
+                return
+            written = 0
+            failed: list[str] = []
+            used_names: set[str] = set()
+            for _, entity_id, name in marks:
+                try:
+                    # Filename sanitization mirrors the single-export route.
+                    safe = (
+                        "".join(c for c in name if c.isalnum() or c in " -_").rstrip()
+                        or "export"
+                    )
+                    candidate = safe
+                    suffix = 2
+                    while candidate in used_names:
+                        candidate = f"{safe}-{suffix}"
+                        suffix += 1
+                    used_names.add(candidate)
+                    target_path = str(Path(str(target_dir)) / f"{candidate}.json")
+                    if kind == "character":
+                        # The TTS-include checkbox is a per-selection export
+                        # decision; bulk export writes plain cards.
+                        await asyncio.to_thread(
+                            self._export_character_json_sync,
+                            int(str(entity_id)),
+                            target_path,
+                            None,
+                        )
+                    else:
+                        record = await self._fetch_profile_record(str(entity_id))
+                        content = json.dumps(
+                            record, indent=2, ensure_ascii=False, default=str
+                        )
+                        await asyncio.to_thread(
+                            self._write_text_file, target_path, content
+                        )
+                    written += 1
+                except Exception:
+                    failed.append(name)
+                    logger.opt(exception=True).warning(
+                        f"Bulk export failed for {kind} {entity_id} ({name})."
+                    )
+            if failed:
+                self._notify(
+                    f"Exported {written} of {len(marks)} items; "
+                    f"failed: {', '.join(failed[:3])}.",
+                    "error",
+                )
+            else:
+                self._notify(
+                    f"Exported {written} items to {target_dir}.", "information"
+                )
+        finally:
+            self._io_dialog_active = False
 
     @on(Button.Pressed, "#personas-export-png")
     async def _handle_export_png_pressed(self, event: Button.Pressed) -> None:
@@ -8542,7 +8646,167 @@ class PersonasScreen(BaseAppScreen):
         # routes through the unsaved guard so a dirty session shows the
         # discard dialog FIRST, then the delete confirm. Two dialogs in
         # sequence is deliberate: the user explicitly approves both losses.
+        # F-040: an active mark set retargets Delete at the marked rows.
+        if self._marked_rows:
+            await self._run_guarded(self._begin_delete_marked)
+            return
         await self._run_guarded(self._begin_delete_selection)
+
+    async def _begin_delete_marked(self) -> None:
+        """Validate the marked set and launch the bulk delete-confirm worker."""
+        marks = tuple(self._marked_rows)
+        if not marks:
+            await self._begin_delete_selection()
+            return
+        if marks[0][0] == "character" and not self._local_character_actions_allowed():
+            self._notify(_SERVER_READ_ONLY_TOOLTIP, "warning")
+            return
+        if self._delete_dialog_active:
+            logger.debug("Delete dialog already active; ignoring delete request.")
+            return
+        self._delete_dialog_active = True
+        self.run_worker(
+            self._delete_marked_worker(marks),
+            group="personas-io",
+        )
+
+    #: Plural nouns for bulk-action confirm/summary copy (F-040).
+    _BULK_NOUNS = {
+        "character": "characters",
+        "persona": "personas",
+        "dictionary": "dictionaries",
+        "lore": "lore books",
+    }
+
+    async def _delete_marked_worker(
+        self, marks: tuple[tuple[str, str, str], ...]
+    ) -> None:
+        """One confirmation, then each marked item's backend delete (F-040)."""
+        try:
+            kind = marks[0][0]
+            noun = self._BULK_NOUNS.get(kind, "items")
+            if not await self._confirm_delete(f"{len(marks)} {noun}"):
+                return
+            if kind == "character" and not self._local_character_actions_allowed():
+                return
+            deleted_ids: set[str] = set()
+            failed: list[str] = []
+            for _, entity_id, name in marks:
+                try:
+                    await self._delete_marked_backend(kind, entity_id)
+                except Exception as exc:
+                    failed.append(name)
+                    logger.opt(exception=True).warning(
+                        f"Bulk delete failed for {kind} {entity_id} ({name}): {exc}"
+                    )
+                else:
+                    deleted_ids.add(str(entity_id))
+            # Selection cleanup when the selection was among the deleted.
+            if str(self.state.selected_entity_id or "") in deleted_ids:
+                self.state.clear_selection()
+                self.state.has_unsaved_changes = False
+                try:
+                    await self.query_one(PersonasInspectorPane).clear_selection()
+                except QueryError:
+                    pass
+                self._show_center(None)
+            self.query_one(PersonasLibraryPane).clear_marks()
+            await self._refresh_rows_after_delete(kind)
+            self._sync_title_and_console_actions()
+            if failed:
+                self._notify(
+                    f"Deleted {len(deleted_ids)} of {len(marks)} {noun}; "
+                    f"failed: {', '.join(failed[:3])}.",
+                    "error",
+                )
+            else:
+                self._notify(
+                    f"Deleted {len(deleted_ids)} {noun}.", "information"
+                )
+        finally:
+            self._delete_dialog_active = False
+
+    async def _delete_marked_backend(self, kind: str, entity_id: str) -> None:
+        """One marked item's backend delete, no UI churn; raises on failure."""
+        if kind == "character":
+            # Per-item fetch: the handler's loaded record only covers the
+            # current selection, and the sparse list rows carry no version.
+            record = await asyncio.to_thread(
+                ccp_character_handler.fetch_character_by_id, entity_id
+            )
+            if not record:
+                raise ValueError(f"character {entity_id} not found")
+            version = int(record.get("version") or 1)
+            ok = await asyncio.to_thread(
+                ccp_character_handler.delete_character, entity_id, version
+            )
+            if not ok:
+                raise ValueError(f"delete conflict for character {entity_id}")
+            return
+        if kind == "persona":
+            service = getattr(
+                self.app_instance, "character_persona_scope_service", None
+            )
+            if service is None:
+                raise ValueError("personas service is not configured")
+            record = await self._fetch_profile_record(entity_id)
+            raw_version = record.get("version")
+            await service.delete_persona_profile(
+                entity_id,
+                expected_version=(
+                    int(raw_version) if raw_version is not None else None
+                ),
+                mode=self.persona_handler.current_mode(),
+            )
+            return
+        if kind == "dictionary":
+            service = self._dictionary_scope_service()
+            if service is None:
+                raise ValueError("dictionaries service is not configured")
+            record = next(
+                (
+                    r
+                    for r in self._dictionaries_cache
+                    if str(r.get("id")) == str(entity_id)
+                ),
+                None,
+            )
+            raw_version = (record or {}).get("version")
+            await service.delete_dictionary(
+                int(entity_id),
+                mode="local",
+                expected_version=(
+                    int(raw_version) if raw_version is not None else None
+                ),
+            )
+            return
+        # kind == "lore"
+        manager = self._lore_manager()
+        if manager is None:
+            raise ValueError("lore database is not configured")
+        record = next(
+            (r for r in self._lore_books_cache if str(r.get("id")) == str(entity_id)),
+            None,
+        )
+        raw_version = (record or {}).get("version")
+        ok = await asyncio.to_thread(
+            manager.delete_world_book,
+            int(entity_id),
+            expected_version=int(raw_version) if raw_version is not None else None,
+        )
+        if not ok:
+            raise ValueError(f"delete conflict for lore book {entity_id}")
+
+    async def _refresh_rows_after_delete(self, kind: str) -> None:
+        """Reload the library rows for the deleted items' mode (F-040)."""
+        if kind == "character":
+            await self.character_handler.refresh_character_list()
+        elif kind == "persona":
+            await self._refresh_profile_rows_worker()
+        elif kind == "dictionary":
+            await self._render_dictionary_rows(query=self.state.search_query)
+        elif kind == "lore":
+            await self._render_lore_rows(query=self.state.search_query)
 
     async def _begin_delete_selection(self) -> None:
         """Validate the selection and launch the delete-confirm dialog worker."""
@@ -9597,6 +9861,12 @@ class PersonasScreen(BaseAppScreen):
                 ShortcutAction("f6", "pane"),
                 ShortcutAction("ctrl+1-4", "mode"),
                 ShortcutAction("[ ]", "mode"),
+                # F-040: the sort cycle key applies where the Sort button shows.
+                ShortcutAction(
+                    "s",
+                    "sort",
+                    available=self.state.active_mode in ("characters", "personas"),
+                ),
                 # The library pane's space binding only acts on dictionary
                 # rows, so it is advertised only in that mode (never claim a
                 # key that does nothing in context).

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3349,7 +3349,12 @@ class PersonasScreen(BaseAppScreen):
             self.conversations.load_conversations(entity_id)
         else:
             inspector.set_avatar_thumbnail(None)
-            await inspector.show_conversations(())
+            # F-036: a server character with no saved conversations gets the
+            # same empty-state copy the local path renders via the
+            # controller, not a bare Conversations header.
+            await inspector.show_conversations(
+                (), empty_copy="No saved conversations."
+            )
             self.query_one(
                 "#personas-card-edit-character", Button
             ).disabled = True

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -274,6 +274,9 @@ _CHARACTERS_EMPTY_GUIDANCE = (
 #: No-selection copy when the library HAS characters (F-035): the next
 #: action is picking one, not creating one.
 _CHARACTERS_EMPTY_PICKER_GUIDANCE = "Pick a character from the list to see it here."
+#: F-037: reason shown on local-only actions (card Edit, inspector
+#: export/delete) while browsing server-owned characters.
+_SERVER_READ_ONLY_TOOLTIP = "Server characters are read-only here."
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 #: Rows per library page. ``page_offset`` is always kept a multiple of this so
 #: the pane's "start-end of N" label math stays exact.
@@ -2138,11 +2141,18 @@ class PersonasScreen(BaseAppScreen):
             edit = self.query_one("#personas-card-edit-character", Button)
             if server_characters:
                 edit.disabled = True
+                edit.tooltip = _SERVER_READ_ONLY_TOOLTIP
             else:
                 edit.disabled = not (
                     self.state.selected_entity_kind == "character"
                     and self.state.selected_entity_id is not None
                 )
+                # Clear a stale server reason when leaving server browsing;
+                # the card widget owns the baseline tooltips otherwise.
+                if edit.tooltip == _SERVER_READ_ONLY_TOOLTIP:
+                    edit.tooltip = (
+                        None if not edit.disabled else "Select a character to edit."
+                    )
 
             inspector = self.query_one(PersonasInspectorPane)
             if server_characters:
@@ -2151,7 +2161,11 @@ class PersonasScreen(BaseAppScreen):
                     "#personas-export-png",
                     "#personas-delete",
                 ):
-                    inspector.query_one(selector, Button).disabled = True
+                    # F-037: server browsing force-disables these local-only
+                    # actions; each one must say why.
+                    button = inspector.query_one(selector, Button)
+                    button.disabled = True
+                    button.tooltip = _SERVER_READ_ONLY_TOOLTIP
             else:
                 # Restore the inspector's existing selection/unsaved gates after
                 # leaving server Characters mode.
@@ -3355,9 +3369,9 @@ class PersonasScreen(BaseAppScreen):
             await inspector.show_conversations(
                 (), empty_copy="No saved conversations."
             )
-            self.query_one(
-                "#personas-card-edit-character", Button
-            ).disabled = True
+            edit_button = self.query_one("#personas-card-edit-character", Button)
+            edit_button.disabled = True
+            edit_button.tooltip = _SERVER_READ_ONLY_TOOLTIP
 
         if restore_preview is not None:
             await self.preview.restore_conversation(

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_card_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_card_widget.py
@@ -111,6 +111,8 @@ class PersonasCharacterCardWidget(Container):
                 id="personas-card-edit-character",
                 classes="console-action-secondary",
                 disabled=True,
+                # F-037: a disabled Edit explains itself.
+                tooltip="Select a character to edit.",
             )
 
     # ===== Public API =====
@@ -181,8 +183,12 @@ class PersonasCharacterCardWidget(Container):
         # for the handler's call_from_thread continuation.
         self.query_one("#personas-character-card-empty").display = False
         self.query_one("#personas-character-card-body").display = True
-        self.query_one("#personas-card-edit-character", Button).disabled = (
-            self._character_id is None
+        edit_button = self.query_one("#personas-card-edit-character", Button)
+        edit_button.disabled = self._character_id is None
+        edit_button.tooltip = (
+            None
+            if self._character_id is not None
+            else "This character has no saved record to edit."
         )
 
     # ===== Events =====

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -108,6 +108,23 @@ class PersonasInspectorPane(Vertical):
         width: 100%;
         height: auto;
     }
+
+    /* F-041: a disabled checkbox must still READ as a checkbox. Textual's
+       base *:disabled:can-focus rule dims it to 0.7 and the stock toggle
+       glyph box is panel-on-panel (a dark gap in the rail). Keep the label
+       dimmed per the ds disabled idiom, restore full opacity, and give the
+       glyph box a visible surface. ($text-disabled/$surface are the theme
+       variables the ds-text-disabled/ds-surface-raised tokens alias; widget
+       DEFAULT_CSS cannot see bundle-scoped ds-* names.) */
+    PersonasInspectorPane #personas-export-include-tts:disabled {
+        opacity: 100%;
+        color: $text-disabled;
+    }
+
+    PersonasInspectorPane #personas-export-include-tts:disabled .toggle--button {
+        background: $surface;
+        color: $text;
+    }
     """
 
     def __init__(self, **kwargs) -> None:
@@ -120,6 +137,18 @@ class PersonasInspectorPane(Vertical):
         self._provider_block_reason: str | None = None
         self._conversation_lookup: dict[str, str] = {}
         self._tts_export_available = False
+        # F-040: marked library rows drive bulk Delete/Export JSON affordances.
+        self._marked_count = 0
+
+    def set_marked_count(self, count: int) -> None:
+        """Bulk-mark awareness for Delete/Export (F-040).
+
+        With marks active, Delete and Export JSON target the marked set
+        (their tooltips say so) and Export PNG - a single-card format - is
+        disabled with a reason. Zero restores the selection-owned gates.
+        """
+        self._marked_count = max(0, int(count))
+        self._apply_action_state()
 
     def compose(self) -> ComposeResult:
         """Compose the Inspector pane summary, readiness, and actions.
@@ -487,17 +516,32 @@ class PersonasInspectorPane(Vertical):
             start_btn.tooltip = f"Chat now blocked: {self._provider_block_reason}"
         else:
             start_btn.tooltip = None
+        # F-040: an active mark set retargets Delete/Export JSON at the
+        # marked rows (tooltips say so) and sidesteps the single-selection
+        # unsaved gate (bulk actions discard/ignore edit state by design,
+        # like single Delete). Export PNG stays single-card.
+        marked = self._marked_count
         json_button = self.query_one("#personas-export-json", Button)
         json_button.display = export_json_applies
-        json_button.disabled = not export_enabled
-        json_button.tooltip = export_tooltip
+        json_button.disabled = (not export_enabled) and marked == 0
+        json_button.tooltip = (
+            f"Export the {marked} marked items as JSON."
+            if marked
+            else export_tooltip
+        )
         png_button = self.query_one("#personas-export-png", Button)
         png_button.display = export_png_applies
-        png_button.disabled = not (export_enabled and kind == "character")
-        png_button.tooltip = export_tooltip
+        png_button.disabled = marked > 0 or not (export_enabled and kind == "character")
+        png_button.tooltip = (
+            "Bulk export is JSON only." if marked else export_tooltip
+        )
         delete_button = self.query_one("#personas-delete", Button)
-        delete_button.disabled = not selected
-        delete_button.tooltip = None if selected else _NO_SELECTION_DELETE_TOOLTIP
+        delete_button.disabled = (not selected) and marked == 0
+        delete_button.tooltip = (
+            f"Delete the {marked} marked items."
+            if marked
+            else (None if selected else _NO_SELECTION_DELETE_TOOLTIP)
+        )
 
     def set_avatar_thumbnail(self, renderable: object | None) -> None:
         """Mount a prepared portrait renderable, or clear the box.

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -15,6 +15,12 @@ from .personas_pane_messages import ConversationRowSelected
 
 _UNSAVED_TOOLTIP = "Save before using this action; the selection has unsaved edits."
 
+#: F-037: every disabled action explains itself. The screen hides the whole
+#: action stack pre-selection (F-031), but the pane keeps the disabled+reason
+#: contract for every state these buttons can render in.
+_NO_SELECTION_EXPORT_TOOLTIP = "Select an item to export."
+_NO_SELECTION_DELETE_TOOLTIP = "Select an item to delete."
+
 #: The one plain line a no-selection inspector shows (F-031): intent-first
 #: guidance instead of a wall of disabled controls and a false
 #: "Validation: OK". Doubles as the Console readiness line pre-selection.
@@ -180,12 +186,14 @@ class PersonasInspectorPane(Vertical):
                 id="personas-start-chat",
                 disabled=True,
                 classes="console-action-primary",
+                tooltip=_NO_SELECTION_GUIDANCE,
             )
             yield Button(
                 "Send to Console draft",
                 id="personas-attach-to-console",
                 disabled=True,
                 classes="console-action-secondary",
+                tooltip=_NO_SELECTION_GUIDANCE,
             )
             yield Checkbox(
                 "Include assigned voice profile",
@@ -198,18 +206,21 @@ class PersonasInspectorPane(Vertical):
                 id="personas-export-json",
                 disabled=True,
                 classes="console-action-subdued",
+                tooltip=_NO_SELECTION_EXPORT_TOOLTIP,
             )
             yield Button(
                 "Export PNG",
                 id="personas-export-png",
                 disabled=True,
                 classes="console-action-subdued",
+                tooltip=_NO_SELECTION_EXPORT_TOOLTIP,
             )
             yield Button(
                 "Delete",
                 id="personas-delete",
                 disabled=True,
                 classes="console-action-subdued personas-destructive",
+                tooltip=_NO_SELECTION_DELETE_TOOLTIP,
             )
 
     def show_selection(self, *, name: str, kind: str) -> None:
@@ -416,16 +427,24 @@ class PersonasInspectorPane(Vertical):
         else:
             readiness.update("Ready to chat in Console.")
         export_enabled = selected and not unsaved
-        export_tooltip = _UNSAVED_TOOLTIP if (selected and unsaved) else None
+        # F-037: every disabled action carries a reason - unsaved edits when
+        # that is the blocker, the select-first reason pre-selection.
+        if selected and unsaved:
+            export_tooltip: str | None = _UNSAVED_TOOLTIP
+        elif not selected:
+            export_tooltip = _NO_SELECTION_EXPORT_TOOLTIP
+        else:
+            export_tooltip = None
         # Send-to-draft tooltip only surfaces when the selection gate itself
-        # is closed.
+        # is closed; the copy matches the readiness line's intent language.
         attach_tooltip = None
         if not self._console_actions_enabled:
-            attach_tooltip = (
-                _UNSAVED_TOOLTIP
-                if selected and unsaved
-                else f"Console action blocked: {self._console_action_block_reason}"
-            )
+            if not selected:
+                attach_tooltip = _NO_SELECTION_GUIDANCE
+            elif unsaved:
+                attach_tooltip = _UNSAVED_TOOLTIP
+            else:
+                attach_tooltip = f"Chat blocked: {self._console_action_block_reason}"
         # Kind gates rendering (task-443); readiness/unsaved/provider-readiness
         # gate the disabled+tooltip state of whatever is rendered (see the
         # module-level constants).
@@ -476,7 +495,9 @@ class PersonasInspectorPane(Vertical):
         png_button.display = export_png_applies
         png_button.disabled = not (export_enabled and kind == "character")
         png_button.tooltip = export_tooltip
-        self.query_one("#personas-delete", Button).disabled = not selected
+        delete_button = self.query_one("#personas-delete", Button)
+        delete_button.disabled = not selected
+        delete_button.tooltip = None if selected else _NO_SELECTION_DELETE_TOOLTIP
 
     def set_avatar_thumbnail(self, renderable: object | None) -> None:
         """Mount a prepared portrait renderable, or clear the box.

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -170,15 +170,20 @@ class PersonasInspectorPane(Vertical):
         actions = Vertical(id="personas-inspector-actions")
         actions.display = False
         with actions:
+            # F-032: one primary Console CTA named by intent (Chat now =
+            # begin immediately) plus one secondary (Send to Console draft =
+            # stage the card for the next Console draft). Ids, handlers, and
+            # the per-intent gating (task-523: Chat now also needs a ready
+            # provider) are unchanged - only labels, order, and emphasis.
             yield Button(
-                "Attach to Console",
-                id="personas-attach-to-console",
+                "Chat now",
+                id="personas-start-chat",
                 disabled=True,
-                classes="console-action-secondary",
+                classes="console-action-primary",
             )
             yield Button(
-                "Start Chat",
-                id="personas-start-chat",
+                "Send to Console draft",
+                id="personas-attach-to-console",
                 disabled=True,
                 classes="console-action-secondary",
             )
@@ -268,7 +273,7 @@ class PersonasInspectorPane(Vertical):
         reason: str | None = None,
         provider_block_reason: str | None = None,
     ) -> None:
-        """Set Attach/Start availability from the screen-owned Console gate.
+        """Set Chat-now/Send-draft availability from the screen-owned Console gate.
 
         Selection, export, and delete state stay local to the inspector, but
         Console action availability must be pushed by ``PersonasScreen`` so
@@ -278,15 +283,16 @@ class PersonasInspectorPane(Vertical):
             enabled: Whether Console actions are currently available.
             reason: Optional user-facing reason shown when actions are blocked.
             provider_block_reason: Optional blocker naming why the provider a
-                Start Chat/Attach Console handoff session would resolve is not
-                ready (task-440). Per-intent gating (task-523): when set (and
-                ``enabled`` is True) it replaces the "Console ready" copy with
-                "Start Chat blocked: ..." and DISABLES Start Chat - which needs
-                an immediate provider reply - while Attach stays enabled: Attach
-                only stages context, so its send is deferred and the user can
-                fix the provider before sending. Ignored when ``enabled`` is
-                False - the selection/unsaved reason already owns the copy and
-                both buttons are disabled by the gate.
+                Chat now/Send to Console draft handoff session would resolve
+                is not ready (task-440). Per-intent gating (task-523): when
+                set (and ``enabled`` is True) it replaces the "Ready to chat
+                in Console." copy with "Chat now blocked: ..." and DISABLES
+                Chat now - which needs an immediate provider reply - while
+                Send to Console draft stays enabled: it only stages context,
+                so its send is deferred and the user can fix the provider
+                before sending. Ignored when ``enabled`` is False - the
+                selection/unsaved reason already owns the copy and both
+                buttons are disabled by the gate.
         """
         self._console_actions_enabled = bool(enabled)
         self._console_action_block_reason = "" if enabled else (reason or "unavailable")
@@ -381,20 +387,30 @@ class PersonasInspectorPane(Vertical):
         self.query_one("#personas-readiness-header", Static).display = selected
         self.query_one("#personas-inspector-actions", Vertical).display = selected
         readiness = self.query_one("#personas-readiness-console", Static)
+        # F-032: readiness speaks in intent (what to do next), not app
+        # topology ("Console blocked: ..."). The per-intent gating is
+        # unchanged - only the copy moved.
         if not selected:
             readiness.update(_NO_SELECTION_GUIDANCE)
         elif not self._console_actions_enabled:
-            reason = self._console_action_block_reason or "unavailable"
-            readiness.update(f"Console blocked: {reason}")
+            if unsaved:
+                readiness.update("Save or discard your edits to chat in Console.")
+            elif kind not in _CONSOLE_ACTION_APPLICABLE_KINDS:
+                readiness.update("Console chat is for characters and personas.")
+            else:
+                reason = self._console_action_block_reason or "unavailable"
+                readiness.update(f"Chat blocked: {reason}")
         elif self._provider_block_reason:
-            # Per-intent (task-523): Attach stays available; only Start Chat is
-            # blocked because it needs an immediate reply from the provider.
-            readiness.update(f"Start Chat blocked: {self._provider_block_reason}")
+            # Per-intent (task-523): Send to Console draft stays available;
+            # only Chat now is blocked because it needs an immediate reply
+            # from the provider.
+            readiness.update(f"Chat now blocked: {self._provider_block_reason}")
         else:
-            readiness.update("Console ready")
+            readiness.update("Ready to chat in Console.")
         export_enabled = selected and not unsaved
         export_tooltip = _UNSAVED_TOOLTIP if (selected and unsaved) else None
-        # Attach tooltip only surfaces when the selection gate itself is closed.
+        # Send-to-draft tooltip only surfaces when the selection gate itself
+        # is closed.
         attach_tooltip = None
         if not self._console_actions_enabled:
             attach_tooltip = (
@@ -424,14 +440,15 @@ class PersonasInspectorPane(Vertical):
                 else "Assign a voice profile before including it."
             )
         )
-        # Attach: the selection gate only (staging context defers the reply).
+        # Send to Console draft: the selection gate only (staging context
+        # defers the reply).
         attach_btn = self.query_one("#personas-attach-to-console", Button)
         attach_btn.display = console_applies
         attach_btn.disabled = not self._console_actions_enabled
         attach_btn.tooltip = attach_tooltip
-        # Start Chat: selection AND a ready handoff provider (task-523) -- it
+        # Chat now: selection AND a ready handoff provider (task-523) -- it
         # needs an immediate reply, so an unready provider disables it while
-        # Attach stays available.
+        # Send to Console draft stays available.
         start_btn = self.query_one("#personas-start-chat", Button)
         start_btn.display = console_applies
         start_btn.disabled = (not self._console_actions_enabled) or bool(
@@ -440,7 +457,7 @@ class PersonasInspectorPane(Vertical):
         if not self._console_actions_enabled:
             start_btn.tooltip = attach_tooltip
         elif self._provider_block_reason:
-            start_btn.tooltip = f"Start Chat blocked: {self._provider_block_reason}"
+            start_btn.tooltip = f"Chat now blocked: {self._provider_block_reason}"
         else:
             start_btn.tooltip = None
         json_button = self.query_one("#personas-export-json", Button)

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -15,6 +15,11 @@ from .personas_pane_messages import ConversationRowSelected
 
 _UNSAVED_TOOLTIP = "Save before using this action; the selection has unsaved edits."
 
+#: The one plain line a no-selection inspector shows (F-031): intent-first
+#: guidance instead of a wall of disabled controls and a false
+#: "Validation: OK". Doubles as the Console readiness line pre-selection.
+_NO_SELECTION_GUIDANCE = "Pick a character or persona to start chatting."
+
 _ID_SAFE = re.compile(r"[^a-zA-Z0-9_-]")
 
 # Kind-applicability for actions that can never apply to some selections
@@ -24,8 +29,10 @@ _ID_SAFE = re.compile(r"[^a-zA-Z0-9_-]")
 # separate from "applies but is currently blocked" (unsaved edits, provider
 # readiness, no selection yet), which stays owned by
 # set_console_actions_enabled/_apply_action_state's disabled+tooltip logic
-# below. Before a kind is known (no selection) every action still renders,
-# matching the pre-selection "select an item" baseline.
+# below. Before a kind is known (no selection) the per-button display flags
+# still reset to visible, but the whole action stack is hidden behind the
+# no-selection guidance line (F-031), so the flags only take effect once a
+# selection reveals the stack again.
 _CONSOLE_ACTION_APPLICABLE_KINDS = {"character", "persona"}
 _EXPORT_JSON_APPLICABLE_KINDS = {"character", "persona"}
 _EXPORT_PNG_APPLICABLE_KINDS = {"character"}
@@ -135,12 +142,34 @@ class PersonasInspectorPane(Vertical):
         # character by its picture at least as much as by its name, and the
         # inspector previously showed every attribute EXCEPT the portrait.
         yield ClickableAvatarBox(id="personas-inspector-avatar-thumb")
-        yield Static("Validation: OK", id="personas-validation-summary")
-        yield Static("Conversations", classes="destination-section")
-        yield ListView(id="personas-conversations-list")
-        yield Static("Readiness", classes="destination-section")
-        yield Static("Console blocked: select an item", id="personas-readiness-console")
-        with Vertical(id="personas-inspector-actions"):
+        # F-031: everything below the portrait is hidden until there is a
+        # selection - pre-selection the inspector is just the summary lines
+        # plus one plain guidance line (the readiness Static below), not a
+        # false "Validation: OK", dangling section headers, and dead buttons.
+        validation = Static("Validation: OK", id="personas-validation-summary")
+        validation.display = False
+        yield validation
+        conversations_header = Static(
+            "Conversations",
+            id="personas-conversations-header",
+            classes="destination-section",
+        )
+        conversations_header.display = False
+        yield conversations_header
+        conversations_list = ListView(id="personas-conversations-list")
+        conversations_list.display = False
+        yield conversations_list
+        readiness_header = Static(
+            "Readiness",
+            id="personas-readiness-header",
+            classes="destination-section",
+        )
+        readiness_header.display = False
+        yield readiness_header
+        yield Static(_NO_SELECTION_GUIDANCE, id="personas-readiness-console")
+        actions = Vertical(id="personas-inspector-actions")
+        actions.display = False
+        with actions:
             yield Button(
                 "Attach to Console",
                 id="personas-attach-to-console",
@@ -342,8 +371,19 @@ class PersonasInspectorPane(Vertical):
         selected = self._has_selection
         unsaved = self._is_unsaved
         kind = self._selected_kind
+        # F-031: pre-selection the inspector is one guidance line only. The
+        # section chrome (Validation, Conversations, Readiness header) and
+        # the action stack stay hidden until there is something to act on;
+        # per-button kind gating below is unchanged for when they render.
+        self.query_one("#personas-validation-summary", Static).display = selected
+        self.query_one("#personas-conversations-header", Static).display = selected
+        self.query_one("#personas-conversations-list", ListView).display = selected
+        self.query_one("#personas-readiness-header", Static).display = selected
+        self.query_one("#personas-inspector-actions", Vertical).display = selected
         readiness = self.query_one("#personas-readiness-console", Static)
-        if not self._console_actions_enabled:
+        if not selected:
+            readiness.update(_NO_SELECTION_GUIDANCE)
+        elif not self._console_actions_enabled:
             reason = self._console_action_block_reason or "unavailable"
             readiness.update(f"Console blocked: {reason}")
         elif self._provider_block_reason:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -382,10 +382,18 @@ class PersonasInspectorPane(Vertical):
         # the action stack stay hidden until there is something to act on;
         # per-button kind gating below is unchanged for when they render.
         self.query_one("#personas-validation-summary", Static).display = selected
-        self.query_one("#personas-conversations-header", Static).display = selected
-        self.query_one("#personas-conversations-list", ListView).display = selected
         self.query_one("#personas-readiness-header", Static).display = selected
         self.query_one("#personas-inspector-actions", Vertical).display = selected
+        # F-036: only characters have saved conversations - the section hides
+        # for persona/dictionary/lore selections (the task-443 kind idiom)
+        # instead of dangling a header over an empty list.
+        conversations_visible = selected and kind == "character"
+        self.query_one(
+            "#personas-conversations-header", Static
+        ).display = conversations_visible
+        self.query_one(
+            "#personas-conversations-list", ListView
+        ).display = conversations_visible
         readiness = self.query_one("#personas-readiness-console", Static)
         # F-032: readiness speaks in intent (what to do next), not app
         # topology ("Console blocked: ..."). The per-intent gating is

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from loguru import logger
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
@@ -23,6 +24,8 @@ from .personas_messages import (
 )
 
 _ID_SAFE = re.compile(r"[^a-zA-Z0-9_-]")
+
+logger = logger.bind(module="PersonasLibraryPane")
 
 #: Columns one toolbar button occupies beyond its label: `padding: 0 1`
 #: plus the `margin-right: 1` gap from the pane CSS below.
@@ -214,6 +217,16 @@ class PersonasLibraryPane(Vertical):
         try:
             required = self._required_toolbar_row_width()
         except Exception:
+            # Widths are label-derived, so a failure here is a teardown or
+            # pre-compose race - but never something to swallow silently:
+            # leaving the bars clipped with no trace was the bug under
+            # review. Debug level, matching the teardown-race idiom used
+            # across the personas widgets (the layout simply keeps its
+            # previous state and re-syncs on the next resize).
+            logger.opt(exception=True).debug(
+                "PersonasLibraryPane toolbar width measurement failed; "
+                "keeping the previous control layout."
+            )
             return
         self.set_class(width < required, "personas-library-stacked-controls")
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -15,6 +15,7 @@ from .personas_messages import (
     PersonaActionRequested,
     PersonaEntityKind,
     PersonaEntitySelected,
+    PersonaMarksChanged,
     PersonaPageChanged,
     PersonaSearchChanged,
     PersonaSortCycleRequested,
@@ -74,6 +75,10 @@ class PersonasLibraryPane(Vertical):
 
     BINDINGS = [
         ("space", "toggle_highlighted", "Toggle on/off"),
+        # F-040: m marks rows for bulk delete/export; s cycles the sort
+        # (both no-op outside their applicable modes/rows).
+        ("m", "toggle_mark", "Mark row"),
+        ("s", "cycle_sort", "Cycle sort"),
     ]
 
     # Structure only: colors come from the app stylesheet
@@ -155,6 +160,13 @@ class PersonasLibraryPane(Vertical):
         super().__init__(**kwargs)
         self._row_lookup: dict[str, LibraryRow] = {}
         self._import_visible: bool = True
+        # F-040: marked (multi-selected) rows for bulk delete/export, as row
+        # dom ids; pruned to the rendered rows on every update_rows.
+        self._marked_ids: set[str] = set()
+        self._sort_visible: bool = True
+        # The count line's filter-state text from the last update_rows; the
+        # "N marked" summary overrides it while marks exist.
+        self._base_count_text: str = ""
 
     def on_mount(self) -> None:
         """Initialize control visibility for default characters mode.
@@ -250,7 +262,7 @@ class PersonasLibraryPane(Vertical):
             yield Button(
                 "Sort: Name",
                 id="personas-library-sort",
-                tooltip="Cycle the list sort order.",
+                tooltip="Cycle the list sort order. (s)",
                 classes="console-action-secondary",
             )
             yield Button(
@@ -303,6 +315,7 @@ class PersonasLibraryPane(Vertical):
             "lore",
         )
         sort_visible = mode in ("characters", "personas")
+        self._sort_visible = sort_visible
         self.query_one("#personas-library-sort", Button).display = sort_visible
         self.query_one("#personas-library-tag", Button).display = mode == "characters"
         if not sort_visible:
@@ -310,6 +323,8 @@ class PersonasLibraryPane(Vertical):
             self.query_one("#personas-library-pagebar").display = False
         # Which buttons render changed, so the single-row fit changed too.
         self._sync_control_layout()
+        # Marks are mode-scoped: a mode switch drops them (F-040).
+        self.clear_marks()
 
     async def update_rows(
         self,
@@ -386,10 +401,14 @@ class PersonasLibraryPane(Vertical):
             classes = "personas-library-row console-action-subdued"
             if row.is_unsaved:
                 classes += " is-unsaved"
+            # F-040: marked rows carry a glyph prefix on the name line.
+            name_text = (
+                f"● {row.name}" if dom_id in self._marked_ids else row.name
+            )
             if row.meta:
                 item = ListItem(
                     Vertical(
-                        Static(row.name, markup=False),
+                        Static(name_text, markup=False),
                         Static(
                             row.meta,
                             markup=False,
@@ -406,15 +425,19 @@ class PersonasLibraryPane(Vertical):
                 items.append(item)
             else:
                 items.append(
-                    ListItem(Static(row.name, markup=False), id=dom_id, classes=classes)
+                    ListItem(Static(name_text, markup=False), id=dom_id, classes=classes)
                 )
         await list_view.extend(items)
+        # F-040: a mark never outlives its row - a refresh that drops a
+        # marked row drops the mark with it.
+        pruned = self._marked_ids - seen
+        if pruned:
+            self._marked_ids -= pruned
         pagebar = self.query_one("#personas-library-pagebar")
-        count_static = self.query_one("#personas-library-count", Static)
         paginated = page_offset is not None and page_size is not None
         if recovery_copy:
             pagebar.display = False
-            count_static.update(f"{noun.capitalize()} unavailable")
+            self._base_count_text = f"{noun.capitalize()} unavailable"
         elif paginated and total > page_size:
             start = page_offset + 1 if total else 0
             end = page_offset + len(rows)
@@ -426,24 +449,27 @@ class PersonasLibraryPane(Vertical):
                 page_offset + page_size >= total
             )
             pagebar.display = True
-            count_static.update("")
+            self._base_count_text = ""
         else:
             pagebar.display = False
             if filtered and filtered_total_unbounded:
                 match_word = "match" if len(rows) == 1 else "matches"
-                count_static.update(
+                self._base_count_text = (
                     f"Showing {len(rows)} {_singular_noun(noun)} "
                     f"{match_word} from full library"
                 )
             elif filtered:
-                count_static.update(
+                self._base_count_text = (
                     f"{len(rows)} of {total} {_noun_for_count(total, noun)}"
                 )
             else:
                 # F-033: the plain total renders once, in the screen's merged
                 # purpose line ("Characters — who the AI plays · N") - the
                 # pane's own count line only speaks for filtered states.
-                count_static.update("")
+                self._base_count_text = ""
+        self._sync_marked_count_line()
+        if pruned:
+            self._post_marks_changed()
 
     def mark_active_row(self, kind: str, item_id: str) -> None:
         """Move the list highlight and the .is-active marker to one row."""
@@ -483,6 +509,70 @@ class PersonasLibraryPane(Vertical):
         self.query_one("#personas-library-sort", Button).label = text
         # A longer/shorter label changes the single-row fit (F-030).
         self._sync_control_layout()
+
+    # ===== F-040: marks (multi-select) =====
+
+    def _sync_marked_count_line(self) -> None:
+        """The count line reports active marks ahead of filter state."""
+        text = (
+            f"{len(self._marked_ids)} marked"
+            if self._marked_ids
+            else self._base_count_text
+        )
+        self.query_one("#personas-library-count", Static).update(text)
+
+    def _post_marks_changed(self) -> None:
+        marks = tuple(
+            (row.kind, row.item_id, row.name)
+            for dom_id, row in self._row_lookup.items()
+            if dom_id in self._marked_ids
+        )
+        self.post_message(PersonaMarksChanged(marks))
+
+    @staticmethod
+    def _render_row_marker(item: ListItem, row: LibraryRow, marked: bool) -> None:
+        """Prefix/unprefix the row's name line with the marked glyph."""
+        name_static = item.query_one(Static)
+        name_static.update(f"● {row.name}" if marked else row.name)
+
+    def clear_marks(self) -> None:
+        """Drop every mark (mode switch, or after a bulk action consumes them)."""
+        if not self._marked_ids:
+            return
+        self._marked_ids = set()
+        list_view = self.query_one("#personas-library-rows", ListView)
+        for item in list_view.children:
+            row = self._row_lookup.get(str(item.id or ""))
+            if row is not None:
+                self._render_row_marker(item, row, False)
+        self._sync_marked_count_line()
+        self._post_marks_changed()
+
+    def action_toggle_mark(self) -> None:
+        """m: mark/unmark the highlighted row for bulk delete/export (F-040)."""
+        list_view = self.query_one("#personas-library-rows", ListView)
+        index = list_view.index
+        if index is None or not 0 <= index < len(list_view.children):
+            return
+        item = list_view.children[index]
+        dom_id = str(item.id or "")
+        row = self._row_lookup.get(dom_id)
+        if row is None:
+            # Placeholder/recovery rows are not markable.
+            return
+        marked = dom_id not in self._marked_ids
+        if marked:
+            self._marked_ids.add(dom_id)
+        else:
+            self._marked_ids.discard(dom_id)
+        self._render_row_marker(item, row, marked)
+        self._sync_marked_count_line()
+        self._post_marks_changed()
+
+    def action_cycle_sort(self) -> None:
+        """s: cycle the list sort order where sorting applies (F-040)."""
+        if self._sort_visible:
+            self.post_message(PersonaSortCycleRequested())
 
     def set_tag_label(self, text: str) -> None:
         """Update the tag button's label (the screen owns the active tag)."""

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -440,7 +440,10 @@ class PersonasLibraryPane(Vertical):
                     f"{len(rows)} of {total} {_noun_for_count(total, noun)}"
                 )
             else:
-                count_static.update(f"{total} {_noun_for_count(total, noun)}")
+                # F-033: the plain total renders once, in the screen's merged
+                # purpose line ("Characters — who the AI plays · N") - the
+                # pane's own count line only speaks for filtered states.
+                count_static.update("")
 
     def mark_active_row(self, kind: str, item_id: str) -> None:
         """Move the list highlight and the .is-active marker to one row."""

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.events import Resize
 from textual.widgets import Button, Input, ListItem, ListView, Static
 
 from .personas_messages import (
@@ -21,6 +22,10 @@ from .personas_messages import (
 )
 
 _ID_SAFE = re.compile(r"[^a-zA-Z0-9_-]")
+
+#: Columns one toolbar button occupies beyond its label: `padding: 0 1`
+#: plus the `margin-right: 1` gap from the pane CSS below.
+_TOOLBAR_BUTTON_CHROME_COLS = 3
 
 
 def _row_dom_id(kind: str, item_id: str) -> str:
@@ -115,6 +120,35 @@ class PersonasLibraryPane(Vertical):
         width: 1fr;
         text-align: center;
     }
+
+    /* F-030: toolbar buttons size to their labels. The Textual Button
+       default min-width:16 let "New" alone fill a narrow pane and clipped
+       Import/Duplicate/Tag off the right edge at supported widths. */
+    PersonasLibraryPane #personas-library-toolbar Button,
+    PersonasLibraryPane #personas-library-filterbar Button {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        border: none;
+        margin-right: 1;
+    }
+
+    /* F-030 narrow panes: stack each bar vertically so every action wraps
+       onto its own full-width row (a Textual Horizontal never wraps, so one
+       over-wide row would clip instead). */
+    PersonasLibraryPane.personas-library-stacked-controls #personas-library-toolbar,
+    PersonasLibraryPane.personas-library-stacked-controls #personas-library-filterbar {
+        layout: vertical;
+        height: auto;
+    }
+
+    PersonasLibraryPane.personas-library-stacked-controls #personas-library-toolbar Button,
+    PersonasLibraryPane.personas-library-stacked-controls #personas-library-filterbar Button {
+        width: 100%;
+        margin-right: 0;
+    }
     """
 
     def __init__(self, **kwargs) -> None:
@@ -131,6 +165,45 @@ class PersonasLibraryPane(Vertical):
         """
         self.query_one("#personas-library-duplicate", Button).display = True
         self.query_one("#personas-library-pagebar").display = False
+        self._sync_control_layout()
+
+    def on_resize(self, event: Resize) -> None:
+        """Re-wrap the toolbar bars when the pane width changes (F-030)."""
+        self._sync_control_layout()
+
+    def _required_toolbar_row_width(self) -> int:
+        """Widest single-row width the currently visible bar buttons need.
+
+        Derived from labels, not rendered sizes, so toggling the stacked
+        class never changes the measurement (no layout oscillation).
+        """
+        required = 0
+        for bar_id in ("#personas-library-toolbar", "#personas-library-filterbar"):
+            row = 0
+            for button in self.query(f"{bar_id} Button").results():
+                if not button.display:
+                    continue
+                row += len(str(button.label)) + _TOOLBAR_BUTTON_CHROME_COLS
+            required = max(required, row)
+        return required
+
+    def _sync_control_layout(self) -> None:
+        """Stack the toolbar bars when one row would clip actions (F-030).
+
+        A pane narrower than the single-row width clipped the rightmost
+        buttons off-screen (at 100x30 that hid Import -- the roleplay
+        onboarding path). Stacking switches each bar to a vertical layout so
+        every action wraps onto its own row instead.
+        """
+        width = self.content_size.width
+        if width <= 0:
+            # Not laid out yet (on_mount); on_resize re-syncs once sized.
+            return
+        try:
+            required = self._required_toolbar_row_width()
+        except Exception:
+            return
+        self.set_class(width < required, "personas-library-stacked-controls")
 
     def compose(self) -> ComposeResult:
         """Compose the Library pane header, search controls, and rows.
@@ -235,6 +308,8 @@ class PersonasLibraryPane(Vertical):
         if not sort_visible:
             # dict/lore never paginate - keep the page bar hidden.
             self.query_one("#personas-library-pagebar").display = False
+        # Which buttons render changed, so the single-row fit changed too.
+        self._sync_control_layout()
 
     async def update_rows(
         self,
@@ -403,10 +478,13 @@ class PersonasLibraryPane(Vertical):
     def set_sort_label(self, text: str) -> None:
         """Update the sort button's label (the screen owns the sort cycle/copy)."""
         self.query_one("#personas-library-sort", Button).label = text
+        # A longer/shorter label changes the single-row fit (F-030).
+        self._sync_control_layout()
 
     def set_tag_label(self, text: str) -> None:
         """Update the tag button's label (the screen owns the active tag)."""
         self.query_one("#personas-library-tag", Button).label = text
+        self._sync_control_layout()
 
     @on(Input.Changed, "#personas-library-search")
     def _search_changed(self, event: Input.Changed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
@@ -103,11 +103,24 @@ class PersonaPageChanged(Message):
         self.delta = delta
 
 
+class PersonaMarksChanged(Message):
+    """The library pane's marked (multi-selected) row set changed (F-040).
+
+    ``marks`` is a tuple of ``(kind, item_id, name)`` triples in row order;
+    empty when the last mark was cleared.
+    """
+
+    def __init__(self, marks: tuple[tuple[str, str, str], ...]) -> None:
+        super().__init__()
+        self.marks = marks
+
+
 __all__ = [
     "PersonaAction",
     "PersonaActionRequested",
     "PersonaEntityKind",
     "PersonaEntitySelected",
+    "PersonaMarksChanged",
     "PersonaModeChanged",
     "PersonaPageChanged",
     "PersonaSearchChanged",

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -147,9 +147,10 @@ class PersonasPreviewPane(Vertical):
                     classes="console-action-subdued",
                 )
                 yield Button(
-                    "Open in Console",
+                    "Continue this chat in Console",
                     id="personas-preview-open-console",
                     classes="console-action-subdued",
+                    tooltip="Move this preview conversation into a Console session.",
                 )
                 yield Button(
                     "Configure",

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -106,7 +106,7 @@ class PersonasPreviewPane(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Button(
-            "Preview conversation",
+            "▸ Preview conversation",
             id="personas-preview-toggle",
             tooltip="Test the selected character or persona in an ephemeral conversation; nothing is saved.",
             classes="console-action-subdued",
@@ -169,6 +169,9 @@ class PersonasPreviewPane(Vertical):
     def expand(self) -> None:
         """Show the collapsible body."""
         self.query_one("#personas-preview-body").display = True
+        self.query_one("#personas-preview-toggle", Button).label = (
+            "▾ Preview conversation"
+        )
 
     async def seed_greeting(self, text: str) -> None:
         """Store the greeting and restart the transcript from it.
@@ -423,6 +426,11 @@ class PersonasPreviewPane(Vertical):
         event.stop()
         body = self.query_one("#personas-preview-body")
         body.display = not body.display
+        # The toggle doubles as the section header, so it carries the
+        # expand/collapse state (F-039).
+        self.query_one("#personas-preview-toggle", Button).label = (
+            "▾ Preview conversation" if body.display else "▸ Preview conversation"
+        )
 
     def _submit_preview_message(self) -> None:
         """Shared Test Reply path: validate, clear, append, request a reply.

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -751,7 +751,7 @@ class TabNavigationProvider(Provider):
         TAB_CHAT: "Open Console for live agent work, approvals, tools, and RAG",
         TAB_LIBRARY: "Open Library for source material, imports, notes, media, conversations, and Search/RAG",
         TAB_ARTIFACTS: "Open Artifacts for generated outputs, reports, datasets, and Chatbooks",
-        TAB_PERSONAS: "Open Roleplay & Chat Dictionaries for characters, personas, dictionaries, and behavior profiles",
+        TAB_PERSONAS: "Open Roleplay for characters, personas, dictionaries, and behavior profiles",
         TAB_WATCHLISTS_COLLECTIONS: "Open Watchlists for monitored sources, runs, alerts, and recovery",
         TAB_SCHEDULES: "Open Schedules for run timing, triggers, pauses, retries, and recovery",
         TAB_WORKFLOWS: "Open Workflows for reusable procedures, dry-runs, and outputs",
@@ -759,7 +759,7 @@ class TabNavigationProvider(Provider):
         TAB_ACP: "Open ACP for agents, sessions, runtimes, diffs, and terminals",
         TAB_SKILLS: "Open Skills for Agent Skills discovery, validation, and attachments",
         TAB_SETTINGS: "Open global preferences, appearance, accounts, storage, and app behavior",
-        TAB_CCP: "Switch to Roleplay & Chat Dictionaries for characters, personas, dictionaries, and world books",
+        TAB_CCP: "Switch to Roleplay for characters, personas, dictionaries, and world books",
         TAB_MEDIA: "Switch to media library",
         TAB_SEARCH: "Switch to Library search and RAG",
         TAB_INGEST: "Switch to content ingestion",
@@ -1137,7 +1137,7 @@ class QuickActionsProvider(Provider):
                 _navigate_via_screen(
                     self.app,
                     TAB_PERSONAS,
-                    "Opened Roleplay & Chat Dictionaries for character setup",
+                    "Opened Roleplay for character setup",
                 )
             elif action_id == "new_note":
                 _navigate_via_screen(
@@ -1313,19 +1313,19 @@ class CharacterProvider(Provider):
                 _navigate_via_screen(
                     self.app,
                     TAB_PERSONAS,
-                    "Opened Roleplay & Chat Dictionaries",
+                    "Opened Roleplay",
                 )
             elif action_id == "new_character":
                 _navigate_via_screen(
                     self.app,
                     TAB_PERSONAS,
-                    "Opened Roleplay & Chat Dictionaries to create a character",
+                    "Opened Roleplay to create a character",
                 )
             elif action_id == "list_characters":
                 _navigate_via_screen(
                     self.app,
                     TAB_PERSONAS,
-                    "Opened Roleplay & Chat Dictionaries to list characters",
+                    "Opened Roleplay to list characters",
                 )
         except Exception as e:
             self.app.notify(


### PR DESCRIPTION
## What

Twelve UX fixes on the Roleplay screen from the UX/HCI review (`Docs/superpowers/qa/2026-08-03-library-roleplay-mcp-ux-review.md`, findings F-030 through F-041). Backlog TASK-2081 through TASK-2092, each with AC + implementation notes.

## Findings fixed

- **F-030 (P0)** — Library toolbar no longer clips at supported widths: buttons size to labels and wrap to stacked full-width rows when narrow; Import (the PNG-card onboarding path) is reachable at 100x30 and 80x24 (TASK-2081)
- **F-031 (P1)** — First paint is designed: first library row auto-selects on mount, inspector shows one guidance line instead of 5 dead buttons + a false "Validation: OK" (TASK-2082)
- **F-032 (P1)** — One primary CTA "Chat now" + one secondary "Send to Console draft"; preview button "Continue this chat in Console"; readiness copy in intent language (TASK-2083)
- **F-033 (P2)** — Header band slimmed: purpose line carries the live count, standalone status strip removed, count shown once (TASK-2084)
- **F-034 (P2)** — One public name ("Roleplay") across header/nav/palette; Personas descriptor teaches "who you play in the chat" (TASK-2085)
- **F-035 (P2)** — Empty-state copy adapts to library contents; alignment per app convention (TASK-2086)
- **F-036 (P2)** — Inspector Conversations is kind-gated with "No saved conversations." empty copy (TASK-2087)
- **F-037 (P2)** — Reason tooltips on every disabled inspector action, incl. server read-only state (TASK-2088)
- **F-038 (P3)** — Accelerators surfaced: per-state footer (f6/ctrl+1-4/[ ]/space where they work), mode chips carry their jump keys (TASK-2089)
- **F-039 (P3)** — Preview pane anchored at the top of the center canvas with an expand/collapse glyph (TASK-2090)
- **F-040 (P3)** — Mark-set bulk delete/export (m to mark, batch confirm, per-item export), `s` sort key, selection restore across all modes (TASK-2091)
- **F-041 (P3)** — Disabled voice-profile checkbox legible as a disabled control (TASK-2092)

## Tests

RED-first per task; per-task evidence in the backlog notes. Batch gates: 975 passed (P2 batch), 735 passed (P3 batch) across the roleplay-affected test files; ruff clean; `check_bundle_sync.py` green.

## Notes

- No ADRs required (UI/copy/behavior fixes; no schema, sync, or boundary changes).
- Deferrals documented in task notes: repo-wide all-buttons tooltip audit, server-browsing toolbar tooltips, TTS-include for bulk export.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UX pass on the Roleplay screen addressing findings F-030–F-041: designed first paint, honest actions, reachable toolbar, simpler header, one public name, and clearer copy. Adds guardrails so invalid restores still auto-select the first row and toolbar layout errors are logged without breaking layout (TASK‑2081–TASK‑2092).

- **New Features**
  - First paint auto-selects the first library row; inspector shows a single guidance line; one primary CTA “Chat now” plus secondary “Send to Console draft”; preview anchored above the canvas with an expand/collapse glyph and “Continue this chat in Console”.
  - Bulk ops and shortcuts: mark rows with “m” for batch Delete/Export JSON; “s” sort key; selection restore across all modes; shortcuts surfaced in the footer and chip tooltips (F6 pane cycle, Ctrl+1–4 mode jumps, [ ] mode cycle, Space in Dictionaries).

- **Bug Fixes**
  - Library toolbar stays reachable at narrow widths by sizing to labels and stacking rows (Import reachable at 100x30 and 80x24).
  - Header slimmed; count appears once in the purpose line; library pane count only shows when filtered.
  - One public name “Roleplay” across nav/header/palette; Personas descriptor now teaches “who you play in the chat”.
  - Honest empty states (including Conversations) and reason tooltips on disabled actions; disabled voice‑profile checkbox remains legible.
  - Invalid saved states no longer suppress first‑paint auto‑select; toolbar width measurement failures are logged and the last good layout is kept.

<sup>Written for commit cccf668e3d57fd9ae50ec88ad5e66eb0b1a9d9aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

