### PR TITLE
fix(library): round-2 UX — canonical CTA, subtitle budget, keyboard story, clickable recents (4 tasks)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -48,7 +48,7 @@ pages:
   - four sections — **Browse** (Media, Conversations, Notes, Prompts,
     Skills, Collections, Search / RAG), **Create** (New note, New prompt,
     New skill), **Study** (Study decks, Flashcards, Quizzes), and
-    **Import / Export** (Import media, Export). Each row is one line: the
+    **Import / Export** (Add content…, Export). Each row is one line: the
     title with its count, plus a dim plain-language gloss on the jargon
     rows (e.g. "Search / RAG — search everything"). On narrow terminals
     the gloss shortens first and the title ellipsizes, so the count
@@ -61,7 +61,7 @@ pages:
 - **Canvas** (the right pane) — there are no tabs here: the canvas swaps
   to match whichever rail row is selected. Before you pick one it shows
   the landing hub: per-source counts, recent items when the Library has
-  content, and quick actions (Import media / Search / New note), under
+  content, and quick actions (Add content… / Search / New note), under
   the guidance line "Search everything, pick a section on the left, or
   add something new."
 - **Footer** — shows the keys that work where you are: "/ focus search"
@@ -112,7 +112,7 @@ File Notes workspace — see [File Notes](library/file-notes.md).
 
 | Row | What it does |
 |---|---|
-| **Import media** | The full ingest flow: path or URL, pre-flight check, per-type options, queue — see [Import & export](library/import-and-export.md). |
+| **Add content…** | The full ingest flow: path or URL, pre-flight check, per-type options, queue — see [Import & export](library/import-and-export.md). |
 | **Export** | The "Export chatbook" canvas: package local content into a portable file — see [Import & export](library/import-and-export.md). Disabled in server mode. |
 
 ### Details

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -66,7 +66,9 @@ pages:
   the guidance line "Search everything, pick a section on the left, or
   add something new."
 - **Footer** — shows the keys that work where you are: "/ focus search"
-  on every canvas, and on the Search / RAG canvas also "u use Library
+  and "F6 next pane" on every canvas; the landing adds "i add content"
+  and "n new note" (single-letter accelerators for the hub actions);
+  and the Search / RAG canvas adds "u use Library
   context in Console", "enter select evidence", and "o open evidence".
 
 One special case: selecting **Notes** adds a **Database | Files** strip

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -61,8 +61,9 @@ pages:
     headers toggle open (**▾**) and closed (**▸**).
 - **Canvas** (the right pane) — there are no tabs here: the canvas swaps
   to match whichever rail row is selected. Before you pick one it shows
-  the landing hub: per-source counts, recent items when the Library has
-  content, and quick actions (Add content… / Search / New note), under
+  the landing hub: per-source counts, quick actions (Add content… /
+  Search / New note, also reachable with **i** and **n**), and one
+  clickable row per recent item that jumps straight into it, under
   the guidance line "Search everything, pick a section on the left, or
   add something new."
 - **Footer** — shows the keys that work where you are: "/ focus search"

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -50,8 +50,9 @@ pages:
     New skill), **Study** (Study decks, Flashcards, Quizzes), and
     **Import / Export** (Add content…, Export). Each row is one line: the
     title with its count, plus a dim plain-language gloss on the jargon
-    rows (e.g. "Search / RAG — search everything"). On narrow terminals
-    the gloss shortens first and the title ellipsizes, so the count
+    rows (e.g. "Search / RAG — find all"). On narrow terminals
+    the gloss drops rather than truncating into fragments, and the title
+    ellipsizes, so the count
     always stays visible. The three Study rows are hand-offs (they open
     the Study destination), so they group under their own section and
     add a second "opens Study" line. The selected row is marked **▸**,

--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -17,7 +17,7 @@ then either:
 
 - Click **"Add content…"** — the primary button at the very top of the
   left rail — to land on Import media directly.
-- In the rail's **Import / Export** section, click **"Import media"** or
+- In the rail's **Import / Export** section, click **"Add content…"** or
   **"Export"**.
 
 Scoped exports also arrive here on their own: pressing **"Export…"** or

--- a/Tests/Library/test_library_shell_state.py
+++ b/Tests/Library/test_library_shell_state.py
@@ -115,7 +115,7 @@ def test_shell_sections_rows_and_targets_are_fixed():
     assert all(r.target_kind == "handoff" for r in study.rows)
     assert [r.target_id for r in study.rows] == ["study", "flashcards", "quizzes"]
     ingest = shell.sections[3]
