### PR TITLE
chore: file tasks 2330/2331 (pre-existing Runs-tab defects)

### DIFF
--- a/backlog/tasks/task-2330 - check-now-failure test asserts a method the screen no longer defines.md
+++ b/backlog/tasks/task-2330 - check-now-failure test asserts a method the screen no longer defines.md
@@ -1,0 +1,29 @@
+---
+id: TASK-2330
+title: check-now-failure test asserts a method the screen no longer defines
+status: To Do
+assignee: []
+created_date: '2026-08-04'
+labels:
+  - watchlists
+  - tests
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+`Tests/UI/test_watchlists_check_now_failure.py` has a parametrized case
+(`[_delete_item]`) that fails on dev: it asserts against a method the screen
+no longer defines (`_delete_item` was removed when the `d` binding was routed
+through the TASK-1541 drain in PR #1342). Found during UAT batch-2 review and
+verified failing on `origin/dev` at the batch-2 merge base (`ab9105c9d`) —
+pre-existing there, not introduced by any open branch.
+
+## Acceptance Criteria (the what)
+
+- [ ] The parametrized case either targets the real current writer path or is
+      removed with the reasoning recorded.
+- [ ] The whole file passes on dev.
+- [ ] The exemption contract the file documents (debug-level loader logging
+      requires a failure toast) still has a discriminating case per loader.

--- a/backlog/tasks/task-2331 - Runs toolbar Refresh reloads and Re-run gives feedback.md
+++ b/backlog/tasks/task-2331 - Runs toolbar Refresh reloads and Re-run gives feedback.md
@@ -1,0 +1,29 @@
+---
+id: TASK-2331
+title: Runs toolbar Refresh reloads and Re-run gives feedback
+status: To Do
+assignee: []
+created_date: '2026-08-04'
+labels:
+  - watchlists
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+Observed live during UAT batch-2 verification and confirmed in review
+(`runs_pane.py:396-397`): the Runs toolbar's Refresh button only re-arms the
+action buttons (`_update_action_buttons`) — it never reloads the runs list.
+"Re-run source" does run the check but gives no visible feedback that it
+started or finished (compounded by Refresh being dead). Pre-existing before
+the batch-2 branch; now more visible since run rows carry real accounting.
+
+## Acceptance Criteria (the what)
+
+- [ ] Refresh reloads the runs list (and the selected run's detail) from the
+      backend.
+- [ ] Re-run source shows an immediate acknowledgment and a completion signal
+      (success and failure), consistent with TASK-2309's check-now feedback.
+- [ ] Both behaviors have discriminating tests.


### PR DESCRIPTION
Both verified pre-existing on origin/dev during UAT batch-2 review. Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog tasks `TASK-2330` and `TASK-2331` to record pre-existing issues found in UAT batch-2 on `origin/dev`. They cover a failing watchlists test that asserts a removed `_delete_item` method, and Runs toolbar bugs where Refresh doesn’t reload runs and Re-run shows no feedback, with acceptance criteria for fixes and tests.

<sup>Written for commit 8de03de45012a2d2e3c64f30641e66f5fc7da49e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

