### PR TITLE
fix(realtime): explain the empty voice-transcript row; bill realtime audio in the cost chip (tasks 2391 + 2390)

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1889,6 +1889,26 @@ def test_image_budget_excludes_failed_send_blocked_echo(monkeypatch):
     assert decoded == b"real"
 
 
+def test_is_empty_transcript_row_tolerates_a_metadata_object_without_the_attribute():
+    """Qodo Q5 (task-2391 review): the docstring promised duck-typed safety
+    via `getattr` on `.metadata`, but the INNER `.transcript_status` read
+    was a plain attribute access -- a metadata object that duck-types some
+    fields but not that one raised `AttributeError` there. This helper runs
+    on every row of three model-facing send paths (`_provider_message_
+    payloads`, `summarize_up_to`, `impersonate_user_reply`), so that crash
+    reached the main send path, not just a narrow test double."""
+    from tldw_chatbook.Chat.console_chat_controller import _is_empty_transcript_row
+
+    message = SimpleNamespace(
+        role=ConsoleMessageRole.USER,
+        content="hello",
+        status="complete",
+        metadata=SimpleNamespace(engine="realtime"),  # no transcript_status
+    )
+
+    assert _is_empty_transcript_row(message) is False
+
+
 def test_provider_payloads_exclude_an_empty_transcript_placeholder():
     """task-2391 fix-now: a committed voice turn whose transcript came back
     empty persists real placeholder CONTENT ("(no speech detected)") so the

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1889,6 +1889,92 @@ def test_image_budget_excludes_failed_send_blocked_echo(monkeypatch):
     assert decoded == b"real"
 
 
+def test_provider_payloads_exclude_an_empty_transcript_placeholder():
+    """task-2391 fix-now: a committed voice turn whose transcript came back
+    empty persists real placeholder CONTENT ("(no speech detected)") so the
+    row can survive a restart -- but that content is UI chrome written so
+    the row could exist at all, not something the user said, and must
+    never reach a provider as if it were a real turn. Before this fix,
+    `_provider_message_payloads` had no `transcript_status` awareness, so
+    the placeholder rode straight through `_emit` into `{"role": "user",
+    "content": "(no speech detected)"}` on every ordinary send/retry/edit/
+    fork built off this session (`_provider_messages_for_session` backs all
+    of them) -- a fabricated user turn, permanently, for the life of the
+    conversation. An ordinary user row in the same session must still ride
+    through untouched."""
+    from tldw_chatbook.Chat.message_metadata import MessageMetadata
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+    )
+
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=StreamingGateway(), model="test-model"
+    )
+    session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content=CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+        metadata=MessageMetadata(engine="realtime", transcript_status="empty"),
+    )
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="a real question",
+    )
+
+    messages = store.messages_for_session(session.id)
+    payloads = controller._provider_message_payloads(messages, skip_failed=True)
+
+    contents = [payload["content"] for payload in payloads]
+    assert CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER not in contents, (
+        "the empty-transcript placeholder must never be narrated to the "
+        "model as if the user said it"
+    )
+    assert "a real question" in contents
+
+
+@pytest.mark.asyncio
+async def test_impersonate_excludes_an_empty_transcript_placeholder():
+    """task-2391 fix-now (audit follow-up): `impersonate_user_reply` hand-
+    rolls its own transcript builder rather than reusing
+    `_provider_message_payloads` (its own comment says "mirror ... rules
+    exactly"), so the payload fix alone did not cover it. This prompt
+    explicitly asks the model to draft the user's NEXT message "in their
+    voice" from this exact transcript -- a fabricated empty-transcript
+    placeholder here is arguably worse than in the ordinary send path."""
+    from tldw_chatbook.Chat.message_metadata import MessageMetadata
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+    )
+
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=gateway, model="test-model"
+    )
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hello")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content=CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+        metadata=MessageMetadata(engine="realtime", transcript_status="empty"),
+    )
+    store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="hi there"
+    )
+
+    await controller.impersonate_user_reply(session.id)
+
+    assert gateway.messages_seen is not None, "the completion must still run"
+    blob = " ".join(str(m["content"]) for m in gateway.messages_seen)
+    assert CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER not in blob
+    assert "hello" in blob
+    assert "hi there" in blob
+
+
 def test_image_budget_counts_images_newest_first(monkeypatch):
     monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: True)
     monkeypatch.setattr(controller_module, "max_history_images", lambda p, m: 3)

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -3081,8 +3081,11 @@ def test_an_empty_transcript_placeholder_persists_through_the_deferred_create():
     a follow-up metadata-only patch (mirroring the "final" case's own
     two-step order: content write, then status write) marks it "empty"."""
     from tldw_chatbook.Chat.message_metadata import MessageMetadata
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+    )
 
-    placeholder = "(no speech detected)"
+    placeholder = CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
     persistence = RecordingPersistence()
     store = ConsoleChatStore(persistence=persistence)
     session = store.ensure_session(title="Chat 1")
@@ -3106,6 +3109,63 @@ def test_an_empty_transcript_placeholder_persists_through_the_deferred_create():
         MessageMetadata(engine="realtime", transcript_status="empty"),
     )
     assert '"transcript_status": "empty"' in persistence.updated[-1]["metadata_json"]
+
+
+def test_empty_transcript_placeholder_reaches_a_real_db_through_the_deferred_create():
+    """Qodo Q2 (task-2391 review): the sibling test above proves WHICH
+    persistence calls happen and with what kwargs via `RecordingPersistence`
+    -- this file's established seam for that class of claim (see also its
+    own direct precedent, `test_set_message_metadata_on_an_unpersisted_row_
+    rides_the_later_create`, and the file-wide count: 9 `RecordingPersistence`
+    call-shape tests vs. 5 real-DB tests, each of the latter carrying its own
+    docstring explaining why a fake can't stand in there). A fake cannot
+    observe whether a REAL DB actually accepts and durably stores the row,
+    though, and `Tests/UI/test_console_resume_active_path.py::test_resume_
+    restores_an_empty_transcript_row_and_its_explanation` -- the existing
+    real-DB coverage for this exact row shape -- HAND-SEEDS the row directly
+    via `db.add_message(...)`; it never exercises `update_message_content`'s
+    deferred-create flush at all, so it does not close this gap either. This
+    test does: drives the real flow (deferred row -> content write -> status
+    write) against a real `ChatPersistenceService`/`CharactersRAGDB` pair and
+    reads the row straight back off the DB, mirroring this file's own
+    established real-DB pattern (`test_persist_session_if_needed_flushes_
+    held_rag_scope_through_real_db`, `test_stop_path_usage_flush_uses_local_
+    write_and_leaves_version_unchanged`) for exactly this kind of durability
+    claim."""
+    from tldw_chatbook.Chat.message_metadata import MessageMetadata
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+    )
+
+    db = CharactersRAGDB(":memory:", "test_client")
+    try:
+        persistence = ChatPersistenceService(db)
+        store = ConsoleChatStore(persistence=persistence)
+        session = store.ensure_session(title="Chat 1")
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="",
+            persist=True,
+            metadata=MessageMetadata(engine="realtime", transcript_status="pending"),
+        )
+        assert message.persisted_message_id is None, "deferred, not yet durable"
+
+        store.update_message_content(
+            message.id, CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
+        )
+        store.set_message_metadata(
+            message.id,
+            MessageMetadata(engine="realtime", transcript_status="empty"),
+        )
+
+        persisted_id = store.get_message(message.id).persisted_message_id
+        assert persisted_id is not None, "the deferred create must have flushed"
+        row = db.get_message_by_id(persisted_id)
+        assert row["content"] == CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
+        assert '"transcript_status": "empty"' in row["metadata_json"]
+    finally:
+        db.close_connection()
 
 
 def test_set_message_metadata_flushes_locally_and_leaves_the_version_alone():

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -3069,6 +3069,45 @@ def test_set_message_metadata_on_an_unpersisted_row_rides_the_later_create():
     assert '"transcript_status": "final"' in persistence.created[-1]["metadata_json"]
 
 