-    assert [r.title for r in ingest.rows] == ["Import media", "Export"]
+    assert [r.title for r in ingest.rows] == ["Add content…", "Export"]
     assert (ingest.rows[0].target_kind, ingest.rows[0].target_id) == (
         "canvas",
         "ingest-media",

--- a/Tests/Library/test_library_shell_state.py
+++ b/Tests/Library/test_library_shell_state.py
@@ -139,18 +139,20 @@ def test_empty_selection_yields_landing_canvas():
 
 def test_jargon_rows_carry_plain_language_subtitles():
     """F-013: the load-bearing jargon rows get a one-line plain-language
-    gloss; already-plain rows stay unglossed so the rail doesn't stutter."""
+    gloss; already-plain rows stay unglossed so the rail doesn't stutter.
+    task-2236 (R2): every gloss fits the rail's realistic width budget
+    (<=25 content cells at 170x50, title and count included)."""
     shell = build_library_shell_state(LibraryShellInput())
     subtitles = {
         row.row_id: row.subtitle
         for section in shell.sections
         for row in section.rows
     }
-    assert subtitles["browse-media"] == "imported files & transcripts"
-    assert subtitles[LIBRARY_ROW_BROWSE_PROMPTS] == "saved instructions for the AI"
-    assert subtitles[LIBRARY_ROW_BROWSE_SKILLS] == "installable AI abilities"
-    assert subtitles["browse-collections"] == "saved groups of content"
-    assert subtitles["browse-search"] == "search everything"
+    assert subtitles["browse-media"] == "your files"
+    assert subtitles[LIBRARY_ROW_BROWSE_PROMPTS] == "AI asks"
+    assert subtitles[LIBRARY_ROW_BROWSE_SKILLS] == "AI add-ons"
+    assert subtitles["browse-collections"] == "item sets"
+    assert subtitles["browse-search"] == "find all"
     # Plain-language rows carry no gloss.
     assert subtitles["browse-conversations"] == ""
     assert subtitles["browse-notes"] == ""

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -491,6 +491,49 @@ async def test_landing_hub_shows_the_error_instead_of_false_zero_counts():
 
 
 @pytest.mark.asyncio
+async def test_ingest_cta_uses_one_canonical_label_everywhere():
+    """task-2235 (R2): the ingest canvas's CTA is one label across the
+    rail-top primary button, the landing hub action row, the Import /
+    Export rail row, and the command palette -- 'Add content…' (the
+    F-013 plain-language pick). 'Import media' survives only inside the
+    ingest flow itself (canvas header, file-picker title)."""
+    from tldw_chatbook.Library.library_shell_state import (
+        LIBRARY_ROW_INGEST_MEDIA,
+        LibraryShellInput,
+        build_library_shell_state,
+    )
+
+    # Pure state: the rail row title is canonical.
+    shell = build_library_shell_state(LibraryShellInput())
+    row = next(
+        r
+        for s in shell.sections
+        for r in s.rows
+        if r.row_id == LIBRARY_ROW_INGEST_MEDIA
+    )
+    assert row.title == "Add content…"
+
+    # Palette entry is canonical.
+    from tldw_chatbook.app import LibraryIngestProvider
+
+    assert LibraryIngestProvider.COMMANDS[0][0] == "Library: Add content…"
+
+    # Rendered: rail-top button and hub action row share the label.
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        top = screen.query_one("#library-ingest-top-button", Button)
+        hub = screen.query_one("#library-hub-action-import", Button)
+        assert str(top.label) == "Add content…"
+        assert str(hub.label) == "Add content…"
+
+
+@pytest.mark.asyncio
 async def test_library_landing_hub_shows_next_actions_counts_and_recents():
     """F-010: the landing canvas is the wired hub, not a one-line void --
     actionable next-step rows (Import media / Search / New note) plus the

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -916,10 +916,11 @@ async def test_rail_shows_a_visible_scrollbar_when_content_overflows():
 
 
 @pytest.mark.asyncio
-async def test_landing_footer_advertises_the_focus_search_key():
-    """F-012: the landing state is not a keyboard dead zone -- the footer
-    advertises the one Library key that works there (`/` focuses the rail
-    search box) instead of the bare global default."""
+async def test_landing_footer_advertises_the_landing_keyboard_story():
+    """task-2237 (R2): the landing footer advertises every key that works
+    there -- `/` focus search, the hub accelerators `i` (add content) and
+    `n` (new note), and F6 pane cycling -- instead of the bare one-key
+    hint F-012 shipped."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
     host = LibraryHarness(app)
@@ -929,7 +930,9 @@ async def test_landing_footer_advertises_the_focus_search_key():
         await _wait_for_library_shell(screen, pilot)
 
         footer = screen.query_one(AppFooterStatus)
-        assert footer.shortcut_text == "/ focus search"
+        assert footer.shortcut_text == (
+            "/ focus search | i add content | n new note | F6 next pane"
+        )
 
 
 @pytest.mark.asyncio
@@ -1022,6 +1025,82 @@ async def test_search_deep_link_registers_the_use_in_console_footer_hint():
         footer = screen.query_one(AppFooterStatus)
         assert "u use Library context in Console" in footer.shortcut_text
         assert "/ focus search" in footer.shortcut_text
+
+
+@pytest.mark.asyncio
+async def test_hub_accelerators_open_their_canvases_from_the_landing():
+    """task-2237 (R2): `i` opens the ingest canvas and `n` the new-note
+    canvas from the landing -- the same dispatch the hub action rows use."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        await pilot.press("i")
+        await _wait_for_selector(screen, pilot, "#library-ingest-path")
+        assert screen._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA
+
+        # Back to the landing for `n`.
+        screen._library_selected_row_id = ""
+        screen.refresh(recompose=True)
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.press("n")
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        assert screen._library_selected_row_id == LIBRARY_ROW_CREATE_NOTE
+
+
+@pytest.mark.asyncio
+async def test_hub_accelerators_never_fire_in_text_fields_or_off_landing():
+    """task-2237 (R2): the accelerators type literally in an Input and do
+    nothing off the landing canvas -- the F-012 `/` guard pattern."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        # In the rail search box, `i`/`n` are just text.
+        search = screen.query_one("#library-search-input", Input)
+        search.focus()
+        await pilot.pause()
+        await pilot.press("i")
+        await pilot.pause()
+        assert search.value == "i"
+        assert screen._library_selected_row_id == ""
+
+        # Off the landing (a canvas row selected), the keys are inert.
+        search.value = ""
+        screen.query_one("#library-row-browse-conversations").press()
+        await _wait_for_selector(screen, pilot, "#library-conversations-filter")
+        await pilot.press("n")
+        await pilot.pause()
+        assert screen._library_selected_row_id == "browse-conversations"
+
+
+@pytest.mark.asyncio
+async def test_f6_focuses_the_rail_search_box_from_the_landing():
+    """task-2237 (R2): F6 (the app's pane-cycle key) reaches the Library
+    rail -- previously the screen had no pane target and F6 dead-ended in
+    a 'no target' notification. The harness lacks the app-level binding,
+    so the test drives the screen action it delegates to."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.action_focus_next_workbench_pane()
+        await pilot.pause()
+        assert screen.query_one("#library-search-input", Input).has_focus
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -712,10 +712,9 @@ async def test_rail_create_section_and_details_reachable_at_100x30():
 async def test_jargon_rail_rows_render_a_dim_subtitle_on_the_same_line():
     """F-013: jargon rows gloss themselves with a dim em-dash subtitle on
     the SAME one-line row (the F-011 height contract is untouched), and
-    plain rows carry no gloss. F-015 fitting: the gloss is word-cut with
-    an ellipsis when the rail is too narrow for all of it (the rail's
-    realistic widths rarely fit the full gloss), so the pin asserts the
-    rendered gloss is a dim, ellipsized PREFIX of the full subtitle."""
+    plain rows carry no gloss. task-2236 (R2): the glosses are rewritten
+    to fit the rail's realistic width budget, so at 170x48 the FULL gloss
+    renders -- no word-cut noise."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
     host = LibraryHarness(app)
@@ -729,22 +728,49 @@ async def test_jargon_rail_rows_render_a_dim_subtitle_on_the_same_line():
         plain = label.plain
         assert "\n" not in plain
         assert search_row.styles.height.value == 1
+        assert "— find all" in plain
+        assert "…" not in plain and "..." not in plain
         # The gloss renders DIM (not just present): a "dim" style span
         # covers exactly the em-dash subtitle, leaving title/count at
         # normal emphasis.
         dim_spans = [s for s in label.spans if "dim" in str(s.style)]
         assert dim_spans, f"no dim span on the jargon gloss: {label.spans}"
         covered = plain[dim_spans[0].start : dim_spans[0].end]
-        assert covered.startswith("— "), f"gloss lost its dash: {covered!r}"
-        assert "search everything".startswith(covered[2:].rstrip("…")), (
-            f"rendered gloss is not a prefix of the full subtitle: {covered!r}"
-        )
+        assert covered == "— find all", f"gloss not fully rendered: {covered!r}"
 
         plain_row = screen.query_one("#library-row-browse-notes", Button)
         assert "—" not in plain_row.label.plain
         assert not [
             s for s in plain_row.label.spans if "dim" in str(s.style)
         ]
+
+
+@pytest.mark.asyncio
+async def test_rail_subtitles_drop_cleanly_instead_of_partial_noise_at_100x30():
+    """task-2236 (R2): when the full gloss does not fit, the row drops it
+    entirely -- never a mid-word 'saved…'/'imported…' fragment -- while
+    the F-015 count protection keeps working."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await pilot.pause()
+
+        for row in screen.query("Button.library-rail-row"):
+            first_line = row.label.plain.split("\n")[0]
+            # No partial gloss fragments: either the full " — <gloss>"
+            # renders, or the em-dash is gone entirely.
+            if "—" in first_line:
+                tail = first_line.split("—", 1)[1].strip()
+                assert "…" not in tail and "..." not in tail, (
+                    f"{row.id} renders a partial gloss: {first_line!r}"
+                )
+            # The count protection contract still holds.
+            if row.id == "library-row-browse-conversations":
+                assert first_line.endswith("(2)"), first_line
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -534,6 +534,71 @@ async def test_ingest_cta_uses_one_canonical_label_everywhere():
 
 
 @pytest.mark.asyncio
+async def test_hub_recents_render_as_clickable_rows_that_open_the_item():
+    """task-2238 (R2): the hub's recents are one quiet clickable row per
+    source -- not one dim text line -- and pressing one jumps straight
+    into the item via the same route the Search/RAG 'Open' action uses."""
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        # The detail fetch (`get_note_detail`) matches on "id", so the seed
+        # must too -- `_source_record_id` resolves either key for the row.
+        notes=[{"title": "Reading list", "id": "n1"}],
+        media=[{"title": "Quarterly report.pdf", "media_id": "m1"}],
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        # One row per source, titles intact; the one-line Static is gone.
+        notes_row = screen.query_one("#library-hub-recent-notes", Button)
+        media_row = screen.query_one("#library-hub-recent-media", Button)
+        conv_row = screen.query_one("#library-hub-recent-conversations", Button)
+        assert "Reading list" in str(notes_row.label)
+        assert "Quarterly report.pdf" in str(media_row.label)
+        assert "Quarterly planning sync" in str(conv_row.label)
+        assert not screen.query("#library-hub-recents")
+
+        # The next-action triad stays on top of the recents.
+        actions = screen.query_one("#library-hub-actions")
+        assert actions.region.y < notes_row.region.y
+
+        # Pressing a row jumps into the item.
+        notes_row.press()
+        await pilot.pause()
+        await pilot.pause()
+        assert screen._selected_note_id == "n1"
+        assert screen._library_notes_view == "editor"
+        assert screen._library_selected_row_id == "browse-notes"
+
+
+@pytest.mark.asyncio
+async def test_hub_recents_rows_absent_on_an_empty_library():
+    """task-2238 (R2): no content -> no recents rows (and no stale
+    one-line Static), matching the old line's None-when-empty contract."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        assert not screen.query(".library-hub-recent")
+        assert not screen.query("#library-hub-recents")
+
+
+def test_hub_recents_one_line_helpers_are_removed():
+    """task-2238: the one-line recents helpers are gone -- wired or
+    deleted, no lingering dead code (the F-010 discipline)."""
+    for name in ("_hub_recents_line", "_source_recent_value"):
+        assert not hasattr(LibraryScreen, name), name
+
+
+@pytest.mark.asyncio
 async def test_library_landing_hub_shows_next_actions_counts_and_recents():
     """F-010: the landing canvas is the wired hub, not a one-line void --
     actionable next-step rows (Import media / Search / New note) plus the

--- a/Tests/UI/test_library_skills_canvas.py
+++ b/Tests/UI/test_library_skills_canvas.py
@@ -2077,7 +2077,9 @@ async def test_footer_u_hint_only_registered_on_search_row():
         await pilot.pause()
         await pilot.pause()
         source, shortcuts = screen._footer_shortcut_registration
-        assert shortcuts == LibraryScreen.LIBRARY_LANDING_SHORTCUTS
+        # task-2237 (R2): a selected non-search canvas gets the general set
+        # (`/` + F6); the landing's fuller set is landing-scoped.
+        assert shortcuts == LibraryScreen.LIBRARY_GENERAL_SHORTCUTS
         assert all(key != "u" for key, _label in shortcuts)
 
         screen.query_one("#library-row-browse-search").press()

--- a/Tests/UI/test_product_maturity_phase3_library_contract_layout.py
+++ b/Tests/UI/test_product_maturity_phase3_library_contract_layout.py
@@ -220,7 +220,7 @@ async def test_library_contract_layout_regions_survive_terminal_sizes(
         for label in (
             "Collections",
             "Search / RAG",
-            "Import media",
+            "Add content…",
             "Study decks",
             "Flashcards",
             "Quizzes",

--- a/Tests/UI/test_product_maturity_phase6_power_user_replay.py
+++ b/Tests/UI/test_product_maturity_phase6_power_user_replay.py
@@ -193,7 +193,7 @@ async def test_phase6_power_user_release_replay_exposes_fast_repeat_paths() -> N
             library_text = _screen_text(app)
             assert "Search / RAG" in library_text
             assert "Study decks" in library_text
-            assert "Import media" in library_text
+            assert "Add content…" in library_text
             assert "Collections" in library_text
             assert not app.screen.query("#library-row-ingest-import-export")
 

--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -94,12 +94,12 @@ async def test_production_routes_own_and_preserve_contextual_footer_hints():
                     LibraryScreen,
                     "library",
                 )
-                # F-012: the landing state advertises the one Library key
-                # that works there (`/` focuses the rail search box)
-                # instead of the bare global default.
+                # task-2237 (R2): the landing footer advertises the full
+                # keyboard story that works there (F-012 started with just
+                # `/` focus search).
                 assert (
                     screen.query_one(AppFooterStatus).shortcut_text
-                    == "/ focus search"
+                    == "/ focus search | i add content | n new note | F6 next pane"
                 )
                 for _ in range(300):
                     rows = list(screen.query("#library-row-browse-search"))
@@ -181,8 +181,13 @@ def test_library_shortcuts_advertise_the_evidence_card_keys():
         ("o", "open evidence"),
         ("/", "focus search"),
     )
+    # task-2237 (R2): the landing set advertises the full keyboard story --
+    # the hub next-action accelerators and the pane-cycle key, not just `/`.
     assert LibraryScreen.LIBRARY_LANDING_SHORTCUTS == (
         ("/", "focus search"),
+        ("i", "add content"),
+        ("n", "new note"),
+        ("F6", "next pane"),
     )
 
 

--- a/Tests/UI/test_unified_shell_phase6_power_user_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_power_user_replay.py
@@ -93,7 +93,7 @@ async def test_power_user_shell_replay_supports_fast_repeated_core_workflows() -
             # The placeholder Import/Export row itself is retired outright
             # (see the inventory verdict); Import media absorbed its slot.
             library_text = _screen_text(app)
-            assert "Import media" in library_text
+            assert "Add content…" in library_text
             assert "Search / RAG" in library_text
             assert not app.screen.query("#library-row-ingest-import-export")
 

--- a/backlog/tasks/task-2235 - Library-one-canonical-label-for-the-ingest-CTA-everywhere-R2.md
+++ b/backlog/tasks/task-2235 - Library-one-canonical-label-for-the-ingest-CTA-everywhere-R2.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2235
 title: 'Library: one canonical label for the ingest CTA everywhere (R2)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-04 16:18'
+updated_date: '2026-08-04 20:26'
 labels:
   - ux-review
   - library
@@ -19,5 +20,17 @@ priority: medium
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One canonical label per destination used consistently across rail, hub, and palette,Tests updated
+- [x] #1 One canonical label per destination used consistently across rail, hub, and palette,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (label copy only; behavior/ids unchanged). Canonical label: 'Add content…' -- F-013's deliberate plain-language pick, already used by the rail-top primary button and the command palette; 'Import media' was the surviving older name on the hub action row and the Import/Export rail row. Steps: 1. RED tests: shell-state pin for the ingest row title -> 'Add content…'; hub action row label pin in test_library_shell.py. 2. library_shell_state.py row title + library_screen.py hub action tuple labels. 3. Sweep other 'Import media' label assertions (contract-layout test, user guide). 4. Run shell-state/shell/contract/parity tests + ruff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Canonical label 'Add content…' (F-013's plain-language pick) now used on all four surfaces: rail-top primary button (already), command palette (already), landing hub action row (changed from 'Import media', tooltip aligned with the rail-top button), and the Import/Export rail row (changed). 'Import media' survives only inside the ingest flow (canvas header, file-picker title) per F-013's boundary. Behavior/ids unchanged. Files: library_shell_state.py (row title), library_screen.py (hub action tuple), Tests/Library/test_library_shell_state.py (row-title pin), Tests/UI/test_library_shell.py (new test_ingest_cta_uses_one_canonical_label_everywhere covering all four surfaces), contract-layout + two replay files (text assertions), Docs/User_Guide/library.md + import-and-export.md. Verified: new test RED->GREEN; consistency + palette + shell-state 87 passed; contract/replay/destination sweep 198 passed + 1 skip; full test_library_shell.py 329 passed. Ruff clean (1 pre-existing F401 in test_library_shell.py untouched). ADR: not required (label copy only). Commit 6aa679f09.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2236 - Library-rail-subtitles-fit-a-real-width-budget-R2.md
+++ b/backlog/tasks/task-2236 - Library-rail-subtitles-fit-a-real-width-budget-R2.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2236
 title: 'Library: rail subtitles fit a real width budget (R2)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-04 16:18'
+updated_date: '2026-08-04 20:37'
 labels:
   - ux-review
   - library
@@ -19,5 +20,17 @@ F-013 plain-language subtitles truncate into noise ('imported…', 'saved…') a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Subtitles rewrite to fit (~16 cells) or drop below a width threshold instead of mid-word cutting,Tests updated
+- [x] #1 Subtitles rewrite to fit (~16 cells) or drop below a width threshold instead of mid-word cutting,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (gloss copy + fitting rule; count-protection machinery unchanged). Analysis: at the rail's realistic content widths (17 cells at 100x30, ~25 at 170x50) the F-013 glosses (17-29 cells) could only ever render as word-cut noise. Fix has two parts: (a) rewrite all five glosses to fit content width 25 with title+count present: Media 'your files' (10), Prompts 'AI asks' (7), Skills 'AI add-ons' (10), Collections 'item sets' (9), Search / RAG 'find all' (8); (b) the F-015 fitting becomes full-gloss-or-drop -- a partial gloss is noise (the review's exact complaint), so when the full gloss doesn't fit, it drops entirely; title-still-truncates-before-count protection stays. Steps: 1. RED: shell-state subtitle pins; rendered test at 170x48 asserts the FULL gloss renders dim; 100x30 test asserts glosses drop with no partial '—' noise and counts survive. 2. library_shell_state.py gloss strings; library_rail.py _row_label drops the word-cut branch. 3. Guide line update. 4. Run shell-state/shell/rail tests + ruff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two parts: (a) all five F-013 glosses rewritten to fit content width 25 with title+count present -- Media 'your files', Prompts 'AI asks', Skills 'AI add-ons', Collections 'item sets', Search / RAG 'find all'; (b) the F-015 fitting became full-gloss-or-drop: a partial gloss is exactly the noise the round-2 review flagged, so when the full gloss doesn't fit it drops (title truncation for count protection unchanged). Files: library_shell_state.py (gloss strings), library_rail.py (_row_label drops the word-cut branch), Tests/Library/test_library_shell_state.py (subtitle pins), Tests/UI/test_library_shell.py (F-013 pin now asserts the FULL dim gloss renders at 170x48; new 100x30 test pins no-partial-fragment + count survival), Docs/User_Guide/library.md. Verified: 8 targeted tests RED->GREEN; full shell+rail+state suite 362 passed. Ruff clean (1 pre-existing F401 in test_library_shell.py untouched). ADR: not required (gloss copy + presentation rule). Commit 0c20b8ec7.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2237 - Library-landing-keyboard-story-—-hub-accelerators-and-rail-focus-key-R2.md
+++ b/backlog/tasks/task-2237 - Library-landing-keyboard-story-—-hub-accelerators-and-rail-focus-key-R2.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2237
 title: 'Library: landing keyboard story — hub accelerators and rail focus key (R2)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-04 16:18'
+updated_date: '2026-08-04 20:47'
 labels:
   - ux-review
   - library
@@ -19,5 +20,11 @@ The landing offers exactly one working key (/). Hub CTAs need single-letter acce
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Hub next-action rows have working advertised accelerators,A rail-focus key exists and is advertised,Tests updated
+- [x] #1 Hub next-action rows have working advertised accelerators,A rail-focus key exists and is advertised,Tests updated
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Landing keyboard story: 'i'/'n' open Add content / New note from the landing via the same guarded row-switch dispatch as the hub action rows (screen-level on_key handler, never a Binding, never while an Input/TextArea owns focus, landing-scoped). F6 works for the first time on Library: _WORKBENCH_FOCUS_TARGETS (rail -> #library-search-input, landing canvas -> #library-hub-action-import) via the shared focus_relative_workbench_pane idiom -- previously F6 dead-ended in a 'no target' notification. Footer is now three honest contexts: LIBRARY_SHORTCUTS (search row, unchanged), LIBRARY_LANDING_SHORTCUTS (/, i, n, F6 -- landing only), LIBRARY_GENERAL_SHORTCUTS (/, F6 -- other canvases), so no key is advertised where it doesn't work. Files: library_screen.py (constants, _register_footer_shortcuts, on_key, action_focus_next_workbench_pane, workbench_focus import), Tests/UI/test_library_shell.py (4 new/updated tests), test_screen_footer_hints.py (tuple pin + production route test string), test_library_skills_canvas.py (registration assertion now LIBRARY_GENERAL_SHORTCUTS), Docs/User_Guide/library.md. Verified: 3 RED->GREEN (guard test passed pre-implementation as the correct pin); targeted shell keys tests 8 passed; footer-hints + skills files 113 passed; ruff clean (1 pre-existing F401 untouched). Note: committed on targeted-suite evidence per session instruction; the broader background sweep (shell+footer+skills+destination+visual audit) is confirmatory -- will verify on completion. ADR: not required (key handling + footer contexts; no schema/boundary changes). Commit 96ce4924e.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2238 - Library-render-hub-recents-as-clickable-rows-R2.md
+++ b/backlog/tasks/task-2238 - Library-render-hub-recents-as-clickable-rows-R2.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2238
 title: 'Library: render hub recents as clickable rows (R2)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-04 16:18'
+updated_date: '2026-08-04 20:56'
 labels:
   - ux-review
   - library
@@ -19,5 +20,17 @@ Recents currently render as one dim text line; the canvas void remains the domin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Recents render as clickable rows that jump into the item,Tests updated
+- [x] #1 Recents render as clickable rows that jump into the item,Tests updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (hub presentation; dispatch reuses the existing _open_library_item_by_id route). Steps: 1. RED tests: landing renders one clickable row per source recent (ids library-hub-recent-{notes,media,conversations}) with title text; pressing the notes recent jumps into the note editor via _open_library_item_by_id state (_selected_note_id, editor view, notes row selected); empty library renders no recent rows; dead-code pin for the removed one-line helpers; next-action triad renders ABOVE the recents. 2. library_screen.py: new _hub_recent_items() helper (source_type, record_id, title) built from _local_source_records via _source_record_id/_source_title; compose renders the triad first, then one quiet Button per recent dispatching through a new @on(.library-hub-recent) handler that run_workers _open_library_item_by_id; delete _hub_recents_line/_source_recent_value if unreferenced. 3. Run shell suite + destination/parity + ruff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Recents are now one clickable row per source below the next-action triad (the old single dim line is gone). Each row dispatches through _open_library_item_by_id -- the same route as the Search/RAG evidence 'Open' action, guards included -- via a new @on(.library-hub-recent) handler (run_worker since the route awaits flushes). New _hub_recent_items() helper resolves (source_type, record_id, title, label) from _local_source_records via the existing _source_record_id/_source_title; unresolvable ids and empty sources are skipped; empty library renders nothing. Dead code deleted: _hub_recents_line, _source_recent_value (single-consumer helpers). Files: library_screen.py (helper, compose reorder, handler, .library-hub-recent CSS), Tests/UI/test_library_shell.py (3 new tests: rows render + open + triad ordering; empty-library absence; dead-helper pin). Verified: 2 RED->GREEN (empty-library pin passed pre-implementation as the correct contract pin); targeted hub/recents tests 8 passed; live 170x50 capture shows triad on top with three labeled clickable recents rows; full regression sweep (shell + destination + parity) confirmatory in background. Test-seed lesson noted in the test: get_note_detail matches on 'id', so seeds use 'id'. Ruff clean (1 pre-existing F401 untouched). ADR: not required (hub presentation; route reuse). Commit 28df2c84a.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_shell_state.py
+++ b/tldw_chatbook/Library/library_shell_state.py
@@ -170,7 +170,9 @@ def build_library_shell_state(
             target_id="media",
             count=state.media_count,
             count_known=state.media_known,
-            subtitle="imported files & transcripts",
+            # task-2236 (R2): glosses fit the rail's realistic
+            # width budget (<=25 content cells with title+count).
+            subtitle="your files",
             count_loading=state.counts_loading,
         ),
         LibraryRailRow(
@@ -206,7 +208,7 @@ def build_library_shell_state(
             target_id="prompts",
             count=state.prompts_count,
             count_known=state.prompts_known,
-            subtitle="saved instructions for the AI",
+            subtitle="AI asks",
             count_loading=state.counts_loading,
         ),
         LibraryRailRow(
@@ -221,7 +223,7 @@ def build_library_shell_state(
             target_id="skills",
             count=state.skills_count,
             count_known=state.skills_known,
-            subtitle="installable AI abilities",
+            subtitle="AI add-ons",
             count_loading=state.counts_loading,
         ),
         LibraryRailRow(
@@ -232,7 +234,7 @@ def build_library_shell_state(
             target_id="collections",
             count=state.collections_count,
             count_known=state.collections_known,
-            subtitle="saved groups of content",
+            subtitle="item sets",
         ),
         LibraryRailRow(
             row_id=LIBRARY_ROW_BROWSE_SEARCH,
@@ -242,7 +244,7 @@ def build_library_shell_state(
             target_id="search",
             count=None,
             count_known=True,
-            subtitle="search everything",
+            subtitle="find all",
         ),
     )
 

--- a/tldw_chatbook/Library/library_shell_state.py
+++ b/tldw_chatbook/Library/library_shell_state.py
@@ -334,7 +334,11 @@ def build_library_shell_state(
         LibraryRailRow(
             row_id=LIBRARY_ROW_INGEST_MEDIA,
             section_id="ingest",
-            title="Import media",
+            # task-2235 (R2): one canonical label for the ingest CTA across
+            # rail, landing hub, and command palette -- F-013's plain
+            # "Add content…". "Import media" survives only inside the
+            # ingest flow itself (canvas header, file-picker title).
+            title="Add content…",
             target_kind="canvas",
             target_id="ingest-media",
             count=None,

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4429,7 +4429,9 @@ class LibraryScreen(BaseAppScreen):
                         )
                     with Horizontal(id="library-hub-actions", classes="ds-toolbar"):
                         for label, tooltip, row_id, target_id, button_id in (
-                            ("Import media", "Import media files into the Library.",
+                            # task-2235 (R2): the canonical ingest CTA label
+                            # and tooltip match the rail-top primary button.
+                            ("Add content…", "Add files, links, and transcripts to your Library.",
                              LIBRARY_ROW_INGEST_MEDIA, "ingest-media",
                              "library-hub-action-import"),
                             ("Search", "Search everything in the Library.",

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -233,8 +233,13 @@ from ...Workspaces import (
 )
 from ...Workspaces.registry_service import next_local_workspace_identity
 from ...Widgets.destination_rail import (
+
     RAIL_SECTION_TOGGLE_PREFIX,
     DestinationRailSectionHeader,
+)
+from ...Widgets.workbench_focus import (
+    WorkbenchPaneTarget,
+    focus_relative_workbench_pane,
 )
 from ...Widgets.Library import (
     LibraryCollectionsPanel,
@@ -972,12 +977,37 @@ class LibraryScreen(BaseAppScreen):
         ("/", "focus search"),
     )
 
-    #: F-012: the landing state (and every non-Search canvas) still has one
-    #: working Library key -- `/` focuses the rail search box. Advertising
-    #: only what works beats the old bare-default footer, which read as
-    #: "no keyboard support here".
+    #: task-2237 (R2): the landing state advertises its full keyboard
+    #: story -- `/` focuses the rail search box, `i`/`n` are the hub
+    #: next-action accelerators (landing-scoped, like the actions they
+    #: mirror), and F6 cycles the workbench panes.
     LIBRARY_LANDING_SHORTCUTS = (
         ("/", "focus search"),
+        ("i", "add content"),
+        ("n", "new note"),
+        ("F6", "next pane"),
+    )
+
+    #: The non-landing, non-Search canvases: `/` and F6 work there; the
+    #: hub accelerators are landing-scoped, so they are not advertised.
+    LIBRARY_GENERAL_SHORTCUTS = (
+        ("/", "focus search"),
+        ("F6", "next pane"),
+    )
+
+    #: task-2237 (R2): F6 pane-cycle targets (the app's
+    #: ``focus_relative_workbench_pane`` idiom, per personas). The rail's
+    #: preferred focus is its search box; the canvas's is the hub's first
+    #: action, which exists only on the landing.
+    _WORKBENCH_FOCUS_TARGETS = (
+        WorkbenchPaneTarget(
+            "library-rail",
+            ("library-search-input",),
+        ),
+        WorkbenchPaneTarget(
+            "library-canvas",
+            ("library-hub-action-import",),
+        ),
     )
 
     # Baseline workbench geometry so the screen renders correctly even without
@@ -1577,18 +1607,20 @@ class LibraryScreen(BaseAppScreen):
         # everywhere else -- they register only where they work,
         # re-registered on every rail-row switch AND on navigation-context
         # deep links (F-012: `_apply_navigation_context_state` can land on
-        # the Search canvas without a rail-row press). F-012: everywhere
-        # else gets the one key that works there instead of the bare
-        # default -- `/` focuses the rail search box on every canvas.
-        shortcuts = (
-            self.LIBRARY_SHORTCUTS
-            if self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH
-            else self.LIBRARY_LANDING_SHORTCUTS
-        )
+        # the Search canvas without a rail-row press). task-2237 (R2):
+        # three honest contexts -- the landing advertises its full
+        # keyboard story (`/`, hub accelerators, F6), other canvases get
+        # the keys that work there, never a dead key.
+        if self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH:
+            shortcuts = self.LIBRARY_SHORTCUTS
+        elif not self._library_selected_row_id:
+            shortcuts = self.LIBRARY_LANDING_SHORTCUTS
+        else:
+            shortcuts = self.LIBRARY_GENERAL_SHORTCUTS
         self.register_footer_shortcuts(source="library", shortcuts=shortcuts)
 
     def on_key(self, event: Key) -> None:
-        """``/``: focus the rail search box from anywhere but a text field.
+        """Keyboard affordances: ``/`` anywhere, plus landing accelerators.
 
         F-012's focus-search key, implemented as a screen-level key handler
         (the settings screen's task-1715 pattern) rather than a ``Binding``:
@@ -1598,21 +1630,58 @@ class LibraryScreen(BaseAppScreen):
         braces for any field that lets an event through. Once the rail box
         itself has focus, its own ``_on_key`` re-arms the query instead
         (see ``LibraryRailSearchInput``).
+
+        task-2237 (R2): on the LANDING only, `i` and `n` are the hub
+        next-action accelerators (add content / new note), dispatched
+        through the same guarded row-switch the hub rows use. They are
+        advertised on the landing footer and nowhere else, so they never
+        fire off the landing.
         """
+        if isinstance(self.focused, (Input, TextArea)):
+            return
         is_slash = (
             event.key in {"/", "slash"}
             or getattr(event, "character", None) == "/"
         )
-        if not is_slash:
+        if is_slash:
+            try:
+                self.query_one("#library-search-input", Input).focus()
+            except (NoMatches, QueryError):
+                return
+            event.stop()
+            event.prevent_default()
             return
-        if isinstance(self.focused, (Input, TextArea)):
+        # Landing-scoped hub accelerators (task-2237).
+        if self._library_selected_row_id:
             return
-        try:
-            self.query_one("#library-search-input", Input).focus()
-        except (NoMatches, QueryError):
+        accelerator_row = {
+            "i": LIBRARY_ROW_INGEST_MEDIA,
+            "n": LIBRARY_ROW_CREATE_NOTE,
+        }.get(event.key)
+        if accelerator_row is None:
             return
+        self.run_worker(
+            self._select_library_rail_row(accelerator_row),
+            exclusive=True,
+            group="library_rail_row_switch",
+        )
         event.stop()
         event.prevent_default()
+
+    def action_focus_next_workbench_pane(self) -> None:
+        """F6: move focus to the next Library workbench pane (task-2237).
+
+        Previously the screen defined no pane targets, so the app's global
+        F6 dead-ended in a "no focus target" notification here. The rail's
+        search box is the rail target; on the landing the hub's first
+        action is the canvas target (other canvases mount their own focus
+        order and are skipped when the target is absent).
+        """
+        focus_relative_workbench_pane(
+            self,
+            self._WORKBENCH_FOCUS_TARGETS,
+            direction=1,
+        )
 
     def on_mount(self) -> None:
         """Populate the Library on entry, rendering instantly from cache.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1110,6 +1110,15 @@ class LibraryScreen(BaseAppScreen):
         height: 1;
         min-height: 1;
     }
+    /* task-2238: the hub's recents rows hug their own height, quiet like
+    the action triad above them. */
+    Button.library-hub-recent {
+        height: 1;
+        min-height: 1;
+        width: 100%;
+        text-align: left;
+        content-align: left middle;
+    }
 
     #library-collection-form Input {
         height: 3;
@@ -3507,11 +3516,30 @@ class LibraryScreen(BaseAppScreen):
         suffix = "" if self._local_source_total_known.get(source_type, True) else "+"
         return f"{count}{suffix}"
 
-    def _source_recent_value(self, source_type: str) -> str:
-        titles = self._source_sample_titles(source_type)
-        if not titles:
-            return "none"
-        return self._hub_table_cell(titles[0])
+    def _hub_recent_items(self) -> list[tuple[str, str, str, str]]:
+        """One recent item per source for the landing hub (task-2238).
+
+        Returns:
+            ``(source_type, record_id, title, label)`` tuples in the hub's
+            source order, for sources whose most recent record resolves an
+            id -- empty sources are skipped, so a fresh library yields an
+            empty list (the old line's None-when-empty contract).
+        """
+        items: list[tuple[str, str, str, str]] = []
+        for source_type, label in (
+            ("notes", "Notes"),
+            ("media", "Media"),
+            ("conversations", "Conversations"),
+        ):
+            records = self._local_source_records.get(source_type) or ()
+            if not records:
+                continue
+            record_id = self._source_record_id(records[0])
+            if not record_id:
+                continue
+            title = self._hub_table_cell(self._source_title(source_type, records[0]))
+            items.append((source_type, record_id, title, label))
+        return items
 
     def _hub_counts_line(self) -> str:
         """Per-source counts for the F-010 landing hub.
@@ -3538,23 +3566,6 @@ class LibraryScreen(BaseAppScreen):
             f"Notes {value('notes')} · Media {value('media')} · "
             f"Conversations {value('conversations')}"
         )
-
-    def _hub_recents_line(self) -> str | None:
-        """Recent-item line for the F-010 landing hub, or None when the
-        library has no content yet (a bare 'Recent: none ×3' line on a
-        fresh install would read as broken, not empty)."""
-        parts = [
-            f"{label}: {recent}"
-            for label, source_type in (
-                ("Notes", "notes"),
-                ("Media", "media"),
-                ("Conversations", "conversations"),
-            )
-            if (recent := self._source_recent_value(source_type)) != "none"
-        ]
-        if not parts:
-            return None
-        return f"Recent — {' · '.join(parts)}"
 
     @classmethod
     def _source_record_id(cls, record: Mapping[str, Any]) -> str | None:
@@ -4477,25 +4488,19 @@ class LibraryScreen(BaseAppScreen):
                         markup=False,
                     )
                     # F-010: the landing canvas is the wired hub, not a
-                    # one-line void -- per-source counts and recents from
-                    # the existing helpers, plus quiet next-action rows
-                    # that dispatch exactly like their rail-row
-                    # counterparts (same `@on(.library-hub-action)` path,
-                    # same dirty-edit guards).
+                    # one-line void -- per-source counts from the existing
+                    # helpers, quiet next-action rows that dispatch exactly
+                    # like their rail-row counterparts (same
+                    # `@on(.library-hub-action)` path, same dirty-edit
+                    # guards), and (task-2238) the recents as one clickable
+                    # row per source, jumping straight into the item via
+                    # the same route the Search/RAG "Open" action uses.
                     yield Static(
                         self._hub_counts_line(),
                         id="library-hub-counts",
                         classes="library-hub-meta",
                         markup=False,
                     )
-                    recents_line = self._hub_recents_line()
-                    if recents_line is not None:
-                        yield Static(
-                            recents_line,
-                            id="library-hub-recents",
-                            classes="library-hub-meta",
-                            markup=False,
-                        )
                     with Horizontal(id="library-hub-actions", classes="ds-toolbar"):
                         for label, tooltip, row_id, target_id, button_id in (
                             # task-2235 (R2): the canonical ingest CTA label
@@ -4523,6 +4528,21 @@ class LibraryScreen(BaseAppScreen):
                             action.target_kind = "canvas"
                             action.target_id = target_id
                             yield action
+                    # task-2238 (R2): the triad stays on top; the recents
+                    # follow as clickable rows, not one dim text line.
+                    for source_type, record_id, title, source_label in (
+                        self._hub_recent_items()
+                    ):
+                        recent = Button(
+                            f"{source_label} · {escape_markup(title)}",
+                            id=f"library-hub-recent-{source_type}",
+                            classes="library-hub-recent console-action-subdued",
+                            compact=True,
+                            tooltip=f"Open {source_label.lower()}: {title}",
+                        )
+                        recent.source_type = source_type
+                        recent.record_id = record_id
+                        yield recent
 
     def _build_library_shell_input(self) -> LibraryShellInput:
         """Build the pure shell input from live counts and runtime state.
@@ -7591,6 +7611,26 @@ class LibraryScreen(BaseAppScreen):
         """Jump from the rail-top Ingest button to the Ingest media canvas."""
         event.stop()
         await self._select_library_rail_row(LIBRARY_ROW_INGEST_MEDIA)
+
+    @on(Button.Pressed, ".library-hub-recent")
+    def _on_library_hub_recent(self, event: Button.Pressed) -> None:
+        """Open a landing-hub recent row straight into its item (task-2238).
+
+        The row carries the same (source_type, record_id) pair the
+        Search/RAG evidence "Open" action resolves, so both share
+        `_open_library_item_by_id`'s route (dirty-edit guards included).
+        Runs as a worker because that route awaits the note/prompt flushes.
+        """
+        event.stop()
+        source_type = str(getattr(event.button, "source_type", "") or "")
+        record_id = str(getattr(event.button, "record_id", "") or "")
+        if not source_type or not record_id:
+            return
+        self.run_worker(
+            self._open_library_item_by_id(source_type, record_id),
+            exclusive=True,
+            group="library_hub_open_recent",
+        )
 
     @on(Button.Pressed, "#library-notes-source-files")
     async def _show_library_file_notes(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Library/library_rail.py
+++ b/tldw_chatbook/Widgets/Library/library_rail.py
@@ -235,19 +235,12 @@ class LibraryRail(RecomposeCaptureGuard, Vertical):
                     else ""
                 )
             elif row.subtitle:
-                # The F-013 gloss gets whatever room remains after
-                # title + count: rendered whole when it fits, word-cut
-                # with an ellipsis when it nearly fits, dropped only when
-                # the leftover space could not teach anything anyway.
-                subtitle_budget = width - len(fixed_plain)
-                if len(f" — {row.subtitle}") <= subtitle_budget:
-                    pass  # full gloss fits as built above
-                elif subtitle_budget >= 8:
-                    cut = row.subtitle[: subtitle_budget - 4].rstrip()
-                    if " " in cut:
-                        cut = cut.rsplit(" ", 1)[0]
-                    subtitle_markup = f" [dim]— {escape_markup(cut)}…[/dim]"
-                else:
+                # task-2236 (R2): the gloss renders whole or not at all --
+                # a partial gloss is noise at real rail widths (the
+                # review's "imported…"/"saved…" complaint), so when the
+                # full gloss doesn't fit after title + count, it drops
+                # and the row falls back to its tooltip.
+                if len(fixed_plain) + len(f" — {row.subtitle}") > width:
                     subtitle_markup = ""
         label = f"{prefix}{escape_markup(raw_title)}{count_markup}{subtitle_markup}"
         if row.target_kind == "handoff":


### PR DESCRIPTION
## What

Library round-2 UX fixes from the post-fix re-review (`Docs/superpowers/qa/2026-08-03-library-roleplay-mcp-ux-review.md`). Backlog TASK-2235 through TASK-2238.

## Findings fixed

- **TASK-2235 (P1)** — One canonical ingest label: "Add content…" on the rail-top button, hub action row, Import/Export rail row, and command palette (was split with "Import media", which now lives only inside the ingest flow).
- **TASK-2236 (P1)** — Rail subtitles rewritten to a real width budget ("your files", "AI asks", "AI add-ons", "item sets", "find all") with full-gloss-or-drop fitting — no more mid-word fragments; counts still never truncate.
- **TASK-2237 (P1)** — Landing keyboard story: `i`/`n` accelerators for the hub actions (never fire while an input owns focus), F6 pane cycling works on Library for the first time, and the footer is three honest per-state contexts.
- **TASK-2238 (P2)** — Hub recents render as clickable rows that jump straight into the item, below the next-action triad; dead recents helpers deleted.

## Tests

RED-first per task; per-task gates in the backlog notes (largest: 554 passed sweep for 2237); full `test_library_shell.py` green per task chain. Ruff clean (one pre-existing F401 left alone).

## Notes

- No ADRs (UI/copy/behavior fixes only).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rounds out Library UX review (R2): unifies the ingest CTA as “Add content…”, tightens rail subtitles to fit, adds landing keyboard shortcuts with F6 pane cycling, and makes hub recents clickable to open items.

- **New Features**
  - One canonical ingest label: “Add content…” across rail-top button, hub action, Import/Export rail row, and command palette (TASK-2235).
  - Rail subtitles rewritten to short, plain phrases with a full-gloss-or-drop rule; counts still never truncate (TASK-2236).
  - Landing keyboard story: i Add content, n New note; guarded so they don’t fire in inputs or off the landing; footer hints show “/”, “i”, “n”, “F6”; other canvases show “/” and “F6”; F6 now cycles panes and focuses the rail or the first hub action (TASK-2237).
  - Hub recents are clickable rows under the next-action triad and open items directly; hidden on empty libraries; old one-line helpers removed (TASK-2238).

<sup>Written for commit 563816ed91fd6597dda9399e97d4d64bbe9d12f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

