### PR TITLE
Toad-inspired UI improvements: textual pin, watcher coalescing, timer guards, tool-call diffs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
           ui-test-results.json
 
   textual-minimum:
-    name: MCP - Minimum Textual 8.0.0
+    name: MCP - Minimum Textual 8.2.8
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -222,7 +222,8 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install -e .
         pip install pytest pytest-asyncio pytest-timeout
-        pip install "textual==8.0.0"
+        # Floor check against the declared minimum supported Textual (pinned in pyproject.toml).
+        pip install "textual==8.2.8"
 
     - name: Verify packaging and MCP at the Textual floor
       run: |

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -130,7 +130,9 @@ def test_ci_exercises_mcp_against_minimum_textual() -> None:
     textual_minimum = _textual_minimum_job_block()
     test_summary = _test_summary_job_block()
 
-    assert 'pip install "textual==8.0.0"' in textual_minimum
+    # Floor check must install the declared minimum supported Textual
+    # (pinned in pyproject.toml, currently ==8.2.8 per TASK-1353/1362).
+    assert 'pip install "textual==8.2.8"' in textual_minimum
     assert "Tests/CI/test_textual_runtime_contract.py" in textual_minimum
     assert "Tests/UI/test_mcp_workbench.py" in textual_minimum
     assert "Tests/UI/test_mcp_tools_mode.py" in textual_minimum

--- a/Tests/CI/test_textual_runtime_contract.py
+++ b/Tests/CI/test_textual_runtime_contract.py
@@ -3,12 +3,10 @@ from pathlib import Path
 import tomllib
 
 from packaging.requirements import Requirement
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-TEXTUAL_8_X = SpecifierSet(">=8.0.0,<9")
 
 
 def _textual_requirement(entries: Iterable[str]) -> Requirement:
@@ -23,26 +21,26 @@ def _textual_requirement(entries: Iterable[str]) -> Requirement:
 
 
 def _assert_textual_8_only(requirement: Requirement) -> None:
-    assert requirement.specifier == TEXTUAL_8_X
     assert Version("7.999.999") not in requirement.specifier
-    assert Version("8.0.0") in requirement.specifier
-    assert Version("8.999.999") in requirement.specifier
     assert Version("9.0.0") not in requirement.specifier