+def test_an_empty_transcript_placeholder_persists_through_the_deferred_create():
+    """task-2391: a committed voice turn whose transcript comes back with no
+    words must still survive a restart. The store defers persistence for a
+    content-less row (same guard proven above), and the DB layer refuses to
+    create a message with neither text nor an image at all
+    (`CharactersRAGDB.add_message`) -- so a metadata-only "empty" record can
+    never durably exist. Writing a short, honest placeholder as the row's
+    real content -- through the SAME `update_message_content` call the
+    "final" transcript case uses above -- flushes the deferred create, and
+    a follow-up metadata-only patch (mirroring the "final" case's own
+    two-step order: content write, then status write) marks it "empty"."""
+    from tldw_chatbook.Chat.message_metadata import MessageMetadata
+
+    placeholder = "(no speech detected)"
+    persistence = RecordingPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.ensure_session(title="Chat 1")
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="",
+        persist=True,
+        metadata=MessageMetadata(engine="realtime", transcript_status="pending"),
+    )
+    assert persistence.created == [], "an empty row has nothing to persist yet"
+
+    store.update_message_content(message.id, placeholder)
+    assert persistence.created[-1]["content"] == placeholder, (
+        "the row must be durably created once its emptiness is final, not "
+        "left stranded in memory"
+    )
+
+    store.set_message_metadata(
+        message.id,
+        MessageMetadata(engine="realtime", transcript_status="empty"),
+    )
+    assert '"transcript_status": "empty"' in persistence.updated[-1]["metadata_json"]
+
+
 def test_set_message_metadata_flushes_locally_and_leaves_the_version_alone():
     """Same local-only contract as the usage flush, against a REAL
     persistence/DB pair: metadata is this device's own observation, so the

--- a/Tests/Chat/test_console_cost_tracker.py
+++ b/Tests/Chat/test_console_cost_tracker.py
@@ -370,3 +370,45 @@ def test_build_cost_rows_totals_empty_is_unpriced_zero():
     assert totals.total_tokens == 0
     assert totals.total_cost_usd is None
     assert totals.row_count == 0
+
+
+# --- task-2390: realtime audio/transcription fields on ConsoleCostRow ------
+
+
+def test_build_cost_rows_carries_audio_and_transcription_fields():
+    usage = ProviderUsage(
+        uncached_input=33, output=118, audio_input=18, audio_output=90,
+        transcription_seconds=2.5, provider="openai", model="gpt-realtime",
+    )
+    rows = build_cost_rows(
+        [_msg(usage=usage)], provider="openai", model="gpt-realtime"
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.audio_input == 18
+    assert row.audio_output == 90
+    assert row.transcription_seconds == 2.5
+    # cost_usd is the row's full total -- audio/transcription costs are
+    # already folded in (see console_cost_modal.py for the breakdown that
+    # keeps them visible rather than an undecomposable single figure).
+    assert row.cost_usd is not None and row.cost_usd > 0
+
+
+def test_build_cost_rows_estimated_row_has_zero_audio_fields():
+    rows = build_cost_rows(
+        [_msg(content="hi there", usage=None, role="user")],
+        provider="anthropic", model="claude-sonnet-4-6",
+    )
+    assert rows[0].audio_input == 0
+    assert rows[0].audio_output == 0
+    assert rows[0].transcription_seconds == 0.0
+
+
+def test_console_cost_row_existing_positional_construction_still_works():
+    # AC3-style pin for ConsoleCostRow's shape: the new fields must be
+    # trailing-optional so every EXISTING positional construction site in
+    # this file (the totals tests above) keeps working unmodified.
+    row = ConsoleCostRow(0, "user", "m", 100, 0, 0, 0, 0.10, False)
+    assert row.audio_input == 0
+    assert row.audio_output == 0
+    assert row.transcription_seconds == 0.0

--- a/Tests/Chat/test_console_rewind_summarize.py
+++ b/Tests/Chat/test_console_rewind_summarize.py
@@ -111,6 +111,69 @@ async def test_summarize_span_is_pre_boundary_user_assistant_only():
 
 
 @pytest.mark.asyncio
+async def test_summarize_span_excludes_an_empty_transcript_placeholder():
+    """task-2391 fix-now (audit follow-up): a committed voice turn whose
+    transcript came back empty persists a real placeholder as CONTENT
+    ("(no speech detected)") -- UI chrome written so the row could exist at
+    all, not something the user said. `summarize_up_to` sends the raw span
+    straight to a real provider call (`_collect_summary_completion`), so
+    leaving the placeholder in would fabricate a user turn in the
+    SUMMARIZER's context too -- the same defect `_provider_message_
+    payloads` had before its fix, one layer removed."""
+    from tldw_chatbook.Chat.message_metadata import MessageMetadata
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+    )
+
+    store = ConsoleChatStore()
+    gateway = SummaryGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content=CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+        metadata=MessageMetadata(engine="realtime", transcript_status="empty"),
+    )
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="a1")
+    u2 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="q2")
+
+    await controller.summarize_up_to(u2.id)
+
+    span_text = gateway.captured_messages[1]["content"]
+    assert CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER not in span_text
+    assert "Assistant: a1" in span_text
+
+
+@pytest.mark.asyncio
+async def test_summarize_nothing_before_target_when_only_prior_is_empty_transcript():
+    """The "nothing to summarize" gate must see the empty-transcript row as
+    absent too -- otherwise it would proceed to send an empty span to the
+    provider instead of the honest block."""
+    from tldw_chatbook.Chat.message_metadata import MessageMetadata
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+    )
+
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=SummaryGateway())
+    session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content=CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+        metadata=MessageMetadata(engine="realtime", transcript_status="empty"),
+    )
+    u2 = store.append_message(session.id, role=ConsoleMessageRole.USER, content="q2")
+
+    result = await controller.summarize_up_to(u2.id)
+
+    assert result.accepted is False
+    assert "Nothing to summarize" in result.visible_copy
+    assert store.session_context_summary(session.id) == (None, None)
+
+
+@pytest.mark.asyncio
 async def test_summarize_provider_not_ready_blocks_and_stores_nothing():
     store = ConsoleChatStore()
     controller = ConsoleChatController(

--- a/Tests/LLM_Calls/test_pricing_catalog.py
+++ b/Tests/LLM_Calls/test_pricing_catalog.py
@@ -422,15 +422,63 @@ def test_cost_for_usage_realtime_transcription_seconds_billed_at_whisper_rate():
     assert cost.total == cost.transcription_cost
 
 
-def test_cost_for_usage_realtime_audio_spilling_into_cache_never_underbills():
-    # audio_input (50) EXCEEDS uncached_input (20) alone, so some audio
-    # tokens must have come from the cache_read bucket -- the genuinely
-    # underdetermined case Trap 1 describes (ProviderUsage cannot say how
-    # many). The conservative (cost-maximizing, never-underbilling)
-    # resolution attributes as much audio as possible to the pricier
-    # uncached bucket first and only removes the unavoidable overflow from
-    # cache_read's own count -- all of it still priced at the uncached
-    # audio rate, never the (unknowable) cached-audio rate.
+def _alternative_realtime_total(usage: ProviderUsage, pricing, audio_from_cache: int) -> float:
+    """Independently re-derive ``cost_for_usage``'s realtime-input total for
+    ONE choice of how much of ``audio_input`` is attributed to
+    ``cache_read`` vs ``uncached_input``.
+
+    Used only by the property test below to prove the production method
+    picks the COST-MAXIMIZING split among the attribution-consistent
+    alternatives, by recomputing the alternatives HERE (independently) --
+    never by re-deriving the implementation's own formula, which would let
+    a bug in that formula pass unnoticed.
+    """
+    audio_from_uncached = usage.audio_input - audio_from_cache
+    text_uncached = usage.uncached_input - audio_from_uncached
+    text_cache_read = usage.cache_read - audio_from_cache
+    input_cost = text_uncached * pricing.input_per_mtok / 1_000_000
+    cache_read_cost = text_cache_read * (pricing.cache_read_per_mtok or 0.0) / 1_000_000
+    audio_input_cost = usage.audio_input * pricing.audio_in_per_mtok / 1_000_000
+    return input_cost + cache_read_cost + audio_input_cost
+
+
+def test_cost_for_usage_realtime_picks_the_cost_maximizing_audio_split():
+    # Trap 1's genuinely underdetermined case: audio_input (500) is smaller
+    # than EITHER bucket alone, so any split between "all from
+    # uncached_input" and "all from cache_read" is attribution-consistent
+    # -- ProviderUsage has no way to say which actually happened. The
+    # task's "price conservatively" mandate requires the MAXIMUM-cost split
+    # among these alternatives (never underbill). Every alternative is
+    # recomputed independently in-test (see _alternative_realtime_total)
+    # and the implementation's total must be >= all of them -- so a future
+    # re-flip of the drain order (which silently UNDER-bills; that was this
+    # test's own headline bug before this fix) fails on the property
+    # itself, not on a magic number that happens to mirror the bug.
+    usage = ProviderUsage(
+        uncached_input=2000, cache_read=8000, audio_input=500,
+        provider="openai", model="gpt-realtime",
+    )
+    catalog = _catalog()
+    pricing = catalog.get_pricing("openai", "gpt-realtime")
+    cost = catalog.cost_for_usage(usage)
+
+    lo = max(0, usage.audio_input - usage.uncached_input)  # 0
+    hi = min(usage.audio_input, usage.cache_read)  # 500
+    for audio_from_cache in (lo, (lo + hi) // 2, hi):
+        alt_total = _alternative_realtime_total(usage, pricing, audio_from_cache)
+        assert cost.total >= round(alt_total, 6) - 1e-9, audio_from_cache
+
+    # And it reaches the actual maximum (the hi boundary), not merely some
+    # value that happens to dominate the other samples above.
+    assert cost.total == round(_alternative_realtime_total(usage, pricing, hi), 6)
+
+
+def test_cost_for_usage_realtime_audio_spills_into_uncached_once_cache_exhausted():
+    # Concrete-numbers companion to the property test above: audio_input
+    # (50) EXCEEDS cache_read (40) alone, so after draining the CHEAP
+    # bucket first (cache_read -- see cost_for_usage's docstring for why
+    # that's the conservative direction), the remaining 10 audio tokens
+    # must spill into the expensive uncached_input bucket.
     usage = ProviderUsage(
         uncached_input=20,
         cache_read=40,
@@ -439,11 +487,12 @@ def test_cost_for_usage_realtime_audio_spilling_into_cache_never_underbills():
         model="gpt-realtime",
     )
     cost = _catalog().cost_for_usage(usage)
-    # uncached_input (20) fully consumed by audio -> 0 text-uncached tokens.
-    assert cost.input_cost == 0.0
-    # Overflow = 50 - 20 = 30 audio tokens "spill" out of cache_read's 40,
-    # leaving 10 text-cache tokens priced at the ordinary cache rate.
-    assert cost.cache_read_cost == round(10 * 0.40 / 1_000_000, 6)
+    # cache_read (40) fully consumed by audio -> 0 text-cache tokens.
+    assert cost.cache_read_cost == 0.0
+    # Overflow = 50 - 40 = 10 audio tokens spill into uncached_input's 20,
+    # leaving 10 text-uncached tokens priced at the ordinary (expensive)
+    # uncached rate.
+    assert cost.input_cost == round(10 * 4.00 / 1_000_000, 6)
     # ALL 50 audio tokens priced at the uncached audio rate, regardless of
     # which bucket they numerically came from -- never double counted
     # against the (now-reduced) uncached_input/cache_read totals above.

--- a/Tests/LLM_Calls/test_pricing_catalog.py
+++ b/Tests/LLM_Calls/test_pricing_catalog.py
@@ -313,3 +313,162 @@ def test_config_patterns_replace_a_providers_seeded_list():
     assert (replaced.input_per_mtok, replaced.output_per_mtok) == (1.0, 2.0)
     # Providers absent from config keep their seeded patterns.
     assert catalog.get_pricing("openai", "gpt-4o-2024-11-20") is not None
+
+
+#
+# task-2390: realtime audio-token + transcription-duration billing
+#
+# Rates verified 2026-08-06 against https://developers.openai.com/api/docs/pricing
+# (see task-2390's "## Research" section for the full source table). Realtime
+# bills per 1M TOKENS like every other model here -- ModelPricing extends
+# additively with optional audio/transcription fields rather than needing a
+# redesign; every field defaults to None/unused for non-realtime models.
+#
+
+
+def test_realtime_gpt_realtime_seeded_rates():
+    pricing = _catalog().get_pricing("openai", "gpt-realtime")
+    assert pricing is not None
+    assert pricing.input_per_mtok == 4.00
+    assert pricing.output_per_mtok == 16.00
+    assert pricing.cache_read_per_mtok == 0.40
+    assert pricing.cache_write_per_mtok is None
+    assert pricing.audio_in_per_mtok == 32.00
+    assert pricing.audio_out_per_mtok == 64.00
+    assert pricing.cached_audio_in_per_mtok == 0.40
+    assert pricing.transcription_per_minute == 0.006
+    assert pricing.as_of == "2026-08-06"
+
+
+def test_realtime_gpt_realtime_mini_diverges_cached_audio_from_cached_text():
+    # The headline trap this task's research flagged: cached AUDIO ($0.30)
+    # != cached TEXT ($0.06) for -mini, unlike gpt-realtime where the two
+    # happen to coincide at $0.40 -- a single shared cache field would be
+    # wrong here.
+    pricing = _catalog().get_pricing("openai", "gpt-realtime-mini")
+    assert pricing is not None
+    assert pricing.cache_read_per_mtok == 0.06
+    assert pricing.cached_audio_in_per_mtok == 0.30
+    assert pricing.cache_read_per_mtok != pricing.cached_audio_in_per_mtok
+    assert pricing.audio_in_per_mtok == 10.00
+    assert pricing.audio_out_per_mtok == 20.00
+
+
+def test_all_shipped_realtime_variants_resolve_with_audio_rates():
+    catalog = _catalog()
+    for model in (
+        "gpt-realtime",
+        "gpt-realtime-mini",
+        "gpt-realtime-2.1",
+        "gpt-realtime-2",
+        "gpt-realtime-1.5",
+    ):
+        pricing = catalog.get_pricing("openai", model)
+        assert pricing is not None, model
+        assert pricing.audio_in_per_mtok is not None, model
+        assert pricing.audio_out_per_mtok is not None, model
+        assert pricing.transcription_per_minute == 0.006, model
+
+
+def test_non_realtime_pricing_has_no_audio_rates():
+    # AC3: extend additively -- an ordinary text model must never inherit
+    # a stray audio/transcription rate.
+    pricing = _catalog().get_pricing("anthropic", "claude-sonnet-4-6")
+    assert pricing.audio_in_per_mtok is None
+    assert pricing.audio_out_per_mtok is None
+    assert pricing.cached_audio_in_per_mtok is None
+    assert pricing.transcription_per_minute is None
+
+
+def test_cost_for_usage_realtime_bills_audio_tokens_without_double_counting():
+    # Shape lifted from openai_session.py's live-confirmed ground truth:
+    # input_token_details.audio_tokens (18) is a SUBSET of uncached_input
+    # (33 = 15 text + 18 audio, no cache in this example) -- so pricing
+    # audio_input on top of the full uncached_input bucket would double
+    # bill those 18 tokens (Trap 2). output_token_details has no cache
+    # concept at all, so the output side is unambiguous.
+    usage = ProviderUsage(
+        uncached_input=33,
+        output=118,
+        audio_input=18,
+        audio_output=90,
+        provider="openai",
+        model="gpt-realtime",
+    )
+    cost = _catalog().cost_for_usage(usage)
+    assert isinstance(cost, CostBreakdown)
+    # Text-only remainder: (33 - 18) = 15 uncached text tokens @ $4/mtok.
+    assert cost.input_cost == round(15 * 4.00 / 1_000_000, 6)
+    # All 18 audio-input tokens @ the UNCACHED audio rate ($32/mtok) -- see
+    # cost_for_usage's own docstring: ProviderUsage cannot attribute cache
+    # hits between audio and text (Trap 1), so no cache discount is ever
+    # applied to the audio-input bucket.
+    assert cost.audio_input_cost == round(18 * 32.00 / 1_000_000, 6)
+    # Text-only output: (118 - 90) = 28 tokens @ $16/mtok; audio output is
+    # unambiguous (output is never cached) so it prices exactly.
+    assert cost.output_cost == round(28 * 16.00 / 1_000_000, 6)
+    assert cost.audio_output_cost == round(90 * 64.00 / 1_000_000, 6)
+    assert cost.total == 0.006844
+
+
+def test_cost_for_usage_realtime_transcription_seconds_billed_at_whisper_rate():
+    usage = ProviderUsage(
+        transcription_seconds=30.0,  # half a minute
+        provider="openai",
+        model="gpt-realtime",
+    )
+    cost = _catalog().cost_for_usage(usage)
+    assert cost.transcription_cost == round(30.0 / 60.0 * 0.006, 6)
+    assert cost.total == cost.transcription_cost
+
+
+def test_cost_for_usage_realtime_audio_spilling_into_cache_never_underbills():
+    # audio_input (50) EXCEEDS uncached_input (20) alone, so some audio
+    # tokens must have come from the cache_read bucket -- the genuinely
+    # underdetermined case Trap 1 describes (ProviderUsage cannot say how
+    # many). The conservative (cost-maximizing, never-underbilling)
+    # resolution attributes as much audio as possible to the pricier
+    # uncached bucket first and only removes the unavoidable overflow from
+    # cache_read's own count -- all of it still priced at the uncached
+    # audio rate, never the (unknowable) cached-audio rate.
+    usage = ProviderUsage(
+        uncached_input=20,
+        cache_read=40,
+        audio_input=50,
+        provider="openai",
+        model="gpt-realtime",
+    )
+    cost = _catalog().cost_for_usage(usage)
+    # uncached_input (20) fully consumed by audio -> 0 text-uncached tokens.
+    assert cost.input_cost == 0.0
+    # Overflow = 50 - 20 = 30 audio tokens "spill" out of cache_read's 40,
+    # leaving 10 text-cache tokens priced at the ordinary cache rate.
+    assert cost.cache_read_cost == round(10 * 0.40 / 1_000_000, 6)
+    # ALL 50 audio tokens priced at the uncached audio rate, regardless of
+    # which bucket they numerically came from -- never double counted
+    # against the (now-reduced) uncached_input/cache_read totals above.
+    assert cost.audio_input_cost == round(50 * 32.00 / 1_000_000, 6)
+
+
+def test_cost_for_usage_non_realtime_math_is_unaffected():
+    # AC3 pin: same fixture as test_cost_for_usage_multiplies_disjoint_buckets
+    # (a model with no published audio/transcription rate), plus explicit
+    # checks that every new field is inert rather than silently changing
+    # the pre-existing total.
+    usage = ProviderUsage(
+        uncached_input=1_000_000,
+        cache_read=1_000_000,
+        cache_write=1_000_000,
+        output=1_000_000,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    cost = _catalog().cost_for_usage(usage)
+    assert cost.input_cost == 3.00
+    assert cost.cache_read_cost == 0.30
+    assert cost.cache_write_cost == 3.75
+    assert cost.output_cost == 15.00
+    assert cost.audio_input_cost == 0.0
+    assert cost.audio_output_cost == 0.0
+    assert cost.transcription_cost == 0.0
+    assert cost.total == 22.05

--- a/Tests/UI/test_console_cost_modal.py
+++ b/Tests/UI/test_console_cost_modal.py
@@ -1,0 +1,52 @@
+"""Console cost-breakdown modal (task-5, PR3): pure row/totals formatting.
+
+task-2390 extends ``_format_row`` to surface realtime audio-token and
+transcription-duration costs -- ``ConsoleCostRow`` already folds them into
+``cost_usd`` (a single dollar figure), and this task's AC requires that the
+modal not silently hide them inside that undecomposable total.
+
+Only the ``@staticmethod`` formatters are exercised here (no Textual app
+needed): they are pure functions over already-computed dataclasses.
+"""
+
+from tldw_chatbook.Chat.console_cost_tracker import ConsoleCostRow
+from tldw_chatbook.Widgets.Console.console_cost_modal import ConsoleCostModal
+
+
+def test_format_row_shows_audio_and_transcription_when_present():
+    row = ConsoleCostRow(
+        index=0,
+        role="assistant",
+        model="gpt-realtime",
+        uncached_input=15,
+        cache_read=0,
+        cache_write=0,
+        output=28,
+        cost_usd=0.006844,
+        estimated=False,
+        audio_input=18,
+        audio_output=90,
+        transcription_seconds=2.5,
+    )
+    text = ConsoleCostModal._format_row(row)
+    assert "audio_in:18" in text
+    assert "audio_out:90" in text
+    assert "transcribe:2.5s" in text
+
+
+def test_format_row_omits_audio_fields_for_a_non_realtime_row():
+    row = ConsoleCostRow(
+        index=0,
+        role="user",
+        model="claude-sonnet-4-6",
+        uncached_input=100,
+        cache_read=0,
+        cache_write=0,
+        output=0,
+        cost_usd=0.10,
+        estimated=False,
+    )
+    text = ConsoleCostModal._format_row(row)
+    assert "audio_in" not in text
+    assert "audio_out" not in text
+    assert "transcribe" not in text

--- a/Tests/UI/test_console_realtime_wiring.py
+++ b/Tests/UI/test_console_realtime_wiring.py
@@ -2534,9 +2534,10 @@ async def test_an_empty_transcript_records_why_the_row_is_empty(monkeypatch):
 @pytest.mark.asyncio
 async def test_a_second_empty_transcript_does_not_double_mark_the_row(monkeypatch):
     """An empty payload landing twice for the same commit (a duplicate
-    provider event, or a race) must not re-write the placeholder or bounce
-    the status -- `_console_realtime_row_has_text` already reports True
-    once the placeholder is written, same guard as the late-final case."""
+    provider event, or a race) must not re-write the placeholder -- the
+    content is already the placeholder, so `_mark_console_realtime_
+    transcript_empty` skips the content write and only (harmlessly,
+    idempotently) re-stamps the status."""
     _patch_realtime_config(monkeypatch)
     app = _build_test_app()
     rig = _install_realtime_fakes(app)
@@ -2561,6 +2562,76 @@ async def test_a_second_empty_transcript_does_not_double_mark_the_row(monkeypatc
         user = _messages(console)[0]
         assert user.content == chat_screen_module.CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
         assert user.metadata.transcript_status == "empty"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_transcript_retries_the_status_after_a_swallowed_metadata_failure(
+    monkeypatch,
+):
+    """Qodo Q4 (task-2391 review): the has-text early return used to treat
+    the PLACEHOLDER itself as "already has text" and bail before ever
+    reaching the status write on retry. That is reachable because
+    `_set_console_realtime_transcript_status` deliberately swallows its own
+    exceptions -- so a content-write-succeeded/metadata-write-failed
+    partial state left a row whose content is the placeholder but whose
+    `transcript_status` never became "empty", permanently: every later
+    attempt hit the SAME early return. Such a row is invisible to
+    `_is_empty_transcript_row` and would reach a provider as a fabricated
+    user turn -- reopening the exact leak the prior fix closed, by a
+    different route."""
+    _patch_realtime_config(monkeypatch)
+    app = _build_test_app()
+    rig = _install_realtime_fakes(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        session = await _enter_live_realtime(console, pilot, rig)
+        store = console._ensure_console_chat_store()
+
+        session.fire_turn_committed()
+        await _wait_for(lambda: len(_messages(console)) == 1, pilot)
+
+        # Simulate the swallowed failure: the content write below succeeds
+        # normally, but the very next `set_message_metadata` call (the
+        # status write) raises once.
+        real_set_message_metadata = store.set_message_metadata
+        state = {"raised": False}
+
+        def _flaky_set_message_metadata(message_id, metadata):
+            if not state["raised"]:
+                state["raised"] = True
+                raise RuntimeError("simulated metadata-write failure")
+            return real_set_message_metadata(message_id, metadata)
+
+        monkeypatch.setattr(store, "set_message_metadata", _flaky_set_message_metadata)
+
+        session.fire_input_transcript("")
+        await _wait_for(
+            lambda: _messages(console)[0].content
+            == chat_screen_module.CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+            pilot,
+        )
+        # Partial state reached: content landed, status write was swallowed.
+        user = _messages(console)[0]
+        assert user.metadata.transcript_status != "empty"
+
+        # A retry (another empty payload for the same commit) must still
+        # reach the status write -- not bail because content is non-blank.
+        session.fire_input_transcript("")
+        await _wait_for(
+            lambda: _messages(console)[0].metadata.transcript_status == "empty",
+            pilot,
+        )
+
+        user = _messages(console)[0]
+        assert (
+            user.content == chat_screen_module.CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
+        )
+
+        from tldw_chatbook.Chat.console_chat_controller import _is_empty_transcript_row
+
+        assert _is_empty_transcript_row(store.get_message(user.id))
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_realtime_wiring.py
+++ b/Tests/UI/test_console_realtime_wiring.py
@@ -2496,7 +2496,18 @@ async def test_turn_commit_records_a_pending_transcript_status(monkeypatch):
 async def test_an_empty_transcript_records_why_the_row_is_empty(monkeypatch):
     """The strand case: the provider transcribed the turn and it held no
     words. Before the field, the row sat empty forever with nothing saying
-    whether the user was silent or the pipeline broke."""
+    whether the user was silent or the pipeline broke.
+
+    task-2391: the row's CONTENT becomes the explanation, not just its
+    metadata -- the store defers persistence for a content-less row, and
+    the DB layer refuses to create a message with neither text nor an
+    image at all (`CharactersRAGDB.add_message`), so a metadata-only
+    "empty" row could never durably exist. Writing a short placeholder as
+    real content flushes the same deferred-create path a real transcript
+    already uses (`update_message_content`), so this row persists like
+    any other -- see `Tests/Chat/test_console_chat_store.py` and
+    `Tests/UI/test_console_resume_active_path.py` for the persistence and
+    restart-survival proofs (this harness has no durable DB backing)."""
     _patch_realtime_config(monkeypatch)
     app = _build_test_app()
     rig = _install_realtime_fakes(app)
@@ -2516,8 +2527,73 @@ async def test_an_empty_transcript_records_why_the_row_is_empty(monkeypatch):
         )
 
         user = _messages(console)[0]
-        assert user.content == ""
+        assert user.content == chat_screen_module.CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
         assert user.metadata.engine == "realtime"
+
+
+@pytest.mark.asyncio
+async def test_a_second_empty_transcript_does_not_double_mark_the_row(monkeypatch):
+    """An empty payload landing twice for the same commit (a duplicate
+    provider event, or a race) must not re-write the placeholder or bounce
+    the status -- `_console_realtime_row_has_text` already reports True
+    once the placeholder is written, same guard as the late-final case."""
+    _patch_realtime_config(monkeypatch)
+    app = _build_test_app()
+    rig = _install_realtime_fakes(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        session = await _enter_live_realtime(console, pilot, rig)
+
+        session.fire_turn_committed()
+        await _wait_for(lambda: len(_messages(console)) == 1, pilot)
+        session.fire_input_transcript("")
+        await _wait_for(
+            lambda: _messages(console)[0].content
+            == chat_screen_module.CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+            pilot,
+        )
+        session.fire_input_transcript("   ")
+        await pilot.pause()
+        await pilot.pause()
+
+        user = _messages(console)[0]
+        assert user.content == chat_screen_module.CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
+        assert user.metadata.transcript_status == "empty"
+
+
+@pytest.mark.asyncio
+async def test_seed_excludes_a_row_whose_transcript_came_back_empty(monkeypatch):
+    """task-2391 AC3: `transcript_status` needs a real consumer. The reseed
+    builder is it -- an "empty" row's content is now the placeholder text,
+    not something the user said, and must never be replayed into a
+    reconnected session's context as if it were."""
+    _patch_realtime_config(monkeypatch)
+    app = _build_test_app()
+    rig = _install_realtime_fakes(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        store.append_message(
+            session_id,
+            role=ConsoleMessageRole.USER,
+            content=chat_screen_module.CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+            metadata=MessageMetadata(engine="realtime", transcript_status="empty"),
+        )
+        store.append_message(
+            session_id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="a real reply",
+        )
+
+        await _enter_live_realtime(console, pilot, rig)
+
+        items, _instructions = rig.session.seeds[0]
+        assert items == [("assistant", "a real reply")]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_resume_active_path.py
+++ b/Tests/UI/test_console_resume_active_path.py
@@ -747,6 +747,53 @@ def test_resume_restores_metadata_from_metadata_json():
         db.close_connection()
 
 
+def test_resume_restores_an_empty_transcript_row_and_its_explanation():
+    """task-2391: a committed voice turn whose transcript came back with no
+    words must still be there -- and still explained -- after a restart.
+    Unlike the `pending`/`final` case above, this row was never real user
+    words in the first place; its content is the placeholder task-2391
+    writes so the row can be durably created at all (the DB layer refuses a
+    message with neither text nor an image, so a metadata-only "empty"
+    record could never survive to be resumed)."""
+    from tldw_chatbook.UI.Screens.chat_screen import (
+        CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+    )
+
+    db = CharactersRAGDB(":memory:", "test_client")
+    try:
+        service = ChatConversationService(db)
+        conversation_id = service.create_conversation(
+            id="meta-conv-2",
+            title="Empty transcript",
+            scope_type="global",
+            state="in-progress",
+        )
+        db.add_message(
+            {
+                "id": "m-meta-empty",
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "role": "user",
+                "content": CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER,
+                "timestamp": "2026-01-01T00:00:00.000000+00:00",
+                "metadata_json": (
+                    '{"engine": "realtime", "provider": "openai",'
+                    ' "model": "gpt-4o-transcribe", "interrupted": false,'
+                    ' "transcript_status": "empty"}'
+                ),
+            }
+        )
+
+        store, session = _resume_into_store(db, conversation_id)
+
+        (user,) = store.messages_for_session(session.id)
+        assert user.content == CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
+        assert user.metadata is not None
+        assert user.metadata.transcript_status == "empty"
+    finally:
+        db.close_connection()
+
+
 def test_resume_tolerates_null_and_garbage_metadata_json():
     # Legacy rows (NULL) and corrupt JSON load with metadata=None, never raise.
     db = CharactersRAGDB(":memory:", "test_client")

--- a/backlog/tasks/task-2390 - Realtime-cost-chip-integration-for-audio-token-and-transcription-duration-usage.md
+++ b/backlog/tasks/task-2390 - Realtime-cost-chip-integration-for-audio-token-and-transcription-duration-usage.md
@@ -28,6 +28,47 @@ TASK-2363 captured realtime's audio/text token split (ProviderUsage.audio_input/
 - [x] #3 Existing token-based cost math for non-realtime providers is unaffected
 <!-- AC:END -->
 
+## Research (verified 2026-08-06, developers.openai.com/api/docs/pricing)
+
+**This task's Description premise is WRONG and should not be built on.** Realtime audio is
+billed **per 1M tokens**, not per audio minute — so `ModelPricing`'s existing per-mtok shape
+extends additively (new optional audio fields, exactly how `cache_read_per_mtok` expresses
+"no published rate") rather than needing a redesign. Only *transcription* is per-minute.
+
+Rates read from the official pricing page, units "per 1M tokens unless noted":
+
+| Model | Text in | Cached text in | Text out | Audio in | Cached audio in | Audio out |
+|---|---|---|---|---|---|---|
+| gpt-realtime (the app's default) | $4.00 | $0.40 | $16.00 | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-mini | $0.60 | $0.06 | $2.40 | $10.00 | $0.30 | $20.00 |
+| gpt-realtime-2.1 | $4.00 | $0.40 | $24.00 | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-2 | $4.00 | $0.40 | $24.00 | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-1.5 | $4.00 | $0.40 | $16.00 | $32.00 | $0.40 | $64.00 |
+
+Whisper transcription: **$0.006 per minute** (the unit `ProviderUsage.transcription_seconds`
+feeds).
+
+Design notes for whoever implements this:
+- Cached AUDIO input is a *separate rate* from cached text input — they coincide at $0.40 for
+  `gpt-realtime` but diverge for `-mini` ($0.30 vs $0.06), so one shared cache field would be
+  wrong. Check first whether `ProviderUsage` can even attribute cache reads to audio vs text
+  (`input_token_details`), and if it cannot, say so and price conservatively rather than
+  guessing.
+- Confirm whether `ProviderUsage.audio_input` is inclusive of cached audio tokens before
+  summing, or the bill will double-count.
+- Re-verify these rates before committing them: the catalog carries `as_of` precisely because
+  published rates go stale.
+
+**Note (2026-08-06, post-implementation review): the drain-order fix.** The first
+implementation drained audio tokens out of `uncached_input` before `cache_read`, which
+*under*-bills on an ordinary multi-turn realtime session (any turn with nonzero `cache_read`)
+-- the exact opposite of this section's "price conservatively" instruction. The corrected,
+shipped direction drains the CHEAP bucket (`cache_read`) first, leaving text tokens stranded
+in the expensive `uncached_input` bucket for as long as possible -- see
+`PricingCatalog.cost_for_usage`'s docstring in `pricing_catalog.py` for the full derivation
+and a worked numeric example. Left here so a future reader re-deriving this from scratch
+starts from the right intuition instead of the tempting-but-wrong one.
+
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
@@ -46,7 +87,7 @@ Approach: the task's Research section (authoritative, supersedes the Description
 
 Two traps resolved by reading the code (not guessed):
 - Trap 1 (cache-vs-audio attribution): ProviderUsage.from_provider_payload only reads input_token_details.cached_tokens (a TOTAL, text+audio mixed) and .audio_tokens (also a total, cached+uncached mixed) -- it never parses the wire payload's cached_tokens_details sub-object (confirmed live in openai_session.py's ground-truth header, which shows the API DOES publish that finer split, just not something this codebase captures). So ProviderUsage genuinely CANNOT attribute a cache-read token to audio vs text today. Resolution: cost_for_usage never reads ModelPricing.cached_audio_in_per_mtok (seeded for the record per AC2, documented as unused); every audio-input token is priced at the higher UNCACHED audio rate, which is cost-maximizing (never underbills) since audio's cached rate is cheaper than its uncached rate for every seeded model.
-- Trap 2 (inclusivity): ProviderUsage's own docstring already states audio_input/audio_output are SUBSETS of uncached_input+cache_read and output respectively, live-confirmed via the ground-truth payload (input_tokens=33 comprises text_tokens=15 + audio_tokens=18). Confirmed by reading from_provider_payload's realtime branch directly. Pricing audio_input on top of the full uncached_input/cache_read totals would double count; cost_for_usage now subtracts audio tokens from those buckets first (uncached_input drained before cache_read, the conservative/cost-maximizing split among the otherwise-underdetermined alternatives) before applying the ordinary text rates to what remains. audio_output is unambiguous (output is never cached) so it needed no such adjustment.
+- Trap 2 (inclusivity): ProviderUsage's own docstring already states audio_input/audio_output are SUBSETS of uncached_input+cache_read and output respectively, live-confirmed via the ground-truth payload (input_tokens=33 comprises text_tokens=15 + audio_tokens=18). Confirmed by reading from_provider_payload's realtime branch directly. Pricing audio_input on top of the full uncached_input/cache_read totals would double count; cost_for_usage now subtracts audio tokens from those buckets first (cache_read drained before uncached_input -- see the "Post-review follow-up" paragraph below for why that order, not the reverse, is the conservative/cost-maximizing split among the otherwise-underdetermined alternatives) before applying the ordinary text rates to what remains. audio_output is unambiguous (output is never cached) so it needed no such adjustment.
 
 Catalog: seeded direct "openai:<model>" entries for gpt-realtime, gpt-realtime-mini, gpt-realtime-2.1, gpt-realtime-2, gpt-realtime-1.5 from the task's verified rate table, as_of "2026-08-06". Added a flat $0.006/minute transcription_per_minute (Whisper) to every entry, feeding ProviderUsage.transcription_seconds -- billed independently of the token buckets.
 
@@ -55,4 +96,6 @@ Modal: ConsoleCostRow gained audio_input/audio_output/transcription_seconds (tra
 Files: tldw_chatbook/LLM_Calls/pricing_catalog.py (ModelPricing/CostBreakdown fields, _entry() helper, realtime seed table, cost_for_usage), tldw_chatbook/Chat/console_cost_tracker.py (ConsoleCostRow fields, build_cost_rows), tldw_chatbook/Widgets/Console/console_cost_modal.py (_format_row), plus new/extended tests in Tests/LLM_Calls/test_pricing_catalog.py, Tests/Chat/test_console_cost_tracker.py, Tests/UI/test_console_cost_modal.py (new file).
 
 Verification: RED confirmed before implementing (12 new tests failing on AttributeError/TypeError), GREEN after. Full targeted run: Tests/LLM_Calls/test_pricing_catalog.py + Tests/Chat/test_console_cost_tracker.py + Tests/UI/test_console_cost_modal.py + Tests/Chat/test_provider_usage.py = 85 passed. Contract trio (test_console_hands_free.py, test_console_hands_free_wiring.py, test_console_dictation.py) = 103 passed, files byte-identical (git diff empty). Cost-chip suites (test_console_status_chips_cost.py, test_console_cost_chip_screen.py) = 28 passed. Repo-wide --collect-only sweep: 30735 tests collected, 4 pre-existing unrelated collection errors (TTS/Web_Scraping, untouched by this change).
+
+Post-review follow-up (2026-08-06, F1/F2): code review caught a money bug in the Trap-2 fix above -- draining audio out of `uncached_input` BEFORE `cache_read` (as originally shipped and as this section still described until this edit) actually MINIMIZES the bill on any turn with nonzero `cache_read`, the opposite of "price conservatively": since `input_per_mtok` > `cache_read_per_mtok` for every seeded model, stranding text tokens in the CHEAP bucket (by draining the EXPENSIVE bucket first) under-counts them. Fixed by flipping the drain order -- `cache_read` first, `uncached_input` only once `cache_read` is exhausted -- which strands text tokens in the EXPENSIVE bucket instead, the true cost-maximizing split. Reviewer's worked example (uncached_input=2000, cache_read=8000, audio_input=500, gpt-realtime): old order billed $0.0252, corrected order bills $0.0270 (~7% higher, not a rare edge case -- it's the normal state of any multi-turn realtime session with a warm cache). `cost_for_usage`'s docstring rewritten with the full sign derivation and an explicit "don't flip this back" note. The pinned-numbers regression test that covered this case passed throughout because it mirrored the (buggy) implementation's own output instead of an independent expectation -- replaced with `test_cost_for_usage_realtime_picks_the_cost_maximizing_audio_split`, which recomputes each candidate split's total independently in-test and asserts the implementation reaches the true maximum; mutation-verified by manually re-flipping the drain order and confirming both that test and its concrete-numbers companion fail. Separately, this file's own "## Research" section (the verified rate table two source comments point readers at) had been silently dropped by a later `backlog task edit --notes`/`-s Done` call, which regenerates the file from its known sections only and does not preserve custom headings -- restored verbatim from `git show 988a64f5d`, added back via direct file edit (not the CLI) to avoid the same loss recurring.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2390 - Realtime-cost-chip-integration-for-audio-token-and-transcription-duration-usage.md
+++ b/backlog/tasks/task-2390 - Realtime-cost-chip-integration-for-audio-token-and-transcription-duration-usage.md
@@ -3,9 +3,11 @@ id: TASK-2390
 title: >-
   Realtime: cost-chip integration for audio-token and transcription-duration
   usage
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-05 04:16'
+updated_date: '2026-08-06 07:42'
 labels:
   - realtime
   - cost
@@ -21,38 +23,36 @@ TASK-2363 captured realtime's audio/text token split (ProviderUsage.audio_input/
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Realtime sessions' cost estimate/display accounts for audio-minute billing using ProviderUsage.audio_input/audio_output and/or transcription_seconds, not just the token buckets pricing_catalog.py already reads
-- [ ] #2 Pricing catalog entries exist (or a documented decision to omit them) for the realtime model(s) this app supports
-- [ ] #3 Existing token-based cost math for non-realtime providers is unaffected
+- [x] #1 Realtime sessions' cost estimate/display accounts for audio-minute billing using ProviderUsage.audio_input/audio_output and/or transcription_seconds, not just the token buckets pricing_catalog.py already reads
+- [x] #2 Pricing catalog entries exist (or a documented decision to omit them) for the realtime model(s) this app supports
+- [x] #3 Existing token-based cost math for non-realtime providers is unaffected
 <!-- AC:END -->
 
-## Research (verified 2026-08-06, developers.openai.com/api/docs/pricing)
+## Implementation Plan
 
-**This task's Description premise is WRONG and should not be built on.** Realtime audio is
-billed **per 1M tokens**, not per audio minute — so `ModelPricing`'s existing per-mtok shape
-extends additively (new optional audio fields, exactly how `cache_read_per_mtok` expresses
-"no published rate") rather than needing a redesign. Only *transcription* is per-minute.
+<!-- SECTION:PLAN:BEGIN -->
+1. Read the task's Research section + reread ProviderUsage.from_provider_payload and openai_session.py's ground-truth header to resolve the two traps (cache-vs-audio attribution; audio_input/output inclusivity).
+2. Extend ModelPricing/CostBreakdown additively with optional audio_in/audio_out/cached_audio_in/transcription_per_minute fields, defaulting to None/0.0 so every non-realtime construction site is unaffected.
+3. Seed direct-mapping catalog entries for openai:gpt-realtime{,-mini,-2.1,-2,-1.5} from the verified rate table, as_of 2026-08-06.
+4. Extend PricingCatalog.cost_for_usage to price audio_input/audio_output/transcription_seconds without double-counting the parent buckets, resolving the cache-attribution gap conservatively (documented in the method's own docstring).
+5. Thread the new ConsoleCostRow fields through build_cost_rows and show them in the cost-breakdown modal so they are not folded invisibly into one total.
+6. TDD: RED tests in Tests/LLM_Calls/test_pricing_catalog.py, Tests/Chat/test_console_cost_tracker.py, Tests/UI/test_console_cost_modal.py, then implement to GREEN; re-run the contract trio + covering suites.
+<!-- SECTION:PLAN:END -->
 
-Rates read from the official pricing page, units "per 1M tokens unless noted":
+## Implementation Notes
 
-| Model | Text in | Cached text in | Text out | Audio in | Cached audio in | Audio out |
-|---|---|---|---|---|---|---|
-| gpt-realtime (the app's default) | $4.00 | $0.40 | $16.00 | $32.00 | $0.40 | $64.00 |
-| gpt-realtime-mini | $0.60 | $0.06 | $2.40 | $10.00 | $0.30 | $20.00 |
-| gpt-realtime-2.1 | $4.00 | $0.40 | $24.00 | $32.00 | $0.40 | $64.00 |
-| gpt-realtime-2 | $4.00 | $0.40 | $24.00 | $32.00 | $0.40 | $64.00 |
-| gpt-realtime-1.5 | $4.00 | $0.40 | $16.00 | $32.00 | $0.40 | $64.00 |
+<!-- SECTION:NOTES:BEGIN -->
+Approach: the task's Research section (authoritative, supersedes the Description) established realtime bills per 1M TOKENS like every other model, so ModelPricing/CostBreakdown extend ADDITIVELY with optional audio/transcription fields (defaulting to None/0.0), never repurposing input_per_mtok/cache_read_per_mtok/etc -- AC3's hard constraint. get_pricing()/cost_for_usage() logic for non-realtime models is untouched byte-for-byte when the new fields are absent.
 
-Whisper transcription: **$0.006 per minute** (the unit `ProviderUsage.transcription_seconds`
-feeds).
+Two traps resolved by reading the code (not guessed):
+- Trap 1 (cache-vs-audio attribution): ProviderUsage.from_provider_payload only reads input_token_details.cached_tokens (a TOTAL, text+audio mixed) and .audio_tokens (also a total, cached+uncached mixed) -- it never parses the wire payload's cached_tokens_details sub-object (confirmed live in openai_session.py's ground-truth header, which shows the API DOES publish that finer split, just not something this codebase captures). So ProviderUsage genuinely CANNOT attribute a cache-read token to audio vs text today. Resolution: cost_for_usage never reads ModelPricing.cached_audio_in_per_mtok (seeded for the record per AC2, documented as unused); every audio-input token is priced at the higher UNCACHED audio rate, which is cost-maximizing (never underbills) since audio's cached rate is cheaper than its uncached rate for every seeded model.
+- Trap 2 (inclusivity): ProviderUsage's own docstring already states audio_input/audio_output are SUBSETS of uncached_input+cache_read and output respectively, live-confirmed via the ground-truth payload (input_tokens=33 comprises text_tokens=15 + audio_tokens=18). Confirmed by reading from_provider_payload's realtime branch directly. Pricing audio_input on top of the full uncached_input/cache_read totals would double count; cost_for_usage now subtracts audio tokens from those buckets first (uncached_input drained before cache_read, the conservative/cost-maximizing split among the otherwise-underdetermined alternatives) before applying the ordinary text rates to what remains. audio_output is unambiguous (output is never cached) so it needed no such adjustment.
 
-Design notes for whoever implements this:
-- Cached AUDIO input is a *separate rate* from cached text input — they coincide at $0.40 for
-  `gpt-realtime` but diverge for `-mini` ($0.30 vs $0.06), so one shared cache field would be
-  wrong. Check first whether `ProviderUsage` can even attribute cache reads to audio vs text
-  (`input_token_details`), and if it cannot, say so and price conservatively rather than
-  guessing.
-- Confirm whether `ProviderUsage.audio_input` is inclusive of cached audio tokens before
-  summing, or the bill will double-count.
-- Re-verify these rates before committing them: the catalog carries `as_of` precisely because
-  published rates go stale.
+Catalog: seeded direct "openai:<model>" entries for gpt-realtime, gpt-realtime-mini, gpt-realtime-2.1, gpt-realtime-2, gpt-realtime-1.5 from the task's verified rate table, as_of "2026-08-06". Added a flat $0.006/minute transcription_per_minute (Whisper) to every entry, feeding ProviderUsage.transcription_seconds -- billed independently of the token buckets.
+
+Modal: ConsoleCostRow gained audio_input/audio_output/transcription_seconds (trailing, defaulted, so every existing positional construction site keeps working); console_cost_modal.py's _format_row appends them as their own segment when non-zero rather than leaving them folded invisibly into the row's single cost_usd figure.
+
+Files: tldw_chatbook/LLM_Calls/pricing_catalog.py (ModelPricing/CostBreakdown fields, _entry() helper, realtime seed table, cost_for_usage), tldw_chatbook/Chat/console_cost_tracker.py (ConsoleCostRow fields, build_cost_rows), tldw_chatbook/Widgets/Console/console_cost_modal.py (_format_row), plus new/extended tests in Tests/LLM_Calls/test_pricing_catalog.py, Tests/Chat/test_console_cost_tracker.py, Tests/UI/test_console_cost_modal.py (new file).
+
+Verification: RED confirmed before implementing (12 new tests failing on AttributeError/TypeError), GREEN after. Full targeted run: Tests/LLM_Calls/test_pricing_catalog.py + Tests/Chat/test_console_cost_tracker.py + Tests/UI/test_console_cost_modal.py + Tests/Chat/test_provider_usage.py = 85 passed. Contract trio (test_console_hands_free.py, test_console_hands_free_wiring.py, test_console_dictation.py) = 103 passed, files byte-identical (git diff empty). Cost-chip suites (test_console_status_chips_cost.py, test_console_cost_chip_screen.py) = 28 passed. Repo-wide --collect-only sweep: 30735 tests collected, 4 pre-existing unrelated collection errors (TTS/Web_Scraping, untouched by this change).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2390 - Realtime-cost-chip-integration-for-audio-token-and-transcription-duration-usage.md
+++ b/backlog/tasks/task-2390 - Realtime-cost-chip-integration-for-audio-token-and-transcription-duration-usage.md
@@ -25,3 +25,34 @@ TASK-2363 captured realtime's audio/text token split (ProviderUsage.audio_input/
 - [ ] #2 Pricing catalog entries exist (or a documented decision to omit them) for the realtime model(s) this app supports
 - [ ] #3 Existing token-based cost math for non-realtime providers is unaffected
 <!-- AC:END -->
+
+## Research (verified 2026-08-06, developers.openai.com/api/docs/pricing)
+
+**This task's Description premise is WRONG and should not be built on.** Realtime audio is
+billed **per 1M tokens**, not per audio minute — so `ModelPricing`'s existing per-mtok shape
+extends additively (new optional audio fields, exactly how `cache_read_per_mtok` expresses
+"no published rate") rather than needing a redesign. Only *transcription* is per-minute.
+
+Rates read from the official pricing page, units "per 1M tokens unless noted":
+
+| Model | Text in | Cached text in | Text out | Audio in | Cached audio in | Audio out |
+|---|---|---|---|---|---|---|
+| gpt-realtime (the app's default) | $4.00 | $0.40 | $16.00 | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-mini | $0.60 | $0.06 | $2.40 | $10.00 | $0.30 | $20.00 |
+| gpt-realtime-2.1 | $4.00 | $0.40 | $24.00 | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-2 | $4.00 | $0.40 | $24.00 | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-1.5 | $4.00 | $0.40 | $16.00 | $32.00 | $0.40 | $64.00 |
+
+Whisper transcription: **$0.006 per minute** (the unit `ProviderUsage.transcription_seconds`
+feeds).
+
+Design notes for whoever implements this:
+- Cached AUDIO input is a *separate rate* from cached text input — they coincide at $0.40 for
+  `gpt-realtime` but diverge for `-mini` ($0.30 vs $0.06), so one shared cache field would be
+  wrong. Check first whether `ProviderUsage` can even attribute cache reads to audio vs text
+  (`input_token_details`), and if it cannot, say so and price conservatively rather than
+  guessing.
+- Confirm whether `ProviderUsage.audio_input` is inclusive of cached audio tokens before
+  summing, or the bill will double-count.
+- Re-verify these rates before committing them: the catalog carries `as_of` precisely because
+  published rates go stale.

--- a/backlog/tasks/task-2391 - Empty-realtime-transcript-row-is-never-persisted-and-its-status-is-never-shown.md
+++ b/backlog/tasks/task-2391 - Empty-realtime-transcript-row-is-never-persisted-and-its-status-is-never-shown.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-2391
-title: >-
-  Empty realtime transcript row is never persisted and its status is never shown
-status: To Do
-assignee: []
+title: Empty realtime transcript row is never persisted and its status is never shown
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-05'
+updated_date: '2026-08-05 06:39'
 labels:
   - realtime
   - console
@@ -26,10 +27,74 @@ task's review (findings F3):
 
 The data model can now express "why this row is empty"; the user still cannot see it.
 
-## Acceptance Criteria (the what)
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A committed voice turn that produced no transcript is visible to the user as an explained state (not a silently blank row), in the transcript itself.
+- [x] #2 That explanation survives a restart, or the row is not created at all — pick one and say which in the notes; a row that exists only until restart is not acceptable.
+- [x] #3 transcript_status has at least one real consumer, or is removed as dead weight.
+<!-- AC:END -->
 
-- [ ] A committed voice turn that produced no transcript is visible to the user as an
-      explained state (not a silently blank row), in the transcript itself.
-- [ ] That explanation survives a restart, or the row is not created at all — pick one and
-      say which in the notes; a row that exists only until restart is not acceptable.
-- [ ] `transcript_status` has at least one real consumer, or is removed as dead weight.
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the DB layer's hard constraint (CharactersRAGDB.add_message refuses a row with neither content nor image_data), which rules out a metadata-only persisted row -- the explanation must live in real, non-blank message content to be durable.
+2. Design choice: write a short human-readable placeholder ("(no speech detected)") into the row's content via the SAME update_message_content path the "final" transcript already uses (this flushes the store's deferred-persistence guard for content-less rows exactly like a real transcript does), then stamp transcript_status="empty" after the content write succeeds -- mirrors the existing interrupted-marker pattern (chrome baked into content, metadata as the machine-readable fact).
+3. Give transcript_status a real consumer: the realtime reseed builder (_console_realtime_seed_items) must skip rows whose transcript_status == "empty" so the placeholder text is never replayed into a reconnect's model context as if the user said it.
+4. RED: write/extend tests first -- wiring test asserting the placeholder content + persistence flush trigger, a console_chat_store test proving the deferred row flushes with the placeholder + "empty" status (RecordingPersistence fake), a resume test proving a durably-written row round-trips through a real CharactersRAGDB, and a reseed-skip test.
+5. GREEN: implement _mark_console_realtime_transcript_empty in chat_screen.py, wire it into _on_console_realtime_input_transcript's empty branch, add the CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER constant, and the reseed skip check.
+6. Run the contract trio unchanged + covering suites; update task file AC boxes and Implementation Notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Design choice (AC#2): the explanation SURVIVES A RESTART, not "row not created at all".
+Reasoning: CharactersRAGDB.add_message hard-refuses a row with neither text nor image_data
+(InputError), so a metadata-only "empty" record could never durably exist regardless of the
+Console store's own deferred-persistence guard -- the explanation has to live in real,
+non-blank message CONTENT to persist at all. Given that constraint, and that AC#1 requires
+the turn be visibly explained "in the transcript itself" (not just transiently), durable
+placeholder content was the only design that satisfies both AC#1 and AC#2 together; silently
+dropping the row would leave the user unsure whether the app heard them, which is the exact
+problem task-2364 set out to fix.
+
+Implementation: a committed voice turn whose transcript resolves empty now writes
+CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER ("(no speech detected)") as the row's real
+content via update_message_content -- the SAME call the "final" (real transcript) branch
+already uses, so it flows through the store's existing deferred-persistence flush
+(_persist_pending_message_if_ready) with no store-level changes needed. transcript_status is
+set to "empty" AFTER the content write succeeds (mirrors the "final" branch's own ordering:
+a status without its content landed would be a lie). The row renders through the existing
+message-body path unchanged -- no new widget, matching the "Generating…" streaming-placeholder
+precedent already in console_transcript.py.
+
+transcript_status's real consumer (AC#3): the realtime reseed builder
+(_console_realtime_seed_items) now skips any row with transcript_status == "empty" before
+building a reconnect's seed items -- the placeholder is UI chrome, not user words, and must
+never be replayed into the model's context as if it were. (The interrupted-marker precedent
+already accepts this same chrome riding into the ordinary skip_failed text-provider context
+builder unstripped, so no change was made there -- out of this task's scope.)
+
+New/changed logic: tldw_chatbook/UI/Screens/chat_screen.py -- added
+CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER; added _mark_console_realtime_transcript_empty
+(idempotent/race-safe via the existing _console_realtime_row_has_text guard, same as the
+late-final-transcript case); wired it into _on_console_realtime_input_transcript's empty
+branch (replacing the old metadata-only, never-persisted call); added the transcript_status
+skip check to _console_realtime_seed_items.
+
+Tests: RED-first across three layers proving persistence end to end --
+Tests/UI/test_console_realtime_wiring.py (updated the empty-transcript assertion to the
+placeholder content; added a double-mark idempotency test and a reseed-exclusion test),
+Tests/Chat/test_console_chat_store.py (store-level proof the deferred row flushes through
+update_message_content with the placeholder + "empty" metadata_json, RecordingPersistence
+fake), Tests/UI/test_console_resume_active_path.py (real CharactersRAGDB round trip proving
+a durably-written empty-transcript row survives resume with content + status intact).
+Contract trio (test_console_hands_free.py, test_console_hands_free_wiring.py,
+test_console_dictation.py) left byte-identical -- confirmed via git status, and all three
+pass unmodified. Full targeted run: 435 passed, 0 failed (contract trio + covering suites +
+message_metadata + native_transcript render tests).
+
+Related but out of scope: the "failed" transcript_status branch (a content write that raises)
+has a similar-shaped unpersisted-in-memory edge once content is mutated before the exception;
+not touched here since it is a distinct failure mode not named in this task's AC.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2391 - Empty-realtime-transcript-row-is-never-persisted-and-its-status-is-never-shown.md
+++ b/backlog/tasks/task-2391 - Empty-realtime-transcript-row-is-never-persisted-and-its-status-is-never-shown.md
@@ -97,4 +97,56 @@ message_metadata + native_transcript render tests).
 Related but out of scope: the "failed" transcript_status branch (a content write that raises)
 has a similar-shaped unpersisted-in-memory edge once content is mutated before the exception;
 not touched here since it is a distinct failure mode not named in this task's AC.
+
+FIX-NOW addendum (review escalation, same day): the review confirmed the AC premises above
+but caught a real regression the "matches the interrupted-marker precedent" reasoning in
+paragraph 3 got wrong. Because the placeholder is now real, non-blank CONTENT, it flows
+through `_provider_message_payloads` (`console_chat_controller.py`) exactly like a genuine
+user turn -- before this task, an empty-content row was silently dropped by that function's
+`if not text: continue` guard; after task-2391's fix alone, the model would receive
+`{"role": "user", "content": "(no speech detected)"}` as if the user had typed it, on every
+ordinary send/retry/edit/fork/regenerate for the life of the conversation. The reseed builder
+exclusion (paragraph 3) only covers the REALTIME reconnect path, not this one -- a distinct
+mainline consumer the interrupted-marker analogy doesn't cover (that marker is a suffix on
+otherwise-real spoken words; this placeholder IS the entire, zero-real-words content of the
+turn).
+
+Fix: added `_is_empty_transcript_row(message)` (module-level helper, `console_chat_controller.
+py`, reads `message.metadata` via `getattr` so it stays safe against test doubles that
+duck-type only role/content/status) and wired it into every place that walks the transcript to
+build a request FOR A MODEL: `_provider_message_payloads`'s two loops (image-budget reservation
++ the `_emit` loop -- skip entirely, mirroring the existing `skip_failed` idiom, rather than
+emitting empty text), `summarize_up_to`'s `before`/`span` list comprehensions (this hand-builds
+a prompt sent to `_collect_summary_completion`, a REAL provider call -- so an empty-transcript
+row was also silently fabricating a turn in the SUMMARIZER's context, and the "nothing to
+summarize" gate needed the same exclusion so it doesn't fall through to sending an empty span),
+and `impersonate_user_reply`'s hand-rolled transcript builder (its own comment already said
+"mirror `_provider_message_payloads`'s rules exactly" -- it simply predates `transcript_status`
+existing; found by continuing the audit, not separately requested, but the same defect class
+and a one-line fix reusing the same helper, and arguably the most dangerous of the three since
+this prompt explicitly asks the model to draft the user's NEXT message "in their voice" from
+this exact transcript).
+
+Export path: deliberately LEFT UNCHANGED, not silently -- audited
+`_save_console_message_as_note/_media/_prompt/_chatbook` (`chat_screen.py`) and
+`build_context_snapshot`'s `current_messages` field. All are human-facing: the save-as actions
+operate on exactly one message the user explicitly selected and save its literal visible
+content (the placeholder read there is exactly what the user saw and chose to save -- hiding it
+would defeat this task's own AC#1), and `current_messages` is a raw snapshot for a UI inspector
+panel, not sent to a provider (`next_send_payload`, the part that IS sent, already routes
+through the now-fixed `_provider_messages_for_session`). No model-facing consumer was found
+outside the three fixed above (also checked: `retry_message`/`regenerate_message`/
+`edit_and_resend_message`/the cost-ticker fingerprint baseline all route through the same fixed
+`_provider_message_payloads`/`_provider_messages_for_session`, so no separate fix needed there).
+
+Tests (RED-first, each mutation-verified by temporarily reverting the guard and re-running):
+`Tests/Chat/test_console_chat_controller.py::test_provider_payloads_exclude_an_empty_
+transcript_placeholder` and `::test_impersonate_excludes_an_empty_transcript_placeholder`;
+`Tests/Chat/test_console_rewind_summarize.py::test_summarize_span_excludes_an_empty_
+transcript_placeholder` and `::test_summarize_nothing_before_target_when_only_prior_is_empty_
+transcript`. Foreground-only per repo convention: covering suites (chat_controller,
+rewind_summarize, composer_menu, chat_store, realtime_wiring, resume_active_path,
+message_metadata) all green; contract trio (test_console_hands_free.py,
+test_console_hands_free_wiring.py, test_console_dictation.py) confirmed byte-identical via
+`git status` and all pass unmodified.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2391 - Empty-realtime-transcript-row-is-never-persisted-and-its-status-is-never-shown.md
+++ b/backlog/tasks/task-2391 - Empty-realtime-transcript-row-is-never-persisted-and-its-status-is-never-shown.md
@@ -149,4 +149,86 @@ rewind_summarize, composer_menu, chat_store, realtime_wiring, resume_active_path
 message_metadata) all green; contract trio (test_console_hands_free.py,
 test_console_hands_free_wiring.py, test_console_dictation.py) confirmed byte-identical via
 `git status` and all pass unmodified.
+
+PR #1366 Qodo round (same day, HEAD f134ea109 -- task-2390 landed on this branch in between,
+verified before editing): 5 findings, 2 real bugs fixed, 1 trivial fix, 2 judgement calls.
+
+Q4 (BUG, fixed): `_mark_console_realtime_transcript_empty`'s early return
+(`_console_realtime_row_has_text`) treated the PLACEHOLDER itself as "already has text" and
+bailed -- so once the content write landed but the FOLLOWING metadata write failed (reachable
+because `_set_console_realtime_transcript_status` deliberately swallows its own exceptions),
+every later retry hit the same early return and could never reach the status write again. A
+row stuck with placeholder content but no `transcript_status="empty"` is invisible to
+`_is_empty_transcript_row` and reaches providers as a fabricated user turn -- reopening the
+exact leak the prior fix-now commit closed, by a different route. Fixed by reading the row's
+actual content and branching three ways: non-blank and NOT the placeholder -> return (a real
+transcript, never overwritten, unchanged behavior); blank -> write the placeholder then stamp
+the status; already the placeholder -> skip the (redundant) content write but still (re-)stamp
+the status, so a stranded row recovers on the next event instead of being permanently stuck.
+`_console_realtime_row_has_text` is now dead (its only caller) and was removed rather than left
+orphaned. RED test (`Tests/UI/test_console_realtime_wiring.py::test_an_empty_transcript_
+retries_the_status_after_a_swallowed_metadata_failure`) monkeypatches `store.set_message_
+metadata` to raise exactly once, drives the exact partial state, and proves a SECOND empty
+event reaches `transcript_status == "empty"` and that `_is_empty_transcript_row` then
+recognizes the row -- failed against the pre-fix code (confirmed), passes after.
+
+Q5 (BUG, fixed): `_is_empty_transcript_row` read `.metadata` via `getattr` (duck-type-safe) but
+then read `.transcript_status` off that metadata object via a plain attribute access -- so a
+metadata object missing that one attribute raised `AttributeError` inside all three model-facing
+builders this helper guards (send/summarize/impersonate), i.e. a crash reachable from the main
+send path, not just a narrow test double. Fixed: `getattr(metadata, "transcript_status", None)
+== "empty"` (also simplifies away the now-redundant `metadata is not None` check, since
+`getattr(None, ..., None)` already resolves to `None`). RED test
+(`Tests/Chat/test_console_chat_controller.py::test_is_empty_transcript_row_tolerates_a_metadata_
+object_without_the_attribute`) passes a `SimpleNamespace` metadata with no `transcript_status` --
+raised before, returns `False` after.
+
+Q1 (trivial, fixed): `Tests/Chat/test_console_chat_store.py`'s
+`test_an_empty_transcript_placeholder_persists_through_the_deferred_create` hardcoded
+`"(no speech detected)"` instead of importing `CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER` --
+now imports the constant, so the test can't silently drift from the real chrome text.
+
+Q2 (JUDGEMENT, evidence-based decision -- keep the existing test on `RecordingPersistence`,
+ADD a new real-DB test rather than converting): checked this file's own convention first, same
+as the earlier `transaction()` precedent. `Tests/Chat/test_console_chat_store.py` uses
+`RecordingPersistence` in 9 tests and a real `CharactersRAGDB`/`ChatPersistenceService` pair in
+5 -- and each of the 5 carries its own docstring explaining WHY a fake can't stand in
+(`test_persist_session_if_needed_flushes_held_rag_scope_through_real_db`: "not a hand-rolled
+fake... end to end"; `test_stop_path_usage_flush_uses_local_write_and_leaves_version_unchanged`:
+"proving the usage-only flush actually lands... rather than only through a fake that can't
+observe that distinction"). My test's direct precedent/sibling,
+`test_set_message_metadata_on_an_unpersisted_row_rides_the_later_create` (same file, tests the
+identical "unpersisted row rides the later create" claim for the `"final"` case), already uses
+`RecordingPersistence` -- converting only the `"empty"`-case sibling would make it the odd one
+out against its own precedent, worse than declining outright. BUT weighing the substance
+honestly: `RecordingPersistence` records exactly which kwargs `create_message`/
+`update_message_content` were called with, which is what BOTH tests actually claim ("the row is
+durably created" == "create_message got called with this content") -- it is not, in itself, a
+version/sync_log/local-only-column nuance a fake can't represent, unlike the 5 tests above. So
+the sibling stays as-is (declined). The one place Qodo's concern has real teeth: neither this
+test NOR the existing real-DB coverage
+(`Tests/UI/test_console_resume_active_path.py::test_resume_restores_an_empty_transcript_row_
+and_its_explanation`) actually drives `update_message_content`'s deferred-create flush against a
+REAL DB and reads the row back -- the resume test HAND-SEEDS the row via `db.add_message(...)`
+directly, so it proves resume reconstructs an already-durable row correctly, not that the
+deferred-flush mechanism itself durably writes one. Closed that specific gap with a new test,
+`test_empty_transcript_placeholder_reaches_a_real_db_through_the_deferred_create`, mirroring
+this file's own two cited real-DB tests: drives the real flow (deferred row -> content write ->
+status write) against a real `ChatPersistenceService`/`CharactersRAGDB` pair and reads the
+persisted row straight off the DB (`db.get_message_by_id`). Net effect: both of Qodo's concerns
+addressed -- the established per-file convention respected, and the actual durability claim now
+has real-DB coverage that didn't exist before in either file.
+
+Q3 (DECLINED, coordinator's adjudication, recorded verbatim): Qodo wants Google-style Args/
+Returns docstrings on the new zero-arg test functions. Declined -- their narrative docstrings
+carry the WHY (the bug, the mechanism, the review finding they close), which is more valuable
+here than Args/Returns boilerplate on a function with neither; Qodo itself rated this Moderate
+with "no clear precedent... may be tolerated narrative test docstrings," and every test suite in
+this repo already uses narrative-only test docstrings uniformly. Not churned.
+
+Second foreground verification round (never background, per repo convention): `Tests/Chat/
+test_console_chat_controller.py` + `test_console_chat_store.py` + `test_console_rewind_
+summarize.py` (319 passed); `Tests/UI/test_console_realtime_wiring.py` (75 passed, was 74 before
+the new Q4 RED test); contract trio (103 passed, confirmed byte-identical via `git status` both
+before and after this round).
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -871,11 +871,13 @@ def _is_empty_transcript_row(message: ConsoleChatMessage) -> bool:
     hiding it would defeat this task's own AC#1.
 
     Args:
-        message: A transcript row to test. Read via ``getattr`` (never a
-            plain attribute access) so a narrow test double that duck-types
-            only ``role``/``content``/``status`` -- several already exist in
-            this codebase -- returns False rather than raising
-            ``AttributeError`` on a ``.metadata`` it never declared.
+        message: A transcript row to test. Both ``.metadata`` and
+            ``.metadata.transcript_status`` are read via ``getattr`` (never
+            a plain attribute access), so a narrow test double that duck-
+            types only some fields -- several already exist in this
+            codebase, and this helper runs on every row of three model-
+            facing send paths -- returns False rather than raising
+            ``AttributeError`` on an attribute it never declared.
 
     Returns:
         True when the row's ``metadata.transcript_status`` is ``"empty"``.
@@ -883,7 +885,7 @@ def _is_empty_transcript_row(message: ConsoleChatMessage) -> bool:
         at all and returns False without inspecting content.
     """
     metadata = getattr(message, "metadata", None)
-    return metadata is not None and metadata.transcript_status == "empty"
+    return getattr(metadata, "transcript_status", None) == "empty"
 
 
 class ConsoleProviderGatewayProtocol(Protocol):

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -849,6 +849,43 @@ def _render_skill_bundle_block(results: Iterable[Mapping[str, Any]]) -> str:
     return "Bundled files (readable via skill_file): " + ", ".join(rows)
 
 
+def _is_empty_transcript_row(message: ConsoleChatMessage) -> bool:
+    """Whether ``message`` is a committed voice turn whose transcript was empty.
+
+    task-2391: the realtime loop persists such a row with a real, non-blank
+    placeholder as its CONTENT ("(no speech detected)") -- durable rows need
+    real content, since the DB layer refuses one with neither text nor an
+    image. That placeholder is UI chrome the app wrote so the row could
+    exist at all, not something the user said, so every builder that walks
+    the transcript to construct a request TO A MODEL must treat it as
+    absent rather than as a real turn: ``_provider_message_payloads`` (the
+    ordinary send/retry/edit/fork/regenerate path), ``summarize_up_to``'s
+    span (feeds the summarizer), and ``impersonate_user_reply``'s
+    transcript (asks a model to draft text "in the user's voice" from this
+    exact history -- arguably the most dangerous place to leave it in) --
+    the same exclusion the realtime reseed builder already applies at
+    reconnect (``ChatScreen._console_realtime_seed_items``). A HUMAN-facing
+    read of the row (the transcript itself, a single-message "Save as
+    Note/Media/Prompt" export the user explicitly selected) is NOT a use of
+    this helper -- the placeholder is honest, readable text there, and
+    hiding it would defeat this task's own AC#1.
+
+    Args:
+        message: A transcript row to test. Read via ``getattr`` (never a
+            plain attribute access) so a narrow test double that duck-types
+            only ``role``/``content``/``status`` -- several already exist in
+            this codebase -- returns False rather than raising
+            ``AttributeError`` on a ``.metadata`` it never declared.
+
+    Returns:
+        True when the row's ``metadata.transcript_status`` is ``"empty"``.
+        Every non-realtime row (the overwhelming majority) has no metadata
+        at all and returns False without inspecting content.
+    """
+    metadata = getattr(message, "metadata", None)
+    return metadata is not None and metadata.transcript_status == "empty"
+
+
 class ConsoleProviderGatewayProtocol(Protocol):
     """Provider gateway surface required by the Console controller."""
 
@@ -4494,6 +4531,7 @@ class ConsoleChatController:
             m
             for m in messages[:target_index]
             if m.role in {ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT}
+            and not _is_empty_transcript_row(m)
         ]
         if not before:
             return self._summarize_block(
@@ -4518,6 +4556,7 @@ class ConsoleChatController:
             m
             for m in messages[start_index:target_index]
             if m.role in {ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT}
+            and not _is_empty_transcript_row(m)
         ]
 
         # "Summarizing..." run state, set the way regenerate sets VALIDATING.
@@ -4671,7 +4710,12 @@ class ConsoleChatController:
         # drop failed rows, and drop every ASSISTANT turn before the first
         # USER turn -- strict providers reject an assistant-first array
         # (task-427). A seeded character greeting therefore travels in the
-        # system row instead, via _seeded_greeting_text (task-1531).
+        # system row instead, via _seeded_greeting_text (task-1531). Also
+        # drop an empty-transcript row (task-2391) -- its content is a
+        # placeholder written so the row could persist, not real user
+        # words, and this prompt asks the model to write "in the user's
+        # voice" from exactly this transcript, so a fabricated turn here is
+        # if anything MORE dangerous than in the ordinary send path.
         transcript: list[dict[str, Any]] = []
         seen_user = False
         for message in session_messages:
@@ -4681,6 +4725,8 @@ class ConsoleChatController:
             if getattr(message, "status", None) == "failed":
                 continue
             if not seen_user and role is ConsoleMessageRole.ASSISTANT:
+                continue
+            if _is_empty_transcript_row(message):
                 continue
             content = str(getattr(message, "content", "") or "").strip()
             if not content:
@@ -8083,6 +8129,13 @@ class ConsoleChatController:
                 # reserve image budget a real message would then lose (TASK-457
                 # code-review finding 2).
                 continue
+            if _is_empty_transcript_row(message):
+                # task-2391: an empty-transcript row never carries real
+                # attachments (it is a bare text placeholder), but excluding
+                # it here too keeps this loop's skip set identical to the
+                # emit loop's below -- same reasoning as skip_failed just
+                # above.
+                continue
             usable = [
                 attachment
                 for attachment in message.attachments
@@ -8113,6 +8166,17 @@ class ConsoleChatController:
             }:
                 continue
             if skip_failed and message.status == "failed":
+                continue
+            if _is_empty_transcript_row(message):
+                # task-2391: this row's content is a placeholder
+                # ("(no speech detected)") written so a committed voice
+                # turn with no words could still be durably created -- it
+                # is UI chrome, not something the user said, and must never
+                # be narrated to the model as a real turn (mirrors the
+                # exclusion the realtime reseed builder already applies at
+                # reconnect, `_console_realtime_seed_items`). Skipped
+                # entirely rather than emitted as empty text, same as a
+                # failed row above.
                 continue
             # A seeded character greeting must not ride in the message array:
             # strict providers (Anthropic, Gemini) reject an assistant-first

--- a/tldw_chatbook/Chat/console_cost_tracker.py
+++ b/tldw_chatbook/Chat/console_cost_tracker.py
@@ -139,9 +139,25 @@ class ConsoleCostRow:
         cache_write: Cache-write input tokens (always 0 for estimated rows).
         output: Output tokens (0 for a non-``assistant`` estimated row).
         cost_usd: Dollar cost for this row, or ``None`` when the row's
-            model has no known pricing.
+            model has no known pricing. Already INCLUDES
+            ``audio_input``/``audio_output``/``transcription_seconds``'
+            dollar contribution (task-2390) -- ``PricingCatalog.
+            cost_for_usage``'s ``total`` folds every bucket together; the
+            three fields below exist so the modal can still show audio and
+            transcription usage as their own line rather than leaving them
+            invisible inside this one figure.
         estimated: True when this row had no recorded ``ProviderUsage`` and
             its tokens/cost came from the local character-ratio estimator.
+        audio_input: Of ``uncached_input``+``cache_read``, how many were
+            audio tokens (task-2390, realtime only; 0 for every other
+            row -- see ``ProviderUsage.audio_input``'s own docstring for
+            the subset relationship). Always 0 for an estimated row.
+        audio_output: Of ``output``, how many were audio tokens
+            (task-2390, realtime only; 0 otherwise, always 0 when
+            estimated).
+        transcription_seconds: Duration of input audio transcribed for
+            this row (task-2390, realtime only; 0.0 otherwise, always 0.0
+            when estimated). Not a token count.
     """
 
     index: int
@@ -153,6 +169,9 @@ class ConsoleCostRow:
     output: int
     cost_usd: Optional[float]
     estimated: bool
+    audio_input: int = 0
+    audio_output: int = 0
+    transcription_seconds: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -723,6 +742,9 @@ def build_cost_rows(
                         output=usage.output,
                         cost_usd=breakdown.total if breakdown is not None else None,
                         estimated=False,
+                        audio_input=usage.audio_input,
+                        audio_output=usage.audio_output,
+                        transcription_seconds=usage.transcription_seconds,
                     )
                 )
                 continue

--- a/tldw_chatbook/LLM_Calls/pricing_catalog.py
+++ b/tldw_chatbook/LLM_Calls/pricing_catalog.py
@@ -87,14 +87,26 @@ _ZERO = {
 }
 
 
-def _entry(inp: float, out: float, cr: Optional[float] = None, cw: Optional[float] = None,
-           as_of: str = _SEED_AS_OF) -> Dict[str, Any]:
+def _entry(
+    inp: float, out: float, cr: Optional[float] = None, cw: Optional[float] = None,
+    as_of: str = _SEED_AS_OF,
+    audio_in: Optional[float] = None, audio_out: Optional[float] = None,
+    cached_audio_in: Optional[float] = None,
+    transcription_per_minute: Optional[float] = None,
+) -> Dict[str, Any]:
     return {
         "input_per_mtok": inp,
         "output_per_mtok": out,
         "cache_read_per_mtok": cr,
         "cache_write_per_mtok": cw,
         "as_of": as_of,
+        # task-2390 (realtime): all four default to None/absent for every
+        # non-realtime entry above, so an ordinary text model's ModelPricing
+        # carries no audio/transcription rate at all.
+        "audio_in_per_mtok": audio_in,
+        "audio_out_per_mtok": audio_out,
+        "cached_audio_in_per_mtok": cached_audio_in,
+        "transcription_per_minute": transcription_per_minute,
     }
 
 
@@ -202,9 +214,68 @@ _OPENAI_MODEL_PRICING: Dict[str, Dict[str, Any]] = {
     # dollar figure -- a `[pricing].models` override is the escape hatch.
 }
 
+# OpenAI Realtime (voice) - verified 2026-08-06 via
+# https://developers.openai.com/api/docs/pricing (task-2390's "## Research"
+# section carries the full source table). Realtime bills per 1M TOKENS like
+# every chat model above, NOT per audio minute -- the task's own Description
+# premise was wrong on that point; only *transcription* (below) is
+# per-minute. "openai:gpt-realtime" is the app's default (see
+# Chat/console_voice_input.py's DEFAULT_REALTIME_MODEL).
+#
+# Cached AUDIO input is a SEPARATE rate from cached TEXT input
+# (cache_read_per_mtok) -- they coincide at $0.40 for gpt-realtime but
+# diverge for -mini ($0.30 audio vs $0.06 text). `cached_audio_in_per_mtok`
+# is seeded here for the record (AC2: catalog entries exist for every
+# published rate) but PricingCatalog.cost_for_usage() does not read it: see
+# that method's own docstring for why (ProviderUsage cannot attribute a
+# cache-read token to audio vs text -- ground truth in
+# LLM_Calls/realtime/openai_session.py's header shows the wire payload
+# splits `cached_tokens_details` this finely, but `ProviderUsage.
+# from_provider_payload` does not parse that sub-object).
+#
+# No published cache-WRITE rate for realtime (prompt caching is automatic,
+# server-managed) -- cache_write_per_mtok stays None like every OpenAI chat
+# model above.
+_REALTIME_AS_OF = "2026-08-06"
+# Whisper transcribes realtime's input audio (see openai_session.py's
+# `_TRANSCRIPTION_MODEL = "whisper-1"`) at a flat per-minute rate,
+# independent of which gpt-realtime variant is running the session --
+# duplicated across every entry below rather than looked up separately,
+# since ProviderUsage never records the transcription sub-model.
+_WHISPER_TRANSCRIPTION_PER_MINUTE = 0.006
+
+_OPENAI_REALTIME_MODEL_PRICING: Dict[str, Dict[str, Any]] = {
+    "openai:gpt-realtime": _entry(
+        4.00, 16.00, 0.40, None, as_of=_REALTIME_AS_OF,
+        audio_in=32.00, audio_out=64.00, cached_audio_in=0.40,
+        transcription_per_minute=_WHISPER_TRANSCRIPTION_PER_MINUTE,
+    ),
+    "openai:gpt-realtime-mini": _entry(
+        0.60, 2.40, 0.06, None, as_of=_REALTIME_AS_OF,
+        audio_in=10.00, audio_out=20.00, cached_audio_in=0.30,
+        transcription_per_minute=_WHISPER_TRANSCRIPTION_PER_MINUTE,
+    ),
+    "openai:gpt-realtime-2.1": _entry(
+        4.00, 24.00, 0.40, None, as_of=_REALTIME_AS_OF,
+        audio_in=32.00, audio_out=64.00, cached_audio_in=0.40,
+        transcription_per_minute=_WHISPER_TRANSCRIPTION_PER_MINUTE,
+    ),
+    "openai:gpt-realtime-2": _entry(
+        4.00, 24.00, 0.40, None, as_of=_REALTIME_AS_OF,
+        audio_in=32.00, audio_out=64.00, cached_audio_in=0.40,
+        transcription_per_minute=_WHISPER_TRANSCRIPTION_PER_MINUTE,
+    ),
+    "openai:gpt-realtime-1.5": _entry(
+        4.00, 16.00, 0.40, None, as_of=_REALTIME_AS_OF,
+        audio_in=32.00, audio_out=64.00, cached_audio_in=0.40,
+        transcription_per_minute=_WHISPER_TRANSCRIPTION_PER_MINUTE,
+    ),
+}
+
 DEFAULT_MODEL_PRICING: Dict[str, Dict[str, Any]] = {
     **_stamped(_RECHECKED_AS_OF, _ANTHROPIC_MODEL_PRICING),
     **_stamped(_RECHECKED_AS_OF, _OPENAI_MODEL_PRICING),
+    **_OPENAI_REALTIME_MODEL_PRICING,
 
     # Google Gemini - verified 2026-08-01 via https://ai.google.dev/gemini-api/docs/pricing
     # (standard, <=200k-token tier for models with a long-context surcharge).
@@ -370,6 +441,27 @@ class ModelPricing:
             verified against the provider's published pricing, surfaced to
             the user so a stale rate is visibly stale rather than silently
             trusted.
+        audio_in_per_mtok: USD cost per 1,000,000 UNCACHED audio input
+            tokens (task-2390, realtime only), or ``None`` when this
+            provider/model has no published audio rate -- i.e. every
+            non-realtime model. Realtime audio bills per TOKEN like text,
+            not per audio minute; see :meth:`PricingCatalog.cost_for_usage`
+            for why this is the only audio-input rate that method reads.
+        audio_out_per_mtok: USD cost per 1,000,000 audio output tokens
+            (task-2390, realtime only), or ``None``. Output is never
+            served from a cache, so this rate is unambiguous to apply.
+        cached_audio_in_per_mtok: USD cost per 1,000,000 CACHED audio
+            input tokens (task-2390), or ``None``. Seeded for the record
+            (a genuinely published, separate rate -- it diverges from
+            ``cache_read_per_mtok`` for at least one shipped model) but
+            :meth:`PricingCatalog.cost_for_usage` does NOT read it: see
+            that method's docstring for the attribution gap that makes it
+            currently unusable.
+        transcription_per_minute: USD cost per minute of input-audio
+            transcription (task-2390, realtime only -- OpenAI's Whisper
+            sub-model), or ``None``. The one PER-MINUTE (not per-token)
+            rate in this dataclass, feeding ``ProviderUsage.
+            transcription_seconds`` rather than any token bucket.
     """
 
     input_per_mtok: float
@@ -377,6 +469,10 @@ class ModelPricing:
     cache_read_per_mtok: Optional[float]
     cache_write_per_mtok: Optional[float]
     as_of: str
+    audio_in_per_mtok: Optional[float] = None
+    audio_out_per_mtok: Optional[float] = None
+    cached_audio_in_per_mtok: Optional[float] = None
+    transcription_per_minute: Optional[float] = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -392,14 +488,29 @@ class CostBreakdown:
     figure.
 
     Attributes:
-        input_cost: USD cost of the uncached input tokens.
-        cache_read_cost: USD cost of the cache-read input tokens.
+        input_cost: USD cost of the uncached (TEXT-only, once audio is
+            accounted for separately -- see ``audio_input_cost``) input
+            tokens.
+        cache_read_cost: USD cost of the cache-read (TEXT-only) input
+            tokens.
         cache_write_cost: USD cost of the cache-write input tokens.
-        output_cost: USD cost of the output tokens.
-        total: Sum of the four cost fields above.
+        output_cost: USD cost of the (TEXT-only) output tokens.
+        total: Sum of every cost field on this dataclass.
         as_of: The ``ModelPricing.as_of`` label the rates were resolved
             from, carried through so a displayed cost can show how current
             its pricing basis is.
+        audio_input_cost: USD cost of ``ProviderUsage.audio_input``
+            (task-2390, realtime only), ``0.0`` when the resolved
+            ``ModelPricing`` has no audio rate or the usage has no audio
+            tokens. Kept as its own field -- rather than folded into
+            ``input_cost`` -- so the breakdown modal can show it as a
+            distinct line instead of an undecomposable total.
+        audio_output_cost: USD cost of ``ProviderUsage.audio_output``
+            (task-2390), same "own field" rationale as ``audio_input_cost``.
+        transcription_cost: USD cost of ``ProviderUsage.
+            transcription_seconds`` at ``ModelPricing.
+            transcription_per_minute`` (task-2390), ``0.0`` when either is
+            unset.
     """
 
     input_cost: float
@@ -408,6 +519,9 @@ class CostBreakdown:
     output_cost: float
     total: float
     as_of: str
+    audio_input_cost: float = 0.0
+    audio_output_cost: float = 0.0
+    transcription_cost: float = 0.0
 
 
 #
@@ -517,6 +631,13 @@ class PricingCatalog:
             cache_read_per_mtok=entry.get("cache_read_per_mtok"),
             cache_write_per_mtok=entry.get("cache_write_per_mtok"),
             as_of=entry.get("as_of", _SEED_AS_OF),
+            # task-2390: absent on every non-realtime entry, so `.get()`
+            # leaves these None -- additive, never repurposes an existing
+            # key.
+            audio_in_per_mtok=entry.get("audio_in_per_mtok"),
+            audio_out_per_mtok=entry.get("audio_out_per_mtok"),
+            cached_audio_in_per_mtok=entry.get("cached_audio_in_per_mtok"),
+            transcription_per_minute=entry.get("transcription_per_minute"),
         )
 
     def get_pricing(self, provider: str, model: str) -> Optional[ModelPricing]:
