### PR TITLE
fix(library): reconcile forecast/receipt vocabulary + visible Retry attempts (task-2231)

### DIFF
--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -2749,7 +2749,7 @@ async def test_empty_file_failure_is_permanent_and_refuses_retry(
 ) -> None:
     """(task-2015) A truly empty file fails identically on every attempt --
     offering Retry for it is dead bait (the UAT pressed it and got the same
-    failure with '· retry 1'). Same permanence family as missing-file and
+    failure with '· attempt 2'). Same permanence family as missing-file and
     unsupported-type."""
     db = _make_db(tmp_path)
     empty = tmp_path / "empty.txt"

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -2180,16 +2180,20 @@ def test_active_rows_show_the_attempt_number_after_a_retry() -> None:
     count, but the in-flight rows never showed it — so pressing Retry
     looked identical to nothing happening.
     """
-    for state_value, word in (
-        (IngestJobState.QUEUED, "queued"),
-        (IngestJobState.PARSING, "parsing"),
-        (IngestJobState.WRITING, "writing"),
+    # (Qodo round) detected_type is appended by the parsing/writing
+    # branches, so the marker must be the row's TRAILING element -- with a
+    # type present it used to read "… · attempt 2 · pdf".
+    for state_value, word, detected in (
+        (IngestJobState.QUEUED, "queued", ""),
+        (IngestJobState.PARSING, "parsing", "pdf"),
+        (IngestJobState.WRITING, "writing", "pdf"),
     ):
         job = _job(
             job_id="ingest-job-1",
             state=state_value,
             source_path="/tmp/broken.pdf",
             retry_count=1,
+            detected_type=detected,
         )
         row = build_library_ingest_state(
             (job,), form=LibraryIngestFormState()
@@ -2245,3 +2249,41 @@ def test_consent_line_requires_every_importable_file_to_match() -> None:
         ),
     )
     assert total.start_quiet_line.startswith("Everything here")
+
+
+def test_queue_tally_and_group_header_agree_on_matched() -> None:
+    """The tally buckets the way the headers and rows do.
+
+    (task-2231 Qodo round) The top-level counts line bucketed purely by
+    state, so it read "2 done" while a group header directly below it
+    read "1 done · 1 matched" — two contradictory summaries on one
+    screen.
+    """
+    imported = _job(
+        job_id="ingest-job-1",
+        state=IngestJobState.DONE,
+        source_path="/tmp/fresh.txt",
+        progress={"message": "Ingested fresh.txt"},
+        batch_id="local-aaa",
+        submitted_at=10.0,
+    )
+    matched = _job(
+        job_id="ingest-job-2",
+        state=IngestJobState.DONE,
+        source_path="/tmp/twin.txt",
+        progress={
+            "message": (
+                "Already in Library — matched an existing item; nothing "
+                "new was imported."
+            )
+        },
+        batch_id="local-aaa",
+        submitted_at=11.0,
+    )
+    state = build_library_ingest_state(
+        (imported, matched), form=LibraryIngestFormState()
+    )
+    assert state.queue_counts_line == "1 done · 1 matched — in queue"
+    headed = next(g for g in state.queue_groups if g.header_line)
+    assert "1 done" in headed.header_line
+    assert "1 matched" in headed.header_line

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -402,7 +402,7 @@ def test_failed_row_line_appends_retry_suffix():
     )
     state = build_library_ingest_state(jobs, form=LibraryIngestFormState())
     row = state.queue_rows[0]
-    assert row.line == "✗ failed · report.txt · bad codec · retry 2"
+    assert row.line == "✗ failed · report.txt · bad codec · attempt 3"
 
 
 def test_basename_used_for_nested_path():
@@ -2124,3 +2124,124 @@ def test_unresolvable_path_gates_start_with_an_explanation() -> None:
         "Can't find that path — check it, or use Browse… to pick a file "
         "or folder."
     )
+
+
+def test_matched_rows_and_tallies_use_the_forecast_vocabulary() -> None:
+    """A dedup match reports as "matched", distinct from an import.
+
+    (task-2231) The forecast promises "will import · will match · will
+    skip"; the receipt used to fold match into "done" and render the two
+    outcomes as byte-identical rows, so the promise could not be audited.
+    """
+    imported = _job(
+        job_id="ingest-job-1",
+        state=IngestJobState.DONE,
+        source_path="/tmp/fresh.txt",
+        progress={"message": "Ingested fresh.txt"},
+        batch_id="local-aaa",
+        submitted_at=10.0,
+    )
+    matched = _job(
+        job_id="ingest-job-2",
+        state=IngestJobState.DONE,
+        source_path="/tmp/twin.txt",
+        progress={
+            "message": (
+                "Already in Library — matched an existing item; nothing "
+                "new was imported."
+            )
+        },
+        batch_id="local-aaa",
+        submitted_at=11.0,
+    )
+    other = _job(
+        job_id="ingest-job-3",
+        state=IngestJobState.DONE,
+        source_path="/tmp/solo.txt",
+        submitted_at=99.0,
+    )
+    state = build_library_ingest_state(
+        (imported, matched, other), form=LibraryIngestFormState()
+    )
+    rows = {row.job_id: row for row in state.queue_rows}
+    assert rows["ingest-job-1"].line.startswith("✓ done · fresh.txt")
+    assert rows["ingest-job-2"].line.startswith("≡ matched · twin.txt")
+    assert rows["ingest-job-2"].glyph == "≡"
+
+    headed = next(g for g in state.queue_groups if g.header_line)
+    assert "1 done" in headed.header_line
+    assert "1 matched" in headed.header_line
+
+
+def test_active_rows_show_the_attempt_number_after_a_retry() -> None:
+    """A re-attempt is visible while it runs, not only once it ends.
+
+    (task-2231) Requeue creates a new QUEUED job with an incremented
+    count, but the in-flight rows never showed it — so pressing Retry
+    looked identical to nothing happening.
+    """
+    for state_value, word in (
+        (IngestJobState.QUEUED, "queued"),
+        (IngestJobState.PARSING, "parsing"),
+        (IngestJobState.WRITING, "writing"),
+    ):
+        job = _job(
+            job_id="ingest-job-1",
+            state=state_value,
+            source_path="/tmp/broken.pdf",
+            retry_count=1,
+        )
+        row = build_library_ingest_state(
+            (job,), form=LibraryIngestFormState()
+        ).queue_rows[0]
+        assert row.line.startswith(f"● {word} · broken.pdf")
+        assert row.line.endswith("· attempt 2"), (
+            f"{word} row must show the attempt number: {row.line!r}"
+        )
+
+    first = _job(job_id="ingest-job-2", state=IngestJobState.PARSING)
+    first_row = build_library_ingest_state(
+        (first,), form=LibraryIngestFormState()
+    ).queue_rows[0]
+    assert "attempt" not in first_row.line
+
+
+def test_consent_line_requires_every_importable_file_to_match() -> None:
+    """"Everything here" only renders when it is true.
+
+    (task-2231) The line rendered on a selection where only some files
+    were predicted matches.
+    """
+    form = LibraryIngestFormState(path="/tmp/folder")
+    partial = build_library_ingest_state(
+        (),
+        form=form,
+        preflight=PreflightResult(
+            type_groups={
+                "generic": ["/tmp/a.txt", "/tmp/b.txt"],
+                "unsupported": ["/tmp/pic.jpg"],
+            },
+            warnings=[],
+            errors=[],
+            total_size=100,
+            truncated=False,
+            total_files=3,
+            already_in_library=2,
+        ),
+    )
+    assert "Everything here" not in partial.start_quiet_line
+
+    total = build_library_ingest_state(
+        (),
+        form=form,
+        preflight=PreflightResult(
+            type_groups={"generic": ["/tmp/a.txt"]},
+            warnings=[],
+            errors=[],
+            total_size=100,
+            truncated=False,
+            total_files=1,
+            already_in_library=1,
+        ),
+    )
+    assert total.start_quiet_line.startswith("Everything here")

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -13194,7 +13194,7 @@ async def test_completion_toast_reports_dedup_as_already_in_library(tmp_path):
             if call.args and str(call.args[0]).startswith("Ingest finished")
         ]
         assert summaries and summaries[-1] == (
-            "Ingest finished — 1 already in Library"
+            "Ingest finished — 1 matched"
         ), f"dedup batch misreported: {summaries}"
         assert summaries[0] == "Ingest finished — 1 imported"
 

--- a/backlog/tasks/task-2231 - Library-ingest-round-7-P2-vocabulary-and-retry.md
+++ b/backlog/tasks/task-2231 - Library-ingest-round-7-P2-vocabulary-and-retry.md
@@ -68,3 +68,15 @@ promises the post-commit surface won't honour.
 **Verification.** 300 core + 56 shell-subset green; 29,815 collect
 clean. Live: forecast "1 will match" + consent line → `≡ matched ·
 copy_of_report.txt` row → "Latest run: 1 matched".
+
+**Qodo round (fixed in `76dc40154`):** two internal inconsistencies from
+this PR's own changes. (1) The attempt suffix was appended BEFORE
+`detected_type`, so only rows WITH a type mis-ordered
+("… · attempt 2 · pdf") — my test used typeless jobs and missed it; the
+marker is now the trailing element in every state and the test carries a
+type. (2) `_queue_counts_line` bucketed purely by state, so the queue
+line said "2 done" while a group header below said "1 done · 1 matched";
+the tally now applies the same dedup predicate as the headers and rows.
+**Lesson: when a new distinction is introduced, EVERY surface that
+aggregates the old bucket has to learn it — the row, the group header,
+the tally, and the toast were four separate places.**

--- a/backlog/tasks/task-2231 - Library-ingest-round-7-P2-vocabulary-and-retry.md
+++ b/backlog/tasks/task-2231 - Library-ingest-round-7-P2-vocabulary-and-retry.md
@@ -2,7 +2,7 @@
 id: TASK-2231
 title: >-
   Library ingest round-7 P2s (forecast/receipt vocabulary reconciliation, Retry feedback)
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04 17:00'
 labels:
@@ -33,13 +33,38 @@ promises the post-commit surface won't honour.
 
 ## Acceptance Criteria (the what)
 
-- [ ] The receipt uses the forecast's vocabulary: matched outcomes are
+- [x] The receipt uses the forecast's vocabulary: matched outcomes are
       reported as "matched", distinct from "imported", in the tally, the
       group header, and the completion toast.
-- [ ] A dedup-matched row is distinguishable from a fresh import at a
+- [x] A dedup-matched row is distinguishable from a fresh import at a
       glance (its own glyph), not only by its sub-line.
-- [ ] The all-match consent line only claims "everything" when every
+- [x] The all-match consent line only claims "everything" when every
       importable file in the selection is a predicted match.
-- [ ] Pressing Retry produces immediate visible feedback (the row shows
+- [x] Pressing Retry produces immediate visible feedback (the row shows
       it is re-attempting) and the resulting row carries an attempt
       count, so a repeat failure is visibly a NEW attempt.
+
+## Implementation Notes
+
+- **Vocabulary:** a dedup match is recognised by the writer's progress
+  marker (the same predicate the tally uses) and now renders
+  `≡ matched · <name>` — its own glyph AND word, so an import and a
+  match are distinguishable at a glance rather than only by the
+  sub-line. `_batch_outcome_parts` splits matched out of done, so group
+  headers and the latest-run line read "1 done · 1 matched"; the
+  completion toast says "N matched" instead of "N already in Library".
+  The forecast's three words (import/match/skip) are now the receipt's
+  three words.
+- **Consent scope:** the "Everything here…" line additionally requires
+  zero predicted skips, so it can no longer claim "everything" for a
+  selection that also contains unsupported files.
+- **Retry feedback:** requeue always created a new QUEUED job with an
+  incremented count, but the in-flight rows never showed it — so a
+  retry was visually identical to nothing happening. Queued/parsing/
+  writing rows now carry the attempt marker, and the suffix reads
+  "· attempt N" (N = retry_count + 1) on every row state, which reads
+  as progress and is unambiguous mid-flight.
+
+**Verification.** 300 core + 56 shell-subset green; 29,815 collect
+clean. Live: forecast "1 will match" + consent line → `≡ matched ·
+copy_of_report.txt` row → "Latest run: 1 matched".

--- a/backlog/tasks/task-2231 - Library-ingest-round-7-P2-vocabulary-and-retry.md
+++ b/backlog/tasks/task-2231 - Library-ingest-round-7-P2-vocabulary-and-retry.md
@@ -1,0 +1,45 @@
+---
+id: TASK-2231
+title: >-
+  Library ingest round-7 P2s (forecast/receipt vocabulary reconciliation, Retry feedback)
+status: In Progress
+assignee: []
+created_date: '2026-08-04 17:00'
+labels:
+  - library
+  - ingest
+  - ux
+priority: medium
+dependencies: []
+---
+
+## Description (the why)
+
+Round-7 critique, the two P2s. Theme: the pre-commit surface makes
+promises the post-commit surface won't honour.
+
+1. **Vocabulary doesn't reconcile.** Pre-flight promises
+   `1 will import · 1 will match · 2 will skip`; the receipt says
+   `2 done · 2 skipped` — "match" silently folds into "done", and the
+   two `✓ done` rows are byte-identical in glyph and colour, so only the
+   sub-line distinguishes an import from a dedup match. The user cannot
+   audit the promise against the outcome, which cancels the value of
+   having made it. Related: the all-match consent line renders on a
+   selection where only SOME files are matches.
+2. **Retry is indistinguishable from a dead button.** Three clicks on a
+   failed row, polled at 0.35s for 3s each: no spinner, no attempt
+   counter, no timestamp change, no toast. Zero visible change at the
+   flow's highest-anxiety moment.
+
+## Acceptance Criteria (the what)
+
+- [ ] The receipt uses the forecast's vocabulary: matched outcomes are
+      reported as "matched", distinct from "imported", in the tally, the
+      group header, and the completion toast.
+- [ ] A dedup-matched row is distinguishable from a fresh import at a
+      glance (its own glyph), not only by its sub-line.
+- [ ] The all-match consent line only claims "everything" when every
+      importable file in the selection is a predicted match.
+- [ ] Pressing Retry produces immediate visible feedback (the row shows
+      it is re-attempting) and the resulting row carries an attempt
+      count, so a repeat failure is visibly a NEW attempt.

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -721,9 +721,13 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
     """
     basename = _basename(job.source_path)
     if job.state == IngestJobState.PARSING:
