### PR TITLE
feat(library): 'Select folder' action in the ingest Browse dialog (task-2222)

### DIFF
--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -14079,10 +14079,17 @@ async def test_arming_clear_finished_disturbs_nothing_and_dead_zone_holds(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_ingest_browse_offers_select_folder_action(tmp_path):
-    """(task-2222 owner ruling) The ingest Browse dialog offers a 'Select
-    folder' action returning the directory being viewed; Open keeps
-    descending. Off by default for every other FileOpen caller."""
+async def test_ingest_browse_offers_select_folder_action(
+    tmp_path: Path,
+) -> None:
+    """Ingest Browse offers a folder action; other pickers do not.
+
+    (task-2222 owner ruling) The action returns the directory being
+    viewed, while "Open" keeps descending into directories.
+
+    Args:
+        tmp_path: pytest temporary directory fixture.
+    """
     from tldw_chatbook.Third_Party.textual_fspicker import FileOpen
 
     folder = tmp_path / "pickme"
@@ -14123,5 +14130,42 @@ async def test_ingest_browse_offers_select_folder_action(tmp_path):
         assert not list(plain.query("#select-current-folder")), (
             "the folder affordance must stay opt-in"
         )
+        plain.dismiss(None)
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_folder_shortcut_hidden_when_affordance_is_off(
+    tmp_path: Path,
+) -> None:
+    """The ctrl+s folder shortcut is hidden on pickers without the action.
+
+    (task-2222 Qodo round) The binding lives on the shared base, so an
+    unconditional declaration advertised a dead shortcut — including in
+    the F1 help — on every other dialog.
+
+    Args:
+        tmp_path: pytest temporary directory fixture.
+    """
+    from tldw_chatbook.Third_Party.textual_fspicker import FileOpen
+
+    db = MediaDatabase(tmp_path / "ingest-canvas.db", client_id="c8-bind")
+    harness = _LibraryIngestCanvasHarness(db)
+
+    async with harness.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = harness.screen_stack[-1]
+        await _wait_for_library_shell(screen, pilot)
+
+        offering = FileOpen(location=str(tmp_path), offer_select_folder=True)
+        harness.push_screen(offering, lambda _r: None)
+        await pilot.pause()
+        assert offering.check_action("select_current_folder", ()) is not None
+        offering.dismiss(None)
+        await pilot.pause()
+
+        plain = FileOpen(location=str(tmp_path))
+        harness.push_screen(plain, lambda _r: None)
+        await pilot.pause()
+        assert plain.check_action("select_current_folder", ()) is None
         plain.dismiss(None)
         await pilot.pause()

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -14076,3 +14076,52 @@ async def test_arming_clear_finished_disturbs_nothing_and_dead_zone_holds(tmp_pa
         assert screen._build_library_ingest_state().recent_jobs, (
             "ledger must survive the confirmed clear"
         )
+
+
+@pytest.mark.asyncio
+async def test_ingest_browse_offers_select_folder_action(tmp_path):
+    """(task-2222 owner ruling) The ingest Browse dialog offers a 'Select
+    folder' action returning the directory being viewed; Open keeps
+    descending. Off by default for every other FileOpen caller."""
+    from tldw_chatbook.Third_Party.textual_fspicker import FileOpen
+
+    folder = tmp_path / "pickme"
+    folder.mkdir()
+    (folder / "doc.txt").write_text("hello")
+
+    db = MediaDatabase(tmp_path / "ingest-canvas.db", client_id="c8-pick")
+    harness = _LibraryIngestCanvasHarness(db)
+
+    async with harness.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = harness.screen_stack[-1]
+        await _wait_for_library_shell(screen, pilot)
+
+        picked: list[object] = []
+        dialog = FileOpen(
+            location=str(folder),
+            title="Import media",
+            offer_select_folder=True,
+        )
+        harness.push_screen(dialog, picked.append)
+        await pilot.pause()
+        await pilot.pause()
+
+        button = dialog.query_one("#select-current-folder", Button)
+        assert "folder" in str(button.label).lower()
+        button.press()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert picked and str(picked[0]) == str(folder), (
+            "Select folder must return the directory being viewed"
+        )
+
+        plain = FileOpen(location=str(folder), title="Open")
+        harness.push_screen(plain, lambda _result: None)
+        await pilot.pause()
+        await pilot.pause()
+        assert not list(plain.query("#select-current-folder")), (
+            "the folder affordance must stay opt-in"
+        )
+        plain.dismiss(None)
+        await pilot.pause()

--- a/backlog/tasks/task-2222 - Library-ingest-folder-select-in-browse.md
+++ b/backlog/tasks/task-2222 - Library-ingest-folder-select-in-browse.md
@@ -2,7 +2,7 @@
 id: TASK-2222
 title: >-
   Library ingest: "Select this folder" action in the Browse dialog
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-04 05:00'
 labels:
@@ -23,9 +23,34 @@ SelectDirectory variant is the reference).
 
 ## Acceptance Criteria (the what)
 
-- [ ] The ingest Browse dialog offers a visible "Select current folder"
+- [x] The ingest Browse dialog offers a visible "Select current folder"
       action (button and/or binding) that returns the directory being
       viewed; Open keeps descending.
-- [ ] Choosing it fills the path field with the directory and triggers
+- [x] Choosing it fills the path field with the directory and triggers
       pre-flight, exactly like typing the path.
-- [ ] File selection behavior is unchanged.
+- [x] File selection behavior is unchanged.
+
+## Implementation Plan (the how)
+
+Add an OPT-IN "Select folder" affordance to the shared picker base
+(`FileOpen(offer_select_folder=True)`), dismissing with the directory
+currently being viewed; the Library ingest Browse opts in.
+
+## Implementation Notes
+
+- `base_dialog`: the input bar renders a `#select-current-folder`
+  Button only when the screen sets `_offer_select_folder`, so every
+  other FileOpen caller's bar is byte-identical. The handler dismisses
+  with `DirectoryNavigation.location` — "Open" keeps descending, per the
+  ruling. A `ctrl+s` binding gives the keyboard route (guarded by the
+  same flag).
+- `file_open`: `offer_select_folder: bool = False` constructor flag,
+  documented; the ingest Browse passes True.
+- The existing callback already fills the path field, remembers the
+  location, and triggers pre-flight — a picked folder therefore behaves
+  exactly like a typed one.
+
+**Verification.** 252 core/picker + 54 shell-subset green; collect
+clean. Live: Browse shows "Select folder"; clicking it fills the path
+with the viewed directory and the forecast reads
+"2 will import · 2 will skip".

--- a/tldw_chatbook/Third_Party/textual_fspicker/base_dialog.py
+++ b/tldw_chatbook/Third_Party/textual_fspicker/base_dialog.py
@@ -164,6 +164,7 @@ class FileSystemPickerScreen(ModalScreen[Union[Path, None]]):
         Binding("ctrl+r", "show_recent", "Show recent locations"),
         Binding("ctrl+f", "focus_search", "Search in directory"),
         Binding("escape", "dismiss(None)", "Cancel"),
+        Binding("ctrl+s", "select_current_folder", "Select this folder"),
     ]
     """The bindings for the dialog."""
 
