### PR TITLE
feat(watchlists): targeted in-place refresh from background loaders (task-2200)

### DIFF
--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from textual.widgets import Button, DataTable, Input, Select, TextArea
+from textual.widgets import Button, DataTable, Input, Select, Static, TextArea
 
 from Tests.UI.app_factory import _build_test_app
 from tldw_chatbook.Subscriptions.noise_defaults import default_ignore_selectors_text
@@ -2673,4 +2673,164 @@ async def test_a_surface_refresh_requested_mid_drain_is_served_by_the_same_drain
         assert screen.query_one("#wl-tree"), (
             "the rail must come back populated, not stripped by an "
             "interrupted remove/mount pair"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_background_tree_reload_repaints_the_artifacts_scope_note():
+    """Review wave I1: a rename must reach EVERY surface that names the scope.
+
+    `ArtifactsPane.scope_label` resolves the scoped watchlist's display name
+    from `_tree_watchlists` (`_briefing_scope_label` ->
+    `_watchlist_display_name`), so it is tree data like the rail, the FEEDS
+    heading and the Inspector breadcrumb -- but it lives on an ITEMS-region
+    pane, which the first pass of TASK-2200 left alone wholesale. The result
+    was two surfaces on one screen naming the same watchlist differently until
+    the user changed tab or scope.
+
+    Drives exactly what `_rename_watchlist_flow` does once its dialog returns:
+    `service.rename(...)` then `_load_tree_data()`.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
+    from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
+        TreeScope,
+        TreeScopeChanged,
+    )
+
+    app = _build_test_app()
+    service = app.watchlist_bundle_service
+    watchlist = service.create("Mroning AI Brief")
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+
+        screen.post_message(
+            TreeScopeChanged(TreeScope(kind="watchlist", watchlist_id=watchlist["id"]))
+        )
+        await pilot.pause()
+        screen.active_section = "artifacts"
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if screen.query("#artifacts-scope-note"):
+                break
+
+        note = screen.query_one("#artifacts-scope-note", Static)
+        assert "Mroning AI Brief" in str(note.renderable), (
+            f"precondition: the pane names the scoped watchlist; it renders "
+            f"{str(note.renderable)!r}"
+        )
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+
+        service.rename(watchlist["id"], "Morning AI Brief")
+        screen._load_tree_data()
+        for _ in range(300):
+            await pilot.pause(0.01)
+            note = screen.query_one("#artifacts-scope-note", Static)
+            if "Morning AI Brief" in str(note.renderable):
+                break
+
+        note = screen.query_one("#artifacts-scope-note", Static)
+        assert "Morning AI Brief" in str(note.renderable), (
+            f"the Artifacts pane still names the pre-rename watchlist: "
+            f"{str(note.renderable)!r}"
+        )
+        assert screen.query_one("#watchlists-artifacts-pane", ArtifactsPane) is pane, (
+            "the scope-label push must patch the mounted pane, not have the "
+            "screen rebuild the region around it"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_surface_refresh_start_does_not_wedge_the_queue():
+    """Review wave M1, the sibling of `test_a_failed_tree_write_start_...`.
+
+    `_surface_refresh_draining` is lowered only by `_drain_surface_refresh`'s
+    `finally`, which never runs if `run_worker` raises synchronously. Arming
+    before scheduling would leave the flag stuck True for the life of the
+    screen: every later request would queue and return, and the rail, FEEDS
+    and centre header would silently stop following every background loader.
+    """
+    import inspect
+
+    app = _build_test_app()
+    service = app.watchlist_bundle_service
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+
+        exploded: list[Any] = []
+        real_run_worker = screen.run_worker
+
+        def _exploding_run_worker(work, **kwargs):
+            if kwargs.get("group") == "wc_surface_refresh" and not exploded:
+                exploded.append(work)
+                raise RuntimeError("worker could not be scheduled")
+            return real_run_worker(work, **kwargs)
+
+        screen.run_worker = _exploding_run_worker
+        screen._request_surface_refresh(screen._SURFACE_HEADER)
+        await pilot.pause()
+
+        assert exploded, "precondition: scheduling really did raise"
+        assert screen._surface_refresh_draining is False, (
+            "a drain that never started must leave the guard down, or every "
+            "later background refresh is silently swallowed"
+        )
+        assert inspect.getcoroutinestate(exploded[0]) == "CORO_CLOSED", (
+            "the un-awaited drain coroutine must be closed, not left to leak "
+            "a RuntimeWarning at collection time"
+        )
+
+        # ...and the next request really drains.
+        created = service.create("Morning AI Brief")
+        node_id = f"#wl-tree-node-watchlist-{created['id']}"
+        screen._load_tree_data()
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if screen.query(node_id):
+                break
+        assert screen.query(node_id), (
+            "the queue stayed wedged: a later background loader never reached "
+            "the rail"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_raising_console_follow_poll_does_not_take_the_app_down():
+    """Review wave M2: every step of the drain loop must be non-fatal.
+
+    `run_worker` defaults to `exit_on_error=True`, so an exception escaping
+    the drainer reaches `App._handle_exception` and the app goes down. The
+    Console-follow poll was the one step outside `_rebuild_surface`'s
+    `except Exception`.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+
+        polls: list[int] = []
+
+        def _exploding_drift() -> bool:
+            polls.append(1)
+            raise RuntimeError("the active-work adapter exploded")
+
+        screen._resolve_console_follow_drift = _exploding_drift
+        screen._request_surface_refresh(screen._SURFACE_INSPECTOR)
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if polls and not screen._surface_refresh_draining:
+                break
+
+        assert polls, "precondition: the drain really did reach the poll"
+        assert screen._surface_refresh_draining is False, (
+            "the drainer must clear its flag even when a step raises"
+        )
+        assert app.is_running, "a raising poll must not take the app down"
+        assert screen.query("#watchlists-follow-in-console"), (
+            "the Inspector must be left standing, not half-swapped"
         )

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -2961,3 +2961,144 @@ async def test_loader_results_landing_before_textual_flips_is_mounted_still_pain
             )
         finally:
             screen._is_mounted = True
