### PR TITLE
backlog: library-ingest round-6 owner rulings → tasks 2220-2223

### DIFF
--- a/backlog/tasks/task-2220 - Library-ingest-skipped-outcome-state.md
+++ b/backlog/tasks/task-2220 - Library-ingest-skipped-outcome-state.md
@@ -1,0 +1,40 @@
+---
+id: TASK-2220
+title: >-
+  Library ingest: unsupported-in-folder files record as "skipped", not "failed"
+status: To Do
+assignee: []
+created_date: '2026-08-04 05:00'
+labels:
+  - library
+  - ingest
+  - ux
+priority: high
+dependencies: []
+---
+
+## Description (the why)
+
+Owner ruling (2026-08-04, round-6 critique follow-up): "failed" is
+reserved for files the pipeline TRIED and could not ingest. A folder of
+100 photos + 1 PDF currently yields 100 red "✗ failed" rows, a
+"1 imported · 100 failed" toast, and 100 permanent failure records —
+alarming bookkeeping for entirely normal folder contents. Unsupported
+files the user pointed at (via a folder) become a distinct, neutral
+"skipped" outcome.
+
+## Acceptance Criteria (the what)
+
+- [ ] An unsupported file inside a folder selection reaches a terminal
+      "skipped" outcome: neutral glyph/color (not the failure ✗/red),
+      no Retry offered, kept in Recent ingests.
+- [ ] The tally and completion toast count skips in their own segment
+      ("1 imported · 100 skipped"), never as failures.
+- [ ] The pre-flight forecast copy matches the new ontology ("100 will
+      be skipped", not "recorded as failures"); the commit summary uses
+      "will skip" for them.
+- [ ] A genuinely attempted-and-failed file (parse error, missing
+      source) still records as "failed" with Retry where applicable —
+      the skipped state never absorbs real failures.
+- [ ] Clear finished clears skipped rows with the same confirm; the
+      armed label counts them distinctly when present.

--- a/backlog/tasks/task-2221 - Library-ingest-batch-grouped-queue.md
+++ b/backlog/tasks/task-2221 - Library-ingest-batch-grouped-queue.md
@@ -1,0 +1,36 @@
+---
+id: TASK-2221
+title: >-
+  Library ingest: batch-grouped queue with latest-batch-first tally
+status: To Do
+assignee: []
+created_date: '2026-08-04 05:00'
+labels:
+  - library
+  - ingest
+  - ux
+priority: high
+dependencies: []
+---
+
+## Description (the why)
+
+Owner ruling (2026-08-04): the queue answers "what did THIS run just
+do". Today the tally is a lifetime "N done — all ingests" and two
+interleaved batches merge into one flat list. Jobs already carry a
+batch_id; the queue groups rows under per-submission headers and the
+tally leads with the latest batch, lifetime total secondary.
+
+## Acceptance Criteria (the what)
+
+- [ ] Queue rows group under a per-submission header carrying the
+      batch's source (folder/file basename), file count, start time, and
+      outcome counts.
+- [ ] The tally line leads with the most recent batch's outcome and
+      shows the lifetime total secondarily.
+- [ ] Two interleaved batches render as two groups; a single-file
+      submission reads naturally (no ceremony regression for the
+      fast-path).
+- [ ] Existing in-place update paths (job ticks, retry, dismiss, clear)
+      keep widget identity and scroll behavior within the grouped
+      layout.

--- a/backlog/tasks/task-2222 - Library-ingest-folder-select-in-browse.md
+++ b/backlog/tasks/task-2222 - Library-ingest-folder-select-in-browse.md
@@ -1,0 +1,31 @@
+---
+id: TASK-2222
+title: >-
+  Library ingest: "Select this folder" action in the Browse dialog
+status: To Do
+assignee: []
+created_date: '2026-08-04 05:00'
+labels:
+  - library
+  - ingest
+  - ux
+priority: medium
+dependencies: []
+---
+
+## Description (the why)
+
+Owner ruling (2026-08-04): folder import must be pickable, not
+type-only. In the Browse dialog, "Open" on a directory descends into it
+(correct), and a dedicated "Select current folder" action returns the
+directory being viewed as the ingest source (the vendored fspicker's
+SelectDirectory variant is the reference).
+
+## Acceptance Criteria (the what)
+
+- [ ] The ingest Browse dialog offers a visible "Select current folder"
+      action (button and/or binding) that returns the directory being
+      viewed; Open keeps descending.
+- [ ] Choosing it fills the path field with the directory and triggers
+      pre-flight, exactly like typing the path.
+- [ ] File selection behavior is unchanged.

--- a/backlog/tasks/task-2223 - Library-ingest-rulings-small-batch.md
+++ b/backlog/tasks/task-2223 - Library-ingest-rulings-small-batch.md
@@ -1,0 +1,50 @@
+---
+id: TASK-2223
+title: >-
+  Library ingest rulings small batch (no-op consent line, Recent readability, chunk units, matched receipt, panel naming)
+status: To Do
+assignee: []
+created_date: '2026-08-04 05:00'
+labels:
+  - library
+  - ingest
+  - ux
+priority: medium
+dependencies: []
+---
+
+## Description (the why)
+
+Owner rulings (2026-08-04, round-6 follow-up), the small items:
+
+1. All-match selections keep Start ENABLED (the dedup probe is capped
+   best-effort) but consent becomes informed via the quiet line.
+2. Recent ingests is unscannable (full ~130-char absolute paths, no
+   times).
+3. Chunk size/overlap never state their unit and disclose the 100-5000
+   range only via error.
+4. "Open in Library" on a matched duplicate lands on the twin with no
+   explanation.
+5. PDF selections render both "PDF documents" and "Plain text /
+   documents / HTML" panels — "documents" collides.
+
+Also recorded: the queue apparatus STAYS (load-bearing for
+minutes-long audio/video transcription; batch grouping gives fast runs
+their result-log feel) — no de-queue work.
+
+## Acceptance Criteria (the what)
+
+- [ ] When the forecast predicts zero imports and ≥1 match, the quiet
+      line beside Start reads to the effect of "Everything here appears
+      to already be in your Library — starting will re-check and match,
+      not re-import." Start stays enabled.
+- [ ] Recent ingests lists basename + relative time per entry, with the
+      full path available (secondary line or expansion), and keeps the
+      "(dismissed)" marker.
+- [ ] Chunk size/overlap labels or placeholders state the unit
+      (characters) and the valid range up front.
+- [ ] The Library media detail view notes when the item was reached via
+      a dedup match ("matched an existing item — nothing new was
+      imported").
+- [ ] The generic panel title no longer collides with the PDF panel's
+      ("documents" appears once across panel titles).


### PR DESCRIPTION
Records the six product rulings from the round-6 critique follow-up (2026-08-04) as backlog tasks:

- **task-2220** (high): unsupported-in-folder files record as **skipped**, not failed — 'failed' reserved for genuinely attempted files.
- **task-2221** (high): **batch-grouped queue** with latest-batch-first tally ('what did this run just do').
- **task-2222** (medium): **'Select this folder'** action in the Browse dialog.
- **task-2223** (medium): small batch — informed-consent line for all-match selections (Start stays enabled), Recent basename+time, chunk units/range up front, matched-duplicate receipt on the detail view, panel-title de-collision.

Also recorded: the queue apparatus **stays** (load-bearing for minutes-long transcription; no de-queue work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog tasks 2220–2223 to capture round‑6 rulings for library ingest. They cover "skipped" for unsupported-in-folder files, batch‑grouped queue with latest‑batch tally, "Select this folder" in Browse, and a small UX batch; also notes the queue apparatus stays.

- **New Features**
  - task‑2220: mark unsupported files in folder imports as "skipped", not "failed".
  - task‑2221: batch‑grouped queue; tally leads with latest batch.
  - task‑2222: add "Select this folder" in the Browse dialog.
  - task‑2223: small UX items — Start enabled with consent on all‑match, Recent shows basename+relative time, chunk units/range, matched‑duplicate note, panel title de‑collision.

<sup>Written for commit 6c6ce2878cdf23c99d1854ec704c4e9ee493fc8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

