### PR TITLE
fix: legacy web_search_tool snippet-key fallback (task-1341)

### DIFF
--- a/Tests/Tools/test_web_search_tool.py
+++ b/Tests/Tools/test_web_search_tool.py
@@ -1,0 +1,41 @@
+"""Regression tests for legacy WebSearchTool result mapping (task-1341)."""
+
+from tldw_chatbook.Tools.web_search_tool import WebSearchTool
+
+
+def _real_payload():
+    """The shape perform_websearch actually returns (WebSearch_APIs.py:
+    process_web_search_results): body text is top-level `content`;
+    `snippet` exists only inside `metadata`."""
+    return {
+        "results": [
+            {
+                "title": "Result 1",
+                "url": "https://example.com/1",
+                "content": "the actual body text",
+                "metadata": {"snippet": "raw engine snippet"},
+            },
+            {
+                "title": "Result 2",
+                "url": "https://example.com/2",
+                "content": "body two",
+                "metadata": {},
+            },
+        ]
+    }
+
+
+def test_snippet_falls_back_to_content(monkeypatch):
+    tool = WebSearchTool()
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.web_search_tool.perform_websearch",
+        lambda *a, **k: _real_payload(),
+    )
+    import asyncio
+
+    out = asyncio.run(tool.execute(query="test"))
+    snippets = [r["snippet"] for r in out["results"]]
+    # Top-level `snippet` is absent in the real payload shape, so both
+    # results fall back to `content` (previously: always "No description
+    # available").
+    assert snippets == ["the actual body text", "body two"]

--- a/Tests/Tools/test_web_search_tool.py
+++ b/Tests/Tools/test_web_search_tool.py
@@ -1,5 +1,7 @@
 """Regression tests for legacy WebSearchTool result mapping (task-1341)."""
 
+import pytest
+
 from tldw_chatbook.Tools.web_search_tool import WebSearchTool
 
 
@@ -25,7 +27,8 @@ def _real_payload():
     }
 
 
-def test_snippet_falls_back_to_content(monkeypatch):
+def test_snippet_falls_back_to_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Snippet mapping prefers `snippet`, then `content`, then the placeholder."""
     tool = WebSearchTool()
     monkeypatch.setattr(
         "tldw_chatbook.Tools.web_search_tool.perform_websearch",
@@ -39,3 +42,17 @@ def test_snippet_falls_back_to_content(monkeypatch):
     # results fall back to `content` (previously: always "No description
     # available").
     assert snippets == ["the actual body text", "body two"]
+
+
+def test_empty_content_falls_through_to_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty-string content must not become a blank snippet."""
+    tool = WebSearchTool()
+    payload = {"results": [{"title": "T", "url": "https://x/", "content": ""}]}
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.web_search_tool.perform_websearch",
+        lambda *a, **k: payload,
+    )
+    import asyncio
+
+    out = asyncio.run(tool.execute(query="test"))
+    assert out["results"][0]["snippet"] == "No description available"

--- a/tldw_chatbook/Tools/web_search_tool.py
+++ b/tldw_chatbook/Tools/web_search_tool.py
@@ -110,7 +110,7 @@ class WebSearchTool(Tool):
                         "position": i + 1,
                         "title": result.get("title", "No title"),
                         "url": result.get("url", ""),
-                        "snippet": result.get("snippet", "No description available"),
+                        "snippet": result.get("snippet") or result.get("content", "No description available"),
                     }
                     formatted_results.append(formatted_result)
 

--- a/tldw_chatbook/Tools/web_search_tool.py
+++ b/tldw_chatbook/Tools/web_search_tool.py
@@ -110,7 +110,7 @@ class WebSearchTool(Tool):
                         "position": i + 1,
                         "title": result.get("title", "No title"),
                         "url": result.get("url", ""),
-                        "snippet": result.get("snippet") or result.get("content", "No description available"),
+                        "snippet": result.get("snippet") or result.get("content") or "No description available",
                     }
                     formatted_results.append(formatted_result)
 


### PR DESCRIPTION
One-line fix: the legacy `WebSearchTool` read a top-level `snippet` key that `perform_websearch`'s normalization never produces (body text is top-level `content`; `snippet` lives under `metadata`), so every real result rendered "No description available". Falls back to `content` now, with a regression test pinning the real payload shape.

Found during the phase-3a review of the new web_search core (which carries the same fix); filed as task-1341.

- [x] Tests: new Tests/Tools/test_web_search_tool.py pins the normalized shape; Tests/Tools 131 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the legacy `WebSearchTool` to prefer `snippet`, then fall back to `content`, otherwise show "No description available", matching the `perform_websearch` payload. Adds regression tests that pin this shape and verify empty `content` falls through to the placeholder; satisfies task-1341.

<sup>Written for commit 42d465776d2bc9c2d9a06ba1e12919a144292244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