@@ -260,6 +261,14 @@ class FileSystemPickerScreen(ModalScreen[Union[Path, None]]):
             with InputBar():
                 yield from self._input_bar()
                 yield Button(self._label(self._select_button, "Select"), id="select")
+                # (task-2222) Opt-in folder affordance: a file picker whose
+                # caller also accepts a directory can offer "this folder"
+                # without a second dialog. Off by default, so every other
+                # caller's bar is unchanged.
+                if getattr(self, "_offer_select_folder", False):
+                    yield Button(
+                        "Select folder", id="select-current-folder"
+                    )
                 yield Button(self._label(self._cancel_button, "Cancel"), id="cancel")
 
     def on_mount(self) -> None:
@@ -335,6 +344,24 @@ class FileSystemPickerScreen(ModalScreen[Union[Path, None]]):
     def _show_permission_error(self) -> None:
         """Show any permission error bubbled up from the directory navigator."""
         self._set_error(self.ERROR_PERMISSION_ERROR)
+
+    def action_select_current_folder(self) -> None:
+        """Keyboard route to the folder affordance (task-2222)."""
+        if getattr(self, "_offer_select_folder", False):
+            self.dismiss(self.query_one(DirectoryNavigation).location)
+
+    @on(Button.Pressed, "#select-current-folder")
+    def _select_current_folder(self, event: Button.Pressed) -> None:
+        """Return the directory currently being viewed (task-2222).
+
+        "Open" keeps descending into directories; this returns the one on
+        screen, which is how every OS folder picker behaves.
+
+        Args:
+            event: The button press event.
+        """
+        event.stop()
+        self.dismiss(self.query_one(DirectoryNavigation).location)
 
     @on(Button.Pressed, "#cancel")
     def _cancel(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Third_Party/textual_fspicker/base_dialog.py
+++ b/tldw_chatbook/Third_Party/textual_fspicker/base_dialog.py
@@ -345,6 +345,30 @@ class FileSystemPickerScreen(ModalScreen[Union[Path, None]]):
         """Show any permission error bubbled up from the directory navigator."""
         self._set_error(self.ERROR_PERMISSION_ERROR)
 
+    def check_action(
+        self, action: str, parameters: tuple[object, ...]
+    ) -> bool | None:
+        """Hide the folder shortcut on dialogs that do not offer it.
+
+        (task-2222 Qodo round) The binding is declared on the shared base,
+        so without this every picker advertised a ctrl+s that did nothing
+        -- including in the F1 help. Returning None removes it from both
+        the key map and the listing.
+
+        Args:
+            action: The action name being checked.
+            parameters: The action's parameters.
+
+        Returns:
+            ``None`` to hide the folder action when this dialog does not
+            offer it; otherwise the base class's decision.
+        """
+        if action == "select_current_folder" and not getattr(
+            self, "_offer_select_folder", False
+        ):
+            return None
+        return super().check_action(action, parameters)
+
     def action_select_current_folder(self) -> None:
         """Keyboard route to the folder affordance (task-2222)."""
         if getattr(self, "_offer_select_folder", False):

--- a/tldw_chatbook/Third_Party/textual_fspicker/file_open.py
+++ b/tldw_chatbook/Third_Party/textual_fspicker/file_open.py
@@ -32,6 +32,7 @@ class FileOpen(BaseFileDialog):
         filters: Filters | None = None,
         must_exist: bool = True,
         default_file: str | Path | None = None,
+        offer_select_folder: bool = False,
     ) -> None:
         """Initialise the `FileOpen` dialog.
 
@@ -43,6 +44,10 @@ class FileOpen(BaseFileDialog):
             filters: Optional filters to show in the dialog.
             must_exist: Flag to say if the file must exist.
             default_file: The default filename to place in the input.
+            offer_select_folder: When True, the dialog also offers a
+                "Select folder" action returning the directory being
+                viewed (task-2222) -- for callers that accept either a
+                file or a folder.
 
         Notes:
             `open_button` and `cancel_button` can either be strings that
@@ -59,6 +64,8 @@ class FileOpen(BaseFileDialog):
         )
         self._must_exist = must_exist
         """Must the file exist?"""
+        self._offer_select_folder = offer_select_folder
+        """Offer the "select the folder being viewed" action?"""
 
     def _should_return(self, candidate: Path) -> bool:
         """Perform the final checks on the chosen file.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -13331,6 +13331,10 @@ class LibraryScreen(BaseAppScreen):
                 location=self._library_ingest_browse_location(),
                 title="Import media",
                 filters=_ingestible_file_filters(),