-        line = f"{_GLYPH_ACTIVE} parsing · {basename}{_retry_suffix(job)}"
+        line = f"{_GLYPH_ACTIVE} parsing · {basename}"
         if job.detected_type:
             line += f" · {job.detected_type}"
+        # (Qodo round) The attempt marker is the row's LAST element in every
+        # state -- appending it before detected_type made it read
+        # "… · attempt 2 · plaintext" only on rows that had a type.
+        line += _retry_suffix(job)
         return IngestQueueRow(
             job_id=job.job_id,
             glyph=_GLYPH_ACTIVE,
@@ -737,9 +741,10 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
             error_detail=job.error_detail,
         )
     if job.state == IngestJobState.WRITING:
-        line = f"{_GLYPH_ACTIVE} writing · {basename}{_retry_suffix(job)}"
+        line = f"{_GLYPH_ACTIVE} writing · {basename}"
         if job.detected_type:
             line += f" · {job.detected_type}"
+        line += _retry_suffix(job)
         return IngestQueueRow(
             job_id=job.job_id,
             glyph=_GLYPH_ACTIVE,
@@ -900,14 +905,26 @@ def _queue_counts_line(jobs: Sequence[LibraryIngestJob]) -> str:
     in this module -- e.g. ``"2 parsing · 1 writing · 3 queued · 1 done · 1
     failed"``), joined by ``" · "``.
     """
+    # (Qodo round) The tally must bucket the way the group headers and the
+    # rows do: counting every DONE job as "done" made the queue line say
+    # "2 done" while a header right below it said "1 done · 1 matched".
     counts = {state.value: 0 for state in IngestJobState}
+    matched = 0
     for job in jobs:
-        counts[job.state.value] += 1
-    joined = " · ".join(
+        if job.state == IngestJobState.DONE and str(
+            (job.progress or {}).get("message", "")
+        ).startswith(INGEST_DUPLICATE_PROGRESS_PREFIX):
+            matched += 1
+        else:
+            counts[job.state.value] += 1
+    segments = [
         f"{counts[state.value]} {state.value}"
         for state in _COUNTS_LINE_ORDER
         if counts[state.value]
-    )
+    ]
+    if matched:
+        segments.append(f"{matched} matched")
+    joined = " · ".join(segments)
     # (task-2043) The registry restores prior sessions from the jobs DB, so
     # these totals span ALL ingests -- say so, or a fresh batch's outcome
     # blurs into history.

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -30,6 +30,7 @@ from tldw_chatbook.Library.ingest_capabilities import (
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Library.library_ingest_jobs import (
     DEFAULT_CHUNK_SIZE,
+    INGEST_DUPLICATE_PROGRESS_PREFIX,
     IngestJobState,
     LibraryIngestJob,
 )
@@ -186,6 +187,9 @@ MAX_CHUNK_SIZE = 5000
 # Queue row state glyphs (binding).
 _GLYPH_ACTIVE = "●"  # "●" -- queued, parsing, or writing
 _GLYPH_DONE = "✓"  # "✓"
+#: (task-2231) A dedup match is a distinct OUTCOME, not a quieter
+#: import -- the two used to be byte-identical rows.
+_GLYPH_MATCHED = "≡"
 _GLYPH_FAILED = "✗"  # "✗"
 _GLYPH_SKIPPED = "○"  # neutral: never attempted (task-2220)
 _GLYPH_CANCELLED = "⊘"  # "⊘" -- stopped deliberately, not an error
@@ -262,7 +266,7 @@ def _retry_suffix(job: LibraryIngestJob) -> str:
     docstring) never has to reach into ``Home`` (the dependency runs the
     other way: ``Home`` already imports from ``Library``).
     """
-    return f" · retry {job.retry_count}" if job.retry_count else ""
+    return f" · attempt {job.retry_count + 1}" if job.retry_count else ""
 
 # Human-readable (singular, plural) labels for pre-flight type groups.
 # ``unsupported`` is popped into ``unsupported_files`` before this mapping is
@@ -717,7 +721,7 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
     """
     basename = _basename(job.source_path)
     if job.state == IngestJobState.PARSING:
-        line = f"{_GLYPH_ACTIVE} parsing · {basename}"
+        line = f"{_GLYPH_ACTIVE} parsing · {basename}{_retry_suffix(job)}"
         if job.detected_type:
             line += f" · {job.detected_type}"
         return IngestQueueRow(
@@ -733,7 +737,7 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
             error_detail=job.error_detail,
         )
     if job.state == IngestJobState.WRITING:
-        line = f"{_GLYPH_ACTIVE} writing · {basename}"
+        line = f"{_GLYPH_ACTIVE} writing · {basename}{_retry_suffix(job)}"
         if job.detected_type:
             line += f" · {job.detected_type}"
         return IngestQueueRow(
@@ -752,7 +756,9 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
         return IngestQueueRow(
             job_id=job.job_id,
             glyph=_GLYPH_ACTIVE,
-            line=f"{_GLYPH_ACTIVE} queued · {basename}",
+            line=(
+                f"{_GLYPH_ACTIVE} queued · {basename}{_retry_suffix(job)}"
+            ),
             can_open=False,
             can_retry=False,
             media_id=job.media_id,
@@ -768,12 +774,23 @@ def _build_queue_row_for_state(job: LibraryIngestJob, *, now: float) -> IngestQu
         elapsed = _format_elapsed(
             job.submitted_at or job.started_at, job.finished_at, now=now
         )
-        line = f"{_GLYPH_DONE} done · {basename}"
+        # (task-2231) The forecast promised "will match"; the receipt says
+        # so too. Matched rows carry their own glyph and word, so an import
+        # and a dedup match are distinguishable at a glance rather than
+        # only by the sub-line.
+        is_matched = bool(
+            str((job.progress or {}).get("message", "")).startswith(
+                INGEST_DUPLICATE_PROGRESS_PREFIX
+            )
+        )
+        glyph = _GLYPH_MATCHED if is_matched else _GLYPH_DONE
+        word = "matched" if is_matched else "done"
+        line = f"{glyph} {word} · {basename}"
         if elapsed:
             line += f" · {elapsed}"
         return IngestQueueRow(
             job_id=job.job_id,
-            glyph=_GLYPH_DONE,
+            glyph=glyph,
             line=line,
             can_open=job.media_id is not None,
             can_retry=False,
@@ -1043,6 +1060,7 @@ def _batch_outcome_parts(members: "Sequence[LibraryIngestJob]") -> list[str]:
     """
     tallies: dict[str, int] = {}
     active = 0
+    matched = 0
     for job in members:
         if job.state in (
             IngestJobState.QUEUED,
@@ -1050,6 +1068,11 @@ def _batch_outcome_parts(members: "Sequence[LibraryIngestJob]") -> list[str]:
             IngestJobState.WRITING,
         ):
             active += 1
+        elif job.state == IngestJobState.DONE and str(
+            (job.progress or {}).get("message", "")
+        ).startswith(INGEST_DUPLICATE_PROGRESS_PREFIX):
+            # (task-2231) "matched" is reported, not folded into "done".
+            matched += 1
         else:
             tallies[job.state.value] = tallies.get(job.state.value, 0) + 1
     parts = [
@@ -1057,6 +1080,8 @@ def _batch_outcome_parts(members: "Sequence[LibraryIngestJob]") -> list[str]:
         for state in _COUNTS_LINE_ORDER
         if tallies.get(state.value)
     ]
+    if matched:
+        parts.append(f"{matched} matched")
     if active:
         parts.append(f"{active} running")
     return parts
@@ -1470,7 +1495,14 @@ def build_library_ingest_state(
         # (task-2223 ruling) Zero imports + ≥1 predicted match keeps Start
         # ENABLED (the dedup probe is capped best-effort, never a blocker)
         # but consent becomes informed: say what starting will actually do.
-        if will_import == 0 and will_match and not will_fail:
+        # (task-2231) "Everything here" must be true: only when every
+        # importable file is a predicted match and nothing else is staged.
+        if (
+            will_import == 0
+            and will_match
+            and not will_fail
+            and not will_skip
+        ):
             start_quiet_line = (
                 "Everything here appears to already be in your Library — "
                 "starting will re-check and match, not re-import."

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6083,7 +6083,9 @@ class LibraryScreen(BaseAppScreen):
                 if imported > 0:
                     parts.append(f"{imported} imported")
                 if matched > 0:
-                    parts.append(f"{matched} already in Library")
+                    # (task-2231) The forecast says "will match"; the
+                    # toast answers in the same word.
+                    parts.append(f"{matched} matched")
                 if skipped > 0:
                     parts.append(f"{skipped} skipped")
                 if failed > 0:


### PR DESCRIPTION
## Summary

Second of two PRs closing round 7. Theme from the critique: **the pre-commit surface makes promises the post-commit surface won't honour.**

- **Vocabulary reconciliation.** The forecast promises `1 will import · 1 will match · 2 will skip`; the receipt used to answer `2 done · 2 skipped` — 'match' folded silently into 'done', and the two `✓ done` rows were byte-identical, so only the sub-line distinguished a fresh import from a dedup match. A match now renders **`≡ matched · <name>`** (own glyph AND word), is split out of 'done' in group headers and the latest-run line, and the completion toast reads **'N matched'**. The forecast's three words are now the receipt's three words.
- **Consent scope.** 'Everything here appears to already be in your Library' additionally requires zero predicted skips — it used to claim 'everything' for a selection that also contained unsupported files.
- **Retry feedback.** Three clicks on a failed row produced zero visible change at the flow's highest-anxiety moment. `requeue` always created a new QUEUED job with an incremented count, but the in-flight rows never displayed it. Queued/parsing/writing rows now carry the attempt marker, and the suffix reads **'· attempt N'** (N = retry_count + 1) on every row state — unambiguous mid-flight and reads as progress.

## Tests
300 core + 56 shell-subset green; 29,815 collect clean. New: matched-vocabulary test (row glyph + group header split), attempt-marker-on-active-rows test (all three in-flight states + a first attempt showing none), consent-scope test (partial vs total match). Live-verified: forecast '1 will match' + consent line → `≡ matched · copy_of_report.txt` → 'Latest run: 1 matched'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the ingest forecast and receipt vocabulary and makes retry attempts visible in Library import (task-2231).

Dedup matches now render as "≡ matched" and are counted as "matched" in rows, group headers, the top queue tally, and the completion toast; queued/parsing/writing rows show "· attempt N" as the trailing suffix (after any detected type); and the "Everything here…" consent line only appears when every importable file is predicted to match (no unsupported files).

<sup>Written for commit cc32bff00dd13518e93e37af4f860798f160e0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

