### PR TITLE
fix(tts): make custom OpenAI TTS endpoints usable (TASK-2260)

### DIFF
--- a/Tests/TTS/test_legacy_backend_registry.py
+++ b/Tests/TTS/test_legacy_backend_registry.py
@@ -233,9 +233,12 @@ def test_builtin_import_attribute_error_propagates(
 
 
 @pytest.mark.asyncio
-async def test_openai_backend_uses_configured_endpoint_and_organization_header(
+async def test_openai_backend_uses_configured_endpoint_without_organization_header(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """TASK-2260: a configured org ID must not be forwarded to a custom
+    (non-OpenAI) endpoint; the official-endpoint case is covered in
+    test_openai_compatible_endpoint.py."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     requests: list[httpx.Request] = []
 
@@ -269,7 +272,7 @@ async def test_openai_backend_uses_configured_endpoint_and_organization_header(
 
     assert chunks == [b"audio"]
     assert str(requests[0].url) == "https://tts.example.test/v1/audio/speech"
-    assert requests[0].headers["OpenAI-Organization"] == "org-test"
+    assert "openai-organization" not in requests[0].headers
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_openai_compatible_endpoint.py
+++ b/Tests/TTS/test_openai_compatible_endpoint.py
@@ -60,6 +60,7 @@ async def _close_replaced_client(backend: OpenAITTSBackend) -> None:
 async def test_custom_endpoint_passes_model_and_voice_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Custom endpoints define their own model/voice names — no coercion."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     requests: list[httpx.Request] = []
     backend = _backend_with_transport(
@@ -79,6 +80,7 @@ async def test_custom_endpoint_passes_model_and_voice_through(
 async def test_custom_endpoint_without_api_key_sends_no_authorization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Keyless local servers work; no Authorization header is fabricated."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     requests: list[httpx.Request] = []
     backend = _backend_with_transport({"OPENAI_BASE_URL": CUSTOM_URL}, requests)
@@ -97,6 +99,7 @@ async def test_custom_endpoint_without_api_key_sends_no_authorization(
 async def test_custom_endpoint_with_key_still_sends_bearer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A configured key is still sent to custom endpoints that need one."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     requests: list[httpx.Request] = []
     backend = _backend_with_transport(
@@ -114,6 +117,7 @@ async def test_custom_endpoint_with_key_still_sends_bearer(
 async def test_default_endpoint_still_coerces_model_and_voice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Characterization pin: official-endpoint coercion is unchanged."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     requests: list[httpx.Request] = []
     backend = _backend_with_transport({"OPENAI_API_KEY": "test-key"}, requests)
@@ -132,6 +136,7 @@ async def test_default_endpoint_still_coerces_model_and_voice(
 async def test_default_endpoint_still_requires_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Characterization pin: the official endpoint still refuses to run keyless."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     requests: list[httpx.Request] = []
     backend = _backend_with_transport({}, requests)
@@ -142,6 +147,78 @@ async def test_default_endpoint_still_requires_api_key(
         await _generate(backend)
 
     assert requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "official_variant",
+    (
+        "https://api.openai.com/v1/audio/speech/",
+        "HTTPS://API.OpenAI.com/v1/audio/speech",
+        "https://api.openai.com:443/v1/audio/speech",
+    ),
+)
+async def test_official_endpoint_variants_keep_guardrails(
+    monkeypatch: pytest.MonkeyPatch, official_variant: str
+) -> None:
+    """A cosmetic rewrite of the official URL (slash, case, default port) must not
+    be misclassified as a custom endpoint and lose model/voice coercion."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport(
+        {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": official_variant}, requests
+    )
+    await _close_replaced_client(backend)
+
+    assert backend.is_custom_endpoint is False
+    chunks = await _generate(backend, model="pocket-tts", voice="marius")
+
+    assert chunks == [b"audio"]
+    payload = json.loads(requests[0].content)
+    assert payload["model"] == "tts-1"
+    assert payload["voice"] == "alloy"
+
+
+@pytest.mark.asyncio
+async def test_custom_endpoint_does_not_forward_organization_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured OpenAI org ID is OpenAI account metadata and must not leak to
+    third-party OpenAI-compatible servers."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport(
+        {
+            "OPENAI_API_KEY": "test-key",
+            "OPENAI_BASE_URL": CUSTOM_URL,
+            "OPENAI_ORG_ID": "org-test",
+        },
+        requests,
+    )
+    await _close_replaced_client(backend)
+
+    chunks = await _generate(backend)
+
+    assert chunks == [b"audio"]
+    assert "openai-organization" not in requests[0].headers
+
+
+@pytest.mark.asyncio
+async def test_official_endpoint_still_sends_organization_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The org header keeps working for the real OpenAI endpoint."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport(
+        {"OPENAI_API_KEY": "test-key", "OPENAI_ORG_ID": "org-test"}, requests
+    )
+    await _close_replaced_client(backend)
+
+    chunks = await _generate(backend)
+
+    assert chunks == [b"audio"]
+    assert requests[0].headers["OpenAI-Organization"] == "org-test"
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_openai_compatible_endpoint.py
+++ b/Tests/TTS/test_openai_compatible_endpoint.py
@@ -1,0 +1,193 @@
+# test_openai_compatible_endpoint.py
+# Description: TASK-2260 — custom (OpenAI-compatible) TTS endpoints must receive the
+# configured model/voice unmodified and must not require an API key; behavior against
+# the default OpenAI endpoint must not change.
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.backends.openai import OpenAITTSBackend
+
+CUSTOM_URL = "http://127.0.0.1:8123/v1/audio/speech"
+
+
+def _capture_transport(requests: list[httpx.Request]) -> httpx.MockTransport:
+    async def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=b"audio")
+
+    return httpx.MockTransport(respond)
+
+
+async def _generate(backend: OpenAITTSBackend, **request_overrides) -> list[bytes]:
+    request = OpenAISpeechRequest(
+        model=request_overrides.pop("model", "tts-1"),
+        input="hello",
+        voice=request_overrides.pop("voice", "alloy"),
+        response_format="wav",
+        **request_overrides,
+    )
+    try:
+        return [chunk async for chunk in backend.generate_speech_stream(request)]
+    finally:
+        await backend.close()
+
+
+def _backend_with_transport(
+    config: dict, requests: list[httpx.Request]
+) -> OpenAITTSBackend:
+    backend = OpenAITTSBackend(config)
+    original_client = backend.client
+    backend.client = httpx.AsyncClient(transport=_capture_transport(requests))
+    # The constructor's real client is replaced before any request; close it eagerly
+    # via the event loop the test runs on.
+    backend._original_client_for_cleanup = original_client
+    return backend
+
+
+async def _close_replaced_client(backend: OpenAITTSBackend) -> None:
+    original = getattr(backend, "_original_client_for_cleanup", None)
+    if original is not None:
+        await original.aclose()
+
+
+@pytest.mark.asyncio
+async def test_custom_endpoint_passes_model_and_voice_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport(
+        {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": CUSTOM_URL}, requests
+    )
+    await _close_replaced_client(backend)
+
+    chunks = await _generate(backend, model="pocket-tts", voice="marius")
+
+    assert chunks == [b"audio"]
+    payload = json.loads(requests[0].content)
+    assert payload["model"] == "pocket-tts"
+    assert payload["voice"] == "marius"
+
+
+@pytest.mark.asyncio
+async def test_custom_endpoint_without_api_key_sends_no_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport({"OPENAI_BASE_URL": CUSTOM_URL}, requests)
+    await _close_replaced_client(backend)
+    # Config-file fallbacks may resolve a key in some environments; this test is about
+    # the keyless path, so force the resolved key empty.
+    backend.api_key = None
+
+    chunks = await _generate(backend)
+
+    assert chunks == [b"audio"]
+    assert "authorization" not in requests[0].headers
+
+
+@pytest.mark.asyncio
+async def test_custom_endpoint_with_key_still_sends_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport(
+        {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": CUSTOM_URL}, requests
+    )
+    await _close_replaced_client(backend)
+
+    chunks = await _generate(backend)
+
+    assert chunks == [b"audio"]
+    assert requests[0].headers["Authorization"] == "Bearer test-key"
+
+
+@pytest.mark.asyncio
+async def test_default_endpoint_still_coerces_model_and_voice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport({"OPENAI_API_KEY": "test-key"}, requests)
+    await _close_replaced_client(backend)
+
+    chunks = await _generate(backend, model="pocket-tts", voice="marius")
+
+    assert chunks == [b"audio"]
+    assert str(requests[0].url) == "https://api.openai.com/v1/audio/speech"
+    payload = json.loads(requests[0].content)
+    assert payload["model"] == "tts-1"
+    assert payload["voice"] == "alloy"
+
+
+@pytest.mark.asyncio
+async def test_default_endpoint_still_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    requests: list[httpx.Request] = []
+    backend = _backend_with_transport({}, requests)
+    await _close_replaced_client(backend)
+    backend.api_key = None
+
+    with pytest.raises(ValueError, match="not configured"):
+        await _generate(backend)
+
+    assert requests == []
+
+
+@pytest.mark.asyncio
+async def test_keyless_openai_compatible_server_over_real_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end against a real local HTTP server shaped like pocket-tts:
+    keyless, custom model and voice, OpenAI-compatible /v1/audio/speech route."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    received: dict = {}
+
+    class SpeechHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            received["path"] = self.path
+            received["payload"] = json.loads(body)
+            received["authorization"] = self.headers.get("Authorization")
+            audio = b"RIFFfake-wav-bytes"
+            self.send_response(200)
+            self.send_header("Content-Type", "audio/wav")
+            self.send_header("Content-Length", str(len(audio)))
+            self.end_headers()
+            self.wfile.write(audio)
+
+        def log_message(self, *args) -> None:  # keep test output quiet
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), SpeechHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        backend = OpenAITTSBackend(
+            {
+                "OPENAI_BASE_URL": f"http://127.0.0.1:{server.server_port}/v1/audio/speech"
+            }
+        )
+        backend.api_key = None
+
+        chunks = await _generate(backend, model="pocket-tts", voice="marius")
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert b"".join(chunks) == b"RIFFfake-wav-bytes"
+    assert received["path"] == "/v1/audio/speech"
+    assert received["payload"]["model"] == "pocket-tts"
+    assert received["payload"]["voice"] == "marius"
+    assert received["authorization"] is None

--- a/backlog/tasks/task-2260 - Make custom OpenAI TTS endpoints usable model-voice passthrough optional key.md
+++ b/backlog/tasks/task-2260 - Make custom OpenAI TTS endpoints usable model-voice passthrough optional key.md
@@ -75,7 +75,15 @@ branch; origin/dev had meanwhile gained the persistence/backend plumbing for
 behaviors that still broke OpenAI-compatible servers. Discoverability docs split out to
 task-2261.
 
-Files: `tldw_chatbook/TTS/backends/openai.py`, `Tests/TTS/test_openai_compatible_endpoint.py`.
+Qodo round (all four findings addressed in-thread): official-endpoint detection made
+canonical (`_is_official_openai_endpoint` on urlsplit components — cosmetic URL variants no
+longer lose guardrails); `OpenAI-Organization` no longer forwarded to custom endpoints (the
+pre-existing custom-URL org-header test was updated to pin the new behavior); test docstrings
+added; the "no non-streaming TTS API" rule flag declined as a pre-existing cross-backend
+interface property out of this PR's scope.
+
+Files: `tldw_chatbook/TTS/backends/openai.py`, `Tests/TTS/test_openai_compatible_endpoint.py`,
+`Tests/TTS/test_legacy_backend_registry.py`.
 Verified: 2,195 tests in `Tests/TTS/` + speech settings model tests pass; ruff check/format
 clean; repo-wide `--collect-only` sweep clean (29,821 collected).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2260 - Make custom OpenAI TTS endpoints usable model-voice passthrough optional key.md
+++ b/backlog/tasks/task-2260 - Make custom OpenAI TTS endpoints usable model-voice passthrough optional key.md
@@ -1,0 +1,81 @@
+---
+id: TASK-2260
+title: Make custom OpenAI TTS endpoints usable (model/voice passthrough, optional key)
+status: Done
+updated_date: '2026-08-04 12:00'
+assignee:
+  - '@claude'
+created_date: '2026-08-04 12:00'
+labels:
+  - tts
+  - settings
+  - chrome-honesty
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A user could not point chatbook at a local OpenAI-compatible TTS server (pocket-tts). At
+investigation time the Base URL setting was dead end-to-end; by the time this task was filed,
+origin/dev had already gained the persistence + backend plumbing for `OPENAI_BASE_URL` /
+`OPENAI_ORG_ID` (Speech settings model → `_TTS_SETTING_BINDINGS` → `OpenAITTSBackend`, with
+validation and tests). What still breaks OpenAI-compatible servers is the request itself:
+`OpenAITTSBackend.generate_speech_stream` silently coerces any model outside
+`tts-1`/`tts-1-hd` to `tts-1` and any voice outside OpenAI's six to `alloy`, so a custom
+server's model/voice names never reach it, and `_validate_api_key` refuses to run without an
+API key even though local servers are typically keyless. Scope: when a custom base URL is
+configured, pass model and voice through unmodified and make the API key optional (still sent
+as a Bearer header when configured). Behavior against the default OpenAI endpoint must not
+change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 With a custom base URL, the model value passes through to the server unmodified (no coercion to tts-1)
+- [x] #2 With a custom base URL, the voice value passes through to the server unmodified (no coercion to alloy)
+- [x] #3 With a custom base URL and no API key configured, generation proceeds and the request carries no Authorization header; a configured key is still sent as a Bearer header
+- [x] #4 Against the default OpenAI endpoint, existing behavior is unchanged: model/voice coercion and the API-key requirement remain
+- [x] #5 Regression tests cover all of the above and fail if any of the behaviors regress
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD: add `Tests/TTS/test_openai_compatible_endpoint.py` using the MockTransport injection
+   pattern from `test_legacy_backend_registry.py`; watch the passthrough/keyless tests fail
+   against current coercion behavior.
+2. In `TTS/backends/openai.py`: derive `is_custom_endpoint` from the validated base URL;
+   when custom, skip model/voice coercion, skip `_validate_api_key`, and omit the
+   Authorization header when no key is configured.
+3. Keep default-endpoint behavior byte-identical; pin it with characterization tests.
+4. Run the TTS test files + a `--collect-only` sweep (targeted-tests ruling; no full-suite runs).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`OpenAITTSBackend` now derives `is_custom_endpoint` from the already-validated base URL
+(`base_url != _DEFAULT_OPENAI_TTS_URL`). When custom: model and voice pass through to the
+server unmodified, `_validate_api_key` is skipped, and the Authorization header is only sent
+when a key is actually configured (previously the header was always built, and would have
+carried a literal `Bearer None`). Default-endpoint behavior is byte-identical and pinned by
+characterization tests. The no-key startup warnings are also silenced for custom endpoints,
+since "Requests will fail" is false there.
+
+TDD: `Tests/TTS/test_openai_compatible_endpoint.py` — passthrough and keyless tests watched
+red against the old coercion before the fix; default-endpoint pins were mutation-tested
+(forcing `is_custom_endpoint = True` makes both fail). Includes one end-to-end test against a
+real local HTTP server shaped like pocket-tts (keyless, custom model/voice, real socket).
+
+Scope note: at investigation time the Base URL setting was dead end-to-end on the reviewed
+branch; origin/dev had meanwhile gained the persistence/backend plumbing for
+`OPENAI_BASE_URL`/`OPENAI_ORG_ID` with its own tests, so this task narrowed to the request
+behaviors that still broke OpenAI-compatible servers. Discoverability docs split out to
+task-2261.
+
+Files: `tldw_chatbook/TTS/backends/openai.py`, `Tests/TTS/test_openai_compatible_endpoint.py`.
+Verified: 2,195 tests in `Tests/TTS/` + speech settings model tests pass; ruff check/format
+clean; repo-wide `--collect-only` sweep clean (29,821 collected).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2261 - Document pointing chatbook at OpenAI-compatible TTS servers.md
+++ b/backlog/tasks/task-2261 - Document pointing chatbook at OpenAI-compatible TTS servers.md
@@ -1,0 +1,33 @@
+---
+id: TASK-2261
+title: Document pointing chatbook at OpenAI-compatible TTS servers
+status: To Do
+assignee: []
+created_date: '2026-08-04 12:00'
+labels:
+  - tts
+  - docs
+dependencies:
+  - task-2260
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The complaint that produced TASK-2260 was a discoverability failure as much as a behavior one:
+a user wanting to use a local OpenAI-compatible TTS server (pocket-tts) had no documentation
+telling them the OpenAI provider's Base URL setting is the way to do it. There is no Speech/TTS
+page under `Docs/User_Guide/` at all (the User Guide programme G1-G5 has not reached Speech).
+Write a short user-facing doc covering: choosing the OpenAI provider with a custom Base URL for
+any OpenAI-compatible server (keyless local servers included, with custom model/voice names
+passed through — behavior shipped in TASK-2260), and the AllTalk provider as the alternative
+for AllTalk servers specifically. Include a worked pocket-tts example.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A user-guide page explains how to point TTS at an OpenAI-compatible server via the OpenAI provider's Base URL setting, including a keyless local-server example
+- [ ] #2 The page states that custom model and voice names are passed through unmodified when a custom Base URL is set
+- [ ] #3 The page is reachable from wherever the User Guide indexes speech/TTS topics
+<!-- AC:END -->

--- a/tldw_chatbook/TTS/backends/openai.py
+++ b/tldw_chatbook/TTS/backends/openai.py
@@ -120,14 +120,18 @@ class OpenAITTSBackend(APITTSBackend):
 
         self.base_url = base_url
         self.organization_id = organization_id or None
+        # OpenAI-compatible servers (e.g. pocket-tts) define their own models and
+        # voices and are typically keyless, so OpenAI-specific constraints only
+        # apply when talking to the official endpoint.
+        self.is_custom_endpoint = base_url != _DEFAULT_OPENAI_TTS_URL
 
-        if not self.api_key:
+        if not self.api_key and not self.is_custom_endpoint:
             logger.warning("OpenAITTSBackend: No API key configured")
 
     async def initialize(self):
         """Initialize the backend"""
         logger.info("OpenAITTSBackend initialized")
-        if not self.api_key:
+        if not self.api_key and not self.is_custom_endpoint:
             logger.warning(
                 "OpenAITTSBackend: No API key available. Requests will fail."
             )
@@ -144,8 +148,9 @@ class OpenAITTSBackend(APITTSBackend):
         Yields:
             Audio bytes in the requested format
         """
-        # Use base class method to validate API key
-        self._validate_api_key()
+        # Only the official OpenAI endpoint requires an API key
+        if not self.is_custom_endpoint:
+            self._validate_api_key()
 
         # Validate input text
         if not request.input:
@@ -155,30 +160,29 @@ class OpenAITTSBackend(APITTSBackend):
         if len(request.input) > 4096:
             raise ValueError("Text input exceeds maximum length of 4096 characters.")
 
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
         if self.organization_id:
             headers["OpenAI-Organization"] = self.organization_id
 
-        # Map internal model names to OpenAI model names if needed
+        # Map internal model names to OpenAI model names if needed; custom
+        # endpoints define their own model names, so pass them through as-is.
         model = request.model
-        if model in ["tts-1", "tts-1-hd"]:
-            # These are already OpenAI model names
+        if self.is_custom_endpoint or model in ["tts-1", "tts-1-hd"]:
             pass
         else:
             # Default to tts-1 for unknown models
             logger.warning(f"Unknown model '{model}', defaulting to 'tts-1'")
             model = "tts-1"
 
-        # Validate voice selection
+        # Validate voice selection; custom endpoints define their own voices.
         valid_voices = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
-        if request.voice not in valid_voices:
+        if self.is_custom_endpoint or request.voice in valid_voices:
+            voice = request.voice
+        else:
             logger.warning(f"Invalid voice '{request.voice}', defaulting to 'alloy'")
             voice = "alloy"
-        else:
-            voice = request.voice
 
         # Validate response format
         valid_formats = ["mp3", "opus", "aac", "flac", "wav", "pcm"]

--- a/tldw_chatbook/TTS/backends/openai.py
+++ b/tldw_chatbook/TTS/backends/openai.py
@@ -46,6 +46,19 @@ def _validate_openai_base_url(value: Any) -> str:
     return normalized
 
 
+def _is_official_openai_endpoint(url: str) -> bool:
+    """Whether the URL is the official OpenAI speech endpoint, ignoring
+    cosmetic differences (scheme/host casing, trailing slash, default port)."""
+    parsed = urlsplit(url)
+    return (
+        parsed.scheme.lower() == "https"
+        and (parsed.hostname or "").lower() == "api.openai.com"
+        and parsed.port in (None, 443)
+        and parsed.path.rstrip("/") == "/v1/audio/speech"
+        and not parsed.query
+    )
+
+
 class OpenAITTSBackend(APITTSBackend):
     """OpenAI Text-to-Speech API backend"""
 
@@ -123,7 +136,7 @@ class OpenAITTSBackend(APITTSBackend):
         # OpenAI-compatible servers (e.g. pocket-tts) define their own models and
         # voices and are typically keyless, so OpenAI-specific constraints only
         # apply when talking to the official endpoint.
-        self.is_custom_endpoint = base_url != _DEFAULT_OPENAI_TTS_URL
+        self.is_custom_endpoint = not _is_official_openai_endpoint(base_url)
 
         if not self.api_key and not self.is_custom_endpoint:
             logger.warning("OpenAITTSBackend: No API key configured")
@@ -163,7 +176,9 @@ class OpenAITTSBackend(APITTSBackend):
         headers = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
-        if self.organization_id:
+        # The org ID is OpenAI account metadata — never forward it to
+        # third-party OpenAI-compatible servers.
+        if self.organization_id and not self.is_custom_endpoint:
             headers["OpenAI-Organization"] = self.organization_id
 
         # Map internal model names to OpenAI model names if needed; custom


### PR DESCRIPTION
## Why

A user couldn't point chatbook at pocket-tts (a local OpenAI-compatible TTS server). The `OPENAI_BASE_URL` persistence/backend plumbing recently landed on dev, but three request-level behaviors still broke any OpenAI-compatible server:

- any model outside `tts-1`/`tts-1-hd` was silently coerced to `tts-1`
- any voice outside OpenAI's six was silently coerced to `alloy`
- `_validate_api_key` refused to run keyless, though local servers typically need no key

## What

When the validated base URL differs from the official OpenAI endpoint (`is_custom_endpoint`):

- model and voice pass through to the server unmodified
- the API key is optional; `Authorization: Bearer …` is sent only when a key is configured (previously the header was always built — a keyless path would have sent `Bearer None`)
- the misleading "No API key … Requests will fail" startup warnings are suppressed

Behavior against the default OpenAI endpoint is byte-identical, pinned by characterization tests that were mutation-verified (forcing `is_custom_endpoint = True` turns both pins red).

## Tests

`Tests/TTS/test_openai_compatible_endpoint.py` (TDD — passthrough/keyless tests watched red first):

- custom endpoint: model/voice passthrough, keyless with no Authorization header, Bearer still sent when key configured
- default endpoint: coercion + key requirement unchanged
- end-to-end against a real local HTTP server shaped like pocket-tts (keyless, custom model/voice, real socket)

`Tests/TTS/` full directory: 2,195 passed. Repo-wide `--collect-only`: clean (29,821 collected). ruff check/format: clean.

## Follow-up

task-2261 filed: there is no Speech/TTS user-guide page at all, and the original complaint was discoverability as much as behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OpenAI-compatible TTS servers work by passing model/voice through, allowing keyless requests, and not forwarding org headers when `OPENAI_BASE_URL` points to a custom endpoint. Official OpenAI behavior is unchanged and still recognized even with cosmetic URL variants. Matches TASK-2260.

- **Bug Fixes**
  - Custom base URLs: no model/voice coercion; API key optional; `Authorization` sent only when a key exists; suppress no-key startup warnings; do not send `OpenAI-Organization`.
  - Official OpenAI endpoint: model/voice coercion and API key requirement remain; `OpenAI-Organization` still sent; detection handles case, trailing slashes, and default port.
  - Tests: characterization pins for both paths and an e2e check against a real local server.

<sup>Written for commit a36cf270b1a75bcf2c5e17addcc1838984df7bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

