### PR TITLE
docs(lessons): record the Library ingest arc's recurring traps

### DIFF
--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -162,6 +162,11 @@ A click computed at 185 "inside New Source" actually lands on Filters. The
 error grows left-to-right, so the further right a control sits, the more
 confidently you will click the wrong one.
 
+`awk index()` is not the only source: `grep -bo` and `wc -c` are byte counters too,
+and a 2026-08-03 Library ingest round re-derived this same bug through them —
+mis-clicking a Clear button by ~12 columns and filing it as "dead to mouse", then
+spending a diagnosis round proving the button was fine.
+
 **What to do.** Compute the column by **character** position, not bytes:
 
 ```python
@@ -340,3 +345,56 @@ pass, before the scratch profile is ever launched; treat the scratch `config.tom
 something the app WILL rewrite on boot and diff it AFTER first launch rather than
 trusting the hand-authored version; and set the provider via `[API] default_api`, not
 `[llm_api_settings] default_api_endpoint`.
+
+---
+
+## A control that moves when the form changes produces phantom "dead click" bugs (2026-08-04)
+
+**What happened.** Two consecutive Library ingest critiques reported an intermittent
+**dead Start button**: a click at the commit moment that produced no job, no toast, and
+no queue row, while the identical click worked moments later. It was filed as a
+suspected event-handling defect and cost a round of investigation plus a regression
+test that could never fail, because the harness reproduces nothing.
+
+The mechanism turned out to be geometric. Typing a valid path replaces the gate line
+("Enter a file path to start.") with a forecast line and a commit summary — **the Start
+button moves down three rows**. A driver that reads the button's coordinates, types a
+path, and then clicks is clicking where the button *was*. The evidence arm hit the same
+trap in its own probe run, re-located the button in a fresh capture, and the first
+click submitted in 0.18s.
+
+**What to do.** Re-locate every control **in the same capture you click from**, never
+from one taken before the last state-changing keystroke:
+
+```bash
+ROW=$(tmux -L "$SOCK" capture-pane -p | grep -n "Start ingest" | head -1 | cut -d: -f1)
+COL=$(tmux -L "$SOCK" capture-pane -p | sed -n "${ROW}p" \
+      | python3 -c "import sys; print(sys.stdin.readline().find('Start ingest')+5)")
+```
+
+And treat "the same click works sometimes" as a **layout-shift** signature, not a
+hit-region defect — the two look identical from outside and only one of them is real.
+
+---
+
+## Critique scores from different agent instances are not like-for-like (2026-08-04)
+
+**What happened.** Seven rounds of dual-agent design critique on one surface scored
+21 → 24 → 29 → 25 → 26 → 31 → 22 out of 40. Read as a time series, round 7 looks like a
+nine-point collapse immediately after four approved improvements shipped. It was the
+opposite: the round-7 reviewer drove paths no previous round had touched (typo paths,
+404 URLs, Retry behaviour, measured WCAG contrast, cross-run counter reconciliation)
+and graded harder — while the same round's **mechanical arm ran 14 probes against every
+shipped behaviour and all 14 passed**, the first fully clean run of the arc. The dips at
+rounds 4 and 7 were both new coverage; the two genuine regressions in the whole arc were
+each caught by mechanical probes, not by the score.
+
+**What to do.** Treat the score as a **prompt for reading the findings**, never as the
+finding. When it moves, say why in the same breath, and cite the comparable signal:
+
+- **Comparable:** deterministic probes over fixed behaviours, pass/fail, same script.
+- **Not comparable:** a judgement score across agent instances, prompts, or coverage depth.
+
+Keep a mechanical arm in every round precisely so there is something to compare when the
+judgement number swings, and never report a delta without stating whether coverage
+changed underneath it.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -614,3 +614,86 @@ slow. And when a threaded pipeline works in tests but not live, dump the worker'
 (`sys._current_frames()[thread.ident]`) once a second before theorizing — it answered in
 one run what three cheaper probes could only narrow. Bonus rig: macOS `say` through the
 speakers + the real microphone is a full live STT test harness needing no human.
