### PR TITLE
fix(chrome): reachable tab destinations at small widths, honest key hints, contextual Tokens chip (2 tasks)

### DIFF
--- a/Tests/UI/test_app_footer_shortcut_context.py
+++ b/Tests/UI/test_app_footer_shortcut_context.py
@@ -1,7 +1,5 @@
 """Tests for global footer shortcut context updates."""
 
-from types import SimpleNamespace
-
 import pytest
 from textual.app import App
 from textual.widgets import Static
@@ -81,69 +79,63 @@ async def test_footer_renders_workbench_shortcuts():
 
 
 @pytest.mark.asyncio
-async def test_db_size_telemetry_caches_on_the_app_and_leaves_the_footer(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """F-014: DB-size telemetry no longer renders in user chrome.
-
-    The manager still computes the spelled-out sizes (task-1714 labels)
-    and logs them, but its output is cached on the app for the Library
-    Details disclosure instead of pushed into the footer, so a fresh
-    install's footer no longer reads "Prompts: N/A | Chats/Notes: N/A |
-    Media: N/A".
-
-    Args:
-        monkeypatch: Pytest fixture used to stub the size lookups.
-    """
-    app = SimpleNamespace()
-    footer = AppFooterStatus(id="footer")
-    manager = DBStatusManager(app=app)
-    monkeypatch.setattr(manager, "_get_db_size", lambda *_args: "1.0 KB")
-
-    await manager.update_db_sizes()
-
-    assert app.db_sizes_status == {
-        "prompts": "1.0 KB",
-        "chachanotes": "1.0 KB",
-        "media": "1.0 KB",
-    }
-    # The footer indicator is never fed -- and stays collapsed (empty).
-    assert str(footer._db_status_display.renderable) == ""
-    assert footer._db_status_display.display is False
-
-
-@pytest.mark.asyncio
-async def test_footer_db_indicator_collapses_when_empty_and_stays_down():
-    """The DB-size indicator only takes footer space while it has content;
-    the priority reflow must not resurrect an empty indicator on resize."""
+async def test_footer_token_chip_hidden_until_a_real_count_lands():
+    """F-003: the Tokens chip is meaningful only where token counts exist
+    (chat contexts). It now starts empty and hidden -- never a
+    "Tokens: --" placeholder -- appears when a real count is pushed, and
+    hides again when the count clears (non-chat tabs write "" via the
+    periodic updater)."""
 
     class TestApp(App):
         def compose(self):
             yield AppFooterStatus(id="footer")
 
     app = TestApp()
-    async with app.run_test(size=(200, 12)) as pilot:
+    async with app.run_test(size=(100, 12)) as pilot:
         footer = app.query_one("#footer", AppFooterStatus)
-        db = app.query_one("#internal-db-size-indicator", Static)
-        # Never fed: collapsed from the start.
-        assert db.display is False
+        chip = app.query_one("#footer-token-count", Static)
 
-        # Feeding content reveals it; clearing collapses it again.
-        footer.update_db_sizes_display("P: 144.0 KB | C/N: 904.0 KB | M: 376.0 KB")
-        await pilot.pause()
-        assert db.display is True
-        footer.update_db_sizes_display("")
-        await pilot.pause()
-        assert db.display is False
+        # Fresh footer: no placeholder text, no chip.
+        assert str(chip.renderable) == ""
+        assert chip.display is False
 
-        # A resize re-runs the priority reflow -- the empty indicator
-        # must stay down rather than reappear as blank chrome.
-        await pilot.resize_terminal(60, 12)
+        # A real count reveals the chip...
+        footer.update_token_count("Tokens: 1,234")
         await pilot.pause()
-        assert db.display is False
-        await pilot.resize_terminal(200, 12)
+        assert "Tokens: 1,234" in str(chip.renderable)
+        assert chip.display is True
+
+        # ...and clearing it (the non-chat updater path) hides it again.
+        footer.update_token_count("")
         await pilot.pause()
-        assert db.display is False
+        assert chip.display is False
+
+
+@pytest.mark.asyncio
+async def test_footer_db_size_stats_use_readable_labels_and_context_tooltip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spell out production DB labels and describe their local context.
+
+    Args:
+        monkeypatch: Pytest fixture used to bind the production manager to the
+            production footer function under test.
+    """
+    footer = AppFooterStatus(id="footer")
+    manager = DBStatusManager(app=object())
+    monkeypatch.setattr(manager, "_get_db_status_widget", lambda: footer)
+    monkeypatch.setattr(manager, "_get_db_size", lambda *_args: "1.0 KB")
+
+    await manager.update_db_sizes()
+
+    rendered = str(footer._db_status_display.renderable)
+    tooltip = str(footer._db_status_display.tooltip or "")
+
+    assert "Prompts:" in rendered
+    assert "Chats/Notes:" in rendered
+    assert "Media:" in rendered
+    assert "local" in tooltip.lower()
+    assert "database file sizes" in tooltip.lower()
 
 
 @pytest.mark.asyncio
@@ -193,7 +185,10 @@ async def test_footer_reflows_when_counts_change_without_a_resize():
             yield AppFooterStatus(id="footer")
 
     app = TestApp()
-    async with app.run_test(size=(100, 12)) as pilot:
+    # F-003 recalibration: the width budget below used to include the
+    # "Tokens: --" placeholder's 10 cells; the chip now starts hidden and
+    # empty, so the same push-over-the-edge exercise runs at 90 cols.
+    async with app.run_test(size=(90, 12)) as pilot:
         footer = app.query_one("#footer", AppFooterStatus)
         footer.update_db_sizes_display("P: 144.0 KB | C/N: 904.0 KB | M: 376.0 KB")
         await pilot.pause()

--- a/Tests/UI/test_app_footer_shortcut_context.py
+++ b/Tests/UI/test_app_footer_shortcut_context.py
@@ -1,5 +1,7 @@
 """Tests for global footer shortcut context updates."""
 
+from types import SimpleNamespace
+
 import pytest
 from textual.app import App
 from textual.widgets import Static
@@ -79,6 +81,72 @@ async def test_footer_renders_workbench_shortcuts():
 
 
 @pytest.mark.asyncio
+async def test_db_size_telemetry_caches_on_the_app_and_leaves_the_footer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-014: DB-size telemetry no longer renders in user chrome.
+
+    The manager still computes the spelled-out sizes (task-1714 labels)
+    and logs them, but its output is cached on the app for the Library
+    Details disclosure instead of pushed into the footer, so a fresh
+    install's footer no longer reads "Prompts: N/A | Chats/Notes: N/A |
+    Media: N/A".
+
+    Args:
+        monkeypatch: Pytest fixture used to stub the size lookups.
+    """
+    app = SimpleNamespace()
+    footer = AppFooterStatus(id="footer")
+    manager = DBStatusManager(app=app)
+    monkeypatch.setattr(manager, "_get_db_size", lambda *_args: "1.0 KB")
+
+    await manager.update_db_sizes()
+
+    assert app.db_sizes_status == {
+        "prompts": "1.0 KB",
+        "chachanotes": "1.0 KB",
+        "media": "1.0 KB",
+    }
+    # The footer indicator is never fed -- and stays collapsed (empty).
+    assert str(footer._db_status_display.renderable) == ""
+    assert footer._db_status_display.display is False
+
+
+@pytest.mark.asyncio
+async def test_footer_db_indicator_collapses_when_empty_and_stays_down():
+    """The DB-size indicator only takes footer space while it has content;
+    the priority reflow must not resurrect an empty indicator on resize."""
+
+    class TestApp(App):
+        def compose(self):
+            yield AppFooterStatus(id="footer")
+
+    app = TestApp()
+    async with app.run_test(size=(200, 12)) as pilot:
+        footer = app.query_one("#footer", AppFooterStatus)
+        db = app.query_one("#internal-db-size-indicator", Static)
+        # Never fed: collapsed from the start.
+        assert db.display is False
+
+        # Feeding content reveals it; clearing collapses it again.
+        footer.update_db_sizes_display("P: 144.0 KB | C/N: 904.0 KB | M: 376.0 KB")
+        await pilot.pause()
+        assert db.display is True
+        footer.update_db_sizes_display("")
+        await pilot.pause()
+        assert db.display is False
+
+        # A resize re-runs the priority reflow -- the empty indicator
+        # must stay down rather than reappear as blank chrome.
+        await pilot.resize_terminal(60, 12)
+        await pilot.pause()
+        assert db.display is False
+        await pilot.resize_terminal(200, 12)
+        await pilot.pause()
+        assert db.display is False
+
+
+@pytest.mark.asyncio
 async def test_footer_token_chip_hidden_until_a_real_count_lands():
     """F-003: the Tokens chip is meaningful only where token counts exist
     (chat contexts). It now starts empty and hidden -- never a
@@ -109,33 +177,6 @@ async def test_footer_token_chip_hidden_until_a_real_count_lands():
         footer.update_token_count("")
         await pilot.pause()
         assert chip.display is False
-
-
-@pytest.mark.asyncio
-async def test_footer_db_size_stats_use_readable_labels_and_context_tooltip(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Spell out production DB labels and describe their local context.
-
-    Args:
-        monkeypatch: Pytest fixture used to bind the production manager to the
-            production footer function under test.
-    """
-    footer = AppFooterStatus(id="footer")
-    manager = DBStatusManager(app=object())
-    monkeypatch.setattr(manager, "_get_db_status_widget", lambda: footer)
-    monkeypatch.setattr(manager, "_get_db_size", lambda *_args: "1.0 KB")
-
-    await manager.update_db_sizes()
-
-    rendered = str(footer._db_status_display.renderable)
-    tooltip = str(footer._db_status_display.tooltip or "")
-
-    assert "Prompts:" in rendered
-    assert "Chats/Notes:" in rendered
-    assert "Media:" in rendered
-    assert "local" in tooltip.lower()
-    assert "database file sizes" in tooltip.lower()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_master_shell_navigation.py
+++ b/Tests/UI/test_master_shell_navigation.py
@@ -436,3 +436,43 @@ async def test_nav_overflow_hint_pages_to_hidden_destinations_at_100_cols():
         else:
             raise AssertionError("More › never wrapped back to the start")
         assert visible(app.query_one("#nav-home", Button))
+
+
+@pytest.mark.asyncio
+async def test_more_hint_pages_by_visible_width_and_never_overscrolls():
+    """PR #1322 review: the pager's increment must be the strip's VISIBLE
+    viewport width, not the full scrollable content width, and a press
+    must never land past the end (clamped to max_scroll_x)."""
+
+    class TestApp(App):
+        def compose(self):
+            yield MainNavigationBar(active="home")
+
+    app = TestApp()
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause(0.1)
+
+        strip = app.query_one("#nav-destination-strip")
+        hint = app.query_one("#nav-overflow-hint", Button)
+
+        # The property the pager reads is the VIEWPORT (region minus
+        # gutter/scrollbar), not the virtual content: the content
+        # overflows it by max_scroll_x.
+        visible_width = strip.scrollable_content_region.width
+        assert visible_width == strip.region.width
+        assert strip.virtual_size.width == visible_width + strip.max_scroll_x
+        assert strip.max_scroll_x > 0
+
+        # One press advances by exactly min(visible width, remaining) --
+        # never past the end.
+        hint.press()
+        await pilot.pause(0.1)
+        expected = min(visible_width, strip.max_scroll_x)
+        assert strip.scroll_offset.x == expected
+        assert strip.scroll_offset.x <= strip.max_scroll_x
+
+        # From the end, the wrap (not another page) fires.
+        hint.press()
+        await pilot.pause(0.1)
+        assert strip.scroll_offset.x == 0

--- a/Tests/UI/test_master_shell_navigation.py
+++ b/Tests/UI/test_master_shell_navigation.py
@@ -47,16 +47,16 @@ async def test_master_shell_navigation_order_and_labels():
         ]
 
     assert actual == [
-        ("nav-home", "1 Home"),
-        ("nav-console", "2 Console"),
-        ("nav-library", "3 Library"),
-        ("nav-artifacts", "4 Artifacts"),
-        ("nav-personas", "5 Roleplay"),
-        ("nav-watchlists_collections", "6 Watchlists"),
-        ("nav-schedules", "7 Schedules"),
-        ("nav-workflows", "8 Workflows"),
-        ("nav-mcp", "9 MCP"),
-        ("nav-acp", "0 ACP"),
+        ("nav-home", "\u23031 Home"),
+        ("nav-console", "\u23032 Console"),
+        ("nav-library", "\u23033 Library"),
+        ("nav-artifacts", "\u23034 Artifacts"),
+        ("nav-personas", "\u23035 Roleplay"),
+        ("nav-watchlists_collections", "\u23036 Watchlists"),
+        ("nav-schedules", "\u23037 Schedules"),
+        ("nav-workflows", "\u23038 Workflows"),
+        ("nav-mcp", "\u23039 MCP"),
+        ("nav-acp", "\u23030 ACP"),
         ("nav-lab", "Lab"),
         ("nav-logs", "Logs"),
         ("nav-settings", "Settings"),
@@ -66,11 +66,14 @@ async def test_master_shell_navigation_order_and_labels():
 def test_nav_button_label_numbering_scheme():
     from tldw_chatbook.UI.Navigation.main_navigation import nav_button_label
 
-    # ctrl+1..ctrl+9 cover the first nine destinations, ctrl+0 the tenth;
-    # the remaining destinations (Lab, Logs, Settings) stay unnumbered.
+    # F-002: the labels used to read "1 Home" -- implying a bare-digit key
+    # -- while the actual binding is ctrl+digit. The label now carries the
+    # control glyph so the affordance matches the keybinding at zero extra
+    # width per tab. ctrl+1..ctrl+9 cover the first nine destinations,
+    # ctrl+0 the tenth; Lab, Logs, Settings stay unnumbered.
     digits = ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
     for index, digit in enumerate(digits):
-        assert nav_button_label(index, "Label") == f"{digit} Label"
+        assert nav_button_label(index, "Label") == f"\u2303{digit} Label"
     assert nav_button_label(10, "Lab") == "Lab"
     assert nav_button_label(11, "Logs") == "Logs"
     assert nav_button_label(12, "Settings") == "Settings"
@@ -185,8 +188,8 @@ async def test_home_and_console_remain_first_primary_destinations():
         buttons = list(app.query(".nav-button"))
 
     assert [(button.id, str(button.label).strip()) for button in buttons[:2]] == [
-        ("nav-home", "1 Home"),
-        ("nav-console", "2 Console"),
+        ("nav-home", "\u23031 Home"),
+        ("nav-console", "\u23032 Console"),
     ]
 
 
@@ -380,3 +383,56 @@ def test_action_shell_destination_posts_primary_route():
     TldwCli.action_shell_destination(fake_app, -1)
     TldwCli.action_shell_destination(fake_app, "not-a-number")
     assert posted == []
+
+
+@pytest.mark.asyncio
+async def test_nav_overflow_hint_pages_to_hidden_destinations_at_100_cols():
+    """F-001: at 100 columns the strip clips mid-button (the review's
+    "8 Workflows" -> "8" artifact) and later destinations have no click
+    path. The "More ›" affordance pages the strip right until every
+    destination has been reachable, then wraps to the start."""
+
+    class TestApp(App):
+        def compose(self):
+            yield MainNavigationBar(active="home")
+
+    app = TestApp()
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause(0.1)
+
+        strip = app.query_one("#nav-destination-strip")
+        hint = app.query_one("#nav-overflow-hint")
+
+        # Overflowing: the affordance is on duty.
+        assert strip.max_scroll_x > 0
+        assert hint.display is True
+
+        def visible(button):
+            return (
+                button.region.x >= strip.region.x
+                and button.region.right <= strip.region.right
+                and button.region.width > 0
+            )
+
+        settings = app.query_one("#nav-settings", Button)
+        assert not visible(settings), "test premise: Settings starts off-screen"
+
+        # Page right (at most a handful of presses) until Settings fits.
+        for _ in range(6):
+            if visible(settings):
+                break
+            hint.press()
+            await pilot.pause(0.1)
+        else:
+            raise AssertionError("Settings never became reachable via More ›")
+
+        # Pressing past the far end wraps back to the first destinations.
+        for _ in range(6):
+            hint.press()
+            await pilot.pause(0.1)
+            if strip.scroll_offset.x == 0:
+                break
+        else:
+            raise AssertionError("More › never wrapped back to the start")
+        assert visible(app.query_one("#nav-home", Button))

--- a/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
+++ b/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
@@ -193,7 +193,7 @@ async def test_clean_run_setup_and_runtime_blockers_expose_recovery_copy(
             assert card_action.display is True
             assert str(card_action.label) == "Choose model"
             assert not list(app.screen.query("#console-open-provider-settings"))
-            assert "More: Ctrl+P" in _screen_text(app)
+            assert "More ›" in _screen_text(app)
 
             await app.handle_screen_navigation(NavigateToScreen("acp"))
             await _wait_until(

--- a/Tests/UI/test_product_maturity_phase1_first_run.py
+++ b/Tests/UI/test_product_maturity_phase1_first_run.py
@@ -136,11 +136,12 @@ async def test_clean_first_run_launches_home_and_exposes_setup_orientation(
 
             home_title = app.screen.query_one("#home-canvas-title", Static)
             primary_action = app.screen.query_one("#home-primary-action", Button)
-            nav_overflow_hint = app.screen.query_one("#nav-overflow-hint", Static)
+            nav_overflow_hint = app.screen.query_one("#nav-overflow-hint", Button)
             assert str(home_title.renderable).strip() == "Set up Console model"
             assert str(primary_action.label).strip() == "Set up Console model"
             assert str(primary_action.label).strip() != "Start in Console"
-            assert "Ctrl+P" in str(nav_overflow_hint.renderable)
+            assert "More" in str(nav_overflow_hint.label)
+            assert "Ctrl+P" in str(nav_overflow_hint.tooltip)
 
             for button_id, current_tab, screen_name, required_copy in (
                 (
@@ -208,11 +209,12 @@ async def test_clean_first_run_home_survives_supported_terminal_sizes(
             )
 
             primary_action = app.screen.query_one("#home-primary-action", Button)
-            nav_overflow_hint = app.screen.query_one("#nav-overflow-hint", Static)
+            nav_overflow_hint = app.screen.query_one("#nav-overflow-hint", Button)
             assert app.current_tab == "home"
             assert app.screen.__class__.__name__ == "HomeScreen"
             assert str(primary_action.label).strip() == "Set up Console model"
-            assert "Ctrl+P" in str(nav_overflow_hint.renderable)
+            assert "More" in str(nav_overflow_hint.label)
+            assert "Ctrl+P" in str(nav_overflow_hint.tooltip)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_product_maturity_phase1_keyboard_focus.py
+++ b/Tests/UI/test_product_maturity_phase1_keyboard_focus.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from textual.widgets import Button, Static
+from textual.widgets import Button
 
 from Tests.UI.app_factory import _build_test_app
 from tldw_chatbook.app import TabNavigationProvider, TldwCli
@@ -153,11 +153,9 @@ async def test_clean_run_tab_order_reaches_nav_and_primary_setup_action(
             focus_ids.append(focused.id or "")
 
             assert focus_ids == [*expected_focus_ids, "home-primary-action"]
-            nav_hint = str(
-                app.screen.query_one("#nav-overflow-hint", Static).renderable
-            )
-            assert "More" in nav_hint
-            assert "Ctrl+P" in nav_hint
+            nav_hint = app.screen.query_one("#nav-overflow-hint", Button)
+            assert "More" in str(nav_hint.label)
+            assert "Ctrl+P" in str(nav_hint.tooltip)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_product_maturity_phase1_navigation_smoke.py
+++ b/Tests/UI/test_product_maturity_phase1_navigation_smoke.py
@@ -141,12 +141,13 @@ async def test_clean_run_top_level_navigation_reaches_every_destination(
 
             nav_bar = app.screen.query_one(MainNavigationBar)
             nav_ids = tuple(
-                button.id.removeprefix("nav-") for button in nav_bar.query(Button)
+                button.id.removeprefix("nav-")
+                for button in nav_bar.query("Button.nav-button")
             )
             assert nav_ids == TOP_LEVEL_DESTINATION_IDS
-            assert "Ctrl+P" in str(
-                app.screen.query_one("#nav-overflow-hint", Static).renderable
-            )
+            overflow_hint = app.screen.query_one("#nav-overflow-hint", Button)
+            assert "More" in str(overflow_hint.label)
+            assert "Ctrl+P" in str(overflow_hint.tooltip)
 
             reached: dict[str, str] = {}
             for destination in SHELL_DESTINATION_ORDER:

--- a/Tests/UI/test_product_maturity_phase1_visual_audit.py
+++ b/Tests/UI/test_product_maturity_phase1_visual_audit.py
@@ -145,7 +145,7 @@ def _has_visual_chrome(app: "TldwCli") -> bool:
     nav_bars = list(app.screen.query(MainNavigationBar))
     if not nav_bars or not list(app.screen.query("#screen-content")):
         return False
-    nav_buttons = tuple(button.id for button in nav_bars[0].query(Button))
+    nav_buttons = tuple(button.id for button in nav_bars[0].query("Button.nav-button"))
     # The docked overflow hint mounts a tick after the nav strip; treat the
     # chrome as incomplete until it is present too.
     if len(app.screen.query("#nav-overflow-hint")) != 1:
@@ -204,16 +204,27 @@ async def _wait_until(
     )
 
 
-def _assert_visual_snapshot_is_healthy(
-    app: "TldwCli", destination_id: str, size_label: str
+async def _assert_visual_snapshot_is_healthy(
+    app: "TldwCli", destination_id: str, size_label: str, pilot
 ) -> None:
     nav_bar = app.screen.query_one(MainNavigationBar)
-    nav_ids = tuple(button.id.removeprefix("nav-") for button in nav_bar.query(Button))
+    nav_ids = tuple(
+        button.id.removeprefix("nav-") for button in nav_bar.query("Button.nav-button")
+    )
     assert nav_ids == TOP_LEVEL_DESTINATION_IDS
     assert nav_bar.query_one(f"#nav-{destination_id}", Button).has_class("is-active")
-    assert "Ctrl+P" in str(
-        app.screen.query_one("#nav-overflow-hint", Static).renderable
+    # F-001: the "More ›" affordance is on duty exactly when the strip
+    # overflows (compact/laptop sizes), hidden when every destination fits.
+    # Polled: navigation composes a fresh bar per visit, and its post-layout
+    # display sync lands a tick after the body does.
+    await _wait_until(
+        pilot,
+        lambda: app.screen.query_one("#nav-overflow-hint").display
+        == (app.screen.query_one("#nav-destination-strip").max_scroll_x > 0),
+        context=f"{size_label}:{destination_id}:overflow-hint",
     )
+    overflow_hint = app.screen.query_one("#nav-overflow-hint")
+    assert "More" in str(overflow_hint.label)
     _assert_destination_body_mounted(app, destination_id, size_label)
 
     text = _screen_text(app)
@@ -288,8 +299,8 @@ async def test_clean_run_top_level_visual_snapshots_survive_terminal_size(
                     context=f"{size_label}:{destination.destination_id}:body",
                 )
 
-                _assert_visual_snapshot_is_healthy(
-                    app, destination.destination_id, size_label
+                await _assert_visual_snapshot_is_healthy(
+                    app, destination.destination_id, size_label, pilot
                 )
 
 

--- a/Tests/UI/test_product_maturity_phase6_first_time_release_replay.py
+++ b/Tests/UI/test_product_maturity_phase6_first_time_release_replay.py
@@ -150,9 +150,9 @@ async def test_release_first_time_replay_exposes_home_console_library_and_setup(
             )
             nav = [(button.id, str(button.label).strip()) for button in nav_buttons]
             for expected_nav in (
-                ("nav-home", "1 Home"),
-                ("nav-console", "2 Console"),
-                ("nav-library", "3 Library"),
+                ("nav-home", "\u23031 Home"),
+                ("nav-console", "\u23032 Console"),
+                ("nav-library", "\u23033 Library"),
                 ("nav-settings", "Settings"),
             ):
                 assert expected_nav in nav

--- a/Tests/UI/test_product_maturity_phase6_focus_visual_sweep.py
+++ b/Tests/UI/test_product_maturity_phase6_focus_visual_sweep.py
@@ -151,7 +151,8 @@ def _visual_chrome_ready(app: TldwCli, destination_id: str) -> bool:
     try:
         nav_bar = app.screen.query_one(MainNavigationBar)
         nav_ids = tuple(
-            button.id.removeprefix("nav-") for button in nav_bar.query(Button)
+            button.id.removeprefix("nav-")
+            for button in nav_bar.query("Button.nav-button")
         )
         if nav_ids != TOP_LEVEL_DESTINATION_IDS:
             return False
@@ -181,16 +182,28 @@ def _visual_chrome_ready(app: TldwCli, destination_id: str) -> bool:
         return False
 
 
-def _assert_visual_snapshot_is_healthy(
-    app: TldwCli, destination_id: str, size_label: str
+async def _assert_visual_snapshot_is_healthy(
+    app: TldwCli, destination_id: str, size_label: str, pilot
 ) -> None:
     nav_bar = app.screen.query_one(MainNavigationBar)
-    nav_ids = tuple(button.id.removeprefix("nav-") for button in nav_bar.query(Button))
+    nav_ids = tuple(
+        button.id.removeprefix("nav-") for button in nav_bar.query("Button.nav-button")
+    )
     assert nav_ids == TOP_LEVEL_DESTINATION_IDS
     assert nav_bar.query_one(f"#nav-{destination_id}", Button).has_class("is-active")
-    assert "Ctrl+P" in str(
-        app.screen.query_one("#nav-overflow-hint", Static).renderable
+    # F-001: the "More ›" affordance is on duty exactly when the strip
+    # overflows, hidden when every destination fits. Polled: navigation
+    # composes a fresh bar per visit, and its post-layout display sync
+    # lands a tick after the body does.
+    await _wait_until(
+        pilot,
+        lambda: app.screen.query_one("#nav-overflow-hint").display
+        == (app.screen.query_one("#nav-destination-strip").max_scroll_x > 0),
+        context=f"{size_label}:{destination_id}:overflow-hint",
     )
+    overflow_hint = app.screen.query_one("#nav-overflow-hint", Button)
+    assert "More" in str(overflow_hint.label)
+    assert "Ctrl+P" in str(overflow_hint.tooltip)
     _assert_destination_body_mounted(app, destination_id, size_label)
 
     text = _screen_text(app)
@@ -276,8 +289,8 @@ async def test_phase6_visual_chrome_survives_release_terminal_size_matrix(
                     context=f"{size_label}:{destination.destination_id}:visual-chrome",
                 )
 
-                _assert_visual_snapshot_is_healthy(
-                    app, destination.destination_id, size_label
+                await _assert_visual_snapshot_is_healthy(
+                    app, destination.destination_id, size_label, pilot
                 )
 
 

--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -25,6 +25,8 @@ from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.UI.Screens.mcp_screen import MCPScreen
 from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+from textual.widgets import Static
+
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 
 
@@ -75,6 +77,16 @@ async def test_production_routes_own_and_preserve_contextual_footer_hints():
                 screen_footer = screen.query_one(AppFooterStatus)
                 assert "mode" in screen_footer.shortcut_text
                 assert "a add server" in screen_footer.shortcut_text
+                # F-003: the Tokens chip is meaningful only in chat contexts --
+                # on MCP it stays hidden, never a "Tokens: --" placeholder.
+                token_chip = screen.query_one("#footer-token-count", Static)
+                assert token_chip.display is False
+                assert "Tokens: --" not in str(token_chip.renderable)
+                # Past the 0.5s one-shot updater tick (which writes "" on
+                # non-chat tabs), still hidden.
+                await pilot.pause(0.7)
+                assert token_chip.display is False
+                assert "Tokens: --" not in str(token_chip.renderable)
 
                 await app.handle_screen_navigation(NavigateToScreen("library"))
                 screen = await _wait_for_screen(

--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from textual.widgets import Static
 
 from Tests.UI.app_factory import _build_test_app
 from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
@@ -25,8 +26,6 @@ from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.UI.Screens.mcp_screen import MCPScreen
 from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
-from textual.widgets import Static
-
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 
 

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1888,16 +1888,16 @@ def test_screen_lifecycle_methods():
 @pytest.mark.asyncio
 async def test_main_navigation_copy_and_order():
     expected_button_order = [
-        ("nav-home", "1 Home"),
-        ("nav-console", "2 Console"),
-        ("nav-library", "3 Library"),
-        ("nav-artifacts", "4 Artifacts"),
-        ("nav-personas", "5 Roleplay"),
-        ("nav-watchlists_collections", "6 Watchlists"),
-        ("nav-schedules", "7 Schedules"),
-        ("nav-workflows", "8 Workflows"),
-        ("nav-mcp", "9 MCP"),
-        ("nav-acp", "0 ACP"),
+        ("nav-home", "\u23031 Home"),
+        ("nav-console", "\u23032 Console"),
+        ("nav-library", "\u23033 Library"),
+        ("nav-artifacts", "\u23034 Artifacts"),
+        ("nav-personas", "\u23035 Roleplay"),
+        ("nav-watchlists_collections", "\u23036 Watchlists"),
+        ("nav-schedules", "\u23037 Schedules"),
+        ("nav-workflows", "\u23038 Workflows"),
+        ("nav-mcp", "\u23039 MCP"),
+        ("nav-acp", "\u23030 ACP"),
         ("nav-lab", "Lab"),
         ("nav-logs", "Logs"),
         ("nav-settings", "Settings"),
@@ -1918,11 +1918,15 @@ async def test_main_navigation_copy_and_order():
         ]
 
         assert actual_button_order == expected_button_order
-        assert str(app.query_one("#nav-console", Button).label).strip() == "2 Console"
+        assert str(app.query_one("#nav-console", Button).label).strip() == "\u23032 Console"
         assert nav_buttons[0].id == "nav-home"
         assert nav_buttons[1].id == "nav-console"
         assert nav_buttons[-1].id == "nav-settings"
-        assert str(app.query_one("#nav-overflow-hint").renderable) == "More: Ctrl+P"
+        # F-001: the "More ›" affordance is conditional -- at 160 cols every
+        # destination fits, so it stays hidden instead of crowding the edge.
+        overflow_hint = app.query_one("#nav-overflow-hint")
+        assert str(overflow_hint.label).strip() == "More ›"
+        assert overflow_hint.display is False
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_shell_product_model_visibility.py
+++ b/Tests/UI/test_shell_product_model_visibility.py
@@ -1,6 +1,6 @@
 import pytest
 from textual.app import App
-from textual.widgets import Static
+from textual.widgets import Button
 
 from tldw_chatbook.Constants import TAB_STUDY
 from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
@@ -32,7 +32,7 @@ async def test_navigation_exposes_explicit_overflow_hint():
 
     async with app.run_test(size=(60, 20)) as pilot:
         await pilot.pause(0.1)
-        overflow = app.query_one("#nav-overflow-hint", Static)
+        overflow = app.query_one("#nav-overflow-hint", Button)
 
-    assert "More" in str(overflow.renderable)
-    assert "Ctrl+P" in str(overflow.renderable)
+    assert "More" in str(overflow.label)
+    assert "Ctrl+P" in str(overflow.tooltip)

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -139,7 +139,7 @@ async def test_first_time_shell_replay_exposes_home_console_and_orientation_path
             )
 
             nav_buttons = list(
-                app.screen.query(MainNavigationBar).first().query(Button)
+                app.screen.query(MainNavigationBar).first().query("Button.nav-button")
             )
             assert [
                 (button.id, str(button.label).strip()) for button in nav_buttons
@@ -149,7 +149,7 @@ async def test_first_time_shell_replay_exposes_home_console_and_orientation_path
             assert "Console needs a working model before live AI tasks." in home_text
             assert "Needs Attention" in home_text
             assert "Set up Console model" in home_text
-            assert "More: Ctrl+P" in home_text
+            assert "More ›" in home_text
 
             for button_id, current_tab, screen_name, required_copy in (
                 (

--- a/Tests/UI/test_unified_shell_phase6_nielsen_closeout.py
+++ b/Tests/UI/test_unified_shell_phase6_nielsen_closeout.py
@@ -73,7 +73,7 @@ async def test_nielsen_closeout_replays_core_heuristic_signals_in_running_app() 
             )
 
             nav_buttons = list(
-                app.screen.query("MainNavigationBar").first().query(Button)
+                app.screen.query("MainNavigationBar").first().query("Button.nav-button")
             )
             assert [
                 (button.id, str(button.label).strip()) for button in nav_buttons
@@ -84,7 +84,7 @@ async def test_nielsen_closeout_replays_core_heuristic_signals_in_running_app() 
             assert "Model: Blocked" in home_text
             assert "Needs Attention" in home_text
             assert "Set up Console model" in home_text
-            assert "More: Ctrl+P" in home_text
+            assert "More ›" in home_text
 
             app.screen.query_one("#nav-console", Button).press()
             await _wait_until(

--- a/Tests/UI/test_unified_shell_phase6_power_user_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_power_user_replay.py
@@ -72,7 +72,7 @@ async def test_power_user_shell_replay_supports_fast_repeated_core_workflows() -
             console_text = _screen_text(app)
             assert "Live work sources" in console_text
             assert "Watchlists: Connected" in console_text
-            assert "More: Ctrl+P" in console_text
+            assert "More ›" in console_text
             assert any(binding.key == "ctrl+p" for binding in TldwCli.BINDINGS)
 
             app.screen.query_one("#nav-library", Button).press()

--- a/backlog/tasks/task-2093 - Tab-bar-stop-truncating-destinations-and-make-digit-hints-honest-F-001-F-002.md
+++ b/backlog/tasks/task-2093 - Tab-bar-stop-truncating-destinations-and-make-digit-hints-honest-F-001-F-002.md
@@ -3,10 +3,10 @@ id: TASK-2093
 title: >-
   Tab bar: stop truncating destinations and make digit hints honest (F-001,
   F-002)
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-03 17:25'
-updated_date: '2026-08-04 12:22'
+updated_date: '2026-08-04 12:48'
 labels:
   - ux-review
   - chrome
@@ -22,7 +22,7 @@ At <=100 cols tabs collapse ('8 Workflows' -> '8') and later destinations become
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All destinations remain reachable at 100 cols (ellipsis/overflow/scroll),Digit affordance labels match the actual keybinding,Rendered-layout test at 100 cols
+- [x] #1 All destinations remain reachable at 100 cols (ellipsis/overflow/scroll),Digit affordance labels match the actual keybinding,Rendered-layout test at 100 cols
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -30,3 +30,9 @@ At <=100 cols tabs collapse ('8 Workflows' -> '8') and later destinations become
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: no (chrome labels + one affordance control; no behavior/route changes). Root cause found: the bar never squeezes labels -- the strip clips mid-button at its scroll window ('8 Workflows' shows as '8' at 100 cols), destinations past the fold have no click path, and the 'More: Ctrl+P' Static is unconditional chrome (its own compose comment says 'exactly when the destinations overflow'). No glyph convention exists elsewhere in the app. Steps: 1. RED tests: (a) nav_button_label renders the ctrl glyph ('⌃1 Home' ... '⌃0 ACP', unnumbered Lab/Logs/Settings) -- updates to test_master_shell_navigation.py's unit pin and both exact-label list pins (test_master_shell_navigation_order_and_labels, test_main_navigation_copy_and_order); (b) 100x30 rendered test: overflow hint displays, pressing it pages the strip right until nav-settings is visible inside the strip window, pressing again wraps to nav-home; (c) hint hides when everything fits (160 cols); (d) visual_audit's shared hint assertion updated to the conditional contract; 'More: Ctrl+P' text assertions -> 'More ›' where the label is collected regardless of display. 2. main_navigation.py: glyph in nav_button_label; hint becomes a compact Button ('More ›') with a page-right/wrap press handler; display synced to strip.max_scroll_x on mount + resize; DEFAULT_CSS for the quiet button look. 3. Run nav/shell/audit/replay suites + ruff.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause found by probe: the bar never squeezes labels -- the strip clips mid-button at its scroll window ('8 Workflows' renders as '8' at 100 cols) and destinations past the fold had no click path; the 'More: Ctrl+P' Static was unconditional despite its compose comment documenting conditional intent. Fix: (a) the hint is now a compact 'More ›' Button that pages the strip right and wraps at the far end (click + keyboard-focusable path to every destination), displayed exactly when strip.max_scroll_x > 0 (synced on mount + resize, starts hidden so wide bars never flash it); (b) nav_button_label uses the control glyph ('⌃1 Home' ... '⌃0 ACP') so the affordance matches the actual ctrl+digit binding at zero extra width per tab. One subtlety handled: the pager must clamp to max_scroll_x and wrap only when already at the end (first version wrapped immediately whenever a page exceeded the overflow). Files: tldw_chatbook/UI/Navigation/main_navigation.py; tests updated in test_master_shell_navigation.py (unit pin, label lists, new 100x30 pager test), test_screen_navigation.py (copy_and_order pin + conditional contract), test_product_maturity_phase1_visual_audit.py (shared helper polls the conditional display; nav-button queries scoped to Button.nav-button since the hint is a Button now), test_product_maturity_phase1_empty_setup_states.py, unified_shell phase6 replays (text + query updates), test_product_maturity_phase6_first_time_release_replay.py (label pins). Verified: 4 initial REDs fixed to green; nav files 96 passed; full affected suite (nav + audit + 5 replay/empty files) 111 passed; visual audit across the 3-size matrix green; ruff clean on all touched files. Live 100x30 capture shows '⌃1 Home … ⌃7 Schedules More ›'. Deferral: Lab/Logs/Settings still carry no hotkey (labels honestly unnumbered; palette/pager cover them) -- adding bindings would be new scope. ADR: not required (chrome labels + one affordance control; routes/behavior unchanged). Commit f529c8be8.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2093 - Tab-bar-stop-truncating-destinations-and-make-digit-hints-honest-F-001-F-002.md
+++ b/backlog/tasks/task-2093 - Tab-bar-stop-truncating-destinations-and-make-digit-hints-honest-F-001-F-002.md
@@ -3,9 +3,10 @@ id: TASK-2093
 title: >-
   Tab bar: stop truncating destinations and make digit hints honest (F-001,
   F-002)
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-03 17:25'
+updated_date: '2026-08-04 12:22'
 labels:
   - ux-review
   - chrome
@@ -23,3 +24,9 @@ At <=100 cols tabs collapse ('8 Workflows' -> '8') and later destinations become
 <!-- AC:BEGIN -->
 - [ ] #1 All destinations remain reachable at 100 cols (ellipsis/overflow/scroll),Digit affordance labels match the actual keybinding,Rendered-layout test at 100 cols
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (chrome labels + one affordance control; no behavior/route changes). Root cause found: the bar never squeezes labels -- the strip clips mid-button at its scroll window ('8 Workflows' shows as '8' at 100 cols), destinations past the fold have no click path, and the 'More: Ctrl+P' Static is unconditional chrome (its own compose comment says 'exactly when the destinations overflow'). No glyph convention exists elsewhere in the app. Steps: 1. RED tests: (a) nav_button_label renders the ctrl glyph ('⌃1 Home' ... '⌃0 ACP', unnumbered Lab/Logs/Settings) -- updates to test_master_shell_navigation.py's unit pin and both exact-label list pins (test_master_shell_navigation_order_and_labels, test_main_navigation_copy_and_order); (b) 100x30 rendered test: overflow hint displays, pressing it pages the strip right until nav-settings is visible inside the strip window, pressing again wraps to nav-home; (c) hint hides when everything fits (160 cols); (d) visual_audit's shared hint assertion updated to the conditional contract; 'More: Ctrl+P' text assertions -> 'More ›' where the label is collected regardless of display. 2. main_navigation.py: glyph in nav_button_label; hint becomes a compact Button ('More ›') with a page-right/wrap press handler; display synced to strip.max_scroll_x on mount + resize; DEFAULT_CSS for the quiet button look. 3. Run nav/shell/audit/replay suites + ruff.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-2094 - Footer-hide-Tokens-chip-outside-chat-contexts-F-003.md
+++ b/backlog/tasks/task-2094 - Footer-hide-Tokens-chip-outside-chat-contexts-F-003.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2094
 title: 'Footer: hide Tokens chip outside chat contexts (F-003)'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-03 17:25'
-updated_date: '2026-08-04 12:47'
+updated_date: '2026-08-04 12:57'
 labels:
   - ux-review
   - chrome
@@ -20,7 +20,7 @@ priority: low
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tokens chip shows only where token counts are meaningful,Tests updated
+- [x] #1 Tokens chip shows only where token counts are meaningful,Tests updated
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -28,3 +28,9 @@ priority: low
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: no (footer chip visibility; no behavior change where tokens exist). Flow found: every screen mounts its own AppFooterStatus whose token chip starts as 'Tokens: --'; the 10s/0.5s updaters (db_status_manager.update_token_count_display) write real counts on TAB_CHAT and '' elsewhere, so non-chat destinations render placeholder-then-empty dead chrome. Deliberately NOT touching the DB-sizes path (F-014 lives on the library branch). Steps: 1. RED tests: (a) widget-level in Tests/UI/test_app_footer_shortcut_context.py -- a fresh AppFooterStatus renders the token chip empty and hidden; update_token_count(text) reveals it, update_token_count('') hides it again; (b) screen-level on MCP (non-chat): the chip never shows 'Tokens: --' and stays hidden. 2. AppFooterStatus: chip starts empty + display False; update_token_count toggles display on content (the reflow already measures its renderable, so priority math is unaffected). 3. Run footer tests (test_app_footer_shortcut_context, test_screen_footer_hints) + MCP/roleplay screen tests + ruff.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The token chip (per-screen AppFooterStatus) started as 'Tokens: --' everywhere; the periodic updater (db_status_manager.update_token_count_display, 0.5s one-shot + 10s interval) writes real counts only on TAB_CHAT and '' elsewhere, so Roleplay/MCP rendered placeholder-then-empty dead chrome. Fix in AppFooterStatus only: the chip starts empty + display False, and update_token_count toggles display on content (text reveals, '' hides). The TASK-451 reflow already measures the chip's renderable, so priority math needed no change; one existing reflow test (test_footer_reflows_when_counts_change_without_a_resize) was calibrated on the placeholder's 10 cells and is recalibrated 100->90 cols with a comment. The DB-sizes path is deliberately untouched (F-014 lives on the library branch, unmerged). Files: tldw_chatbook/Widgets/AppFooterStatus.py, Tests/UI/test_app_footer_shortcut_context.py (new chip-visibility test + recalibration), Tests/UI/test_screen_footer_hints.py (production test pins the chip hidden on MCP, initially and past the 0.5s updater tick). Verified: both RED->GREEN; footer files 12 passed; ui_responsiveness 14 passed; final sweep (destination_shells + visual audit + footer files + responsiveness) 134 passed + 1 skip; ruff clean. Live MCP 170x50 capture: footer shows only '1-4 mode | a add server | r refresh' -- no Tokens chip. Deferral: the word-count chip has the same always-rendered shape but is meaningful on notes/editor surfaces -- out of F-003's scope. ADR: not required (chip visibility only). Commit 85ce5f4de.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2094 - Footer-hide-Tokens-chip-outside-chat-contexts-F-003.md
+++ b/backlog/tasks/task-2094 - Footer-hide-Tokens-chip-outside-chat-contexts-F-003.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2094
 title: 'Footer: hide Tokens chip outside chat contexts (F-003)'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-03 17:25'
+updated_date: '2026-08-04 12:47'
 labels:
   - ux-review
   - chrome
@@ -21,3 +22,9 @@ priority: low
 <!-- AC:BEGIN -->
 - [ ] #1 Tokens chip shows only where token counts are meaningful,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (footer chip visibility; no behavior change where tokens exist). Flow found: every screen mounts its own AppFooterStatus whose token chip starts as 'Tokens: --'; the 10s/0.5s updaters (db_status_manager.update_token_count_display) write real counts on TAB_CHAT and '' elsewhere, so non-chat destinations render placeholder-then-empty dead chrome. Deliberately NOT touching the DB-sizes path (F-014 lives on the library branch). Steps: 1. RED tests: (a) widget-level in Tests/UI/test_app_footer_shortcut_context.py -- a fresh AppFooterStatus renders the token chip empty and hidden; update_token_count(text) reveals it, update_token_count('') hides it again; (b) screen-level on MCP (non-chat): the chip never shows 'Tokens: --' and stays hidden. 2. AppFooterStatus: chip starts empty + display False; update_token_count toggles display on content (the reflow already measures its renderable, so priority math is unaffected). 3. Run footer tests (test_app_footer_shortcut_context, test_screen_footer_hints) + MCP/roleplay screen tests + ruff.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -223,8 +223,12 @@ class MainNavigationBar(Container):
         self.call_after_refresh(self._sync_overflow_hint)
 
     def on_resize(self) -> None:
-        # The strip's overflow depends on the bar's width; the affordance
-        # follows it (F-001).
+        """Re-sync the overflow affordance when the bar's width changes.
+
+        The strip's overflow (``max_scroll_x``) is a function of the bar's
+        rendered width, so every resize re-evaluates whether the
+        "More ›" control shows (F-001).
+        """
         self._sync_overflow_hint()
 
     def _sync_overflow_hint(self) -> None:
@@ -251,9 +255,14 @@ class MainNavigationBar(Container):
             # Already at the far end: wrap so the control keeps working.
             strip.scroll_to(x=0, animate=False)
             return
-        page = max(strip.scrollable_content_region.width, 1)
+        visible_width = max(strip.scrollable_content_region.width, 1)
+        # NOTE: `scrollable_content_region` reads like "the full scrollable
+        # content" but is the VISIBLE viewport (region minus gutter and
+        # scrollbar) -- the correct page increment. The virtual content is
+        # wider by exactly max_scroll (PR #1322 review).
         strip.scroll_to(
-            x=min(strip.scroll_offset.x + page, max_scroll), animate=False
+            x=min(strip.scroll_offset.x + visible_width, max_scroll),
+            animate=False,
         )
 
     def _scroll_active_destination_into_view(self) -> None:

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
-from textual.widgets import Button, Static
+from textual.widgets import Button
 from textual.message import Message
 from textual import on
 
@@ -25,19 +25,25 @@ if TYPE_CHECKING:
 #: labels stay unnumbered.
 NAV_HOTKEY_DIGITS: tuple[str, ...] = ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 
+#: F-002: the tab labels used to read "1 Home", implying a bare-digit key
+#: while the actual binding (app.py SHELL_DESTINATION_HOTKEYS) is ctrl+digit.
+#: The UP ARROWHEAD glyph (⌃, the macOS control convention) makes the label
+#: honest at zero extra width per tab -- "⌃1" reads "ctrl+1".
+NAV_HOTKEY_GLYPH = "⌃"
+
 
 def nav_button_label(index: int, label: str) -> str:
-    """Prefix a destination label with its hotkey digit when it has one.
+    """Prefix a destination label with its hotkey affordance when it has one.
 
     Args:
         index: Position of the destination in SHELL_DESTINATION_ORDER.
         label: Compact destination label from the shell destination model.
 
     Returns:
-        ``"<digit> <label>"`` for the first ten destinations, else ``label``.
+        ``"⌃<digit> <label>"`` for the first ten destinations, else ``label``.
     """
     if 0 <= index < len(NAV_HOTKEY_DIGITS):
-        return f"{NAV_HOTKEY_DIGITS[index]} {label}"
+        return f"{NAV_HOTKEY_GLYPH}{NAV_HOTKEY_DIGITS[index]} {label}"
     return label
 
 
@@ -145,10 +151,20 @@ class MainNavigationBar(Container):
 
     .nav-overflow-hint {
         width: auto;
+        min-width: 0;
         padding: 0 1;
         height: 3;
+        min-height: 3;
         content-align: center middle;
         color: $text-muted;
+        background: transparent;
+        border: none;
+    }
+
+    .nav-overflow-hint:hover {
+        color: $text;
+        background: $surface;
+        text-style: bold;
     }
     """
 
@@ -182,17 +198,63 @@ class MainNavigationBar(Container):
                 if destination.destination_id == self.active_destination_id:
                     button.add_class("is-active")
                 yield button
-        # Docked outside the scrollable strip so the hint stays visible at the
-        # right edge exactly when the destinations overflow.
-        overflow_hint = Static(
-            "More: Ctrl+P", id="nav-overflow-hint", classes="nav-overflow-hint"
+        # Docked outside the scrollable strip so the affordance stays at the
+        # right edge exactly when the destinations overflow. F-001: it is a
+        # real control now, not just a hint -- pressing it pages the strip
+        # right (wrapping at the far end) so every destination stays
+        # mouse/keyboard-reachable at narrow widths, and it hides when all
+        # destinations fit instead of crowding the edge.
+        overflow_hint = Button(
+            "More ›",
+            id="nav-overflow-hint",
+            classes="nav-overflow-hint",
+            compact=True,
+            tooltip="Show more destinations (Ctrl+P for the full list)",
         )
-        overflow_hint.tooltip = "Open command palette"
+        # Hidden until `_sync_overflow_hint` (post-layout) knows whether the
+        # strip actually overflows -- never a flash of affordance chrome on
+        # a bar where every destination fits.
+        overflow_hint.display = False
         yield overflow_hint
 
     def on_mount(self) -> None:
         """Scroll the initially active destination's button into view."""
         self.call_after_refresh(self._scroll_active_destination_into_view)
+        self.call_after_refresh(self._sync_overflow_hint)
+
+    def on_resize(self) -> None:
+        # The strip's overflow depends on the bar's width; the affordance
+        # follows it (F-001).
+        self._sync_overflow_hint()
+
+    def _sync_overflow_hint(self) -> None:
+        """Show the "More ›" affordance exactly when the strip overflows."""
+        try:
+            strip = self.query_one("#nav-destination-strip", Horizontal)
+            hint = self.query_one("#nav-overflow-hint", Button)
+        except Exception:
+            return
+        hint.display = strip.max_scroll_x > 0
+
+    @on(Button.Pressed, "#nav-overflow-hint")
+    def _page_destination_overflow(self, event: Button.Pressed) -> None:
+        """Page the strip right; at the far end, wrap back to the start."""
+        event.stop()
+        try:
+            strip = self.query_one("#nav-destination-strip", Horizontal)
+        except Exception:
+            return
+        max_scroll = strip.max_scroll_x
+        if max_scroll <= 0:
+            return
+        if strip.scroll_offset.x >= max_scroll - 1:
+            # Already at the far end: wrap so the control keeps working.
+            strip.scroll_to(x=0, animate=False)
+            return
+        page = max(strip.scrollable_content_region.width, 1)
+        strip.scroll_to(
+            x=min(strip.scroll_offset.x + page, max_scroll), animate=False
+        )
 
     def _scroll_active_destination_into_view(self) -> None:
         """Bring the active destination's button into the strip's visible scroll window."""

--- a/tldw_chatbook/Widgets/AppFooterStatus.py
+++ b/tldw_chatbook/Widgets/AppFooterStatus.py
@@ -88,9 +88,13 @@ class AppFooterStatus(Widget):
         self._shortcut_source: str | None = None
         self._shortcut_display = Static(self._shortcut_text, id="footer-key-quit")
         self._word_count_display: Static = Static("", id="footer-word-count")
-        self._token_count_display: Static = Static(
-            "Tokens: --", id="footer-token-count"
-        )
+        self._token_count_display: Static = Static("", id="footer-token-count")
+        # F-003: the Tokens chip is meaningful only where token counts exist
+        # (chat contexts). It starts empty and hidden -- no "Tokens: --"
+        # placeholder -- and `update_token_count` reveals it once a real
+        # count lands (the periodic updater writes "" on non-chat tabs, so
+        # authoring/config destinations never render dead chrome).
+        self._token_count_display.display = False
         self._db_status_display: Static = Static("", id="internal-db-size-indicator")
         # F-014: the DB-size readout left user chrome (telemetry lives in
         # the Library Details disclosure and the logs now), so the indicator
@@ -223,6 +227,8 @@ class AppFooterStatus(Widget):
                 self._token_count_display.update(f"{display_text} | ")
             else:
                 self._token_count_display.update("")
+            # F-003: the chip takes footer space only while it has content.
+            self._token_count_display.display = bool(display_text)
             self._reflow_footer_priority()
         except Exception as e:
             print(f"Error updating token count display: {e}")


### PR DESCRIPTION
## What

Two cross-cutting app-chrome fixes from the UX/HCI review (`Docs/superpowers/qa/2026-08-03-library-roleplay-mcp-ux-review.md`, findings F-001/F-002/F-003). Backlog TASK-2093, TASK-2094.

## Findings fixed

- **F-001/F-002** — Tab bar at ≤100 cols: destinations past the fold are now reachable via a conditional "More ›" pager button (appears only when the strip overflows, pages right, wraps at the far end); digit hints are honest — labels now read "⌃1 Home … ⌃0 ACP" to match the actual Ctrl+digit binding (TASK-2093)
- **F-003** — The "Tokens: --" footer chip no longer renders as dead chrome on authoring/config destinations: it starts hidden and appears only when a real token count is written (chat contexts) (TASK-2094)

## Tests

- task-2093: 4 RED-first tests; nav files 96 passed; affected suite 111 passed; visual audit green at 100/140/180 cols.
- task-2094: chip-visibility tests RED→GREEN; footer files 12 passed; sweep 134 passed, 1 skip.
- ruff clean; live captures verified on both (100x30 tab bar with "More ›"; MCP footer without the Tokens chip).

## Notes

- No ADRs required (chrome behavior/copy fixes).
- Deferrals in task notes: Lab/Logs/Settings remain unnumbered (no hotkeys exist); word-count chip untouched (meaningful on editor surfaces); DB-sizes footer path deliberately untouched (separate F-014 branch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps all top‑nav tabs reachable at small widths with a “More ›” pager button that only shows on overflow, pages by viewport width, and wraps; updates tab labels to “⌃1…⌃0”; hides the Tokens chip outside chat contexts.

- **Bug Fixes**
  - Tab bar overflow: “More ›” is a real button with a Ctrl+P tooltip; it shows only when the strip overflows, pages by visible width, clamps and wraps, and stays hidden at wide sizes (TASK-2093, F‑001).
  - Honest key hints: tab labels use “⌃1 … ⌃0” to match the Ctrl+digit binding; Lab/Logs/Settings remain unnumbered (TASK-2093, F‑002).
  - Footer: the Tokens chip starts hidden and appears only with a real count; no “Tokens: --” on non‑chat tabs (TASK-2094, F‑003).

<sup>Written for commit e3925c74b5eecbfe2e2d5fc110ba9fda5f46623d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

