### PR TITLE
Console port series: composer history + ghost text (TASK-1364), transcript pruning, tool diffs

### DIFF
--- a/Tests/Chat/test_console_agent_diff_channel.py
+++ b/Tests/Chat/test_console_agent_diff_channel.py
@@ -8,12 +8,13 @@ result (AC1 data path + AC3).
 """
 
 import json
+from collections import deque
 
 import pytest
 
 import tldw_chatbook.config as config_module
 from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
-from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge, _pair_step_diff
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
@@ -190,3 +191,92 @@ def test_plain_write_result_without_capture_has_no_diff(
     tool_rows = _tool_rows(store, session)
     assert tool_rows
     assert tool_rows[0].tool_diff is None
+
+
+class TestPairStepDiff:
+    """_pair_step_diff: capture/step pairing under the real threading model.
+
+    invoke() runs on a per-call daemon thread (AgentService
+    ._call_with_timeout) -- joined before the result step normally,
+    abandoned unjoined on timeout/cancel, so a late capture can land
+    after its own step passed. The pairing rule (most-recent name match;
+    everything older is stale) must keep such a capture from pairing with
+    a later write.
+    """
+
+    @staticmethod
+    def _capture(name, path):
+        return (name, path, f"old {path}\n", f"new {path}\n")
+
+    def test_normal_case_pairs_the_only_capture(self):
+        queue = deque([self._capture("write_file", "/tmp/a.py")])
+        assert _pair_step_diff(queue, "write_file") == (
+            "/tmp/a.py",
+            "old /tmp/a.py\n",
+            "new /tmp/a.py\n",
+        )
+        assert not queue
+
+    def test_stale_capture_from_abandoned_call_does_not_pair_with_next_write(self):
+        """A timed-out write's capture lands late (after its result step
+        passed); the NEXT write's result must pair with its OWN capture,
+        and the stale one is dropped."""
+        queue = deque(
+            [
+                self._capture("write_file", "/tmp/stale.py"),
+                self._capture("write_file", "/tmp/fresh.py"),
+            ]
+        )
+        assert _pair_step_diff(queue, "write_file") == (
+            "/tmp/fresh.py",
+            "old /tmp/fresh.py\n",
+            "new /tmp/fresh.py\n",
+        )
+        assert not queue, "the stale capture must be dropped with the pair"
+
+    def test_older_capture_for_other_tool_is_stale_and_dropped(self):
+        """An unmatched older entry had its own result step pass already;
+        it must not survive to pair with a later same-name step."""
+        queue = deque(
+            [
+                self._capture("read_file", "/tmp/unrelated.py"),
+                self._capture("write_file", "/tmp/b.py"),
+            ]
+        )
+        assert _pair_step_diff(queue, "write_file") is not None
+        assert not queue
+
+    def test_no_match_clears_stale_queue(self):
+        """A captureless result step (plain/oversized write, non-diff
+        tool) leaves nothing behind for a later step to mis-pair."""
+        queue = deque([self._capture("write_file", "/tmp/stale.py")])
+        assert _pair_step_diff(queue, "calculator") is None
+        assert not queue
+
+    def test_no_match_on_empty_queue_is_a_noop(self):
+        queue = deque()
+        assert _pair_step_diff(queue, "write_file") is None
+        assert not queue
+
+    def test_same_name_race_pairs_most_recent_and_leaves_no_residue(self):
+        """A cross-thread append that lands AFTER the current call's
+        capture (newer, same tool name) is indistinguishable from the
+        current call's own capture -- the documented residual mis-pair.
+        The important half: nothing older survives to cascade into
+        FUTURE steps."""
+        queue = deque(
+            [
+                self._capture("write_file", "/tmp/current.py"),
+                self._capture("write_file", "/tmp/late.py"),
+            ]
+        )
+        paired = _pair_step_diff(queue, "write_file")
+        assert paired[0] == "/tmp/late.py"
+        assert not queue
+
+    def test_sequential_writes_each_pair_with_their_own_capture(self):
+        queue = deque([self._capture("write_file", "/tmp/one.py")])
+        assert _pair_step_diff(queue, "write_file")[0] == "/tmp/one.py"
+        queue.append(self._capture("write_file", "/tmp/two.py"))
+        assert _pair_step_diff(queue, "write_file")[0] == "/tmp/two.py"
+        assert not queue

--- a/Tests/Chat/test_console_agent_diff_channel.py
+++ b/Tests/Chat/test_console_agent_diff_channel.py
@@ -1,0 +1,192 @@
+"""TASK-1366: WriteFileTool diffs reach the Console TOOL marker rows.
+
+End-to-end through ``ConsoleAgentBridge.run_reply``: the raw before/after
+contents captured at the provider's strip seam land on the TOOL marker
+message as the session-only ``tool_diff`` field, while the marker text,
+its full output, and the persisted run record carry only the stripped
+result (AC1 data path + AC3).
+"""
+
+import json
+
+import pytest
+
+import tldw_chatbook.config as config_module
+from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Tools.file_operation_tools import WriteFileTool
+
+
+class _ChunkGateway:
+    """A gateway whose stream_chat replays a script keyed by call index."""
+
+    def __init__(self, scripts):
+        self._scripts = list(scripts)
+        self.calls = 0
+
+    async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+        chunks = self._scripts[self.calls]
+        self.calls += 1
+        for chunk in chunks:
+            yield chunk
+
+
+class _AllowAllBuiltinGate:
+    """Minimal ``BuiltinToolGate`` double that permits every tool."""
+
+    def check(self, tool):
+        return None
+
+
+def _fence(name, args):
+    return f"{FENCE_OPEN}\n{json.dumps({'name': name, 'arguments': args})}\n```"
+
+
+def _enable_write_file(monkeypatch):
+    monkeypatch.setattr(
+        config_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: (
+            True
+            if section == "tools" and key == "write_file_enabled"
+            else default
+        ),
+    )
+
+
+@pytest.fixture
+def diff_execute(monkeypatch):
+    """WriteFileTool.execute stub returning a diff-carrying result."""
+
+    async def _fake_execute(self, **kwargs):
+        return {
+            "action": "overwritten",
+            "file_path": "/tmp/note.txt",
+            "lines_written": 1,
+            "old_content": "raw before text\n",
+            "new_content": "raw after text\n",
+        }
+
+    monkeypatch.setattr(WriteFileTool, "execute", _fake_execute)
+
+
+def _make_bridge(tmp_path, scripts):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db,
+        store=store,
+        provider_gateway=_ChunkGateway(scripts),
+    )
+    return bridge, db, store, session, assistant.id
+
+
+def _run(bridge, store, session, assistant_id):
+    _run_id, outcome = bridge.run_reply(
+        conversation_id="conv-1",
+        session_id=session.id,
+        resolution=object(),
+        assistant_message_id=assistant_id,
+        model="test-model",
+        session_system_prompt="",
+        agent_messages=[{"role": "user", "content": "hi"}],
+        should_cancel=lambda: False,
+        builtin_gate=_AllowAllBuiltinGate(),
+    )
+    return outcome
+
+
+def _tool_rows(store, session):
+    return [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+
+
+def test_write_file_marker_carries_session_only_diff(
+    tmp_path, monkeypatch, diff_execute
+):
+    """The TOOL marker gets (path, old, new); every string form stays stripped."""
+    _enable_write_file(monkeypatch)
+    scripts = [
+        [_fence("write_file", {"file_path": "note.txt", "content": "x"})],
+        ["Saved."],
+    ]
+    bridge, db, store, session, aid = _make_bridge(tmp_path, scripts)
+
+    outcome = _run(bridge, store, session, aid)
+
+    assert outcome.status == "done"
+    tool_rows = _tool_rows(store, session)
+    assert tool_rows, "a write_file turn must drop a TOOL marker"
+    marker = tool_rows[0]
+    # AC1 data path: the raw diff reached the UI-side message, in memory only.
+    assert marker.tool_diff == (
+        "/tmp/note.txt",
+        "raw before text\n",
+        "raw after text\n",
+    )
+    # AC3: neither the preview nor the expanded full output carries raw
+    # contents (both are built from the post-strip result text).
+    assert "raw before text" not in marker.content
+    assert "raw after text" not in marker.content
+    assert "old_content" not in marker.content
+    full = marker.tool_output_full or ""
+    assert "raw before text" not in full
+    assert "raw after text" not in full
+    assert "old_content" not in full
+    # AC3: the persisted run record (run-log-bound steps) is stripped too.
+    runs = db.list_runs("conv-1", include_superseded=True)
+    persisted = json.dumps(runs, default=str)
+    assert "raw before text" not in persisted
+    assert "raw after text" not in persisted
+
+
+def test_non_diff_tool_marker_has_no_diff(tmp_path, monkeypatch, diff_execute):
+    """AC4: ordinary tool results render exactly as before (no tool_diff)."""
+    scripts = [
+        [_fence("calculator", {"expression": "6*7"})],
+        ["It is 42."],
+    ]
+    bridge, _db, store, session, aid = _make_bridge(tmp_path, scripts)
+
+    outcome = _run(bridge, store, session, aid)
+
+    assert outcome.status == "done"
+    tool_rows = _tool_rows(store, session)
+    assert tool_rows, "a tool turn must drop a TOOL marker"
+    assert tool_rows[0].tool_diff is None
+    assert "calculator" in tool_rows[0].content
+
+
+def test_plain_write_result_without_capture_has_no_diff(
+    tmp_path, monkeypatch
+):
+    """A write result that did not capture contents yields no diff row data."""
+    _enable_write_file(monkeypatch)
+
+    async def _plain_execute(self, **kwargs):
+        return {"action": "created", "file_path": "/tmp/plain.txt", "lines_written": 1}
+
+    monkeypatch.setattr(WriteFileTool, "execute", _plain_execute)
+    scripts = [
+        [_fence("write_file", {"file_path": "plain.txt", "content": "x"})],
+        ["Saved."],
+    ]
+    bridge, _db, store, session, aid = _make_bridge(tmp_path, scripts)
+
+    outcome = _run(bridge, store, session, aid)
+
+    assert outcome.status == "done"
+    tool_rows = _tool_rows(store, session)
+    assert tool_rows
+    assert tool_rows[0].tool_diff is None

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -4659,3 +4660,72 @@ async def test_baseline_ignores_dispatch_time_substitution_and_stays_comparable(
     # No break immediately after an ordinary send -- the substitution never
     # touched the store, so both sides read the same raw view.
     assert fingerprint_break_reason(baseline, current) is None
+
+
+# ---------------------------------------------------------------------------
+# Prompt-history recording (TASK-1364)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accepted_send_records_cleaned_draft_to_prompt_history(tmp_path):
+    """AC4: an accepted send lands in the shared JSONL history exactly once."""
+    from tldw_chatbook.Chat.prompt_history import PromptHistory
+
+    history_path = tmp_path / "prompt_history.jsonl"
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    controller.prompt_history = PromptHistory(history_path)
+
+    result = await controller.submit_draft("record this prompt")
+    assert result.accepted
+    assert controller.prompt_history.size == 1
+    entry = await controller.prompt_history.get_entry(-1)
+    assert entry["input"] == "record this prompt"
+
+    # Persisted as JSONL (one object per line, real timestamp).
+    lines = history_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    persisted = json.loads(lines[0])
+    assert persisted["input"] == "record this prompt"
+    assert persisted["timestamp"] > 0
+
+
+@pytest.mark.asyncio
+async def test_blocked_send_records_nothing_to_prompt_history(tmp_path):
+    """Refused/blocked sends never reach the history (validation failures)."""
+    from tldw_chatbook.Chat.prompt_history import PromptHistory
+
+    history_path = tmp_path / "prompt_history.jsonl"
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=BlockedGateway())
+    controller.prompt_history = PromptHistory(history_path)
+
+    result = await controller.submit_draft("blocked prompt")
+    assert not result.accepted
+    assert controller.prompt_history.size == 0
+    assert not history_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_empty_and_whitespace_drafts_record_nothing(tmp_path):
+    """Attachment-only (empty cleaned draft) sends skip recording."""
+    from tldw_chatbook.Chat.prompt_history import PromptHistory
+
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    controller.prompt_history = PromptHistory(tmp_path / "prompt_history.jsonl")
+
+    await controller._record_prompt_history("")
+    await controller._record_prompt_history("   \n  ")
+    assert controller.prompt_history.size == 0
+
+
+@pytest.mark.asyncio
+async def test_submit_without_prompt_history_configured_is_a_noop():
+    """Controllers with no history wired (tests, embedders) send as before."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    assert controller.prompt_history is None
+    result = await controller.submit_draft("hello")
+    assert result.accepted

--- a/Tests/Chat/test_console_message_actions.py
+++ b/Tests/Chat/test_console_message_actions.py
@@ -859,3 +859,65 @@ def test_save_image_is_disabled_with_a_reason_in_a_temporary_chat():
     }
     assert normal_actions["save-image"].enabled is True
     assert normal_actions["save-image"].disabled_reason == ""
+
+
+def _tool_output_action(message):
+    return {
+        action.action_id: action
+        for action in ConsoleMessageActionService().available_actions(message)
+    }.get("tool-output")
+
+
+def test_diff_only_tool_marker_offers_expansion_labeled_diff():
+    """TASK-1366: a file-write marker whose stripped result fit the preview
+    (tool_output_full is None -- the common case) must still offer the
+    expansion affordance, labeled for what it actually opens: the diff."""
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content="write_file → /tmp/a.py",
+        tool_diff=("/tmp/a.py", "old\n", "new\n"),
+    )
+
+    action = _tool_output_action(message)
+
+    assert action is not None, "diff-only marker must offer expansion"
+    assert action.label == "Diff"
+
+
+def test_full_output_tool_marker_keeps_full_output_label():
+    """TASK-1860 copy is unchanged for a marker with hidden full text."""
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content="calculator → 42",
+        tool_output_full="the whole untruncated result",
+    )
+
+    action = _tool_output_action(message)
+
+    assert action is not None
+    assert action.label == "Full output"
+
+
+def test_tool_marker_with_full_output_and_diff_keeps_full_output_label():
+    """Expansion shows both the full text and the diff; name the text."""
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content="write_file → /tmp/a.py",
+        tool_output_full="the whole untruncated result",
+        tool_diff=("/tmp/a.py", "old\n", "new\n"),
+    )
+
+    action = _tool_output_action(message)
+
+    assert action is not None
+    assert action.label == "Full output"
+
+
+def test_plain_tool_marker_offers_no_expansion():
+    """No hidden text and no diff: no dead affordance (TASK-1843 rule)."""
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content="calculator → 42",
+    )
+
+    assert _tool_output_action(message) is None

