### PR TITLE
chore: mark UAT batch-1 tasks Done (PR #1342 merged)

### DIFF
--- a/backlog/tasks/task-2300 - Watchlists Selects render empty option lists.md
+++ b/backlog/tasks/task-2300 - Watchlists Selects render empty option lists.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2300
 title: Watchlists Selects render empty option lists
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2301 - Items list honors its status filter and triaged items stay reachable.md
+++ b/backlog/tasks/task-2301 - Items list honors its status filter and triaged items stay reachable.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2301
 title: Items list honors its status filter and triaged items stay reachable
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2304 - Rail counts and the scoped sources table tell the truth.md
+++ b/backlog/tasks/task-2304 - Rail counts and the scoped sources table tell the truth.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2304
 title: Rail counts and the scoped sources table tell the truth
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks UAT batch-1 backlog tasks as Done to reflect completed work. Sets status to Done for TASK-2300, TASK-2301, and TASK-2304.

<sup>Written for commit 528d914b71f189e988d34ba1e0c436f9f4dc159d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