@@ -565,6 +686,36 @@ class PricingCatalog:
         """
         Compute a dollar cost breakdown for a ProviderUsage's disjoint token buckets.
 
+        task-2390 (realtime audio/transcription billing): ``ProviderUsage.
+        audio_input``/``audio_output`` are documented SUBSETS of
+        ``uncached_input``+``cache_read`` and ``output`` respectively (see
+        that dataclass's own docstring) -- never additional tokens, so
+        pricing them on top of the plain buckets without adjustment would
+        double count. Two attribution gaps this method resolves
+        conservatively rather than guessing:
+
+        1. Cache attribution (input side only): ``ProviderUsage`` cannot
+           say how many of ``audio_input``'s tokens came from
+           ``uncached_input`` vs ``cache_read`` -- the wire payload splits
+           ``cached_tokens_details`` this finely (see
+           ``LLM_Calls/realtime/openai_session.py``'s ground-truth header)
+           but ``from_provider_payload`` does not parse that sub-object,
+           and this method does not invent a split. Every audio-input
+           token is therefore priced at the (higher) UNCACHED audio rate
+           -- ``ModelPricing.cached_audio_in_per_mtok`` is never read here
+           -- which is cost-MAXIMIZING (never underbills) for every seeded
+           realtime model, since audio's cached rate is always cheaper
+           than its uncached rate. To avoid double-counting those same
+           tokens under ``input_cost``/``cache_read_cost``, audio tokens
+           are subtracted from ``uncached_input`` first and only "spill"
+           into ``cache_read`` once ``uncached_input`` is exhausted -- the
+           unique split-choice that minimizes the (cheaper) cached-audio
+           attribution, i.e. the conservative bound of the otherwise
+           underdetermined true split.
+        2. Output side: unambiguous. Output is never served from a cache
+           (only input can be), so ``audio_output`` is a clean subset of
+           ``output`` alone with no cache-attribution question at all.
+
         Args:
             usage: Normalized per-message token usage.
 
@@ -575,15 +726,46 @@ class PricingCatalog:
         if pricing is None:
             return None
 
-        input_cost = round(usage.uncached_input * pricing.input_per_mtok / 1_000_000, 6)
+        # Defensive clamp: a corrupted stored record (e.g. hand-edited JSON)
+        # could carry an audio count larger than its own parent bucket(s);
+        # without this, the subtractions below would go negative.
+        audio_input = min(usage.audio_input, usage.uncached_input + usage.cache_read)
+        audio_output = min(usage.audio_output, usage.output)
+
+        if pricing.audio_in_per_mtok is not None and audio_input:
+            audio_from_uncached = min(audio_input, usage.uncached_input)
+            audio_from_cache = audio_input - audio_from_uncached
+            text_uncached = usage.uncached_input - audio_from_uncached
+            text_cache_read = usage.cache_read - audio_from_cache
+            audio_input_cost = round(audio_input * pricing.audio_in_per_mtok / 1_000_000, 6)
+        else:
+            text_uncached = usage.uncached_input
+            text_cache_read = usage.cache_read
+            audio_input_cost = 0.0
+
+        if pricing.audio_out_per_mtok is not None and audio_output:
+            text_output = usage.output - audio_output
+            audio_output_cost = round(audio_output * pricing.audio_out_per_mtok / 1_000_000, 6)
+        else:
+            text_output = usage.output
+            audio_output_cost = 0.0
+
+        input_cost = round(text_uncached * pricing.input_per_mtok / 1_000_000, 6)
         cache_read_cost = round(
-            usage.cache_read * (pricing.cache_read_per_mtok or 0.0) / 1_000_000, 6
+            text_cache_read * (pricing.cache_read_per_mtok or 0.0) / 1_000_000, 6
         )
         cache_write_cost = round(
             usage.cache_write * (pricing.cache_write_per_mtok or 0.0) / 1_000_000, 6
         )
-        output_cost = round(usage.output * pricing.output_per_mtok / 1_000_000, 6)
-        total = round(input_cost + cache_read_cost + cache_write_cost + output_cost, 6)
+        output_cost = round(text_output * pricing.output_per_mtok / 1_000_000, 6)
+        transcription_cost = round(
+            usage.transcription_seconds / 60.0 * (pricing.transcription_per_minute or 0.0), 6
+        )
+        total = round(
+            input_cost + cache_read_cost + cache_write_cost + output_cost
+            + audio_input_cost + audio_output_cost + transcription_cost,
+            6,
+        )
 
         return CostBreakdown(
             input_cost=input_cost,
@@ -592,6 +774,9 @@ class PricingCatalog:
             output_cost=output_cost,
             total=total,
             as_of=pricing.as_of,
+            audio_input_cost=audio_input_cost,
+            audio_output_cost=audio_output_cost,
+            transcription_cost=transcription_cost,
         )
 
 

--- a/tldw_chatbook/LLM_Calls/pricing_catalog.py
+++ b/tldw_chatbook/LLM_Calls/pricing_catalog.py
@@ -703,15 +703,27 @@ class PricingCatalog:
            and this method does not invent a split. Every audio-input
            token is therefore priced at the (higher) UNCACHED audio rate
            -- ``ModelPricing.cached_audio_in_per_mtok`` is never read here
-           -- which is cost-MAXIMIZING (never underbills) for every seeded
-           realtime model, since audio's cached rate is always cheaper
-           than its uncached rate. To avoid double-counting those same
-           tokens under ``input_cost``/``cache_read_cost``, audio tokens
-           are subtracted from ``uncached_input`` first and only "spill"
-           into ``cache_read`` once ``uncached_input`` is exhausted -- the
-           unique split-choice that minimizes the (cheaper) cached-audio
-           attribution, i.e. the conservative bound of the otherwise
-           underdetermined true split.
+           -- regardless of which bucket it is numerically attributed to
+           below; that attribution only decides how many TEXT tokens are
+           left over in each bucket, never audio's own rate.
+
+           To avoid double-counting those same audio tokens under
+           ``input_cost``/``cache_read_cost``, they must be subtracted
+           from ``uncached_input``/``cache_read`` before those buckets are
+           priced at their (much cheaper) TEXT rates. Which bucket a given
+           audio token is subtracted from therefore changes how many TEXT
+           tokens remain in the expensive ``uncached_input`` bucket vs the
+           cheap ``cache_read`` bucket -- and since ``input_per_mtok`` is
+           always higher than ``cache_read_per_mtok``, the conservative
+           (cost-MAXIMIZING, never-underbilling) choice is to remove audio
+           tokens from ``cache_read`` FIRST, leaving as many TEXT tokens
+           as possible stranded in the expensive ``uncached_input``
+           bucket -- and only "spill" the removal into ``uncached_input``
+           once ``cache_read`` itself is exhausted. (Removing from the
+           EXPENSIVE bucket first -- the intuitive-looking order -- is
+           backwards: it evacuates text OUT of the bucket that costs the
+           most, which minimizes the bill instead of bounding it from
+           above. Don't "fix" this back without re-deriving the sign.)
         2. Output side: unambiguous. Output is never served from a cache
            (only input can be), so ``audio_output`` is a clean subset of
            ``output`` alone with no cache-attribution question at all.
@@ -733,8 +745,11 @@ class PricingCatalog:
         audio_output = min(usage.audio_output, usage.output)
 
         if pricing.audio_in_per_mtok is not None and audio_input:
-            audio_from_uncached = min(audio_input, usage.uncached_input)
-            audio_from_cache = audio_input - audio_from_uncached
+            # Drain the CHEAP bucket (cache_read) first -- see this
+            # method's docstring, point 1, for why that (not uncached_input
+            # first) is the conservative direction.
+            audio_from_cache = min(audio_input, usage.cache_read)
+            audio_from_uncached = audio_input - audio_from_cache
             text_uncached = usage.uncached_input - audio_from_uncached
             text_cache_read = usage.cache_read - audio_from_cache
             audio_input_cost = round(audio_input * pricing.audio_in_per_mtok / 1_000_000, 6)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -889,6 +889,22 @@ CONSOLE_REALTIME_SEED_CHARS = 8000
 #: seeds/exports/summarizes the conversation.
 CONSOLE_REALTIME_INTERRUPTED_MARKER = " ⏹ interrupted"
 
+#: Written as a committed voice turn's row CONTENT when the provider's
+#: transcription resolves with no words (task-2391). The store defers
+#: persistence for a content-less row, and the DB layer refuses to create a
+#: message with neither text nor an image at all
+#: (`CharactersRAGDB.add_message`) -- so a blank row explained only through
+#: `MessageMetadata.transcript_status` could never durably exist; a restart
+#: would find nothing here. This placeholder is real, non-blank content
+#: (mirroring how the interrupted marker above is chrome baked into content,
+#: not just a metadata flag), so it renders through the ordinary
+#: message-body path with no new widget and persists through the same
+#: `update_message_content` flush the "final" transcript case already uses.
+#: The reseed builder (`_console_realtime_seed_items`) is the machine reader
+#: that keeps this text out of a reconnected session's context despite it
+#: now being non-blank -- it is UI chrome, not something the user said.
+CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER = "(no speech detected)"
+
 #: `MessageMetadata.engine` value stamped on every row this loop writes
 #: (task-2364). The marker above stays as the reader's cue; machine
 #: consumers -- reseed, exports, summaries -- read the structured record.
@@ -7676,8 +7692,14 @@ class ChatScreen(BaseAppScreen):
         Console conversation is billed context on every reconnect.
 
         Only user/assistant rows with real text are replayed -- tool
-        markers and empty placeholder rows (a turn whose transcript never
-        landed) would seed noise the user never said.
+        markers would seed noise the user never said. A row whose
+        transcript came back empty (`transcript_status == "empty"`,
+        task-2391) is excluded the same way even though its content is no
+        longer blank: that content is now the empty-transcript placeholder
+        (`CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER`), UI chrome written
+        so the row could persist at all, not something the user said --
+        replaying it would teach the model the user typed that literal
+        phrase.
 
         An over-budget message is SKIPPED, not treated as the end of the
         walk (fix round 1, F6): stopping there meant one long newest reply
@@ -7697,6 +7719,9 @@ class ChatScreen(BaseAppScreen):
                 ConsoleMessageRole.USER,
                 ConsoleMessageRole.ASSISTANT,
             ):
+                continue
+            metadata = message.metadata
+            if metadata is not None and metadata.transcript_status == "empty":
                 continue
             text = self._console_realtime_seed_text(message)
             if not text:
@@ -8272,13 +8297,14 @@ class ChatScreen(BaseAppScreen):
         failed marks it `failed`, and a filled row becomes `final`. Before
         the metadata field, the empty case simply returned here and left an
         empty user row stranded forever with nothing saying whether the
-        user had been silent or the pipeline had broken.
+        user had been silent or the pipeline had broken. The empty case is
+        now also durable (task-2391): see
+        `_mark_console_realtime_transcript_empty`.
         """
         spoken = str(text or "").strip()
         row_id = session.user_row_id
         if not spoken:
-            if row_id is not None and not self._console_realtime_row_has_text(row_id):
-                self._set_console_realtime_transcript_status(row_id, "empty")
+            self._mark_console_realtime_transcript_empty(session, row_id)
             return
         if row_id is None:
             session.user_row_id = self._append_console_realtime_row(
@@ -8342,6 +8368,53 @@ class ChatScreen(BaseAppScreen):
                 f"op=realtime_transcript_status row_id={row_id}"
             )
             return True
+
+    def _mark_console_realtime_transcript_empty(
+        self, session: ConsoleRealtimeSession, row_id: str | None
+    ) -> None:
+        """Record a committed turn whose transcript came back with no words.
+
+        task-2391: `set_message_metadata` alone (the pre-fix behavior) only
+        ever reached a row that was ALREADY persisted -- an empty realtime
+        user row never is, because the store defers persistence for
+        content-less rows and the DB layer refuses to create a message with
+        neither text nor an image at all (`CharactersRAGDB.add_message`).
+        So the metadata write landed in memory only and vanished on
+        restart. `CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER` is written
+        as the row's CONTENT instead, through the same
+        `update_message_content` call the "final" (real transcript) branch
+        above uses -- which flushes the deferred create exactly as a real
+        transcript would. The status write follows the content write, same
+        order and same reason as the "final" branch: a status of "empty" on
+        a row whose placeholder never landed would be a lie.
+
+        Idempotent and race-safe via `_console_realtime_row_has_text`: a
+        row that already carries text -- a real transcript that landed
+        first, or an earlier call already having written the placeholder --
+        is left alone, matching the late-final-transcript guard above.
+
+        Args:
+            session: The live realtime loop state, for the repaint flag.
+            row_id: Native store id of the committed turn's user row, or
+                ``None`` when no row exists to mark (a commit this wiring
+                never saw).
+        """
+        if row_id is None:
+            return
+        if self._console_realtime_row_has_text(row_id):
+            return
+        store = self._ensure_console_chat_store()
+        try:
+            store.update_message_content(
+                row_id, CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
+            )
+        except Exception:  # noqa: BLE001 - transcript upkeep is never fatal
+            logger.opt(exception=True).warning(
+                "Console realtime: could not record the empty-transcript row"
+            )
+            return
+        self._set_console_realtime_transcript_status(row_id, "empty")
+        session.transcript_dirty = True
 
     def _set_console_realtime_transcript_status(self, row_id: str, status: str) -> None:
         """Record what became of a user row's transcript (task-2364).

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -8347,28 +8347,6 @@ class ChatScreen(BaseAppScreen):
         self._set_console_realtime_transcript_status(row_id, "final")
         session.transcript_dirty = True
 
-    def _console_realtime_row_has_text(self, row_id: str) -> bool:
-        """Whether a transcript row already holds text; never raises.
-
-        Args:
-            row_id: Native store id of the row.
-
-        Returns:
-            True when the row exists and its content is non-blank. An
-            unreadable row reports True so a late empty payload is treated
-            as "leave it alone" rather than relabelling a row it cannot
-            see.
-        """
-        store = self._ensure_console_chat_store()
-        try:
-            return bool(str(store.get_message(row_id).content or "").strip())
-        except Exception:  # noqa: BLE001 - an unreadable row is left untouched
-            logger.opt(exception=True).debug(
-                "Console realtime: could not read a transcript row's text: "
-                f"op=realtime_transcript_status row_id={row_id}"
-            )
-            return True
-
     def _mark_console_realtime_transcript_empty(
         self, session: ConsoleRealtimeSession, row_id: str | None
     ) -> None:
@@ -8388,10 +8366,27 @@ class ChatScreen(BaseAppScreen):
         order and same reason as the "final" branch: a status of "empty" on
         a row whose placeholder never landed would be a lie.
 
-        Idempotent and race-safe via `_console_realtime_row_has_text`: a
-        row that already carries text -- a real transcript that landed
-        first, or an earlier call already having written the placeholder --
-        is left alone, matching the late-final-transcript guard above.
+        Race-safe against a REAL transcript (matching the late-final-
+        transcript guard above): a row already carrying different non-blank
+        text is left alone, never overwritten.
+
+        Retry-safe against a SWALLOWED status write (Qodo review, task-2391
+        follow-up): the content write and the status write are two separate
+        store calls, and `_set_console_realtime_transcript_status` (below)
+        deliberately never raises -- a metadata-write failure there is
+        logged and swallowed, not surfaced. An earlier version of this
+        method used "does the row already have text" as its sole retry
+        guard, which -- once the placeholder itself IS that text -- also
+        blocked every later retry from ever reaching the status write
+        again, permanently stranding a row whose content says "empty" but
+        whose `transcript_status` never does (invisible to
+        `_is_empty_transcript_row`, and so reachable by a provider as a
+        fabricated user turn: the exact leak the placeholder was written to
+        avoid, reopened by a different route). So content and status are
+        each retried independently: content is written only when the row
+        is genuinely still blank; status is (re-)written whenever the
+        content is blank OR already the placeholder, never when it holds
+        something else.
 
         Args:
             session: The live realtime loop state, for the repaint flag.
@@ -8401,18 +8396,33 @@ class ChatScreen(BaseAppScreen):
         """
         if row_id is None:
             return