--- a/Tests/Chat/test_prompt_history.py
+++ b/Tests/Chat/test_prompt_history.py
@@ -1,0 +1,244 @@
+"""Tests for the JSONL prompt history store (ported for backlog task-1364).
+
+Covers:
+- JSONL append/load round-trip with async (off-loop) file IO and real timestamps.
+- Shell-style indexing: 0 is the live draft pseudo-entry, negatives walk back.
+- validate_*-style index clamping at both boundaries.
+- Consecutive-duplicate dedupe, including the rapid-send race (optimistic
+  in-memory update with rollback on write failure).
+- max_entries cap enforcement on both load and append.
+- Most-recent-wins prefix completion for ghost text.
+"""
+
+import json
+
+import pytest
+
+from tldw_chatbook.Chat.prompt_history import PromptHistory
+
+
+def _seed(history: PromptHistory, *inputs: str) -> None:
+    """Seed stored entries directly (no file IO)."""
+    history._entries = [{"input": text, "timestamp": 0.0} for text in inputs]
+    history._loaded = True
+
+
+@pytest.fixture
+def history(tmp_path):
+    return PromptHistory(tmp_path / "prompt_history.jsonl")
+
+
+class TestAppendLoadRoundTrip:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_append_then_load_round_trip(self, tmp_path):
+        path = tmp_path / "prompt_history.jsonl"
+        writer = PromptHistory(path)
+        assert await writer.append("first prompt")
+        assert await writer.append("second prompt")
+
+        reader = PromptHistory(path)
+        await reader.load()
+        assert reader.size == 2
+        assert (await reader.get_entry(-1))["input"] == "second prompt"
+        assert (await reader.get_entry(-2))["input"] == "first prompt"
+
+    async def test_append_writes_one_json_object_per_line(self, history):
+        await history.append("hello world")
+        lines = history.path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["input"] == "hello world"
+        assert isinstance(entry["timestamp"], float)
+
+    async def test_persisted_timestamps_survive_round_trip(self, tmp_path):
+        """Stored entries report their persisted timestamp, not a fabricated one."""
+        path = tmp_path / "prompt_history.jsonl"
+        writer = PromptHistory(path)
+        await writer.append("timed prompt")
+        written = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+
+        reader = PromptHistory(path)
+        await reader.load()
+        entry = await reader.get_entry(-1)
+        assert entry["timestamp"] == written["timestamp"]
+        assert entry["timestamp"] > 0
+
+    async def test_load_missing_file_is_empty_history(self, history):
+        await history.load()
+        assert history.size == 0
+
+    async def test_load_tolerates_corrupt_lines(self, tmp_path):
+        path = tmp_path / "prompt_history.jsonl"
+        path.write_text(
+            '{"input": "good", "timestamp": 1.0}\n'
+            "not json at all\n"
+            '{"input": 42}\n'
+            "\n"
+            '{"input": "also good", "timestamp": 2.0}\n',
+            encoding="utf-8",
+        )
+        history = PromptHistory(path)
+        await history.load()
+        assert history.size == 2
+        assert (await history.get_entry(-1))["input"] == "also good"
+
+    async def test_append_empty_text_is_skipped(self, history):
+        assert await history.append("") is False
+        assert history.size == 0
+        assert not history.path.exists()
+
+    async def test_consecutive_duplicates_are_skipped(self, history):
+        assert await history.append("same") is True
+        assert await history.append("same") is False
+        assert await history.append("different") is True
+        assert await history.append("same") is True  # Non-consecutive is kept.
+        assert history.size == 3
+        lines = history.path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+
+    async def test_append_clears_stashed_draft(self, history):
+        history.stash_draft("in progress")
+        await history.append("sent")
+        assert history.current == ""
+
+
+class TestMaxEntriesCap:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_load_keeps_only_most_recent_entries(self, tmp_path):
+        path = tmp_path / "prompt_history.jsonl"
+        with path.open("w", encoding="utf-8") as history_file:
+            for index in range(5):
+                history_file.write(
+                    json.dumps({"input": f"prompt {index}", "timestamp": float(index)})
+                    + "\n"
+                )
+        history = PromptHistory(path, max_entries=3)
+        await history.load()
+        assert history.size == 3
+        assert (await history.get_entry(-1))["input"] == "prompt 4"
+        assert (await history.get_entry(-3))["input"] == "prompt 2"
+
+    async def test_append_rewrites_file_with_tail_when_cap_exceeded(self, tmp_path):
+        path = tmp_path / "prompt_history.jsonl"
+        history = PromptHistory(path, max_entries=3)
+        for index in range(4):
+            assert await history.append(f"prompt {index}") is True
+
+        assert history.size == 3
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3  # File was rewritten, not just appended.
+        inputs = [json.loads(line)["input"] for line in lines]
+        assert inputs == ["prompt 1", "prompt 2", "prompt 3"]
+        assert (await history.get_entry(-3))["input"] == "prompt 1"
+        with pytest.raises(IndexError):
+            await history.get_entry(-4)  # Oldest entry was dropped.
+
+    async def test_cap_of_one_keeps_latest_only(self, tmp_path):
+        history = PromptHistory(tmp_path / "prompt_history.jsonl", max_entries=1)
+        await history.append("old")
+        await history.append("new")
+        assert history.size == 1
+        assert (await history.get_entry(-1))["input"] == "new"
+        lines = history.path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+
+
+class TestWriteFailureRollback:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_failed_write_rolls_back_optimistic_entry(self, tmp_path):
+        """A failed write must not poison the dedupe check for the next send."""
+        # A directory at the history path makes every write fail.
+        history = PromptHistory(tmp_path / "prompt_history.jsonl")
+        history.path.mkdir()
+
+        assert await history.append("unsaved") is False
+        assert history.size == 0  # Optimistic entry rolled back.
+
+        # Retry once the path is writable: not treated as a duplicate.
+        history.path.rmdir()
+        assert await history.append("unsaved") is True
+        assert history.size == 1
+
+    async def test_failed_write_keeps_stashed_draft(self, tmp_path):
+        history = PromptHistory(tmp_path / "prompt_history.jsonl")
+        history.path.mkdir()
+        history.stash_draft("draft")
+        assert await history.append("unsaved") is False
+        assert history.current == "draft"
+
+
+class TestIndexClamping:
+    def test_clamp_with_empty_history(self, history):
+        assert history.clamp_index(0) == 0
+        assert history.clamp_index(-1) == 0
+        assert history.clamp_index(-100) == 0
+        assert history.clamp_index(5) == 0
+
+    def test_clamp_at_boundaries(self, history):
+        _seed(history, "a", "b", "c")
+        assert history.clamp_index(0) == 0
+        assert history.clamp_index(-1) == -1
+        assert history.clamp_index(-3) == -3
+        assert history.clamp_index(-4) == -3  # Clamped to -size.
+        assert history.clamp_index(-100) == -3
+        assert history.clamp_index(1) == 0  # Positive clamps to live draft.
+
+
+class TestGetEntry:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_index_zero_returns_stashed_draft(self, history):
+        history.stash_draft("draft text")
+        entry = await history.get_entry(0)
+        assert entry["input"] == "draft text"
+
+    async def test_index_zero_without_draft_returns_empty(self, history):
+        entry = await history.get_entry(0)
+        assert entry["input"] == ""
+
+    async def test_negative_indexes_walk_backwards(self, history):
+        await history.append("one")
+        await history.append("two")
+        assert (await history.get_entry(-1))["input"] == "two"
+        assert (await history.get_entry(-2))["input"] == "one"
+
+    async def test_out_of_range_indexes_raise(self, history):
+        await history.append("only")
+        with pytest.raises(IndexError):
+            await history.get_entry(1)
+        with pytest.raises(IndexError):
+            await history.get_entry(-2)
+
+    async def test_draft_stash_restore_round_trip(self, history):
+        """Stashing a draft never affects stored entries and is restored."""
+        await history.append("stored")
+        history.stash_draft("my draft")
+        assert (await history.get_entry(-1))["input"] == "stored"
+        assert (await history.get_entry(0))["input"] == "my draft"
+        history.stash_draft("edited draft")
+        assert (await history.get_entry(0))["input"] == "edited draft"
+        history.clear_draft()
+        assert (await history.get_entry(0))["input"] == ""
+
+
+class TestComplete:
+    def test_most_recent_match_wins(self, history):
+        _seed(history, "fix the bug", "find the bug", "fix the tests")
+        assert history.complete("fi") == "fix the tests"
+        assert history.complete("fix") == "fix the tests"
+        assert history.complete("fin") == "find the bug"
+
+    def test_exact_match_is_not_suggested(self, history):
+        _seed(history, "hello")
+        assert history.complete("hello") is None
+
+    def test_empty_prefix_matches_nothing(self, history):
+        _seed(history, "hello")
+        assert history.complete("") is None
+
+    def test_no_match_returns_none(self, history):
+        _seed(history, "hello")
+        assert history.complete("xyz") is None