+                # (task-2222 owner ruling) Folder import must be pickable,
+                # not type-only: "Open" keeps descending, this returns the
+                # folder on screen.
+                offer_select_folder=True,
             ),
             browse_callback,
         )


### PR DESCRIPTION
## Summary

Last of the four owner-ruling tasks (rulings in #1323): **folder import is pickable, not type-only.**

- The shared picker base gains an **opt-in** affordance: `FileOpen(offer_select_folder=True)` renders a 'Select folder' button (plus a `ctrl+s` binding) that dismisses with the directory currently being viewed. Default is False, so every other FileOpen caller's dialog is unchanged. 'Open' still descends into directories, per the ruling.
- The Library ingest Browse opts in. The existing callback already fills the path field, remembers the location, and triggers pre-flight — so a picked folder behaves exactly like a typed one.

## Tests
252 core/picker + 54 shell-subset green; collect clean. New test asserts the button returns the viewed directory AND that the affordance stays absent for a plain `FileOpen`. Live-verified: Browse shows 'Select folder' → click fills the path with the viewed folder → forecast reads '2 will import · 2 will skip'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Select folder" action to the Library ingest Browse dialog so users can pick the current directory instead of typing (task-2222). Also hides the ctrl+s shortcut on dialogs that don’t offer this action; "Open" still navigates into folders.

- **New Features**
  - `FileOpen(offer_select_folder=True)` shows a "Select folder" button and `ctrl+s` to return the viewed directory.
  - Library ingest Browse opts in; picking a folder fills the path and triggers pre-flight like typing.
  - Default stays False; all other `FileOpen` dialogs are unchanged.

- **Bug Fixes**
  - Hide the `ctrl+s` binding and help entry on pickers without the affordance using `check_action`.

<sup>Written for commit 7e6363ec081ebd464b7db93e10a240d2caff8ff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

