### PR TITLE
chore: close task-1341, file FastMCP smoke task-2511

### DIFF
--- a/backlog/tasks/task-1341 - Legacy-web_search_tool-snippet-key-bug.md
+++ b/backlog/tasks/task-1341 - Legacy-web_search_tool-snippet-key-bug.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-1341
 title: Legacy web_search_tool snippet-key bug
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-05 16:47'
 labels: []
@@ -16,5 +16,9 @@ Found during task-1340 review: Tools/web_search_tool.py:113 reads item.get('snip
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Legacy web_search_tool renders result body text from real perform_websearch payloads,Tests pin the real normalized shape
+- [x] #1 Legacy web_search_tool renders result body text from real perform_websearch payloads,Tests pin the real normalized shape
 <!-- AC:END -->
+
+## Implementation Notes
+
+Fixed in PR #1364 (merged to dev): `Tools/web_search_tool.py` snippet mapping now falls back `snippet` → `content` → "No description available" (empty-string `content` falls through too, per Qodo review). Regression tests in `Tests/Tools/test_web_search_tool.py` pin the real normalized payload shape and the empty-content case.

--- a/backlog/tasks/task-2511 - Smoke-test-FastMCP-local-tool-binding-with-the-mcp-extra.md
+++ b/backlog/tasks/task-2511 - Smoke-test-FastMCP-local-tool-binding-with-the-mcp-extra.md
@@ -1,0 +1,20 @@
+---
+id: TASK-2511
+title: Smoke-test FastMCP local-tool binding with the mcp extra
+status: To Do
+assignee: []
+created_date: '2026-08-06 07:12'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase-4 follow-up (task-1345 notes): the FastMCP binding path in MCP/server.py::_register_local_agent_tools has never executed in CI because the mcp package isn't in the repo venv (binding tests skip). Do a one-time manual smoke run in a throwaway venv with the [mcp] extra: start the server with [mcp] expose_local_tools=true, list tools, call fs_read (granted) and fs_write (refused). Note: binding tests use the FastMCP-1.x mcp._tool_manager API — FastMCP 2.x made list_tools async; tests may need updating then.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Server starts with expose_local_tools=true and lists the local tools,fs_read callable after grant, fs_write refused with EXTERNAL_NO_CALLBACK_REFUSAL,Findings recorded (including any FastMCP 2.x API drift)
+<!-- AC:END -->


### PR DESCRIPTION
Bookkeeping after #1363/#1364: closes task-1341 (legacy snippet fix merged in #1364) with implementation notes, and files task-2511 for the FastMCP binding smoke run deferred from phase 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes task-1341 by marking the legacy web_search_tool snippet-key bug as fixed and adding implementation notes from #1364 (fallback snippet → content → placeholder mapping, tests added). Adds task-2511 to smoke-test the FastMCP local-tool binding with the `mcp` extra: start with expose_local_tools=true, list tools, verify `fs_read` works after grant and `fs_write` is refused.

<sup>Written for commit 3681e5522d899ce57cb9f28d6a9e3753ec32b99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