--- a/Tests/Chat/test_prompt_history.py
+++ b/Tests/Chat/test_prompt_history.py
@@ -10,6 +10,7 @@ Covers:
 - Most-recent-wins prefix completion for ghost text.
 """
 
+import asyncio
 import json
 
 import pytest
@@ -143,6 +144,19 @@ class TestMaxEntriesCap:
         assert (await history.get_entry(-1))["input"] == "new"
         lines = history.path.read_text(encoding="utf-8").splitlines()
         assert len(lines) == 1
+
+    async def test_concurrent_appends_are_serialized(self, tmp_path):
+        """Racing appends (e.g. composer + controller sharing one instance)
+        cannot interleave a cap rewrite with another append — every entry
+        lands exactly once, in order."""
+        path = tmp_path / "prompt_history.jsonl"
+        history = PromptHistory(path, max_entries=5)
+        await asyncio.gather(*(history.append(f"prompt {index}") for index in range(8)))
+
+        inputs = [entry["input"] for entry in history._entries]
+        assert inputs == [f"prompt {index}" for index in range(3, 8)]
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert [json.loads(line)["input"] for line in lines] == inputs
 
 
 class TestWriteFailureRollback:

--- a/Tests/Tools/test_write_file_diff_capture.py
+++ b/Tests/Tools/test_write_file_diff_capture.py
@@ -214,3 +214,79 @@ class TestBuiltinProviderStripsDiffContents:
         assert result.ok
         assert '"action": "created"' in result.content
         assert '"lines_written": 1' in result.content
+
+
+class TestBuiltinProviderDiffSink:
+    """TASK-1366: invoke hands raw diff contents to a UI-side sink.
+
+    The sink is the narrow channel that lets the live Console render a
+    diff: it fires at the strip seam, BEFORE old_content/new_content are
+    removed from the dict that becomes the LLM/run-log-bound JSON, so the
+    UI gets the raw contents while the strip guarantee is untouched.
+    """
+
+    def test_sink_receives_raw_contents_while_result_stays_stripped(
+        self, _sandbox_only_roots
+    ):
+        captured = []
+        provider = BuiltinToolProvider(gate=AllowAllGate(), diff_sink=captured.append)
+        provider._tools["write_file"] = WriteFileTool()
+
+        result = provider.invoke(
+            "builtin:write_file",
+            {"file_path": "note.txt", "content": "secret after text\n"},
+        )
+
+        assert result.ok
+        assert captured == [
+            (
+                "write_file",
+                str(_sandbox_only_roots / "note.txt"),
+                "",
+                "secret after text\n",
+            )
+        ]
+        # The strip guarantee is unchanged: nothing raw in the LLM-bound text.
+        assert "old_content" not in result.content
+        assert "new_content" not in result.content
+        assert "secret after text" not in result.content
+
+    def test_sink_not_called_for_results_without_diff_content(
+        self, _sandbox_only_roots
+    ):
+        captured = []
+        provider = BuiltinToolProvider(gate=AllowAllGate(), diff_sink=captured.append)
+
+        result = provider.invoke("builtin:calculator", {"expression": "6*7"})
+
+        assert result.ok
+        assert captured == []
+
+    def test_sink_not_called_when_unset(self, _sandbox_only_roots):
+        """Default construction (no sink) behaves exactly as before."""
+        provider = BuiltinToolProvider(gate=AllowAllGate())
+        provider._tools["write_file"] = WriteFileTool()
+
+        result = provider.invoke(
+            "builtin:write_file", {"file_path": "note.txt", "content": "hi\n"}
+        )
+
+        assert result.ok
+        assert '"action": "created"' in result.content
+
+    def test_raising_sink_never_breaks_invoke(self, _sandbox_only_roots):
+        """A UI-side failure must never fail or corrupt the tool call."""
+
+        def boom(_capture):
+            raise RuntimeError("UI exploded")
+
+        provider = BuiltinToolProvider(gate=AllowAllGate(), diff_sink=boom)
+        provider._tools["write_file"] = WriteFileTool()
+
+        result = provider.invoke(
+            "builtin:write_file", {"file_path": "note.txt", "content": "hi\n"}
+        )
+
+        assert result.ok
+        assert '"action": "created"' in result.content
+        assert "old_content" not in result.content

--- a/Tests/UI/test_console_agent_tool_row_css.py
+++ b/Tests/UI/test_console_agent_tool_row_css.py
@@ -32,3 +32,12 @@ def test_agent_rail_section_css_is_styled_in_source_and_bundle():
         Path("tldw_chatbook/css/tldw_cli_modular.tcss"),
     ):
         assert ".console-agent-section-steps" in path.read_text(encoding="utf-8")
+
+
+def test_tool_diff_row_class_is_styled_in_source_and_bundle():
+    """TASK-1366: the inline diff row under a file-write TOOL marker."""
+    for path in (
+        Path("tldw_chatbook/css/components/_agentic_terminal.tcss"),
+        Path("tldw_chatbook/css/tldw_cli_modular.tcss"),
+    ):
+        assert ".console-transcript-tool-diff" in path.read_text(encoding="utf-8")

--- a/Tests/UI/test_console_composer_history.py
+++ b/Tests/UI/test_console_composer_history.py
@@ -1,0 +1,462 @@
+"""Console composer prompt-history UX (TASK-1364): ghost text and recall.
+
+Covers the toad-inspired input UX ported onto the composer's segment/caret
+model:
+
+- Ghost text: most-recent-wins history prefix match rendered as a dimmed
+  suffix after the caret; offered only on the live draft with an empty
+  selection, the caret at end, and a draft that does not start with ``/``
+  (the slash-command popup owns completion there). Right-arrow accepts.
+- Recall: Up/Down walk history only when the caret sits on the first/last
+  visual row of the wrapped draft; index 0 is the live draft, stashed while
+  navigating and restored on return; clamped at the oldest entry.
+"""
+
+import json
+
+import pytest
+from textual.widgets import Static
+
+from Tests.UI.test_console_native_chat_flow import (
+    _configure_native_ready_console,
+)
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.prompt_history import PromptHistory
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+
+def _seeded_history(*inputs: str) -> PromptHistory:
+    """Build a history store with in-memory entries only (no file IO)."""
+    history = PromptHistory("/nonexistent/prompt_history.jsonl")
+    history._entries = [{"input": text, "timestamp": 0.0} for text in inputs]
+    history._loaded = True
+    return history
+
+
+def _composer_with_history(*inputs: str) -> ConsoleComposerBar:
+    """Build an unmounted composer wired to a seeded history store."""
+    composer = ConsoleComposerBar()
+    composer.set_prompt_history(_seeded_history(*inputs))
+    return composer
+
+
+# ---------------------------------------------------------------------------
+# Ghost-text suffix computation (unmounted segment-model tests)
+# ---------------------------------------------------------------------------
+
+
+def test_ghost_suffix_offers_most_recent_prefix_match():
+    composer = _composer_with_history("fix the bug", "find it", "fix the tests")
+    composer.insert_text("fi")
+    assert composer._ghost_suffix() == "x the tests"
+
+    composer.clear_draft()
+    composer.insert_text("fin")
+    assert composer._ghost_suffix() == "d it"
+
+
+def test_ghost_suffix_requires_caret_at_end():
+    composer = _composer_with_history("hello world")
+    composer.insert_text("hel")
+    assert composer._ghost_suffix() == "lo world"
+    composer.move_cursor_left()
+    assert composer._ghost_suffix() == ""
+    composer.move_cursor_end()
+    assert composer._ghost_suffix() == "lo world"
+
+
+def test_ghost_suffix_suppressed_for_slash_command_drafts():
+    """The slash-command popup owns completion for '/'-prefixed drafts."""
+    composer = _composer_with_history("/help me with this")
+    composer.insert_text("/he")
+    assert composer._ghost_suffix() == ""
+
+
+def test_ghost_suffix_suppressed_with_selection_and_empty_draft():
+    composer = _composer_with_history("hello world")
+    assert composer._ghost_suffix() == ""  # empty draft
+
+    composer.insert_text("hel")
+    composer.select_all_draft()
+    assert composer._ghost_suffix() == ""  # selection active
+
+
+def test_ghost_suffix_suppressed_while_navigating_history():
+    composer = _composer_with_history("hello world")
+    composer.insert_text("hel")
+    composer._history_index = -1
+    assert composer._ghost_suffix() == ""
+
+
+def test_ghost_suffix_exact_match_offers_nothing():
+    composer = _composer_with_history("hello")
+    composer.insert_text("hello")
+    assert composer._ghost_suffix() == ""
+
+
+def test_ghost_suffix_without_history_store_is_empty():
+    composer = ConsoleComposerBar()
+    composer.insert_text("hel")
+    assert composer._ghost_suffix() == ""
+
+
+# ---------------------------------------------------------------------------
+# Ghost-text rendering (the composer's own render pass)
+# ---------------------------------------------------------------------------
+
+
+def test_draft_renderable_renders_dimmed_ghost_after_caret():
+    rendered = ConsoleComposerBar._draft_renderable(
+        "hel",
+        width=40,
+        focused=True,
+        cursor_visible=True,
+        cursor_index=3,
+        ghost_suffix="lo world",
+    )
+    assert rendered.plain == "hel▌lo world"
+    ghost_spans = [
+        span for span in rendered.spans if span.style == ConsoleComposerBar.GHOST_TEXT_STYLE
+    ]
+    assert len(ghost_spans) == 1
+    assert (ghost_spans[0].start, ghost_spans[0].end) == (4, 12)
+
+
+def test_draft_renderable_ghost_only_at_caret_end_and_focused():
+    # Caret mid-draft: the ghost suffix is dropped entirely.
+    rendered = ConsoleComposerBar._draft_renderable(
+        "hello",
+        width=40,
+        focused=True,
+        cursor_visible=True,
+        cursor_index=2,
+        ghost_suffix=" world",
+    )
+    assert rendered.plain == "he▌llo"
+
+    # Unfocused: no caret, no ghost.
+    rendered = ConsoleComposerBar._draft_renderable(
+        "hel",
+        width=40,
+        focused=False,
+        ghost_suffix="lo world",
+    )
+    assert rendered.plain == "hel"
+
+
+def test_draft_renderable_ghost_wraps_without_affecting_height_math():
+    """A long ghost shares the wrap pass but never grows the row count."""
+    draft = "hel"
+    ghost = "lo " + "word " * 30
+    rendered = ConsoleComposerBar._draft_renderable(
+        draft,
+        width=40,
+        focused=True,
+        cursor_visible=True,
+        cursor_index=3,
+        ghost_suffix=ghost,
+    )
+    assert rendered.plain.splitlines()[0].startswith("hel▌lo")
+    # The composer's own height math only ever sees the draft, not the ghost.
+    assert ConsoleComposerBar._visible_draft_row_count(
+        draft, 40, reserve_trailing_cell=True
+    ) == 1
+
+
+# ---------------------------------------------------------------------------
+# Right-arrow acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_accept_ghost_text_inserts_suffix_and_moves_caret_to_end():
+    composer = _composer_with_history("hello world")
+    composer.insert_text("hello w")
+
+    assert composer.accept_ghost_text() is True
+    assert composer.draft_text() == "hello world"
+    assert composer.cursor_index == len("hello world")
+    # The completed draft now matches the entry exactly -- nothing left to
+    # suggest, so a second accept is a no-op (caret movement resumes).
+    assert composer.accept_ghost_text() is False
+
+
+def test_accept_ghost_text_without_suggestion_is_noop():
+    composer = _composer_with_history("hello world")
+    composer.insert_text("zzz")
+    assert composer.accept_ghost_text() is False
+    assert composer.draft_text() == "zzz"
+    assert composer.cursor_index == 3
+
+
+# ---------------------------------------------------------------------------
+# Recall gating: first/last visual row of the wrapped draft
+# ---------------------------------------------------------------------------
+
+
+def test_recall_gating_single_row_draft():
+    composer = _composer_with_history("older prompt")
+    composer.insert_text("short")
+    # A single-row draft is simultaneously the first and last visual row.
+    assert composer._can_recall_history(-1) is True
+    # Down only recalls while navigating (index < 0); at the live draft it
+    # falls through to ordinary caret movement.
+    assert composer._can_recall_history(1) is False
+
+
+def test_recall_gating_wrapped_draft_rows():
+    composer = _composer_with_history("older prompt")
+    # Unmounted composers wrap at FALLBACK_DRAFT_WIDTH (80 cells).
+    composer.insert_text("x" * 100)  # wraps to 2 visual rows
+    # Caret at end -> last row: Up moves the caret, no recall.
+    assert composer._can_recall_history(-1) is False
+    composer.move_cursor_home()  # first row
+    assert composer._can_recall_history(-1) is True
+
+
+def test_recall_gating_middle_row_recalls_neither_direction():
+    composer = _composer_with_history("older prompt", "newer prompt")
+    composer.insert_text("x" * 200)  # wraps to 3 visual rows
+    composer._move_cursor_to(100)  # middle row
+    assert composer._can_recall_history(-1) is False
+    composer._history_index = -1  # pretend we are navigating
+    assert composer._can_recall_history(1) is False
+    composer.move_cursor_end()  # last row
+    assert composer._can_recall_history(1) is True
+    composer.move_cursor_home()  # first row
+    assert composer._can_recall_history(1) is False
+
+
+def test_recall_gating_requires_history_and_empty_selection():
+    composer = ConsoleComposerBar()
+    composer.insert_text("short")
+    assert composer._can_recall_history(-1) is False  # no store injected
+
+    composer.set_prompt_history(_seeded_history())
+    assert composer._can_recall_history(-1) is False  # empty history
+
+    composer.set_prompt_history(_seeded_history("older prompt"))
+    composer.select_all_draft()
+    assert composer._can_recall_history(-1) is False  # selection active
+
+
+# ---------------------------------------------------------------------------
+# Recall navigation: stash/restore round-trip and clamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_move_history_stashes_and_restores_live_draft():
+    composer = _composer_with_history("first prompt", "second prompt")
+    composer.insert_text("wip draft")
+    history = composer._prompt_history
+
+    await composer._move_history(-1)
+    assert composer.draft_text() == "second prompt"
+    assert composer._history_index == -1
+    assert composer.cursor_index == len("second prompt")
+    assert history.current == "wip draft"  # live draft stashed
+
+    await composer._move_history(-1)
+    assert composer.draft_text() == "first prompt"
+    assert composer._history_index == -2
+
+    # Clamped at the oldest entry: no-op, index unchanged.
+    await composer._move_history(-1)
+    assert composer.draft_text() == "first prompt"
+    assert composer._history_index == -2
+
+    await composer._move_history(1)
+    assert composer.draft_text() == "second prompt"
+    assert composer._history_index == -1
+
+    # Back at the live draft: the stashed in-progress text is restored.
+    await composer._move_history(1)
+    assert composer.draft_text() == "wip draft"
+    assert composer._history_index == 0
+    assert composer.cursor_index == len("wip draft")
+
+
+@pytest.mark.asyncio
+async def test_move_history_repeated_stash_leaving_live_draft_once():
+    """Re-navigating from the live draft re-stashes the CURRENT text."""
+    composer = _composer_with_history("older prompt")
+    composer.insert_text("wip one")
+    history = composer._prompt_history
+
+    await composer._move_history(-1)
+    await composer._move_history(1)
+    assert composer.draft_text() == "wip one"
+
+    composer.insert_text(" v2")
+    await composer._move_history(-1)
+    assert history.current == "wip one v2"
+    await composer._move_history(1)
+    assert composer.draft_text() == "wip one v2"
+
+
+def test_clear_history_resets_recall_index_to_live_draft():
+    """An accepted send (the clear_history barrier) ends history navigation."""
+    composer = _composer_with_history("older prompt")
+    composer.insert_text("wip")
+    composer._history_index = -1
+    composer.clear_history()
+    assert composer._history_index == 0
+
+
+# ---------------------------------------------------------------------------
+# Screen-level key routing (pilot tests)
+# ---------------------------------------------------------------------------
+
+
+def _seed_history_file(path, *inputs: str) -> None:
+    with open(path, "w", encoding="utf-8") as history_file:
+        for index, text in enumerate(inputs):
+            history_file.write(
+                json.dumps({"input": text, "timestamp": float(index)}) + "\n"
+            )
+
+
+@pytest.mark.asyncio
+async def test_console_ghost_text_renders_and_right_arrow_accepts(
+    tmp_path, monkeypatch
+):
+    history_path = tmp_path / "prompt_history.jsonl"
+    _seed_history_file(history_path, "explain quantum computing")
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.chat_screen.default_prompt_history_path",
+        lambda: history_path,
+    )
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        visible_draft = composer.query_one("#console-command-visible-text", Static)
+        # The screen shares ONE history store between composer and controller.
+        assert composer._prompt_history is console._ensure_console_prompt_history()
+        composer.focus()
+        await pilot.pause(0.3)  # let the mount-time history load land
+        composer._cursor_blink_timer.pause()
+
+        composer.insert_text("explain qu")
+        await pilot.pause(0.1)
+        assert "explain qu▌antum computing" in visible_draft.renderable.plain
+
+        # Typing dismisses the ghost implicitly (prefix no longer matches).
+        await pilot.press("x")
+        await pilot.pause(0.1)
+        assert "antum computing" not in visible_draft.renderable.plain
+        composer.delete_left()
+        await pilot.pause(0.1)
+        assert "explain qu▌antum computing" in visible_draft.renderable.plain
+
+        await pilot.press("right")
+        await pilot.pause(0.1)
+        assert composer.draft_text() == "explain quantum computing"
+        assert composer.cursor_index == len("explain quantum computing")
+
+        # Right at the end with no suggestion falls back to a (no-op) move.
+        await pilot.press("right")
+        await pilot.pause(0.1)
+        assert composer.cursor_index == len("explain quantum computing")
+
+
+@pytest.mark.asyncio
+async def test_console_up_down_recall_gated_to_boundary_rows(tmp_path, monkeypatch):
+    history_path = tmp_path / "prompt_history.jsonl"
+    _seed_history_file(history_path, "first prompt", "second prompt")
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.chat_screen.default_prompt_history_path",
+        lambda: history_path,
+    )
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.focus()
+        await pilot.pause(0.3)
+        composer._cursor_blink_timer.pause()
+
+        # Two-row draft, caret at end (last row): Up moves the caret, it
+        # does NOT recall.
+        composer.load_draft("line one\nline two")
+        await pilot.pause(0.1)
+        await pilot.press("up")
+        await pilot.pause(0.1)
+        assert composer.draft_text() == "line one\nline two"
+        # Caret moved up one row at the same column (row 0, col 8).
+        assert composer.cursor_index == 8
+        assert composer._caret_visual_row() == (0, 2)
+
+        # Now on the first visual row: Up recalls older history.
+        await pilot.press("up")
+        await pilot.pause(0.2)
+        assert composer.draft_text() == "second prompt"
+        await pilot.press("up")
+        await pilot.pause(0.2)
+        assert composer.draft_text() == "first prompt"
+        # Clamped at the oldest entry.
+        await pilot.press("up")
+        await pilot.pause(0.2)
+        assert composer.draft_text() == "first prompt"
+
+        # Down walks back; the stashed live draft returns at index 0.
+        await pilot.press("down")
+        await pilot.pause(0.2)
+        assert composer.draft_text() == "second prompt"
+        await pilot.press("down")
+        await pilot.pause(0.2)
+        assert composer.draft_text() == "line one\nline two"
+        assert composer.cursor_index == len("line one\nline two")
+
+
+@pytest.mark.asyncio
+async def test_console_send_records_to_shared_prompt_history(tmp_path, monkeypatch):
+    """An accepted send lands once in the JSONL store the composer reads."""
+    from Tests.UI.test_console_native_chat_flow import CapturingGateway
+
+    history_path = tmp_path / "prompt_history.jsonl"
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.chat_screen.default_prompt_history_path",
+        lambda: history_path,
+    )
+    gateway = CapturingGateway()
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.focus()
+        await pilot.pause(0.3)
+
+        composer.load_draft("record this send")
+        await pilot.pause(0.1)
+        await pilot.press("enter")
+        for _ in range(50):
+            await pilot.pause(0.1)
+            if history_path.exists() and history_path.read_text().strip():
+                break
+
+        lines = history_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["input"] == "record this send"
+
+        # The accepted send also ended history navigation at the live draft.
+        assert composer._history_index == 0

--- a/Tests/UI/test_console_transcript_diff_row.py
+++ b/Tests/UI/test_console_transcript_diff_row.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.widgets import Button
 from textual_diff_view import DiffView
 
 from tldw_chatbook.Chat.console_chat_models import (
@@ -61,7 +62,8 @@ def _tool_message(**overrides) -> ConsoleChatMessage:
 @pytest.mark.asyncio
 async def test_expanded_write_marker_mounts_prepared_diff(monkeypatch):
     """AC1+AC2: expanding a diff-carrying marker mounts a DiffView whose
-    diff was computed off the UI thread (prepare ran before mount)."""
+    diff was computed off the UI thread (prepare ran before mount). Covers
+    the marker that ALSO has hidden full text (expansion shows both)."""
     prepared = []
     real_make_diff = transcript_module.make_diff
 
@@ -121,6 +123,42 @@ async def test_expanded_write_marker_mounts_prepared_diff(monkeypatch):
             lambda: not transcript.query(ConsoleToolDiffRow)
         )
         assert removed, "diff row was not removed on collapse"
