### PR TITLE
feat(library): unsupported-in-folder files record as SKIPPED, not failed (task-2220)

### DIFF
--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -293,12 +293,10 @@ async def test_submitting_a_directory_queues_one_job_per_file(
 
 
 @pytest.mark.asyncio
-async def test_directory_unsupported_file_fails_alone(tmp_path: Path) -> None:
-    """One unsupported file in a folder fails on its own row.
-
-    The supported siblings must still reach DONE rather than being taken
-    down with it.
-    """
+async def test_directory_unsupported_file_is_skipped_alone(tmp_path: Path) -> None:
+    """(task-2220 ruling) One unsupported file in a folder is SKIPPED on
+    its own row -- a neutral outcome, never a failure -- and the supported
+    siblings still reach DONE rather than being taken down with it."""
     db = _make_db(tmp_path)
     folder = tmp_path / "mixed"
     folder.mkdir()
@@ -315,9 +313,10 @@ async def test_directory_unsupported_file_fails_alone(tmp_path: Path) -> None:
         await _wait_for_job_state(
             app, pilot, jobs["good.txt"].job_id, IngestJobState.DONE
         )
-        await _wait_for_job_state(
-            app, pilot, jobs["cover.jpg"].job_id, IngestJobState.FAILED
+        skipped = await _wait_for_job_state(
+            app, pilot, jobs["cover.jpg"].job_id, IngestJobState.SKIPPED
         )
+        assert "Unsupported file type" in skipped.error
 
         await _wait_for_runner_idle(app, pilot)
 
@@ -501,25 +500,25 @@ async def test_missing_file_failure_is_permanent_and_refuses_retry(
 
 
 @pytest.mark.asyncio
-async def test_unsupported_file_type_failure_is_permanent_and_refuses_retry(
+async def test_unsupported_file_type_is_skipped_and_refuses_retry(
     tmp_path: Path,
 ) -> None:
-    """(M4) An unsupported extension is a validation-class failure too --
-    classified ``permanent`` inside the parse worker, Retry refused."""
+    """(M4, contract revised by task-2220) An unsupported extension records
+    as SKIPPED -- the pipeline never attempted it, so it is not a failure --
+    and Retry stays refused (``requeue`` is FAILED-only)."""
     db = _make_db(tmp_path)
     unsupported = _write_text_file(tmp_path, "note.xyz", "irrelevant content")
     app = _IngestRunnerHarness(db)
 
     async with app.run_test() as pilot:
-        failing_job = app.submit_library_ingest_job(source_path=str(unsupported))
-        failed = await _wait_for_job_state(
-            app, pilot, failing_job.job_id, IngestJobState.FAILED
+        submitted = app.submit_library_ingest_job(source_path=str(unsupported))
+        skipped = await _wait_for_job_state(
+            app, pilot, submitted.job_id, IngestJobState.SKIPPED
         )
         await _wait_for_runner_idle(app, pilot)
 
-        assert failed.permanent is True
-        assert "Unsupported file type" in failed.error
-        assert app.retry_library_ingest_job(failed.job_id) is None
+        assert "Unsupported file type" in skipped.error
+        assert app.retry_library_ingest_job(skipped.job_id) is None
 
 
 @pytest.mark.asyncio

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -1989,3 +1989,15 @@ def test_commit_summary_splits_skip_from_fail():
         "2 will import · 1 will skip · 1 will fail"
     )
     assert "will be skipped: pic.jpg." in state.unsupported_line
+
+
+def test_skips_only_queue_still_offers_clear_finished():
+    """(task-2220 Qodo round) A queue holding ONLY skipped rows must show
+    the Clear finished control -- skips count as finished everywhere."""
+    skipped = _job(
+        job_id="ingest-job-1",
+        state=IngestJobState.SKIPPED,
+        source_path="/tmp/photo.jpg",
+    )
+    state = build_library_ingest_state((skipped,), form=LibraryIngestFormState())
+    assert state.queue_show_clear_finished is True

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -1649,7 +1649,7 @@ def test_unsupported_line_names_files_and_matches_gate():
         ),
     )
     assert mixed.unsupported_line == (
-        "1 unsupported file will be recorded as a failure: x.json."
+        "1 unsupported file will be skipped: x.json."
     )
 
     blocked = build_library_ingest_state(
@@ -1932,3 +1932,60 @@ def test_all_match_selection_gets_consent_line_and_stays_enabled():
         "starting will re-check and match, not re-import."
     )
     assert state.commit_summary_line == "0 will import · 1 will match"
+
+
+def test_skipped_jobs_render_neutral_and_count_separately():
+    """(task-2220 ruling) A skipped job renders with the neutral glyph, no
+    Retry, dismiss offered; the tally counts skips in their own segment,
+    never as failures; the armed clear label counts them as finished but
+    not as failed."""
+    skipped = _job(
+        job_id="ingest-job-1",
+        state=IngestJobState.SKIPPED,
+        source_path="/tmp/photo.jpg",
+        error="Unsupported file type: .jpg.",
+    )
+    done = _job(job_id="ingest-job-2", state=IngestJobState.DONE)
+    state = build_library_ingest_state(
+        (skipped, done),
+        form=LibraryIngestFormState(),
+        clear_finished_armed=True,
+    )
+    row = next(r for r in state.queue_rows if r.job_id == "ingest-job-1")
+    assert row.glyph == "○"
+    assert row.line.startswith("○ skipped · photo.jpg")
+    assert row.can_retry is False
+    assert row.can_dismiss is True
+    assert state.queue_counts_line == "1 done · 1 skipped — all ingests"
+    assert state.queue_clear_finished_label == (
+        "Press again to clear 2 finished"
+    )
+    assert [j.job_id for j in state.recent_jobs] == [
+        "ingest-job-1",
+        "ingest-job-2",
+    ]
+
+
+def test_commit_summary_splits_skip_from_fail():
+    """(task-2220) Unsupported files forecast as 'will skip'; empty files
+    keep 'will fail' (they are enqueued and genuinely fail)."""
+    state = build_library_ingest_state(
+        (),
+        form=LibraryIngestFormState(path="/tmp/folder"),
+        preflight=PreflightResult(
+            type_groups={
+                "generic": ["/tmp/a.txt", "/tmp/b.txt"],
+                "unsupported": ["/tmp/pic.jpg"],
+            },
+            warnings=[],
+            errors=[],
+            total_size=100,
+            truncated=False,
+            total_files=4,
+            empty_files=("/tmp/zero.txt",),
+        ),
+    )
+    assert state.commit_summary_line == (
+        "2 will import · 1 will skip · 1 will fail"
+    )
+    assert "will be skipped: pic.jpg." in state.unsupported_line

--- a/backlog/tasks/task-2220 - Library-ingest-skipped-outcome-state.md
+++ b/backlog/tasks/task-2220 - Library-ingest-skipped-outcome-state.md
@@ -2,7 +2,7 @@
 id: TASK-2220
 title: >-
   Library ingest: unsupported-in-folder files record as "skipped", not "failed"
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-04 05:00'
 labels:
@@ -25,16 +25,47 @@ files the user pointed at (via a folder) become a distinct, neutral
 
 ## Acceptance Criteria (the what)
 
-- [ ] An unsupported file inside a folder selection reaches a terminal
+- [x] An unsupported file inside a folder selection reaches a terminal
       "skipped" outcome: neutral glyph/color (not the failure ✗/red),
       no Retry offered, kept in Recent ingests.
-- [ ] The tally and completion toast count skips in their own segment
+- [x] The tally and completion toast count skips in their own segment
       ("1 imported · 100 skipped"), never as failures.
-- [ ] The pre-flight forecast copy matches the new ontology ("100 will
+- [x] The pre-flight forecast copy matches the new ontology ("100 will
       be skipped", not "recorded as failures"); the commit summary uses
       "will skip" for them.
-- [ ] A genuinely attempted-and-failed file (parse error, missing
+- [x] A genuinely attempted-and-failed file (parse error, missing
       source) still records as "failed" with Retry where applicable —
       the skipped state never absorbs real failures.
-- [ ] Clear finished clears skipped rows with the same confirm; the
+- [x] Clear finished clears skipped rows with the same confirm; the
       armed label counts them distinctly when present.
+
+## Implementation Plan (the how)
+
+New `IngestJobState.SKIPPED` + `mark_skipped` transition (mirrors the
+CANCELLED neutral-terminal pattern); route at the parse-failure choke
+point on `category == "unsupported_file_type"`; surfaces follow.
+
+## Implementation Notes
+
+- Jobs: `SKIPPED` enum member; terminal + dismissible sets extended;
+  `mark_skipped(job_id, reason, error_detail)` persists and notifies
+  like `mark_failed` minus retry semantics (requeue stays FAILED-only).
+  DB round-trip is free (`IngestJobState(row["state"])`).
+- app.py `_handle_ingest_parse_result`: unsupported_file_type →
+  `mark_skipped`; everything else keeps `mark_failed`.
+- State: `○ skipped · name · reason` row (no Retry, dismiss offered,
+  the CANCELLED template); counts line gains its own `skipped` segment;
+  recent/finished include SKIPPED; the armed clear label counts skips as
+  finished but only FAILED as "(incl. N failed)".
+- Forecast: "N unsupported files will be skipped: …" (was "recorded as
+  failures"); commit summary splits "will skip" (unsupported) from
+  "will fail" (empty files, which ARE enqueued and genuinely fail).
+- Toast: own "N skipped" segment; 4-tuple batch baseline; severity
+  warns only when real failures are the batch's only outcome.
+- Ledger snapshot at clear time includes SKIPPED.
+- Contract pins updated: the two runner tests now assert SKIPPED
+  end-to-end (real parse worker), forecast copy pin updated; new pins
+  for row rendering/tally/label and the skip-vs-fail commit split.
+
+**Verification.** 289 core + 52 shell-subset targeted green; collect
+sweep clean.

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -966,7 +966,7 @@ class LibraryIngestJobRegistry:
         self._jobs[index] = updated
         self._persist(updated)
         self._notify_listeners()
-        return updated
+        return _copy_job(updated)
 
     def requeue(
         self,

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -101,6 +101,10 @@ class IngestJobState(str, Enum):
     WRITING = "writing"
     DONE = "done"
     FAILED = "failed"
+    #: (task-2220 owner ruling) An unsupported file the user pointed at via
+    #: a folder: never attempted, never an error. "failed" is reserved for
+    #: files the pipeline TRIED and could not ingest.
+    SKIPPED = "skipped"
     #: Stopped deliberately rather than succeeding or erroring. Only a
     #: server-origin job reaches this today: the server reports it for a
     #: job the user cancelled.
@@ -111,7 +115,12 @@ class IngestJobState(str, Enum):
 #: cannot drift between the places that ask -- ``clear_finished``, the
 #: cancellation guard, and the queue's terminal-row rendering.
 _TERMINAL_STATES: frozenset[IngestJobState] = frozenset(
-    {IngestJobState.DONE, IngestJobState.FAILED, IngestJobState.CANCELLED}
+    {
+        IngestJobState.DONE,
+        IngestJobState.FAILED,
+        IngestJobState.CANCELLED,
+        IngestJobState.SKIPPED,
+    }
 )
 
 
@@ -120,7 +129,7 @@ _TERMINAL_STATES: frozenset[IngestJobState] = frozenset(
 #: purpose -- but Retry stays withheld, since ``requeue`` is FAILED-only and
 #: offering a dead action is worse than offering none.
 _DISMISSIBLE_STATES: frozenset[IngestJobState] = frozenset(
-    {IngestJobState.FAILED, IngestJobState.CANCELLED}
+    {IngestJobState.FAILED, IngestJobState.CANCELLED, IngestJobState.SKIPPED}
 )
 
 
@@ -916,6 +925,48 @@ class LibraryIngestJobRegistry:
         self._notify_listeners()
         self._persist(updated)
         return _copy_job(updated)
+
+    def mark_skipped(
+        self,
+        job_id: str,
+        *,
+        reason: str,
+        error_detail: dict[str, Any] | None = None,
+    ) -> LibraryIngestJob | None:
+        """Transition a job to ``SKIPPED`` (task-2220 owner ruling).
+
+        For files the pipeline never attempts (unsupported type inside a
+        folder selection): a neutral terminal outcome, cleared by Clear
+        finished, dismissible like a failure, never offered Retry
+        (``requeue`` is FAILED-only and would no-op).
+
+        Args:
+            job_id: The job to transition.
+            reason: A sanitized, single-line explanation.
+            error_detail: Optional structured payload (category etc.).
+
+        Returns:
+            The updated job (a copy), or ``None`` when ``job_id`` is
+            unknown or hidden.
+        """
+        index = self._find_index(job_id)
+        if index is None:
+            return None
+        current = self._jobs[index]
+        if current.superseded or current.dismissed:
+            return None
+        updated = replace(
+            current,
+            state=IngestJobState.SKIPPED,
+            error=reason,
+            error_detail=error_detail,
+            finished_at=time.monotonic(),
+            finished_at_wall=datetime.now(timezone.utc).isoformat(),
+        )
+        self._jobs[index] = updated
+        self._persist(updated)
+        self._notify_listeners()
+        return updated
 
     def requeue(
         self,

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -181,6 +181,7 @@ MAX_CHUNK_SIZE = 5000
 _GLYPH_ACTIVE = "●"  # "●" -- queued, parsing, or writing
 _GLYPH_DONE = "✓"  # "✓"
 _GLYPH_FAILED = "✗"  # "✗"
+_GLYPH_SKIPPED = "○"  # neutral: never attempted (task-2220)
 _GLYPH_CANCELLED = "⊘"  # "⊘" -- stopped deliberately, not an error
 
 # L4: the marker `local_file_ingestion.py`'s "Unsupported file type" error
@@ -804,6 +805,26 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
             error_detail=job.error_detail,
         )
 
+    if job.state == IngestJobState.SKIPPED:
+        # (task-2220) Neutral outcome: the pipeline never attempted this
+        # file. No Retry (requeue is FAILED-only); dismiss offered.
+        line = f"{_GLYPH_SKIPPED} skipped · {basename}"
+        if job.error:
+            line += f" · {short_ingest_error(job.error)}"
+        return IngestQueueRow(
+            job_id=job.job_id,
+            glyph=_GLYPH_SKIPPED,
+            line=line,
+            can_open=False,
+            can_retry=False,
+            can_dismiss=True,
+            media_id=job.media_id,
+            state=job.state,
+            source_path=job.source_path,
+            progress=job.progress,
+            error_detail=job.error_detail,
+        )
+
     is_unsupported = (
         job.error_detail is not None
         and job.error_detail.get("category") == "unsupported_file_type"
@@ -835,6 +856,7 @@ _COUNTS_LINE_ORDER: tuple[IngestJobState, ...] = (
     IngestJobState.WRITING,
     IngestJobState.QUEUED,
     IngestJobState.DONE,
+    IngestJobState.SKIPPED,
     IngestJobState.FAILED,
     IngestJobState.CANCELLED,
 )
@@ -879,6 +901,7 @@ _TERMINAL_ROW_STATES = (
     IngestJobState.DONE,
     IngestJobState.FAILED,
     IngestJobState.CANCELLED,
+    IngestJobState.SKIPPED,
 )
 
 
@@ -1086,7 +1109,12 @@ def build_library_ingest_state(
     finished_count = sum(
         1
         for job in jobs
-        if job.state in (IngestJobState.DONE, IngestJobState.FAILED)
+        if job.state
+        in (
+            IngestJobState.DONE,
+            IngestJobState.FAILED,
+            IngestJobState.SKIPPED,
+        )
     )
     failed_count = sum(
         1 for job in jobs if job.state == IngestJobState.FAILED
@@ -1241,7 +1269,8 @@ def build_library_ingest_state(
         match_capped = bool(
             getattr(active_preflight, "already_in_library_capped", False)
         )
-        will_fail = len(unsupported_files) + len(empty_files)
+        will_skip = len(unsupported_files)
+        will_fail = len(empty_files)
         will_import = max(supported_total - will_match, 0)
         parts: list[str] = [f"{will_import} will import"]
         if will_match:
@@ -1249,6 +1278,8 @@ def build_library_ingest_state(
                 f"at least {will_match}" if match_capped else str(will_match)
             )
             parts.append(f"{match_text} will match")
+        if will_skip:
+            parts.append(f"{will_skip} will skip")
         if will_fail:
             parts.append(f"{will_fail} will fail")
         commit_summary_line = " · ".join(parts)
@@ -1284,12 +1315,11 @@ def build_library_ingest_state(
             )
         else:
             file_noun = "file" if unsupported_count == 1 else "files"
-            recorded_as = (
-                "a failure" if unsupported_count == 1 else "failures"
-            )
+            # (task-2220 owner ruling) Skipped, not "recorded as
+            # failures" -- the pipeline never attempts these.
             unsupported_line = (
                 f"{unsupported_count} unsupported {file_noun} will be "
-                f"recorded as {recorded_as}: {unsupported_names}."
+                f"skipped: {unsupported_names}."
             )
     else:
         unsupported_line = ""
@@ -1326,7 +1356,12 @@ def build_library_ingest_state(
     recent_jobs = [
         job
         for job in jobs
-        if job.state in (IngestJobState.DONE, IngestJobState.FAILED)
+        if job.state
+        in (
+            IngestJobState.DONE,
+            IngestJobState.FAILED,
+            IngestJobState.SKIPPED,
+        )
     ]
     live_ids = {job.job_id for job in recent_jobs}
     recent_jobs.extend(

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -1103,8 +1103,16 @@ def build_library_ingest_state(
         )
         for job in jobs
     )
+    # (task-2220 Qodo round) SKIPPED counts as finished everywhere, so it
+    # must also SHOW the control -- a skips-only queue was unclearble.
     queue_show_clear_finished = any(
-        job.state in (IngestJobState.DONE, IngestJobState.FAILED) for job in jobs
+        job.state
+        in (
+            IngestJobState.DONE,
+            IngestJobState.FAILED,
+            IngestJobState.SKIPPED,
+        )
+        for job in jobs
     )
     finished_count = sum(
         1

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1450,7 +1450,12 @@ class LibraryScreen(BaseAppScreen):
         # queue went from idle to active -- the settle toast reports deltas
         # against that baseline.
         self._library_ingest_last_active_count: int = 0
-        self._library_ingest_batch_baseline: tuple[int, int, int] = (0, 0, 0)
+        self._library_ingest_batch_baseline: tuple[int, int, int, int] = (
+            0,
+            0,
+            0,
+            0,
+        )
         # (task-2015) Two-press "Clear finished": first press arms, second
         # clears; any registry mutation disarms.
         self._library_ingest_clear_finished_armed: bool = False
@@ -5967,6 +5972,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_ingest_last_active_count = active_count
         done_now = counts.get("done", 0)
         failed_now = counts.get("failed", 0)
+        skipped_now = counts.get("skipped", 0)
         # (task-2041) A dedup match reaches DONE without importing anything;
         # counting it as "imported" made the toast contradict the row copy.
         # Matches are recognised by the writer's progress-message prefix
@@ -5982,13 +5988,17 @@ class LibraryScreen(BaseAppScreen):
             matched_now = count_duplicate_done_jobs(
                 jobs_fn() if callable(jobs_fn) else ()
             )
-        baseline_done, baseline_failed, baseline_matched = (
-            self._library_ingest_batch_baseline
-        )
+        (
+            baseline_done,
+            baseline_failed,
+            baseline_matched,
+            baseline_skipped,
+        ) = self._library_ingest_batch_baseline
         if (
             done_now < baseline_done
             or failed_now < baseline_failed
             or matched_now < baseline_matched
+            or skipped_now < baseline_skipped
         ):
             # (task-2015 review) Clear/dismiss mid-batch shrinks DONE/FAILED
             # below the baseline; without re-anchoring, the settle deltas go
@@ -5997,39 +6007,50 @@ class LibraryScreen(BaseAppScreen):
             baseline_done = min(baseline_done, done_now)
             baseline_failed = min(baseline_failed, failed_now)
             baseline_matched = min(baseline_matched, matched_now)
+            baseline_skipped = min(baseline_skipped, skipped_now)
             self._library_ingest_batch_baseline = (
                 baseline_done,
                 baseline_failed,
                 baseline_matched,
+                baseline_skipped,
             )
         if previous_active == 0 and active_count > 0:
             self._library_ingest_batch_baseline = (
                 done_now,
                 failed_now,
                 matched_now,
+                skipped_now,
             )
         elif previous_active > 0 and active_count == 0:
-            baseline_done, baseline_failed, baseline_matched = (
-                self._library_ingest_batch_baseline
-            )
+            (
+                baseline_done,
+                baseline_failed,
+                baseline_matched,
+                baseline_skipped,
+            ) = self._library_ingest_batch_baseline
             matched = max(0, matched_now - baseline_matched)
             imported = (done_now - baseline_done) - matched
             failed = failed_now - baseline_failed
-            if imported > 0 or matched > 0 or failed > 0:
+            skipped = max(0, skipped_now - baseline_skipped)
+            if imported > 0 or matched > 0 or failed > 0 or skipped > 0:
                 parts = []
                 if imported > 0:
                     parts.append(f"{imported} imported")
                 if matched > 0:
                     parts.append(f"{matched} already in Library")
+                if skipped > 0:
+                    parts.append(f"{skipped} skipped")
                 if failed > 0:
                     parts.append(f"{failed} failed")
                 notify = getattr(self.app_instance, "notify", None)
                 if callable(notify):
+                    # (task-2220) Skips are neutral -- only a batch whose
+                    # sole outcome is real failures warns.
                     notify(
                         "Ingest finished — " + " · ".join(parts),
                         severity=(
                             "information"
-                            if imported > 0 or matched > 0
+                            if imported > 0 or matched > 0 or failed == 0
                             else "warning"
                         ),
                     )
@@ -14384,7 +14405,12 @@ class LibraryScreen(BaseAppScreen):
             terminal = [
                 job
                 for job in jobs_fn()
-                if job.state in (IngestJobState.DONE, IngestJobState.FAILED)
+                if job.state
+                in (
+                    IngestJobState.DONE,
+                    IngestJobState.FAILED,
+                    IngestJobState.SKIPPED,
+                )
             ]
             known = {job.job_id for job in terminal}
             terminal.extend(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6044,8 +6044,11 @@ class LibraryScreen(BaseAppScreen):
                     parts.append(f"{failed} failed")
                 notify = getattr(self.app_instance, "notify", None)
                 if callable(notify):
-                    # (task-2220) Skips are neutral -- only a batch whose
-                    # sole outcome is real failures warns.
+                    # (task-2220) Skips are neutral and never warn on
+                    # their own (failed == 0 -> information). Real failures
+                    # with zero successes DO warn even when skips are also
+                    # present -- something the user pointed at genuinely
+                    # broke and nothing landed.
                     notify(
                         "Ingest finished — " + " · ".join(parts),
                         severity=(

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2611,13 +2611,29 @@ class LibraryIngestQueueMixin:
             error_text = _sanitize_library_ingest_error_text(
                 str(result.get("error") or "Library ingest parsing failed.")
             )
-            self.library_ingest_jobs.mark_failed(
-                job_id,
-                error=error_text or "Library ingest parsing failed.",
-                permanent=bool(result.get("permanent", False)),
-                error_detail=result.get("error_detail"),
-                stt_failure_provenance=result.get("stt_failure_provenance"),
-            )
+            error_detail = result.get("error_detail")
+            # (task-2220 owner ruling) An unsupported file was never
+            # attempted -- it records as SKIPPED, a neutral terminal
+            # outcome; "failed" is reserved for files the pipeline tried.
+            if (
+                isinstance(error_detail, dict)
+                and error_detail.get("category") == "unsupported_file_type"
+            ):
+                self.library_ingest_jobs.mark_skipped(
+                    job_id,
+                    reason=error_text or "Unsupported file type.",
+                    error_detail=error_detail,
+                )
+            else:
+                self.library_ingest_jobs.mark_failed(
+                    job_id,
+                    error=error_text or "Library ingest parsing failed.",
+                    permanent=bool(result.get("permanent", False)),
+                    error_detail=error_detail,
+                    stt_failure_provenance=result.get(
+                        "stt_failure_provenance"
+                    ),
+                )
         self._top_up_ingest_parse_pool()
 
     def _handle_broken_ingest_parse_pool(


### PR DESCRIPTION
## Summary

Second owner-ruling task from the round-6 follow-up (rulings in #1323): **'failed' is reserved for files the pipeline TRIED and could not ingest.** A folder of 100 photos + 1 PDF no longer produces 100 red failure rows.

- New `IngestJobState.SKIPPED` + `mark_skipped` (mirrors the CANCELLED neutral-terminal pattern), routed at the parse-failure choke point on `category == "unsupported_file_type"`. DB round-trip free.
- Row renders `○ skipped · name · reason` — no Retry (`requeue` stays FAILED-only), dismiss offered; counts line, completion toast, Recent, the durable ledger, and Clear finished all treat skips as their own neutral segment; toast severity warns only when real failures are the batch's only outcome.
- Pre-flight copy follows the ontology: "N unsupported files will be skipped: …", and the commit summary splits "will skip" (unsupported) from "will fail" (empty files — enqueued and genuinely failing).

## Tests
289 core + 52 shell-subset targeted green; collect sweep clean. The two runner tests that pinned FAILED-for-unsupported now pin SKIPPED end-to-end against the real parse worker; new pins for row rendering, tally segments, armed-label counting, and the skip/fail commit split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unsupported files selected via a folder are now recorded as SKIPPED, not FAILED. This aligns with task-2220 so failures only represent files we actually tried to ingest.

- **New Features**
  - Added `IngestJobState.SKIPPED` and `mark_skipped` (returns the updated job); set when parse reports `error_detail.category: unsupported_file_type`. Retry stays FAILED-only; rows are dismissible.
  - UI: rows show "○ skipped · name · reason"; counts and completion toasts include a "skipped" segment; Clear Finished shows and clears even when only skips are present; commit summary says "will skip" (unsupported) and keeps "will fail" for empty files; toasts only warn when there are real failures with no successes.

- **Tests**
  - Updated runner and state tests to expect SKIPPED end-to-end, pin row rendering, tally segments, clear-finished visibility, and the skip/fail commit split.

<sup>Written for commit 1f652253079c0db6a913be37165e3a883ae8b86a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

