### PR TITLE
chore: file task-2510 (source type options vs service vocabulary)

### DIFF
--- a/backlog/tasks/task-2510 - Source type options offer values the local service rejects.md
+++ b/backlog/tasks/task-2510 - Source type options offer values the local service rejects.md
@@ -1,0 +1,36 @@
+---
+id: TASK-2510
+title: Source type options offer values the local service rejects
+status: To Do
+assignee: []
+created_date: '2026-08-05'
+labels:
+  - watchlists
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+The create-source form's type Select (`_TYPE_OPTIONS`) offers `Feed`,
+`Playlist` and `Channel`, none of which `_local_type_for_source_type`
+accepts — it raises `ValueError`, so choosing one fails the create with a
+generic "Failed to create source." toast that names neither the cause nor the
+offending choice. Verified pre-existing on `origin/dev` during UAT batch-3
+review.
+
+Two changes in batch 3 (PR #1355) made it **more reachable**, without
+introducing it: the type control now carries a visible label (so users find
+and use it), and the chosen type persists across a form rebuild instead of
+being silently reset to `rss` by the next recompose.
+
+## Acceptance Criteria (the what)
+
+- [ ] The type Select offers only values the active backend can actually
+      create, or the unsupported ones are visibly unavailable with a reason.
+- [ ] If an unsupported type does reach the service, the failure names the
+      type and what to choose instead — never a bare "Failed to create
+      source."
+- [ ] A test pins the option list against the service's accepted vocabulary,
+      so the two cannot drift apart again.


### PR DESCRIPTION
Pre-existing on dev; confirmed and characterised during UAT batch-3 review. Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog task TASK-2510 documenting a bug where the create-source type select offers `Feed`, `Playlist`, and `Channel` that the local service rejects, leading to generic create failures. The task sets acceptance criteria to align UI options with backend vocabulary, improve error messages, and add a test to prevent drift.

<sup>Written for commit da08fcc7a3fe9e442741da0db5128a852fa60db9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