+
+
+@pytest.mark.asyncio
+async def test_diff_only_marker_expands_via_action_button():
+    """AC1 end-to-end: a typical file write (stripped result fits the
+    preview, so ``tool_output_full`` is None) must still reach its diff --
+    through the real selected-message action button, not a direct toggle.
+    """
+    app = DiffHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([_tool_message(tool_output_full=None)])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        # The action row offers the expansion affordance for a diff-only
+        # marker, labeled for what it opens.
+        transcript.select_message("m1")
+        found = await wait_for_condition(
+            lambda: bool(transcript.query("#console-message-action-tool-output-m1"))
+        )
+        assert found, "diff-only marker must offer the expansion action"
+        button = transcript.query_one(
+            "#console-message-action-tool-output-m1", Button
+        )
+        assert str(button.label) == "Diff"
+
+        # Pressing it (the real Button.Pressed -> _intercept_tool_output_press
+        # -> toggle path) mounts the diff row.
+        button.press()
+        mounted = await wait_for_condition(lambda: bool(transcript.query(DiffView)))
+        assert mounted, "pressing the Diff action did not mount the diff row"
+        diff_view = transcript.query(DiffView).first()
+        assert diff_view.path_modified == "/tmp/a.py"
+        assert diff_view.code_original == "def f():\n    return 1\n"
+        assert diff_view.code_modified == "def f():\n    return 2\n"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_transcript_diff_row.py
+++ b/Tests/UI/test_console_transcript_diff_row.py
@@ -1,0 +1,170 @@
+"""TASK-1366: expandable inline diff rows for file-write TOOL markers.
+
+A TOOL marker carrying ``tool_diff`` (raw before/after contents, captured
+live at the provider's strip seam) renders a ``DiffView`` row directly
+under its message row when expanded via the existing full-output toggle.
+The diff is prepared off the UI thread before mounting (AC2), non-diff
+markers render exactly as before (AC4), and the row is part of its
+message's group so view-window pruning drops it with the message.
+"""
+
+import asyncio
+import time
+from collections.abc import Callable
+
+import pytest
+from textual.app import App, ComposeResult
+from textual_diff_view import DiffView
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Widgets.Console import console_transcript as transcript_module
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    ConsoleToolDiffRow,
+    ConsoleTranscript,
+    ConsoleTranscriptMessage,
+)
+
+
+async def wait_for_condition(
+    predicate: Callable[[], bool], timeout: float = 5.0, interval: float = 0.02
+) -> bool:
+    """Poll ``predicate`` until true or ``timeout`` seconds elapse."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if predicate():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(interval)
+
+
+class DiffHarness(App):
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _tool_message(**overrides) -> ConsoleChatMessage:
+    kwargs = {
+        "role": ConsoleMessageRole.TOOL,
+        "content": "write_file → /tmp/a.py",
+        "id": "m1",
+        "tool_output_full": "action: overwritten\nlines_written: 1",
+        "tool_diff": ("/tmp/a.py", "def f():\n    return 1\n", "def f():\n    return 2\n"),
+    }
+    kwargs.update(overrides)
+    return ConsoleChatMessage(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_expanded_write_marker_mounts_prepared_diff(monkeypatch):
+    """AC1+AC2: expanding a diff-carrying marker mounts a DiffView whose
+    diff was computed off the UI thread (prepare ran before mount)."""
+    prepared = []
+    real_make_diff = transcript_module.make_diff
+
+    def tracking_make_diff(path, old, new, **kwargs):
+        diff_view = real_make_diff(path, old, new, **kwargs)
+        original_prepare = diff_view.prepare
+
+        async def tracked_prepare():
+            prepared.append(path)
+            await original_prepare()
+
+        diff_view.prepare = tracked_prepare
+        return diff_view
+
+    monkeypatch.setattr(transcript_module, "make_diff", tracking_make_diff)
+
+    app = DiffHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([_tool_message()])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        # Collapsed: no diff row.
+        assert not transcript.query(ConsoleToolDiffRow)
+
+        transcript.toggle_tool_output("m1")
+        found = await wait_for_condition(
+            lambda: bool(transcript.query(ConsoleToolDiffRow))
+            and bool(transcript.query(DiffView))
+        )
+        assert found, "DiffView was not mounted within the timeout"
+        await pilot.pause()
+
+        # prepare() ran before the DiffView mounted (off-thread prepare).
+        assert prepared == ["/tmp/a.py"]
+        diff_view = transcript.query(DiffView).first()
+        assert diff_view.is_mounted
+        assert diff_view.path_modified == "/tmp/a.py"
+        assert diff_view.code_original == "def f():\n    return 1\n"
+        assert diff_view.code_modified == "def f():\n    return 2\n"
+
+        # The diff row sits directly after its message row, inside the
+        # same message group.
+        children = list(transcript.children)
+        message_index = next(
+            i for i, w in enumerate(children) if isinstance(w, ConsoleTranscriptMessage)
+        )
+        diff_index = next(
+            i for i, w in enumerate(children) if isinstance(w, ConsoleToolDiffRow)
+        )
+        assert diff_index == message_index + 1
+
+        # Collapsing removes the diff row again.
+        transcript.toggle_tool_output("m1")
+        removed = await wait_for_condition(
+            lambda: not transcript.query(ConsoleToolDiffRow)
+        )
+        assert removed, "diff row was not removed on collapse"
+
+
+@pytest.mark.asyncio
+async def test_non_diff_tool_message_expands_as_text_only():
+    """AC4: a marker without tool_diff expands to plain text, no diff row."""
+    app = DiffHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([_tool_message(tool_diff=None)])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        transcript.toggle_tool_output("m1")
+        await pilot.pause()
+        await pilot.pause()
+
+        # Bounded negative wait: no diff row should ever appear.
+        appeared = await wait_for_condition(
+            lambda: bool(transcript.query(ConsoleToolDiffRow)), timeout=0.5
+        )
+        assert not appeared
+        # The text expansion still happens (pre-diff behavior, unchanged).
+        rows = transcript._transcript_rows()
+        message_row = next(row for row in rows if row.kind == "message")
+        assert "lines_written" in str(message_row.signature)
+
+
+@pytest.mark.asyncio
+async def test_pruned_message_drops_its_diff_row():
+    """Pruning invariant: the diff row is inside its message's group, so
+    the view window drops it together with the message (never orphaned)."""
+    app = DiffHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([_tool_message()])
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        transcript.toggle_tool_output("m1")
+        await pilot.pause()
+        keys = {row.key for row in transcript._transcript_rows()}
+        assert "diff:m1" in keys
+
+        transcript._pruned_message_ids.add("m1")
+        keys = {row.key for row in transcript._transcript_rows()}
+        assert "message:m1" not in keys
+        assert "diff:m1" not in keys

--- a/Tests/UI/test_console_transcript_pruning.py
+++ b/Tests/UI/test_console_transcript_pruning.py
@@ -1,0 +1,310 @@
+"""TASK-1365: height-based pruning of the native Console transcript.
+
+Long Console sessions mount one widget tree per message with no bound. When
+the transcript's virtual height crosses ``[chat_defaults] prune_high_watermark``
+the oldest message rows are dropped from the VIEW until the remainder fits
+under ``prune_low_watermark`` — the store keeps the full history, the
+streaming row is never pruned, and the scroll position is preserved (or
+re-anchored when following the tail). Pruning is a persistent view window:
+refresh/reconcile must never resurrect pruned rows.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    DEFAULT_PRUNE_HIGH_WATERMARK,
+    DEFAULT_PRUNE_LOW_WATERMARK,
+    ConsoleTranscript,
+    ConsoleTranscriptMessage,
+    get_console_prune_watermarks,
+)
+
+
+class PruneHarness(App):
+    """Small viewport so a handful of messages overflow it."""
+
+    CSS = "ConsoleTranscript { height: 10; }"
+
+    def __init__(self, *, low: int = 25, high: int = 40) -> None:
+        super().__init__()
+        self.app_config = {
+            "chat_defaults": {
+                "prune_high_watermark": high,
+                "prune_low_watermark": low,
+            }
+        }
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _msg(
+    i: int | str,
+    role: ConsoleMessageRole = ConsoleMessageRole.ASSISTANT,
+    *,
+    status: str = "completed",
+) -> ConsoleChatMessage:
+    return ConsoleChatMessage(
+        role=role,
+        content="\n".join(f"line {i}.{j}" for j in range(4)),
+        id=f"m{i}",
+        status=status,
+    )
+
+
+def _messages(n: int) -> list[ConsoleChatMessage]:
+    return [
+        _msg(i, ConsoleMessageRole.USER if i % 2 == 0 else ConsoleMessageRole.ASSISTANT)
+        for i in range(n)
+    ]
+
+
+def _mounted_message_ids(transcript: ConsoleTranscript) -> list[str]:
+    return [
+        widget.message_id
+        for widget in transcript.query(ConsoleTranscriptMessage)
+    ]
+
+
+async def _wait_for(pilot, predicate, *, attempts: int = 50) -> bool:
+    for _ in range(attempts):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+def test_get_console_prune_watermarks_defaults_and_clamps():
+    assert get_console_prune_watermarks(None) == (
+        DEFAULT_PRUNE_LOW_WATERMARK,
+        DEFAULT_PRUNE_HIGH_WATERMARK,
+    )
+    assert get_console_prune_watermarks({}) == (
+        DEFAULT_PRUNE_LOW_WATERMARK,
+        DEFAULT_PRUNE_HIGH_WATERMARK,
+    )
+    # low is clamped to <= high.
+    assert get_console_prune_watermarks(
+        {"chat_defaults": {"prune_high_watermark": 10, "prune_low_watermark": 99}}
+    ) == (10, 10)
+    # Invalid values fall back to the defaults.
+    assert get_console_prune_watermarks(
+        {"chat_defaults": {"prune_high_watermark": "x", "prune_low_watermark": None}}
+    ) == (DEFAULT_PRUNE_LOW_WATERMARK, DEFAULT_PRUNE_HIGH_WATERMARK)
+    # A non-dict chat_defaults section is ignored.
+    assert get_console_prune_watermarks({"chat_defaults": "nope"}) == (
+        DEFAULT_PRUNE_LOW_WATERMARK,
+        DEFAULT_PRUNE_HIGH_WATERMARK,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pruning_drops_oldest_rows_over_high_watermark():
+    """Virtual height over the high mark drops oldest rows down to the low mark."""
+    # Seed with pruning disabled so the pre-prune state is observable, then
+    # arm the watermarks and refresh to trigger the prune.
+    app = PruneHarness(low=25, high=0)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(12))
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert len(_mounted_message_ids(transcript)) == 12, (
+            "seed must mount every row before pruning runs"
+        )
+        assert transcript.virtual_size.height > 40, "seed must cross the high mark"
+
+        app.app_config["chat_defaults"]["prune_high_watermark"] = 40
+        await transcript.refresh_messages()
+
+        assert await _wait_for(
+            pilot, lambda: len(_mounted_message_ids(transcript)) < 12
+        ), "pruning never fired"
+
+        mounted = _mounted_message_ids(transcript)
+        assert "m0" not in mounted
+        assert mounted, "pruning must keep the newest rows"
+        assert mounted[-1] == "m11"
+        assert len(mounted) == 12 - len(transcript._pruned_message_ids)
+        # Pruned down to (at most) the high watermark, erring on keeping rows.
+        assert transcript.virtual_size.height <= 40
+        # The store snapshot the widget was handed is untouched.
+        assert len(transcript._messages) == 12
+
+
+@pytest.mark.asyncio
+async def test_pruning_is_view_only_store_keeps_full_history():
+    """messages_for_session still returns everything after pruning (AC4)."""
+    store = ConsoleChatStore()
+    session = store.create_session()
+    for message in _messages(12):
+        store.append_message(
+            session.id,
+            role=message.role,
+            content=message.content,
+        )
+
+    app = PruneHarness(low=25, high=40)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(store.messages_for_session(session.id))
+        await transcript.refresh_messages()
+
+        assert await _wait_for(
+            pilot, lambda: bool(transcript._pruned_message_ids)
+        ), "pruning never fired"
+
+        remaining = store.messages_for_session(session.id)
+        assert len(remaining) == 12
+        # Exports render the full history, pruned rows included.
+        plain = transcript.to_plain_text(width=40)
+        assert "line 0.0" in plain
+        assert "line 11.3" in plain
+
+
+@pytest.mark.asyncio
+async def test_pruning_preserves_scroll_position_when_scrolled_up():
+    """A scrolled-up reader keeps the same content in view across a prune."""
+    app = PruneHarness(low=40, high=60)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(30))
+        await transcript.refresh_messages()
+        assert await _wait_for(
+            pilot, lambda: bool(transcript._pruned_message_ids)
+        ), "initial prune never fired"
+
+        def _top_visible_message_id() -> str | None:
+            region = transcript.content_region
+            viewport_top = region.y
+            viewport_bottom = region.y + region.height
+            for widget in transcript.query(ConsoleTranscriptMessage):
+                row = widget.region
+                if row.y + row.height > viewport_top and row.y < viewport_bottom:
+                    return widget.message_id
+            return None
+
+        # Detach and read the newest content (a small later prune drops the
+        # oldest groups, so these rows are guaranteed to survive it).
+        transcript.release_anchor()
+        transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
+        await pilot.pause()
+        top_before = _top_visible_message_id()
+        assert top_before is not None
+        assert top_before not in transcript._pruned_message_ids
+        pruned_count = len(transcript._pruned_message_ids)
+
+        # Grow the transcript past the high mark again (assistant growth, like
+        # streaming, must not yank the reader either).
+        history = list(transcript._messages) + [
+            _msg(100 + i, ConsoleMessageRole.ASSISTANT) for i in range(3)
+        ]
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        assert await _wait_for(
+            pilot, lambda: len(transcript._pruned_message_ids) > pruned_count
+        ), "second prune never fired"
+        # Let the deferred scroll restoration land.
+        for _ in range(5):
+            await pilot.pause()
+
+        assert not transcript._is_following_tail(), (
+            "pruning must not re-attach a detached reader"
+        )
+        assert _top_visible_message_id() == top_before, (
+            "pruning while scrolled up must keep the same row at the viewport top"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pruning_reanchors_when_following_tail():
+    """Following the tail: the view stays pinned to the bottom after a prune."""
+    app = PruneHarness(low=25, high=40)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(12))
+        await transcript.refresh_messages()
+
+        assert await _wait_for(
+            pilot, lambda: bool(transcript._pruned_message_ids)
+        ), "pruning never fired"
+        assert await _wait_for(
+            pilot,
+            lambda: transcript.scroll_y == transcript.max_scroll_y
+            and transcript._is_following_tail(),
+        ), "tail-follow was not restored after pruning"
+
+
+@pytest.mark.asyncio
+async def test_streaming_row_is_never_pruned():
+    """The in-progress streaming row survives even an aggressive prune."""
+    app = PruneHarness(low=1, high=5)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(10) + [
+            _msg("stream", ConsoleMessageRole.ASSISTANT, status="streaming")
+        ]
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+
+        assert await _wait_for(
+            pilot, lambda: bool(transcript._pruned_message_ids)
+        ), "pruning never fired"
+
+        assert "mstream" not in transcript._pruned_message_ids
+        assert "mstream" in _mounted_message_ids(transcript)
+
+
+@pytest.mark.asyncio
+async def test_pruning_disabled_when_high_watermark_nonpositive():
+    """prune_high_watermark <= 0 disables pruning entirely."""
+    app = PruneHarness(low=1, high=0)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(_messages(12))
+        await transcript.refresh_messages()
+        # Give the (disabled) check a chance to run.
+        for _ in range(5):
+            await pilot.pause()
+
+        assert transcript._pruned_message_ids == set()
+        assert len(_mounted_message_ids(transcript)) == 12
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_recompose_do_not_resurrect_pruned_rows():
+    """Pruning is a persistent view window, not a one-shot row removal."""
+    app = PruneHarness(low=25, high=40)
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(12)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+
+        assert await _wait_for(
+            pilot, lambda: bool(transcript._pruned_message_ids)
+        ), "pruning never fired"
+        pruned = set(transcript._pruned_message_ids)
+        mounted_after_prune = _mounted_message_ids(transcript)
+
+        # Same-messages refresh (the streaming tick re-sets the list).
+        transcript.set_messages(list(history))
+        await transcript.refresh_messages()
+        assert await _wait_for(
+            pilot, lambda: _mounted_message_ids(transcript) == mounted_after_prune
+        )
+        assert not (set(_mounted_message_ids(transcript)) & pruned)
+
+        # A full recompose derives rows through the same pruned window.
+        transcript.refresh(recompose=True)
+        assert await _wait_for(
+            pilot, lambda: _mounted_message_ids(transcript) == mounted_after_prune
+        )
+        assert not (set(_mounted_message_ids(transcript)) & pruned)

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Iterable, Mapping, NamedTuple, Protocol
+from typing import Any, Callable, Iterable, Mapping, NamedTuple, Protocol
 
 from loguru import logger
 
@@ -467,7 +467,7 @@ class BuiltinToolProvider:
         gate: Any | None = None,
         workspace_id: str | None = None,
         ephemeral: bool = False,
-        diff_sink: Any | None = None,
+        diff_sink: Callable[[tuple[str, str, str, str]], None] | None = None,
     ) -> None:
         # settings-workspaces-folder-roots spec §3: the run's workspace,
         # bound around every tool execution (see `invoke`) so file tools
@@ -534,10 +534,15 @@ class BuiltinToolProvider:
         # This is the ONLY way the live Console can render a diff: the
         # stripped JSON text is all that leaves this method. `None` (the
         # default) means no UI is listening -- behavior is byte-identical
-        # to pre-diff-channel runs. A sink runs on the caller's thread and
-        # its exceptions are swallowed (a UI failure must never break a
-        # tool call), so it must be cheap and non-blocking -- the bridge
-        # hands in a `deque.append` (single-argument contract).
+        # to pre-diff-channel runs. The sink runs on the tool call's
+        # PER-CALL DAEMON THREAD (AgentService._call_with_timeout) -- on
+        # timeout/cancel that thread is abandoned unjoined and the sink
+        # can fire LATE, after the call's result step already passed (the
+        # bridge's pairing tolerates this; see console_agent_bridge.
+        # _pair_step_diff). Its exceptions are swallowed (a UI failure
+        # must never break a tool call), so it must be cheap, non-
+        # blocking, and safe to call cross-thread -- the bridge hands in
+        # a `deque.append` (single-argument contract, atomic in CPython).
         self._diff_sink = diff_sink
 
     def _tool_id(self, name: str) -> str:
@@ -668,8 +673,9 @@ class BuiltinToolProvider:
                             )
                         )
                     except Exception:  # noqa: BLE001 — UI failure never breaks a tool call
