### PR TITLE
chore: mark UAT batch-3 tasks Done (PR #1355 merged)

### DIFF
--- a/backlog/tasks/task-2302 - New Source form states its destination and lands there.md
+++ b/backlog/tasks/task-2302 - New Source form states its destination and lands there.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2302
 title: New Source form states its destination and lands there
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2303 - Create-source and assign-source stop sharing a vocabulary.md
+++ b/backlog/tasks/task-2303 - Create-source and assign-source stop sharing a vocabulary.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2303
 title: Create-source and assign-source stop sharing a vocabulary
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:


### PR DESCRIPTION
Bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked UAT batch-3 backlog tasks as Done by updating `TASK-2302` and `TASK-2303` (status changed from In Progress to Done) to reflect completed work.

<sup>Written for commit 96d9fde035a9887ca7d349665528d1baf6f9f7ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

