### PR TITLE
docs(guide): how-to for OpenAI-compatible TTS servers (TASK-2261)

### DIFF
--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -45,6 +45,12 @@ can sync with a tldw server you configure).
 Lab, Logs, and Settings have no hotkey — reach them by clicking the nav
 label or via the command palette (**Ctrl+P**).
 
+## How-to guides
+
+| Guide | What it covers |
+|-------|----------------|
+| [Using OpenAI-compatible TTS servers](openai-compatible-tts.md) | Pointing text-to-speech at your own server (e.g. a local, keyless engine like pocket-tts) via Settings ▸ Speech & TTS. |
+
 **Note:** The digit shown before each nav label is that screen's hotkey
 digit: press **Ctrl+digit** (Ctrl+1 … Ctrl+9, Ctrl+0) to switch to it from
 anywhere — the chord works even while a text field has focus. Bare digit

--- a/Docs/User_Guide/openai-compatible-tts.md
+++ b/Docs/User_Guide/openai-compatible-tts.md
@@ -1,0 +1,114 @@
+# Using OpenAI-compatible TTS servers — point speech at your own server
+
+tldw_chatbook's OpenAI TTS provider can talk to **any server that speaks the
+OpenAI speech API** (`POST /v1/audio/speech`), not just OpenAI itself. That
+includes local, keyless engines such as **pocket-tts**, and self-hosted
+gateways. When you point it at your own server, your server's model and
+voice names are passed through exactly as you type them, and no API key is
+required.
+
+## What you need
+
+- A running OpenAI-compatible TTS server and its address — for a local
+  server, typically something like `http://127.0.0.1:8080`. Check the
+  server's startup output or docs for the exact port, plus the model and
+  voice names it accepts.
+- tldw_chatbook with audio playback working (the Console speak button or
+  the Speech Lab).
+
+## Getting there
+
+Click **Settings** in the nav bar (no hotkey digit; **Ctrl+P** →
+"Switch to Settings" also works), then pick **Speech & TTS** in the left
+category rail (it sits in the **Core** group). The panel has three cards:
+**Global defaults**, **Provider setup**, and **Configuration inspector**,
+with a **Save** / **Revert** action row at the bottom.
+
+## Point the OpenAI provider at your server
+
+1. In **Provider setup**, set **Configure Provider** to **OpenAI**. (As the
+   panel notes, this only chooses which provider's form you're editing — it
+   does not change the Default TTS Provider yet.)
+2. Set **Base URL** to your server's *full* speech endpoint — the server
+   address followed by the API path. For a local server on port 8080:
+
+   ```
+   http://127.0.0.1:8080/v1/audio/speech
+   ```
+
+   The default value, `https://api.openai.com/v1/audio/speech`, is the
+   official OpenAI endpoint; replace the whole thing.
+3. **Credentials — usually skip this for local servers.** Keyless servers
+   like pocket-tts need no credential: leave it unset and requests are sent
+   with no `Authorization` header. If your server *does* require a key, use
+   **Set credential**. Note that the `OPENAI_API_KEY` environment variable,
+   if set, is also sent to a custom Base URL — unset it (or use a saved
+   local credential) if you don't want that key going to your server.
+   Your OpenAI **Organization ID**, if configured, is *never* sent to a
+   custom Base URL — only to the official OpenAI endpoint.
+4. In **Global defaults**:
+   - **Default TTS Provider** → **OpenAI**
+   - **Model policy** → **Exact**, and **Model value** → the model name
+     your server expects (whatever its docs say — it is passed through
+     unmodified).
+   - **Voice policy** → **Exact**, and **Voice value** → one of your
+     server's voice names (also passed through unmodified). Or choose
+     **Server default** to let the server pick.
+   - **Output format** and **Speed** as you like (check which formats your
+     server supports; `mp3` and `wav` are the most widely implemented).
+5. Press **Save**.
+
+## Try it
+
+- **Console:** select a completed assistant message and press its **🔊**
+  action — you should hear your server's voice. Press **⏹** to stop.
+- **Speech Lab:** open **Lab** in the nav bar, switch the mode chip to
+  **Speech**, pick **🎤 TTS Playground**, enter text, and press
+  **Generate**.
+
+## Worked example: pocket-tts
+
+pocket-tts is a small local TTS engine that exposes the OpenAI speech API
+and needs no API key. With its server running (see its own docs for the
+start command and port):
+
+| Setting | Value |
+|---------|-------|
+| Configure Provider | OpenAI |
+| Base URL | `http://127.0.0.1:<its-port>/v1/audio/speech` |
+| Credential | leave unset |
+| Default TTS Provider | OpenAI |
+| Model policy / Model value | Exact / the model name from pocket-tts's docs |
+| Voice policy / Voice value | Exact / a pocket-tts voice name (or Server default) |
+
+## If you run an AllTalk server
+
+AllTalk has its own first-class provider — use it instead of the OpenAI
+form: **Provider setup** → **Configure Provider** → **AllTalk**, then set
+**Server URL** (default `http://127.0.0.1:7851`) and **Default language**,
+and set **Default TTS Provider** → **AllTalk**. No key is needed.
+
+## Quirks & troubleshooting
+
+- **"Unable to connect to TTS service"** — the server isn't running at the
+  Base URL, or the URL is wrong. Confirm you included the `/v1/audio/speech`
+  path: requests go to the Base URL exactly as written.
+- **Model or voice names only pass through for custom Base URLs.** Against
+  the official OpenAI endpoint, a model outside `tts-1`/`tts-1-hd` falls
+  back to `tts-1`, and a voice outside OpenAI's six falls back to `alloy`.
+- **Wrong audio or errors after switching servers** — re-check **Model
+  value** and **Voice value**; they must be names *your* server accepts,
+  since tldw_chatbook no longer rewrites them for custom endpoints.
+- The Base URL must be an absolute `http://` or `https://` URL without
+  embedded credentials or a `#fragment` — anything else is rejected on
+  save.
+
+## Related settings & docs
+
+- Console speak actions: [Console ▸ Attachments, images & voice](console/attachments-images-voice.md)
+- The Speech Lab (playground, voice profiles, audiobooks): [Lab](lab.md) 🚧
+
+—
+*Verified against dev @ 265dbd687 — 2026-08-04 (labels quoted from
+`speech_tts_settings_panel.py`; keyless/passthrough behavior shipped in
+TASK-2260, PR #1332).*

--- a/backlog/tasks/task-2261 - Document pointing chatbook at OpenAI-compatible TTS servers.md
+++ b/backlog/tasks/task-2261 - Document pointing chatbook at OpenAI-compatible TTS servers.md
@@ -1,8 +1,10 @@
 ---
 id: TASK-2261
 title: Document pointing chatbook at OpenAI-compatible TTS servers
-status: To Do
-assignee: []
+status: Done
+updated_date: '2026-08-04 19:30'
+assignee:
+  - '@claude'
 created_date: '2026-08-04 12:00'
 labels:
   - tts
@@ -27,7 +29,37 @@ for AllTalk servers specifically. Include a worked pocket-tts example.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A user-guide page explains how to point TTS at an OpenAI-compatible server via the OpenAI provider's Base URL setting, including a keyless local-server example
-- [ ] #2 The page states that custom model and voice names are passed through unmodified when a custom Base URL is set
-- [ ] #3 The page is reachable from wherever the User Guide indexes speech/TTS topics
+- [x] #1 A user-guide page explains how to point TTS at an OpenAI-compatible server via the OpenAI provider's Base URL setting, including a keyless local-server example
+- [x] #2 The page states that custom model and voice names are passed through unmodified when a custom Base URL is set
+- [x] #3 The page is reachable from wherever the User Guide indexes speech/TTS topics
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Map the CURRENT Speech/TTS settings UI on dev (exact navigation path, section titles,
+   field labels) so the page documents reality, not memory.
+2. Write `Docs/User_Guide/` page covering: reaching TTS settings; OpenAI provider with a
+   custom Base URL for any OpenAI-compatible server (keyless local servers, custom
+   model/voice passthrough per TASK-2260); worked pocket-tts example; AllTalk provider as
+   the AllTalk-specific alternative; match house style incl. "Verified against" stamp.
+3. Link the page from the User Guide index/nav location the other pages use.
+4. Verify statements against the live code paths (labels quoted from source), PR, merge.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `Docs/User_Guide/openai-compatible-tts.md`: a how-to for pointing the OpenAI TTS
+provider at any OpenAI-compatible server via Settings ▸ Speech & TTS (Provider setup ▸
+Configure Provider ▸ OpenAI ▸ Base URL), with the keyless-credential path, the
+model/voice exact-passthrough behavior from TASK-2260, a pocket-tts worked example
+(values kept honest — port/model/voice deferred to the server's own docs rather than
+invented), the AllTalk provider as the AllTalk-specific alternative, and troubleshooting
+(full endpoint path required — requests go to the Base URL as written; org ID never sent
+to custom URLs; OPENAI_API_KEY env caveat). Linked from a new "How-to guides" section in
+`Docs/User_Guide/index.md`. Every quoted label was verified against
+`Widgets/Settings_Widgets/speech_tts_settings_panel.py` on dev 265dbd687 (the settings
+UI moved from STTS_Window to the Settings screen since the task was filed); stamp per
+`_template.md` convention. Docs-only change — no tests to run; no link-checker exists.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Closes the discoverability half of the pocket-tts complaint (TASK-2260 shipped the behavior in #1332; this ships the page that tells users it exists).

- New `Docs/User_Guide/openai-compatible-tts.md`: Settings ▸ Speech & TTS ▸ Provider setup ▸ OpenAI ▸ Base URL, keyless-credential path, exact model/voice passthrough, pocket-tts worked example, AllTalk alternative, troubleshooting (full endpoint path required; org ID never sent to custom URLs; `OPENAI_API_KEY` env caveat).
- Linked from a new "How-to guides" section in the guide index.
- Every quoted label verified against `speech_tts_settings_panel.py` on dev `265dbd687`; stamped per `_template.md`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Using OpenAI-compatible TTS servers” how-to and a new “How-to guides” section in the User Guide index, so users can point TTS at custom Base URLs. Covers setup via Settings ▸ Speech & TTS, keyless local servers like `pocket-tts`, exact model/voice passthrough, the AllTalk alternative, and troubleshooting; completes TASK-2261.

<sup>Written for commit c472ac72d5e73df2bd95bd035ea29db949c9ad68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