-        if self._console_realtime_row_has_text(row_id):
-            return
         store = self._ensure_console_chat_store()
         try:
-            store.update_message_content(
-                row_id, CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
-            )
-        except Exception:  # noqa: BLE001 - transcript upkeep is never fatal
-            logger.opt(exception=True).warning(
-                "Console realtime: could not record the empty-transcript row"
+            existing = str(store.get_message(row_id).content or "").strip()
+        except Exception:  # noqa: BLE001 - an unreadable row is left untouched
+            logger.opt(exception=True).debug(
+                "Console realtime: could not read a transcript row's text: "
+                f"op=realtime_transcript_status row_id={row_id}"
             )
             return
+        if existing and existing != CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER:
+            # A real transcript is already there -- never relabel it "empty".
+            return
+        if not existing:
+            try:
+                store.update_message_content(
+                    row_id, CONSOLE_REALTIME_EMPTY_TRANSCRIPT_PLACEHOLDER
+                )
+            except Exception:  # noqa: BLE001 - transcript upkeep is never fatal
+                logger.opt(exception=True).warning(
+                    "Console realtime: could not record the empty-transcript row"
+                )
+                return
+        # Reached with the placeholder now in place -- either just written
+        # above, or already there from an earlier call whose status write
+        # was swallowed. Either way, (re-)stamp the status: idempotent when
+        # it already succeeded, and the only way a stranded row recovers
+        # when it did not.
         self._set_console_realtime_transcript_status(row_id, "empty")
         session.transcript_dirty = True
 

--- a/tldw_chatbook/Widgets/Console/console_cost_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_cost_modal.py
@@ -90,15 +90,28 @@ class ConsoleCostModal(ModalScreen[None]):
 
     @staticmethod
     def _format_row(row: ConsoleCostRow) -> str:
-        """Pure ``str`` render for one breakdown row."""
+        """Pure ``str`` render for one breakdown row.
+
+        task-2390: ``row.cost_usd`` already folds in any audio/
+        transcription dollar contribution (see ``ConsoleCostRow``'s own
+        docstring), so a realtime row's audio-token and transcription-
+        duration usage is appended here as its own segment -- omitted
+        entirely for a non-realtime row (all three fields 0) -- rather
+        than left invisible inside that one total.
+        """
         cost_text = "unpriced" if row.cost_usd is None else f"${row.cost_usd:.4f}"
         if row.estimated:
             cost_text = f"~{cost_text}"
-        return (
+        text = (
             f"[{row.index}] {row.role} ({row.model or 'unknown'}) -- "
             f"in:{row.uncached_input} cache_r:{row.cache_read} "
-            f"cache_w:{row.cache_write} out:{row.output} -- {cost_text}"
+            f"cache_w:{row.cache_write} out:{row.output}"
         )
+        if row.audio_input or row.audio_output:
+            text += f" audio_in:{row.audio_input} audio_out:{row.audio_output}"
+        if row.transcription_seconds:
+            text += f" transcribe:{row.transcription_seconds:g}s"
+        return f"{text} -- {cost_text}"
 
     @staticmethod
     def _format_totals(totals: ConsoleCostRowTotals) -> str:


### PR DESCRIPTION
## What this is

**task-2391** — the last user-visible gap from the realtime voice engine (V4): a voice turn that produced no transcript left an unexplained blank row in the Console.

The row's `transcript_status="empty"` existed only in memory (the store defers persistence for content-less rows, and `CharactersRAGDB.add_message` refuses a message with neither text nor image — both verified during review), and nothing anywhere read the field. So the row vanished on restart and told the user nothing while it was there.

## The change

An empty voice turn now writes a real, visible placeholder — `(no speech detected)` — through the existing update-content flush path, so the explanation is durable and renders through the ordinary message path with no new widget. `metadata.transcript_status` remains the machine fact; the content carries only the human-readable chrome. That's the same split task-2364 established (visible `⏹ interrupted` marker in content, structured flag for deciding logic), not a return to state-in-content.

## The regression this PR also fixes (worth reading)

Making the row non-blank had a consequence the first commit missed: it stopped being skipped by the falsy-content guard when building provider context, so the model started receiving `{"role": "user", "content": "(no speech detected)"}` — **a fabricated user turn**, on the mainline retry/edit/fork/send paths, for the life of the conversation.

The second commit excludes empty-transcript rows from every model-facing context builder behind a shared `_is_empty_transcript_row()` guard: `_provider_message_payloads`, `summarize_up_to`, and `impersonate_user_reply`. The guard keys on `metadata.transcript_status`, not on the placeholder text — so a user who literally types "(no speech detected)" still has their words reach the model, and legacy rows (no metadata) are unaffected.

Export paths were deliberately left alone: they are human-facing reads of a single message the user explicitly selected, and the context-preview modal's "what would be sent" field is built by the now-fixed builder. Reasoning recorded in the task's Implementation Notes.

## Review

Reviewed in two rounds. Highlights:

- The design premise was **verified, not assumed** — `add_message`'s refusal of content-less rows is genuinely unconditional, and the Console store's deferred-create guard independently requires content, so a metadata-only durable row was never possible.
- Completeness of the context-builder fix was checked by **independent enumeration** rather than by confirming the three fixed sites: every route from a stored message to a provider call was traced (retry, continue, edit-and-resend, submit, regenerate, the agent and direct branches, skill/dictionary/world-info processing, context compaction, auto-titling). No missed path.
- Mutation-checked: neutering the guard in two separate paths turns named tests red.

## Tests

177 passed across the realtime wiring suite plus the three V3 contract files (byte-identical to base); 296 passed across the console controller and store suites. Rebased onto current dev (121 commits, no conflicts).

Note for anyone rebuilding a venv: dev now requires `textual-diff-view`, which is unrelated to this change but is needed for these suites to collect.

## Remaining

**task-2390** (realtime cost-chip integration) is the last open follow-up and is *not* in this PR. Its research is done and recorded in the task file: the task's original premise was wrong — realtime audio is billed per 1M tokens, not per minute, so the existing per-mtok pricing model extends additively rather than needing redesign. Verified rates are in the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Empty realtime voice turns now persist a clear "(no speech detected)" row and are excluded from all model-facing contexts. Realtime cost is now billed: audio tokens and Whisper transcription are priced and surfaced in the cost chip using seeded `openai:gpt-realtime` rates; addresses task-2391 and task-2390.

- **Bug Fixes**
  - Made the empty-transcript write path retry-safe: write the placeholder via `update_message_content`, then stamp `transcript_status="empty"`; if the placeholder already exists, still stamp the status.
  - Guarded all model-facing builders with `_is_empty_transcript_row()` and safe metadata reads, preventing crashes and fabricated user turns in send/summarize/impersonate paths.
  - Skipped empty-transcript rows in the realtime reseed builder; added tests across store, resume, controller, summarization, wiring, and pricing.

- **New Features**
  - Seeded pricing for `openai:gpt-realtime` (`-mini`, `-2.1`, `-2`, `-1.5`) and Whisper ($0.006/min); non-realtime models unchanged.
  - Updated `cost_for_usage` to price `audio_input`/`audio_output` and `transcription_seconds`, draining `cache_read` before `uncached_input` to avoid underbilling and double counting.
  - Extended `ConsoleCostRow` and the cost modal to show `audio_input`, `audio_output`, and `transcription_seconds`, with tests for pricing math and row/modal formatting.

<sup>Written for commit e18bced8737a59a5ea18df26b49e59e40002f8f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