-                        logger.opt(exception=True).debug(
-                            "diff_sink raised during tool result capture; continuing"
+                        logger.opt(exception=True).warning(
+                            "diff_sink raised during tool result capture; "
+                            "console diff rows will be missing for this write"
                         )
             raw = {
                 key: value for key, value in raw.items() if key not in DIFF_CONTENT_KEYS

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -467,6 +467,7 @@ class BuiltinToolProvider:
         gate: Any | None = None,
         workspace_id: str | None = None,
         ephemeral: bool = False,
+        diff_sink: Any | None = None,
     ) -> None:
         # settings-workspaces-folder-roots spec §3: the run's workspace,
         # bound around every tool execution (see `invoke`) so file tools
@@ -526,6 +527,18 @@ class BuiltinToolProvider:
         # and its per-run registry) passes nothing today, so an ungated
         # default would silently leave the shipping path unprotected.
         self._gate = gate
+        # TASK-1366: optional UI-side channel for raw before/after file
+        # contents, invoked at the strip seam in `invoke()` with a single
+        # ``(tool_name, file_path, old_content, new_content)`` tuple just
+        # BEFORE the raw keys are removed from the LLM/run-log-bound dict.
+        # This is the ONLY way the live Console can render a diff: the
+        # stripped JSON text is all that leaves this method. `None` (the
+        # default) means no UI is listening -- behavior is byte-identical
+        # to pre-diff-channel runs. A sink runs on the caller's thread and
+        # its exceptions are swallowed (a UI failure must never break a
+        # tool call), so it must be cheap and non-blocking -- the bridge
+        # hands in a `deque.append` (single-argument contract).
+        self._diff_sink = diff_sink
 
     def _tool_id(self, name: str) -> str:
         return f"{self.SOURCE}:{name}"
@@ -637,6 +650,27 @@ class BuiltinToolProvider:
             # contents are never replayed to a provider or persisted.
             from tldw_chatbook.Tools.file_operation_tools import DIFF_CONTENT_KEYS
 
+            # TASK-1366: hand the raw contents to the UI diff channel
+            # FIRST, while they still exist -- after the strip below they
+            # are gone from everything this method returns. Only the sink
+            # (an in-memory, live-session channel) ever sees them.
+            if self._diff_sink is not None:
+                old_content = raw.get("old_content")
+                new_content = raw.get("new_content")
+                if isinstance(old_content, str) and isinstance(new_content, str):
+                    try:
+                        self._diff_sink(
+                            (
+                                name,
+                                str(raw.get("file_path") or "file"),
+                                old_content,
+                                new_content,
+                            )
+                        )
+                    except Exception:  # noqa: BLE001 — UI failure never breaks a tool call
+                        logger.opt(exception=True).debug(
+                            "diff_sink raised during tool result capture; continuing"
+                        )
             raw = {
                 key: value for key, value in raw.items() if key not in DIFF_CONTENT_KEYS
             }

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -380,6 +380,60 @@ def full_step_output(
     return text
 
 
+def _pair_step_diff(
+    pending_diffs: deque[tuple[str, str, str, str]],
+    tool_name: str | None,
+) -> tuple[str, str, str] | None:
+    """Pair one STEP_TOOL_RESULT with its queued diff capture (TASK-1366).
+
+    Captures are appended by the provider's ``diff_sink`` at the strip seam,
+    on the tool call's PER-CALL DAEMON THREAD (``AgentService.
+    _call_with_timeout``). That thread is joined before the result step is
+    emitted in the normal case, so the current call's capture -- when it
+    exists -- is the MOST RECENT queued entry for its tool name. On
+    timeout/cancel the thread is abandoned unjoined and a late capture can
+    land AFTER its own result step already passed; that stale entry must
+    never pair with a later call.
+
+    Pairing rule: take the RIGHTMOST (most recent) entry matching
+    ``tool_name`` and drop it together with every older entry -- anything
+    older had its own result step pass already (dispatch and step emission
+    are sequential), so it is stale by construction. When nothing matches,
+    the whole queue is stale for the same reason and is cleared.
+
+    Residual, documented and cosmetic-only: a stale capture from an
+    abandoned call that shares the tool name AND arrives after the current
+    call's own capture can still mis-pair (the two are indistinguishable
+    without threading call identity through invoke()). The consequence is a
+    wrong diff shown under a live marker -- in-memory only, never persisted
+    or replayed, and self-correcting on the next result step.
+
+    Args:
+        pending_diffs: This run's capture queue (mutated in place).
+        tool_name: The result step's tool name.
+
+    Returns:
+        ``(file_path, old_content, new_content)`` for the paired capture,
+        or ``None`` when this call produced no diff.
+    """
+    match_index = next(
+        (
+            index
+            for index in range(len(pending_diffs) - 1, -1, -1)
+            if pending_diffs[index][0] == tool_name
+        ),
+        None,
+    )
+    if match_index is None:
+        pending_diffs.clear()
+        return None
+    _name, diff_path, diff_old, diff_new = pending_diffs[match_index]
+    # deque has no slice-delete; drop the pair and everything older (stale).
+    for _ in range(match_index + 1):
+        pending_diffs.popleft()
+    return (diff_path, diff_old, diff_new)
+
+
 #: TASK-1844: transcript marker kind for an approval that expired. Not an
 #: `AgentStep` kind -- the timeout happens in the approval round, before any
 #: step exists -- but it renders through the same formatter so live and
@@ -1088,7 +1142,7 @@ def _compose_run_registry_and_allowed(
     builtin_gate: Any | None = None,
     workspace_id: str | None = None,
     ephemeral: bool = False,
-    diff_sink: Any | None = None,
+    diff_sink: Callable[[tuple[str, str, str, str]], None] | None = None,
 ) -> tuple[ToolCatalogRegistry, tuple[str, ...], tuple[str, ...]]:
     """Build a fresh per-run tool registry + allow-list from a skills snapshot.
 
@@ -1432,12 +1486,18 @@ class ConsoleAgentBridge:
         # (BuiltinToolProvider.invoke) appends
         # ``(tool_name, file_path, old, new)`` here BEFORE the raw contents
         # are removed from the LLM/run-log-bound result; the on_step
-        # handler below pairs each capture with its STEP_TOOL_RESULT and
-        # hangs it on the TOOL marker message (session-only ``tool_diff``).
-        # A plain deque: invoke() and on_step both run on this run's worker
-        # thread, dispatch is sequential, and every capture is followed by
-        # exactly one result step before the next dispatch -- FIFO with a
-        # tool-name check is exact. The shared fast path's construction-
+        # handler below pairs each capture with its STEP_TOOL_RESULT (via
+        # ``_pair_step_diff``) and hangs it on the TOOL marker message
+        # (session-only ``tool_diff``). Threading: invoke() runs on the
+        # tool call's PER-CALL DAEMON THREAD (AgentService.
+        # _call_with_timeout) while on_step runs on this run's worker
+        # thread. In the normal case the daemon thread is joined before
+        # the result step is emitted, so a capture always precedes its
+        # step; on timeout/cancel the thread is abandoned unjoined and a
+        # late capture can land cross-thread AFTER its step -- the pairing
+        # rule (most-recent match, everything older is stale) tolerates
+        # both orderings, and deque append/scan/del degrade to a cosmetic
+        # missed pairing at worst. The shared fast path's construction-
         # time provider has no sink (a cross-run provider must not capture
         # into one run's queue), so gate-less callers simply get no diff
         # capture -- their rows render exactly as before. Production always
@@ -1768,19 +1828,15 @@ class ConsoleAgentBridge:
             )
             # TASK-1366: pair this result step with the raw before/after
             # contents the provider's diff_sink captured at the strip seam,
-            # when this call was a diff-carrying file write. The name check
-            # keeps the FIFO honest: only THIS tool's own result step may
-            # claim its capture. Sub-agent result steps drain the queue too
-            # (their writes ride this run's provider) even though only
-            # primary steps drop markers.
+            # when this call was a diff-carrying file write. Sub-agent
+            # result steps pair-and-discard too (their writes can ride this
+            # run's provider) even though only primary steps drop markers.
+            # See _pair_step_diff for the threading model and the staleness
+            # rule that keeps an abandoned call's late capture from pairing
+            # with a later write.
             tool_diff: tuple[str, str, str] | None = None
-            if (
-                step.kind == STEP_TOOL_RESULT
-                and pending_diffs
-                and pending_diffs[0][0] == step.tool_name
-            ):
-                _diff_tool, diff_path, diff_old, diff_new = pending_diffs.popleft()
-                tool_diff = (diff_path, diff_old, diff_new)
+            if step.kind == STEP_TOOL_RESULT and pending_diffs:
+                tool_diff = _pair_step_diff(pending_diffs, step.tool_name)
             if agent_kind == AGENT_KIND_PRIMARY:
                 if step.kind == STEP_SPAWN:
                     subagents.append(SubAgentSummary(step.summary or ""))

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -14,6 +14,7 @@ import asyncio
 import contextlib
 import os
 import time
+from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -1087,6 +1088,7 @@ def _compose_run_registry_and_allowed(
     builtin_gate: Any | None = None,
     workspace_id: str | None = None,
     ephemeral: bool = False,
+    diff_sink: Any | None = None,
 ) -> tuple[ToolCatalogRegistry, tuple[str, ...], tuple[str, ...]]:
     """Build a fresh per-run tool registry + allow-list from a skills snapshot.
 
@@ -1138,6 +1140,9 @@ def _compose_run_registry_and_allowed(
             and MCP tools out of the run's catalog and allow-list so the
             model is never offered them. ``False`` (the default)
             preserves every pre-existing caller's behavior unchanged.
+        diff_sink: TASK-1366 -- this run's UI-side diff channel, threaded
+            into the freshly-constructed ``BuiltinToolProvider`` (see its
+            ``__init__``). ``None`` (the default) means no diff capture.
 
     Returns:
         ``(registry, allowed_tools, builtin_names)`` -- the per-run
@@ -1149,7 +1154,10 @@ def _compose_run_registry_and_allowed(
     """
     registry = ToolCatalogRegistry(ephemeral=ephemeral)
     builtin_provider = BuiltinToolProvider(
-        gate=builtin_gate, workspace_id=workspace_id, ephemeral=ephemeral
+        gate=builtin_gate,
+        workspace_id=workspace_id,
+        ephemeral=ephemeral,
+        diff_sink=diff_sink,
     )
     registry.register_provider(builtin_provider)
     builtin_names = tuple(entry.name for entry in builtin_provider.list_catalog())
@@ -1419,6 +1427,23 @@ class ConsoleAgentBridge:
         registry = self._registry
         allowed_tools = self._allowed_tools
         skill_runner = None
+        # TASK-1366: this run's UI-side diff channel. When this run takes
+        # the fresh-build branch below, the provider's strip seam
+        # (BuiltinToolProvider.invoke) appends
+        # ``(tool_name, file_path, old, new)`` here BEFORE the raw contents
+        # are removed from the LLM/run-log-bound result; the on_step
+        # handler below pairs each capture with its STEP_TOOL_RESULT and
+        # hangs it on the TOOL marker message (session-only ``tool_diff``).
+        # A plain deque: invoke() and on_step both run on this run's worker
+        # thread, dispatch is sequential, and every capture is followed by
+        # exactly one result step before the next dispatch -- FIFO with a
+        # tool-name check is exact. The shared fast path's construction-
+        # time provider has no sink (a cross-run provider must not capture
+        # into one run's queue), so gate-less callers simply get no diff
+        # capture -- their rows render exactly as before. Production always
+        # passes builtin_gate (console_chat_controller), i.e. the
+        # fresh-build branch.
+        pending_diffs: deque[tuple[str, str, str, str]] = deque()
         # task-4 (skills-fork-reachability): one SkillFileBindings per run,
         # handed to BOTH AgentService (the loop's authorization + reader
         # closure -- Task 3) and this run's _BridgeSkillRunner (which grants
@@ -1458,12 +1483,15 @@ class ConsoleAgentBridge:
                     run_is_ephemeral = self._store.session_is_ephemeral(session_id)
                 except KeyError:
                     run_is_ephemeral = False
+            # TASK-1366: wire this run's diff channel (declared above) into
+            # the freshly-built provider.
             registry, allowed_tools, builtin_names = _compose_run_registry_and_allowed(
                 context,
                 mcp_provider=mcp_provider,
                 builtin_gate=builtin_gate,
                 workspace_id=run_workspace_id,
                 ephemeral=run_is_ephemeral,
+                diff_sink=pending_diffs.append,
             )
             if self._skills_service is not None:
                 skill_names = frozenset(
@@ -1738,6 +1766,21 @@ class ConsoleAgentBridge:
             live_steps.append(
                 AgentLiveStep(step.kind, self._summarize(step), agent_kind)
             )
+            # TASK-1366: pair this result step with the raw before/after
+            # contents the provider's diff_sink captured at the strip seam,
+            # when this call was a diff-carrying file write. The name check
+            # keeps the FIFO honest: only THIS tool's own result step may
+            # claim its capture. Sub-agent result steps drain the queue too
+            # (their writes ride this run's provider) even though only
+            # primary steps drop markers.
+            tool_diff: tuple[str, str, str] | None = None
+            if (
+                step.kind == STEP_TOOL_RESULT
+                and pending_diffs
+                and pending_diffs[0][0] == step.tool_name
+            ):
+                _diff_tool, diff_path, diff_old, diff_new = pending_diffs.popleft()
+                tool_diff = (diff_path, diff_old, diff_new)
             if agent_kind == AGENT_KIND_PRIMARY:
                 if step.kind == STEP_SPAWN:
                     subagents.append(SubAgentSummary(step.summary or ""))
@@ -1762,6 +1805,7 @@ class ConsoleAgentBridge:
                             summary=step.summary,
                             marker_text=marker_text,
                         ),
+                        tool_diff=tool_diff,
                     )
             # Diagnostic logging for every tool call and result. The actual
             # tool invocation lives inside AgentService, so we observe it
@@ -2436,7 +2480,12 @@ class ConsoleAgentBridge:
         )
 
     def _append_marker(
-        self, session_id: str, text: str, *, full_output: str | None = None
+        self,
+        session_id: str,
+        text: str,
+        *,
+        full_output: str | None = None,
+        tool_diff: tuple[str, str, str] | None = None,
     ) -> None:
         # Kept raw (no escaping): both consumers render markup-off --
         # console_transcript.py's _message_render_text builds a Content via
@@ -2445,12 +2494,18 @@ class ConsoleAgentBridge:
         # markup-parsed). Escaping here for a parser that never runs used to
         # leave literal backslashes in the rendered marker (`fetch [docs]` ->
         # `fetch \[docs]`).
+        # `tool_diff` (TASK-1366) is the raw (path, before, after) capture
+        # for a file-writing marker -- session-only display state for the
+        # transcript's diff row; the store never persists TOOL markers, and
+        # `text`/`full_output` (built from the post-strip result) remain
+        # the only forms the model history and run log ever see.
         try:
             self._store.append_message(
                 session_id,
                 role=ConsoleMessageRole.TOOL,
                 content=text,
                 tool_output_full=full_output,
+                tool_diff=tool_diff,
             )
         except KeyError:
             pass  # session vanished mid-run; the rail still has the live snapshot

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -74,6 +74,7 @@ from tldw_chatbook.Chat.console_skill_resolver import (
     find_embedded_mentions,
     resolve_skill_command,
 )
+from tldw_chatbook.Chat.prompt_history import PromptHistory
 from loguru import logger
 
 from tldw_chatbook.Agents.builtin_tool_gate import build_builtin_gate
@@ -952,6 +953,13 @@ class ConsoleChatController:
         #: persisted, run about to start) so the composer can clear immediately
         #: instead of holding the sent text for the whole run.
         self.on_submission_accepted: Callable[[], None] | None = None
+        #: TASK-1364: optional shared JSONL prompt-history store, assigned by
+        #: the owning screen (mirroring ``on_submission_accepted``). An
+        #: ACCEPTED send's cleaned draft is appended here -- never a blocked,
+        #: refused, or empty (attachment-only) one -- so the composer's ghost
+        #: text and Up/Down recall can offer it later. ``None`` (e.g. in
+        #: controller-only tests) disables recording.
+        self.prompt_history: PromptHistory | None = None
         # Task 3b: PER-SESSION maps, mirroring `_run_states`' own keying --
         # two sessions can each have their own in-flight stream/cancel state
         # without clobbering each other. Written/cleared at the SAME
@@ -1890,6 +1898,12 @@ class ConsoleChatController:
         # never reach this hook -- this ordering just extends that same
         # rule to cover it too.
         self._notify_submission_accepted()
+        # TASK-1364: record the accepted send to the shared prompt history.
+        # Same placement rule as the accepted-hook above: only a send that is
+        # confirmed to proceed is recorded -- every `_block`/refusal path
+        # returns before this point, and `_record_prompt_history` itself
+        # skips empty (attachment-only) drafts.
+        await self._record_prompt_history(clean_draft)
         # TASK-485: the turn is confirmed to proceed — flush the deferred USER
         # echo to durable storage now (creating the conversation), BEFORE the
         # assistant row, so a reload shows the user's prompt ahead of its reply.
@@ -5908,6 +5922,27 @@ class ConsoleChatController:
             # The hook is a UI convenience (composer clearing); a failure there
             # must never abort an already-accepted provider run.
             pass
+
+    async def _record_prompt_history(self, text: str) -> None:
+        """Append an accepted send's draft to the shared prompt history.
+
+        Best-effort (TASK-1364): ``PromptHistory.append`` already logs and
+        swallows its own IO failures, and the guard here keeps even an
+        unexpected raise from breaking an already-accepted run. Empty or
+        whitespace-only drafts (attachment-only sends) record nothing.
+
+        Args:
+            text: The cleaned draft text that was just accepted for sending.
+        """
+        history = self.prompt_history
+        if history is None or not text.strip():
+            return
+        try:
+            await history.append(text)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Prompt-history recording failed for an accepted send."
+            )
 
     _IMAGE_REJECTION_RECOVERY_HINT = (
         " This conversation includes an image attachment; if the model can't "

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Protocol
 from uuid import uuid4
 
+from loguru import logger
+
 from tldw_chatbook.Chat.attachment_core import (
     image_url_part,
     max_history_images,
@@ -75,7 +77,6 @@ from tldw_chatbook.Chat.console_skill_resolver import (
     resolve_skill_command,
 )
 from tldw_chatbook.Chat.prompt_history import PromptHistory
-from loguru import logger
 
 from tldw_chatbook.Agents.builtin_tool_gate import build_builtin_gate
 from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall, MCPToolProvider

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -436,6 +436,17 @@ class ConsoleChatMessage:
     #: that is not a tool marker, and for a marker whose result was short
     #: enough that ``content`` already shows all of it.
     tool_output_full: str | None = None
+    #: TASK-1366: the raw (file_path, before, after) contents behind a
+    #: file-writing TOOL marker, captured live at the provider's strip seam
+    #: (``BuiltinToolProvider.invoke``) for the transcript's inline diff
+    #: row. Session-only display state: TOOL markers return from
+    #: ``append_message`` before the persistence path, so this is NEVER
+    #: persisted, and it is never echoed to the model or the run log --
+    #: ``content``/``tool_output_full`` (post-strip text) are the only
+    #: forms those consumers see. None for non-diff rows and for
+    #: resume-rebuilt markers (AgentRunsDB holds only the stripped record,
+    #: so a resumed run renders exactly as pre-diff).
+    tool_diff: tuple[str, str, str] | None = None
     #: TASK-1972: set on a change-summary transcript row -- the agent run
     #: whose diff the row reviews. Session-only, never persisted; resume
     #: re-derives it from change_snapshots. The `v` action needs to know

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1104,6 +1104,7 @@ class ConsoleChatStore:
         terminal_citation_finalizer: TerminalCitationFinalizer | None = None,
         defer_terminal_persistence: bool = False,
         tool_output_full: str | None = None,
+        tool_diff: tuple[str, str, str] | None = None,
         change_review_run_id: str | None = None,
         metadata: "MessageMetadata | None" = None,
     ) -> ConsoleChatMessage:
@@ -1113,6 +1114,10 @@ class ConsoleChatStore:
         (engine provenance, interrupted, transcript status) at creation
         time, so a row that knows its own provenance writes it with the
         create instead of chasing it with a second update.
+
+        ``tool_diff`` (TASK-1366) is the raw (path, before, after) capture
+        behind a file-writing TOOL marker -- session-only, never persisted
+        (see ``ConsoleChatMessage.tool_diff``).
         """
         self._session_or_raise(session_id)
         effective = tuple(attachments)
@@ -1163,6 +1168,7 @@ class ConsoleChatStore:
             content=content,
             status=self._initial_status(role=role, content=content),
             tool_output_full=tool_output_full,
+            tool_diff=tool_diff,
             change_review_run_id=change_review_run_id,
             metadata=metadata,
         )

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -74,6 +74,12 @@ class ConsoleMessageActionService:
     _TOOL_OUTPUT_ACTIONS: tuple[tuple[str, str], ...] = (
         ("tool-output", "Full output"),
     )
+    #: TASK-1366: a diff-carrying marker whose stripped result FIT the
+    #: preview has no fuller text to show -- expansion reveals the inline
+    #: diff row instead, so the affordance says what it opens.
+    _TOOL_DIFF_ACTIONS: tuple[tuple[str, str], ...] = (
+        ("tool-output", "Diff"),
+    )
     #: TASK-1972: offered only on a change-summary row (one carrying the
     #: run id it reviews). Opens the Change Review screen for THAT turn.
     _REVIEW_CHANGES_ACTIONS: tuple[tuple[str, str], ...] = (
@@ -101,7 +107,10 @@ class ConsoleMessageActionService:
         # EXPANDED row does contain it, and that must not remove the control
         # that collapses it again. Whether there is more to show is settled
         # once, when the marker is built.
-        return bool(message.tool_output_full)
+        # TASK-1366: a diff-carrying marker always has more to show -- the
+        # inline diff row -- even when the stripped result was short enough
+        # that `tool_output_full` is None (the common case for file writes).
+        return bool(message.tool_output_full) or message.tool_diff is not None
 
     @staticmethod
     def _has_image(message: ConsoleChatMessage) -> bool:
@@ -195,7 +204,14 @@ class ConsoleMessageActionService:
         if extra_actions:
             completed_actions = self._base_actions_with(tuple(extra_actions))
         if self._has_tool_output(message):
-            completed_actions = completed_actions + list(self._TOOL_OUTPUT_ACTIONS)
+            # Diff-only marker (no fuller TEXT behind the preview): the
+            # expand control opens the inline diff row, so label it that
+            # way. Full-output and full-output+diff markers keep the
+            # TASK-1860 copy.
+            if message.tool_output_full:
+                completed_actions = completed_actions + list(self._TOOL_OUTPUT_ACTIONS)
+            else:
+                completed_actions = completed_actions + list(self._TOOL_DIFF_ACTIONS)
         if getattr(message, "change_review_run_id", None):
             completed_actions = completed_actions + list(
                 self._REVIEW_CHANGES_ACTIONS

--- a/tldw_chatbook/Chat/prompt_history.py
+++ b/tldw_chatbook/Chat/prompt_history.py
@@ -58,6 +58,9 @@ class PromptHistory:
         self._entries: list[HistoryEntry] = []
         self._current: str | None = None
         self._loaded: bool = False
+        # Serializes append() so a whole-file cap rewrite can never
+        # interleave with another append from a concurrent send.
+        self._append_lock = asyncio.Lock()
 
     @property
     def size(self) -> int:
@@ -70,7 +73,12 @@ class PromptHistory:
         return self._current or ""
 
     def stash_draft(self, text: str) -> None:
-        """Stash in-progress text so history recall never loses it."""
+        """Stash in-progress text so history recall never loses it.
+
+        Args:
+            text: The current in-progress draft to preserve as the live
+                (index 0) pseudo-entry.
+        """
         self._current = text
 
     def clear_draft(self) -> None:
@@ -134,6 +142,22 @@ class PromptHistory:
         self._loaded = True
 
     async def append(self, text: str) -> bool:
+        """Append a prompt to the history (serialized, fire-and-forget friendly).
+
+        Concurrent appends are serialized with an internal lock so a
+        whole-file cap rewrite can never interleave with another append.
+
+        Args:
+            text: The prompt text to record.
+
+        Returns:
+            True when the entry was recorded, False on write failure or when
+            the entry was skipped (empty text or consecutive duplicate).
+        """
+        async with self._append_lock:
+            return await self._append_impl(text)
+
+    async def _append_impl(self, text: str) -> bool:
         """Append a prompt to the history (fire-and-forget friendly).
 
         Consecutive duplicates are skipped. The in-memory entry is added

--- a/tldw_chatbook/Chat/prompt_history.py
+++ b/tldw_chatbook/Chat/prompt_history.py
@@ -1,0 +1,241 @@
+"""
+Persistent prompt history for the chat input (JSONL-backed).
+
+Stores one JSON object per line — ``{"input": ..., "timestamp": ...}`` — in a
+per-user data file. All file IO runs in a worker thread (``asyncio.to_thread``)
+so the Textual event loop is never blocked.
+
+Recall uses shell-style indexing: index 0 is the *live draft* pseudo-entry (the
+in-progress text stashed while navigating), and negative indexes walk backwards
+through stored entries (-1 is the most recent prompt). ``clamp_index`` provides
+the validate_*-style clamping used by the input widget to keep navigation in
+bounds. ``complete`` powers fish-shell-style ghost text: the most recent entry
+matching the current text as a prefix wins.
+
+Growth is bounded by ``max_entries``: load keeps only the most recent entries
+in memory, and append rewrites the file with the tail once the cap is exceeded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import TypedDict
+
+from loguru import logger
+
+DEFAULT_MAX_ENTRIES = 1000
+
+
+def default_prompt_history_path() -> Path:
+    """Return the default per-user prompt history file path."""
+    from ..config import get_user_data_dir
+
+    return get_user_data_dir() / "prompt_history.jsonl"
+
+
+class HistoryEntry(TypedDict):
+    """A single entry in the history file."""
+
+    input: str
+    timestamp: float
+
+
+class PromptHistory:
+    """Manages a JSONL prompt-history file with async IO and draft stashing."""
+
+    def __init__(self, path: Path | str, max_entries: int = DEFAULT_MAX_ENTRIES) -> None:
+        """Initialize the history store.
+
+        Args:
+            path: Path of the JSONL history file (created on first write).
+            max_entries: Cap on stored entries; the most recent entries win.
+        """
+        self.path = Path(path)
+        self.max_entries = max_entries
+        self._entries: list[HistoryEntry] = []
+        self._current: str | None = None
+        self._loaded: bool = False
+
+    @property
+    def size(self) -> int:
+        """Number of stored entries (excludes the live draft pseudo-entry)."""
+        return len(self._entries)
+
+    @property
+    def current(self) -> str:
+        """The stashed live-draft text, or an empty string when not stashed."""
+        return self._current or ""
+
+    def stash_draft(self, text: str) -> None:
+        """Stash in-progress text so history recall never loses it."""
+        self._current = text
+
+    def clear_draft(self) -> None:
+        """Drop the stashed draft (e.g. after a successful send)."""
+        self._current = None
+
+    def clamp_index(self, index: int) -> int:
+        """Clamp a history index into the valid range ``[-size, 0]``.
+
+        Args:
+            index: Requested index; 0 is the live draft, negatives walk back.
+
+        Returns:
+            The clamped index.
+        """
+        return max(-self.size, min(0, index))
+
+    async def load(self) -> None:
+        """Load entries from the history file, off the event loop.
+
+        Only the most recent ``max_entries`` entries are kept in memory.
+        Corrupt lines are tolerated; read failures log and leave an empty
+        history.
+        """
+        if self._loaded:
+            return
+
+        def read_history() -> list[HistoryEntry]:
+            """Read and parse the JSONL file in a worker thread."""
+            if not self.path.exists():
+                return []
+            entries: list[HistoryEntry] = []
+            with self.path.open("r", encoding="utf-8") as history_file:
+                for line in history_file:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue  # Tolerate corrupt lines; keep the rest.
+                    text = entry.get("input")
+                    if isinstance(text, str) and text:
+                        timestamp = entry.get("timestamp")
+                        entries.append(
+                            {
+                                "input": text,
+                                "timestamp": timestamp
+                                if isinstance(timestamp, (int, float))
+                                else 0.0,
+                            }
+                        )
+            return entries
+
+        try:
+            entries = await asyncio.to_thread(read_history)
+        except Exception as error:
+            logger.warning(f"Could not read prompt history {self.path}: {error}")
+            entries = []
+        self._entries = entries[-self.max_entries :]
+        self._loaded = True
+
+    async def append(self, text: str) -> bool:
+        """Append a prompt to the history (fire-and-forget friendly).
+
+        Consecutive duplicates are skipped. The in-memory entry is added
+        optimistically before the awaited write so two rapid identical sends
+        cannot both pass the dedupe check; it is rolled back on write failure.
+        When the cap is exceeded the file is rewritten with the tail. The file
+        IO runs in a worker thread; failures are logged and reported, never
+        raised.
+
+        Args:
+            text: The prompt text to record.
+
+        Returns:
+            True when the entry was recorded, False on write failure or when
+            the entry was skipped (empty text or consecutive duplicate).
+        """
+        if not text:
+            return False
+        if not self._loaded:
+            await self.load()
+        if self._entries and self._entries[-1]["input"] == text:
+            return False  # Consecutive duplicate — already recorded.
+
+        entry: HistoryEntry = {"input": text, "timestamp": time.time()}
+        # Optimistic in-memory update (rolled back on write failure) so a
+        # second identical send racing this one hits the dedupe check above.
+        self._entries.append(entry)
+        excess = len(self._entries) - self.max_entries
+        dropped: list[HistoryEntry] = []
+        if excess > 0:
+            dropped = self._entries[:excess]
+            del self._entries[:excess]
+
+        def write_history() -> None:
+            """Write to the JSONL file in a worker thread."""
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            if dropped:
+                # Cap exceeded — rewrite the file with the retained tail.
+                with self.path.open("w", encoding="utf-8") as history_file:
+                    for retained in self._entries:
+                        history_file.write(
+                            f"{json.dumps(retained, ensure_ascii=False)}\n"
+                        )
+            else:
+                with self.path.open("a", encoding="utf-8") as history_file:
+                    history_file.write(f"{json.dumps(entry, ensure_ascii=False)}\n")
+
+        try:
+            await asyncio.to_thread(write_history)
+        except Exception as error:
+            logger.warning(f"Could not write prompt history {self.path}: {error}")
+            if dropped:
+                self._entries = dropped + self._entries
+            try:
+                self._entries.remove(entry)
+            except ValueError:
+                pass
+            return False
+        self._current = None
+        return True
+
+    async def get_entry(self, index: int) -> HistoryEntry:
+        """Get a history entry by shell-style index.
+
+        Args:
+            index: 0 for the live draft pseudo-entry, negative indexes for
+                stored entries (-1 is the most recent).
+
+        Returns:
+            The history entry. Stored entries carry their persisted timestamp;
+            the live draft pseudo-entry reports the current time.
+
+        Raises:
+            IndexError: When the index is out of range.
+        """
+        if index > 0:
+            raise IndexError("History indices must be 0 or negative.")
+        if not self._loaded:
+            await self.load()
+        if index == 0:
+            return {"input": self.current, "timestamp": time.time()}
+        try:
+            return self._entries[index]
+        except IndexError:
+            raise IndexError(f"No history entry at index {index}") from None
+
+    def complete(self, prefix: str) -> str | None:
+        """Return the most recent entry starting with ``prefix``.
+
+        Used for ghost-text suggestions; exact matches are excluded so a fully
+        typed prompt never suggests itself.
+
+        Args:
+            prefix: The current input text.
+
+        Returns:
+            The matching entry, or None when no entry matches.
+        """
+        if not prefix:
+            return None
+        for entry in reversed(self._entries):
+            text = entry["input"]
+            if text.startswith(prefix) and text != prefix:
+                return text
+        return None

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3292,6 +3292,7 @@ class ChatScreen(BaseAppScreen):
         #: silence detection it can't deliver" constraint).
         self._console_hands_free_vad_degraded = False
         self._console_provider_gateway: Any | None = None
+        self._console_prompt_history: Any | None = None
         self._console_chat_controller: ConsoleChatController | None = None
         self._console_command_registry: ConsoleCommandRegistry = (
             default_console_registry()

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -69,6 +69,7 @@ from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ...Chat.chat_persistence_service import ChatPersistenceService
 from ...Chat.citation_trace_repository import ActiveCitationTraceState
 from ...Chat.console_chat_controller import ConsoleChatController
+from ...Chat.prompt_history import PromptHistory, default_prompt_history_path
 from ...Chat.console_cost_tracker import (
     ConsoleCacheState,
     ConsoleCostRowTotals,
@@ -5225,6 +5226,27 @@ class ChatScreen(BaseAppScreen):
             )
         return self._console_provider_gateway
 
+    def _ensure_console_prompt_history(self) -> PromptHistory:
+        """Return the shared JSONL prompt-history store (TASK-1364).
+
+        One instance feeds both the composer (ghost text, Up/Down recall)
+        and the controller (recording accepted sends). Creation is lazy and
+        IO-free -- the store self-loads on first awaited use, and the
+        composer kicks a background `load()` on mount so ghost text works on
+        the first keystroke. `console_prompt_history_factory` on the app is
+        the test seam, mirroring `console_provider_gateway_factory`.
+        """
+        history = getattr(self, "_console_prompt_history", None)
+        if history is None:
+            factory = getattr(self.app_instance, "console_prompt_history_factory", None)
+            history = (
+                factory()
+                if callable(factory)
+                else PromptHistory(default_prompt_history_path())
+            )
+            self._console_prompt_history = history
+        return history
+
     def _ensure_console_chat_controller(self) -> ConsoleChatController:
         """Return the native Console chat controller with fresh selection state."""
         if self._console_chat_controller is None:
@@ -5261,6 +5283,11 @@ class ChatScreen(BaseAppScreen):
             )
         self._console_chat_controller.on_submission_accepted = (
             self._on_console_submission_accepted
+        )
+        # TASK-1364: accepted sends are recorded to the shared prompt
+        # history (inside `submit_draft`, past every block/refusal gate).
+        self._console_chat_controller.prompt_history = (
+            self._ensure_console_prompt_history()
         )
         # MCP batch-approval bridge (task-5): `request_mcp_approvals` runs
         # on the agent bridge's worker thread and needs both a
@@ -16307,6 +16334,10 @@ class ChatScreen(BaseAppScreen):
                 collapse_large_pastes=self._console_collapse_large_pastes_enabled(),
                 paste_collapse_threshold=self._console_paste_collapse_threshold(),
             )
+            # TASK-1364: the composer shares the screen's prompt-history
+            # store with the controller (which records accepted sends) so
+            # ghost text and Up/Down recall see this app's own past prompts.
+            composer.set_prompt_history(self._ensure_console_prompt_history())
             store = self._console_chat_store
             if store is not None and store.active_session_id is not None:
                 try:
@@ -22650,7 +22681,10 @@ class ChatScreen(BaseAppScreen):
             event.prevent_default()
             return
         if event.key == "right":
-            composer.move_cursor_right()
+            # TASK-1364: with a ghost-text suggestion visible (caret at end,
+            # live draft), Right accepts it instead of moving the caret.
+            if not composer.accept_ghost_text():
+                composer.move_cursor_right()
             event.stop()
             event.prevent_default()
             return
@@ -22663,13 +22697,17 @@ class ChatScreen(BaseAppScreen):
         # preserving whatever up/down would otherwise do on this screen
         # (nothing today; a future transcript scroll or default focus
         # behavior must not be silently swallowed by a no-op composer move).
+        # TASK-1364: on exactly those boundary rows, Up/Down first offer
+        # prompt-history recall (the composer gates on first/last visual row
+        # of the wrapped draft); only when recall declines does ordinary
+        # caret movement get its chance.
         if event.key == "up":
-            if composer.move_cursor_up():
+            if composer.recall_history_previous() or composer.move_cursor_up():
                 event.stop()
                 event.prevent_default()
                 return
         if event.key == "down":
-            if composer.move_cursor_down():
+            if composer.recall_history_next() or composer.move_cursor_down():
                 event.stop()
                 event.prevent_default()
                 return

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -2245,6 +2245,9 @@ class ConsoleComposerBar(Horizontal):
             # TASK-1364: warm the history entries so ghost text and recall
             # work on the first keystroke; the file IO itself already runs
             # off the event loop inside `load()`, and the call is idempotent.
+            # Note: recall workers run exclusive=True in this same group and
+            # may cancel this warm load mid-flight — safe because `get_entry`
+            # re-awaits `load()` inline when `_loaded` is still False.
             self.run_worker(
                 self._prompt_history.load(),
                 exclusive=False,

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -52,6 +52,7 @@ from ...Chat.console_voice_input import (
     STATE_LISTENING,
     STATE_PREPARING,
 )
+from ...Chat.prompt_history import PromptHistory
 from ...config import (
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MAX_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
@@ -286,6 +287,9 @@ class ConsoleComposerBar(Horizontal):
     FALLBACK_DRAFT_WIDTH = 80
     PASTE_TOKEN_STYLE = "bold cyan"
     PASTE_CONFIRM_STYLE = "bold black on yellow"
+    #: TASK-1364: ghost-text history suggestions render in the same dim style
+    #: as the empty-draft placeholder -- visibly "not your text yet".
+    GHOST_TEXT_STYLE = "bright_black"
     CURSOR_GLYPH = "▌"  # LEFT HALF BLOCK, terminal-style caret
     CURSOR_BLINK_INTERVAL = 0.53
     #: TASK-1281: max entries kept per undo/redo stack; the oldest entry is
@@ -440,6 +444,15 @@ class ConsoleComposerBar(Horizontal):
         self._draft_selection_range: tuple[int, int] | None = None
         self._cursor_visible = True
         self._cursor_blink_timer: Any | None = None
+        #: TASK-1364: shared JSONL prompt-history store, injected by the
+        #: owning screen (`set_prompt_history`). Drives fish-shell-style
+        #: ghost text (most-recent prefix match) and Up/Down recall. None
+        #: (e.g. a bare composer in unit tests) disables both.
+        self._prompt_history: PromptHistory | None = None
+        #: Shell-style recall index: 0 is the live draft pseudo-entry (whose
+        #: in-progress text is stashed in the history store while
+        #: navigating), negatives walk backwards through stored entries.
+        self._history_index: int = 0
 
     @property
     def collapse_large_pastes_enabled(self) -> bool:
@@ -1802,6 +1815,7 @@ class ConsoleComposerBar(Horizontal):
         focused: bool = False,
         cursor_visible: bool = True,
         cursor_index: int | None = None,
+        ghost_suffix: str = "",
     ) -> Text:
         if text:
             # While focused, exactly one display cell is always reserved at
@@ -1825,14 +1839,32 @@ class ConsoleComposerBar(Horizontal):
                     if cursor_index is None
                     else max(0, min(cursor_index, len(text)))
                 )
+                # TASK-1364: ghost text is render-only -- appended after the
+                # reserved caret cell (only meaningful with the caret at the
+                # draft's end, its sole offer condition) and dimmed so it
+                # never reads as draft content. It shares the draft's wrap
+                # pass; the caret-following window keeps the caret row
+                # visible and any overflow tail is simply cropped, and the
+                # composer's own row-count math (`_visible_draft_row_count`)
+                # never sees it, so a suggestion can never grow the bar.
+                ghost = ghost_suffix if caret_position == len(text) else ""
                 render_text = (
                     f"{text[:caret_position]}{caret_cell}{text[caret_position:]}"
+                    f"{ghost}"
                 )
                 if style_ranges:
                     style_ranges = cls._shift_style_ranges_for_caret(
                         style_ranges,
                         caret_position,
                     )
+                if ghost:
+                    style_ranges = list(style_ranges or []) + [
+                        (
+                            caret_position + 1,
+                            caret_position + 1 + len(ghost),
+                            cls.GHOST_TEXT_STYLE,
+                        )
+                    ]
             else:
                 caret_position = None
                 render_text = text
@@ -2141,6 +2173,11 @@ class ConsoleComposerBar(Horizontal):
                     if focused and self._segments_initialized
                     else None
                 ),
+                # Ghost text only shows while focused (the caret it trails is
+                # focus-only too) and `_ghost_suffix` self-gates on caret-at-
+                # end/selection/live-draft, so this recomputes cleanly on
+                # every blink tick and edit.
+                ghost_suffix=self._ghost_suffix() if focused else "",
             )
         return self._placeholder_renderable(width=width)
 
@@ -2204,6 +2241,16 @@ class ConsoleComposerBar(Horizontal):
         self._refresh_visible_draft()
         self._sync_interaction_classes()
         self._sync_current_action_state()
+        if self._prompt_history is not None:
+            # TASK-1364: warm the history entries so ghost text and recall
+            # work on the first keystroke; the file IO itself already runs
+            # off the event loop inside `load()`, and the call is idempotent.
+            self.run_worker(
+                self._prompt_history.load(),
+                exclusive=False,
+                group="console-prompt-history",
+                exit_on_error=False,
+            )
 
     def on_resize(self, event: Any) -> None:
         self._refresh_visible_draft()
@@ -2379,6 +2426,11 @@ class ConsoleComposerBar(Horizontal):
         self._undo_stack = []
         self._redo_stack = []
         self._coalescing_active = False
+        # TASK-1364: an accepted send also ends any prompt-history
+        # navigation -- the next Up restarts from the live draft (and
+        # `PromptHistory.append` clears the stashed index-0 draft on its
+        # own successful write).
+        self._history_index = 0
 
     # -- Undo/redo history (TASK-1281) ------------------------------------
     #
@@ -3181,6 +3233,172 @@ class ConsoleComposerBar(Horizontal):
         if not self._segments_initialized:
             return self._move_cursor_to(self._cursor_index)
         return self._move_cursor_to(len(self._canonical_draft_text()))
+
+    # -- Prompt history: ghost text and recall (TASK-1364) ------------------
+    #
+    # Port of the toad-inspired input UX (`Chat/prompt_history.py` +
+    # the deprecated `ChatInputTextArea`) onto this composer's segment/caret
+    # model. Ghost text is a render-only suffix appended after the caret in
+    # `_draft_renderable` (never part of the draft); recall swaps the whole
+    # draft via `load_draft`, with the live draft stashed in the history
+    # store's index-0 pseudo-entry while navigating.
+
+    def set_prompt_history(self, history: PromptHistory | None) -> None:
+        """Inject the shared prompt-history store used for ghost text/recall.
+
+        Args:
+            history: The store to read suggestions and recalled entries from,
+                or None to disable both (recall keys fall through to ordinary
+                caret movement).
+        """
+        self._prompt_history = history
+        self._history_index = 0
+
+    def _ghost_suffix(self) -> str:
+        """Return the ghost-text suffix for the current draft, or ``""``.
+
+        Offered only on the live draft (recall index 0) with an empty
+        selection, a non-empty draft, and the caret at the very end of the
+        canonical text. Drafts starting with ``/`` never get a suggestion:
+        the slash-command popup owns completion there. Typing dismisses the
+        ghost implicitly -- it is recomputed from the current draft on every
+        render, so a keystroke that breaks the prefix match simply yields no
+        suffix.
+        """
+        history = self._prompt_history
+        if history is None or self._history_index != 0:
+            return ""
+        if not self._segments_initialized:
+            return ""
+        if self._draft_selection_all or self._draft_selection_range is not None:
+            return ""
+        canonical = self._canonical_draft_text()
+        if not canonical or canonical.startswith("/"):
+            return ""
+        if self._cursor_index != len(canonical):
+            return ""
+        match = history.complete(canonical)
+        if match is None:
+            return ""
+        return match[len(canonical) :]
+
+    def accept_ghost_text(self) -> bool:
+        """Insert the visible ghost-text suffix into the draft (Right arrow).
+
+        Returns:
+            True when a suggestion was accepted (the caller consumes the
+            key); False when none is visible, so Right falls back to ordinary
+            caret movement.
+        """
+        suffix = self._ghost_suffix()
+        if not suffix:
+            return False
+        # The ghost is only offered with the caret at the end, so this
+        # inserts exactly the suggested suffix as ordinary typed text.
+        self.insert_text(suffix)
+        return True
+
+    def _caret_visual_row(self) -> tuple[int, int]:
+        """Return the caret's (visual row index, row count) in the full wrap.
+
+        Uses the same full, unwindowed wrap of the display draft as
+        `_move_cursor_vertically` (never the bounded 4-row painted window).
+        An uninitialized composer tracks the caret at the draft tail (every
+        lazy-init entry point places it there), so it reports the last row.
+        """
+        display_text = self._display_draft_text()
+        line_slices = self._wrap_draft_line_slices(
+            display_text, self._draft_render_width()
+        )
+        if not self._segments_initialized:
+            return len(line_slices) - 1, len(line_slices)
+        caret_display_index = max(
+            0, min(self._cursor_display_index(), len(display_text))
+        )
+        return (
+            self._row_index_for_canonical_offset(line_slices, caret_display_index),
+            len(line_slices),
+        )
+
+    def _can_recall_history(self, direction: int) -> bool:
+        """Return whether an Up/Down keypress should recall history instead of moving the caret.
+
+        Recall is gated to the draft's first (Up/older) or last (Down/newer)
+        visual row of the full wrap, with an empty selection and a loaded,
+        non-empty history; anywhere else the key keeps its ordinary caret
+        movement. Down only recalls while actually navigating (index < 0) --
+        at the live draft there is nothing newer, so it always falls through.
+        """
+        history = self._prompt_history
+        if history is None or history.size == 0:
+            return False
+        if direction > 0 and self._history_index >= 0:
+            return False
+        if self._draft_selection_all or self._draft_selection_range is not None:
+            return False
+        row, row_count = self._caret_visual_row()
+        if direction < 0:
+            return row == 0
+        return row == row_count - 1
+
+    def recall_history_previous(self) -> bool:
+        """Consume an Up keypress as older-history recall when gated in.
+
+        Returns:
+            True when recall was triggered (the caller consumes the key);
+            False when the key should fall through to `move_cursor_up`.
+        """
+        if not self._can_recall_history(-1):
+            return False
+        self.run_worker(
+            self._move_history(-1),
+            exclusive=True,
+            group="console-prompt-history",
+            exit_on_error=False,
+        )
+        return True
+
+    def recall_history_next(self) -> bool:
+        """Consume a Down keypress as newer-history recall when gated in.
+
+        Returns:
+            True when recall was triggered (the caller consumes the key);
+            False when the key should fall through to `move_cursor_down`.
+        """
+        if not self._can_recall_history(1):
+            return False
+        self.run_worker(
+            self._move_history(1),
+            exclusive=True,
+            group="console-prompt-history",
+            exit_on_error=False,
+        )
+        return True
+
+    async def _move_history(self, direction: int) -> None:
+        """Move through prompt history, stashing/restoring the live draft.
+
+        Args:
+            direction: -1 for older entries (Up), +1 for newer (Down).
+        """
+        history = self._prompt_history
+        if history is None:
+            return
+        if self._history_index == 0 and direction < 0:
+            # Leaving the live draft -- stash the in-progress text so recall
+            # never loses it (restored when navigation returns to index 0).
+            history.stash_draft(self.draft_text())
+        new_index = history.clamp_index(self._history_index + direction)
+        if new_index == self._history_index:
+            return
+        try:
+            entry = await history.get_entry(new_index)
+        except IndexError:
+            return
+        self._history_index = new_index
+        # A scope swap, not a recorded edit (mirrors session-switch draft
+        # loads): wipes undo/redo and lands the caret at the end.
+        self.load_draft(entry["input"])
 
     def position_cursor_from_display_index(self, display_index: int) -> bool:
         """Set the caret from an unwrapped display-string offset (click-to-position).

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1025,11 +1025,21 @@ class ConsoleTranscript(VerticalScroll):
         total_height = self.virtual_size.height
         if total_height <= high_mark:
             return
-        prune_ids, _estimated_height = self._compute_prunable_prefix(
+        prune_ids, estimated_height = self._compute_prunable_prefix(
             total_height, low_mark
         )
         if not prune_ids:
+            if total_height > high_mark:
+                logger.debug(
+                    "Console transcript over high watermark "
+                    f"({total_height} > {high_mark}) but no prunable prefix: "
+                    "a protected or non-message row is blocking the walk"
+                )
             return
+        logger.debug(
+            f"Pruning {len(prune_ids)} console transcript messages "
+            f"(estimated height {estimated_height})"
+        )
         following = self._is_following_tail()
         anchor_y = self.scroll_y
         self._pruned_message_ids.update(prune_ids)

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -18,6 +18,7 @@ from textual.content import Content
 from textual.css.query import NoMatches
 from textual.dom import NoScreen
 from textual.events import Click, Key
+from textual.message_pump import NoActiveAppError
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -51,6 +52,12 @@ from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 CONSOLE_TRANSCRIPT_RULE = "─" * 200
 CONSOLE_GENERATING_PLACEHOLDER = "Generating…"
+#: TASK-1365: virtual-height watermarks (terminal rows) for transcript pruning.
+#: 20000 rows is several hundred long messages; rows are cheap to measure but
+#: expensive to keep laid out. Mirrored from the legacy chat log pruning
+#: (``UI/Chat_Modules/chat_log_pruning.py`` on feat/toad-ui-improvements).
+DEFAULT_PRUNE_HIGH_WATERMARK = 20000
+DEFAULT_PRUNE_LOW_WATERMARK = 12000
 #: SP2 /rewind: render-derived (never a tree node) one-line banner shown above
 #: the boundary message when "summarize up to here" is in effect.
 CONSOLE_SUMMARY_BANNER_COPY = (
@@ -99,6 +106,43 @@ def _coerce_card_state(value: object) -> ConsoleSetupCardState:
     if isinstance(value, ConsoleSetupCardState):
         return value
     return ConsoleSetupCardState(mode="quiet", body_copy=CONSOLE_QUIET_EMPTY_COPY)
+
+
+def _coerce_prune_int(value: object, default: int) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def get_console_prune_watermarks(
+    app_config: Mapping[str, object] | None,
+) -> tuple[int, int]:
+    """Resolve ``(low_mark, high_mark)`` pruning watermarks from config.
+
+    Reads ``[chat_defaults] prune_high_watermark`` / ``prune_low_watermark``,
+    falling back to :data:`DEFAULT_PRUNE_HIGH_WATERMARK` /
+    :data:`DEFAULT_PRUNE_LOW_WATERMARK` when missing or invalid, and clamps
+    ``low <= high``. A ``high_mark <= 0`` disables pruning.
+
+    Args:
+        app_config: The loaded application config dict (``app.app_config``).
+
+    Returns:
+        Tuple of ``(low_mark, high_mark)`` in virtual rows.
+    """
+    chat_defaults = (app_config or {}).get("chat_defaults", {})
+    if not isinstance(chat_defaults, Mapping):
+        chat_defaults = {}
+    high = _coerce_prune_int(
+        chat_defaults.get("prune_high_watermark"), DEFAULT_PRUNE_HIGH_WATERMARK
+    )
+    low = _coerce_prune_int(
+        chat_defaults.get("prune_low_watermark"), DEFAULT_PRUNE_LOW_WATERMARK
+    )
+    if low > high:
+        low = high
+    return low, high
 
 
 def _message_role_label(message: ConsoleChatMessage) -> str:
@@ -666,6 +710,13 @@ class ConsoleTranscript(VerticalScroll):
         #: Last-applied (visible, text) pill state; lets the 0.2s streaming sync
         #: tick skip the query_one + update when nothing changed (Qodo #826).
         self._jump_pill_state: tuple[bool, str] | None = None
+        #: TASK-1365: view-only prune window. Ids of the oldest messages whose
+        #: rows were dropped after the virtual height crossed the high
+        #: watermark. The store keeps the full history; ``_transcript_rows``
+        #: filters these ids, so a refresh or recompose never resurrects them
+        #: and the reconciliation stale-key path owns their removal.
+        self._pruned_message_ids: set[str] = set()
+        self._prune_check_scheduled = False
 
     def on_mount(self) -> None:
         """Engage tail-follow: stay scrolled to the newest content.
@@ -676,6 +727,9 @@ class ConsoleTranscript(VerticalScroll):
         viewport used to finish below the fold with no scroll).
         """
         self.anchor()
+        # TASK-1365: a transcript composed with a preloaded (resumed) history
+        # can already exceed the watermarks before any refresh_messages call.
+        self._schedule_prune_check()
 
     def compose(self) -> ComposeResult:
         self._row_widgets.clear()
@@ -805,6 +859,9 @@ class ConsoleTranscript(VerticalScroll):
         # set grows for the life of the widget and a recycled id would come
         # back already expanded.
         self._expanded_tool_output_ids &= message_ids
+        # TASK-1365: same lifecycle for the prune window -- a session switch
+        # re-renders from scratch, and a deleted message must not linger here.
+        self._pruned_message_ids &= message_ids
         new_user_send = any(
             message.id not in self._seen_message_ids
             and message.role == ConsoleMessageRole.USER
@@ -929,6 +986,153 @@ class ConsoleTranscript(VerticalScroll):
         """Reconcile mounted message rows from the current transcript state."""
         async with self._refresh_lock:
             await self._reconcile_rows(self._transcript_rows())
+        self._schedule_prune_check()
+
+    def _schedule_prune_check(self) -> None:
+        """Run one watermark pruning check after the pending refresh settles.
+
+        Heights are only meaningful once layout has run, so the check is
+        deferred with ``call_after_refresh`` rather than firing on a timer or
+        mid-reconcile. Coalesced: at most one check is ever queued.
+        """
+        if self._prune_check_scheduled or not self.is_mounted:
+            return
+        self._prune_check_scheduled = True
+        self.call_after_refresh(self._run_prune_check)
+
+    def _prune_watermarks(self) -> tuple[int, int]:
+        """Return the configured ``(low_mark, high_mark)`` for this transcript."""
+        try:
+            app_config = getattr(self.app, "app_config", None)
+        except NoActiveAppError:
+            app_config = None
+        return get_console_prune_watermarks(app_config)
+
+    async def _run_prune_check(self) -> None:
+        """Drop the oldest message rows when virtual height exceeds the marks.
+
+        View-only: ids are added to ``_pruned_message_ids`` and the regular
+        reconciliation pass removes the now-undesired rows, so the store and
+        ``_messages`` keep the full history. The scroll position is preserved
+        for a scrolled-up reader and re-anchored when following the tail.
+        """
+        self._prune_check_scheduled = False
+        if not self.is_mounted:
+            return
+        low_mark, high_mark = self._prune_watermarks()
+        if high_mark <= 0:
+            return
+        total_height = self.virtual_size.height
+        if total_height <= high_mark:
+            return
+        prune_ids, _estimated_height = self._compute_prunable_prefix(
+            total_height, low_mark
+        )
+        if not prune_ids:
+            return
+        following = self._is_following_tail()
+        anchor_y = self.scroll_y
+        self._pruned_message_ids.update(prune_ids)
+        logger.info(
+            f"Pruned {len(prune_ids)} oldest Console transcript message(s) "
+            f"(virtual height {total_height} over high mark {high_mark})"
+        )
+        async with self._refresh_lock:
+            await self._reconcile_rows(self._transcript_rows())
+
+        def _restore_scroll() -> None:
+            if not self.is_mounted:
+                return
+            if following:
+                self.anchor()
+                self.scroll_end(animate=False)
+            else:
+                # Keep the same content in view: shift the offset up by the
+                # height actually removed (measured, not estimated).
+                removed = total_height - self.virtual_size.height
+                self.scroll_to(y=max(0.0, anchor_y - removed), animate=False)
+
+        self.call_after_refresh(_restore_scroll)
+
+    def _compute_prunable_prefix(
+        self, total_height: int, low_mark: int
+    ) -> tuple[list[str], int]:
+        """Walk mounted rows top-down and pick oldest whole messages to drop.
+
+        Rows of one message (rule, body, citations, image, actions, ...) are
+        contiguous, so they are committed as a group: a message is either
+        fully pruned or fully kept. The walk stops at the first protected
+        group (the in-progress streaming message or the selected message) or
+        when dropping another group would push the remaining height below
+        ``low_mark`` -- pruning is a prefix removal that errs on keeping
+        content. Margin-collapse math mirrors the legacy chat-log pruning.
+
+        Args:
+            total_height: Current virtual height of the transcript.
+            low_mark: Target remaining height after pruning.
+
+        Returns:
+            Tuple of ``(message_ids, prune_height)``.
+        """
+        key_by_widget_id = {
+            id(widget): key for key, widget in self._row_widgets.items()
+        }
+        message_ids = {message.id for message in self._messages}
+        protected_ids = {
+            message.id for message in self._messages if message.status == "streaming"
+        }
+        if self.selected_message_id is not None:
+            protected_ids.add(self.selected_message_id)
+
+        prune_ids: list[str] = []
+        prune_height = 0
+        bottom_margin = 0
+        group_id: str | None = None
+        group_height = 0
+        group_margin = 0
+
+        def _try_close_group() -> bool:
+            """Commit the finished group, or return False to stop the walk."""
+            nonlocal prune_height, bottom_margin
+            if group_id is None or group_id in protected_ids:
+                return False
+            if total_height - group_height <= low_mark:
+                return False
+            prune_height = group_height
+            bottom_margin = group_margin
+            prune_ids.append(group_id)
+            return True
+
+        for child in self.children:
+            key = key_by_widget_id.get(id(child))
+            row_message_id: str | None = None
+            if key is not None and ":" in key:
+                candidate = key.split(":", 1)[1]
+                if candidate in message_ids:
+                    row_message_id = candidate
+            if row_message_id is None:
+                # The trailing end-rule, the empty panel, or the docked jump
+                # pill: nothing prunable lives past a non-message row.
+                break
+            if row_message_id != group_id:
+                if group_id is not None and not _try_close_group():
+                    break
+                group_id = row_message_id
+                group_height = prune_height
+                group_margin = bottom_margin
+            if not child.display:
+                # Hidden rows take no space; the group decision covers them.
+                continue
+            top, _, bottom, _ = child.styles.margin
+            group_height = (
+                (group_height - group_margin + max(group_margin, top))
+                + bottom
+                + child.outer_size.height
+            )
+            group_margin = bottom
+        if group_id is not None:
+            _try_close_group()
+        return prune_ids, prune_height
 
     def row_build_counts(self) -> dict[str, int]:
         """Return row build counts for focused reconciliation tests."""
@@ -1057,8 +1261,9 @@ class ConsoleTranscript(VerticalScroll):
         if self.selected_message_id is not None:
             self.toggle_message_selection(self.selected_message_id)
             return
-        if self._messages:
-            self.select_message(self._messages[0].id)
+        visible = self._visible_messages()
+        if visible:
+            self.select_message(visible[0].id)
 
     def action_clear_selection(self) -> None:
         self.selected_message_id = None
@@ -1194,26 +1399,41 @@ class ConsoleTranscript(VerticalScroll):
             event.stop()
 
     def _select_relative(self, offset: int) -> None:
-        if not self._messages:
+        visible = self._visible_messages()
+        if not visible:
             return
         if self.selected_message_id is None:
-            index = 0 if offset >= 0 else len(self._messages) - 1
+            index = 0 if offset >= 0 else len(visible) - 1
         else:
             current = next(
                 (
                     index
-                    for index, message in enumerate(self._messages)
+                    for index, message in enumerate(visible)
                     if message.id == self.selected_message_id
                 ),
                 0,
             )
-            index = min(max(current + offset, 0), len(self._messages) - 1)
-        self.select_message(self._messages[index].id)
+            index = min(max(current + offset, 0), len(visible) - 1)
+        self.select_message(visible[index].id)
 
     def _message_by_id(self, message_id: str) -> ConsoleChatMessage | None:
         return next(
             (message for message in self._messages if message.id == message_id), None
         )
+
+    def _visible_messages(self) -> list[ConsoleChatMessage]:
+        """Return the messages with rendered rows (excludes the pruned window).
+
+        Keyboard selection walks this list so j/k never lands on a pruned
+        (row-less) message; the store-facing ``_messages`` keeps full history.
+        """
+        if not self._pruned_message_ids:
+            return self._messages
+        return [
+            message
+            for message in self._messages
+            if message.id not in self._pruned_message_ids
+        ]
 
     def _notify_selection_changed(self) -> None:
         """Let the owning screen refresh inspector/control surfaces after selection changes."""
@@ -1226,6 +1446,10 @@ class ConsoleTranscript(VerticalScroll):
     def _transcript_rows(self) -> list[_TranscriptRow]:
         rows: list[_TranscriptRow] = []
         for message in self._messages:
+            if message.id in self._pruned_message_ids:
+                # TASK-1365: pruned by the height watermarks; the store keeps
+                # the message, the view window drops every row derived from it.
+                continue
             message = self._with_expanded_tool_output(message)
             selected = message.id == self.selected_message_id
             rows.append(

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -47,6 +47,7 @@ from tldw_chatbook.Widgets.Console.console_generation_card import (
     ConsoleGenerationCardSpec,
     generation_card_signature,
 )
+from tldw_chatbook.Widgets.diff_widgets import make_diff
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 
@@ -395,6 +396,7 @@ class _TranscriptRow:
         "rule",
         "banner",
         "message",
+        "diff",
         "citations",
         "original-attempt",
         "image",
@@ -453,6 +455,53 @@ class ConsoleTranscriptMessage(Static):
             transcript = transcript.parent
         if isinstance(transcript, ConsoleTranscript):
             transcript.toggle_message_selection(self.message_id)
+
+
+class ConsoleToolDiffRow(Vertical):
+    """Inline diff row under an expanded file-write TOOL marker (TASK-1366).
+
+    Mounts empty and fills in asynchronously: the diff is computed off the
+    UI thread (``DiffView.prepare``) BEFORE the DiffView mounts, mirroring
+    ``tool_message_widgets.ToolExecutionWidget``'s integration. The row is
+    render-derived view state -- it exists only while its marker message is
+    expanded via the full-output toggle, and disappears with it (or when
+    the message leaves the view window).
+    """
+
+    can_focus = False
+
+    def __init__(self, message_id: str, diff: tuple[str, str, str]) -> None:
+        self.message_id = message_id
+        self._diff = diff
+        super().__init__(
+            id=f"console-tool-diff-{message_id}",
+            classes="console-transcript-tool-diff",
+        )
+
+    def on_mount(self) -> None:
+        path, old_content, new_content = self._diff
+        self.run_worker(
+            self._prepare_and_mount(path, old_content, new_content),
+            thread=False,
+            group="console-tool-diff-mount",
+        )
+
+    async def _prepare_and_mount(
+        self, path: str, old_content: str, new_content: str
+    ) -> None:
+        """Prepare the diff off the UI thread, then mount the DiffView."""
+        try:
+            diff_view = make_diff(path, old_content, new_content)
+            await diff_view.prepare()
+            if not self.is_mounted:
+                # Row was unmounted (collapse/prune/session swap) while the
+                # diff prepared off-thread.
+                return
+            await self.mount(diff_view)
+        except Exception as exc:  # noqa: BLE001 — a render failure never breaks the transcript
+            logger.opt(exception=True).error(
+                f"Failed to render console tool diff for {path}: {exc}"
+            )
 
 
 class ConsoleTranscriptActionButton(Button):
@@ -1490,6 +1539,23 @@ class ConsoleTranscript(VerticalScroll):
                     selected=selected,
                 )
             )
+            if (
+                message.id in self._expanded_tool_output_ids
+                and message.tool_diff is not None
+            ):
+                # TASK-1366: inline diff row for a file-write marker,
+                # directly under its message row so it stays inside the
+                # message group (pruning drops every row derived from a
+                # pruned message id at the top of this loop). Signature is
+                # stable: a marker's tool_diff is fixed at append time.
+                rows.append(
+                    _TranscriptRow(
+                        key=f"diff:{message.id}",
+                        kind="diff",
+                        signature=("diff", message.id),
+                        message=message,
+                    )
+                )
             citation_count = self._citation_counts.get(message.id, 0)
             if citation_count > 0:
                 rows.append(
@@ -1696,6 +1762,12 @@ class ConsoleTranscript(VerticalScroll):
             )
         if row.kind == "message" and row.message is not None:
             return ConsoleTranscriptMessage(row.message, selected=row.selected)
+        if (
+            row.kind == "diff"
+            and row.message is not None
+            and row.message.tool_diff is not None
+        ):
+            return ConsoleToolDiffRow(row.message.id, row.message.tool_diff)
         if row.kind == "citations" and row.message is not None:
             button = Button(
                 row.renderable,

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2870,6 +2870,15 @@ min_p = 0.05
 top_k = 50
 strip_thinking_tags = true
 
+# Console transcript view pruning: when the transcript's virtual height (in
+# terminal rows) exceeds prune_high_watermark, the oldest message rows are
+# dropped from the view until the remaining height fits under
+# prune_low_watermark. Scroll position is preserved, the in-progress
+# streaming row is never pruned, and the store keeps the full history
+# (pruning is view-only). Set prune_high_watermark <= 0 to disable pruning.
+prune_high_watermark = 20000
+prune_low_watermark = 12000
+
 # Image attachment settings for chat
 [chat.images]
 enabled = true

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3182,6 +3182,14 @@ with stray left-edge border fragments), and padding 0 1 so the full
     text-style: italic;
 }
 
+/* TASK-1366: inline diff row under an expanded file-write TOOL marker.
+   Indented to read as belonging to the marker above it; height stays
+   auto so the mounted DiffView sizes itself. */
+.console-transcript-tool-diff {
+    height: auto;
+    padding: 0 0 0 4;
+}
+
 .console-transcript-message-system {
     color: $ds-text-muted;
 }

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -5010,6 +5010,14 @@ with stray left-edge border fragments), and padding 0 1 so the full
     text-style: italic;
 }
 
+/* TASK-1366: inline diff row under an expanded file-write TOOL marker.
+   Indented to read as belonging to the marker above it; height stays
+   auto so the mounted DiffView sizes itself. */
+.console-transcript-tool-diff {
+    height: auto;
+    padding: 0 0 0 4;
+}
+
 .console-transcript-message-system {
     color: $ds-text-muted;
 }


### PR DESCRIPTION
## Summary

Console-native port of the toad-inspired UX work (study: `backlog/docs/toad-tui-improvement-study.md`), following PR #1359 which landed the surface-independent foundations. The Console is the only live chat UI; the legacy surface this UX was first built on has been removed from dev.

**Landed so far (TASK-1364):**
- `Chat/prompt_history.py`: shared JSONL prompt history (async IO, index-0-as-draft, 1000-entry cap, real timestamps) — ported from the earlier branch.
- Composer ghost text: dimmed suffix rendered in the composer's own render pass (render-only, height-invisible), most-recent-wins from history, right-arrow accepts; suppressed while the slash-command popup owns the draft.
- History recall: Up/Down gated to first/last visual row using the composer's real wrap math; live draft stashed/restored; caret to end on recall.
- Send recording at `submit_draft`'s accepted point (blocked/refused/empty sends record nothing); shared instance owned by ChatScreen with a factory test seam.

**Still to land on this branch:** TASK-1365 (transcript pruning), TASK-1366 (tool-call diff rows).

## Test plan

- [x] 46 new tests (22 composer history + 24 prompt history) — pass
- [x] Existing composer/controller/paste suites — 301 passed (test_console_command_composer, cursor, collapse, popup, chat_controller, paste_attach)
- [x] Two-stage review (spec + quality) passed; quality-review nits applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports console prompt history UX (TASK-1364) and adds height-based transcript pruning (TASK-1365) to keep long sessions responsive. Adds inline diffs for file-write tool markers (TASK-1366) with safe capture and session‑only display.

- **New Features**
  - PromptHistory: JSONL async store (1000 cap), real timestamps, consecutive-duplicate skip, most‑recent prefix complete() for ghost text.
  - Composer: ghost text (dimmed, caret at end, not for “/”; Right arrow accepts) and Up/Down recall gated to first/last visual row; stashes index 0; caret lands at end. Controller records only accepted sends; Screen owns a shared PromptHistory; composer warm‑loads; test seam via console_prompt_history_factory.
  - Transcript pruning: when virtual height > prune_high_watermark, drop oldest message groups until under prune_low_watermark. View‑only (store keeps full history), streaming/selected protected, scroll preserved or re‑anchored at tail; checks after refresh and at mount; high<=0 disables. Keyboard selection walks visible messages. Defaults in config: 20000/12000.
  - Tool diffs: file‑write results capture raw before/after at the provider strip seam via a diff_sink, paired with STEP_TOOL_RESULT, and attached as session‑only tool_diff (never persisted or sent to the model). Transcript renders an expandable inline `DiffView` row under the TOOL marker; shows a “Diff” expansion when no hidden full text; styled via `.console-transcript-tool-diff`.

- **Bug Fixes**
  - Diff‑only TOOL markers now offer the expansion affordance labeled “Diff”.
  - Diff pairing hardened for abandoned tool threads: pair by most‑recent matching tool name and drop stale captures; strip guarantee unchanged.
  - PromptHistory.append is serialized (asyncio.Lock) to prevent concurrent appends from interleaving with cap rewrites.

<sup>Written for commit b39b2f5a7e44127a88f0b4eea932e5e7d5c3aee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