+
+
+@pytest.mark.asyncio
+async def test_section_loader_results_landing_in_the_mount_window_still_paint():
+    """Re-review L1: the six section loaders share the `is_mounted` trap.
+
+    `on_mount` starts exactly one of them (`_load_active_section_data`), and
+    the section it starts is attacker-chosen in the sense that matters here:
+    `apply_navigation_context` sets `active_section` on an UNMOUNTED screen
+    (`app.py` calls it before `switch_screen`), which is how the "open this run
+    in Watchlists" deep link works. On a cold database that loader lands inside
+    the mount window -- `is_mounted` False, every widget present -- so its
+    `if self.is_mounted:` push was dropped and the section's table rendered
+    blank until the user clicked something. The full-screen recompose this task
+    removed used to cover it.
+
+    Set up through the real deep-link entry point (`apply_navigation_context`
+    on the unmounted screen), then reconstructs the mount window for each of
+    the six sections in turn -- the guard is identical at all six sites, and a
+    test that only covered the deep-link's own section would let the other five
+    rot.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
+    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.overview_pane import OverviewPane  # noqa: F401
+    from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import (
+        TreeScope,
+        TreeScopeChanged,
+    )
+
+    app = _build_test_app()
+    watchlist = app.watchlist_bundle_service.create("Morning AI Brief")
+    host = DestinationHarness(app, "watchlists_collections")
+
+    # THE DEEP LINK: applied while the screen is unmounted, exactly as
+    # `app.py` does before `switch_screen`.
+    host.context_screen.apply_navigation_context({"section": "runs"})
+    assert host.context_screen.active_section == "runs", (
+        "precondition: the deep link really did set the section pre-mount"
+    )
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+
+        screen._controller.list_sources = AsyncMock(
+            return_value=[{"id": "s1", "name": "Feed One", "source_type": "rss"}]
+        )
+        screen._controller.list_runs = AsyncMock(
+            return_value=[{"id": "r1", "source_title": "Feed One", "status": "ok"}]
+        )
+        screen._controller.list_items = AsyncMock(
+            return_value=[{"id": "i1", "title": "Item One", "source_name": "Feed One"}]
+        )
+        screen._controller.list_alert_rules = AsyncMock(
+            return_value=[{"id": "a1", "name": "Rule One", "condition_type": "no_items"}]
+        )
+        screen._notifications_controller.load_rows = AsyncMock(
+            return_value=[
+                {
+                    "id": 7,
+                    "title": "Research complete",
+                    "message": "The synthesis is ready.",
+                    "category": "research",
+                    "severity": "info",
+                    "is_read": False,
+                }
+            ]
+        )
+
+        cases = [
+            ("runs", "#watchlists-runs-pane", "runs", lambda: screen._load_runs()),
+            ("sources", "#watchlists-sources-pane", "sources", lambda: screen._load_sources()),
+            ("items", "#watchlists-items-pane", "items", lambda: screen._load_items()),
+            ("rules", "#watchlists-rules-pane", "rules", lambda: screen._load_rules()),
+            (
+                "notifications",
+                "#watchlists-notifications-pane",
+                "notifications",
+                lambda: screen._load_notifications(),
+            ),
+        ]
+
+        for section, selector, attribute, loader in cases:
+            screen.active_section = section
+            pane = None
+            for _ in range(300):
+                await pilot.pause(0.01)
+                found = screen.query(selector)
+                if found:
+                    pane = found.first()
+                    break
+            assert pane is not None, f"precondition: the {section} pane mounted"
+
+            # Rewind the pane to "nothing loaded", so only an in-window push
+            # can satisfy the assertion below.
+            setattr(pane, attribute, [])
+            await pilot.pause()
+            assert not getattr(pane, attribute), f"precondition: {section} rewound"
+
+            screen._is_mounted = False
+            try:
+                await loader()
+                assert getattr(pane, attribute), (
+                    f"the {section} loader's rows never reached the mounted pane: "
+                    f"they landed while Textual still reported is_mounted=False, "
+                    f"and nothing re-pushes them"
+                )
+            finally:
+                screen._is_mounted = True
+
+        # Artifacts: the same guard, but the push is a bundle of pane state
+        # rather than a row list, so it is asserted on its own terms.
+        screen.post_message(
+            TreeScopeChanged(TreeScope(kind="watchlist", watchlist_id=watchlist["id"]))
+        )
+        await pilot.pause()
+        screen.active_section = "artifacts"
+        artifacts = None
+        for _ in range(300):
+            await pilot.pause(0.01)
+            found = screen.query("#watchlists-artifacts-pane")
+            if found:
+                artifacts = found.first(ArtifactsPane)
+                break
+        assert artifacts is not None, "precondition: the artifacts pane mounted"
+
+        artifacts.scope_label = ""
+        artifacts.can_generate = False
+        await pilot.pause()
+
+        screen._is_mounted = False
+        try:
+            await screen._load_briefings()
+            assert artifacts.scope_label, (
+                "the briefings loader never repainted the mounted Artifacts pane "
+                "from inside the mount window"
+            )
+            assert artifacts.can_generate is True
+        finally:
+            screen._is_mounted = True

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -3102,3 +3102,65 @@ async def test_section_loader_results_landing_in_the_mount_window_still_paint():
             assert artifacts.can_generate is True
         finally:
             screen._is_mounted = True
+
+
+@pytest.mark.asyncio
+async def test_a_deep_linked_run_seeds_the_inspector_from_the_mount_window():
+    """Qodo, PR #1331: the selection watchers are in the mount-window class too.
+
+    The deep link that carries a run id is the reachable path.
+    `apply_navigation_context` sets `active_section = "runs"` **and**
+    `_pending_navigation_run_id` on an unmounted screen; `on_mount` then starts
+    `_load_runs`, which on a cold database finishes inside the mount window and
+    calls `_select_entity(requested_run)` (`_load_runs`'s `had_pending_target`
+    branch). That writes `selected_entity`, `watch_selected_entity` fires -- and
+    an `is_mounted` guard drops the push while the Inspector is mounted and
+    queryable.
+
+    Nothing recovers it afterwards: `_build_inspector_pane` re-seeds only on a
+    REBUILD, and the one rebuild this screen still schedules for the right rail
+    is gated on `_resolve_console_follow_drift()`, which is False on a normal
+    cold start. So the user follows a run deep link and the Inspector shows
+    "Nothing to inspect yet." over a run the screen believes is selected.
+    """
+    run = {"id": "r1", "source_title": "Feed One", "status": "ok", "backend": "local"}
+    app = _build_test_app()
+    screen = WatchlistsCollectionsScreen(app)
+    screen._controller.list_runs = AsyncMock(return_value=[run])
+    screen.apply_navigation_context({"section": "runs", "run_id": "r1"})
+    assert screen.active_section == "runs"
+    assert screen._pending_navigation_run_id == "r1", (
+        "precondition: the deep link armed a run target pre-mount"
+    )
+
+    host = WatchlistsContextHarness(screen)
+    async with host.run_test(size=(180, 50)) as pilot:
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if screen.query("#watchlists-runs-pane"):
+                break
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+
+        # Rewind to the instant `on_mount` fired: the deep-link target armed,
+        # nothing selected yet, the Inspector mounted and empty.
+        screen._pending_navigation_run_id = "r1"
+        screen._pending_navigation_run_backend = "local"
+        screen.selected_entity = None
+        screen.selected_run = None
+        inspector.selected_entity = None
+        await pilot.pause()
+        assert inspector.selected_entity is None, "precondition: Inspector rewound"
+
+        screen._is_mounted = False
+        try:
+            await screen._load_runs()
+            assert screen.selected_entity is not None, (
+                "precondition: the deep link really did resolve to a run"
+            )
+            assert inspector.selected_entity == screen.selected_entity, (
+                "the deep-linked run never reached the mounted Inspector: the "
+                "selection landed while Textual still reported is_mounted=False "
+                "and nothing re-seeds it"
+            )
+        finally:
+            screen._is_mounted = True

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -1197,18 +1197,18 @@ async def test_saving_a_rule_edit_does_not_leave_a_phantom_form_open():
         }
         screen._controller.list_alert_rules = AsyncMock(return_value=[rule])
         # A fast-completing mocked save is exactly the case that lets the
-        # screen's overview-data-triggered recompose win the race against
-        # RulesPane's own RuleFormVisibilityChanged message still bubbling
-        # up to the screen (see `handle_save_rule_requested`).
+        # screen's overview-data refresh win the race against RulesPane's own
+        # RuleFormVisibilityChanged message still bubbling up to the screen
+        # (see `handle_save_rule_requested`).
         screen._controller.save_alert_rule = AsyncMock(return_value=dict(rule))
-        # `overview_data` is a `recompose=True` reactive that only rebuilds
-        # the screen when the *value* actually changes; the real
-        # `get_overview_data()` return value is otherwise byte-for-byte
-        # identical before and after this mocked save (nothing in the
-        # backing store actually changed), which would mask the race this
-        # test targets. Returning a distinct dict on every call reproduces
-        # the real-world case where a save legitimately changes a count
-        # (e.g. `active_alert_rules`), which is what triggers the recompose.
+        # A distinct payload on every call, so `overview_data` really changes
+        # value and its watcher really fires: the real `get_overview_data()`
+        # return is otherwise byte-for-byte identical before and after this
+        # mocked save (nothing in the backing store actually changed), which
+        # would mask the interleaving this test targets. TASK-2200 took
+        # `recompose=True` off that reactive -- so this now also pins that the
+        # background refresh no longer rebuilds the pane at all (see the
+        # identity assertion below), which is the whole point of that change.
         overview_call_count = itertools.count(1)
 
         async def _fake_overview_data(**_kwargs: Any) -> dict[str, Any]:
@@ -1237,22 +1237,40 @@ async def test_saving_a_rule_edit_does_not_leave_a_phantom_form_open():
 
         screen.query_one("#rules-create-submit", Button).press()
 
-        # Drive enough ticks for the save worker to finish and its
-        # overview-data refresh to trigger the screen-level recompose.
-        rebuilt_rules_pane = rules_pane
+        # Drive enough ticks for the save worker to finish, its overview-data
+        # refresh to land, and the pane's own form-close to settle.
+        settled_rules_pane = rules_pane
         for _ in range(30):
             await asyncio.sleep(0.02)
             await pilot.pause()
-            rebuilt_rules_pane = screen.query_one("#watchlists-rules-pane", RulesPane)
-            if rebuilt_rules_pane is not rules_pane:
+            settled_rules_pane = screen.query_one("#watchlists-rules-pane", RulesPane)
+            if not settled_rules_pane.show_rule_form and not screen.query(
+                "#rules-create-name"
+            ):
                 break
 
-        assert rebuilt_rules_pane is not rules_pane, (
-            "the recompose triggered by the save should have rebuilt the pane"
+        assert screen._controller.save_alert_rule.await_count == 1, (
+            "the precondition: pressing Save really did reach the controller"
         )
-        assert rebuilt_rules_pane.show_rule_form is False, (
+        assert next(overview_call_count) > 1, (
+            "the precondition: the save's `_refresh_overview_data()` really "
+            "did run, so `overview_data` really did change value"
+        )
+        # TASK-2200: the background overview refresh must NOT rebuild the
+        # pane. This used to assert the opposite (`is not rules_pane`) and
+        # relied on that rebuild to close the form; a pane rebuilt out from
+        # under an in-flight pane recompose is the destroyer TASK-1960
+        # confirmed.
+        assert settled_rules_pane is rules_pane, (
+            "a background overview refresh must not replace the mounted pane"
+        )
+        assert settled_rules_pane.show_rule_form is False, (
             "the rule edit form must be closed after a successful save, not "
             "reopened pre-filled with the just-submitted rule"
+        )
+        assert settled_rules_pane.query("#rules-table"), (
+            "the pane must still have its table -- a form that 'closed' by "
+            "leaving an empty pane behind is the masked defect, not a fix"
         )
         assert not screen.query("#rules-create-name"), (
             "no rule edit form fields should remain in the DOM after a "
@@ -2346,4 +2364,313 @@ async def test_focus_leaving_the_header_for_a_non_region_widget_clears_the_flag(
         assert not screen._focus_in_centre_header, (
             "focus outside the status header must clear the sentinel; a stale "
             "True would wrongly refuse a later z/Z"
+        )
+
+
+# --- TASK-2200: background loaders patch in place, never recompose the screen -
+#
+# `_apply_local_wc_snapshot`, `_load_tree_data` and the `overview_data` reactive
+# all used to end in a screen-level `refresh(recompose=True)`, which tore down
+# and rebuilt every region -- including whichever detail pane was mid-recompose
+# of its own. That is the confirmed destroyer behind TASK-1960's crash class.
+# Each test below drives one of the three loaders, asserts the surface it feeds
+# really did change, and asserts the ITEMS pane was NOT replaced while it did.
+
+
+async def _sources_tab(pilot, host):
+    """Put the screen on the Sources tab with its pane mounted."""
+    screen = host.screen_stack[-1]
+    screen.active_section = "sources"
+    for _ in range(200):
+        await pilot.pause(0.01)
+        if screen.query("#watchlists-sources-pane"):
+            break
+    return screen, screen.query_one("#watchlists-sources-pane", SourcesPane)
+
+
+@pytest.mark.asyncio
+async def test_a_background_snapshot_lands_in_place_without_rebuilding_the_pane():
+    """AC#1/AC#2: the snapshot's four surfaces update, the detail pane does not.
+
+    The snapshot feeds the loading/error/empty/summary marker (rendered in the
+    centre header off the Read tab), the Inspector's `State:` line, and the
+    Console attach button's `disabled`/tooltip pair. Every one of those used to
+    be repainted only as a side effect of rebuilding the entire screen.
+    """
+    app = _build_test_app()
+    # A real source, so the pre-change state is "loaded, populated, attach
+    # ENABLED" -- otherwise `disabled` is True before and after and proves
+    # nothing.
+    app.watchlist_bundle_service._db.add_subscription(
+        name="ArXiv", type="rss", source="https://a.example/feed"
+    )
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen, pane = await _sources_tab(pilot, host)
+
+        attach = screen.query_one("#wc-attach-to-console", Button)
+        for _ in range(200):
+            await pilot.pause(0.01)
+            if screen._wc_loaded and not attach.disabled:
+                break
+        assert not attach.disabled, (
+            "precondition: the real snapshot resolved populated, so Stage is "
+            "armed before the failing snapshot below lands"
+        )
+        assert not screen.query("#wc-service-error")
+
+        screen._apply_local_wc_snapshot((), 0, True, "Watchlists services unavailable; retry Watchlists later.", None)
+        for _ in range(200):
+            await pilot.pause(0.01)
+            if screen.query("#wc-service-error"):
+                break
+
+        assert screen.query("#wc-service-error"), (
+            "the snapshot's own error marker must reach the centre header "
+            "without a screen recompose"
+        )
+        assert str(screen.query_one("#watchlists-state-summary").renderable) == (
+            "State: unavailable"
+        ), "the Inspector's State line must follow the snapshot"
+        attach = screen.query_one("#wc-attach-to-console", Button)
+        assert attach.disabled is True, (
+            "Stage must be disarmed once the snapshot reports the service is "
+            "unavailable"
+        )
+        assert "Watchlists services are unavailable" in str(attach.tooltip)
+        assert screen.query_one("#watchlists-sources-pane", SourcesPane) is pane, (
+            "a background snapshot must not replace the mounted detail pane"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_background_tree_reload_lands_in_the_rail_without_rebuilding_the_pane():
+    """AC#1/AC#2: newly created watchlists appear in the rail in place."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen, pane = await _sources_tab(pilot, host)
+
+        created = app.watchlist_bundle_service.create("Morning AI Brief")
+        node_id = f"#wl-tree-node-watchlist-{created['id']}"
+        assert not screen.query(node_id), (
+            "precondition: the rail has not heard about the new watchlist yet"
+        )
+
+        screen._load_tree_data()
+        for _ in range(200):
+            await pilot.pause(0.01)
+            if screen.query(node_id):
+                break
+
+        assert screen.query(node_id), (
+            "a tree reload must repaint the rail without a screen recompose"
+        )
+        assert screen.query_one("#watchlists-sources-pane", SourcesPane) is pane, (
+            "a background tree reload must not replace the mounted detail pane"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_background_overview_refresh_repaints_the_inspector_in_place():
+    """AC#1/AC#2: `overview_data`'s two Inspector counts follow the payload.
+
+    `overview_data` was `reactive({}, recompose=True)`, so these two lines were
+    only ever repainted by rebuilding the whole screen. `watch_overview_data`
+    now updates them directly; the Inspector instance must survive.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen, pane = await _sources_tab(pilot, host)
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+
+        async def _fake_overview_data(**_kwargs: Any) -> dict[str, Any]:
+            return {
+                "total_sources": 3,
+                "active_sources": 3,
+                "sources_in_error": 0,
+                "total_items": 9,
+                "new_items": 2,
+                "latest_run_status": "completed",
+                "failed_runs": [],
+                "active_alert_rules": 7,
+            }
+
+        screen._controller.get_overview_data = _fake_overview_data
+        screen._refresh_overview_data()
+        for _ in range(200):
+            await pilot.pause(0.01)
+            if "7" in str(screen.query_one("#watchlists-alerts-summary").renderable):
+                break
+
+        assert str(screen.query_one("#watchlists-alerts-summary").renderable) == (
+            "Alert rules active: 7"
+        )
+        assert str(screen.query_one("#watchlists-latest-run-summary").renderable) == (
+            "Latest run status: completed"
+        )
+        assert screen.query_one("#watchlists-entity-inspector", InspectorPane) is (
+            inspector
+        ), "a background overview refresh must not replace the Inspector"
+        assert screen.query_one("#watchlists-sources-pane", SourcesPane) is pane, (
+            "a background overview refresh must not replace the detail pane"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_background_tree_reload_updates_the_first_run_copy_in_place():
+    """AC#2: TASK-998's watchlist-count-dependent first-run copy still follows.
+
+    `OverviewPane.watchlist_count` is the one thing the ITEMS region reads out
+    of `_load_tree_data`, and it decides which of two first-run paragraphs a
+    brand-new profile is shown ("create a watchlist" vs "your watchlists have
+    no sources yet"). The full-screen recompose used to carry it via
+    `_build_detail_pane`; the tree reload now pushes it into the live pane.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.overview_pane import OverviewPane
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        assert screen.active_section == "overview"
+
+        overview = None
+        for _ in range(300):
+            await pilot.pause(0.01)
+            overview = screen.query_one("#watchlists-overview-pane", OverviewPane)
+            if overview.query("#overview-first-run-body"):
+                break
+        body = str(overview.query_one("#overview-first-run-body").renderable)
+        assert "a watchlist is a folder of feeds" in body.lower(), (
+            f"precondition: a profile with no watchlists gets the 'make one' "
+            f"copy; it renders {body!r}"
+        )
+
+        app.watchlist_bundle_service.create("Morning AI Brief")
+        screen._load_tree_data()
+        for _ in range(300):
+            await pilot.pause(0.01)
+            overview = screen.query_one("#watchlists-overview-pane", OverviewPane)
+            if overview.watchlist_count:
+                break
+
+        assert overview.watchlist_count == 1, (
+            "the tree reload must push the new count into the live pane"
+        )
+        body = str(overview.query_one("#overview-first-run-body").renderable)
+        assert "no sources yet" in body.lower(), (
+            f"a user who already has a watchlist must be told their next step "
+            f"is a SOURCE; it renders {body!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_switching_backend_clears_the_mounted_panes_selection():
+    """AC#2: the backend switch's own state reset still reaches the pane.
+
+    `watch_runtime_backend` clears `selected_source`/`selected_run`/
+    `selected_notification` on the SCREEN, and until TASK-2200 the only thing
+    that carried those clears into the mounted pane was the full-screen
+    recompose its snapshot refresh triggered (`_build_detail_pane` re-seeds
+    every pane from exactly those attributes). Without an explicit push, the
+    Sources pane keeps its old selection -- so Preview / Check now stay armed
+    on a source from a backend the user just left.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        screen._controller.list_sources = AsyncMock(
+            return_value=[{"id": "s1", "name": "Feed One", "source_type": "rss"}]
+        )
+
+        screen.query_one("#wl-tab-sources", Button).press()
+        await pilot.pause()
+        await _wait_for_table_rows(pilot, "#sources-table", screen, 1)
+
+        pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+        pane.select_source_by_id("s1")
+        await pilot.pause()
+        assert pane.selected_source is not None, "precondition: a row is selected"
+
+        screen.runtime_backend = "server"
+        await pilot.pause(0.2)
+
+        assert screen.query_one("#watchlists-sources-pane", SourcesPane) is pane, (
+            "the backend switch must not rebuild the pane either"
+        )
+        assert pane.selected_source is None, (
+            "the mounted pane kept a selection the screen had already cleared"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_surface_refresh_requested_mid_drain_is_served_by_the_same_drainer():
+    """TASK-2200: record intent, drain serially, never cancel.
+
+    `refresh_region_content`/`refresh_header_content` are remove-then-mount
+    pairs with an `await` between the halves, so a worker cancelled in that
+    window (what `exclusive=True` does to its predecessor) leaves the region
+    stripped and never refilled. Three call sites now want those swaps, so the
+    screen queues surfaces and runs at most one drainer. This drives the exact
+    interleaving: a second request arrives WHILE the drainer is awaiting the
+    first swap, and must be picked up by that same drainer rather than
+    starting -- or cancelling -- anything.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+        WatchlistsWorkbench,
+    )
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        workbench = screen.query_one(WatchlistsWorkbench)
+
+        drains: list[int] = []
+        real_drain = screen._drain_surface_refresh
+
+        def _counting_drain():
+            drains.append(1)
+            return real_drain()
+
+        screen._drain_surface_refresh = _counting_drain
+
+        rebuilt: list[Region] = []
+        real_region = workbench.refresh_region_content
+
+        async def _tracking_region(region):
+            rebuilt.append(region)
+            if len(rebuilt) == 1:
+                # Lands while the drainer is inside its first swap.
+                screen._request_surface_refresh(screen._SURFACE_RAIL)
+            await real_region(region)
+
+        workbench.refresh_region_content = _tracking_region
+
+        screen._request_surface_refresh(screen._SURFACE_FEEDS)
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if Region.LEFT_RAIL in rebuilt and not screen._surface_refresh_draining:
+                break
+
+        assert Region.LEFT_RAIL in rebuilt, (
+            "a request made mid-drain was dropped -- the drainer stopped "
+            "without serving it"
+        )
+        assert drains == [1], (
+            f"exactly one drainer must run for a burst; started {len(drains)}"
+        )
+        assert not screen._surface_refresh_draining, "the drainer must clear its flag"
+        assert screen.query_one("#wl-tree"), (
+            "the rail must come back populated, not stripped by an "
+            "interrupted remove/mount pair"
         )

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -2834,3 +2834,130 @@ async def test_a_raising_console_follow_poll_does_not_take_the_app_down():
         assert screen.query("#watchlists-follow-in-console"), (
             "the Inspector must be left standing, not half-swapped"
         )
+
+
+@pytest.mark.asyncio
+async def test_loader_results_landing_before_textual_flips_is_mounted_still_paint():
+    """Live-verification wave: the in-place updates must not use `is_mounted`.
+
+    `Widget.is_mounted` returns `_is_mounted`, which `MessagePump._pre_process`
+    sets in its `finally` -- AFTER dispatching both `Compose` and `Mount`. So
+    for the whole of `on_mount`, and for anything `on_mount` starts that
+    finishes before that `finally` runs, `is_mounted` is False while the entire
+    subtree is already registered and queryable. On a cold local database the
+    Watchlists loaders finish inside exactly that window; instrumented on a real
+    terminal at 235x52:
+
+        OVERVIEW watcher is_mounted=False keys=[]  pane=0 inspector=0
+        ON_MOUNT         is_mounted=False wb=1 centre=1 status=1
+        SNAPSHOT applied is_mounted=False loaded=True wb=1 centre=1 status=1
+        OVERVIEW watcher is_mounted=False keys=[...] pane=1 inspector=1
+
+    Every update was dropped by an `is_mounted` guard and nothing re-requested
+    them: the screen sat on "Loading local Watchlists snapshot..." /
+    "Loading watchlist activity..." / "State: unavailable" for 100+ seconds
+    until an unrelated tab switch recomposed it.
+
+    `run_test`'s pilot settles the DOM before loader results are applied, so
+    the ordering cannot be raced for here. This RECONSTRUCTS the captured state
+    instead -- a live, fully-attached screen with `_is_mounted` forced back to
+    False -- the same technique TASK-1960 used for its own captured DOM state.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.overview_pane import OverviewPane
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if screen._wc_loaded and screen.query("#wc-empty-state"):
+                break
+        assert screen.query("#wc-empty-state"), "precondition: the normal path paints"
+
+        # Rewind to what a cold screen looks like a millisecond into `on_mount`:
+        # nothing loaded, the loading markers on screen, the DOM fully attached.
+        screen._wc_loaded = False
+        screen._wc_lookup_error = None
+        screen._local_watchlist_records = ()
+        screen._local_watchlist_count = 0
+        screen.overview_data = {}
+        screen._request_surface_refresh(
+            screen._SURFACE_FEEDS, screen._SURFACE_HEADER
+        )
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if screen.query("#wc-loading-state"):
+                break
+        assert screen.query("#wc-loading-state"), "precondition: rewound to loading"
+        overview = screen.query_one("#watchlists-overview-pane", OverviewPane)
+        assert overview.query("#overview-loading"), "precondition: overview loading"
+        assert screen.is_attached, "precondition: the DOM is live throughout"
+
+        # THE WINDOW. Everything below -- including the drain worker's own
+        # loop, which the live log shows running at `is_mounted=False` -- runs
+        # with `is_mounted` False and every widget present, byte-for-byte the
+        # state the log above captured. The assertions are made INSIDE the
+        # window too, so nothing can be satisfied by the restore below.
+        screen._is_mounted = False
+        try:
+            assert not screen.is_mounted
+            assert screen.query_one("#wl-centre-status"), (
+                "precondition: the header really is queryable in this window"
+            )
+            screen._apply_local_wc_snapshot((), 0, True, None, None)
+            screen.overview_data = {
+                "total_sources": 0,
+                "active_sources": 0,
+                "sources_in_error": 0,
+                "total_items": 0,
+                "new_items": 0,
+                "latest_run_status": "unavailable",
+                "failed_runs": [],
+                "active_alert_rules": 0,
+            }
+
+            for _ in range(300):
+                await pilot.pause(0.01)
+                if screen.query("#wc-empty-state") and not screen.query(
+                    "#overview-loading"
+                ):
+                    break
+
+            assert not screen.query("#wc-loading-state"), (
+                "the snapshot marker is still 'Loading local Watchlists "
+                "snapshot...' after the load landed -- the update was dropped "
+                "and nothing re-requests it"
+            )
+            assert screen.query("#wc-empty-state"), (
+                "the loaded snapshot state must paint"
+            )
+            overview = screen.query_one("#watchlists-overview-pane", OverviewPane)
+            assert not overview.query("#overview-loading"), (
+                "the Overview pane is still 'Loading watchlist activity...' "
+                "after `overview_data` landed"
+            )
+            assert overview.query("#overview-first-run"), (
+                "the loaded (empty-profile) Overview state must paint"
+            )
+            assert str(screen.query_one("#watchlists-state-summary").renderable) == (
+                "State: ready"
+            ), "the Inspector's State line must follow the snapshot here too"
+
+            # The tree loader lands in the same window (`on_mount` starts it
+            # too), so its own updater has to reach the rail from here as well.
+            created = app.watchlist_bundle_service.create("Morning AI Brief")
+            node_id = f"#wl-tree-node-watchlist-{created['id']}"
+            assert not screen.query(node_id), "precondition: the rail is stale"
+            screen._load_tree_data()
+            for _ in range(300):
+                await pilot.pause(0.01)
+                if screen.query(node_id):
+                    break
+            assert screen.query(node_id), (
+                "the rail never picked up the tree reload that landed before "
+                "Textual flipped `is_mounted`"
+            )
+        finally:
+            screen._is_mounted = True

--- a/Tests/UI/test_watchlists_source_create_form.py
+++ b/Tests/UI/test_watchlists_source_create_form.py
@@ -714,3 +714,104 @@ async def test_creating_a_source_refreshes_the_table_and_the_tree_counts():
             "creating a source must reload the tree counts; without it the "
             "rail says 0 while the centre says 1"
         )
+
+
+# --- TASK-2200 -------------------------------------------------------------
+#
+# TASK-1960 proved the crash class here came from the SCREEN recomposing out of
+# `_apply_local_wc_snapshot`/`_load_tree_data` while this pane was mid-recompose
+# of its own, and recorded a second, masked defect on the same path: the pane's
+# form-close recompose can mount *nothing*, invisible only because the screen
+# rebuilt the pane wholesale straight afterwards. Both tests below assert
+# against the SAME pane instance the user was already looking at, so neither can
+# be satisfied by a screen-level rebuild papering over an empty pane.
+
+
+@pytest.mark.asyncio
+async def test_a_background_refresh_does_not_tear_down_an_open_create_form():
+    """AC#1: a half-typed create form survives a background load landing.
+
+    Before TASK-2200 both loaders ended in `refresh(recompose=True)`, which
+    replaced the pane, the form and every widget in it. The draft *text*
+    survived (the screen mirrors it), so text alone does not discriminate --
+    these assertions are on widget identity, which only survives if nothing
+    rebuilt the region.
+    """
+    host = _watchlists_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen, pane = await _open_sources_create_form(pilot, host)
+
+        await pilot.press(*"Morning")
+        await pilot.pause(0.05)
+        name_input = pane.query_one("#sources-create-name", Input)
+        assert name_input.value == "Morning", "precondition: the draft was typed"
+        assert not screen.query("#wc-service-error")
+
+        # Both background loaders, together -- the exact pair `_create_source`
+        # fires, and the pair whose recomposes TASK-1960 caught destroying this
+        # pane.
+        screen._apply_local_wc_snapshot(
+            (), 0, True, "Watchlists services unavailable; retry Watchlists later.", None
+        )
+        screen._load_tree_data()
+        for _ in range(300):
+            await pilot.pause(0.01)
+            if screen.query("#wc-service-error"):
+                break
+
+        assert screen.query("#wc-service-error"), (
+            "precondition: the background snapshot really did land and repaint "
+            "the centre header"
+        )
+        assert screen.query_one("#watchlists-sources-pane", SourcesPane) is pane, (
+            "the background load replaced the Sources pane"
+        )
+        assert pane.query_one("#sources-create-name", Input) is name_input, (
+            "the background load rebuilt the create form's Name field out from "
+            "under the user"
+        )
+        assert name_input.value == "Morning"
+        assert pane.query("#sources-create-form"), "the form must still be open"
+
+
+@pytest.mark.parametrize("size", SIZES)
+@pytest.mark.asyncio
+async def test_closing_the_create_form_repopulates_the_same_pane(size):
+    """AC#4: form-close no longer leans on a screen rebuild to look right.
+
+    The masked defect TASK-1960 recorded: `SourcesPane`'s form-close recompose
+    silently mounts nothing when the screen's own recompose prunes it
+    mid-flight, and that was invisible only because the screen immediately
+    rebuilt the pane. With the screen recompose gone, the pane the user keeps
+    looking at is the pane that has to come back correct -- so this asserts
+    identity first, then that the same instance really did remount its table
+    and drop its form.
+    """
+    host = _watchlists_host()
+    async with host.run_test(size=size) as pilot:
+        screen, pane = await _open_sources_create_form(pilot, host)
+        created = AsyncMock(return_value={"id": 1, "name": "Morning"})
+        screen._controller.create_source = created
+
+        await pilot.press(*"Morning")
+        await pilot.press("tab")
+        await pilot.pause(0.05)
+        await pilot.press(*"https://example.com/feed")
+        await pilot.pause(0.05)
+
+        pane.query_one("#sources-create-submit", Button).press()
+        settled = await _settled_sources_pane(screen, pilot)
+
+        assert created.await_count == 1, "precondition: Create reached the controller"
+        assert settled is pane, (
+            "the create flow's background loaders must not replace the pane -- "
+            "the whole point is that the pane's own form-close is what has to "
+            "come back correct"
+        )
+        assert pane.query("#sources-table"), (
+            "the pane's own form-close recompose mounted nothing: the masked "
+            "TASK-1960 defect, now unmasked"
+        )
+        assert not pane.query("#sources-create-form"), (
+            "the create form must be gone from the pane the user is looking at"
+        )

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -832,6 +832,15 @@ async def test_renaming_a_watchlist_updates_the_rail():
             == "Feeds in Morning AI Brief (0)"
         )
         assert screen._breadcrumb_labels == ["Morning AI Brief"]
+        # ...and the MOUNTED Inspector, not only the screen's mirror of it
+        # (TASK-2200). `watch_selected_scope` pushed the pre-rename label when
+        # the scope moved and never fires again; nothing else rebuilds the
+        # Inspector now that the tree reload patches in place instead of
+        # recomposing the screen, so the reload has to push it itself.
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+        assert inspector.breadcrumb_labels == ["Morning AI Brief"], (
+            "the renamed watchlist must reach the Inspector's breadcrumb too"
+        )
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
+++ b/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
@@ -296,3 +296,43 @@ loader results are applied, which is precisely why 8 484 tests missed this.
 + Create source / Import OPML, Overview "Nothing is being watched yet." with
 its first-run guidance, Inspector "State: ready" — all within ~2 s of
 navigation and stable at T+10 s.
+
+#### The guard-shape trap, for the record
+
+This is not a Watchlists quirk. `if self.is_mounted:` around "push data into
+my own widgets" is a shape used widely in this codebase, and it is wrong in
+**both** directions. Measured, not argued:
+
+| | during `on_mount` (and anything it starts that finishes in that window) | after a real `switch_screen` teardown |
+|---|---|---|
+| `is_mounted` | **False** — while the whole subtree is registered and queryable | **True** — still |
+| `is_attached` | **True** — correct | **False** — correct |
+
+`Widget.is_mounted` returns `_is_mounted`, which `MessagePump._pre_process`
+sets in its `finally`, *after* dispatching `Compose` **and** `Mount`.
+`MessagePump.is_attached` walks `_parent` to the DOM root, so it answers the
+question the guard is actually asking: *can I query and mount inside my own
+subtree right now?*
+
+So an `is_mounted` guard is not a teardown gate at all (the re-review measured
+`is_mounted=True` on a screen already swapped out), and it *is* a false
+negative for the entire mount window. The only thing it reliably does is drop
+updates that arrive early. Where the surrounding code already degrades per
+widget (`except NoMatches` / `except Exception: pass` — which every site here
+does), `is_attached` is strictly better on both axes.
+
+**Two waves of this task were spent on it.** The first fixed the six guards
+this task introduced. The re-review then found the same shape at six
+PRE-EXISTING sites — the section loaders `_load_sources`, `_load_runs`,
+`_load_notifications`, `_load_items`, `_load_rules`, `_load_briefings` — which
+`on_mount` reaches through `_load_active_section_data()`, and which the
+Watchlists **deep link** (`apply_navigation_context` sets the section on an
+unmounted screen, before `switch_screen`) points at a section whose loader then
+lands in the mount window on a cold database. Those were masked by the
+full-screen recompose this task removed, so they had to ship with it or the
+deep link would regress: `LENS: in-window push rows=0; after a dev-style
+recompose rows=1`. All twelve now use `_dom_is_live`.
+
+Guards on user-gesture watchers (`watch_selected_scope`, `watch_tree_scope`,
+`_open_sources_create_form`, …) are deliberately left on `is_mounted`: none can
+fire inside the mount window, and rewriting them is not this task's business.

--- a/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
+++ b/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
@@ -196,3 +196,50 @@ no form, so a screen-level rebuild can no longer satisfy it).
   (+2: AC#1 draft survival, AC#4 pane identity),
   `Tests/Watchlists/test_watchlists_collections_screen.py` (the rename test now
   also asserts the mounted Inspector's breadcrumb).
+
+### Review wave (whole-branch adversarial review: 0 Critical, 1 Important, 5 Minor + 1 nit)
+
+The intent queue was independently scaffold-attacked and judged sound (two
+drainers impossible, no gap at the loop-exit boundary, `CancelledError`
+propagates past `_rebuild_surface`'s `except Exception` to the `finally`,
+unmount/tab-switch/gated-region all degrade). All findings fixed:
+
+* **I1 — a real AC#2 regression, now fixed.** `ArtifactsPane.scope_label`
+  resolves a watchlist DISPLAY NAME out of `_tree_watchlists`
+  (`_briefing_scope_label` → `_watchlist_display_name`), so it is tree data
+  living on an ITEMS-region pane — and the first pass left ITEMS alone
+  wholesale. Renaming the scoped watchlist while the Artifacts tab was open
+  repainted the rail, the FEEDS heading and the breadcrumb but left
+  `#artifacts-scope-note` on the old name. Pushed alongside the other two
+  ITEMS-region pushes, with a discriminating test. The method's docstring
+  now states the actual rule ("no pane is REBUILT", not "no pane is touched")
+  and enumerates every consumer.
+* **M1 — the drain armed before it scheduled.** A raising `run_worker` would
+  wedge `_surface_refresh_draining` True for the life of the screen, silently
+  stopping every background refresh. Now follows this file's own
+  `_start_tree_write` discipline (arm, disarm on failure, `close()` the
+  un-awaited coroutine), pinned by the sibling of that method's own test.
+* **M2 — one unguarded step in the drain loop.** The Console-follow poll sat
+  outside `_rebuild_surface`'s `except Exception`, and `run_worker` defaults
+  to `exit_on_error=True`, so a raising adapter took the app down. Moved into
+  `_rebuild_inspector_if_console_follow_drifted`, inside the guard.
+* **M3 — decided (b), documented.** Verified the cache's exact semantics
+  rather than assuming: `WatchlistsConsoleHandoff._latest_console_follow_loaded`
+  is set on success and on "no adapter", **never on failure** — so failure is
+  retried and success is frozen for the life of the screen. The drift check is
+  therefore *only* a failure-recovery mechanism, which is exactly what the old
+  full recompose provided (it hit the identical cache). Making the re-poll live
+  would be new product behaviour plus a multi-query fan-out per background
+  load, so it was not built. The machinery is kept (it is the only thing making
+  `test_watchlists_destination_retries_console_follow_after_initial_adapter_failure`
+  pass), and the comment that promised a live re-poll is corrected.
+* **M4 — adapter call out of `compose()`.** `_console_follow_item` is now a
+  screen-held mirror: `compose_content` resolves once per compose pass (the
+  pre-TASK-2200 call site) and `_resolve_console_follow_drift` refreshes it
+  before asking for the rail rebuild; the RIGHT_RAIL factory reads the
+  attribute. Region toggles cost zero adapter calls again.
+* **M5** — `_request_surface_refresh`'s `Args:` now documents
+  `_SURFACE_INSPECTOR` and that it is the conditional one.
+* **M6 (nit)** — `_watchlists_are_empty()` was already orphaned on `dev`
+  (`git show b5a8fcec5:…` finds the definition and no callers), so it is left
+  alone: not orphaned by this branch, and deleting it is not this task's call.

--- a/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
+++ b/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2200
 title: Watchlists screen stops full-screen recomposing from background loaders
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-04'
 labels:
@@ -43,21 +43,156 @@ targeted in-place update discipline the screen already uses elsewhere
 
 ## Acceptance Criteria (the what)
 
-- [ ] Completing a background load (`_load_tree_data`) or applying a local
+- [x] Completing a background load (`_load_tree_data`) or applying a local
       watchlists snapshot (`_apply_local_wc_snapshot`) no longer rebuilds the
       whole screen: the affected panes/regions are updated in place, and
       unrelated in-flight pane recomposes (e.g. the Sources create-form
       open/close) are not torn down by it.
-- [ ] The rendered result after a background refresh is equivalent to what the
+- [x] The rendered result after a background refresh is equivalent to what the
       full recompose produced today, covering the overview/first-run/loading
       states (the TASK-1347-strengthened tests stay green).
-- [ ] The TASK-1960 e2e reproduction
+- [x] The TASK-1960 e2e reproduction
       (`test_a_source_can_be_created_end_to_end_through_the_form`) stays green
       10/10 in isolation and in the poisoned order after
       `Tests/UI/test_watchlists_content_pane.py` — now with the destroyer
       removed rather than merely guarded against.
-- [ ] The masked SourcesPane defect is addressed or made impossible: closing the
+- [x] The masked SourcesPane defect is addressed or made impossible: closing the
       create form yields a correctly-populated pane without depending on a
       screen-level rebuild to paper over an empty recompose.
-- [ ] `PruneSafeSelect` remains in place as defense-in-depth (this task removes
+- [x] `PruneSafeSelect` remains in place as defense-in-depth (this task removes
       the known destroyer; it does not un-fix TASK-1960).
+
+## Implementation Plan
+
+1. Map every recompose site on `watchlists_collections_screen.py` and classify
+   each as user-gesture-driven (keep) or background-loader-driven (convert).
+2. Give the screen one owner for in-place workbench surface rebuilds: a
+   record-intent / drain-serially helper (`_request_surface_refresh` +
+   `_drain_surface_refresh`) over `WatchlistsWorkbench.refresh_region_content`
+   / `refresh_header_content`, so two loaders landing together coalesce
+   instead of cancelling each other mid remove-then-mount.
+3. Convert `_apply_local_wc_snapshot`: request FEEDS + centre-header rebuilds
+   and patch the Inspector's snapshot-derived widgets (`State:` line, the
+   Console attach button's `disabled`/tooltip) in place.
+4. Convert `_load_tree_data`: request LEFT_RAIL + FEEDS + centre-header
+   rebuilds and push `breadcrumb_labels` / `watchlist_count` into the live
+   Inspector and Overview panes.
+5. Convert `overview_data` from a screen-level `recompose=True` reactive to a
+   plain reactive plus a watcher that pushes into the live `OverviewPane`,
+   the Inspector's `profile_state`, and the two summary `Static`s.
+6. Route `watch_tree_scope`'s existing FEEDS/header refreshes through the same
+   drain, so nothing else can swap those regions concurrently.
+7. Add regression tests for AC#1 (an in-flight create form survives a
+   background load) and AC#4 (form-close yields a correct pane with the same
+   pane instance, i.e. no screen rebuild papering over it); update the tests
+   whose assertions pinned the old full-recompose behaviour.
+8. Run the verification gates: overview/first-run/loading-state, region
+   gating, content pane, source create form (full), sources pane, inspector,
+   the AC#3 10x/5x e2e repeats, `--collect-only`, and mutation-revert every
+   behavioural change.
+
+## Implementation Notes
+
+The three background destroyers are gone. The screen keeps exactly one
+`refresh(recompose=True)`, in `watch_active_section` — a user gesture that
+genuinely changes which regions mount (`_hidden_centre_regions`) and whether
+the workbench gets a `header=` factory at all.
+
+### Every recompose site, classified
+
+| Site | Driver | Verdict |
+|---|---|---|
+| `overview_data` reactive (`:401`) | background (`_refresh_overview_data`, its only writer) | **converted** — plain reactive + `watch_overview_data` |
+| `_load_tree_data` (`:913`) | background worker | **converted** — `_apply_tree_data_to_live_surfaces` |
+| `_apply_local_wc_snapshot` (`:984`) | background worker + the snapshot timeout | **converted** — `_apply_snapshot_to_live_surfaces` |
+| `watch_active_section` (`:2963`) | user gesture (tab switch) | **kept** — changes which regions exist |
+| `region_layout` (`:410`) | user gesture (`z`/`Z`/`[`/`]`) | **kept, out of scope** — and it is *not* `recompose=True` on the screen; the reactive with that flag is `WatchlistsWorkbench.region_layout`, pushed by `_apply_layout` |
+
+### One owner for DOM swaps
+
+`refresh_region_content`/`refresh_header_content` are remove-then-mount pairs
+with an `await` between the halves (Textual's `NodeList._ensure_unique_id`
+refuses to mount the replacement while the old widget still holds the id).
+Three call sites now want those swaps, so `exclusive=True` per surface — the
+shape `watch_tree_scope` used — becomes unsound: whichever request lands
+second cancels the first *between* its `remove()` and its `mount()`, leaving a
+bordered empty box. `_request_surface_refresh`/`_drain_surface_refresh` record
+intent and drain serially instead, never cancelling (TASK-1541's lesson,
+applied to DOM swaps rather than durable writes). `watch_tree_scope`'s two
+refreshes were routed through the same queue for the same reason.
+
+### What each converted loader now updates
+
+* **Snapshot** — FEEDS + centre header (the loading/error/empty/summary marker
+  lives in exactly those two places), plus two in-place patches on the
+  Inspector: the `State:` line (`Static.update`) and the Console attach
+  button's `disabled`/tooltip.
+* **Tree data** — the rail, FEEDS + header (the scope heading resolves a
+  watchlist name out of `_tree_watchlists`, so a rename would otherwise sit
+  stale), the Inspector's `breadcrumb_labels`, and the Overview's
+  `watchlist_count` (TASK-998's first-run copy).
+* **`overview_data`** — `OverviewPane.data` and `InspectorPane.profile_state`
+  (both pane-scoped `recompose=True` reactives; the pane swaps between three
+  whole layouts, so there are no cells to patch), plus the Inspector's two
+  count `Static`s.
+
+`overview_data`'s fate was a real question, not a formality: TASK-1960 proved
+it does **not** fire on the post-submit path (an equal dict), but it fires
+whenever counts genuinely change, and `_update_item_status`'s `refresh=False`
+path and `_save_noise_selectors` both exist *only* to dodge the screen
+recompose it used to cause. So it was the third destroyer, and it is converted.
+
+### Two things the full recompose was carrying that nothing else was
+
+Found by running the suites, not by reading:
+
+1. **The backend switch.** `watch_runtime_backend` clears
+   `selected_source`/`selected_run`/`selected_notification` on the screen, and
+   the snapshot refresh's recompose is what pushed those clears into the
+   mounted pane. `_reseed_live_detail_pane` now does it directly (also called
+   from `_delete_source`/`_delete_run`, which clear the same state).
+2. **The Console-follow row.** It is polled from an app-level adapter *at
+   render time only*, so an adapter that failed once recovered on whichever
+   recompose came next. `_resolve_console_follow_drift` re-polls and compares
+   against the DOM; the right rail is rebuilt only when it genuinely differs.
+   Deliberately conditional: the rail hosts the noise-selector editor, and
+   rebuilding it on every background load would destroy a half-typed selector
+   set — the same harm this task removes from the Sources create form. The
+   RIGHT_RAIL factory had to stop closing over `compose_content`'s captured
+   values for that rebuild to mean anything.
+
+### AC#4
+
+Addressed by removal. With the screen recompose gone from both loaders,
+nothing prunes `SourcesPane` mid-form-close, so the pane's own recompose
+mounts its children normally — and the pane the user is looking at is the one
+the assertions now target (`test_closing_the_create_form_repopulates_the_same_pane`
+asserts pane identity *first*, then that the same instance has its table and
+no form, so a screen-level rebuild can no longer satisfy it).
+
+### Verification
+
+* AC#3: **10/10** e2e in isolation, **5/5** of
+  (`test_watchlists_content_pane.py` + the e2e) in one invocation, that order.
+* `Tests/Watchlists/` 384 → **480 passed** together with the watchlists UI
+  files; `test_watchlists_destination_shell.py` + `overview_loading_state` +
+  `inspector` **110 passed**; `test_destination_shells.py` +
+  `test_destination_visual_parity_correction.py` + `source_create_form`
+  **243 passed, 1 skipped**; `test_console_live_work_handoffs.py` +
+  `test_no_side_effecting_predicates.py` **49 passed**; shell/navigation/
+  maturity sweep **124 passed**; `--collect-only Tests/UI Tests/Watchlists
+  Tests/Widgets` **8750 collected**, no errors.
+* 15 mutations, each reverted individually → RED → restored byte-exact
+  (md5-verified, `git status --short` unchanged between).
+
+### Files
+
+* `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` — the whole
+  change.
+* `tldw_chatbook/UI/Watchlists_Modules/items_pane.py` — one stale comment.
+* Tests: `Tests/UI/test_watchlists_destination_shell.py` (+6 tests, and the
+  rule-edit test's `is not rules_pane` assertion inverted to `is` — it used to
+  *require* the destroyer), `Tests/UI/test_watchlists_source_create_form.py`
+  (+2: AC#1 draft survival, AC#4 pane identity),
+  `Tests/Watchlists/test_watchlists_collections_screen.py` (the rename test now
+  also asserts the mounted Inspector's breadcrumb).

--- a/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
+++ b/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
@@ -336,3 +336,29 @@ recompose rows=1`. All twelve now use `_dom_is_live`.
 Guards on user-gesture watchers (`watch_selected_scope`, `watch_tree_scope`,
 `_open_sources_create_form`, …) are deliberately left on `is_mounted`: none can
 fire inside the mount window, and rewriting them is not this task's business.
+
+#### Qodo round (PR #1331) — the surviving `is_mounted` guards, adjudicated
+
+Qodo claimed the mount-window class continues into the two selection watchers
+this task had left on `is_mounted` as "user-gesture, cannot fire in the
+window". **Half right, and the half that was right was a real defect.** Every
+remaining guard on this screen was then swept with the same question — *does
+anything in the mount window write the state this guard protects?* — so this is
+the last round of this class.
+
+| Guard | In-window writer? | Verdict |
+|---|---|---|
+| `watch_selected_entity` | **YES** — the run deep link arms `_pending_navigation_run_id` pre-mount, `on_mount` starts `_load_runs`, its `had_pending_target` branch calls `_select_entity(requested_run)` | **FIXED** → `_dom_is_live`. Proven RED first: screen holds the run, mounted Inspector holds `None`. Nothing recovered it — `_build_inspector_pane` re-seeds only on a rebuild, and the right rail's only remaining rebuild is gated on `_resolve_console_follow_drift()`, `False` on a cold start. |
+| `watch_selected_scope` | **NO** — measured, 0 firings in-window | **DECLINED, no production change.** `_select_entity` is the only in-window writer and can only ever write `TreeScope(kind="all")`, which is byte-equal to the reactive's class default and to the value nothing pre-mount changes — so the write is structurally a no-op, not a lucky one. Probe: `scope_before == scope_after == TreeScope(kind='all', …)`, `watch_selected_scope fired 0 time(s)`. Confirmed behaviour-neutral by the inverse mutation (swapping it to `_dom_is_live` anyway leaves 112 tests unchanged). Its other half, `breadcrumb_labels`, is already pushed directly by `_apply_tree_data_to_live_surfaces`. |
+| `watch_active_section` | writes are pre-attach only (`apply_navigation_context`) | **KEEP, load-bearing as `is_mounted`.** Flipping it would make an in-window section write recompose a screen whose `compose()` already reflects it *and* double-start the loader `on_mount` starts. |
+| `apply_navigation_context` | n/a — it is itself the pre-mount caller | **KEEP.** A "should I start work" gate, not a "can I paint" gate; `on_mount` owns the first load. |
+| `watch_tree_scope` | no — only `_apply_tree_scope` (tree click, breadcrumb promotion, tree write flows) | KEEP |
+| `watch_runtime_backend` | pre-attach only (`apply_navigation_context`) or the Backend `Select` | KEEP |
+| `_open_sources_create_form`, `_open_sources_import_opml` | reached via a 0.05 s `set_timer` or `action_new_source` | KEEP |
+| `_load_sources_preserving_selection` | callers are `_check_now_source` / `_resume_source` | KEEP |
+| `_open_citation`, `open_edit_form`, `action_new_source`, `_load_briefing_presets` | user gestures / modal returns | KEEP |
+
+The rule that falls out: **`is_attached` for "can I paint into my own subtree",
+`is_mounted` only where the guard genuinely means "has the first mount already
+happened"** — which on this screen is exactly the two places that decide
+whether `on_mount` or a watcher owns the first load.

--- a/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
+++ b/backlog/tasks/task-2200 - Watchlists screen stops full-screen recomposing from background loaders.md
@@ -243,3 +243,56 @@ unmount/tab-switch/gated-region all degrade). All findings fixed:
 * **M6 (nit)** — `_watchlists_are_empty()` was already orphaned on `dev`
   (`git show b5a8fcec5:…` finds the definition and no callers), so it is left
   alone: not orphaned by this branch, and deleting it is not this task's call.
+
+### Live-verification wave — `is_mounted` is False for the whole of `on_mount`
+
+The whole test suite was green and the feature was **broken on a cold app**:
+navigate to Watchlists and the centre header sat on "Loading local Watchlists
+snapshot...", the Overview on "Loading watchlist activity..." and the Inspector
+on "State: unavailable" **indefinitely** (measured 100+ seconds, zero
+interaction). Clicking any tab painted the loaded state instantly, so the data
+had arrived — only the DOM had not.
+
+**Confirmed by instrumentation on a real 235x52 terminal**, not by reasoning:
+
+```
+OVERVIEW watcher is_mounted=False keys=[]      pane=0 inspector=0
+ON_MOUNT         is_mounted=False wb=1 centre=1 status=1
+SNAPSHOT applied is_mounted=False loaded=True   wb=1 centre=1 status=1
+OVERVIEW watcher is_mounted=False keys=[...]    pane=1 inspector=1
+```
+
+`Widget.is_mounted` returns `_is_mounted`, which `MessagePump._pre_process`
+sets in its `finally` — **after** it has dispatched `Compose` *and* `Mount`. So
+for the whole of `on_mount`, and for anything `on_mount` starts that finishes
+before that `finally` runs, `is_mounted` is `False` while the entire subtree is
+already registered and queryable. On a cold local database this screen's
+loaders finish inside exactly that window (the snapshot landed 7 ms after
+`on_mount` began). Every `if not self.is_mounted: return` guard therefore
+dropped its update, and nothing re-requested it.
+
+Why this is a regression **introduced by this task** and not pre-existing: the
+`overview_data` reactive's `refresh(recompose=True)` was called by Textual's
+own reactive machinery, which has no `is_mounted` guard anywhere in its path —
+so on `dev` that recompose repainted the whole screen a few milliseconds later
+and covered the snapshot's own (identically guarded, identically skipped)
+repaint. Replacing it with guarded in-place updates removed the only unguarded
+path.
+
+**Fix:** a `_dom_is_live` property (`self.is_attached` — "is there a path from
+me up to the DOM root", true from `App._register` and false once unmounted or
+exiting) replaces `is_mounted` at the six guards this task introduced. Every
+caller still degrades per widget via `except NoMatches`, so this is an outer
+gate, not the only protection. The pre-existing `is_mounted` guards on
+user-gesture watchers (`watch_selected_scope`, `watch_tree_scope`, …) are left
+alone: they cannot fire inside the mount window.
+
+Regression test reconstructs the captured state (a live, fully-attached screen
+with `_is_mounted` forced back to `False`, assertions made **inside** that
+window) rather than racing for it — `run_test`'s pilot settles the DOM before
+loader results are applied, which is precisely why 8 484 tests missed this.
+
+**Live re-verified after the fix, zero interaction:** header "No sources yet."
++ Create source / Import OPML, Overview "Nothing is being watched yet." with
+its first-run guidance, Inspector "State: ready" — all within ~2 s of
+navigation and stable at T+10 s.

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -3576,7 +3576,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 setattr(pane, attribute, value)
 
     def watch_selected_entity(self) -> None:
-        if not self.is_mounted:
+        """Push the current selection into the live Inspector.
+
+        `_dom_is_live`, not `is_mounted` (Qodo, PR #1331): this watcher IS
+        reachable inside the mount window, unlike its `watch_selected_scope`
+        sibling. The Watchlists run deep link arms `_pending_navigation_run_id`
+        on an unmounted screen (`apply_navigation_context`), `on_mount` starts
+        `_load_runs`, and on a cold database that loader resolves the target
+        and calls `_select_entity(requested_run)` before Textual has flipped
+        `_is_mounted`. An `is_mounted` guard dropped that push, and nothing
+        re-seeds it: `_build_inspector_pane` re-seeds only on a REBUILD, and
+        the one right-rail rebuild this screen still schedules is gated on
+        `_resolve_console_follow_drift()`, which is `False` on a normal cold
+        start. The user followed a run link and the Inspector said "Nothing to
+        inspect yet." over a run the screen believed was selected.
+        """
+        if not self._dom_is_live:
             return
         try:
             inspector = self.query_one("#watchlists-entity-inspector", InspectorPane)

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -285,10 +285,14 @@ class _ItemStatusIntent:
             surface a toast. `False` only for the silent mark-read-on-open
             path, matching `_update_item_status`'s previous default.
         refresh: Whether a successful write should reload `ItemsPane.items`
-            and recompose via `_refresh_overview_data()`. `False` only for
-            mark-read-on-open, which patches `patch_item` in place instead
-            -- see `_mark_item_read_on_open`'s docstring for why a recompose
-            on every item SELECTION was a CRITICAL regression.
+            and refresh the overview counts via `_refresh_overview_data()`.
+            `False` only for mark-read-on-open, which patches `patch_item`
+            in place instead -- see `_mark_item_read_on_open`'s docstring
+            for why a recompose on every item SELECTION was a CRITICAL
+            regression. (TASK-2200 removed the screen-level recompose that
+            made it one; `refresh=False` is kept because reloading every
+            item and re-querying the overview on every arrow key is still
+            work nobody asked for.)
         patch_item: The live dict object (already held by `ItemsPane.items`/
             `_selected_content_item`/`ContentPane.item`) to mutate in place
             on a successful write, or `None` when the caller relies on
@@ -398,7 +402,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     selected_notification = reactive(None)
     selected_entity = reactive(None)
     recovery_state = reactive(None)
-    overview_data = reactive({}, recompose=True)
+    # NOT `recompose=True` (TASK-2200). Its only writer is
+    # `_refresh_overview_data`, a background worker fired by mount, every
+    # backend switch and every write verb on this screen -- so a screen-level
+    # recompose here was a third background destroyer alongside
+    # `_load_tree_data`/`_apply_local_wc_snapshot`, and a documented one: it
+    # detached the mounted `ItemsPane`, reset the `DataTable` cursor and
+    # dropped focus on any item-status write whose counts actually changed
+    # (see `_update_item_status`'s `refresh=False` path, which exists solely
+    # to dodge it). `watch_overview_data` pushes the payload into the three
+    # live surfaces that read it instead.
+    overview_data = reactive({})
     # Through Phase C, CONTENT held only a placeholder stub and started
     # collapsed to avoid spending screen space on it. Phase D wires a real
     # reader (`ContentPane`) into CONTENT, so it now starts expanded like
@@ -750,6 +764,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # new entry on its own next loop.
         self._item_status_desired: dict[Any, "_ItemStatusIntent"] = {}
         self._item_status_draining: set[Any] = set()
+        # TASK-2200. Which workbench surfaces still need rebuilding in place,
+        # and whether the drainer that rebuilds them is already running. See
+        # `_request_surface_refresh` for why this is a record-intent/drain
+        # queue rather than `run_worker(exclusive=True)` per surface.
+        self._pending_surface_refresh: set[str] = set()
+        self._surface_refresh_draining = False
         self._controller = WatchlistsBackendController(
             app_instance=app_instance,
             scope_service=getattr(app_instance, "watchlist_scope_service", None),
@@ -873,6 +893,62 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 "active_alert_rules": 0,
             }
 
+    def watch_overview_data(self) -> None:
+        """Push new overview counts into the live panes, never recompose.
+
+        TASK-2200 — see the note on the reactive itself. Three surfaces read
+        `overview_data`, and each is updated at the narrowest granularity
+        that actually re-renders it:
+
+        * `OverviewPane.data` — the pane's own `recompose=True` reactive, so
+          this is a PANE-scoped rebuild. It has to be: the pane swaps between
+          three whole layouts (loading line / first-run copy / seven cards
+          plus a failed-runs table) depending on `profile_state`, so there is
+          no set of cells to patch.
+        * `InspectorPane.profile_state` — likewise pane-scoped, and likewise
+          layout-changing.
+        * The Inspector's two count `Static`s — one `update()` each, since
+          only their text changes.
+
+        Every lookup degrades: the Overview pane exists only on its own tab,
+        and the Inspector is unmounted whenever the right rail is collapsed.
+        """
+        if not self.is_mounted:
+            return
+        try:
+            overview = self.query_one("#watchlists-overview-pane", OverviewPane)
+        except NoMatches:
+            pass
+        else:
+            overview.data = self.overview_data
+        try:
+            inspector = self.query_one("#watchlists-entity-inspector", InspectorPane)
+        except NoMatches:
+            pass
+        else:
+            inspector.profile_state = self._watchlists_profile_state()
+        # Built exactly as `_build_inspector_pane` builds them, so a rebuild
+        # and a patch cannot render differently.
+        for widget_id, text in (
+            (
+                "#watchlists-alerts-summary",
+                f"Alert rules active: {self.overview_data.get('active_alert_rules', 0)}",
+            ),
+            (
+                "#watchlists-latest-run-summary",
+                f"Latest run status: {self.overview_data.get('latest_run_status', 'unavailable')}",
+            ),
+        ):
+            try:
+                self.query_one(widget_id, Static).update(text)
+            except NoMatches:
+                continue
+        # An overview refresh follows every write verb on this screen, and a
+        # write verb is exactly when a run can have started or finished --
+        # so this is also where the Console-follow row used to be re-polled,
+        # via the recompose this reactive no longer triggers.
+        self._request_surface_refresh(self._SURFACE_INSPECTOR)
+
     @work(exclusive=True, group="wc_tree")
     async def _load_tree_data(self) -> None:
         """Load the left-rail tree's two inputs: watchlists and counts.
@@ -906,11 +982,62 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # The write verbs break that: creating a watchlist scopes to an id
         # that is not in the list yet (the crumb would read "Watchlist 3"),
         # and renaming one leaves the crumb on the old name until the user
-        # navigates away and back. The `refresh(recompose=True)` below
-        # rebuilds the Inspector, which seeds itself from this value.
+        # navigates away and back. `_apply_tree_data_to_live_surfaces` below
+        # pushes the resolved labels into the mounted Inspector.
         self._breadcrumb_labels = self._resolve_breadcrumb_labels(self.selected_scope)
-        if self.is_mounted:
-            self.refresh(recompose=True)
+        self._apply_tree_data_to_live_surfaces()
+
+    def _apply_tree_data_to_live_surfaces(self) -> None:
+        """Publish freshly loaded tree data without recomposing the screen.
+
+        TASK-2200. `_load_tree_data` used to end in `refresh(recompose=True)`,
+        which tore down and rebuilt every region — including ITEMS, whose
+        pane may be mid-recompose of its own (a `SourcesPane` closing its
+        create form, a `RulesPane` closing an edit form). That is the
+        confirmed destroyer behind TASK-1960's crash class: a widget caught
+        by the resulting prune mounts nothing, silently, while still
+        reporting `is_mounted=True`.
+
+        Only three things on this screen actually read what this loader
+        writes, so only those three are updated:
+
+        * The rail itself (`_tree_watchlists`/`_tree_counts`) — rebuilt from
+          `_build_tree_pane`, which re-seeds the expansion, tag filter and
+          scope the user had, exactly as the full recompose did.
+        * FEEDS and the centre header, whose scope heading resolves a
+          watchlist's display name out of `_tree_watchlists` (a rename would
+          otherwise sit stale) and whose source rows are re-queried.
+        * The Inspector's breadcrumb labels and the Overview's watchlist
+          count, both pushed into the live panes the way `watch_selected_scope`
+          and `_load_sources` already push theirs.
+
+        ITEMS and CONTENT are deliberately untouched: nothing in either reads
+        tree data except the Overview's `watchlist_count`, handled above.
+        """
+        if not self.is_mounted:
+            return
+        self._request_surface_refresh(
+            self._SURFACE_RAIL,
+            self._SURFACE_FEEDS,
+            self._SURFACE_HEADER,
+            self._SURFACE_INSPECTOR,
+        )
+        try:
+            inspector = self.query_one("#watchlists-entity-inspector", InspectorPane)
+        except NoMatches:
+            pass
+        else:
+            inspector.breadcrumb_labels = self._breadcrumb_labels
+        try:
+            overview = self.query_one("#watchlists-overview-pane", OverviewPane)
+        except NoMatches:
+            pass
+        else:
+            # TASK-998: the first-run panel distinguishes "no watchlists at
+            # all" from "a watchlist with no sources", and only this loader
+            # knows the answer. `_build_detail_pane` seeds the same value on
+            # a rebuild.
+            overview.watchlist_count = len(self._tree_watchlists)
 
     def _resolve_breadcrumb_labels(self, scope: TreeScope) -> list[str]:
         """Display names for `scope`'s ancestor chain, for the Inspector.
@@ -980,8 +1107,50 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._wc_lookup_error = lookup_error
         self._wc_lookup_recovery_state = recovery_state
         self._wc_loaded = True
-        if self.is_mounted:
-            self.refresh(recompose=True)
+        self._apply_snapshot_to_live_surfaces()
+
+    def _apply_snapshot_to_live_surfaces(self) -> None:
+        """Publish a freshly applied local snapshot without recomposing.
+
+        TASK-2200, the twin of `_apply_tree_data_to_live_surfaces` — see that
+        method for why the full-screen `refresh(recompose=True)` this
+        replaces was the destroyer behind TASK-1960.
+
+        The snapshot's loading/error/empty/summary marker
+        (`_watchlists_status_marker_widgets`) is rendered in exactly two
+        places, and this rebuilds both: inline in FEEDS on the Read tab, and
+        in the centre header on every other tab. Each call is a no-op where
+        that surface is not mounted, so no tab test is needed here.
+
+        The Inspector's two snapshot-derived widgets are patched rather than
+        rebuilt, following `_repaint_item_status_cell`'s discipline: the
+        `State:` line is one `Static.update`, and the Console attach control
+        is one `disabled`/`tooltip` pair straight off `_wc_attach_state()` —
+        the same tuple `compose_content` hands `_build_inspector_pane`.
+        """
+        if not self.is_mounted:
+            return
+        self._request_surface_refresh(
+            self._SURFACE_FEEDS, self._SURFACE_HEADER, self._SURFACE_INSPECTOR
+        )
+        try:
+            summary = self.query_one("#watchlists-state-summary", Static)
+        except NoMatches:
+            pass
+        else:
+            summary.update(
+                "State: ready"
+                if self._wc_loaded and not self._wc_lookup_error
+                else "State: unavailable"
+            )
+        attach_disabled, attach_tooltip = self._wc_attach_state()
+        try:
+            attach = self.query_one("#wc-attach-to-console", Button)
+        except NoMatches:
+            pass
+        else:
+            attach.disabled = attach_disabled
+            attach.tooltip = attach_tooltip
 
     @staticmethod
     def _safe_text(value: Any, fallback: str = "", *, max_length: int = 500) -> str:
@@ -1744,6 +1913,103 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         """
         return OverviewPane.profile_state(self.overview_data)
 
+    @staticmethod
+    def _console_follow_copy(
+        latest_console_item: Any,
+    ) -> tuple[str, Any, Any, bool, str]:
+        """Everything the Inspector's Console-follow row renders, as data.
+
+        Extracted (TASK-2200) so the same derivation serves two callers: the
+        builder below, and `_resolve_console_follow_drift`, which compares it
+        against what is actually on screen. The Console-follow state comes
+        from an app-level adapter that is only ever *polled* at render time --
+        until this task, "render time" meant every full-screen recompose, so
+        an adapter that failed once (or a run that started since) was picked
+        up by whichever background loader recomposed next. With those
+        recomposes gone, the drift has to be detected deliberately.
+
+        Args:
+            latest_console_item: The adapter's answer, or `None`.
+
+        Returns:
+            `(status_widget_id, status_copy, button_label, button_disabled,
+            button_tooltip)` -- byte-identical to what this section rendered
+            before the extraction, including the two DIFFERENT status ids
+            (they are the section's own available/unavailable signal).
+        """
+        if latest_console_item is None:
+            return (
+                "watchlists-console-unavailable",
+                "No active Watchlists run is available for Console follow.",
+                "Console follow unavailable",
+                True,
+                "Unavailable until Watchlists has an active run with Console context.",
+            )
+        title = str(getattr(latest_console_item, "title", None) or "Untitled")
+        status = str(getattr(latest_console_item, "status", None) or "unknown")
+        return (
+            "watchlists-console-available",
+            Text.from_markup(
+                "Console can follow latest Watchlists run: "
+                f"{escape_markup(title)} ({escape_markup(status)})."
+            ),
+            Text.from_markup(f"Follow {escape_markup(title)} in Console"),
+            False,
+            "Open the latest active Watchlists run in Console.",
+        )
+
+    def _resolve_console_follow_drift(self) -> bool:
+        """Re-poll the Console-follow adapter and say whether the rail is stale.
+
+        Not a pure predicate despite the boolean return, which is why it is
+        named for the action: `resolve_latest_follow_item()` refreshes the
+        handoff's cached item id as a deliberate side effect ("ahead of a
+        render pass" -- see its docstring), exactly as `compose_content` used
+        to do on every recompose.
+
+        Compares against the DOM rather than a remembered key, so there is no
+        second copy of "what is currently rendered" to drift: the rendered
+        answer IS the state.
+
+        Returns:
+            True when the Inspector is mounted and its Console-follow row no
+            longer matches the adapter, so the right rail should be rebuilt.
+        """
+        status_id, status_copy, button_label, _disabled, _tooltip = (
+            self._console_follow_copy(
+                self._console_handoff.resolve_latest_follow_item()
+            )
+        )
+        try:
+            button = self.query_one("#watchlists-follow-in-console", Button)
+        except NoMatches:
+            # Nothing rendered (right rail collapsed, or mid-rebuild): the
+            # next build resolves it from scratch anyway.
+            return False
+        status_widgets = list(self.query(f"#{status_id}"))
+        if not status_widgets:
+            return True
+        if str(status_widgets[0].renderable) != str(status_copy):
+            return True
+        return str(button.label) != str(button_label)
+
+    def _build_inspector_region(self) -> Vertical:
+        """The RIGHT_RAIL content factory.
+
+        Resolves the Console-follow item and the Console attach state at CALL
+        time rather than closing over values captured in `compose_content`
+        (TASK-2200): the workbench calls this factory again on every region
+        rebuild, including the targeted right-rail rebuild
+        `_resolve_console_follow_drift` asks for, and a captured value would
+        make that rebuild repaint the very staleness it was asked to fix.
+        """
+        attach_disabled, attach_tooltip = self._wc_attach_state()
+        return self._build_inspector_pane(
+            self._console_handoff.resolve_latest_follow_item(),
+            attach_disabled,
+            attach_tooltip,
+        )
+
     def _build_inspector_pane(
         self,
         latest_console_item: Any,
@@ -1790,40 +2056,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 tooltip="Open the current watchlist/subscription surface.",
             ),
         ]
-        if latest_console_item is not None:
-            title = str(getattr(latest_console_item, "title", None) or "Untitled")
-            status = str(getattr(latest_console_item, "status", None) or "unknown")
-            children.append(
-                Static(
-                    Text.from_markup(
-                        "Console can follow latest Watchlists run: "
-                        f"{escape_markup(title)} ({escape_markup(status)})."
-                    ),
-                    id="watchlists-console-available",
-                )
+        status_id, status_copy, button_label, button_disabled, button_tooltip = (
+            self._console_follow_copy(latest_console_item)
+        )
+        children.append(Static(status_copy, id=status_id))
+        children.append(
+            Button(
+                button_label,
+                id="watchlists-follow-in-console",
+                disabled=button_disabled,
+                tooltip=button_tooltip,
             )
-            children.append(
-                Button(
-                    Text.from_markup(f"Follow {escape_markup(title)} in Console"),
-                    id="watchlists-follow-in-console",
-                    tooltip="Open the latest active Watchlists run in Console.",
-                )
-            )
-        else:
-            children.append(
-                Static(
-                    "No active Watchlists run is available for Console follow.",
-                    id="watchlists-console-unavailable",
-                )
-            )
-            children.append(
-                Button(
-                    "Console follow unavailable",
-                    id="watchlists-follow-in-console",
-                    disabled=True,
-                    tooltip="Unavailable until Watchlists has an active run with Console context.",
-                )
-            )
+        )
         # Seed from screen state (Finding 3, fix round 2): `region_layout` is
         # `recompose=True`, so any collapse/solo/rail toggle constructs a
         # brand new InspectorPane. Without this, the screen keeps
@@ -1887,7 +2131,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         return f"Backend: {self.runtime_backend}"
 
     def compose_content(self) -> ComposeResult:
-        latest_console_item = self._console_handoff.resolve_latest_follow_item()
         with Vertical(id="watchlists-collections-shell"):
             yield Static(
                 "Watchlists | Monitored sources, runs, alerts, recovery | Mixed | Local/Server",
@@ -1916,7 +2159,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     self._backend_label_text(),
                     id="watchlists-backend-label",
                 )
-            attach_disabled, attach_tooltip = self._wc_attach_state()
             yield WatchlistsWorkbench(
                 self._rendered_region_layout(),
                 content={
@@ -1931,9 +2173,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     Region.FEEDS: self._build_list_pane,
                     Region.ITEMS: self._build_detail_pane,
                     Region.CONTENT: self._build_content_pane,
-                    Region.RIGHT_RAIL: lambda: self._build_inspector_pane(
-                        latest_console_item, attach_disabled, attach_tooltip
-                    ),
+                    Region.RIGHT_RAIL: self._build_inspector_region,
                 },
                 hidden=self._hidden_centre_regions(),
                 # `None` on the Read tab: `_build_list_pane` (FEEDS's own
@@ -2847,55 +3087,148 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 self._load_briefings(), exclusive=True, group="wl-briefings-load"
             )
 
-    @work(exclusive=True, group="wc_feeds_scope_refresh")
-    async def _refresh_feeds_region_for_scope(self) -> None:
-        """Worker wrapper so `watch_selected_scope` (a sync reactive watcher)
-        can await `WatchlistsWorkbench.refresh_region_content`'s remove/mount
-        pair. `exclusive=True` collapses a fast burst of tree clicks to the
-        last one requested, the same reasoning `_schedule_layout_persist`
-        documents for its own worker.
+    def _refresh_feeds_region_for_scope(self) -> None:
+        """Queue a FEEDS rebuild so it follows the tree selection.
+
+        Was its own `@work(exclusive=True, group="wc_feeds_scope_refresh")`
+        worker until TASK-2200. It now records intent on the shared surface
+        queue instead, because it is no longer the only actor that rebuilds
+        FEEDS: `_apply_local_wc_snapshot` and `_load_tree_data` both changed
+        from a full-screen recompose to a FEEDS/header rebuild, and three
+        independent `exclusive=True` workers swapping the SAME region would
+        either interleave two remove/mount pairs over one `#watchlists-list-
+        pane` id or -- with a shared group -- cancel one of them between its
+        `remove()` and its `mount()`, leaving an empty bordered box. See
+        `_request_surface_refresh`.
+        """
+        self._request_surface_refresh(self._SURFACE_FEEDS)
+
+    def _refresh_centre_header_for_scope(self) -> None:
+        """Queue a centre-header rebuild, the header's twin of the above.
+
+        Off the Read tab FEEDS is unmounted and `_build_centre_status_header`
+        carries the same scoped summary, so a FEEDS-only refresh is a silent
+        no-op there (task-1344 fix wave, Qodo correctness).
+        """
+        self._request_surface_refresh(self._SURFACE_HEADER)
+
+    #: The workbench surfaces this screen rebuilds in place, rather than by
+    #: recomposing itself (TASK-2200). Each maps to one call on
+    #: `WatchlistsWorkbench`; ITEMS and CONTENT are deliberately absent --
+    #: their panes are patched through their own reactives (see
+    #: `_load_sources`, `watch_overview_data`) precisely so an in-flight
+    #: create/edit form is never torn down by a background load.
+    #:
+    #: `_SURFACE_INSPECTOR` is the one CONDITIONAL surface: it rebuilds the
+    #: right rail only when `_resolve_console_follow_drift` finds the
+    #: Console-follow row no longer matches the adapter. The rail is where
+    #: the noise-selector editor lives, and rebuilding it unconditionally on
+    #: every background load would destroy a half-typed selector set -- the
+    #: same class of harm this task removes from the Sources create form.
+    _SURFACE_RAIL = "rail"
+    _SURFACE_FEEDS = "feeds"
+    _SURFACE_HEADER = "header"
+    _SURFACE_INSPECTOR = "inspector"
+
+    def _request_surface_refresh(self, *surfaces: str) -> None:
+        """Record that one or more workbench surfaces need rebuilding.
+
+        Record intent, drain serially, never cancel (TASK-1541's lesson,
+        applied here to DOM swaps rather than durable writes). Both
+        `WatchlistsWorkbench.refresh_region_content` and
+        `refresh_header_content` are remove-then-mount pairs with an `await`
+        between the two halves -- Textual's `NodeList._ensure_unique_id`
+        refuses to mount the replacement while the old widget still holds the
+        same id, so there is no atomic single-await swap available. A worker
+        cancelled in that window (which is exactly what `exclusive=True`
+        does to its predecessor) leaves the region with its content removed
+        and nothing put back: a bordered empty box that survives until some
+        unrelated rebuild happens along.
+
+        So callers queue a surface name here and at most one drainer ever
+        runs. Requests that arrive while it is running are picked up by its
+        next loop rather than starting -- or cancelling -- anything.
+
+        Args:
+            surfaces: Any of `_SURFACE_RAIL`/`_SURFACE_FEEDS`/
+                `_SURFACE_HEADER`. Unknown names are ignored by the drainer.
         """
         if not self.is_mounted:
             return
-        try:
-            workbench = self.query_one(WatchlistsWorkbench)
-        except NoMatches:
+        self._pending_surface_refresh.update(surfaces)
+        if self._surface_refresh_draining:
             return
-        try:
-            await workbench.refresh_region_content(Region.FEEDS)
-        except Exception:
-            logger.opt(exception=True).debug(
-                "Failed to refresh the Feeds region for the new scope."
-            )
+        self._surface_refresh_draining = True
+        # Its own group, not the default one: several call sites on this
+        # screen run `run_worker(..., exclusive=True)` without a group (e.g.
+        # `_load_active_section_data`), and those would otherwise cancel this
+        # drainer mid-swap -- the very failure this queue exists to prevent.
+        self.run_worker(self._drain_surface_refresh(), group="wc_surface_refresh")
 
-    @work(exclusive=True, group="wc_header_scope_refresh")
-    async def _refresh_centre_header_for_scope(self) -> None:
-        """Worker wrapper mirroring `_refresh_feeds_region_for_scope`, for
-        the centre header that carries the scoped summary off the Read tab.
+    async def _drain_surface_refresh(self) -> None:
+        """Rebuild every queued surface in place, one at a time.
 
-        Own exclusive worker GROUP, deliberately not shared with
-        `_refresh_feeds_region_for_scope`: `watch_tree_scope` calls both
-        from the same reactive watcher (this one only when the header
-        exists at all), and a shared `exclusive=True` group would let
-        whichever call lands second cancel the other before it finishes,
-        even though in practice only one of the two ever does real work for
-        a given tab. `exclusive=True` here still collapses a fast burst of
-        tree clicks to the last one requested, the same reasoning
-        `_refresh_feeds_region_for_scope` and `_schedule_layout_persist`
-        both already document for their own workers.
+        Loops until the queue is empty so a request that lands mid-drain is
+        served by this same worker. There is no `await` between the loop's
+        emptiness check and the `finally` that clears the flag, so a request
+        can never slip into the gap and be dropped by a drainer that has
+        already decided to stop.
         """
-        if not self.is_mounted:
-            return
         try:
-            workbench = self.query_one(WatchlistsWorkbench)
-        except NoMatches:
-            return
+            while self.is_mounted and self._pending_surface_refresh:
+                surfaces = self._pending_surface_refresh
+                self._pending_surface_refresh = set()
+                try:
+                    workbench = self.query_one(WatchlistsWorkbench)
+                except NoMatches:
+                    # Nothing to patch. Whatever removed the workbench (a tab
+                    # switch, a layout push) rebuilds every region from this
+                    # screen's current state on the way back, so the pending
+                    # update is not lost -- it arrives with that rebuild.
+                    break
+                if self._SURFACE_RAIL in surfaces:
+                    await self._rebuild_surface(
+                        workbench.refresh_region_content(Region.LEFT_RAIL),
+                        "the Watchlists rail",
+                    )
+                if self._SURFACE_FEEDS in surfaces:
+                    await self._rebuild_surface(
+                        workbench.refresh_region_content(Region.FEEDS),
+                        "the Feeds region",
+                    )
+                if self._SURFACE_HEADER in surfaces:
+                    await self._rebuild_surface(
+                        workbench.refresh_header_content(),
+                        "the centre header",
+                    )
+                if self._SURFACE_INSPECTOR in surfaces and (
+                    self._resolve_console_follow_drift()
+                ):
+                    await self._rebuild_surface(
+                        workbench.refresh_region_content(Region.RIGHT_RAIL),
+                        "the Inspector rail",
+                    )
+        finally:
+            self._pending_surface_refresh = set()
+            self._surface_refresh_draining = False
+
+    @staticmethod
+    async def _rebuild_surface(rebuild: Any, what: str) -> None:
+        """Await one surface rebuild, logging rather than killing the drain.
+
+        A single failing surface must not abandon the ones queued behind it,
+        and it must not leave `_surface_refresh_draining` stuck either (the
+        drainer's own `finally` covers that, but only if this coroutine does
+        not propagate).
+
+        Args:
+            rebuild: The workbench coroutine to await.
+            what: Human-readable surface name, for the debug log only.
+        """
         try:
-            await workbench.refresh_header_content()
+            await rebuild
         except Exception:
-            logger.opt(exception=True).debug(
-                "Failed to refresh the centre header for the new scope."
-            )
+            logger.opt(exception=True).debug(f"Failed to rebuild {what} in place.")
 
     def on_descendant_focus(self, event: events.DescendantFocus) -> None:
         """Keep `focused_region` in step with whatever actually holds focus.
@@ -3020,12 +3353,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         except Exception:
             pass
         # task-895: push the new write-availability into the still-mounted
-        # tree, the same way `watch_tree_scope` pushes `active_scope`. The
-        # snapshot refresh below does eventually recompose the whole screen
-        # (and `_build_tree_pane` would then re-seed this), but that is an
-        # async round trip -- until it lands, the five action buttons would
-        # sit enabled over a backend that cannot service them, which is the
-        # exact "disabled button that looks enabled" shape in reverse.
+        # tree, the same way `watch_tree_scope` pushes `active_scope`. This
+        # is now the ONLY thing that updates it on a backend switch
+        # (TASK-2200): the snapshot refresh below used to recompose the whole
+        # screen, and `_build_tree_pane` re-seeded this on the way through.
+        # It no longer does, so without this the five action buttons would
+        # sit enabled over a backend that cannot service them -- the exact
+        # "disabled button that looks enabled" shape in reverse.
         try:
             self.query_one("#wl-tree", WatchlistTree).write_disabled_reason = (
                 self._tree_write_disabled_reason()
@@ -3037,8 +3371,53 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self.selected_notification = None
         self.selected_entity = None
         self._loaded_runs = []
+        # Same reason as the tree push above (TASK-2200): the four lines
+        # above clear the screen's mirrored state, and until this task the
+        # snapshot refresh's full-screen recompose is what carried that into
+        # whichever detail pane was mounted (`_build_detail_pane` re-seeds
+        # every pane from exactly these attributes). `selected_entity` is
+        # the one that already had its own watcher.
+        self._reseed_live_detail_pane()
         self._refresh_local_wc_snapshot()
         self._refresh_overview_data()
+
+    def _reseed_live_detail_pane(self) -> None:
+        """Push the screen's mirrored rows/selection into the mounted pane.
+
+        The in-place half of `_build_detail_pane`'s seeding, for callers that
+        change that mirrored state without rebuilding the ITEMS region
+        (TASK-2200). Only the pane for the active section can be mounted, so
+        at most one branch does anything; each is a no-op when its pane is
+        absent (the region collapsed, or a different tab).
+        """
+        if not self.is_mounted:
+            return
+        for selector, pane_type, values in (
+            (
+                "#watchlists-sources-pane",
+                SourcesPane,
+                {"sources": self._loaded_sources, "selected_source": self.selected_source},
+            ),
+            (
+                "#watchlists-runs-pane",
+                RunsPane,
+                {"runs": self._loaded_runs, "selected_run": self.selected_run},
+            ),
+            (
+                "#watchlists-notifications-pane",
+                NotificationsPane,
+                {
+                    "notifications": self._loaded_notifications,
+                    "selected_notification": self.selected_notification,
+                },
+            ),
+        ):
+            try:
+                pane = self.query_one(selector, pane_type)
+            except NoMatches:
+                continue
+            for attribute, value in values.items():
+                setattr(pane, attribute, value)
 
     def watch_selected_entity(self) -> None:
         if not self.is_mounted:
@@ -6750,17 +7129,21 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `refresh=False` + `patch_item=item` (Task 5 fix round 1, CRITICAL):
         this fires on every single item SELECTION, not just a deliberate
         button click. A default `refresh` reloads `ItemsPane.items` and
-        calls `_refresh_overview_data()`, and `overview_data` is
-        `reactive({}, recompose=True)` -- a SCREEN-level recompose, which
-        rebuilds every region via its factory
+        calls `_refresh_overview_data()`, which used to set `overview_data`,
+        then a `reactive({}, recompose=True)` -- a SCREEN-level recompose,
+        which rebuilt every region via its factory
         (`_build_list_pane`/`_build_content_pane`/etc.), replacing the live
         `ItemsPane`/`DataTable` instances wholesale. Proven live: with the
         default refresh, one item selection detached the old `ItemsPane`,
         reset the table cursor to 0, cleared screen focus, and a SECOND
-        arrow-key press did nothing at all. `patch_item` mutates the same
-        dict object already held by `ItemsPane.items`/
-        `_selected_content_item`/`ContentPane.item` in place instead, so a
-        later status check sees "reviewed" without forcing a rebuild.
+        arrow-key press did nothing at all. TASK-2200 took the recompose off
+        that reactive (`watch_overview_data` patches the three surfaces that
+        read it), so the crash-shaped half of this is gone; the reload of
+        every item on every arrow key is not, which is why this path still
+        passes `refresh=False`. `patch_item` mutates the same dict object
+        already held by `ItemsPane.items`/`_selected_content_item`/
+        `ContentPane.item` in place instead, so a later status check sees
+        "reviewed" without forcing a rebuild.
 
         This reuses the exact status column Ingest/Ignore/the unread toggle
         already write -- `SubscriptionsDB.mark_item_status`, keyed by the
@@ -7265,12 +7648,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         TASK-1362 (spec §2). Deliberately does NOT call `_load_sources()`,
         `_refresh_overview_data()` or `_refresh_local_wc_snapshot()` the way
-        `_create_source` does. `overview_data` is `reactive({}, recompose=True)`
-        on this screen, so touching it rebuilds every region through its
-        factory and replaces the mounted panes wholesale -- proven live in
-        Phase D Task 5 to detach the `ItemsPane`, reset the `DataTable` cursor
-        and drop keyboard focus. Nothing the user can see is derived from a
-        source's selectors: not the Sources table's five columns, not the
+        `_create_source` does. `overview_data` was `reactive({}, recompose=
+        True)` on this screen when that decision was taken, so touching it
+        rebuilt every region through its factory and replaced the mounted
+        panes wholesale -- proven live in Phase D Task 5 to detach the
+        `ItemsPane`, reset the `DataTable` cursor and drop keyboard focus.
+        TASK-2200 removed that recompose, but the conclusion is unchanged
+        for a simpler reason: nothing the user can see is derived from a
+        source's selectors -- not the Sources table's five columns, not the
         overview counts, not the staging line. So the only stale surface is
         the entity dict itself, which is patched in place -- the SAME object
         held by `selected_entity`, `selected_source` and `SourcesPane.sources`
@@ -7544,12 +7929,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         `refresh=False` (fix round 1, CRITICAL) skips the reload of
         `ItemsPane.items` and `_refresh_overview_data()`. The latter sets
-        `overview_data`, `reactive({}, recompose=True)` on the screen, so
-        calling it after EVERY item selection forced a full screen
-        recompose -- proven live to detach the mounted `ItemsPane`, reset
-        the `DataTable` cursor, and drop keyboard focus, so a second arrow
-        key did nothing. Used only by the silent auto-mark-read-on-open
-        path; every deliberate action (Ingest/Ignore, the unread toggle)
+        `overview_data`, which was `reactive({}, recompose=True)` on the
+        screen until TASK-2200, so calling it after EVERY item selection
+        forced a full screen recompose -- proven live to detach the mounted
+        `ItemsPane`, reset the `DataTable` cursor, and drop keyboard focus,
+        so a second arrow key did nothing. Used only by the silent
+        auto-mark-read-on-open path; every deliberate action
+        (Ingest/Ignore, the unread toggle)
         keeps refreshing as before. When `refresh` is False and the write
         succeeds, `patch_item` -- the same dict object already held by
         `ItemsPane.items`/`_selected_content_item`/`ContentPane.item` -- is
@@ -7732,6 +8118,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
             self.selected_entity = None
             self.selected_source = None
+            # The mounted pane keeps its own copy of the selection, and
+            # nothing rebuilds it from screen state any more (TASK-2200) --
+            # `_load_sources` below refreshes the ROWS but only re-selects
+            # when `selected_source` is set. Without this the pane's Preview
+            # / Check now buttons stay armed on a source that is gone.
+            self._reseed_live_detail_pane()
             notify = getattr(self.app_instance, "notify", None)
             if callable(notify):
                 notify("Source deleted.", severity="information")
@@ -7760,6 +8152,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
             self.selected_entity = None
             self.selected_run = None
+            # See `_delete_source`: the deleted run's own pane holds the
+            # selection, and nothing rebuilds it from screen state any more
+            # (TASK-2200).
+            self._reseed_live_detail_pane()
             notify = getattr(self.app_instance, "notify", None)
             if callable(notify):
                 notify("Run deleted.", severity="information")

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -785,6 +785,51 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             store=getattr(app_instance, "client_notifications_db", None),
         )
 
+    @property
+    def _dom_is_live(self) -> bool:
+        """Whether this screen's widgets are in the DOM and can be patched.
+
+        **Not `self.is_mounted`** (TASK-2200 live-verification wave), and the
+        difference is a real, shipped defect rather than a nicety.
+        `Widget.is_mounted` returns `_is_mounted`, which
+        `MessagePump._pre_process` sets in its `finally` -- *after* it has
+        dispatched `Compose` **and** `Mount`. So for the whole of `on_mount`,
+        and for anything `on_mount` starts that completes before that
+        `finally` runs, `is_mounted` is `False` while the entire subtree is
+        already registered and queryable.
+
+        This screen's loaders complete inside exactly that window on a cold
+        local database. Instrumented on a real terminal:
+
+        ```
+        OVERVIEW watcher is_mounted=False keys=[]  pane=0 inspector=0
+        ON_MOUNT         is_mounted=False wb=1 centre=1 status=1
+        SNAPSHOT applied is_mounted=False loaded=True wb=1 centre=1 status=1
+        OVERVIEW watcher is_mounted=False keys=[...] pane=1 inspector=1
+        ```
+
+        -- the workbench, `#wl-centre`, the status header, the Overview pane
+        and the Inspector are all present, and `is_mounted` is `False` for
+        every one of those lines. An `is_mounted` guard therefore dropped
+        every in-place update on the floor, and nothing re-requested them:
+        the screen sat on "Loading local Watchlists snapshot..." /
+        "Loading watchlist activity..." / "State: unavailable" indefinitely
+        until an unrelated tab switch recomposed it.
+
+        The full-screen `refresh(recompose=True)` this task replaced did not
+        have that problem, because the `overview_data` reactive calls
+        `Widget.refresh` itself, with no `is_mounted` guard anywhere in the
+        path. Reproducing that reach is what this property is for.
+
+        `is_attached` asks the question that actually matters -- "is there a
+        path from me up to the DOM root" (`MessagePump.is_attached`) -- which
+        is `True` from `App._register` onwards and `False` once unmounted or
+        once the app is exiting. Every caller still degrades per-widget via
+        `except NoMatches`, so this is a cheap outer gate, not the only
+        protection.
+        """
+        return self.is_attached
+
     def _watchlist_bundle_service(self) -> WatchlistBundleService | None:
         """The live watchlist bundle service, or ``None`` if unavailable.
 
@@ -918,7 +963,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         Every lookup degrades: the Overview pane exists only on its own tab,
         and the Inspector is unmounted whenever the right rail is collapsed.
         """
-        if not self.is_mounted:
+        if not self._dom_is_live:
             return
         try:
             overview = self.query_one("#watchlists-overview-pane", OverviewPane)
@@ -1037,7 +1082,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         CONTENT is untouched: `ContentPane` reads nothing this loader writes.
         """
-        if not self.is_mounted:
+        if not self._dom_is_live:
             return
         self._request_surface_refresh(
             self._SURFACE_RAIL,
@@ -1161,7 +1206,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         is one `disabled`/`tooltip` pair straight off `_wc_attach_state()` —
         the same tuple `compose_content` hands `_build_inspector_pane`.
         """
-        if not self.is_mounted:
+        if not self._dom_is_live:
             return
         self._request_surface_refresh(
             self._SURFACE_FEEDS, self._SURFACE_HEADER, self._SURFACE_INSPECTOR
@@ -3227,7 +3272,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 matches the adapter; see `_resolve_console_follow_drift`).
                 Unknown names are ignored by the drainer.
         """
-        if not self.is_mounted:
+        if not self._dom_is_live:
             return
         self._pending_surface_refresh.update(surfaces)
         if self._surface_refresh_draining:
@@ -3269,7 +3314,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         already decided to stop.
         """
         try:
-            while self.is_mounted and self._pending_surface_refresh:
+            while self._dom_is_live and self._pending_surface_refresh:
                 surfaces = self._pending_surface_refresh
                 self._pending_surface_refresh = set()
                 try:
@@ -3501,7 +3546,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         at most one branch does anything; each is a no-op when its pane is
         absent (the region collapsed, or a different tab).
         """
-        if not self.is_mounted:
+        if not self._dom_is_live:
             return
         for selector, pane_type, values in (
             (

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -4076,7 +4076,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # SourcesPane instead of leaving its table empty; see
             # `_build_detail_pane` and `_loaded_sources` in __init__.
             self._loaded_sources = [dict(source) for source in sources]
-            if self.is_mounted:
+            if self._dom_is_live:
                 try:
                     sources_pane = self.query_one("#watchlists-sources-pane", SourcesPane)
                     sources_pane.sources = self._loaded_sources
@@ -4110,7 +4110,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 # through the same reconciliation rather than setting
                 # `selected_entity` directly.
                 self._select_entity(requested_run)
-            if self.is_mounted:
+            if self._dom_is_live:
                 try:
                     runs_pane = self.query_one("#watchlists-runs-pane", RunsPane)
                     runs_pane.runs = self._loaded_runs
@@ -4209,7 +4209,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if self.selected_notification
             else None
         )
-        if not self.is_mounted:
+        if not self._dom_is_live:
             return
         try:
             pane = self.query_one("#watchlists-notifications-pane", NotificationsPane)
@@ -4750,7 +4750,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
             self._loaded_briefing_presets = preset_rows
             self._watchlist_has_audio_episodes = has_audio_episodes
-        if not self.is_mounted:
+        if not self._dom_is_live:
             return
         try:
             pane = self.query_one("#watchlists-artifacts-pane", ArtifactsPane)
@@ -7239,7 +7239,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # on `_loaded_sources` in `_load_sources` above; same rebuild,
             # same gap, same fix.
             self._loaded_items = [dict(item) for item in items]
-            if self.is_mounted:
+            if self._dom_is_live:
                 try:
                     items_pane = self.query_one("#watchlists-items-pane", ItemsPane)
                     items_pane.items = self._loaded_items
@@ -7699,7 +7699,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # on `_loaded_sources` in `_load_sources` above; same rebuild,
             # same gap, same fix.
             self._loaded_rules = [dict(rule) for rule in rules]
-            if self.is_mounted:
+            if self._dom_is_live:
                 try:
                     rules_pane = self.query_one("#watchlists-rules-pane", RulesPane)
                     rules_pane.rules = self._loaded_rules

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -770,6 +770,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # queue rather than `run_worker(exclusive=True)` per surface.
         self._pending_surface_refresh: set[str] = set()
         self._surface_refresh_draining = False
+        # The Console-follow adapter's latest answer, mirrored here so the
+        # RIGHT_RAIL factory reads an attribute instead of polling from
+        # `compose()` (TASK-2200 review wave, M4). Refreshed by
+        # `compose_content` and by `_resolve_console_follow_drift`.
+        self._console_follow_item: Any = None
         self._controller = WatchlistsBackendController(
             app_instance=app_instance,
             scope_service=getattr(app_instance, "watchlist_scope_service", None),
@@ -943,10 +948,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 self.query_one(widget_id, Static).update(text)
             except NoMatches:
                 continue
-        # An overview refresh follows every write verb on this screen, and a
-        # write verb is exactly when a run can have started or finished --
-        # so this is also where the Console-follow row used to be re-polled,
-        # via the recompose this reactive no longer triggers.
+        # An overview refresh follows every write verb on this screen, so this
+        # is one of the points where the recompose this reactive no longer
+        # triggers used to re-enter the Console-follow adapter. What that
+        # actually recovers is an adapter that FAILED on the first compose --
+        # not a run that has since started, which the handoff caches away
+        # permanently after one success. See `_resolve_console_follow_drift`,
+        # which states both halves of that cache's behaviour.
         self._request_surface_refresh(self._SURFACE_INSPECTOR)
 
     @work(exclusive=True, group="wc_tree")
@@ -998,8 +1006,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         by the resulting prune mounts nothing, silently, while still
         reporting `is_mounted=True`.
 
-        Only three things on this screen actually read what this loader
-        writes, so only those three are updated:
+        Everything on this screen that reads what this loader writes, and
+        nothing else:
 
         * The rail itself (`_tree_watchlists`/`_tree_counts`) — rebuilt from
           `_build_tree_pane`, which re-seeds the expansion, tag filter and
@@ -1007,12 +1015,27 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         * FEEDS and the centre header, whose scope heading resolves a
           watchlist's display name out of `_tree_watchlists` (a rename would
           otherwise sit stale) and whose source rows are re-queried.
-        * The Inspector's breadcrumb labels and the Overview's watchlist
-          count, both pushed into the live panes the way `watch_selected_scope`
-          and `_load_sources` already push theirs.
+        * The Inspector's breadcrumb labels, and — in the ITEMS region — the
+          Overview's watchlist count and the Artifacts pane's scope label,
+          all pushed into the live panes the way `watch_selected_scope` and
+          `_load_sources` already push theirs.
 
-        ITEMS and CONTENT are deliberately untouched: nothing in either reads
-        tree data except the Overview's `watchlist_count`, handled above.
+        The two ITEMS-region pushes are not an exception to "background loads
+        leave ITEMS alone"; they are the reason that rule is stated as "no
+        pane is REBUILT" rather than "no pane is touched". Both are single
+        reactive assignments onto whichever pane happens to be mounted, so a
+        `SourcesPane` create form or a `RulesPane` edit form -- neither of
+        which reads tree data -- is not even queried, let alone torn down.
+
+        `ArtifactsPane.scope_label` was missed on the first pass and found by
+        the whole-branch review (I1): it resolves a watchlist DISPLAY NAME via
+        `_briefing_scope_label` -> `_watchlist_display_name` -> the same
+        `_tree_watchlists` list, so renaming the scoped watchlist while the
+        Artifacts tab was open repainted the rail, the FEEDS heading and the
+        breadcrumb but left `#artifacts-scope-note` naming the old one — two
+        surfaces on one screen disagreeing about the same watchlist.
+
+        CONTENT is untouched: `ContentPane` reads nothing this loader writes.
         """
         if not self.is_mounted:
             return
@@ -1038,6 +1061,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # knows the answer. `_build_detail_pane` seeds the same value on
             # a rebuild.
             overview.watchlist_count = len(self._tree_watchlists)
+        try:
+            artifacts = self.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        except NoMatches:
+            pass
+        else:
+            # Review wave, I1. `_briefing_scope_label` resolves the scoped
+            # watchlist's display NAME out of `_tree_watchlists`, so a rename
+            # left `#artifacts-scope-note` on the old one. Same seed
+            # `_build_detail_pane` applies on a rebuild.
+            artifacts.scope_label = self._briefing_scope_label()
 
     def _resolve_breadcrumb_labels(self, scope: TreeScope) -> list[str]:
         """Display names for `scope`'s ancestor chain, for the Inspector.
@@ -1924,9 +1957,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         against what is actually on screen. The Console-follow state comes
         from an app-level adapter that is only ever *polled* at render time --
         until this task, "render time" meant every full-screen recompose, so
-        an adapter that failed once (or a run that started since) was picked
-        up by whichever background loader recomposed next. With those
-        recomposes gone, the drift has to be detected deliberately.
+        an adapter that failed once was picked up by whichever background
+        loader recomposed next. With those recomposes gone, that recovery has
+        to be detected deliberately.
 
         Args:
             latest_console_item: The adapter's answer, or `None`.
@@ -1961,24 +1994,47 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _resolve_console_follow_drift(self) -> bool:
         """Re-poll the Console-follow adapter and say whether the rail is stale.
 
+        **What this can and cannot detect** (review wave, M3 -- verified
+        against `WatchlistsConsoleHandoff._latest_console_follow_item`,
+        `watchlists_console_handoff.py:39-75`, not assumed):
+
+        * A **successful** poll sets `_latest_console_follow_loaded = True`,
+          and nothing ever resets it -- so after one success the adapter's
+          answer is frozen for the life of this screen, and this method can
+          only return `False`. That is not a regression: the full-screen
+          recompose this replaces hit the identical cache. A live re-poll on
+          every background load would be NEW behaviour -- and expensive, since
+          the adapter fans out over watchlist-run, chatbook-artifact,
+          ingest-job and notification queries plus a server-event fetch -- so
+          it is deliberately not built here.
+        * A **failed** poll does NOT set that flag, so failure is retried. That
+          is the one real case this exists for, and it is the case the old
+          recompose covered: an adapter that fails during the first compose
+          renders `#watchlists-console-unavailable`, and the next background
+          loader picks up the recovered answer. Pinned by
+          `test_watchlists_destination_retries_console_follow_after_initial_adapter_failure`.
+
         Not a pure predicate despite the boolean return, which is why it is
-        named for the action: `resolve_latest_follow_item()` refreshes the
-        handoff's cached item id as a deliberate side effect ("ahead of a
-        render pass" -- see its docstring), exactly as `compose_content` used
-        to do on every recompose.
+        named for the action: it refreshes the handoff's cached item id (a
+        deliberate side effect, "ahead of a render pass" -- see
+        `resolve_latest_follow_item`) and mirrors the answer onto
+        `_console_follow_item` for `_build_inspector_region` to render.
 
         Compares against the DOM rather than a remembered key, so there is no
         second copy of "what is currently rendered" to drift: the rendered
-        answer IS the state.
+        answer IS the state. Because the only reachable transition is
+        failure -> success, which changes the status widget's *id*, the
+        `if not status_widgets` branch below is what actually fires; the two
+        text comparisons after it are belt-and-braces for a future handoff
+        whose cache does expire.
 
         Returns:
             True when the Inspector is mounted and its Console-follow row no
             longer matches the adapter, so the right rail should be rebuilt.
         """
+        self._console_follow_item = self._console_handoff.resolve_latest_follow_item()
         status_id, status_copy, button_label, _disabled, _tooltip = (
-            self._console_follow_copy(
-                self._console_handoff.resolve_latest_follow_item()
-            )
+            self._console_follow_copy(self._console_follow_item)
         )
         try:
             button = self.query_one("#watchlists-follow-in-console", Button)
@@ -1996,16 +2052,24 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def _build_inspector_region(self) -> Vertical:
         """The RIGHT_RAIL content factory.
 
-        Resolves the Console-follow item and the Console attach state at CALL
-        time rather than closing over values captured in `compose_content`
-        (TASK-2200): the workbench calls this factory again on every region
-        rebuild, including the targeted right-rail rebuild
-        `_resolve_console_follow_drift` asks for, and a captured value would
-        make that rebuild repaint the very staleness it was asked to fix.
+        Reads `_console_follow_item` -- a plain attribute -- rather than
+        polling the adapter (review wave, M4). The workbench calls this
+        factory again on every region rebuild, and `region_layout` is
+        `recompose=True`, so a `z`/`Z`/`[`/`]`/chevron toggle would otherwise
+        re-run the adapter's multi-query fan-out from inside `compose()`. The
+        handoff's cache makes that free once a poll has SUCCEEDED, but on the
+        failure path it is retried every time -- exactly the shape this file
+        insists its content factories must not have.
+
+        The attribute is refreshed in the two places a fresh answer is
+        actually wanted: once per compose pass (`compose_content`, restoring
+        the pre-TASK-2200 call site) and by `_resolve_console_follow_drift`
+        immediately before it asks for this rebuild -- so the targeted rail
+        rebuild still repaints the staleness it was asked to fix.
         """
         attach_disabled, attach_tooltip = self._wc_attach_state()
         return self._build_inspector_pane(
-            self._console_handoff.resolve_latest_follow_item(),
+            self._console_follow_item,
             attach_disabled,
             attach_tooltip,
         )
@@ -2131,6 +2195,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         return f"Backend: {self.runtime_backend}"
 
     def compose_content(self) -> ComposeResult:
+        # Resolved once per compose pass, as it was before TASK-2200 -- but
+        # mirrored onto the screen instead of captured in the RIGHT_RAIL
+        # factory's closure, so a region rebuild reads an attribute rather
+        # than re-running the adapter (review wave, M4). See
+        # `_build_inspector_region`.
+        self._console_follow_item = self._console_handoff.resolve_latest_follow_item()
         with Vertical(id="watchlists-collections-shell"):
             yield Static(
                 "Watchlists | Monitored sources, runs, alerts, recovery | Mixed | Local/Server",
@@ -3150,20 +3220,44 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         next loop rather than starting -- or cancelling -- anything.
 
         Args:
-            surfaces: Any of `_SURFACE_RAIL`/`_SURFACE_FEEDS`/
-                `_SURFACE_HEADER`. Unknown names are ignored by the drainer.
+            surfaces: Any of `_SURFACE_RAIL`, `_SURFACE_FEEDS`,
+                `_SURFACE_HEADER` (each an unconditional rebuild of that
+                surface) or `_SURFACE_INSPECTOR` (conditional -- the right
+                rail is rebuilt only when the Console-follow row no longer
+                matches the adapter; see `_resolve_console_follow_drift`).
+                Unknown names are ignored by the drainer.
         """
         if not self.is_mounted:
             return
         self._pending_surface_refresh.update(surfaces)
         if self._surface_refresh_draining:
             return
-        self._surface_refresh_draining = True
+        # Arm, then disarm if scheduling fails -- `_start_tree_write`'s
+        # discipline, for the identical failure mode (review wave, M1). Only
+        # `_drain_surface_refresh`'s `finally` ever lowers this flag, and it
+        # never runs if `run_worker` raises synchronously; the flag would then
+        # be stuck True for the life of the screen, every later request would
+        # queue and return, and the rail/FEEDS/header would silently stop
+        # following every background loader. Arming *after* scheduling is not
+        # the fix either: the drainer's `finally` could already have lowered
+        # the flag by the time we raised it.
+        #
         # Its own group, not the default one: several call sites on this
         # screen run `run_worker(..., exclusive=True)` without a group (e.g.
         # `_load_active_section_data`), and those would otherwise cancel this
         # drainer mid-swap -- the very failure this queue exists to prevent.
-        self.run_worker(self._drain_surface_refresh(), group="wc_surface_refresh")
+        drain = self._drain_surface_refresh()
+        self._surface_refresh_draining = True
+        try:
+            self.run_worker(drain, group="wc_surface_refresh")
+        except Exception:
+            self._surface_refresh_draining = False
+            # Close the un-awaited coroutine explicitly, or it leaks a
+            # `RuntimeWarning` at collection time.
+            drain.close()
+            logger.opt(exception=True).warning(
+                "Watchlists surface refresh could not be scheduled."
+            )
 
     async def _drain_surface_refresh(self) -> None:
         """Rebuild every queued surface in place, one at a time.
@@ -3201,16 +3295,33 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                         workbench.refresh_header_content(),
                         "the centre header",
                     )
-                if self._SURFACE_INSPECTOR in surfaces and (
-                    self._resolve_console_follow_drift()
-                ):
+                if self._SURFACE_INSPECTOR in surfaces:
                     await self._rebuild_surface(
-                        workbench.refresh_region_content(Region.RIGHT_RAIL),
+                        self._rebuild_inspector_if_console_follow_drifted(workbench),
                         "the Inspector rail",
                     )
         finally:
             self._pending_surface_refresh = set()
             self._surface_refresh_draining = False
+
+    async def _rebuild_inspector_if_console_follow_drifted(
+        self, workbench: WatchlistsWorkbench
+    ) -> None:
+        """Re-poll the Console-follow adapter; rebuild the rail if it moved.
+
+        Wrapped in a coroutine rather than inlined into the drain loop's `if`
+        (review wave, M2) so `_rebuild_surface`'s `except Exception` covers
+        the poll as well as the rebuild. `run_worker` defaults to
+        `exit_on_error=True`, so an exception escaping the drainer reaches
+        `App._handle_exception` and takes the app down -- and every other step
+        in that loop was deliberately made non-fatal.
+
+        Args:
+            workbench: The mounted workbench, resolved once by the drainer.
+        """
+        if not self._resolve_console_follow_drift():
+            return
+        await workbench.refresh_region_content(Region.RIGHT_RAIL)
 
     @staticmethod
     async def _rebuild_surface(rebuild: Any, what: str) -> None:

--- a/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
@@ -35,8 +35,9 @@ class ItemsFilterChanged(Message):
     Same reason `SourcesPane.CreateFormDraftChanged` exists (see
     `sources_pane.py`): this pane is rebuilt from scratch by
     `_build_detail_pane` on every workbench recompose -- a `z`/`[`/`]`
-    keypress, a chevron click, or the `overview_data` recompose an
-    item-status refresh can trigger -- so `status_filter`/`search_query`
+    keypress, a chevron click, a tab switch (and, until TASK-2200 took the
+    recompose off it, the `overview_data` write an item-status refresh
+    triggers) -- so `status_filter`/`search_query`
     reset to their class defaults and the user's filter and half-typed
     search silently vanish. The screen mirrors this into its own state and
     seeds it back into the fresh pane.


### PR DESCRIPTION
## What (task-2200)

Removes the Watchlists screen's background-driven full-screen recomposes — the architectural root cause behind task-1960's prune-time crash class. The screen keeps exactly one `refresh(recompose=True)`, in `watch_active_section` (a user gesture that genuinely changes which regions mount).

**Converted to targeted in-place updates:**
- `overview_data` reactive (was screen-level `recompose=True`; two production code paths existed solely to dodge its recompose) → plain reactive + watcher pushing into the live OverviewPane/Inspector.
- `_load_tree_data` → rail + FEEDS + header rebuilds; breadcrumbs, watchlist count, and Artifacts scope label pushed into live panes.
- `_apply_local_wc_snapshot` → FEEDS + header rebuilds; Inspector `State:` line and Console attach button patched in place.

**One owner for DOM swaps:** the workbench's remove-then-mount region rebuilds are serialized through a record-intent/drain-serially queue (`_request_surface_refresh`/`_drain_surface_refresh`) — `exclusive=True` was unsound once three actors wanted the swaps (a cancelled predecessor between `remove()` and `mount()` leaves a bordered empty region). Task-1541's cancellation lesson, applied to DOM work.

**Behaviors the old recompose silently carried, now explicit:** backend-switch selection reseed (`_reseed_live_detail_pane`); Console-follow drift re-poll (`_resolve_console_follow_drift`, conditional so a half-typed noise-selector draft is never destroyed by a background refresh).

## The live-only defect this surfaced (and the lesson)

Green suites, two clean reviews — and in a real terminal the initial load never painted: **during the whole of `on_mount`, `Widget.is_mounted` is still False** (`_pre_process` sets it in its `finally`, after Compose+Mount dispatch — the same `finally` as task-1960, seen from the other side). Every new `if not self.is_mounted` guard skipped the 7ms cold-DB load, and dev's reactive recompose had silently masked the identical skip for the six pre-existing section loaders too. Measured in review: after a real `switch_screen` teardown `is_attached` is False while `is_mounted` is **still True** — these guards were never a teardown gate, only a false negative for the mount window. All twelve sites now use `is_attached` (`_dom_is_live`); the trap is recorded in the task notes.

## Verification

- Whole-branch review + 3 fix waves (opus, adversarial): artifacts scope-label regression proven bidirectionally and fixed; drain hardening (no wedge on failed worker launch, drift poll inside the guard); honest drift-cache docs; mount-window fixes above. Final scoped re-reviews: all findings closed.
- **28 mutations across the waves, all RED, all restored byte-exact (md5-verified)** — including per-site sweeps of both guard sets, proven disjoint.
- **Live-verified in a real terminal, twice, independently** (fresh scratch profiles, zero interaction): before the mount-window fix the screen sat on "Loading…" for 100+s; after, loaded/empty states paint in ≤5s and the Inspector reads "State: ready".
- e2e create-form: 10/10 isolation, poisoned-order 50-passed runs repeated across every wave. Region-gating, overview/first-run/loading-state, inspector, panes, modal suites all green; `--collect-only` 8485 clean.
- AC#1 draft-survival and AC#4 form-close-without-screen-rebuild covered by identity-asserting regression tests; `PruneSafeSelect` untouched (AC#5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces full-screen recomposes on the Watchlists screen with targeted in-place updates to keep panes/forms mounted, and fixes cold-start loads not painting by using a DOM-live guard during the mount window. Linear task-2200; addresses the crash class from task-1960.

- **Refactors**
  - Replaced screen-level recomposes from `overview_data`, `_load_tree_data`, and `_apply_local_wc_snapshot` with focused updates to the rail, FEEDS, headers, `OverviewPane`, and `Inspector` (includes breadcrumbs, watchlist count, scope label, profile state, and a screen-held console-follow mirror).
  - Added a serialized region-swap queue (`_request_surface_refresh` / `_drain_surface_refresh`) to own remove-then-mount cycles and prevent empty regions when a half is cancelled.
  - Made backend-switch reseed and console-follow drift handling explicit; right rail rebuilds only when the adapter’s answer changes. Kept `watch_active_section` as the only recompose.

- **Bug Fixes**
  - Switched guards to `is_attached` (`_dom_is_live`) so overview, section loaders, and `watch_selected_entity` paint during the mount window (covers cold starts and deep links).
  - Hardened the refresh queue and drift logic: avoid wedges on failed worker scheduling; moved console-follow poll under the guarded rebuild; stop re-running the adapter in `compose()` by mirroring `console_follow_item` on the screen.
  - Ensured renamed watchlists reach the mounted Inspector (breadcrumb and `#artifacts-scope-note`) and that overview counts/statics update in place.

<sup>Written for commit 49ac443c57c51aadf797b40a98ac10816dcb4cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