+    exact_pins = [spec for spec in requirement.specifier if spec.operator == "=="]
+    if exact_pins:
+        # Exact pin (e.g. ==8.2.8 per TASK-1353): must stay within the 8.x line.
+        assert all(Version(spec.version).major == 8 for spec in exact_pins)
+    else:
+        assert Version("8.0.0") in requirement.specifier
+        assert Version("8.999.999") in requirement.specifier
 
 
 def test_pyproject_supports_only_textual_8_x() -> None:
     pyproject = tomllib.loads(
         (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     )
-
     requirement = _textual_requirement(pyproject["project"]["dependencies"])
-
     _assert_textual_8_only(requirement)
 
 
 def test_development_requirements_support_only_textual_8_x() -> None:
     requirements = (PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8")
-
     requirement = _textual_requirement(requirements.splitlines())
-
     _assert_textual_8_only(requirement)

--- a/Tests/Notes/test_auto_sync_manager_coalescing.py
+++ b/Tests/Notes/test_auto_sync_manager_coalescing.py
@@ -1,0 +1,91 @@
+"""
+Tests for notes file-watcher UI notification coalescing (TASK-1352).
+
+A burst of watchdog filesystem events must collapse into at most one
+UI-facing ``on_files_changed`` notification per coalescing window, instead
+of one callback (previously one asyncio task) per raw event.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tldw_chatbook.Notes.auto_sync_manager import (
+    FILES_CHANGED_NOTIFY_COALESCE_SECONDS,
+    AutoSyncManager,
+    NotesFileWatcher,
+)
+
+
+def _make_manager(tmp_path: Path) -> AutoSyncManager:
+    manager = AutoSyncManager(
+        sync_service=MagicMock(),
+        sync_folder=tmp_path,
+        user_id="test-user",
+    )
+    # Simulate start() without spinning up the watchdog observer/sync loop.
+    manager.is_running = True
+    manager._loop = asyncio.get_running_loop()
+    manager.file_watcher = NotesFileWatcher(manager._on_file_changed)
+    return manager
+
+
+def _fire_modify(manager: AutoSyncManager, path: Path) -> None:
+    """Simulate a watchdog on_modified event through the watcher."""
+    event = MagicMock()
+    event.is_directory = False
+    event.src_path = str(path)
+    manager.file_watcher.on_modified(event)
+
+
+@pytest.mark.asyncio
+async def test_event_burst_produces_single_ui_notification(tmp_path):
+    manager = _make_manager(tmp_path)
+    notifications = []
+    manager.on_files_changed = notifications.append
+
+    for i in range(10):
+        _fire_modify(manager, tmp_path / f"note-{i}.md")
+
+    await asyncio.sleep(FILES_CHANGED_NOTIFY_COALESCE_SECONDS * 3)
+
+    assert notifications == [10]
+    assert manager.pending_sync
+
+
+@pytest.mark.asyncio
+async def test_separate_bursts_each_produce_one_notification(tmp_path):
+    manager = _make_manager(tmp_path)
+    notifications = []
+    manager.on_files_changed = notifications.append
+
+    _fire_modify(manager, tmp_path / "a.md")
+    _fire_modify(manager, tmp_path / "b.md")
+    await asyncio.sleep(FILES_CHANGED_NOTIFY_COALESCE_SECONDS * 3)
+
+    _fire_modify(manager, tmp_path / "c.md")
+    await asyncio.sleep(FILES_CHANGED_NOTIFY_COALESCE_SECONDS * 3)
+
+    assert len(notifications) == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_pending_notification(tmp_path):
+    manager = _make_manager(tmp_path)
+    notifications = []
+    manager.on_files_changed = notifications.append
+
+    _fire_modify(manager, tmp_path / "note.md")
+    manager.stop()
+
+    await asyncio.sleep(FILES_CHANGED_NOTIFY_COALESCE_SECONDS * 3)
+    assert notifications == []
+
+
+@pytest.mark.asyncio
+async def test_no_callback_set_still_marks_pending_sync(tmp_path):
+    manager = _make_manager(tmp_path)
+    manager._on_file_changed(tmp_path / "note.md")
+    assert manager.pending_sync

--- a/Tests/Tools/test_write_file_diff_capture.py
+++ b/Tests/Tools/test_write_file_diff_capture.py
@@ -143,6 +143,26 @@ class TestWriteFileDiffCapture:
         assert result["new_content"] == content
 
     @pytest.mark.asyncio
+    async def test_append_combined_size_over_cap_skips_capture(self, tool, _sandbox_only_roots):
+        """Append mode materializes new_content as old + appended, so the
+        combined size (not just the appended chunk) must stay within the cap."""
+        target = _sandbox_only_roots / "append_big.txt"
+        old_text = "o" * (DIFF_CAPTURE_MAX_BYTES - 10)
+        target.write_text(old_text, encoding="utf-8")
+        chunk = "c" * 2000  # under the cap alone, over it combined
+
+        result = await tool.execute(
+            file_path="append_big.txt", content=chunk, mode="append"
+        )
+
+        assert "error" not in result
+        assert result["action"] == "appended to"
+        assert "old_content" not in result
+        assert "new_content" not in result
+        # The append itself still happened.
+        assert target.read_text(encoding="utf-8") == old_text + chunk
+
+    @pytest.mark.asyncio
     async def test_error_results_have_no_diff_content(self, tool):
         result = await tool.execute(content="no path given")
         assert result == {"error": "No file path provided"}
@@ -150,7 +170,7 @@ class TestWriteFileDiffCapture:
         assert "new_content" not in result
 
 
-class _AllowAllGate:
+class AllowAllGate:
     """Provider gate stub that permits every tool."""
 
     def check(self, tool):
@@ -166,7 +186,7 @@ class TestBuiltinProviderStripsDiffContents:
     """
 
     def test_invoke_strips_diff_content_keys(self, _sandbox_only_roots):
-        provider = BuiltinToolProvider(gate=_AllowAllGate())
+        provider = BuiltinToolProvider(gate=AllowAllGate())
         provider._tools["write_file"] = WriteFileTool()
 
         result = provider.invoke(
@@ -183,7 +203,7 @@ class TestBuiltinProviderStripsDiffContents:
         assert "created" in result.content
 
     def test_invoke_leaves_plain_results_untouched(self, _sandbox_only_roots):
-        provider = BuiltinToolProvider(gate=_AllowAllGate())
+        provider = BuiltinToolProvider(gate=AllowAllGate())
         provider._tools["write_file"] = WriteFileTool()
 
         result = provider.invoke(

--- a/Tests/Tools/test_write_file_diff_capture.py
+++ b/Tests/Tools/test_write_file_diff_capture.py
@@ -1,0 +1,196 @@
+"""Tests for before/after content capture in file-writing tools (TASK-1351)."""
+
+import pytest
+
+from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+from tldw_chatbook.Tools import file_operation_tools as fot
+from tldw_chatbook.Tools import workspace_file_roots as wfr
+from tldw_chatbook.Tools.file_operation_tools import (
+    DIFF_CAPTURE_MAX_BYTES,
+    WriteFileTool,
+)
+
+
+@pytest.fixture(autouse=True)
+def _sandbox_only_roots(monkeypatch, tmp_path):
+    """Point the file-tool sandbox at tmp_path, with no workspace roots.
+
+    Same idiom as ``Tests/Tools/test_file_tool_sandbox.py``: raising from
+    the registry factory drives ``allowed_file_roots`` into its documented
+    fail-safe fallback (sandbox-only).
+    """
+    sandbox = (tmp_path / "tool_sandbox").resolve()
+    sandbox.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(fot, "_tool_sandbox_root", lambda: sandbox)
+
+    def _raise():
+        raise RuntimeError("no workspace registry in this test")
+
+    monkeypatch.setattr(wfr, "_registry_factory", _raise)
+    return sandbox
+
+
+@pytest.fixture
+def tool():
+    return WriteFileTool()
+
+
+class TestWriteFileDiffCapture:
+    """WriteFileTool results carry old_content/new_content for diff rendering."""
+
+    @pytest.mark.asyncio
+    async def test_new_file_has_empty_old_content(self, tool, _sandbox_only_roots):
+        result = await tool.execute(file_path="new_file.txt", content="hello\nworld\n")
+
+        assert "error" not in result
+        assert result["action"] == "created"
+        assert result["old_content"] == ""
+        assert result["new_content"] == "hello\nworld\n"
+        assert result["file_path"] == str(_sandbox_only_roots / "new_file.txt")
+
+    @pytest.mark.asyncio
+    async def test_overwrite_captures_old_content(self, tool, _sandbox_only_roots):
+        target = _sandbox_only_roots / "existing.txt"
+        target.write_text("line one\nline two\n", encoding="utf-8")
+
+        result = await tool.execute(
+            file_path="existing.txt", content="line one\nchanged\n"
+        )
+
+        assert "error" not in result
+        assert result["action"] == "overwritten"
+        assert result["old_content"] == "line one\nline two\n"
+        assert result["new_content"] == "line one\nchanged\n"
+
+    @pytest.mark.asyncio
+    async def test_append_captures_combined_new_content(self, tool, _sandbox_only_roots):
+        target = _sandbox_only_roots / "append.txt"
+        target.write_text("start\n", encoding="utf-8")
+
+        result = await tool.execute(
+            file_path="append.txt", content="more\n", mode="append"
+        )
+
+        assert "error" not in result
+        assert result["action"] == "appended to"
+        assert result["old_content"] == "start\n"
+        assert result["new_content"] == "start\nmore\n"
+
+    @pytest.mark.asyncio
+    async def test_undecodable_old_content_skips_capture(self, tool, _sandbox_only_roots):
+        """Binary (undecodable) pre-existing files omit the capture keys —
+        a fabricated "before" state would render a misleading diff."""
+        target = _sandbox_only_roots / "binary.bin"
+        target.write_bytes(b"\xff\xfe\x00\x01binary")
+
+        result = await tool.execute(file_path="binary.bin", content="text\n")
+
+        assert "error" not in result
+        assert "old_content" not in result
+        assert "new_content" not in result
+
+    @pytest.mark.asyncio
+    async def test_undecodable_append_skips_capture(self, tool, _sandbox_only_roots):
+        """Append to an undecodable file omits the capture keys too."""
+        target = _sandbox_only_roots / "binary.bin"
+        target.write_bytes(b"\xff\xfe\x00\x01binary")
+
+        result = await tool.execute(
+            file_path="binary.bin", content="text\n", mode="append"
+        )
+
+        assert "error" not in result
+        assert result["action"] == "appended to"
+        assert "old_content" not in result
+        assert "new_content" not in result
+
+    @pytest.mark.asyncio
+    async def test_oversized_existing_file_skips_capture(self, tool, _sandbox_only_roots):
+        """Pre-existing files over DIFF_CAPTURE_MAX_BYTES are not captured."""
+        target = _sandbox_only_roots / "big.txt"
+        target.write_text("x" * (DIFF_CAPTURE_MAX_BYTES + 1), encoding="utf-8")
+
+        result = await tool.execute(file_path="big.txt", content="small\n")
+
+        assert "error" not in result
+        assert result["action"] == "overwritten"
+        assert "old_content" not in result
+        assert "new_content" not in result
+        # The write itself still happened.
+        assert target.read_text(encoding="utf-8") == "small\n"
+
+    @pytest.mark.asyncio
+    async def test_oversized_new_content_skips_capture(self, tool, _sandbox_only_roots):
+        """Writes whose new content exceeds the cap are not captured."""
+        result = await tool.execute(
+            file_path="new_big.txt", content="y" * (DIFF_CAPTURE_MAX_BYTES + 1)
+        )
+
+        assert "error" not in result
+        assert result["action"] == "created"
+        assert "old_content" not in result
+        assert "new_content" not in result
+
+    @pytest.mark.asyncio
+    async def test_content_at_cap_is_captured(self, tool, _sandbox_only_roots):
+        """Content exactly at the cap is still captured (boundary check)."""
+        content = "z" * DIFF_CAPTURE_MAX_BYTES
+
+        result = await tool.execute(file_path="at_cap.txt", content=content)
+
+        assert "error" not in result
+        assert result["old_content"] == ""
+        assert result["new_content"] == content
+
+    @pytest.mark.asyncio
+    async def test_error_results_have_no_diff_content(self, tool):
+        result = await tool.execute(content="no path given")
+        assert result == {"error": "No file path provided"}
+        assert "old_content" not in result
+        assert "new_content" not in result
+
+
+class _AllowAllGate:
+    """Provider gate stub that permits every tool."""
+
+    def check(self, tool):
+        return None
+
+
+class TestBuiltinProviderStripsDiffContents:
+    """The provider seam never replays raw diff contents to the LLM/run log.
+
+    ``BuiltinToolProvider.invoke`` is where a builtin tool's result dict
+    becomes the JSON text that feeds both the model history and the on-disk
+    run log (TASK-1351) — old_content/new_content must not survive it.
+    """
+
+    def test_invoke_strips_diff_content_keys(self, _sandbox_only_roots):
+        provider = BuiltinToolProvider(gate=_AllowAllGate())
+        provider._tools["write_file"] = WriteFileTool()
+
+        result = provider.invoke(
+            "builtin:write_file",
+            {"file_path": "note.txt", "content": "secret before/after text\n"},
+        )
+
+        assert result.ok
+        assert "old_content" not in result.content
+        assert "new_content" not in result.content
+        assert "secret before/after text" not in result.content
+        # The ordinary result fields are still reported to the model.
+        assert "note.txt" in result.content
+        assert "created" in result.content
+
+    def test_invoke_leaves_plain_results_untouched(self, _sandbox_only_roots):
+        provider = BuiltinToolProvider(gate=_AllowAllGate())
+        provider._tools["write_file"] = WriteFileTool()
+
+        result = provider.invoke(
+            "builtin:write_file",
+            {"file_path": "plain.txt", "content": "hi\n"},
+        )
+
+        assert result.ok
+        assert '"action": "created"' in result.content
+        assert '"lines_written": 1' in result.content

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -259,33 +259,43 @@ async def test_save_invalid_toml_format(settings_window: ToolsSettingsWindow, mo
     assert mock_app_instance.notify.call_args.kwargs == {"severity": "error"}
 
 
-# Test for save I/O error (conceptual - requires mocking 'open')
-@pytest.mark.skip(reason="Complex to mock built-in open reliably for this specific write operation only")
 @pytest.mark.asyncio
-async def test_save_io_error(settings_window: ToolsSettingsWindow, mock_app_instance, monkeypatch):
-    """Test saving config when an IOError occurs."""
+async def test_save_io_error(
+    settings_window: ToolsSettingsWindow,
+    mock_app_instance,
+    temp_config_path: Path,
+    monkeypatch,
+):
+    """Test saving config when an IOError occurs.
+
+    The window module imports ``replace_cli_config`` by name
+    (``from tldw_chatbook.config import replace_cli_config``), so patching the
+    module-level reference in ``Tools_Settings_Window`` deterministically
+    forces the write step to fail without touching the fragile builtin
+    ``open`` -- which is what made the old version of this test a permanent
+    skip.
+    """
     config_text_area = settings_window.query_one("#config-text-area", TextArea)
+    save_button = settings_window.query_one("#save-config-button", Button)
 
-    config_text_area.text = toml.dumps({"good": "data"})
+    new_config_dict = {"good": "data"}
+    config_text_area.text = toml.dumps(new_config_dict)
+    original_bytes = temp_config_path.read_bytes()
 
-    # Mock 'open' within the tldw_chatbook.UI.Tools_Settings_Window context or globally
-    # to raise IOError only for the specific write operation.
-    # This is tricky because 'open' is a builtin and patching it requires care.
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Tools_Settings_Window.replace_cli_config",
+        MagicMock(side_effect=IOError("Disk full")),
+    )
 
-    # For example, using a more specific patch target if 'open' is imported like 'from io import open':
-    # with monkeypatch.context() as m:
-    # m.setattr("tldw_chatbook.UI.Tools_Settings_Window.open", MagicMock(side_effect=IOError("Disk full")))
-    # await settings_window.on_button_pressed(Button.Pressed(save_button))
+    await settings_window.on_button_pressed(Button.Pressed(save_button))
 
-    # Or if it uses the global 'open':
-    # with patch('builtins.open', MagicMock(side_effect=IOError("Cannot write"))):
-    # await settings_window.on_button_pressed(Button.Pressed(save_button))
+    message = mock_app_instance.notify.call_args.args[0]
+    assert message.startswith("Error: Could not write to configuration file:")
+    assert "Disk full" in message
+    assert mock_app_instance.notify.call_args.kwargs == {"severity": "error"}
 
-    # This test is skipped because such mocking is highly dependent on exact 'open' usage
-    # and can be fragile. A more robust way might involve filesystem-level mocks if available.
-
-    # mock_app_instance.notify.assert_called_with("Error: Could not write to configuration file.", severity="error")
-    pass
+    # The failed save must not have modified the on-disk config.
+    assert temp_config_path.read_bytes() == original_bytes
 
 
 # ===========================================

--- a/Tests/Widgets/test_tool_diff_widgets.py
+++ b/Tests/Widgets/test_tool_diff_widgets.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import time
+from collections.abc import Callable
 
 import pytest
 from textual.app import App
@@ -21,11 +22,22 @@ from tldw_chatbook.Widgets.tool_message_widgets import (
 )
 
 
-async def wait_for_condition(predicate, timeout: float = 5.0, interval: float = 0.02):
-    """Poll `predicate` until it is true or `timeout` seconds elapse.
+async def wait_for_condition(
+    predicate: Callable[[], bool], timeout: float = 5.0, interval: float = 0.02
+) -> bool:
+    """Poll ``predicate`` until it is true or ``timeout`` seconds elapse.
 
-    Returns the predicate's final value. Used instead of a fixed number of
-    pilot.pause() calls, which is timing-dependent and flaky.
+    Used instead of a fixed number of ``pilot.pause()`` calls, which is
+    timing-dependent and flaky.
+
+    Args:
+        predicate: Zero-argument callable returning True when the awaited
+            condition holds.
+        timeout: Maximum seconds to poll before giving up.
+        interval: Seconds between polls.
+
+    Returns:
+        True if the predicate became true before the deadline, False otherwise.
     """
     deadline = time.monotonic() + timeout
     while True:

--- a/Tests/Widgets/test_tool_diff_widgets.py
+++ b/Tests/Widgets/test_tool_diff_widgets.py
@@ -1,0 +1,372 @@
+"""Tests for tool-call diff rendering with textual-diff-view (TASK-1351)."""
+
+import asyncio
+import json
+import time
+
+import pytest
+from textual.app import App
+from textual_diff_view import DiffView
+
+from tldw_chatbook.Widgets import tool_message_widgets
+from tldw_chatbook.Widgets.diff_widgets import (
+    extract_diff_from_result,
+    make_diff,
+    set_default_diff_view_mode,
+    strip_diff_contents,
+)
+from tldw_chatbook.Widgets.tool_message_widgets import (
+    ToolExecutionWidget,
+    ToolResultMessage,
+)
+
+
+async def wait_for_condition(predicate, timeout: float = 5.0, interval: float = 0.02):
+    """Poll `predicate` until it is true or `timeout` seconds elapse.
+
+    Returns the predicate's final value. Used instead of a fixed number of
+    pilot.pause() calls, which is timing-dependent and flaky.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if predicate():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(interval)
+
+
+class DiffTestApp(App):
+    """Test app for mounting diff-related widgets."""
+
+    def __init__(self, widget):
+        super().__init__()
+        self.test_widget = widget
+
+    def compose(self):
+        yield self.test_widget
+
+
+@pytest.fixture(autouse=True)
+def reset_diff_view_mode():
+    """Restore the module-level default view mode after each test."""
+    yield
+    set_default_diff_view_mode("auto")
+
+
+@pytest.fixture
+def diff_tool_result():
+    """A tool result carrying before/after file contents."""
+    return [
+        {
+            "tool_call_id": "call_diff",
+            "result": {
+                "file_path": "/tmp/example.py",
+                "action": "overwritten",
+                "size_bytes": 20,
+                "encoding": "utf-8",
+                "lines_written": 2,
+                "old_content": "def f():\n    return 1\n",
+                "new_content": "def f():\n    return 2\n",
+            },
+        }
+    ]
+
+
+class TestExtractDiffFromResult:
+    """extract_diff_from_result finds before/after content in tool results."""
+
+    def test_extracts_diff_fields(self, diff_tool_result):
+        extracted = extract_diff_from_result(diff_tool_result[0])
+        assert extracted == (
+            "/tmp/example.py",
+            "def f():\n    return 1\n",
+            "def f():\n    return 2\n",
+        )
+
+    def test_plain_result_returns_none(self):
+        result = {"tool_call_id": "call_1", "result": {"answer": 42}}
+        assert extract_diff_from_result(result) is None
+
+    def test_error_result_returns_none(self):
+        result = {"tool_call_id": "call_2", "error": "boom"}
+        assert extract_diff_from_result(result) is None
+
+    def test_missing_old_content_returns_none(self):
+        result = {
+            "tool_call_id": "call_3",
+            "result": {"file_path": "/tmp/x", "new_content": "data"},
+        }
+        assert extract_diff_from_result(result) is None
+
+    def test_non_dict_payload_returns_none(self):
+        result = {"tool_call_id": "call_4", "result": "just a string"}
+        assert extract_diff_from_result(result) is None
+
+
+class TestStripDiffContents:
+    """strip_diff_contents removes raw contents from outbound/stored payloads."""
+
+    def test_strips_keys_from_copy(self, diff_tool_result):
+        stripped = strip_diff_contents(diff_tool_result[0])
+
+        assert stripped is not diff_tool_result[0]
+        assert stripped["tool_call_id"] == "call_diff"
+        assert "old_content" not in stripped["result"]
+        assert "new_content" not in stripped["result"]
+        # Other fields are preserved.
+        assert stripped["result"]["file_path"] == "/tmp/example.py"
+        assert stripped["result"]["action"] == "overwritten"
+
+    def test_non_mutating(self, diff_tool_result):
+        """The in-memory record keeps its contents for live UI rendering."""
+        strip_diff_contents(diff_tool_result[0])
+
+        assert diff_tool_result[0]["result"]["old_content"] == "def f():\n    return 1\n"
+        assert diff_tool_result[0]["result"]["new_content"] == "def f():\n    return 2\n"
+
+    def test_result_without_diff_keys_returned_as_is(self):
+        result = {"tool_call_id": "call_1", "result": {"answer": 42}}
+        assert strip_diff_contents(result) is result
+
+    def test_error_result_returned_as_is(self):
+        result = {"tool_call_id": "call_2", "error": "boom"}
+        assert strip_diff_contents(result) is result
+
+    def test_serialized_payload_drops_contents(self, diff_tool_result):
+        """End-to-end: the stored/outbound JSON carries no raw contents."""
+        payload = json.dumps([strip_diff_contents(r) for r in diff_tool_result])
+        assert "old_content" not in payload
+        assert "new_content" not in payload
+        assert "return 1" not in payload
+        assert "return 2" not in payload
+        assert "overwritten" in payload
+
+
+class TestMakeDiff:
+    """make_diff builds a DiffView from a tool-call record's contents."""
+
+    def test_paths_and_content(self):
+        diff_view = make_diff("/tmp/a.py", "old\n", "new\n")
+
+        assert isinstance(diff_view, DiffView)
+        assert diff_view.path_original == "/tmp/a.py"
+        assert diff_view.path_modified == "/tmp/a.py"
+        assert diff_view.code_original == "old\n"
+        assert diff_view.code_modified == "new\n"
+
+    def test_none_content_becomes_empty(self):
+        diff_view = make_diff("/tmp/a.py", None, "new\n")
+        assert diff_view.code_original == ""
+
+    def test_default_mode_is_auto(self):
+        diff_view = make_diff("/tmp/a.py", "old\n", "new\n")
+        assert diff_view.auto_split is True
+
+    def test_mode_switching(self):
+        set_default_diff_view_mode("split")
+        assert make_diff("p", "a", "b").split is True
+        assert make_diff("p", "a", "b").auto_split is False
+
+        set_default_diff_view_mode("unified")
+        assert make_diff("p", "a", "b").split is False
+        assert make_diff("p", "a", "b").auto_split is False
+
+        set_default_diff_view_mode("auto")
+        assert make_diff("p", "a", "b").auto_split is True
+
+    def test_invalid_mode_rejected(self):
+        with pytest.raises(ValueError):
+            set_default_diff_view_mode("sideways")
+
+
+class TestAutoSplit:
+    """Auto view mode flips between unified and split based on width."""
+
+    @pytest.mark.asyncio
+    async def test_wide_terminal_enables_split(self):
+        diff_view = make_diff("/tmp/a.py", "a\nb\n", "a\nc\n")
+        app = DiffTestApp(diff_view)
+
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause()
+            assert diff_view.auto_split is True
+            assert diff_view.split is True
+
+    @pytest.mark.asyncio
+    async def test_resize_flips_split_mode(self):
+        """Resizing the terminal flips split off and back on (AC2)."""
+        long_line = "x" * 60
+        diff_view = make_diff("/tmp/a.py", f"{long_line}\nb\n", f"{long_line}\nc\n")
+        app = DiffTestApp(diff_view)
+
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause()
+            assert diff_view.split is True
+
+            await pilot.resize_terminal(80, 24)
+            await pilot.pause()
+            assert diff_view.split is False
+
+            await pilot.resize_terminal(200, 50)
+            await pilot.pause()
+            assert diff_view.split is True
+
+
+class TestToolExecutionWidgetDiffs:
+    """ToolExecutionWidget mounts DiffViews for results with diff content."""
+
+    @pytest.mark.asyncio
+    async def test_diff_mounted_after_prepare(self, monkeypatch, diff_tool_result):
+        """Diff is prepared off the UI thread before being mounted (AC3)."""
+        prepared = []
+        real_make_diff = tool_message_widgets.make_diff
+
+        def tracking_make_diff(path, old, new, **kwargs):
+            diff_view = real_make_diff(path, old, new, **kwargs)
+            original_prepare = diff_view.prepare
+
+            async def tracked_prepare():
+                prepared.append(path)
+                await original_prepare()
+
+            diff_view.prepare = tracked_prepare
+            return diff_view
+
+        monkeypatch.setattr(tool_message_widgets, "make_diff", tracking_make_diff)
+
+        tool_calls = [
+            {
+                "function": {
+                    "name": "write_file",
+                    "arguments": json.dumps(
+                        {"file_path": "/tmp/example.py", "content": "x"}
+                    ),
+                }
+            }
+        ]
+        widget = ToolExecutionWidget(tool_calls=tool_calls)
+        app = DiffTestApp(widget)
+
+        async with app.run_test() as pilot:
+            widget.update_results(diff_tool_result)
+
+            found = await wait_for_condition(
+                lambda: len(widget.query(DiffView)) == 1
+            )
+            assert found, "DiffView was not mounted within the timeout"
+            await pilot.pause()
+
+            diff_view = widget.query(DiffView).first()
+            # prepare() ran before the widget was mounted
+            assert prepared == ["/tmp/example.py"]
+            assert diff_view.is_mounted
+            assert diff_view.path_modified == "/tmp/example.py"
+            assert diff_view.code_original == "def f():\n    return 1\n"
+            assert diff_view.code_modified == "def f():\n    return 2\n"
+            # Text result widget still renders alongside the diff
+            assert widget.tool_result_widget is not None
+
+    @pytest.mark.asyncio
+    async def test_results_without_diff_content_render_as_before(self):
+        """Plain tool results produce text only, no DiffView (AC, no regression)."""
+        tool_calls = [
+            {
+                "function": {
+                    "name": "calculator",
+                    "arguments": json.dumps({"expression": "1+1"}),
+                }
+            }
+        ]
+        widget = ToolExecutionWidget(tool_calls=tool_calls)
+        app = DiffTestApp(widget)
+
+        async with app.run_test():
+            widget.update_results(
+                [{"tool_call_id": "call_1", "result": {"answer": 2}}]
+            )
+
+            mounted = await wait_for_condition(
+                lambda: widget.tool_result_widget is not None
+                and widget.tool_result_widget.is_mounted
+            )
+            assert mounted, "ToolResultMessage was not mounted within the timeout"
+            # Bounded negative wait: no DiffView should ever appear.
+            appeared = await wait_for_condition(
+                lambda: len(widget.query(DiffView)) > 0, timeout=0.5
+            )
+            assert not appeared
+            assert isinstance(widget.tool_result_widget, ToolResultMessage)
+            assert "answer: 2" in widget.tool_result_widget.message_text
+
+    @pytest.mark.asyncio
+    async def test_results_passed_at_init_mount_diff_on_mount(self, diff_tool_result):
+        """Results supplied to the constructor also get a DiffView."""
+        tool_calls = [
+            {
+                "function": {
+                    "name": "write_file",
+                    "arguments": json.dumps({"file_path": "/tmp/example.py"}),
+                }
+            }
+        ]
+        widget = ToolExecutionWidget(
+            tool_calls=tool_calls, tool_results=diff_tool_result
+        )
+        app = DiffTestApp(widget)
+
+        async with app.run_test():
+            found = await wait_for_condition(
+                lambda: len(widget.query(DiffView)) == 1
+            )
+            assert found, "DiffView was not mounted within the timeout"
+
+    @pytest.mark.asyncio
+    async def test_repeated_update_results_does_not_double_render(
+        self, diff_tool_result
+    ):
+        """A second update_results call replaces the diff, not duplicates it."""
+        tool_calls = [
+            {
+                "function": {
+                    "name": "write_file",
+                    "arguments": json.dumps({"file_path": "/tmp/example.py"}),
+                }
+            }
+        ]
+        widget = ToolExecutionWidget(tool_calls=tool_calls)
+        app = DiffTestApp(widget)
+
+        async with app.run_test():
+            widget.update_results(diff_tool_result)
+            assert await wait_for_condition(
+                lambda: len(widget.query(DiffView)) == 1
+            )
+
+            updated_result = [
+                {
+                    **diff_tool_result[0],
+                    "result": {
+                        **diff_tool_result[0]["result"],
+                        "new_content": "def f():\n    return 3\n",
+                    },
+                }
+            ]
+            widget.update_results(updated_result)
+
+            # Exactly one DiffView, showing the latest content (the old diff
+            # may transiently coexist while its removal is processed, so wait
+            # for the settled state).
+            settled = await wait_for_condition(
+                lambda: len(widget.query(DiffView)) == 1
+                and widget.query(DiffView).first().code_modified
+                == "def f():\n    return 3\n"
+            )
+            assert settled, "DiffView was not replaced within the timeout"
+
+    def test_raw_contents_skipped_in_text_formatting(self, diff_tool_result):
+        """old_content/new_content are not dumped into the text rendering."""
+        result_widget = ToolResultMessage(tool_results=diff_tool_result)
+        assert "return 1" not in result_widget.message_text
+        assert "return 2" not in result_widget.message_text
+        assert "overwritten" in result_widget.message_text

--- a/backlog/decisions/032-textual-diff-view-for-tool-call-diff-rendering.md
+++ b/backlog/decisions/032-textual-diff-view-for-tool-call-diff-rendering.md
@@ -24,6 +24,10 @@ The `textual-diff-view` package (by Will McGugan, used by the `toad` ACP client)
 - Raw before/after contents are display-only: they are stripped from DB-persisted tool messages and from the LLM continuation payload (`strip_diff_contents`), so diffs render from the in-memory record during the live session only; reloaded conversations show the text result.
 - Lays the foundation for a future notes-sync conflict diff view (adjacent to task-97) using the same widget and split-view pattern.
 
+## Amendment (2026-08-05, salvage onto `feat/toad-console-improvements` / dev)
+
+The original strip sites (`chat_streaming_events.py` / `worker_events.py`) were deleted on dev. In dev's Console agent flow a builtin tool's result dict is stringified at a single seam — `Agents/tool_catalog.py` `BuiltinToolProvider.invoke()` (`json.dumps(raw)`) — which feeds BOTH the model history (`agent_runtime._append_tool_result`) and the on-disk run log (`agent_runtime._emit_record`). The strip therefore lives at that seam (keys shared via `Tools.file_operation_tools.DIFF_CONTENT_KEYS`, used by both the seam and `Widgets/diff_widgets.strip_diff_contents`). `ToolExecutionWidget` DiffView mounting is unchanged; on dev that widget's only surface is the CCP/Personas flow.
+
 ## Alternatives considered
 
 - **Hand-rolled diff rendering**: rejected — significant effort to match hunk folding, split/auto modes, and scalable strip rendering; the package is purpose-built and already proven in `toad`.

--- a/backlog/decisions/032-textual-diff-view-for-tool-call-diff-rendering.md
+++ b/backlog/decisions/032-textual-diff-view-for-tool-call-diff-rendering.md
@@ -1,0 +1,31 @@
+# ADR-032: Adopt textual-diff-view for tool-call diff rendering
+
+## Status
+
+Accepted (2026-08-05), implemented under TASK-1351 on branch `feat/toad-ui-improvements`.
+
+## Context
+
+Tool calls that write files (e.g. `WriteFileTool`) currently render in chat as truncated plain-text arguments/results (`tool_message_widgets.py`), with no structured view of what changed. Users cannot review an edit before or after execution in any meaningful way.
+
+The `textual-diff-view` package (by Will McGugan, used by the `toad` ACP client) provides a standalone `DiffView` Textual widget: unified/split/auto view modes with width-based auto-switching, syntax highlighting, intra-line char diffs, hunk folding via `difflib.get_grouped_opcodes`, and strip-based rendering that scales to large diffs without per-line widgets. It has no coupling to `toad`.
+
+## Decision
+
+1. Add `textual-diff-view` as a pinned runtime dependency (exact pin, matching the deliberate-pin policy set for `textual` in TASK-1353).
+2. Transport pattern: capture **before/after file contents** on file-writing tool-call records and diff client-side with `difflib` (via the widget). Do not parse or apply unified-diff patches in the UI.
+3. Compute diffs off the UI thread (`await diff_view.prepare()`) before mounting.
+4. Rendering site: the tool-execution area of the chat window, alongside/within the existing `ToolExecutionWidget` flow.
+
+## Consequences
+
+- New runtime dependency with a single-author bus factor; pinned exactly, so upgrades are deliberate. The widget is small enough to vendor later if the package is abandoned.
+- File-writing tools must capture pre-write content, which adds a read before the first write per file per turn (bounded — capture is skipped entirely above a 256 KB per-side cap (`DIFF_CAPTURE_MAX_BYTES`), and only for tools that opt in).
+- Raw before/after contents are display-only: they are stripped from DB-persisted tool messages and from the LLM continuation payload (`strip_diff_contents`), so diffs render from the in-memory record during the live session only; reloaded conversations show the text result.
+- Lays the foundation for a future notes-sync conflict diff view (adjacent to task-97) using the same widget and split-view pattern.
+
+## Alternatives considered
+
+- **Hand-rolled diff rendering**: rejected — significant effort to match hunk folding, split/auto modes, and scalable strip rendering; the package is purpose-built and already proven in `toad`.
+- **Patch-based transport (unified diffs from tools)**: rejected — requires a patch parser and loses syntax-highlighted full-context rendering; before/after contents with client-side `difflib` is simpler and more robust.
+- **rich/textual built-ins only**: no maintained diff widget exists in core Textual.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "chardet",
     "httpx",
     "loguru",
-    "textual>=8.2.8,<9",
+    "textual==8.2.8",  # exact pin: UI framework, bump deliberately (TASK-1353)
+    "textual-diff-view==0.1.5",  # exact pin: diff widget, bump deliberately (TASK-1351)
     "requests",
     "rich",
     "rich-pixels>=3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,8 @@ chardet
 toml
 tomli
 rich
-textual>=8.0.0,<9
+textual==8.2.8
+textual-diff-view==0.1.5
 psutil
 requests
 pillow

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -628,6 +628,18 @@ class BuiltinToolProvider:
             return ToolResult(ok=False, error=str(exc))
         if isinstance(raw, dict) and raw.get("error"):
             return ToolResult(ok=False, error=str(raw["error"]))
+        if isinstance(raw, dict):
+            # Raw before/after contents captured for UI diff rendering
+            # (TASK-1351) are live-session display state only. This is the
+            # seam where a builtin tool's result dict becomes the JSON text
+            # that feeds BOTH the model history (_append_tool_result) and
+            # the on-disk run log (_emit_record) -- strip here so the raw
+            # contents are never replayed to a provider or persisted.
+            from tldw_chatbook.Tools.file_operation_tools import DIFF_CONTENT_KEYS
+
+            raw = {
+                key: value for key, value in raw.items() if key not in DIFF_CONTENT_KEYS
+            }
         content = json.dumps(raw) if isinstance(raw, (dict, list)) else str(raw)
         return ToolResult(ok=True, content=content)
 

--- a/tldw_chatbook/Notes/auto_sync_manager.py
+++ b/tldw_chatbook/Notes/auto_sync_manager.py
@@ -29,6 +29,10 @@ from .sync_engine import SyncDirection, ConflictResolution
 #
 # Classes:
 
+# Coalescing window for UI-facing file-change notifications: a burst of
+# watchdog events within this window produces a single on_files_changed call.
+FILES_CHANGED_NOTIFY_COALESCE_SECONDS = 0.25
+
 
 class NotesFileWatcher(FileSystemEventHandler):
     """Watches for file changes in the notes directory."""
@@ -91,6 +95,11 @@ class AutoSyncManager:
         self.pending_sync = False
         self.sync_in_progress = False
 
+        # Event loop captured on start() so the watchdog thread can safely
+        # schedule coalesced UI notifications.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._files_changed_notify_handle: Optional[asyncio.TimerHandle] = None
+
         # Callbacks for UI updates
         self.on_sync_started: Optional[Callable] = None
         self.on_sync_completed: Optional[Callable] = None
@@ -103,6 +112,7 @@ class AutoSyncManager:
             return
 
         self.is_running = True
+        self._loop = asyncio.get_running_loop()
 
         # Start file watcher
         self._start_file_watcher()
@@ -115,6 +125,11 @@ class AutoSyncManager:
     def stop(self):
         """Stop auto-sync monitoring."""
         self.is_running = False
+
+        # Cancel any pending coalesced UI notification
+        if self._files_changed_notify_handle is not None:
+            self._files_changed_notify_handle.cancel()
+            self._files_changed_notify_handle = None
 
         # Stop file watcher
         if self.observer:
@@ -144,19 +159,46 @@ class AutoSyncManager:
         self.observer.start()
 
     def _on_file_changed(self, file_path: Path):
-        """Handle file change events."""
+        """Handle file change events (called from the watchdog thread)."""
         # Mark that we need to sync
         self.pending_sync = True
 
-        # Notify UI if callback is set
-        if self.on_files_changed:
-            asyncio.create_task(self._notify_files_changed())
+        # Notify UI if callback is set, coalescing event bursts into a single
+        # notification per window instead of one callback per raw event.
+        if not self.on_files_changed:
+            return
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        try:
+            loop.call_soon_threadsafe(self._schedule_files_changed_notification)
+        except RuntimeError:
+            pass  # Loop closed between the check and the call
 
-    async def _notify_files_changed(self):
-        """Notify UI about file changes."""
-        if self.on_files_changed:
-            changed_count = len(self.file_watcher.changed_files)
+    def _schedule_files_changed_notification(self):
+        """Runs on the event loop; collapses bursts into one UI update."""
+        if not self.is_running:
+            return
+        if self._files_changed_notify_handle is not None:
+            # A notification is already scheduled; this event folds into it.
+            return
+        self._files_changed_notify_handle = self._loop.call_later(
+            FILES_CHANGED_NOTIFY_COALESCE_SECONDS,
+            self._emit_files_changed_notification,
+        )
+
+    def _emit_files_changed_notification(self):
+        """Deliver the single coalesced notification for a burst of events."""
+        self._files_changed_notify_handle = None
+        if not self.is_running or not self.on_files_changed:
+            return
+        changed_count = (
+            len(self.file_watcher.changed_files) if self.file_watcher else 0
+        )
+        try:
             self.on_files_changed(changed_count)
+        except Exception as e:
+            logger.error(f"Error in on_files_changed callback: {e}")
 
     async def _sync_loop(self):
         """Main sync loop that runs periodically."""

--- a/tldw_chatbook/Notes/auto_sync_manager.py
+++ b/tldw_chatbook/Notes/auto_sync_manager.py
@@ -198,7 +198,10 @@ class AutoSyncManager:
         try:
             self.on_files_changed(changed_count)
         except Exception as e:
-            logger.error(f"Error in on_files_changed callback: {e}")
+            logger.error(
+                f"Error in on_files_changed callback "
+                f"(changed_count={changed_count}, is_running={self.is_running}): {e}"
+            )
 
     async def _sync_loop(self):
         """Main sync loop that runs periodically."""

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -27,6 +27,17 @@ from ..Utils.sensitive_paths import (
 )
 from .workspace_file_roots import allowed_file_roots, run_workspace
 
+# Maximum size (bytes) of file content captured for diff rendering (TASK-1351).
+# Files or writes larger than this skip before/after capture entirely and
+# render as plain text results.
+DIFF_CAPTURE_MAX_BYTES = 256 * 1024
+
+# Result keys carrying the raw before/after contents captured for UI diff
+# rendering (TASK-1351). Display-only, live-session state: they must be
+# stripped before a result is persisted or serialized back to a provider
+# (see Agents/tool_catalog.py and Widgets/diff_widgets.py).
+DIFF_CONTENT_KEYS = ("old_content", "new_content")
+
 
 def _resolve_sandbox_config() -> str:
     """Return the configured sandbox root string (indirection for tests)."""
@@ -622,6 +633,27 @@ class WriteFileTool(Tool):
             # Check if we're overwriting an existing file
             file_exists = path.exists()
 
+            # Capture pre-write content for diff rendering (TASK-1351), bounded
+            # by DIFF_CAPTURE_MAX_BYTES so the extra read stays cheap and no
+            # oversized payloads are produced. Capture is skipped entirely
+            # (keys omitted, result renders as plain text) when either side is
+            # oversized or the pre-existing file is undecodable — a partial or
+            # fabricated diff would be misleading.
+            old_content = None
+            if file_exists:
+                try:
+                    if path.stat().st_size <= DIFF_CAPTURE_MAX_BYTES:
+                        old_content = path.read_text(encoding=encoding)
+                except (UnicodeDecodeError, OSError):
+                    old_content = None
+            else:
+                old_content = ""
+
+            if old_content is not None and (
+                len(content.encode(encoding)) > DIFF_CAPTURE_MAX_BYTES
+            ):
+                old_content = None
+
             # Create parent directories if requested
             if create_directories and not path.parent.exists():
                 # TASK-849: `is_sensitive_path(path)` just above only ever
@@ -662,22 +694,32 @@ class WriteFileTool(Tool):
                 with open(path, "a", encoding=encoding) as f:
                     f.write(content)
                 action = "appended to"
+                new_content = (
+                    old_content + content if old_content is not None else None
+                )
             else:
                 # Overwrite mode
                 with open(path, "w", encoding=encoding) as f:
                     f.write(content)
                 action = "created" if not file_exists else "overwritten"
+                new_content = content if old_content is not None else None
 
             # Get file info after writing
             stat = path.stat()
 
-            return {
+            result = {
                 "file_path": str(path),
                 "action": action,
                 "size_bytes": stat.st_size,
                 "encoding": encoding,
                 "lines_written": len(content.splitlines()),
             }
+            # Before/after contents for client-side diff rendering (TASK-1351);
+            # omitted when capture was skipped (oversized or undecodable).
+            if new_content is not None:
+                result["old_content"] = old_content
+                result["new_content"] = new_content
+            return result
 
         except PermissionError:
             return {"file_path": file_path, "error": "Permission denied to write file"}

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -649,10 +649,18 @@ class WriteFileTool(Tool):
             else:
                 old_content = ""
 
-            if old_content is not None and (
-                len(content.encode(encoding)) > DIFF_CAPTURE_MAX_BYTES
-            ):
-                old_content = None
+            if old_content is not None:
+                new_size = len(content.encode(encoding))
+                # Append mode materializes new_content as old + appended, so
+                # the combined size is what must stay within the capture cap
+                # (otherwise a single captured field can reach ~2x the cap).
+                capped_size = (
+                    len(old_content.encode(encoding)) + new_size
+                    if mode == "append"
+                    else new_size
+                )
+                if capped_size > DIFF_CAPTURE_MAX_BYTES:
+                    old_content = None
 
             # Create parent directories if requested
             if create_directories and not path.parent.exists():

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -333,6 +333,10 @@ class LLMManagementWindow(Container):
         The banner already says "requires running service"; without gating,
         every dependent action fails at click-time (UX-091).
         """
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU
+        # (the probe hits the local Ollama HTTP endpoint on every tick).
+        if not self.is_attached or not self.screen.is_active:
+            return
         excluded = {
             "ollama-start-service-button",
             "ollama-stop-service-button",

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -251,6 +251,9 @@ class MainNavigationBar(Container):
 
     def _update_overflow_hints(self) -> None:
         """Toggle the ‹ / More indicators and their text from real state."""
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
         try:
             strip = self.query_one("#nav-destination-strip", Horizontal)
             left_hint = self.query_one("#nav-overflow-hint-left", Static)

--- a/tldw_chatbook/Widgets/Console/console_background_effect.py
+++ b/tldw_chatbook/Widgets/Console/console_background_effect.py
@@ -182,6 +182,9 @@ class ConsoleBackgroundEffect(Widget):
             self._timer = None
 
     def _advance_frame(self) -> None:
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
         width = self.size.width
         height = self.size.height
         if not self.is_effect_active or width <= 0 or height <= 0:

--- a/tldw_chatbook/Widgets/Tamagotchi/base_tamagotchi.py
+++ b/tldw_chatbook/Widgets/Tamagotchi/base_tamagotchi.py
@@ -472,6 +472,9 @@ class BaseTamagotchi(Static):
         frame_index = [0]
 
         def next_frame():
+            # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+            if not self.is_attached or not self.screen.is_active:
+                return
             if frame_index[0] < len(frames):
                 self.sprite = frames[frame_index[0]]
                 frame_index[0] += 1

--- a/tldw_chatbook/Widgets/activity_log.py
+++ b/tldw_chatbook/Widgets/activity_log.py
@@ -400,6 +400,9 @@ class ActivityLogWidget(Widget):
 
     def _update_timestamps(self) -> None:
         """Update relative timestamps periodically."""
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
         # This would update all visible timestamps
         # For now, just trigger a display update
         self._update_display()

--- a/tldw_chatbook/Widgets/audio_troubleshooting_dialog.py
+++ b/tldw_chatbook/Widgets/audio_troubleshooting_dialog.py
@@ -389,6 +389,9 @@ class AudioTroubleshootingDialog(ModalScreen[bool]):
 
     def _update_level_meter(self):
         """Update the level meter with current audio level."""
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
         if not self.is_testing or not self.dictation_service:
             return
 

--- a/tldw_chatbook/Widgets/detailed_progress.py
+++ b/tldw_chatbook/Widgets/detailed_progress.py
@@ -286,6 +286,10 @@ class DetailedProgressBar(Widget):
         if not self.start_time:
             return
 
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
+
         try:
             # Calculate elapsed time
             elapsed = datetime.now() - self.start_time - self.total_pause_duration

--- a/tldw_chatbook/Widgets/diff_widgets.py
+++ b/tldw_chatbook/Widgets/diff_widgets.py
@@ -1,0 +1,132 @@
+# diff_widgets.py
+"""
+Diff rendering helpers for tool-call file edits.
+
+Uses the `textual-diff-view` package (`DiffView` widget) to render file
+before/after contents captured by file-writing tools as syntax-highlighted
+unified/split diffs. See ADR-032
+(`backlog/decisions/032-textual-diff-view-for-tool-call-diff-rendering.md`).
+"""
+
+from typing import Any, Dict, Literal, Optional, Tuple
+
+from textual_diff_view import DiffView
+
+from tldw_chatbook.Tools.file_operation_tools import DIFF_CONTENT_KEYS
+
+DiffViewMode = Literal["unified", "split", "auto"]
+
+# Default presentation for tool-call diffs. "auto" starts unified and flips
+# to split when the terminal is wide enough (DiffView handles resize itself).
+# Module-level on purpose: a settings UI is out of scope (TASK-1351).
+DEFAULT_DIFF_VIEW_MODE: DiffViewMode = "auto"
+DEFAULT_DIFF_WRAP = False
+DEFAULT_DIFF_ANNOTATIONS = False
+
+
+def set_default_diff_view_mode(mode: DiffViewMode) -> None:
+    """Set the default view mode for newly created diff widgets.
+
+    Args:
+        mode: One of "unified", "split", or "auto".
+
+    Raises:
+        ValueError: If the mode is not recognized.
+    """
+    global DEFAULT_DIFF_VIEW_MODE
+    if mode not in ("unified", "split", "auto"):
+        raise ValueError(f"Unknown diff view mode: {mode!r}")
+    DEFAULT_DIFF_VIEW_MODE = mode
+
+
+def make_diff(
+    path: str,
+    code_before: Optional[str],
+    code_after: Optional[str],
+    *,
+    id: Optional[str] = None,
+    classes: Optional[str] = None,
+) -> DiffView:
+    """Make a diff view widget from before/after file contents.
+
+    Args:
+        path: Path of the edited file (used for the title and language guess).
+        code_before: File content before the edit ("" for new files).
+        code_after: File content after the edit.
+        id: Textual CSS id.
+        classes: Textual CSS classes.
+
+    Returns:
+        A configured DiffView widget. Callers mounting large diffs should
+        `await diff_view.prepare()` first so the diff is computed off the UI
+        thread.
+    """
+    mode = DEFAULT_DIFF_VIEW_MODE
+    return DiffView(
+        path,
+        path,
+        code_before or "",
+        code_after or "",
+        split=mode == "split",
+        annotations=DEFAULT_DIFF_ANNOTATIONS,
+        auto_split=mode == "auto",
+        wrap=DEFAULT_DIFF_WRAP,
+        id=id,
+        classes=classes,
+    )
+
+
+def extract_diff_from_result(
+    result: Dict[str, Any],
+) -> Optional[Tuple[str, str, str]]:
+    """Extract (path, old_content, new_content) from a tool result, if present.
+
+    Tool results carry before/after contents as `result.old_content` /
+    `result.new_content` (see `WriteFileTool`). Results without them, error
+    results, and non-dict payloads return None.
+
+    Args:
+        result: A tool execution result record (`{"tool_call_id", "result"|"error"}`).
+
+    Returns:
+        (path, old_content, new_content) or None when there is nothing to diff.
+    """
+    if not isinstance(result, dict) or "error" in result:
+        return None
+    data = result.get("result")
+    if not isinstance(data, dict):
+        return None
+    old_content = data.get("old_content")
+    new_content = data.get("new_content")
+    if not isinstance(old_content, str) or not isinstance(new_content, str):
+        return None
+    path = data.get("file_path") or "file"
+    return str(path), old_content, new_content
+
+
+def strip_diff_contents(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of a tool result record without raw diff contents.
+
+    The before/after contents captured for UI diff rendering (TASK-1351) are
+    display-only: they must not be persisted to the conversation DB or echoed
+    back to the LLM (DB bloat, context bloat, replay leaks). This helper is
+    non-mutating — the in-memory record keeps its contents so the live
+    session can still render the diff.
+
+    Args:
+        result: A tool execution result record (`{"tool_call_id", "result"|"error"}`).
+
+    Returns:
+        A shallow copy with `result.old_content`/`result.new_content` removed,
+        or the original record when there is nothing to strip.
+    """
+    if not isinstance(result, dict):
+        return result
+    data = result.get("result")
+    if not isinstance(data, dict) or all(key not in data for key in DIFF_CONTENT_KEYS):
+        return result
+    stripped = dict(result)
+    stripped["result"] = {
+        key: value for key, value in data.items() if key not in DIFF_CONTENT_KEYS
+    }
+    return stripped

--- a/tldw_chatbook/Widgets/loading_states.py
+++ b/tldw_chatbook/Widgets/loading_states.py
@@ -236,6 +236,9 @@ class InlineLoader(Static):
 
     def _update_dots(self) -> None:
         """Update the loading dots animation."""
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
         if self.state == "loading":
             self.dots = (self.dots + 1) % 4
             dots_str = "." * self.dots

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -395,6 +395,9 @@ class SplashScreen(Container):
 
     def _update_animation(self) -> None:
         """Update animation frame."""
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
         if self.effect_handler:
             try:
                 # Get next frame from effect

--- a/tldw_chatbook/Widgets/status_dashboard.py
+++ b/tldw_chatbook/Widgets/status_dashboard.py
@@ -217,6 +217,10 @@ class StatusDashboard(Widget):
         if not self.start_time or not self.show_time:
             return
 
+        # Skip while the screen/tab is inactive so hidden tabs burn no CPU.
+        if not self.is_attached or not self.screen.is_active:
+            return
+
         try:
             elapsed = datetime.now() - self.start_time
             minutes, seconds = divmod(int(elapsed.total_seconds()), 60)

--- a/tldw_chatbook/Widgets/tool_message_widgets.py
+++ b/tldw_chatbook/Widgets/tool_message_widgets.py
@@ -26,12 +26,15 @@ and ``console_transcript.py``.
 import json
 from typing import List, Dict, Any, Optional
 
+from loguru import logger
 from rich.text import Text
 from textual.widgets import Static
 from textual.containers import Vertical
 from textual.css.query import QueryError
+from textual_diff_view import DiffView
 
 from tldw_chatbook.Widgets.Chat_Widgets.chat_message import ChatMessage
+from tldw_chatbook.Widgets.diff_widgets import extract_diff_from_result, make_diff
 
 
 class ToolCallMessage(ChatMessage):
@@ -164,8 +167,11 @@ class ToolResultMessage(ChatMessage):
 
                 result_data = result.get("result", {})
                 if isinstance(result_data, dict):
-                    # Format dict results
+                    # Format dict results (skip raw before/after contents;
+                    # those render as a DiffView instead, see TASK-1351)
                     for key, value in result_data.items():
+                        if key in ("old_content", "new_content"):
+                            continue
                         value_str = str(value)
                         if len(value_str) > 100:
                             value_str = value_str[:97] + "..."
@@ -230,6 +236,11 @@ class ToolExecutionWidget(Vertical):
         if self.tool_result_widget:
             yield self.tool_result_widget
 
+    async def on_mount(self):
+        """Mount diff views for any results already present at mount time."""
+        if self.tool_results:
+            self._queue_diff_mounts(self.tool_results)
+
     def update_results(self, tool_results: List[Dict[str, Any]]):
         """
         Update the widget with tool execution results.
@@ -255,3 +266,40 @@ class ToolExecutionWidget(Vertical):
                 static_widget.update(Text.from_markup(self.tool_result_widget.message))
             except QueryError:
                 pass
+
+        # Results carrying before/after file contents also render as a
+        # DiffView; the diff is prepared off the UI thread (TASK-1351).
+        # Cancel pending prepare workers and drop previously rendered diffs
+        # first so a repeated update can't double-render.
+        self.workers.cancel_group(self, "tool-diff-mount")
+        self.remove_children(DiffView)
+        self._queue_diff_mounts(tool_results)
+
+    def _queue_diff_mounts(self, tool_results: List[Dict[str, Any]]):
+        """Schedule DiffView mounts for results with before/after content."""
+        for result in tool_results:
+            diff_data = extract_diff_from_result(result)
+            if diff_data is None:
+                continue
+            path, old_content, new_content = diff_data
+            self.run_worker(
+                self._prepare_and_mount_diff(path, old_content, new_content),
+                thread=False,
+                group="tool-diff-mount",
+            )
+
+    async def _prepare_and_mount_diff(
+        self, path: str, old_content: str, new_content: str
+    ):
+        """Prepare the diff off the UI thread, then mount the DiffView."""
+        try:
+            diff_view = make_diff(path, old_content, new_content)
+            await diff_view.prepare()
+            if not self.is_mounted:
+                # Widget was unmounted while the diff prepared off-thread.
+                return
+            await self.mount(diff_view)
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Failed to render tool-call diff for {path}: {e}"
+            )


### PR DESCRIPTION
## Summary

Salvage of the surface-independent work from a toad-inspired UI improvement series (study: `backlog/docs/toad-tui-improvement-study.md`). **Context/history:** this work was originally implemented against the legacy `ChatWindowEnhanced` surface; that surface has since been removed from `dev`, so this branch re-applies only what is meaningful on current dev. The console-native port of the remaining UX work (input ghost-text/history, transcript pruning, inline tool-call diffs) is tracked as follow-up tasks.

- **Deps (TASK-1353/1351):** exact-pin `textual==8.2.8` and add `textual-diff-view==0.1.5` (pyproject + requirements); runtime contract test accepts exact 8.x pins; ADR-032 for the new dependency.
- **Notes watcher (TASK-1352):** coalesce watchdog event bursts into one `on_files_changed` callback (250ms window via `call_soon_threadsafe` + single `call_later`); fixes latent `asyncio.create_task`-from-watchdog-thread bug.
- **Timer guards (TASK-1352):** `is_attached`/`screen.is_active` early-returns on 10 continuous `set_interval` animation/poll sites so hidden tabs burn no CPU.
- **Tool-call diffs (TASK-1351):** `WriteFileTool` captures before/after content (256KB/side cap, validated paths, undecodable/oversized → skip); new `diff_widgets.py` (`make_diff`/`extract_diff_from_result`/`strip_diff_contents`); `ToolExecutionWidget` mounts `DiffView` after off-thread `prepare()`; raw contents stripped at the single dev serialization seam (`Agents/tool_catalog.py` `BuiltinToolProvider.invoke`) so they never reach the LLM or run logs.

## Notes for reviewers

- `ToolExecutionWidget` currently has no production caller on dev (its only consumer was the removed legacy surface); the DiffView integration is complete and tested, ready for the console tool-row port.
- Per-side 256KB capture cap; reloads show plain text results (ADR-032 documents the trade-off).

## Test plan

- [x] `Tests/CI/test_textual_runtime_contract.py` — 2 passed
- [x] `Tests/Notes` — 1308 passed
- [x] `Tests/Tools` — 120 passed; `Tests/Agents` — 781 passed
- [x] `Tests/Widgets` (tool/diff + guarded widgets) — 215+ passed
- [x] New: `test_auto_sync_manager_coalescing.py`, `test_write_file_diff_capture.py`, `test_tool_diff_widgets.py` — 59 passed combined
- [x] Pre-existing failures on dev base verified unrelated (17 speech navigation, 1 console image-gen)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline diffs for file-writing tool calls and reduces background CPU work in the console. Pins `textual` to 8.2.8, adds `textual-diff-view` 0.1.5, and updates CI/tests to enforce the new floor and remove a permanent skip. (TASK-1351/1352/1353/1362/1363)

- **New Features**
  - `WriteFileTool` captures before/after content for diffs (256 KB cap; skips binary/oversized; append mode enforces the cap on combined size). (TASK-1351)
  - `ToolExecutionWidget` mounts a `DiffView` built off-thread; plain results still render as text.
  - Raw diff contents are stripped at `BuiltinToolProvider.invoke` so they never reach the model or run logs.
  - New helpers in `diff_widgets.py`: `make_diff`, `extract_diff_from_result`, `strip_diff_contents`.

- **Bug Fixes**
  - Coalesced notes watcher events into a single UI callback per 250 ms window using the main loop; cancels pending on stop; error logs include `changed_count`/`is_running`. (TASK-1352)
  - Guarded recurring timers on inactive screens (`is_attached`/`screen.is_active`) across widgets to avoid CPU burn. (TASK-1352)
  - CI textual-minimum job installs `textual==8.2.8`, and the CI test asserts this exact floor. (TASK-1362)
  - Unskipped tools settings I/O error test by patching `replace_cli_config`; asserts error notification and no file change. (TASK-1363)

<sup>Written for commit f3bbafedd8a49e3e74e809e141138e8d7eb7429d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