+
+---
+
+## In a render-from-state UI, the in-place updater must own EVERY conditional (2026-08-04)
+
+**What happened.** Four separate times in the Library ingest arc (tasks 2100, 2130,
+2140, 2230), a canvas element was rendered by a `compose()`-time conditional while the
+hot paths deliberately skip recompose (job ticks and text-input edits must preserve
+focus, cursor position, and scroll). Each time the element was correct on first render
+and wrong forever after:
+
+- "Recent ingests" expanded into an empty unlabeled shell after a clear.
+- The commit-summary line rendered for PDF selections and **never** for plain text —
+  a PDF adds an options panel, which forces the structural recompose that happens to
+  mount the line; a text-only pre-flight applies through the non-structural path,
+  which mounts nothing. It also went stale after Clear ("0 will import · 1 will match"
+  above an empty field).
+- The invalid-option field marker was applied at compose time only, so it never
+  toggled on the edit path it existed to serve — the field stayed marked after
+  becoming valid and never got marked after becoming invalid, while the gate line
+  instructed the user to "fix the highlighted options".
+
+**Why tests kept missing it.** The harness passes when it *re-queries* after the
+update, because a fresh query returns whatever was composed most recently. The failure
+only appears when you assert that the widget you held is the widget still mounted.
+
+**What to do.** Two rules, both cheap:
+
+1. Anything the in-place updater does not explicitly own must be **always mounted and
+   `display`-managed**, never conditionally composed. If a canvas-level element can
+   appear and disappear, the updater sets its content *and* its visibility.
+2. Pin it with **object identity**, not a re-query:
+
+```python
+before = screen.query_one("#library-ingest-start", Button)
+...trigger the hot path...
+assert screen.query_one("#library-ingest-start", Button) is before   # no recompose
+```
+
+A re-query test agrees with the bug; `is` does not.
+
+---
+
+## A new distinction must be learned by every surface that aggregates the old one (2026-08-04)
+
+**What happened.** TASK-2231 introduced "matched" as an outcome distinct from "done"
+(a dedup match is not a fresh import). The row got its own glyph and word, and the
+change looked complete. Review found two surfaces still folding matched into done:
+the per-batch group header, and the top-level queue tally — which produced two
+contradictory summaries on the same screen ("2 done" directly above "1 done ·
+1 matched"). The completion toast was a third surface, caught only because it was
+grepped for by hand. TASK-2220 had the same shape one PR earlier: adding a `SKIPPED`
+job state updated the row and the tally but missed `queue_show_clear_finished`, which
+still tested `state in (DONE, FAILED)` — so a queue holding only skipped rows could
+not be cleared at all.
+
+**What to do.** When you add a state, an outcome, or any new bucket, grep for **every
+predicate that enumerates the old set** and every surface that counts it, then list
+them before writing code. In this feature that list was: the row builder, the group
+header, the queue tally, the completion toast, the "show clear" gate, the "finished"
+count, the ledger snapshot, and the durable-history filter — eight places, and the
+first attempt updated three.
+
+Related: a fixture that omits the interesting axis hides the bug. My own attempt-marker
+test used jobs with no `detected_type`, so it passed while every *typed* row rendered
+the marker in the wrong position.
+
+---
+
+## An error fallback that returns a valid-looking value becomes a confident lie (2026-08-04)
+
+**What happened.** `_safe_size(path)` returned `0` on `OSError` — a reasonable "I don't
+know" for summing sizes. TASK-2160 then added an empty-file classifier that read
+`size == 0` as "this file is empty and will fail", and surfaced it as user-facing
+copy: *"1 empty file will fail — notes.txt is 0 B."* For an unreadable or unstatable
+file, that sentence is a measurement nobody took, and the file was pulled out of its
+type group on the strength of it.
+
+**What to do.** A sentinel is safe for aggregation and unsafe for classification. When
+a new consumer needs to *distinguish* failure from a real value, give it a probe that
+says so — `_statted_size()` returning `None` on `OSError` — and leave the summing
+caller on the old fallback. Before reusing any helper whose docstring says "or `0` on
+error", ask what your caller will conclude from that zero.


### PR DESCRIPTION
## Summary

Writes the traps from the seven-round Library ingest critique arc into the repo's lessons docs, following their house rule that **every entry states the incident that produced it**.

### `lessons-testing-evidence.md`
- **In a render-from-state UI, the in-place updater must own EVERY conditional.** Four occurrences across tasks 2100/2130/2140/2230 — an element correct on first render and wrong forever after, because the hot paths deliberately skip recompose. Includes why the harness kept passing (a re-query returns whatever was composed most recently) and the identity-pin that actually catches it.
- **A new distinction must be learned by every surface that aggregates the old one.** Adding `SKIPPED` and `matched` each left surfaces folding the new bucket into the old one — including two contradictory summaries on the same screen. Lists the eight places this feature counts outcomes; the first attempt updated three.
- **An error fallback that returns a valid-looking value becomes a confident lie.** `_safe_size() -> 0 on OSError` was safe for summing and unsafe the moment a classifier read `size == 0` as "this file is empty", printing a measurement nobody took.

### `lessons-live-verification.md`
- **A control that moves when the form changes produces phantom "dead click" bugs.** The Start button shifts three rows when a valid path is typed; two rounds filed the resulting misses as an event-handling defect. Includes the same-capture re-location snippet and the signature that distinguishes layout shift from a real hit-region bug.
- **Critique scores from different agent instances are not like-for-like.** 21 → 24 → 29 → 25 → 26 → 31 → 22 across seven rounds, where the largest dip coincided with the first fully clean mechanical run. States what is comparable (deterministic probes) and what is not (judgement scores across instances/coverage).
- **Augmented** the existing `awk index()` byte-offset entry: `grep -bo` and `wc -c` are the same trap, re-derived at the cost of one diagnosis round.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incident-backed lessons from the Library ingest critique to `backlog/docs/lessons-testing-evidence.md` and `backlog/docs/lessons-live-verification.md` to prevent repeat regressions. No code changes.

- **Docs**
  - Render-from-state UIs: in-place updater owns all conditionals; pin tests with object identity.
  - New outcomes/states: update every aggregating surface (rows, headers, tallies, toasts, gates).
  - Error fallbacks: don’t use 0 as a sentinel for classifiers; return None on failure when needed.
  - Live verification: re-locate controls in the same capture; cross-agent scores aren’t comparable; `grep -bo`/`wc -c` are byte counters like `awk index()`.

<sup>Written for commit 30520bda82300d26fc668f7b51ac3f6d696708fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

