### PR TITLE
chore: mark UAT batch-2 tasks Done (PR #1348 merged)

### DIFF
--- a/backlog/tasks/task-2305 - Runs carry real accounting and their source name.md
+++ b/backlog/tasks/task-2305 - Runs carry real accounting and their source name.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2305
 title: Runs carry real accounting and their source name
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2306 - Run selection populates the run detail region.md
+++ b/backlog/tasks/task-2306 - Run selection populates the run detail region.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2306
 title: Run selection populates the run detail region
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks UAT batch-2 tasks as Done to reflect completed work. Updates the status in task-2305 and task-2306 markdown from "In Progress" to "Done".

<sup>Written for commit ed75f4ed96c9a83ea80c84dfe93876700ae9b671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

