### PR TITLE
feat(watchlists): UAT batch 4 — readable reader, humane timestamps, check-now feedback (tasks 2307/2308/2309)

### DIFF
--- a/Tests/Subscriptions/test_html_text.py
+++ b/Tests/Subscriptions/test_html_text.py
@@ -206,6 +206,32 @@ def test_tab_and_newline_survive_control_stripping():
     assert out == "line one\nline two\tindented"
 
 
+def test_carriage_return_does_not_survive_control_stripping():
+    """Batch-4 review, M1. The docstring's own claim ("C0 minus tab and
+    newline") always meant to cover CR (0x0D, neither tab nor newline), but
+    the regex range used to jump `\\x0c` -> `\\x0e-\\x1f` and skip it by one
+    code point -- a much weaker primitive than ESC/OSC (a bare CR can only
+    overwrite characters earlier on the same terminal line, a line-overwrite
+    spoof), but a real mismatch between what this module documents and what
+    it did.
+    """
+    out = strip_control_characters("Real Title\rEVIL OVERWRITE")
+    assert "\r" not in out
+    assert out == "Real TitleEVIL OVERWRITE"
+
+
+def test_a_crlf_feed_body_is_not_left_with_doubled_blank_lines():
+    """The reviewer's own condition for the fix: stripping CR must not turn
+    a `\\r\\n` line ending into a doubled blank line -- the `\\n` in the pair
+    is the one line break and it must survive untouched, exactly as if the
+    body had used `\\n` alone.
+    """
+    with_crlf = strip_control_characters("line one\r\nline two\r\nline three")
+    with_lf = strip_control_characters("line one\nline two\nline three")
+    assert with_crlf == with_lf == "line one\nline two\nline three"
+    assert "\n\n" not in with_crlf
+
+
 def test_none_becomes_empty_string():
     assert strip_control_characters(None) == ""
     assert html_to_display_text(None) == ""
@@ -248,3 +274,56 @@ def test_readable_body_text_hostile_end_to_end():
     assert "label" in out
     assert "steal()" not in out
     assert "\x1b" not in out and "\x07" not in out
+
+
+# --- Batch-4 review, I3: self-closed (XHTML-style) void tags -------------
+#
+# Real RSS/Atom feeds commonly emit the self-closed form of a void element
+# (`<br/>`, `<img .../>`, `<hr/>`) rather than the bare `<br>`/`<img>` shape
+# every other test in this file uses -- these arrive at
+# `handle_startendtag`, not `handle_starttag` (`_DisplayTextExtractor`'s own
+# docstring says so), and that method had zero test coverage: mutation-
+# verified by the review to gut to a no-op with all 84 tests in this file
+# plus `test_watchlists_content_pane.py` staying green.
+
+
+def test_self_closed_br_becomes_a_line_break():
+    out = html_to_display_text("Line one<br/>Line two")
+    assert out == "Line one\nLine two", (
+        "the self-closed <br/> must become an actual line break, not a "
+        f"space-join or dropped tag: {out!r}"
+    )
+
+
+def test_self_closed_img_alt_text_is_kept_as_a_caption():
+    out = html_to_display_text('<p>Before</p><img alt="A chart of Q3 revenue"/><p>After</p>')
+    assert "A chart of Q3 revenue" in out
+    assert "<img" not in out
+    assert "Before" in out and "After" in out
+
+
+def test_self_closed_img_with_no_alt_text_produces_nothing_visible():
+    out = html_to_display_text('<img src="x.png"/>')
+    assert "<img" not in out
+
+
+def test_self_closed_hr_becomes_a_line_break_not_dropped_content():
+    out = html_to_display_text("<p>Above</p><hr/><p>Below</p>")
+    assert "Above" in out and "Below" in out
+    assert "<hr" not in out
+
+
+def test_self_closed_void_tag_inside_drop_content_is_still_dropped():
+    """The self-closed path must respect `_drop_depth` too -- an `<img/>`
+    inside a `<script>` must not leak an `[image: ...]` caption."""
+    out = html_to_display_text('<script>var x = "<img alt=leak/>";</script><p>Safe</p>')
+    assert "leak" not in out
+    assert "Safe" in out
+
+
+def test_a_self_closed_void_tag_is_bracket_shaped_text_that_still_survives_inert():
+    """The hostile-payload discipline this whole file exists for, through
+    the self-closed path specifically: an `alt` attribute shaped like Rich
+    markup must reach the caller as literal characters."""
+    out = html_to_display_text('<img alt="[bold red]not a style[/]"/>')
+    assert "[bold red]not a style[/]" in out

--- a/Tests/Subscriptions/test_html_text.py
+++ b/Tests/Subscriptions/test_html_text.py
@@ -54,6 +54,91 @@ def test_empty_and_none_are_not_html():
     assert not looks_like_html(None)
 
 
+# --- Batch-4 review, Qodo Q5: angle-bracket autolinks are not tags -------
+#
+# `<https://x>`/`<mailto:a@b>` (RFC 2822 "obs-angle-addr") are standard in
+# mailing-list and plain-text feed bodies. The old `_HTML_SHAPED` regex
+# accepted any letter-then-anything-up-to-`>` as tag-shaped, so these were
+# misclassified as HTML and routed through `html.parser`, which reads
+# `<https://x>` as a start tag named `https:` (`:` is a legal tag-name
+# character, for namespace-prefixed tags like `<xlink:href>`) with a bare
+# attribute -- and silently drops the whole URL, since nothing handles an
+# unrecognized tag. Real content loss, not just a classification quibble.
+
+
+def test_a_bare_autolink_is_not_classified_as_html():
+    assert not looks_like_html("<https://x>")
+    assert not looks_like_html("<mailto:a@b>")
+
+
+def test_a_bare_autolink_survives_readable_body_text_verbatim():
+    """The end-to-end path a feed body actually takes. Not classified as
+    HTML at all, so it never reaches the parser that used to eat it."""
+    assert "https://x" in readable_body_text("<https://x>")
+    assert "a@b" in readable_body_text("<mailto:a@b>")
+
+
+def test_real_tags_are_still_classified_as_html():
+    """The fix must not overcorrect -- these must all still match."""
+    assert looks_like_html("<b>bold</b>")
+    assert looks_like_html("<BR/>")
+    assert looks_like_html('<div class="x">')
+
+
+def test_the_stray_angle_bracket_prose_case_is_unaffected_by_the_tightening():
+    """`a < b and c > d` was ALREADY a harmless false positive before this
+    fix (`< b and c >` reads as tag-shaped to the old regex too) and stays
+    one after it -- `< ` (space right after `<`) is not a valid tag start to
+    the real parser either way, so the text round-trips unchanged regardless
+    of which regex flags it. Pinned so a future tightening cannot silently
+    start corrupting this common prose shape while "fixing" something else.
+    """
+    assert html_to_display_text("a < b and c > d") == "a < b and c > d"
+    assert readable_body_text("a < b and c > d") == "a < b and c > d"
+
+
+def test_an_autolink_mixed_with_real_html_still_converts_and_keeps_the_url():
+    """The case tightening `_HTML_SHAPED` alone does NOT fix: real HTML
+    elsewhere in the body correctly keeps `looks_like_html` True, so the
+    whole body still reaches `html.parser` -- which still cannot tell an
+    autolink from a namespace-prefixed tag on its own. The body must still
+    convert (the real HTML must still become prose) AND the autolink's URL
+    must still survive, verbatim.
+    """
+    body = "Check out <https://example.com> for more, or <b>bold</b> stuff."
+    assert looks_like_html(body)
+    out = html_to_display_text(body)
+    assert "<b>" not in out and "</b>" not in out, "the real tag must still convert"
+    assert "bold" in out
+    assert "https://example.com" in out, "the autolink's URL must survive verbatim"
+    assert "<https://example.com>" not in out, (
+        "the raw tag-shaped form must not leak through unconverted"
+    )
+
+
+def test_two_autolinks_in_one_body_both_survive():
+    """Guards the placeholder-restoration loop against only handling one
+    match -- each occurrence gets its own index."""
+    body = "See <https://a.example> and also <https://b.example>, or <i>this</i>."
+    out = html_to_display_text(body)
+    assert "https://a.example" in out
+    assert "https://b.example" in out
+    assert "this" in out
+
+
+def test_an_autolink_inside_dropped_content_does_not_leak():
+    """The protect-before-parse step must not accidentally rescue an
+    autolink that legitimately belongs inside a `<script>` block -- it has
+    to vanish along with the rest of that content, not leak through the
+    placeholder-restoration step as an exception to the drop rule.
+    """
+    out = html_to_display_text(
+        '<script>var x = "<https://evil.example>";</script><p>Safe</p>'
+    )
+    assert "evil.example" not in out
+    assert "Safe" in out
+
+
 # --- html_to_display_text: readability ----------------------------------
 
 

--- a/Tests/Subscriptions/test_html_text.py
+++ b/Tests/Subscriptions/test_html_text.py
@@ -1,0 +1,250 @@
+"""Unit tests for `html_text.py` (TASK-2307).
+
+Two properties matter here, and each gets its own hostile-payload coverage:
+inertness (nothing this module produces can be interpreted by a terminal or
+a Rich markup parser) and readability (a real feed's HTML actually turns
+into prose a person can read, not a mangled mess).
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from tldw_chatbook.Subscriptions.html_text import (
+    html_to_display_text,
+    looks_like_html,
+    readable_body_text,
+    strip_control_characters,
+)
+
+
+# --- looks_like_html ---------------------------------------------------
+
+
+def test_a_plain_sentence_is_not_treated_as_html():
+    assert not looks_like_html("Just an ordinary sentence.")
+
+
+def test_a_bare_less_than_sign_is_not_mistaken_for_a_tag():
+    """A mathematical `<` in plain prose must not trigger the converter --
+    the whole reason `_HTML_SHAPED` requires a closing `>` and a letter (or
+    `/`) right after `<`."""
+    assert not looks_like_html("1 < 2 and 2 < 3, all in plain text.")
+
+
+def test_a_real_tag_is_detected():
+    assert looks_like_html("<p>hello</p>")
+
+
+def test_an_html_comment_is_detected():
+    assert looks_like_html("before <!-- a comment --> after")
+
+
+def test_a_named_entity_reference_is_detected():
+    assert looks_like_html("Tom &amp; Jerry")
+
+
+def test_a_numeric_entity_reference_is_detected():
+    assert looks_like_html("caf&#233;")
+    assert looks_like_html("caf&#xE9;")
+
+
+def test_empty_and_none_are_not_html():
+    assert not looks_like_html("")
+    assert not looks_like_html(None)
+
+
+# --- html_to_display_text: readability ----------------------------------
+
+
+def test_paragraphs_become_readable_prose_with_blank_lines_between_them():
+    out = html_to_display_text("<p>First paragraph.</p><p>Second paragraph.</p>")
+    assert "<p>" not in out and "</p>" not in out
+    assert "First paragraph." in out
+    assert "Second paragraph." in out
+    assert "\n\n" in out
+
+
+def test_a_link_keeps_its_label_and_shows_its_destination_as_text():
+    """The UAT's exact shape: `<a href>` must not vanish into a hidden
+    hyperlink -- both halves must be visible, plain text."""
+    out = html_to_display_text('Article URL: <a href="https://example.test/x">read more</a>')
+    assert "<a href" not in out
+    assert "read more" in out
+    assert "https://example.test/x" in out
+
+
+def test_a_link_whose_label_already_is_the_url_is_not_printed_twice():
+    out = html_to_display_text('<a href="https://example.test/x">https://example.test/x</a>')
+    assert out.count("https://example.test/x") == 1
+
+
+def test_list_items_become_bullets():
+    out = html_to_display_text("<ul><li>First</li><li>Second</li></ul>")
+    assert "- First" in out
+    assert "- Second" in out
+    assert "<li>" not in out
+
+
+def test_line_breaks_become_newlines():
+    out = html_to_display_text("Line one<br>Line two")
+    assert "Line one" in out
+    assert "Line two" in out
+    assert "<br" not in out
+
+
+def test_image_alt_text_is_kept_as_a_caption():
+    out = html_to_display_text('<img src="x.png" alt="A chart of Q3 revenue">')
+    assert "A chart of Q3 revenue" in out
+    assert "<img" not in out
+
+
+def test_image_with_no_alt_text_produces_nothing_visible():
+    out = html_to_display_text('<img src="x.png">')
+    assert "<img" not in out
+
+
+def test_entities_are_unescaped_exactly_once():
+    out = html_to_display_text("Tom &amp; Jerry")
+    assert out == "Tom & Jerry"
+
+
+def test_entities_are_not_double_unescaped():
+    """`&amp;lt;` must become `&lt;`, not `<` -- double-unescaping would
+    manufacture a tag-shaped fragment out of literal feed text."""
+    out = html_to_display_text("literal: &amp;lt;not-a-tag&amp;gt;")
+    assert "&lt;not-a-tag&gt;" in out
+
+
+def test_script_and_style_content_is_dropped_not_shown_as_text():
+    out = html_to_display_text(
+        "<p>Visible</p><script>alert('x')</script><style>.a{color:red}</style>"
+    )
+    assert "Visible" in out
+    assert "alert" not in out
+    assert "color:red" not in out
+    assert "<script>" not in out and "<style>" not in out
+
+
+def test_nested_drop_content_is_not_reenabled_by_the_inner_close_tag():
+    """`<svg><style>...</style>...</svg>`: the inner `</style>` must not
+    turn dropping back off while still inside the outer `<svg>`."""
+    out = html_to_display_text("<p>Before</p><svg><style>.a{}</style>leaked?</svg><p>After</p>")
+    assert "Before" in out and "After" in out
+    assert "leaked?" not in out
+
+
+def test_malformed_nesting_does_not_raise():
+    """`html.parser` tolerates bad markup; a stray close tag must not crash."""
+    out = html_to_display_text("<p>Unclosed paragraph <b>bold <i>italic</p> stray </a> tail")
+    assert "Unclosed paragraph" in out
+    assert "tail" in out
+
+
+def test_a_plain_text_value_with_no_markup_survives_essentially_unchanged():
+    out = html_to_display_text("Just a sentence with no markup at all.")
+    assert out == "Just a sentence with no markup at all."
+
+
+def test_runs_of_inline_whitespace_are_collapsed():
+    out = html_to_display_text("<p>too    much     space</p>")
+    assert "too much space" in out
+    assert "  " not in out
+
+
+def test_more_than_one_blank_line_is_collapsed_to_one():
+    out = html_to_display_text("<p>A</p>" + "<div></div>" * 5 + "<p>B</p>")
+    assert "\n\n\n" not in out
+
+
+# --- Hostile payloads: inertness -----------------------------------------
+
+
+def test_bracket_shaped_text_survives_as_literal_characters():
+    """Rich markup shape inside an HTML body must come out as plain text,
+    for `Text.append` to render verbatim rather than interpret."""
+    out = html_to_display_text("<p>[bold red]not a style[/]</p>")
+    assert "[bold red]not a style[/]" in out
+
+
+def test_raw_esc_control_byte_does_not_survive():
+    """A raw ESC in a feed body must never reach the terminal -- an OSC-8
+    hyperlink whose label lies about its destination, or a cursor-control
+    sequence, both start here."""
+    out = html_to_display_text("<p>before \x1b[31mred\x1b[0m after</p>")
+    assert "\x1b" not in out
+    assert "before" in out and "red" in out and "after" in out
+
+
+def test_osc8_hyperlink_sequence_loses_its_control_bytes():
+    """The exact payload the module's own docstring names: an OSC-8
+    hyperlink whose visible label lies about where it actually points."""
+    payload = "<p>\x1b]8;;http://evil.test\x07Anthropic docs\x1b]8;;\x07 tail</p>"
+    out = html_to_display_text(payload)
+    assert "\x1b" not in out
+    assert "\x07" not in out
+    assert "Anthropic docs" in out
+    assert "tail" in out
+
+
+def test_javascript_href_is_shown_as_inert_text_not_executed_or_hidden():
+    out = html_to_display_text('<a href="javascript:alert(1)">click</a>')
+    assert "click" in out
+    assert "javascript:alert(1)" in out
+
+
+def test_c1_control_range_is_also_stripped():
+    """`strip_control_characters` covers C1 (0x80-0x9F), not just C0/DEL --
+    an 8-bit CSI/OSC introducer is just as capable as the 7-bit form."""
+    out = strip_control_characters("before \x9b31mfake-csi after")
+    assert "\x9b" not in out
+    assert "before" in out and "after" in out
+
+
+def test_tab_and_newline_survive_control_stripping():
+    out = strip_control_characters("line one\nline two\tindented")
+    assert out == "line one\nline two\tindented"
+
+
+def test_none_becomes_empty_string():
+    assert strip_control_characters(None) == ""
+    assert html_to_display_text(None) == ""
+    assert readable_body_text(None) == ""
+
+
+# --- readable_body_text: the dispatch the reader actually calls ----------
+
+
+def test_readable_body_text_converts_an_html_body():
+    out = readable_body_text("<p>Article URL: <a href=\"https://x.test\">here</a></p>")
+    assert "<p>" not in out
+    assert "here" in out and "https://x.test" in out
+
+
+def test_readable_body_text_leaves_plain_text_alone_apart_from_control_bytes():
+    """Only the control BYTE is removed, not the printable characters that
+    happened to follow it -- `strip_control_characters` strips control
+    characters, not ANSI escape sequences as a unit (see its own docstring:
+    "nothing is escaped or substituted -- the characters simply do not
+    survive"). The literal `[31m` that remains is exactly that: ordinary
+    text with no control byte left to interpret it as a colour code.
+    """
+    out = readable_body_text("1 < 2, plainly written, no markup at all.\x1b[31m")
+    assert out == "1 < 2, plainly written, no markup at all.[31m"
+    assert "\x1b" not in out
+
+
+def test_readable_body_text_hostile_end_to_end():
+    """The full path a real hostile feed body takes: HTML detection, tag
+    stripping, entity unescaping, and control-byte removal, all together."""
+    payload = (
+        '<p>[bold red]injected[/] <a href="javascript:alert(1)">click</a></p>'
+        "<p>\x1b]8;;http://evil.test\x07label\x1b]8;;\x07</p>"
+        "<script>steal()</script>"
+    )
+    out = readable_body_text(payload)
+    assert "[bold red]injected[/]" in out
+    assert "click" in out and "javascript:alert(1)" in out
+    assert "label" in out
+    assert "steal()" not in out
+    assert "\x1b" not in out and "\x07" not in out

--- a/Tests/Subscriptions/test_watchlist_opml_service.py
+++ b/Tests/Subscriptions/test_watchlist_opml_service.py
@@ -17,3 +17,64 @@ def test_export_opml():
         {"name": "AI", "url": "http://example.com/ai", "source_type": "rss"}
     ])
     assert "http://example.com/ai" in xml
+
+
+def test_a_c1_control_byte_in_an_imported_name_survives_parse():
+    """Batch-4 review, I1 (the delivery vector). A raw 7-bit ESC embedded in
+    an OPML `text=` attribute is rejected by `xml.etree.ElementTree` --
+    `ParseError: not well-formed` -- so the classic ESC-injection form is
+    blocked by XML's own grammar. A C1 control byte (0x80-0x9F, e.g. 0x9B,
+    the single-byte CSI introducer `html_text.strip_control_characters`'s
+    own docstring calls "just as capable" as `ESC [`) is valid in XML 1.0's
+    character range and parses cleanly. This is the precondition for the
+    next test: `parse()` itself does no sanitization at all, by design (it
+    is a structural parser, not a content sanitizer) -- the display
+    boundary is where this has to be stopped.
+    """
+    xml = (
+        '<?xml version="1.0"?><opml version="2.0"><body>'
+        '<outline text="Evil\x9b31mFeed" type="rss" '
+        'xmlUrl="http://example.com/feed"/>'
+        "</body></opml>"
+    )
+    svc = WatchlistOpmlService()
+    items = svc.parse(xml)
+    assert len(items) == 1
+    assert items[0]["name"] == "Evil\x9b31mFeed", (
+        "parse() must not silently sanitize -- that is not its job; if this "
+        "assertion ever goes red because \\x9b vanished here, the render-"
+        "boundary test below has stopped testing what it claims to"
+    )
+
+
+def test_a_c1_control_byte_from_opml_import_is_stripped_at_the_sources_table_cell():
+    """Batch-4 review, I1 (the fix). The C1 byte confirmed to survive
+    `parse()` above must not reach the Sources table's rendered cell --
+    `SourcesPane._source_row_cells` is the render boundary
+    `strip_control_characters` was extended to cover, the same discipline
+    `content_pane.py` already applies to the reader.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.sources_pane import SourcesPane
+
+    xml = (
+        '<?xml version="1.0"?><opml version="2.0"><body>'
+        '<outline text="Evil\x9b31mFeed" type="rss" '
+        'xmlUrl="http://example.com/feed"/>'
+        "</body></opml>"
+    )
+    payload = WatchlistOpmlService().parse(xml)[0]
+    # The shape `_source_row_cells` actually reads: a normalized source
+    # dict carrying the imported name.
+    source = {"name": payload["name"], "source_type": payload["source_type"]}
+
+    cells = SourcesPane._source_row_cells(source, False)
+    name_cell = cells[0].plain
+
+    assert "\x9b" not in name_cell, (
+        f"a C1 control byte from an imported OPML name reached the Sources "
+        f"table cell verbatim: {name_cell!r}"
+    )
+    assert "Evil" in name_cell and "31mFeed" in name_cell, (
+        "the surrounding text must still render -- only the control byte is "
+        "removed, not the characters around it"
+    )

--- a/Tests/Subscriptions/test_watchlist_scope_service.py
+++ b/Tests/Subscriptions/test_watchlist_scope_service.py
@@ -522,3 +522,103 @@ async def test_scope_service_routes_alert_rule_crud_with_watchlists_alert_rule_a
         ("update_alert_rule", "12", {"enabled": False}),
         ("delete_alert_rule", "12"),
     ]
+
+
+# --- Batch-4 review round 2, N1: one notification per cancelled check -----
+#
+# `WatchlistScopeService.launch_run`'s two-layer defense-in-depth
+# (`LocalWatchlistsService.execute_run` catches `asyncio.CancelledError` and
+# records the run's terminal state, `launch_run` catches it too as a
+# fallback for whatever might escape that inner handler) is real
+# `LocalWatchlistsService`, not `FakeLocalWatchlists` above: the bug lives in
+# the INTERACTION between the two real `except asyncio.CancelledError`
+# branches, and a fake single-method mock cannot reproduce a second write
+# happening at all.
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_check_produces_exactly_one_notification_not_two(tmp_path):
+    """N1 (Important, introduced by the C1 fix). Before the fix, a
+    cancelled check with a status-agnostic alert rule present (here,
+    "no_items", which fires whenever `items_ingested == 0` regardless of
+    whether the run succeeded or failed) produced TWO identical
+    `client_notifications` rows: one written by `execute_run`'s own
+    `except asyncio.CancelledError` handler, a second written by
+    `launch_run`'s outer one re-recording the SAME cancellation after the
+    re-raise propagated up to it. The run row itself was never doubled
+    (`record_run_result`'s UPDATE is idempotent by id) -- only the
+    notification INSERT, which has no deduplicating check despite
+    `dedupe_key` existing in the payload.
+
+    The executor is gated on two events rather than the single-event/poll
+    pattern used elsewhere in this suite: `entered` is set the instant the
+    executor is actually invoked (i.e. AFTER `_mark_run_started` has
+    already run, inside `execute_run`'s own `try` block) so the test can
+    `task.cancel()` at exactly that suspension point deterministically,
+    with no timing race and no reliance on a fixed sleep matching real
+    fetch latency.
+    """
+    import asyncio
+
+    from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+    from tldw_chatbook.Notifications import (
+        ClientNotificationsDB,
+        NotificationDispatchService,
+    )
+    from tldw_chatbook.Subscriptions import LocalWatchlistsService
+
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    notification_store = ClientNotificationsDB(tmp_path / "notifications.db")
+    dispatcher = NotificationDispatchService(store=notification_store)
+    local_service = LocalWatchlistsService(
+        db_factory=lambda: db, notification_dispatcher=dispatcher
+    )
+    scope = WatchlistScopeService(local_service=local_service, server_service=None)
+
+    source = await local_service.create_source(
+        {
+            "name": "Feed",
+            "url": "https://example.com/feed.xml",
+            "source_type": "rss",
+        }
+    )
+    # Status-agnostic: fires on `items_ingested == 0` whatever the run's
+    # final status is -- exactly the rule shape the review named.
+    await local_service.create_alert_rule(
+        name="No items",
+        condition_type="no_items",
+        job_id=source["source_id"],
+    )
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _gated_executor(subscription):
+        entered.set()
+        await release.wait()
+        return {"items": []}
+
+    local_service.run_executor = _gated_executor
+
+    task = asyncio.create_task(
+        scope.launch_run(runtime_backend="local", source_id=source["source_id"])
+    )
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    notifications = notification_store.list_notifications(limit=10)
+    assert len(notifications) == 1, (
+        f"a single cancelled check must produce exactly one notification, "
+        f"got {len(notifications)}: {notifications!r}"
+    )
+    # The "no_items" rule's own message, naming the condition it matched --
+    # confirms the ONE row that does exist is the real alert, not an empty
+    # placeholder.
+    assert "0 items" in notifications[0]["message"]
+    runs = await local_service.list_runs(source_id=source["source_id"])
+    assert runs[0]["status"] == "failed", (
+        "the run itself must still reach a terminal state (this is C1's "
+        "own guarantee, re-checked here as the test's precondition)"
+    )

--- a/Tests/UI/test_watchlists_check_now_failure.py
+++ b/Tests/UI/test_watchlists_check_now_failure.py
@@ -92,9 +92,15 @@ async def test_a_failed_fetch_is_reported_as_a_failure_and_leaves_a_trace():
         pane.select_source_by_id(str(pane.sources[0]["id"]))
         await pilot.pause(0.2)
         pane.query_one("#sources-check-now-button", Button).press()
+        # TASK-2309: pressing Check now now ALSO posts an immediate
+        # "Checking …" acknowledgment (severity=information) before the
+        # worker even starts, so `notified.calls` goes non-empty on that
+        # ack alone. Poll for `notified.errors` specifically -- the failure
+        # this test is actually about -- so the loop does not exit before
+        # the check has even run.
         for _ in range(60):
             await pilot.pause()
-            if notified.calls:
+            if notified.errors:
                 break
 
         assert notified.errors, (
@@ -260,10 +266,20 @@ def test_source_row_cells_render_the_normalizer_status_summary():
     `status`/`last_scraped` shape that the real normalizer never produces,
     which is how a column reading `-` for every source in every state stayed
     green.
+
+    TASK-2308: this used to assert the column rendered the raw ISO-8601
+    string verbatim -- exactly the premise that task exists to remove. The
+    column now renders `humane_timestamp` of the same value; asserted here
+    by calling that formatter directly (not by pinning one of its outputs),
+    since which of "Today HH:MM"/"Jul 28 09:00"/"2025-12-31" it produces for
+    a fixed stored value depends on the machine's local zone and the date the
+    suite happens to run -- exactly why `humane_time.py` has its own,
+    clock-controlled unit tests (`test_humane_time.py`) covering every branch.
     """
     from tldw_chatbook.Subscriptions.watchlist_normalizers import (
         normalize_local_subscription_row,
     )
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
 
     source = normalize_local_subscription_row(
         {
@@ -282,8 +298,9 @@ def test_source_row_cells_render_the_normalizer_status_summary():
     assert "error" in cells[2].plain.lower(), (
         f"Status column rendered {cells[2].plain!r} for an errored source"
     )
-    assert cells[3].plain == "2026-07-28T09:00:00+00:00", (
-        f"Last scraped column rendered {cells[3].plain!r}"
+    assert cells[3].plain == humane_timestamp("2026-07-28T09:00:00+00:00"), (
+        f"Last scraped column rendered {cells[3].plain!r}, not through "
+        "humane_timestamp"
     )
 
 

--- a/Tests/UI/test_watchlists_check_now_progress.py
+++ b/Tests/UI/test_watchlists_check_now_progress.py
@@ -333,3 +333,79 @@ async def test_the_inspector_check_now_button_shows_the_same_busy_state():
                 break
         assert str(inspector_button.label) == "Check now"
         assert not inspector_button.disabled
+
+
+@pytest.mark.asyncio
+async def test_leaving_the_screen_mid_check_reaches_a_terminal_status_not_stuck_running():
+    """C1 (batch-4 whole-branch review, CRITICAL).
+
+    Textual's `Widget._on_unmount` cancels every worker registered on the
+    widget being torn down (`self.workers.cancel_node(self)`), regardless of
+    the worker's group name -- the named "wc_check_now" group only protects
+    against a SECOND `run_worker` call in the same group; it does nothing
+    about the screen itself going away. This app's screens are never cached
+    (`app.py`'s own `_create_navigation_screen` docstring), so switching tabs
+    while a check is running -- an entirely ordinary action -- reaches
+    exactly this path.
+
+    `asyncio.CancelledError` is `BaseException`, not `Exception` (Python
+    >=3.8), so before this fix neither `LocalWatchlistsService.execute_run`'s
+    nor `WatchlistScopeService.launch_run`'s `except Exception` guard ever
+    saw it: the run row `_mark_run_started` set to `running` moments earlier
+    was never transitioned to anything else, silently, forever.
+    """
+    app = _build_test_app()
+    source_id = _seed_source(app)
+    app.notify = Notified()
+
+    gate = asyncio.Event()
+    app.local_watchlists_service.run_executor = _gated_run_executor(gate)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen, pane = await _open_sources(pilot, host)
+        pane.select_source_by_id(str(pane.sources[0]["id"]))
+        await pilot.pause(0.2)
+
+        pane.query_one("#sources-check-now-button", Button).press()
+
+        # Precondition: the run really is at `running` before we leave.
+        runs: list = []
+        for _ in range(60):
+            await pilot.pause()
+            runs = await app.local_watchlists_service.list_runs(source_id=source_id)
+            if runs and runs[0]["status"] == "running":
+                break
+        assert runs and runs[0]["status"] == "running", (
+            f"precondition not met -- the run never reached 'running': {runs!r}"
+        )
+
+        # Leave the screen the way the app actually does: unmount it, the
+        # same teardown `switch_screen` performs on the outgoing screen.
+        await screen.remove()
+        await pilot.pause(0.3)
+
+        # Release the gate anyway, in case anything survived the unmount --
+        # the worker should already be cancelled and nothing should be
+        # listening on the other side of it.
+        gate.set()
+        await pilot.pause(0.3)
+
+        runs = await app.local_watchlists_service.list_runs(source_id=source_id)
+        assert runs, "the run must not vanish just because the screen did"
+        assert runs[0]["status"] != "running", (
+            "a run must never be left 'running' after the user navigates "
+            f"away; got {runs[0]!r}"
+        )
+        assert runs[0]["status"] == "failed"
+        assert "cancel" in str(runs[0].get("error_msg") or "").lower(), (
+            "the recorded reason must say the check was cancelled, not "
+            f"blame the feed: {runs[0].get('error_msg')!r}"
+        )
+
+        db = app.local_watchlists_service._db()
+        row = db.get_subscription(source_id)
+        assert row["last_error"], (
+            "the source must record that the attempt failed too, the same "
+            "as any other failed check"
+        )

--- a/Tests/UI/test_watchlists_check_now_progress.py
+++ b/Tests/UI/test_watchlists_check_now_progress.py
@@ -1,0 +1,335 @@
+"""Check now gives progress and a completion signal — TASK-2309.
+
+UAT F19: pressing "Check now" produced ~5 seconds of dead air (no
+acknowledgment, no busy state, no completion signal), and a confused second
+press queued a duplicate check. Every scenario here gates the fake run
+executor behind an `asyncio.Event` so the "check is still running" window is
+deterministic rather than a race against a real fetch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.full_app_destination_context import (
+    FullAppDestinationContext as DestinationHarness,
+)
+from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import InspectorPane
+from tldw_chatbook.UI.Watchlists_Modules.sources_pane import SourcesPane
+from Tests.UI.app_factory import _build_test_app
+
+
+class Notified:
+    """Capture what the app told the user, since the toast itself is transient."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, message, *args, severity: str = "information", **kwargs) -> None:
+        self.calls.append((str(message), severity))
+
+    def messages(self, severity: str | None = None) -> list[str]:
+        if severity is None:
+            return [message for message, _ in self.calls]
+        return [message for message, sev in self.calls if sev == severity]
+
+
+def _seed_source(app, *, name: str = "Summit Route") -> int:
+    db = app.local_watchlists_service._db()
+    return db.add_subscription(
+        name=name, type="rss", source="https://summitroute.com/blog/feed.xml"
+    )
+
+
+async def _open_sources(pilot, host):
+    screen = host.screen_stack[-1]
+    screen.active_section = "sources"
+    await pilot.pause(0.3)
+    pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+    for _ in range(40):
+        await pilot.pause()
+        if pane.sources:
+            break
+    return screen, pane
+
+
+def _gated_run_executor(gate: asyncio.Event, *, items: list[dict] | None = None):
+    """A `run_executor` that blocks on `gate` before returning.
+
+    Lets a test hold a check "in flight" for exactly as long as it needs to
+    press a second time / inspect the busy state, then release it
+    deterministically -- no sleeps, no timing races.
+    """
+
+    async def _executor(subscription):
+        await gate.wait()
+        return {"items": list(items or [])}
+
+    return _executor
+
+
+@pytest.mark.asyncio
+async def test_pressing_check_now_gives_an_immediate_toast_and_a_busy_button():
+    """AC#1: acknowledgment before the worker even finishes, and a busy
+    state (disabled + relabelled) that outlives the toast."""
+    app = _build_test_app()
+    _seed_source(app)
+    notified = Notified()
+    app.notify = notified
+
+    gate = asyncio.Event()
+    app.local_watchlists_service.run_executor = _gated_run_executor(gate)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen, pane = await _open_sources(pilot, host)
+        pane.select_source_by_id(str(pane.sources[0]["id"]))
+        await pilot.pause(0.2)
+
+        button = pane.query_one("#sources-check-now-button", Button)
+        assert str(button.label) == "Check now"
+        assert not button.disabled
+
+        button.press()
+        for _ in range(40):
+            await pilot.pause()
+            if notified.calls:
+                break
+
+        # The immediate acknowledgment (AC#1) -- posted before the gated
+        # executor has returned anything at all.
+        assert any("checking" in m.lower() for m in notified.messages()), (
+            f"no immediate acknowledgment toast, got: {notified.calls!r}"
+        )
+        assert str(button.label) == "Checking...", (
+            f"the button must relabel while busy, got: {button.label!r}"
+        )
+        assert button.disabled, "the button must disable while a check is running"
+
+        # Release the gate and let the check finish.
+        gate.set()
+        for _ in range(60):
+            await pilot.pause()
+            if str(button.label) == "Check now":
+                break
+
+        assert str(button.label) == "Check now", "the busy state must clear on completion"
+        assert not button.disabled
+        assert any(
+            "complete" in m.lower() or "started" in m.lower()
+            for m in notified.messages("information")
+        ), f"no completion signal, got: {notified.calls!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_second_press_while_checking_is_refused_not_duplicated():
+    """AC#2: a second activation while the same source is mid-check is
+    refused with a stated toast, and never starts a second run executor
+    call."""
+    app = _build_test_app()
+    _seed_source(app)
+    notified = Notified()
+    app.notify = notified
+
+    gate = asyncio.Event()
+    call_count = 0
+
+    async def _counting_executor(subscription):
+        nonlocal call_count
+        call_count += 1
+        await gate.wait()
+        return {"items": []}
+
+    app.local_watchlists_service.run_executor = _counting_executor
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen, pane = await _open_sources(pilot, host)
+        pane.select_source_by_id(str(pane.sources[0]["id"]))
+        await pilot.pause(0.2)
+
+        button = pane.query_one("#sources-check-now-button", Button)
+        button.press()
+        for _ in range(40):
+            await pilot.pause()
+            if call_count >= 1:
+                break
+        assert call_count == 1, "the precondition: the first check must have started"
+
+        # A confused second press while it is still running. The button is
+        # disabled by this point (proven by the previous test), so drive the
+        # SAME message a second click would post, exactly as
+        # `on_button_pressed` does, to prove the screen-level debounce holds
+        # even if some other path posted it.
+        from tldw_chatbook.UI.Watchlists_Modules.inspector_pane import CheckNowRequested
+
+        screen.post_message(CheckNowRequested(pane.selected_source))
+        await pilot.pause(0.3)
+
+        assert call_count == 1, (
+            "a second activation while the same source is mid-check must "
+            "NOT start a second run"
+        )
+        assert any(
+            "already checking" in m.lower() for m in notified.messages("warning")
+        ), f"the refusal must be stated, not silent: {notified.calls!r}"
+
+        gate.set()
+        await pilot.pause(0.3)
+
+
+@pytest.mark.asyncio
+async def test_a_different_source_can_still_be_checked_while_one_is_busy():
+    """The debounce is per-source, not global: `run_worker` uses a named
+    group instead of the old screen-wide `exclusive=True`, specifically so
+    checking source B does not touch source A's in-flight run."""
+    app = _build_test_app()
+    _seed_source(app, name="Source A")
+    _seed_source(app, name="Source B")
+    app.notify = Notified()
+
+    gate_a = asyncio.Event()
+    calls: dict[str, int] = {"a": 0, "b": 0}
+
+    async def _executor(subscription):
+        # `subscription` here is the RAW db row (`db.get_subscription`), not
+        # the normalized entity `pane.sources` holds -- it carries "name",
+        # the actual DB column.
+        name = subscription.get("name") if hasattr(subscription, "get") else None
+        key = "a" if name == "Source A" else "b"
+        calls[key] += 1
+        if key == "a":
+            await gate_a.wait()
+        return {"items": []}
+
+    app.local_watchlists_service.run_executor = _executor
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen, pane = await _open_sources(pilot, host)
+        # `normalize_local_subscription_row` surfaces the display name as
+        # "title", not "name" -- `pane.sources` holds the normalized shape.
+        source_a = next(s for s in pane.sources if s.get("title") == "Source A")
+        source_b = next(s for s in pane.sources if s.get("title") == "Source B")
+
+        pane.select_source_by_id(str(source_a["id"]))
+        await pilot.pause(0.2)
+        pane.query_one("#sources-check-now-button", Button).press()
+        for _ in range(40):
+            await pilot.pause()
+            if calls["a"] >= 1:
+                break
+        assert calls["a"] == 1
+
+        pane.select_source_by_id(str(source_b["id"]))
+        await pilot.pause(0.2)
+        pane.query_one("#sources-check-now-button", Button).press()
+        for _ in range(40):
+            await pilot.pause()
+            if calls["b"] >= 1:
+                break
+
+        assert calls["b"] == 1, (
+            "checking a DIFFERENT source must not be blocked by source A's "
+            "in-flight check"
+        )
+        gate_a.set()
+        await pilot.pause(0.3)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_check_still_clears_the_busy_state():
+    """AC#1's failure half: the busy state must clear in a `finally`, so a
+    raising check cannot strand the button permanently disabled."""
+    app = _build_test_app()
+    _seed_source(app)
+    notified = Notified()
+    app.notify = notified
+
+    async def dead_host(subscription):
+        raise ConnectionError("Name or service not known: summitroute.com")
+
+    app.local_watchlists_service.run_executor = dead_host
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen, pane = await _open_sources(pilot, host)
+        pane.select_source_by_id(str(pane.sources[0]["id"]))
+        await pilot.pause(0.2)
+
+        button = pane.query_one("#sources-check-now-button", Button)
+        button.press()
+        for _ in range(60):
+            await pilot.pause()
+            if notified.messages("error"):
+                break
+
+        assert notified.messages("error"), (
+            f"a failed check must still be reported as a failure: {notified.calls!r}"
+        )
+        for _ in range(40):
+            await pilot.pause()
+            if not button.disabled:
+                break
+        assert not button.disabled, (
+            "a check that failed must not leave the button permanently disabled"
+        )
+        assert str(button.label) == "Check now"
+
+
+@pytest.mark.asyncio
+async def test_the_inspector_check_now_button_shows_the_same_busy_state():
+    """Both activation sites (Sources pane, Inspector) post the identical
+    `CheckNowRequested`, so both must show the same busy state -- otherwise
+    the Inspector's copy stays enabled while a duplicate run is already
+    refused elsewhere, inviting exactly the confused click AC#2 is about."""
+    app = _build_test_app()
+    _seed_source(app)
+    app.notify = Notified()
+
+    gate = asyncio.Event()
+    app.local_watchlists_service.run_executor = _gated_run_executor(gate)
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen, pane = await _open_sources(pilot, host)
+        pane.select_source_by_id(str(pane.sources[0]["id"]))
+        await pilot.pause(0.2)
+
+        pane.query_one("#sources-check-now-button", Button).press()
+        for _ in range(40):
+            await pilot.pause()
+            inspector = screen.query_one(
+                "#watchlists-entity-inspector", InspectorPane
+            )
+            try:
+                inspector_button = inspector.query_one(
+                    "#inspector-check-now-button", Button
+                )
+            except Exception:
+                continue
+            if str(inspector_button.label) == "Checking...":
+                break
+
+        inspector_button = screen.query_one(
+            "#watchlists-entity-inspector", InspectorPane
+        ).query_one("#inspector-check-now-button", Button)
+        assert str(inspector_button.label) == "Checking...", (
+            "the Inspector's Check now must show the same busy state as the "
+            "Sources pane's own button"
+        )
+        assert inspector_button.disabled
+
+        gate.set()
+        for _ in range(60):
+            await pilot.pause()
+            inspector_button = screen.query_one(
+                "#watchlists-entity-inspector", InspectorPane
+            ).query_one("#inspector-check-now-button", Button)
+            if str(inspector_button.label) == "Check now":
+                break
+        assert str(inspector_button.label) == "Check now"
+        assert not inspector_button.disabled

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -1634,6 +1634,111 @@ async def test_the_expand_button_label_reflects_expanded_when_seeded():
         )
 
 
+@pytest.mark.asyncio
+async def test_pressing_expand_actually_solos_content_and_restores_on_a_second_press():
+    """Batch-4 review round 3, Qodo Q4. Closes the gap I5 deliberately left
+    open (AC#2's screen-level handler, "honestly unwired" at the time):
+    `ExpandReaderRequested` now routes to the SAME `RegionLayout.solo`
+    mechanism `Z`/`action_solo_region` already uses (task-1344), so pressing
+    the button must produce the identical, real effect a `Z` keypress does
+    -- not a second, parallel maximize implementation.
+    """
+    from textual.widgets import Button
+
+    from Tests.UI.test_destination_shells import DestinationHarness
+    from Tests.UI.app_factory import _build_test_app
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+    from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region
+
+    item = {
+        "id": 11,
+        "title": "Expand me",
+        "source_name": "Feed",
+        "content": "body",
+        "content_kind": "article",
+        "content_format": "text",
+    }
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "items"
+        await pilot.pause(0.2)
+
+        items_pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        items_pane.items = [item]
+        await pilot.pause(0.2)
+        items_pane.select_item_by_id("11")
+        await pilot.pause(0.3)
+
+        assert screen.query("#wl-region-feeds"), "precondition: FEEDS starts visible"
+        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
+        expand_button = content_pane.query_one("#content-expand-button", Button)
+        assert str(expand_button.label) == "Expand"
+
+        expand_button.press()
+        await pilot.pause(0.3)
+
+        assert screen.region_layout.solo_region is Region.CONTENT, (
+            "the SAME solo mechanism Z uses must actually have run"
+        )
+        assert screen.query("#wl-region-content")
+        assert not screen.query("#wl-region-feeds"), (
+            "soloing CONTENT must actually collapse FEEDS around it -- the "
+            "real, visible effect, not just a state flag"
+        )
+        assert not screen.query("#wl-region-items")
+
+        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
+        restore_button = content_pane.query_one("#content-expand-button", Button)
+        assert str(restore_button.label) == "Restore", (
+            "the freshly-rebuilt pane must be seeded from the live layout, "
+            "not silently reset to Expand"
+        )
+
+        restore_button.press()
+        await pilot.pause(0.3)
+
+        assert screen.region_layout.solo_region is None, "a second press must restore"
+        assert screen.query("#wl-region-feeds")
+        assert screen.query("#wl-region-items")
+        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
+        assert str(
+            content_pane.query_one("#content-expand-button", Button).label
+        ) == "Expand"
+
+
+@pytest.mark.asyncio
+async def test_expand_reader_requested_off_the_read_tab_is_refused_defensively():
+    """The button cannot actually be pressed off Read (CONTENT is unmounted
+    everywhere else), so this drives the message directly -- the same
+    defensive-gate shape `test_solo_on_content_off_the_read_tab_is_refused`
+    already pins for `Z`, now pinned for this second entry point into the
+    identical gate.
+    """
+    from Tests.UI.test_destination_shells import DestinationHarness
+    from Tests.UI.app_factory import _build_test_app
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ExpandReaderRequested
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "sources"
+        await pilot.pause(0.3)
+        before = screen.region_layout
+
+        screen.post_message(ExpandReaderRequested())
+        await pilot.pause(0.3)
+
+        assert screen.region_layout == before
+        assert screen.region_layout.solo_region is None
+
+
 # --- PR #1091 review ---------------------------------------------------------
 
 

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -1553,6 +1553,87 @@ async def test_the_mark_unread_button_is_compact():
         assert button.compact, "the reader's button must not cost three rows"
 
 
+@pytest.mark.asyncio
+async def test_the_expand_button_posts_the_request():
+    """Batch-4 review, I5 (half 1/2). task-2307's own Implementation Notes
+    honestly disclose that `ExpandReaderRequested` has no SCREEN-level
+    handler yet (AC#2 stays unchecked for exactly that reason -- not tested
+    here, on purpose). But the PANE-level half -- the button existing and
+    posting the message on press -- had zero test coverage at all:
+    mutation-verified by the review, gutting the `content-expand-button`
+    branch of `on_button_pressed` left all 52 tests in this file green.
+    """
+    from textual.app import App
+    from textual.widgets import Button
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import (
+        ContentPane,
+        ExpandReaderRequested,
+    )
+
+    class _PaneHost(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.captured: list[str] = []
+
+        def compose(self):
+            pane = ContentPane()
+            pane.item = {"title": "x", "content": "y", "content_kind": "article"}
+            yield pane
+
+        def on_expand_reader_requested(self, message: ExpandReaderRequested) -> None:
+            self.captured.append("expand_reader_requested")
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        button = app.query_one("#content-expand-button", Button)
+        assert str(button.label) == "Expand", (
+            "the button must read Expand while the pane is not expanded"
+        )
+
+        button.press()
+        await pilot.pause()
+
+        assert app.captured == ["expand_reader_requested"], (
+            "pressing the button must post ExpandReaderRequested exactly once"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_expand_button_label_reflects_expanded_when_seeded():
+    """Batch-4 review, I5 (half 2/2). `expanded` is a plain reactive, not
+    `recompose=True` -- by design (see its own docstring): in production the
+    screen's region-solo toggle rebuilds the whole workbench through the
+    region factories, which constructs a brand new `ContentPane` and seeds
+    `expanded` on it BEFORE it mounts, so a second, pane-local recompose
+    would be pure churn. This mirrors that exact seeding shape -- set before
+    the pane is yielded -- rather than mutating the reactive on an
+    already-mounted pane, which would not be a fair test of how this
+    reactive is actually meant to be driven.
+    """
+    from textual.app import App
+    from textual.widgets import Button
+
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+
+    class _PaneHost(App):
+        def compose(self):
+            pane = ContentPane()
+            pane.item = {"title": "x", "content": "y", "content_kind": "article"}
+            pane.expanded = True
+            yield pane
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        button = app.query_one("#content-expand-button", Button)
+        assert str(button.label) == "Restore", (
+            "a pane seeded with expanded=True must offer to give the room "
+            "back, not offer to expand again"
+        )
+
+
 # --- PR #1091 review ---------------------------------------------------------
 
 
@@ -1860,6 +1941,43 @@ def test_a_hostile_markdown_body_never_emits_a_terminal_hyperlink():
     # And the destination is disclosed rather than hidden behind the label.
     assert "https://evil.test/steal" in plain
     assert "https://evil.test/autolink" in plain
+
+
+def test_a_raw_control_byte_in_a_markdown_body_is_stripped_before_rendering():
+    """Batch-4 review, I4. Every existing hostile-markdown test (including
+    the one directly above) attacks the `Markdown(hyperlinks=False)` OSC-8
+    suppression through `[label](url)` LINK SYNTAX -- none embeds a raw
+    control byte directly in the markdown source, so nothing had proven the
+    `strip_control_characters(raw_body)` call in `render_article`'s markdown
+    branch (`_is_markdown(item)` true) does anything at all. Mutation-
+    verified by the review: replacing that branch with unstripped
+    `str(raw_body or "")` left the whole content-pane suite green.
+
+    A raw OSC-8 sequence has no CommonMark significance -- to the parser it
+    is ordinary inline text, so `Markdown` would hand it straight through to
+    the terminal exactly as written unless stripped first.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import render_article
+
+    payload = "before \x1b]8;;http://evil.test\x07label\x1b]8;;\x07 after"
+    plain, ansi = _render_to_console(
+        render_article(
+            {
+                "title": "Raw control byte in markdown",
+                "source_name": "Hostile Feed",
+                "content": payload,
+                "content_kind": "article",
+                "content_format": "markdown",
+            }
+        ),
+        width=200,
+    )
+    assert "\x1b" not in plain, "the raw ESC byte must not reach the rendered text"
+    assert "\x1b]8;;" not in ansi, (
+        "no OSC-8 hyperlink may be manufactured from a raw byte sequence "
+        "embedded directly in the markdown source"
+    )
+    assert "before" in plain and "label" in plain and "after" in plain
 
 
 # --- TASK-1494: the reader's `[full page]`/`[previous snapshot]` affordances -

--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -2284,3 +2284,129 @@ async def test_snapshot_modal_renders_remote_markup_as_literal_text():
 
         modal.query_one("#svm-close", Button).press()
         await pilot.pause(0.3)
+
+
+# --- TASK-2307: HTML feed bodies render as readable text -------------------
+
+
+def test_an_html_body_renders_as_readable_prose_with_the_link_visible_as_text():
+    """The UAT finding, at the unit level: a feed's `<p>`/`<a href>` body
+    used to show up on screen exactly as written, one long unreadable line.
+    `readable_body_text` converts it before `render_article` ever appends it,
+    so the tags themselves must be gone and the link's destination must
+    still be legible -- as ordinary visible text, not a hidden hyperlink.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import render_article
+
+    out = str(render_article({
+        "title": "Claude Opus 4.5 is now available",
+        "source_name": "Anthropic News",
+        "content": (
+            "<p>Article URL: <a href=\"https://example.test/opus\">"
+            "read more</a></p><p>It is <strong>fast</strong>.</p>"
+        ),
+        "content_kind": "article",
+        "content_format": "text",
+    }))
+
+    assert "<p>" not in out and "</p>" not in out, "block tags must be gone"
+    assert "<a href" not in out, "the raw anchor tag must be gone"
+    assert "<strong>" not in out
+    assert "read more" in out, "the link's label must survive"
+    assert "https://example.test/opus" in out, (
+        "the destination must be legible as text -- a terminal reader who "
+        "cannot see the address cannot judge it"
+    )
+    assert "It is fast." in out
+
+
+def test_html_derived_prose_is_still_inert_when_actually_rendered():
+    """The escaping-terminal rule holds at the NEW final render step too
+    (AC#1): the HTML converter must not turn a feed body into something a
+    real Rich console would interpret, and a raw control byte the HTML
+    parser passes through untouched must not reach the terminal either.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import render_article
+
+    hostile = (
+        "<p>[bold red]not a style[/] and "
+        "<a href=\"javascript:alert(1)\">click</a></p>"
+        "<p>\x1b]8;;http://evil.test\x07label\x1b]8;;\x07 tail</p>"
+    )
+    plain, ansi = _render_to_console(render_article({
+        "title": "Hostile",
+        "source_name": "Hostile Feed",
+        "content": hostile,
+        "content_kind": "article",
+        "content_format": "text",
+    }))
+
+    assert "[bold red]not a style[/]" in plain, "bracket text must survive as characters"
+    assert "\x1b[31m" not in ansi, "the [bold red] tag must not have styled anything"
+    assert "\x1b]8;;" not in ansi, "no OSC-8 hyperlink may reach the terminal"
+    assert "\x1b" not in plain, "the raw ESC byte must not have survived at all"
+    assert "label" in plain and "tail" in plain, "the surrounding text must still render"
+
+
+def test_a_non_html_body_is_left_alone_apart_from_control_bytes():
+    """The other half of `readable_body_text`'s dispatch: a plain-text feed
+    body (most of them) must not be run through the HTML converter at all,
+    and must survive byte-for-byte apart from characters that cannot
+    legally reach the terminal.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import render_article
+
+    out = str(render_article({
+        "title": "Plain text feed",
+        "source_name": "Feed",
+        "content": "1 < 2 and 2 < 3, plainly written, no markup at all.",
+        "content_kind": "article",
+        "content_format": "text",
+    }))
+
+    assert "1 < 2 and 2 < 3, plainly written, no markup at all." in out
+
+
+@pytest.mark.asyncio
+async def test_selecting_an_html_item_shows_readable_prose_in_the_mounted_reader():
+    """End to end through the real screen wiring (not a direct renderer
+    call): the same `<p>`/`<a href>` shape the UAT found, opened the way a
+    user actually opens it, must not show a single literal tag on screen.
+    """
+    from textual.widgets import Static
+
+    from Tests.UI.test_destination_shells import DestinationHarness
+    from Tests.UI.app_factory import _build_test_app
+    from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+    from tldw_chatbook.UI.Watchlists_Modules.items_pane import ItemsPane
+
+    item = {
+        "id": 9,
+        "title": "Site update",
+        "source_name": "Some Blog",
+        "content": '<p>Article URL: <a href="https://example.test/post">here</a></p>',
+        "content_kind": "article",
+        "content_format": "text",
+    }
+
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "items"
+        await pilot.pause(0.2)
+
+        items_pane = screen.query_one("#watchlists-items-pane", ItemsPane)
+        items_pane.items = [item]
+        await pilot.pause(0.2)
+        items_pane.select_item_by_id("9")
+        await pilot.pause(0.3)
+
+        content_pane = screen.query_one("#watchlists-content-pane", ContentPane)
+        body = content_pane.query_one("#content-body", Static)
+        rendered = str(body.renderable)
+
+        assert "<p>" not in rendered and "<a href=" not in rendered
+        assert "here" in rendered
+        assert "https://example.test/post" in rendered

--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -130,6 +130,44 @@ async def test_selecting_source_updates_inspector_actions():
 
 
 @pytest.mark.asyncio
+async def test_entity_title_strips_control_characters():
+    """Batch-4 review, I1. `title` is remote-derived (the same source name
+    OPML import hands through with zero sanitization -- see
+    `Tests/Subscriptions/test_watchlist_opml_service.py`), and
+    `Text(f"Selected: {title}")` protects only against Rich markup, not a
+    raw control byte.
+    """
+    sources = [
+        {
+            "id": "source-1",
+            "name": "Evil\x9b31mFeed",
+            "source_type": "rss",
+            "url": "http://example.com/feed",
+            "active": True,
+        },
+    ]
+    app = _app_with_watchlists(sources)
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = host.screen_stack[-1]
+        screen.active_section = "sources"
+        await pilot.pause()
+
+        sources_pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+        sources_pane.sources = sources
+        await pilot.pause()
+        sources_pane.select_source_by_id("source-1")
+        await pilot.pause()
+
+        inspector = screen.query_one("#watchlists-entity-inspector", InspectorPane)
+        title = inspector.query_one("#inspector-entity-title", Static)
+        rendered = title.renderable.plain
+        assert "\x9b" not in rendered
+        assert "Evil" in rendered and "31mFeed" in rendered
+
+
+@pytest.mark.asyncio
 async def test_selecting_run_updates_inspector_actions():
     runs = [
         {

--- a/Tests/Watchlists/test_humane_time.py
+++ b/Tests/Watchlists/test_humane_time.py
@@ -1,0 +1,169 @@
+"""Unit tests for `humane_time.py` (TASK-2308).
+
+One formatter, one house style, for every Watchlists table timestamp.
+`now=` is threaded through every relative-format test so nothing here reads
+the real clock -- the whole point of the module's own `now` parameter.
+
+`humane_timestamp` converts to the machine's LOCAL zone (`.astimezone()`)
+before formatting, so the exact `HH:MM` in its relative-format branches
+(Today/Yesterday/same-year) depends on wherever the test happens to run.
+`_pin_local_zone_to_utc` pins the process's local zone to UTC for the
+duration of this module's tests, the same way `now=` pins the clock --
+without it these tests are only correct on a machine whose local zone
+happens to already be UTC, which is exactly the kind of "passed on my
+machine" gap this batch's UAT was born from.
+"""
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from tldw_chatbook.UI.Watchlists_Modules.humane_time import (
+    humane_timestamp,
+    parse_timestamp,
+)
+
+
+@pytest.fixture(autouse=True)
+def _pin_local_zone_to_utc(monkeypatch):
+    """Force `datetime.astimezone()` to be a no-op for this module's tests.
+
+    `time.tzset()` is POSIX-only (absent on Windows); this repo's dev/CI
+    environment is macOS/Linux (see the venv-only pytest convention), so the
+    fixture applies unconditionally rather than silently degrading to an
+    unpinned, machine-dependent run.
+    """
+    monkeypatch.setenv("TZ", "UTC")
+    time.tzset()
+    yield
+    time.tzset()
+
+
+# --- parse_timestamp ------------------------------------------------------
+
+
+def test_parses_iso_with_microseconds_and_utc_offset():
+    parsed = parse_timestamp("2026-08-04T18:15:22.123456+00:00")
+    assert parsed == datetime(2026, 8, 4, 18, 15, 22, 123456, tzinfo=timezone.utc)
+
+
+def test_parses_iso_without_microseconds():
+    parsed = parse_timestamp("2026-08-04T18:15:22+00:00")
+    assert parsed == datetime(2026, 8, 4, 18, 15, 22, tzinfo=timezone.utc)
+
+
+def test_parses_a_z_suffix_as_utc():
+    parsed = parse_timestamp("2026-08-04T18:15:22Z")
+    assert parsed == datetime(2026, 8, 4, 18, 15, 22, tzinfo=timezone.utc)
+
+
+def test_parses_sqlites_space_separated_current_timestamp_shape():
+    """SQLite's `CURRENT_TIMESTAMP` writes a space, not a `T` -- the exact
+    shape the Artifacts pane's "humane-looking" column actually stored."""
+    parsed = parse_timestamp("2026-08-04 18:22:44")
+    assert parsed == datetime(2026, 8, 4, 18, 22, 44, tzinfo=timezone.utc)
+
+
+def test_a_naive_value_is_treated_as_utc_not_local():
+    """Every writer behind these columns stores UTC -- assuming local would
+    silently shift every pre-existing row by the viewer's own offset."""
+    parsed = parse_timestamp("2026-08-04T18:15:22")
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset().total_seconds() == 0
+
+
+def test_a_naive_python_datetime_is_also_treated_as_utc():
+    parsed = parse_timestamp(datetime(2026, 8, 4, 18, 15, 22))
+    assert parsed == datetime(2026, 8, 4, 18, 15, 22, tzinfo=timezone.utc)
+
+
+def test_an_aware_python_datetime_is_returned_unchanged():
+    aware = datetime(2026, 8, 4, 18, 15, 22, tzinfo=timezone.utc)
+    assert parse_timestamp(aware) is aware
+
+
+def test_a_bare_date_becomes_midnight_utc():
+    from datetime import date
+
+    parsed = parse_timestamp(date(2026, 7, 18))
+    assert parsed == datetime(2026, 7, 18, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_none_and_empty_string_are_unparseable():
+    assert parse_timestamp(None) is None
+    assert parse_timestamp("") is None
+    assert parse_timestamp("   ") is None
+
+
+def test_garbage_text_is_unparseable():
+    assert parse_timestamp("not a timestamp at all") is None
+
+
+# --- humane_timestamp: empty / unparseable --------------------------------
+
+
+def test_empty_value_renders_the_dash():
+    assert humane_timestamp(None) == "-"
+    assert humane_timestamp("") == "-"
+    assert humane_timestamp("   ") == "-"
+
+
+def test_unparseable_value_passes_through_unchanged():
+    """Rendering a dash over a value that exists would be a lie; raising
+    inside a `compose()` exits the whole application."""
+    assert humane_timestamp("not-a-real-timestamp") == "not-a-real-timestamp"
+
+
+# --- humane_timestamp: relative formatting (clock-controlled) -------------
+
+
+def test_today_renders_as_today_hh_mm():
+    now = datetime(2026, 8, 4, 20, 0, 0, tzinfo=timezone.utc)
+    out = humane_timestamp("2026-08-04T18:15:00+00:00", now=now)
+    assert out == "Today 18:15"
+
+
+def test_yesterday_renders_as_yesterday_hh_mm():
+    now = datetime(2026, 8, 4, 9, 0, 0, tzinfo=timezone.utc)
+    out = humane_timestamp("2026-08-03T18:15:00+00:00", now=now)
+    assert out == "Yesterday 18:15"
+
+
+def test_an_earlier_day_this_year_renders_month_day_and_time():
+    now = datetime(2026, 8, 4, 9, 0, 0, tzinfo=timezone.utc)
+    out = humane_timestamp("2026-07-18T09:30:00+00:00", now=now)
+    assert out == "Jul 18 09:30"
+
+
+def test_a_prior_year_renders_as_a_bare_date():
+    now = datetime(2026, 8, 4, 9, 0, 0, tzinfo=timezone.utc)
+    out = humane_timestamp("2025-12-31T23:59:00+00:00", now=now)
+    assert out == "2025-12-31"
+
+
+def test_a_date_only_value_renders_as_that_calendar_day_not_shifted():
+    """A date-only value must never be converted to local time: doing so
+    could render midnight UTC as the day before in a western timezone."""
+    now = datetime(2026, 8, 4, 9, 0, 0, tzinfo=timezone.utc)
+    out = humane_timestamp("2026-07-18", now=now)
+    assert out == "2026-07-18"
+
+
+def test_more_than_two_days_ago_but_still_this_year_is_not_today_or_yesterday():
+    now = datetime(2026, 8, 4, 9, 0, 0, tzinfo=timezone.utc)
+    out = humane_timestamp("2026-08-01T09:00:00+00:00", now=now)
+    assert out not in ("Today 09:00", "Yesterday 09:00")
+    assert out == "Aug 01 09:00"
+
+
+def test_a_naive_now_is_treated_as_utc_too():
+    """`now=` documents that it defaults to the current UTC instant; a naive
+    `now` passed explicitly must be handled the same way `parse_timestamp`
+    handles a naive stored value, not raise on the mixed-awareness compare."""
+    now = datetime(2026, 8, 4, 20, 0, 0)  # naive
+    out = humane_timestamp("2026-08-04T18:15:00+00:00", now=now)
+    assert out == "Today 18:15"

--- a/Tests/Watchlists/test_snapshot_view_modal.py
+++ b/Tests/Watchlists/test_snapshot_view_modal.py
@@ -1,9 +1,14 @@
-"""Unit tests for `snapshot_view_modal.py`'s header formatting.
+"""Unit tests for `snapshot_view_modal.py`'s header and body rendering.
 
 Batch-4 review, I2: task-2308's own scope ("every Watchlists table
 timestamp") missed this modal's `Captured <created_at>` line -- it opens
 from the Full page/Previous snapshot buttons in the same `#content-actions`
 row this batch's reader byline already humanizes.
+
+Batch-4 review round 2, N2: `_snapshot_body` -- the Full page/Previous
+snapshot viewer's actual scraped page content, the highest-risk string in
+this feature -- was still unstripped in this same module. A raw ESC byte
+survived to render.
 """
 
 import pytest
@@ -11,7 +16,10 @@ import pytest
 pytestmark = pytest.mark.unit
 
 from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
-from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import _snapshot_header
+from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import (
+    _snapshot_body,
+    _snapshot_header,
+)
 
 
 def test_snapshot_header_humanizes_created_at():
@@ -31,3 +39,72 @@ def test_snapshot_header_degrades_honestly_with_no_created_at():
 def test_snapshot_header_still_shows_the_url():
     header = _snapshot_header("https://example.test/page", "2026-08-04T18:15:22+00:00")
     assert "https://example.test/page" in header.plain
+
+
+# --- N2: the snapshot BODY is remote page content and must be inert too --
+
+
+def test_snapshot_body_strips_a_raw_esc_byte():
+    body = _snapshot_body("before \x1b[31mred\x1b[0m after")
+    assert "\x1b" not in body.plain
+    assert "before" in body.plain and "red" in body.plain and "after" in body.plain
+
+
+def test_snapshot_body_strips_a_c1_control_byte():
+    """The single-byte CSI introducer (0x80-0x9F) -- `html_text.strip_
+    control_characters`'s own docstring calls it "just as capable" as the
+    7-bit `ESC [` form, and unlike a raw ESC it is valid inside content a
+    lenient HTML/text pipeline would not reject upstream.
+    """
+    body = _snapshot_body("Evil\x9b31mPage")
+    assert "\x9b" not in body.plain
+    assert "Evil" in body.plain and "31mPage" in body.plain
+
+
+def test_snapshot_body_converts_raw_html_to_readable_prose():
+    """`extracted_content` is not guaranteed to already be plain text --
+    `URLMonitor._fetch_url_content` only strips HTML when the source's
+    `extraction_method` is "full"/"auto"; a raw-extraction source stores
+    literal HTML in this column.
+    """
+    body = _snapshot_body("<p>Hello <a href=\"https://example.test/x\">world</a></p>")
+    assert "<p>" not in body.plain and "<a href=" not in body.plain
+    assert "Hello" in body.plain and "world" in body.plain
+    assert "https://example.test/x" in body.plain
+
+
+def test_snapshot_body_keeps_markup_shaped_text_literal():
+    """Unchanged from before N2 -- pinning the property the module docstring
+    states, now routed through `readable_body_text` instead of a bare
+    `str()`."""
+    body = _snapshot_body("before [bold red]INJECTED[/] and [link=evil]click[/link] after")
+    assert "[bold red]INJECTED[/]" in body.plain
+    assert "[link=evil]click[/link]" in body.plain
+
+
+def test_snapshot_body_with_no_content_says_so():
+    from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import _NO_CONTENT
+
+    assert _snapshot_body(None).plain == _NO_CONTENT
+    assert _snapshot_body("").plain == _NO_CONTENT
+
+
+def test_snapshot_body_hostile_payload_is_inert_through_a_real_console():
+    """The property that actually matters, proven through a real Rich
+    `Console` render rather than just checking which characters survive --
+    the same discipline `test_watchlists_content_pane.py`'s
+    `_render_to_console` helper applies to the reader.
+    """
+    import io
+
+    from rich.console import Console
+
+    console = Console(
+        width=120, record=True, color_system="standard", force_terminal=True,
+        file=io.StringIO(),
+    )
+    console.print(_snapshot_body("before \x1b]8;;http://evil.test\x07label\x1b]8;;\x07 after"))
+    plain = console.export_text(clear=False)
+    ansi = console.export_text(styles=True)
+    assert "\x1b]8;;" not in ansi, "no OSC-8 hyperlink may be manufactured from raw bytes"
+    assert "before" in plain and "label" in plain and "after" in plain

--- a/Tests/Watchlists/test_snapshot_view_modal.py
+++ b/Tests/Watchlists/test_snapshot_view_modal.py
@@ -1,0 +1,33 @@
+"""Unit tests for `snapshot_view_modal.py`'s header formatting.
+
+Batch-4 review, I2: task-2308's own scope ("every Watchlists table
+timestamp") missed this modal's `Captured <created_at>` line -- it opens
+from the Full page/Previous snapshot buttons in the same `#content-actions`
+row this batch's reader byline already humanizes.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+from tldw_chatbook.UI.Watchlists_Modules.snapshot_view_modal import _snapshot_header
+
+
+def test_snapshot_header_humanizes_created_at():
+    header = _snapshot_header("https://example.test/page", "2026-08-04T18:15:22.123456+00:00")
+    plain = header.plain
+    assert "2026-08-04T18:15:22.123456+00:00" not in plain, (
+        "the raw ISO timestamp must not reach the header verbatim"
+    )
+    assert humane_timestamp("2026-08-04T18:15:22.123456+00:00") in plain
+
+
+def test_snapshot_header_degrades_honestly_with_no_created_at():
+    header = _snapshot_header("https://example.test/page", None)
+    assert "Captured at an unknown time" in header.plain
+
+
+def test_snapshot_header_still_shows_the_url():
+    header = _snapshot_header("https://example.test/page", "2026-08-04T18:15:22+00:00")
+    assert "https://example.test/page" in header.plain

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -5901,3 +5901,81 @@ async def test_kept_briefings_button_notifies_when_chachanotes_missing_at_press_
     _args, kwargs = app.notify.call_args
     assert kwargs.get("severity") == "error"
     assert kwargs.get("markup") is False
+
+
+def test_briefing_detail_model_used_strips_control_characters():
+    """Batch-4 review, I1. `model_used`/`preset_name` are appended straight
+    into the detail header's `Text`, which protects only against Rich
+    markup, not a raw control byte -- the same discipline this batch already
+    applies to every other identity cell it touches.
+    """
+    from rich.console import Group
+
+    pane = ArtifactsPane()
+    pane.selected_briefing = {
+        "status": "complete",
+        "model_used": "Evil\x9b31mModel",
+        "body_markdown": "hello",
+        "created_at": "2026-07-18 10:00",
+    }
+    rendered = pane._detail_renderable()
+    header = rendered.renderables[0] if isinstance(rendered, Group) else rendered
+    assert "\x9b" not in header.plain
+    assert "Evil" in header.plain and "31mModel" in header.plain
+
+
+@pytest.mark.asyncio
+async def test_scripts_table_preset_column_strips_control_characters():
+    """Batch-4 review, I1. The Scripts table's own Preset cell is a
+    SEPARATE write site from the script detail header (`_script_detail_
+    renderable`) -- both read `preset_name`, but the table row is built
+    inline in `compose()`, not through that method, so it needs its own
+    stripping and its own coverage.
+    """
+    from textual.app import App
+    from textual.widgets import DataTable
+
+    class _Harness(App):
+        def compose(self):
+            yield ArtifactsPane()
+
+    app = _Harness()
+    async with app.run_test(size=(180, 50)) as pilot:
+        pane = app.query_one(ArtifactsPane)
+        # The Scripts section only renders once a briefing is selected.
+        pane.selected_briefing = {"id": 1, "status": "complete"}
+        pane.scripts = [
+            {
+                "id": 1,
+                "preset_name": "Evil\x9b31mPreset",
+                "status": "complete",
+                "created_at": "2026-07-18 10:00",
+            }
+        ]
+        await pilot.pause()
+
+        table = pane.query_one("#artifacts-scripts-table", DataTable)
+        cell = table.get_cell_at((0, 0))
+        assert "\x9b" not in cell.plain
+        assert "Evil" in cell.plain and "31mPreset" in cell.plain
+
+
+def test_script_detail_preset_name_and_model_used_strip_control_characters():
+    """Batch-4 review, I1. Same as the briefing detail header, for the
+    script detail's own `preset_name`/`model_used` cells.
+    """
+    from rich.console import Group
+
+    pane = ArtifactsPane()
+    pane.selected_script = {
+        "status": "complete",
+        "preset_name": "Evil\x9b31mPreset",
+        "model_used": "Evil\x9b31mModel",
+        "created_at": "2026-07-18 10:00",
+        "script_json": "[]",
+    }
+    rendered = pane._script_detail_renderable()
+    header = rendered.renderables[0] if isinstance(rendered, Group) else rendered
+    assert "\x9b" not in header.plain
+    assert "Evil" in header.plain
+    assert "31mPreset" in header.plain and "31mModel" in header.plain

--- a/Tests/Watchlists/test_watchlists_items_pane.py
+++ b/Tests/Watchlists/test_watchlists_items_pane.py
@@ -231,3 +231,75 @@ async def test_update_item_queued_cell_repaints_in_place_without_recompose(sampl
         pane.update_item_queued_cell(row_key, False)
         await pilot.pause()
         assert table.get_row(row_key)[4] == "", "toggling back must clear the glyph"
+
+
+# --- TASK-2308: the Items table shows PUBLISH date, not ingest time -------
+
+
+def test_item_published_text_prefers_the_real_publish_date():
+    """AC#2: the column reads `published_date`, not `created_at` -- the
+    UAT's exact defect (every row from one check carrying the same
+    microsecond-identical ingest time under a "Published" heading)."""
+    text = ItemsPane.item_published_text({
+        "published_date": "2026-08-04T17:55:00+00:00",
+        "created_at": "2026-08-04T18:15:22.123456+00:00",
+    })
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+
+    assert text == humane_timestamp("2026-08-04T17:55:00+00:00")
+    # And it must actually differ from what the ingest time would render as
+    # -- pinning the UAT's own repro (17:55 reader byline vs. 18:15 table).
+    assert text != humane_timestamp("2026-08-04T18:15:22.123456+00:00")
+
+
+def test_item_published_text_falls_back_honestly_when_the_feed_omits_one():
+    """When a feed supplies no publish date (`_parse_date` returns `None`
+    rather than defaulting to "now" -- see `monitoring_engine.py`), the cell
+    must say it is showing ingest time, never present it silently as a
+    publish date under a "Published" heading."""
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+
+    text = ItemsPane.item_published_text({
+        "published_date": None,
+        "created_at": "2026-08-04T18:15:22+00:00",
+    })
+    assert text == f"added {humane_timestamp('2026-08-04T18:15:22+00:00')}"
+    assert "Published" not in text  # no false claim of being a publish date
+
+
+def test_item_published_text_with_neither_field_shows_the_dash():
+    assert ItemsPane.item_published_text({}) == "-"
+    assert ItemsPane.item_published_text(
+        {"published_date": None, "created_at": None}
+    ) == "-"
+
+
+@pytest.mark.asyncio
+async def test_the_published_column_header_and_cells_are_wired_end_to_end():
+    """The column mapping at the pane level: header says "Published", and
+    the cell for a real item comes from `published_date` through
+    `item_published_text`/`humane_timestamp`, not the raw ingest column."""
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+
+    items = [
+        {
+            "id": "local:watchlist_item:9",
+            "item_id": 9,
+            "title": "Published item",
+            "source_name": "Feed",
+            "status": "new",
+            "published_date": "2026-08-04T17:55:00+00:00",
+            "created_at": "2026-08-04T18:15:22.123456+00:00",
+        }
+    ]
+    app = ItemsPaneHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ItemsPane)
+        pane.items = items
+        await pilot.pause()
+
+        table = pane.query_one("#items-table", DataTable)
+        assert [str(col.label) for col in table.columns.values()][3] == "Published"
+        cell = table.get_row(str(items[0]["id"]))[3]
+        assert cell == escape_markup(humane_timestamp("2026-08-04T17:55:00+00:00"))
+        assert cell != escape_markup("2026-08-04T18:15:22.123456+00:00")

--- a/Tests/Watchlists/test_watchlists_notifications_pane.py
+++ b/Tests/Watchlists/test_watchlists_notifications_pane.py
@@ -155,3 +155,30 @@ async def test_notification_selection_highlight_moves_on_reselection(
         table = pane.query_one("#notifications-table", DataTable)
         assert not _cell_style(table, "1", 0).reverse
         assert _cell_style(table, "2", 0).reverse
+
+
+@pytest.mark.asyncio
+async def test_notification_title_strips_control_characters():
+    """Batch-4 review, I1. A notification's title can carry remote-derived
+    content (an alert fired against a feed item's own title/snippet), and
+    `Text(...)` protects only against Rich markup, not a raw control byte.
+    """
+    app = NotificationsPaneHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(NotificationsPane)
+        pane.notifications = [
+            {
+                "id": 1,
+                "title": "Evil\x9b31mAlert",
+                "category": "research",
+                "severity": "info",
+                "created_at": "2026-07-18 10:00",
+                "is_read": False,
+            },
+        ]
+        await pilot.pause()
+
+        table = pane.query_one("#notifications-table", DataTable)
+        cell = table.get_cell_at((0, 1))
+        assert "\x9b" not in cell.plain
+        assert "Evil" in cell.plain and "31mAlert" in cell.plain

--- a/Tests/Watchlists/test_watchlists_runs_pane.py
+++ b/Tests/Watchlists/test_watchlists_runs_pane.py
@@ -331,7 +331,17 @@ def test_stats_text_omits_the_withheld_percentage_when_nothing_was_withheld():
 def test_stats_text_without_dispositions_key_is_unchanged():
     """A feed run (no `dispositions` key at all) must render exactly the
     pre-Task-7 text -- no empty `Checks:` line tacked on.
+
+    TASK-2308: `Started:` used to interpolate `run.get('started_at')`
+    verbatim; it now goes through `humane_timestamp`, so this asserts via
+    that formatter rather than pinning one of its outputs -- see the
+    identical note on `test_source_row_cells_render_the_normalizer_status_
+    summary` in `Tests/UI/test_watchlists_check_now_failure.py`, and
+    `Tests/Watchlists/test_humane_time.py` for that formatter's own,
+    clock-controlled coverage.
     """
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+
     run = {
         "id": "run-2",
         "source_title": "AI News RSS",
@@ -350,7 +360,7 @@ def test_stats_text_without_dispositions_key_is_unchanged():
     assert RunsPane._stats_text(run) == (
         "Source: AI News RSS\n"
         "Status: completed\n"
-        "Started: 2026-07-18 10:00\n"
+        f"Started: {humane_timestamp('2026-07-18 10:00')}\n"
         "Duration: 5m\n"
         "Found: 12 | Processed: 10 | Filtered: 2 | Errors: 0"
     )

--- a/Tests/Watchlists/test_watchlists_runs_pane.py
+++ b/Tests/Watchlists/test_watchlists_runs_pane.py
@@ -570,3 +570,34 @@ async def test_a_run_identity_reaches_the_table_inert():
         cell = pane.query_one("#runs-table", DataTable).get_cell_at((0, 0))
         assert cell.plain == hostile
         assert cell.spans == []
+
+
+def test_run_identity_strips_control_characters_from_source_and_watchlist_names():
+    """Batch-4 review, I1. `_run_identity` wraps its result in a `Text(...)`,
+    which stops Rich markup but not a raw control byte -- `source_title` is
+    remote-derived (an imported source's name) the same way an item's title
+    is, and `watchlist_names` is user-typed free text with the same gap.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.runs_pane import RunsPane
+
+    cell = RunsPane._run_identity(
+        {
+            "source_title": "Evil\x9b31mFeed",
+            "watchlist_names": ["Morning\x1bread"],
+        }
+    )
+    assert "\x9b" not in cell and "\x1b" not in cell
+    assert "Evil" in cell and "31mFeed" in cell
+    assert "Morning" in cell and "read" in cell
+
+
+def test_run_item_row_title_strips_control_characters():
+    """Batch-4 review, I1. An item title is remote content (a feed entry's
+    own `<title>`); the same stripping the reader applies must reach this
+    cell too.
+    """
+    from tldw_chatbook.UI.Watchlists_Modules.runs_pane import RunsPane
+
+    cells = RunsPane._run_item_row_cells({"title": "Evil\x9b31mTitle"})
+    assert "\x9b" not in cells[0].plain
+    assert "Evil" in cells[0].plain and "31mTitle" in cells[0].plain

--- a/Tests/Watchlists/test_watchlists_sources_pane.py
+++ b/Tests/Watchlists/test_watchlists_sources_pane.py
@@ -784,3 +784,17 @@ async def test_every_select_in_the_pane_is_prune_safe():
             if not isinstance(select, PruneSafeSelect)
         ]
         assert not offenders, f"stock Select still used for: {offenders}"
+
+
+def test_source_row_name_strips_control_characters():
+    """Batch-4 review, I1. `name` is remote-derived (OPML import hands an
+    `<outline text=...>` attribute straight through with zero sanitization
+    -- see `Tests/Subscriptions/test_watchlist_opml_service.py` for the full
+    delivery-path proof), and `Text(...)` protects only against Rich markup,
+    not a raw control byte.
+    """
+    cells = SourcesPane._source_row_cells(
+        {"name": "Evil\x9b31mFeed", "source_type": "rss"}, False
+    )
+    assert "\x9b" not in cells[0].plain
+    assert "Evil" in cells[0].plain and "31mFeed" in cells[0].plain

--- a/backlog/tasks/task-2307 - Reader renders feed HTML as readable text.md
+++ b/backlog/tasks/task-2307 - Reader renders feed HTML as readable text.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2307
 title: Reader renders feed HTML as readable text
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-04'
 labels:
@@ -32,3 +32,29 @@ UAT findings F26 (high), F27.
       visible expand affordance).
 - [ ] Regression tests cover HTML-to-text rendering and the injection-
       inertness of rendered remote content.
+
+## Implementation Plan (the how)
+
+1. Grep for an existing html-to-text helper first. (Done: the repo has
+   `ContentExtractor.extract_text_from_html` in `monitoring_engine.py`, but it
+   collapses the whole document to ONE line and drops every `href` -- unusable
+   as a reader. `html2text` is an optional `[ebook]` extra, not a hard dep.)
+2. New module `Subscriptions/html_text.py`, stdlib `html.parser` only: block
+   tags become newlines, `<a href>` becomes `label (url)` as plain text,
+   `<li>` becomes a bullet, `script`/`style`/`head` content is dropped, entity
+   refs are unescaped once. Plus `strip_control_characters` (C0 except
+   `\n`/`\t`, and C1) so a body carrying raw ESC cannot reach the terminal.
+3. `content_pane.render_article`/`render_change` run every remote-derived
+   field through that pair as the LAST step before `Text.append`. The result
+   is a plain `str` appended to a `rich.text.Text`, which never markup-parses
+   -- the existing inertness property is preserved by construction, not by a
+   sanitizer.
+4. AC#2: a visible expand affordance. `ContentPane` grows an `Expand`/
+   `Restore` button beside `Mark unread` (same row, zero extra rows) that
+   posts `ExpandReaderRequested`; the screen solos/unsolos `Region.CONTENT`
+   through the same `_apply_layout` path `Z` uses, and seeds the button's
+   label from the live layout so it never lies.
+5. Tests: a unit file for the converter (including hostile payloads --
+   `[bold]`, `<script>`, ESC/OSC-8, malformed nesting) plus content-pane
+   tests proving the rendered output is inert when actually rendered through
+   a Rich console.

--- a/backlog/tasks/task-2307 - Reader renders feed HTML as readable text.md
+++ b/backlog/tasks/task-2307 - Reader renders feed HTML as readable text.md
@@ -28,7 +28,7 @@ UAT findings F26 (high), F27.
       converted; links presented legibly), while remote-derived text remains
       inert against markup/injection — the escaping-terminal rule holds at
       the NEW final render step.
-- [ ] The reader advertises how to give itself more room (or provides a
+- [x] The reader advertises how to give itself more room (or provides a
       visible expand affordance).
 - [x] Regression tests cover HTML-to-text rendering and the injection-
       inertness of rendered remote content.
@@ -81,22 +81,57 @@ property through `render_article` and, end to end, through a mounted
 reader shows "Article URL: https://buttondown.com/blog/..." as legible
 prose, not `<p>Article URL: <a href=...>`.
 
-**AC#2 -- NOT done; left unchecked on purpose.** The button renders and
-carries the right tooltip, but nothing in `watchlists_collections_screen.py`
-imports or handles `ExpandReaderRequested` -- confirmed by grep and by
-mutation (there is no `@on(ExpandReaderRequested)` anywhere). Pressing
-Expand currently does nothing. This batch's dispatch explicitly scoped the
-remaining work to the Items publish column (task-2308) and Check-now
-progress (task-2309) plus tests, and did not include finishing this AC's
-region-solo wiring (`_apply_layout`/`Region.CONTENT`, per this task's own
-step 4) -- so it was left alone rather than expanding scope past what was
-asked. Filed as a gap for a follow-up task rather than silently checked off.
+**AC#2 -- done, closed in the Qodo re-review round (Q4).** Was left
+unchecked through two review rounds (the button rendered and posted
+`ExpandReaderRequested`, but nothing handled it) because it was out of
+those rounds' explicit scope. Qodo flagged the dead button as worse than no
+button at all and asked for a decision: wire it to the existing mechanism
+or remove it. Read task-1344's region-solo machinery
+(`action_solo_region`/`RegionLayout.solo`, bound to `Z`) first, per the
+review's instruction, and it was a clean fit -- `handle_expand_reader_
+requested` now calls the exact same `self._apply_layout(self.region_
+layout.solo(Region.CONTENT))` `action_solo_region` calls for a `Z`
+keypress, through `_refuse_region_gesture_off_read_tab` for the same
+defense-in-depth every other region-layout entry point goes through. No
+second maximize mechanism was built. `_build_content_pane` also now seeds
+`pane.expanded` from `self.region_layout.solo_region == Region.CONTENT`,
+which the earlier rounds had not done either -- without it the button's
+label would silently go stale across the very rebuild pressing it causes.
+Live-verified: pressing Expand collapses Feeds and Items to one-line
+headers and gives Content the whole centre stack (visible: the reader
+showed more of the item, e.g. a "# Comments: 1" line that had been
+scrolled off before); the button relabels to "Restore"; a second press
+restores the three-pane view exactly.
 
 **AC#3 -- done.** See above; 32 unit tests + 4 content-pane tests, all
 passing, including a mutation-verified check that a link whose label already
 IS the destination is not printed twice.
 
-Modified/added: `Tests/Subscriptions/test_html_text.py` (new),
-`Tests/UI/test_watchlists_content_pane.py` (4 tests appended). No production
-code changed for this task in this session -- `html_text.py` and
-`content_pane.py`'s HTML wiring were already complete in the WIP commit.
+Modified/added: `Tests/Subscriptions/test_html_text.py` (new, later
+extended), `Tests/UI/test_watchlists_content_pane.py` (tests appended
+across rounds). No production code changed for AC#1/#3 in the original
+session -- `html_text.py` and `content_pane.py`'s HTML wiring were already
+complete in the WIP commit.
+
+**Qodo Q5 (later round, same module):** `_HTML_SHAPED` (the `looks_like_
+html` classifier) accepted a plain-text angle-bracket autolink
+(`<https://x>`, `<mailto:a@b>` -- RFC 2822, standard in mailing-list/
+plain-text feed bodies) as tag-shaped, so `html.parser` read it as a
+namespace-prefixed start tag (`:` is a legal tag-name character) and
+silently dropped the whole URL -- real content loss, the exact failure
+`looks_like_html`'s own conservatism exists to avoid. Fixed in two parts:
+`_HTML_SHAPED`'s tag alternative now requires a plausible tag name
+(letters/digits only) immediately followed by a real delimiter
+(whitespace/`/`/`>`), which excludes a bare autolink from classification
+entirely; and a new `_AUTOLINK`-based protect/restore step inside
+`html_to_display_text` covers the case tightening the classifier alone
+cannot -- a body that legitimately mixes an autolink WITH real HTML (the
+real tag correctly keeps the whole body routed through the parser, which
+still cannot tell an autolink from a tag on its own). Verified against
+every case Qodo listed, `Tests/Subscriptions/test_html_text.py` grew 8
+tests, and both mechanisms are independently mutation-verified.
+
+**Qodo Q4 (docstrings, Q1-Q3):** unrelated docstring completeness findings
+on `watchlists_collections_screen.handle_check_now_requested`,
+`sources_pane.source_last_scraped_text`, and `sources_pane.watch_busy_
+source_ids` -- `Args:`/`Returns:` sections added, no behavioural change.

--- a/backlog/tasks/task-2307 - Reader renders feed HTML as readable text.md
+++ b/backlog/tasks/task-2307 - Reader renders feed HTML as readable text.md
@@ -24,13 +24,13 @@ UAT findings F26 (high), F27.
 
 ## Acceptance Criteria (the what)
 
-- [ ] Feed HTML content renders as readable text (tags stripped or
+- [x] Feed HTML content renders as readable text (tags stripped or
       converted; links presented legibly), while remote-derived text remains
       inert against markup/injection — the escaping-terminal rule holds at
       the NEW final render step.
 - [ ] The reader advertises how to give itself more room (or provides a
       visible expand affordance).
-- [ ] Regression tests cover HTML-to-text rendering and the injection-
+- [x] Regression tests cover HTML-to-text rendering and the injection-
       inertness of rendered remote content.
 
 ## Implementation Plan (the how)
@@ -58,3 +58,45 @@ UAT findings F26 (high), F27.
    `[bold]`, `<script>`, ESC/OSC-8, malformed nesting) plus content-pane
    tests proving the rendered output is inert when actually rendered through
    a Rich console.
+
+## Implementation Notes
+
+Picked up mid-flight after a previous implementer was cut off by a rate
+limit (`wip(watchlists): batch-4 partial`, tasks 2307/2308/2309 together).
+That commit had already landed `Subscriptions/html_text.py` (complete,
+including `strip_control_characters`) and `content_pane.py`'s wiring
+(`readable_body_text` on the render path, plus the `Expand`/`Restore`
+button in `#content-actions` posting `ExpandReaderRequested`). This session
+added the test suite (AC#3) and live-verified AC#1.
+
+**AC#1 -- verified, live and in tests.** `Tests/Subscriptions/test_html_text.py`
+(32 cases) covers readability (paragraphs, lists, `<br>`, image alt text,
+entity unescaping exactly once, nested drop-content) and the hostile set the
+task asked for: bracket-shaped text (`[bold red]x[/]`), raw ESC, a full
+OSC-8 hyperlink sequence, a `javascript:` href, and the C1 control range --
+all proven to lose their control bytes while the surrounding prose survives.
+`Tests/UI/test_watchlists_content_pane.py` adds 4 more proving the SAME
+property through `render_article` and, end to end, through a mounted
+`ContentPane`. Live-verified against a real feed (hnrss.org/frontpage): the
+reader shows "Article URL: https://buttondown.com/blog/..." as legible
+prose, not `<p>Article URL: <a href=...>`.
+
+**AC#2 -- NOT done; left unchecked on purpose.** The button renders and
+carries the right tooltip, but nothing in `watchlists_collections_screen.py`
+imports or handles `ExpandReaderRequested` -- confirmed by grep and by
+mutation (there is no `@on(ExpandReaderRequested)` anywhere). Pressing
+Expand currently does nothing. This batch's dispatch explicitly scoped the
+remaining work to the Items publish column (task-2308) and Check-now
+progress (task-2309) plus tests, and did not include finishing this AC's
+region-solo wiring (`_apply_layout`/`Region.CONTENT`, per this task's own
+step 4) -- so it was left alone rather than expanding scope past what was
+asked. Filed as a gap for a follow-up task rather than silently checked off.
+
+**AC#3 -- done.** See above; 32 unit tests + 4 content-pane tests, all
+passing, including a mutation-verified check that a link whose label already
+IS the destination is not printed twice.
+
+Modified/added: `Tests/Subscriptions/test_html_text.py` (new),
+`Tests/UI/test_watchlists_content_pane.py` (4 tests appended). No production
+code changed for this task in this session -- `html_text.py` and
+`content_pane.py`'s HTML wiring were already complete in the WIP commit.

--- a/backlog/tasks/task-2308 - Humane timestamps and publish dates across Watchlists.md
+++ b/backlog/tasks/task-2308 - Humane timestamps and publish dates across Watchlists.md
@@ -26,11 +26,11 @@ UAT findings F20, F24, F41.
 
 ## Acceptance Criteria (the what)
 
-- [ ] All Watchlists tables show local-time, human-scale timestamps (short
+- [x] All Watchlists tables show local-time, human-scale timestamps (short
       format or relative), consistent with the Artifacts style.
-- [ ] The Items list shows the item's publish date where available, falling
+- [x] The Items list shows the item's publish date where available, falling
       back honestly when the feed omits it.
-- [ ] Column widths return to proportionate sizes.
+- [x] Column widths return to proportionate sizes.
 
 ## Implementation Plan (the how)
 
@@ -51,3 +51,67 @@ UAT findings F20, F24, F41.
    feed omits one, the cell says `added <time>` -- the ingest time, explicitly
    labelled as such -- so it never shows ingest time under a publish heading.
 5. Correct the one existing test that asserts the raw ISO string as a premise.
+
+## Implementation Notes
+
+Picked up mid-flight after a previous implementer was cut off by a rate
+limit. The WIP commit had already landed `humane_time.py` (complete) and
+wired it into Sources ("Last scraped"), Runs ("Started", row + detail),
+Notifications ("Created") and Artifacts (both tables' "Created" columns plus
+both detail headers). `items_pane.py` was barely touched: the column header
+had been renamed to "Published" and `compose()` already called
+`self.item_published_text(item)`, but that method did not exist anywhere in
+the repo -- this session's core job was implementing it.
+
+**AC#1/#3 (house style + column width) -- done, by the WIP for five of six
+surfaces and confirmed working here; the sixth (Items) closed this session.**
+Live-verified against a real feed check (hnrss.org/frontpage, 20 items):
+Sources "Last scraped" reads "Today 01:19", four Runs rows all read "Started:
+Today 01:19", and the Items table's twenty rows show a spread of distinct,
+short, local-time values ("Today 00:34" through "Yesterday 09:05") -- the
+column no longer dominates row width, and titles get the space back. No
+separate width CSS was needed: `DataTable` auto-sizes to content, and a
+15-character humane string versus a 32-character ISO one is the whole fix.
+
+**AC#2 (publish, not ingest) -- done, this session.** Added
+`ItemsPane.item_published_text` (`items_pane.py`): reads `published_date`
+first (confirmed the correct field by tracing `get_new_items`'s `SELECT
+i.*` through `normalize_watchlist_item`, which is the same field
+`content_pane`'s reader byline already reads -- so the two can never
+disagree again), and falls back to `f"added {humane_timestamp(created_at)}"`
+-- ingest time, but explicitly labelled as ingest, never presented silently
+under the "Published" heading -- when the feed supplied no publish date
+(`monitoring_engine._parse_date` returns `None` rather than defaulting to
+"now" for a feed that omits one). Live-verified: the UAT's own repro (reader
+byline vs. table disagreeing) is gone -- opening "What I love about Django"
+showed "HN Frontpage · Today 00:34" in the reader, matching the Items table's
+"Today 00:34" in the same row, both sourced from the same field through the
+same formatter.
+
+**Test-suite fallout from the WIP's own wiring (fixed here, not new
+regressions from this session's changes):** two pre-existing tests asserted
+the raw ISO string as their premise -- exactly the step 5 this plan calls
+for, but for TWO sibling surfaces, not the one originally anticipated.
+`Tests/UI/test_watchlists_check_now_failure.py::test_source_row_cells_
+render_the_normalizer_status_summary` (Sources) and `Tests/Watchlists/
+test_watchlists_runs_pane.py::test_stats_text_without_dispositions_key_is_
+unchanged` (Runs) both now assert via `humane_timestamp(...)` rather than a
+hardcoded string, since the exact rendering depends on the machine's local
+zone and the date the suite runs.
+
+Tests: `Tests/Watchlists/test_humane_time.py` (new, 19 cases, `TZ=UTC`
+pinned via `time.tzset()` so the Today/Yesterday/same-year branches are not
+machine-dependent) plus 4 new cases in `Tests/Watchlists/
+test_watchlists_items_pane.py` for `item_published_text` (publish
+preferred, honest ingest fallback, dash when neither exists, wired
+end-to-end through the mounted table). Mutation-verified: breaking the
+Yesterday-boundary comparison and disabling the publish-date preference
+both turned tests red; both reverted with an md5-verified byte-identical
+restore.
+
+Modified/added: `tldw_chatbook/UI/Watchlists_Modules/items_pane.py`
+(`item_published_text`, import), `Tests/Watchlists/test_humane_time.py`
+(new), `Tests/Watchlists/test_watchlists_items_pane.py` (4 tests),
+`Tests/UI/test_watchlists_check_now_failure.py` and `Tests/Watchlists/
+test_watchlists_runs_pane.py` (test corrections for the WIP's pre-existing
+humane-timestamp wiring).

--- a/backlog/tasks/task-2308 - Humane timestamps and publish dates across Watchlists.md
+++ b/backlog/tasks/task-2308 - Humane timestamps and publish dates across Watchlists.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2308
 title: Humane timestamps and publish dates across Watchlists
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-04'
 labels:
@@ -31,3 +31,23 @@ UAT findings F20, F24, F41.
 - [ ] The Items list shows the item's publish date where available, falling
       back honestly when the feed omits it.
 - [ ] Column widths return to proportionate sizes.
+
+## Implementation Plan (the how)
+
+1. Look for an existing humane formatter first. (Done: there is none shared --
+   Artifacts' "2026-08-04 18:22:44" is simply the raw SQLite `CURRENT_TIMESTAMP`
+   string, i.e. UTC that merely *looks* humane. So the house style has to be
+   written down, once.)
+2. New `UI/Watchlists_Modules/humane_time.py`: parse ISO-8601 (with or without
+   microseconds, `Z` or offset, SQLite's space separator), treat a naive value
+   as UTC (which is what every writer on this screen stores), convert to the
+   system local zone, and render `Today HH:MM` / `Yesterday HH:MM` /
+   `Mon DD HH:MM` / `YYYY-MM-DD`. Unparseable input passes through unchanged;
+   empty input renders the column's dash.
+3. Apply it at every Watchlists table timestamp: Sources "Last scraped", Runs
+   "Started" (row + detail block), Notifications "Created", Artifacts
+   briefings/scripts "Created" and both detail headers.
+4. Items: the column becomes "Published" and reads `published_date`. When the
+   feed omits one, the cell says `added <time>` -- the ingest time, explicitly
+   labelled as such -- so it never shows ingest time under a publish heading.
+5. Correct the one existing test that asserts the raw ISO string as a premise.

--- a/backlog/tasks/task-2309 - Check now shows progress and completion.md
+++ b/backlog/tasks/task-2309 - Check now shows progress and completion.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2309
 title: Check now shows progress and completion
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-04'
 labels:
@@ -27,3 +27,23 @@ UAT finding F19.
       case).
 - [ ] A second activation while a check runs is debounced or explicitly
       queued, never silently duplicated.
+
+## Implementation Plan (the how)
+
+1. The screen records which source ids have a check in flight
+   (`_checks_in_flight`). `handle_check_now_requested` refuses a second
+   activation for a source already being checked, with a toast that says so
+   -- debounce, stated, never silent.
+2. Immediate acknowledgment: a `Checking <name>...` toast posted before the
+   worker starts, and a busy state that outlives the toast -- both Check now
+   buttons (Sources pane and Inspector) go disabled and read `Checking...`
+   for the source being checked.
+3. Completion: the existing success/failure toasts gain the source's name and
+   the run's own counters, and the busy state is cleared in a `finally` so a
+   raising check cannot strand a permanently-disabled button.
+4. Drop `exclusive=True` from the check worker in favour of a named group: it
+   made a second press CANCEL the first mid-write, which is exactly the
+   unsound cancellation-supersede TASK-1541 documents (a cancelled
+   `execute_run` leaves its run row at `running` forever).
+5. Tests: a new UI file covering acknowledgment, busy state, the debounce
+   refusal, and the failure path's completion signal.

--- a/backlog/tasks/task-2309 - Check now shows progress and completion.md
+++ b/backlog/tasks/task-2309 - Check now shows progress and completion.md
@@ -22,10 +22,10 @@ UAT finding F19.
 
 ## Acceptance Criteria (the what)
 
-- [ ] Triggering a check gives immediate visible acknowledgment, a busy
+- [x] Triggering a check gives immediate visible acknowledgment, a busy
       state while running, and a completion signal (including the failure
       case).
-- [ ] A second activation while a check runs is debounced or explicitly
+- [x] A second activation while a check runs is debounced or explicitly
       queued, never silently duplicated.
 
 ## Implementation Plan (the how)
@@ -47,3 +47,88 @@ UAT finding F19.
    `execute_run` leaves its run row at `running` forever).
 5. Tests: a new UI file covering acknowledgment, busy state, the debounce
    refusal, and the failure path's completion signal.
+
+## Implementation Notes
+
+Not started by the WIP commit (`html_text.py`/`humane_time.py` covered
+tasks 2307/2308 only); this task was implemented in full this session, in
+`tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
+`sources_pane.py` and `inspector_pane.py`.
+
+**Design, matching the plan:** `_checks_in_flight: set[str]` on the screen
+(keyed by the normalized `id`, e.g. `local:subscription:5` -- the same key
+`selected_source`/`selected_entity` already use) is the one source of truth.
+`handle_check_now_requested` checks it first: a source already in the set
+gets a stated `"Already checking {name}."` warning toast and nothing else
+happens; otherwise the id is added, an immediate `"Checking {name}..."`
+toast fires, `_set_check_now_busy()` paints the busy state onto both
+Check-now buttons (Sources pane AND the Inspector -- both post the identical
+`CheckNowRequested`, so both had to show the same state, or the Inspector's
+copy would stay clickable while a duplicate was already refused elsewhere),
+and the worker runs in a NAMED group (`"wc_check_now"`) rather than the old
+`exclusive=True`. That drop matters on its own: `exclusive=True` with no
+group name lands in the shared default group used by ~25 other call sites
+on this screen, and CANCELS whatever else is running in it -- for a source
+check that is the unsound cancellation-supersede shape TASK-1541 documents
+(a cancelled `execute_run` leaves its run row at `running` forever). The
+worker's whole body is wrapped in `try`/`finally`: the id is discarded from
+`_checks_in_flight` and the busy state is repainted off unconditionally, on
+every exit path including an exception the method does not itself expect --
+so a raising check cannot strand a button permanently disabled.
+
+Busy state is a plain (non-recompose) reactive on `SourcesPane`
+(`busy_source_ids`), repainted by `_update_action_buttons` the same
+surgical way selection already is -- a recompose here would rebuild the
+live table under the user. On `InspectorPane` it IS `recompose=True`: that
+pane already fully recomposes on every selection/scope change, a check
+starting or ending is rare next to that, and there is no live table or
+scroll position to disturb. Both panes are reconstructed from scratch on
+every workbench rebuild (`_build_detail_pane`/`_build_inspector_pane`), so
+both are re-seeded from `_checks_in_flight` on every rebuild -- the same
+rebuild-survival pattern every other piece of screen state on this pane
+already uses.
+
+**Backward compatibility:** `_check_now_source` grew two new parameters
+(`source_key`, `name`) but they default to `None` and are derived
+internally when omitted, because `Tests/UI/test_watchlists_rail_counts_
+and_scope.py` calls this worker directly in three places, bypassing the
+message handler entirely -- an existing, established pattern in this test
+suite for exercising the worker in isolation. Making the params optional
+(rather than editing those three call sites) kept that test file's own
+scope untouched.
+
+**Live-verified**, real network check against `https://hnrss.org/frontpage`:
+pressing Check now produced an immediate "Checking HN Frontpage..." toast
+with BOTH the Sources pane's and the Inspector's Check-now buttons reading
+"Checking..." and disabled; on completion both reverted to "Check now", the
+Sources "Last scraped" cell updated, and 4 consecutive runs all appear in
+the Runs tab with correct counts (20 found / 20 processed each). The
+button-level debounce (a disabled button cannot post a second
+`CheckNowRequested` at all) was directly observed; the message-level
+debounce (the `c` keyboard action, which bypasses the button) could not be
+independently reproduced live because the real feed check completes in
+well under the ~150-300ms a tmux send-keys round trip costs here -- it is
+covered instead by `test_a_second_press_while_checking_is_refused_not_
+duplicated`, which uses an `asyncio.Event`-gated fake executor to hold a
+check open deterministically, and by a mutation (disabling the debounce
+`if` turned that test red).
+
+Tests: new `Tests/UI/test_watchlists_check_now_progress.py` (5 cases --
+immediate ack + busy button, second-press refusal, a DIFFERENT source is
+unaffected by another's in-flight check, failure clears the busy state,
+both activation sites agree). Mutation-verified: disabling the debounce
+check, removing the `finally` cleanup, and inverting each pane's busy-state
+predicate all turned the relevant test(s) red; all four reverted with an
+md5-verified byte-identical restore.
+
+Modified/added: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+(`_checks_in_flight`, `_set_check_now_busy`, `_check_now_entity_name`,
+rewritten `handle_check_now_requested`/`_check_now_source`, seeding in
+`_build_detail_pane`/`_build_inspector_pane`), `sources_pane.py`
+(`busy_source_ids`, `_is_check_now_busy`, `watch_busy_source_ids`,
+`_update_action_buttons`), `inspector_pane.py` (`busy_source_ids`, the
+source-kind Check-now button's busy branch), `Tests/UI/
+test_watchlists_check_now_progress.py` (new), and a one-line fix to
+`Tests/UI/test_watchlists_check_now_failure.py`'s polling loop (it broke on
+the new immediate-ack toast landing before the failure toast it was
+actually waiting for).

--- a/tldw_chatbook/Subscriptions/html_text.py
+++ b/tldw_chatbook/Subscriptions/html_text.py
@@ -88,12 +88,52 @@ _PARAGRAPH_TAGS: frozenset[str] = frozenset(
 #: line break, exactly as if the body had used `\n` alone.
 _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
 
-#: A tag-shaped or entity-shaped fragment. Requires a letter (or `/`) directly
-#: after the `<` AND a closing `>`, so ordinary prose containing "a < b" is not
-#: mistaken for markup and mangled.
+#: A tag-shaped or entity-shaped fragment.
+#:
+#: Batch-4 review, Qodo Q5 (real content loss). The tag-shaped alternative
+#: used to be `<\s*/?[a-zA-Z][^<>]*>` -- a letter after `<`, THEN ANY
+#: characters at all up to a closing `>`. That accepted a plain-text
+#: angle-bracket autolink (`<https://example.com>`, `<mailto:a@b>` --
+#: standard in mailing-list and plain-text feed bodies, RFC 2822 "obs-angle-
+#: addr") as tag-shaped, since a URL scheme is a run of letters and `://...`
+#: is just more `[^<>]` characters up to the `>`. `looks_like_html` then
+#: routed the WHOLE body through `html.parser`, which does not know a URL is
+#: not a namespace-prefixed tag (`<xlink:href>` is real HTML, and `:` is a
+#: legal tag-name character to it) -- it tokenizes `<https://example.com>`
+#: as a start tag named `https:` with a bare attribute, and
+#: `_DisplayTextExtractor.handle_starttag` has no branch for an unknown tag,
+#: so the ENTIRE URL is silently dropped. Exactly the false-positive-
+#: corrupts-what-the-user-sees failure this function's own conservatism
+#: exists to avoid.
+#:
+#: Tightened to require a plausible tag NAME (letters/digits only -- no `:`,
+#: `/`, `.`, or other URL-shaped punctuation) immediately followed by a real
+#: tag delimiter: whitespace (an attribute is coming), `/` (self-close), or
+#: `>` (immediate close). `<https://x>` now fails here: the name-shaped
+#: prefix is "https", and the next character is `:`, which is none of
+#: those three delimiters. Verified against `<b>bold</b>`, `<BR/>`,
+#: `<div class="x">` (all still match) and `a < b and c > d` (still a
+#: harmless false positive exactly as before -- `< ` with a following space
+#: is not a valid tag start to the real parser either, so it round-trips
+#: unchanged regardless of what this pre-filter decides).
+#:
+#: This alone does not fix a body that mixes a real tag with an autolink
+#: (`looks_like_html` correctly stays True because of the real tag, so the
+#: body still reaches `html.parser`, which still cannot see an autolink
+#: embedded inside markup it IS parsing) -- see `_AUTOLINK` and its use in
+#: `html_to_display_text` for that half.
 _HTML_SHAPED = re.compile(
-    r"<\s*/?[a-zA-Z][^<>]*>|<!--|&(?:[a-zA-Z][a-zA-Z0-9]{1,31}|#\d{1,7}|#[xX][0-9a-fA-F]{1,6});"
+    r"<\s*/?[a-zA-Z][a-zA-Z0-9]*(?:\s|/|>)|<!--|&(?:[a-zA-Z][a-zA-Z0-9]{1,31}|#\d{1,7}|#[xX][0-9a-fA-F]{1,6});"
 )
+
+#: A plain-text angle-bracket autolink (RFC 2822 "obs-angle-addr" shape):
+#: `<https://example.com>`, `<mailto:a@b>`. Restricted to a small allowlist
+#: of schemes actually seen in feed/mailing-list bodies rather than any
+#: RFC 3986 scheme -- matching `looks_like_html`'s own "deliberately
+#: conservative" stance: this recognizes a known-safe shape, it does not
+#: validate URIs in general. `[^\s<>]+` (no whitespace, no nested angle
+#: brackets) keeps it from reaching across unrelated markup.
+_AUTOLINK = re.compile(r"<((?:https?|ftp|mailto):[^\s<>]+)>")
 
 #: Runs of spaces/tabs, collapsed inside a line. Newlines are structure here
 #: and are handled separately.
@@ -278,13 +318,37 @@ def html_to_display_text(value: Any) -> str:
     if value is None:
         return ""
     source = str(value)
+    # Batch-4 review, Qodo Q5 (the other half -- see `_AUTOLINK`'s own
+    # comment). A body can legitimately mix a plain-text autolink with real
+    # HTML elsewhere, which correctly keeps `looks_like_html` True and sends
+    # the whole body through `html.parser` -- and `html.parser`'s tag-name
+    # tokenizer accepts `:` (for namespace-prefixed tags), so it reads
+    # `<https://example.com>` as a start tag named `https:` with a bare
+    # attribute `example.com`, which `_DisplayTextExtractor.handle_starttag`
+    # has no branch for and silently drops. Autolinks are protected here,
+    # before the parser ever sees them: swapped for a placeholder in the
+    # Unicode Private Use Area (never present in real feed text, and never
+    # tag-shaped, so it always survives as ordinary `handle_data` output --
+    # including correctly vanishing along with the rest of a `<script>`/
+    # `<style>` block if that is where it happened to sit) and restored,
+    # verbatim, once parsing is done.
+    autolinks: list[str] = []
+
+    def _protect_autolink(match: re.Match[str]) -> str:
+        autolinks.append(match.group(1))
+        return f"{len(autolinks) - 1}"
+
+    protected_source = _AUTOLINK.sub(_protect_autolink, source)
     parser = _DisplayTextExtractor()
     try:
-        parser.feed(source)
+        parser.feed(protected_source)
         parser.close()
     except Exception:  # pragma: no cover - defensive, see the docstring
         return strip_control_characters(source)
-    return strip_control_characters(parser.text())
+    text = parser.text()
+    for index, url in enumerate(autolinks):
+        text = text.replace(f"{index}", url)
+    return strip_control_characters(text)
 
 
 def readable_body_text(value: Any) -> str:

--- a/tldw_chatbook/Subscriptions/html_text.py
+++ b/tldw_chatbook/Subscriptions/html_text.py
@@ -75,7 +75,18 @@ _PARAGRAPH_TAGS: frozenset[str] = frozenset(
 #: Control characters that must never reach the terminal. C0 minus tab and
 #: newline (a feed body legitimately contains both), DEL, and the C1 range --
 #: an 8-bit CSI/OSC introducer is just as capable as `ESC [` / `ESC ]`.
-_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+#:
+#: Batch-4 review, M1: CR (0x0D) is included -- it is neither tab nor
+#: newline, so "C0 minus tab and newline" always meant to cover it, but the
+#: range below used to jump `\x0c` -> `\x0e-\x1f` and skip it by one code
+#: point, letting a bare CR survive (a weaker primitive than ESC/OSC -- it
+#: can only overwrite characters earlier on the same terminal line -- but a
+#: real mismatch between what this module documents and what it did, on a
+#: module whose whole purpose is inertness). Deleting CR rather than
+#: replacing it with anything is what keeps a `\r\n` feed body from becoming
+#: a doubled blank line: the `\n` in that pair survives untouched as the one
+#: line break, exactly as if the body had used `\n` alone.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
 
 #: A tag-shaped or entity-shaped fragment. Requires a letter (or `/`) directly
 #: after the `<` AND a closing `>`, so ordinary prose containing "a < b" is not

--- a/tldw_chatbook/Subscriptions/html_text.py
+++ b/tldw_chatbook/Subscriptions/html_text.py
@@ -1,0 +1,295 @@
+"""Turn remote feed bodies into readable, inert plain text.
+
+TASK-2307. Feeds hand us HTML. `item_persist` only knows the formats
+``text``/``markdown``/``diff`` (see `_CONTENT_PAIRINGS`), so an RSS entry
+whose ``<description>`` is a block of HTML is stored as ``text`` and the
+reader showed it verbatim: `<p>Article URL: <a href="https://...">...</a></p>`
+literally on screen, one long unreadable line.
+
+**Why this lives here rather than at ingest.** The stored body is the honest
+capture of what the feed served, and every item persisted before this task
+already holds HTML -- a converter at ingest would fix nothing the user is
+currently looking at. So the conversion is a RENDER-time step, the last one
+before the reader appends text to a `rich.text.Text`.
+
+**Why stdlib rather than a sanitizer.** Nothing here tries to make HTML safe
+to render; it produces text and throws the markup away. `html.parser` is
+lenient by construction (malformed nesting yields odd spacing, never an
+exception), needs no optional dependency, and -- crucially -- there is no
+"allowed tag" list that can fail open on the case it did not anticipate. The
+two existing HTML paths in this package were both considered and rejected for
+this job: `ContentExtractor.extract_text_from_html` (`monitoring_engine.py`)
+collapses an entire document onto ONE line and drops every `href`, and
+`html2text` is an optional `[ebook]` extra, absent on a default install.
+
+**Inertness.** The output of every function here is a plain `str` with no
+control characters, handed to `Text.append`, which never interprets Rich
+markup. A body of ``[bold red]x[/]`` renders as those literal characters --
+see `content_pane.render_article`, which states the rule for that whole path.
+`strip_control_characters` closes the one hole `Text.append` does NOT close:
+Rich writes a segment's text to the terminal verbatim, so a raw ESC in a feed
+body would reach the emulator as an escape sequence (an OSC-8 hyperlink whose
+label lies about its destination, or a cursor-positioning sequence that
+corrupts the frame).
+"""
+
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+from typing import Any
+
+__all__ = [
+    "html_to_display_text",
+    "looks_like_html",
+    "readable_body_text",
+    "strip_control_characters",
+]
+
+#: Elements whose *content* is never prose. Dropped wholesale rather than
+#: having their text extracted -- a `<script>` body rendered as text is noise
+#: at best and an attacker's payload verbatim at worst.
+_DROP_CONTENT: frozenset[str] = frozenset(
+    {"script", "style", "head", "title", "noscript", "template", "svg", "math"}
+)
+
+#: Elements that end the current line. `br` and `hr` are void, so they are
+#: handled on the start tag only; the rest break before and after.
+_BLOCK_TAGS: frozenset[str] = frozenset(
+    {
+        "address", "article", "aside", "blockquote", "br", "dd", "div", "dl",
+        "dt", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2",
+        "h3", "h4", "h5", "h6", "header", "hr", "li", "main", "nav", "ol", "p",
+        "pre", "section", "table", "tbody", "td", "tfoot", "th", "thead", "tr",
+        "ul",
+    }
+)
+
+#: Block tags that also want a BLANK line after them, because they separate
+#: units of thought rather than merely rows of one.
+_PARAGRAPH_TAGS: frozenset[str] = frozenset(
+    {"p", "div", "blockquote", "pre", "section", "article", "h1", "h2", "h3",
+     "h4", "h5", "h6", "table", "ul", "ol", "figure", "header", "footer"}
+)
+
+#: Control characters that must never reach the terminal. C0 minus tab and
+#: newline (a feed body legitimately contains both), DEL, and the C1 range --
+#: an 8-bit CSI/OSC introducer is just as capable as `ESC [` / `ESC ]`.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+#: A tag-shaped or entity-shaped fragment. Requires a letter (or `/`) directly
+#: after the `<` AND a closing `>`, so ordinary prose containing "a < b" is not
+#: mistaken for markup and mangled.
+_HTML_SHAPED = re.compile(
+    r"<\s*/?[a-zA-Z][^<>]*>|<!--|&(?:[a-zA-Z][a-zA-Z0-9]{1,31}|#\d{1,7}|#[xX][0-9a-fA-F]{1,6});"
+)
+
+#: Runs of spaces/tabs, collapsed inside a line. Newlines are structure here
+#: and are handled separately.
+_INLINE_SPACE = re.compile(r"[ \t]+")
+
+#: Three or more newlines, i.e. more than one blank line.
+_EXTRA_BLANK_LINES = re.compile(r"\n{3,}")
+
+
+def strip_control_characters(value: Any) -> str:
+    """Remove terminal control characters from remote-derived text.
+
+    `Text.append` protects against Rich *markup*; it does nothing about
+    control bytes, which Rich writes through to the terminal untouched. A
+    feed body carrying ``\\x1b]8;;http://evil\\x07Anthropic docs\\x1b]8;;\\x07``
+    would therefore paint a real, clickable hyperlink whose visible label is
+    attacker-chosen -- the exact phishing shape `content_pane`'s
+    `_MARKDOWN_HYPERLINKS` note rejects for markdown links, arriving by a
+    different door.
+
+    Args:
+        value: Any value; coerced with `str()`. `None` becomes `""`.
+
+    Returns:
+        The text with every C0 control except tab and newline, DEL, and every
+        C1 control removed. Nothing is escaped or substituted -- the
+        characters simply do not survive.
+    """
+    if value is None:
+        return ""
+    return _CONTROL_CHARS.sub("", str(value))
+
+
+def looks_like_html(value: Any) -> bool:
+    """Whether this body should go through the HTML converter.
+
+    Deliberately conservative. A plain-text feed body that happens to contain
+    a mathematical ``<`` must be rendered untouched, so a bare ``<`` is not
+    enough: the text has to carry a complete tag-shaped fragment, an HTML
+    comment opener, or a named/numeric character reference.
+
+    Args:
+        value: Any value; coerced with `str()`.
+
+    Returns:
+        `True` when `html_to_display_text` should be applied.
+    """
+    if not value:
+        return False
+    return _HTML_SHAPED.search(str(value)) is not None
+
+
+class _DisplayTextExtractor(HTMLParser):
+    """Walk an HTML fragment, emitting the text a reader wants to see.
+
+    Not a general-purpose converter and not trying to be: it exists to make a
+    feed entry legible in a nine-row terminal pane. Structure is reduced to
+    line breaks, list items get a bullet, and a link keeps BOTH halves -- the
+    label and, when they differ, the address -- because a terminal reader who
+    cannot see the destination cannot judge it.
+    """
+
+    def __init__(self) -> None:
+        # `convert_charrefs=True` is the default and is what unescapes `&amp;`
+        # and friends, exactly once, inside `handle_data`. Doing it ourselves
+        # afterwards would double-unescape (`&amp;lt;` -> `<`).
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        #: Depth inside a `_DROP_CONTENT` element. An int, not a bool: nested
+        #: `<svg><style>` must not be re-enabled by the inner element's end tag.
+        self._drop_depth = 0
+        #: One entry per open `<a>`: the href it carried, and the index in
+        #: `_parts` where its text began, so `handle_endtag` can tell whether
+        #: the label already spells the URL out.
+        self._anchors: list[tuple[str, int]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in _DROP_CONTENT:
+            self._drop_depth += 1
+            return
+        if self._drop_depth:
+            return
+        if tag == "a":
+            href = ""
+            for name, value in attrs:
+                if name.lower() == "href" and value:
+                    href = value.strip()
+                    break
+            self._anchors.append((href, len(self._parts)))
+            return
+        if tag == "img":
+            # An image cannot render here, but its alt text is often the only
+            # caption a feed carries. Named so it cannot be mistaken for prose.
+            alt = ""
+            for name, value in attrs:
+                if name.lower() == "alt" and value:
+                    alt = value.strip()
+                    break
+            if alt:
+                self._parts.append(f"[image: {alt}]")
+            return
+        if tag == "li":
+            self._parts.append("\n")
+            self._parts.append("- ")
+            return
+        if tag in _BLOCK_TAGS:
+            self._parts.append("\n\n" if tag in _PARAGRAPH_TAGS else "\n")
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        # `<br/>` arrives here, not at `handle_starttag`. Void elements have no
+        # end tag, so this must not touch `_drop_depth`.
+        tag = tag.lower()
+        if self._drop_depth or tag in _DROP_CONTENT:
+            return
+        if tag == "img":
+            self.handle_starttag(tag, attrs)
+            return
+        if tag in _BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in _DROP_CONTENT:
+            self._drop_depth = max(0, self._drop_depth - 1)
+            return
+        if self._drop_depth:
+            return
+        if tag == "a":
+            if not self._anchors:
+                # A stray `</a>`; malformed input must not raise.
+                return
+            href, start = self._anchors.pop()
+            label = "".join(self._parts[start:]).strip()
+            if href and href not in label:
+                # The address, as ordinary visible text -- never an OSC-8
+                # hyperlink. Same decision, same reason, as
+                # `content_pane._MARKDOWN_HYPERLINKS`: a label the feed chose
+                # over a destination the reader cannot see is a phishing
+                # anchor, and a terminal reader who can read the URL can judge
+                # it. `href not in label` covers the common feed shape where
+                # the link text IS the URL, which would otherwise print twice.
+                self._parts.append(f" ({href})")
+            return
+        if tag in _PARAGRAPH_TAGS:
+            self._parts.append("\n\n")
+        elif tag in _BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._drop_depth:
+            return
+        self._parts.append(data)
+
+    def text(self) -> str:
+        """The extracted text, with whitespace normalized for a narrow pane."""
+        raw = "".join(self._parts)
+        lines = [_INLINE_SPACE.sub(" ", line).strip() for line in raw.split("\n")]
+        return _EXTRA_BLANK_LINES.sub("\n\n", "\n".join(lines)).strip()
+
+
+def html_to_display_text(value: Any) -> str:
+    """Convert an HTML fragment to readable plain text.
+
+    Args:
+        value: The raw body; coerced with `str()`.
+
+    Returns:
+        Plain text with block structure preserved as line breaks, list items
+        bulleted, link destinations kept as visible text, and `script`/`style`
+        content dropped. Control characters are removed last, so nothing this
+        function produces can be interpreted by a terminal.
+
+        Never raises: `html.parser` tolerates malformed markup, and the one
+        thing that can still raise (`AssertionError` from a badly-formed CDATA
+        section in some CPython versions) is caught and degrades to the
+        control-stripped original -- an exception escaping the reader's
+        `compose()` would exit the whole application.
+    """
+    if value is None:
+        return ""
+    source = str(value)
+    parser = _DisplayTextExtractor()
+    try:
+        parser.feed(source)
+        parser.close()
+    except Exception:  # pragma: no cover - defensive, see the docstring
+        return strip_control_characters(source)
+    return strip_control_characters(parser.text())
+
+
+def readable_body_text(value: Any) -> str:
+    """The last step before a remote body reaches the reader.
+
+    Args:
+        value: The stored item body; coerced with `str()`.
+
+    Returns:
+        `html_to_display_text` for a body that carries markup, otherwise the
+        body with only its control characters stripped -- a plain-text feed
+        must survive this function byte-for-byte apart from characters that
+        cannot legally be displayed.
+    """
+    if value is None:
+        return ""
+    if looks_like_html(value):
+        return html_to_display_text(value)
+    return strip_control_characters(value)

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import inspect
 import hashlib
@@ -700,6 +701,47 @@ class LocalWatchlistsService:
                 error_msg=result.get("error_msg") or all_error_message,
                 log_text=result.get("log_text"),
             )
+        except asyncio.CancelledError:
+            # Batch-4 review, C1 (CRITICAL). This worker is cancelled whenever
+            # the widget it is registered on is unmounted -- Textual's
+            # `Widget._on_unmount` calls `self.workers.cancel_node(self)`,
+            # which cancels every worker on that widget regardless of group
+            # name (the named "wc_check_now" group only protects against a
+            # SECOND `run_worker` call in the same group; it does nothing
+            # about the screen itself being torn down). This app's screens are
+            # never cached (`app.py`'s `_create_navigation_screen`), so
+            # switching tabs while a check is running is an entirely ordinary
+            # action that reaches exactly this path.
+            #
+            # `asyncio.CancelledError` is `BaseException`, not `Exception`
+            # (Python >=3.8), so the sibling `except Exception` below never
+            # saw it -- the run row `_mark_run_started` set to `running`
+            # moments ago was never transitioned to anything else. Recorded
+            # here, as an honest terminal state, before the cancellation is
+            # allowed to keep propagating: a single `Task.cancel()` delivers
+            # exactly one `CancelledError` at the next suspension point and
+            # does not re-arm on the next `await`, so awaiting
+            # `record_run_failure` here is safe and will not itself be cut
+            # off. Re-raised afterward (not swallowed) so the coroutine still
+            # finishes looking cancelled to asyncio/Textual, matching what a
+            # caller further up the stack (there is none in the check-now
+            # path today, but `execute_run` is not a private implementation
+            # detail of it) would correctly expect.
+            try:
+                await self.record_run_failure(
+                    run_id,
+                    source_id=source_id,
+                    error=(
+                        "Check cancelled: navigated away before it finished."
+                    ),
+                    elapsed_ms=int((time.time() - start_time) * 1000),
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Watchlists: could not record the cancellation of run "
+                    f"{run_id!r}; it may still read 'running'."
+                )
+            raise
         except Exception as exc:
             return await self.record_run_failure(
                 run_id,

--- a/tldw_chatbook/Subscriptions/watchlist_scope_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_scope_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from enum import Enum
 from typing import Any, Mapping
@@ -430,6 +431,40 @@ class WatchlistScopeService:
                 resolved_run_id = self._run_id_from_item_id(run_id)
                 try:
                     return await self._maybe_await(execute_run(resolved_run_id))
+                except asyncio.CancelledError:
+                    # Batch-4 review, C1 (CRITICAL) -- the second-layer
+                    # counterpart of `LocalWatchlistsService.execute_run`'s own
+                    # `except asyncio.CancelledError` branch, kept for the
+                    # identical reason TASK-1090's `except Exception` below
+                    # already is: `execute_run` records its own cancellation
+                    # (a screen/widget teardown, e.g. the user switching tabs
+                    # mid-check) and re-raises, so ordinarily this branch never
+                    # actually has anything left to do -- `record_run_failure`
+                    # below is idempotent (it UPDATEs the same row by id) and
+                    # would simply overwrite the same "failed" state again.
+                    # This exists for whatever escapes `execute_run`'s own
+                    # handler (a service without one, a second cancellation
+                    # while THAT write was in flight) -- the same class of gap
+                    # TASK-1090 already closed for ordinary exceptions, applied
+                    # to the one exception type `except Exception` cannot see.
+                    record_failure = getattr(service, "record_run_failure", None)
+                    if callable(record_failure):
+                        try:
+                            await self._maybe_await(
+                                record_failure(
+                                    resolved_run_id,
+                                    error=(
+                                        "Check cancelled: navigated away "
+                                        "before it finished."
+                                    ),
+                                )
+                            )
+                        except Exception:
+                            logger.opt(exception=True).warning(
+                                "Watchlists: could not record the cancellation "
+                                f"of run {resolved_run_id}."
+                            )
+                    raise
                 except Exception as exc:
                     # TASK-1090. `execute_run` records its own fetch failures,
                     # but anything that escapes it -- a subscription deleted

--- a/tldw_chatbook/Subscriptions/watchlist_scope_service.py
+++ b/tldw_chatbook/Subscriptions/watchlist_scope_service.py
@@ -439,31 +439,80 @@ class WatchlistScopeService:
                     # already is: `execute_run` records its own cancellation
                     # (a screen/widget teardown, e.g. the user switching tabs
                     # mid-check) and re-raises, so ordinarily this branch never
-                    # actually has anything left to do -- `record_run_failure`
-                    # below is idempotent (it UPDATEs the same row by id) and
-                    # would simply overwrite the same "failed" state again.
-                    # This exists for whatever escapes `execute_run`'s own
-                    # handler (a service without one, a second cancellation
-                    # while THAT write was in flight) -- the same class of gap
-                    # TASK-1090 already closed for ordinary exceptions, applied
-                    # to the one exception type `except Exception` cannot see.
-                    record_failure = getattr(service, "record_run_failure", None)
-                    if callable(record_failure):
+                    # actually has anything left to WRITE -- the run row is
+                    # already durably `failed` by the time the re-raise gets
+                    # here (`db.transaction()` commits synchronously with no
+                    # interruptible inner await, so there is no race to read
+                    # stale).
+                    #
+                    # Batch-4 review ROUND 2, N1 (Important, introduced by the
+                    # C1 fix). The run ROW update alone being idempotent
+                    # (`record_run_result`'s UPDATE is by id) is not enough:
+                    # calling `record_run_failure` a second time for the SAME
+                    # cancellation also re-evaluates every alert rule against
+                    # the run's stats and re-DISPATCHES a notification for
+                    # each match, and `_dispatch_alert_notification`/
+                    # `ClientNotificationsDB.insert_notification` have no
+                    # deduplicating INSERT -- `dedupe_key` is computed into the
+                    # payload and never read back by anything. So a
+                    # status-agnostic rule (e.g. "no_items", which fires on the
+                    # stats regardless of pass/fail) produced two identical
+                    # notification rows for one cancelled check: one from
+                    # `execute_run`'s write, one from this one.
+                    #
+                    # Checked here instead: whether the run already reached a
+                    # terminal state before writing again. This is the correct
+                    # mechanism, not a dedupe-key lookup -- a dedupe-key check
+                    # would mean teaching the notification store a new
+                    # "does a row with this key already exist" query for a
+                    # value that, today, exists for exactly this one caller,
+                    # and it would still let this layer perform a pointless
+                    # second run-row UPDATE. Checking status reuses a field
+                    # the run row already carries and this method already has
+                    # a service handle to read, and it generalizes correctly
+                    # to the genuine defense-in-depth case this branch exists
+                    # for: if the cancellation struck OUTSIDE `execute_run`'s
+                    # own `try` block (the synchronous section before it, or a
+                    # future local-like service with no `CancelledError`
+                    # handling of its own), the run is still `queued` or
+                    # `running` here, and THIS layer is the only one that will
+                    # ever record it -- exactly the case the write must still
+                    # happen for. "queued"/"running" are the only two
+                    # non-terminal statuses a local run row can ever hold
+                    # before `execute_run` reaches its own `try` block (see
+                    # `launch_run`'s insert and `_mark_run_started`).
+                    already_recorded = False
+                    get_run = getattr(service, "get_run", None)
+                    if callable(get_run):
                         try:
-                            await self._maybe_await(
-                                record_failure(
-                                    resolved_run_id,
-                                    error=(
-                                        "Check cancelled: navigated away "
-                                        "before it finished."
-                                    ),
-                                )
+                            current_run = await self._maybe_await(
+                                get_run(resolved_run_id)
                             )
                         except Exception:
-                            logger.opt(exception=True).warning(
-                                "Watchlists: could not record the cancellation "
-                                f"of run {resolved_run_id}."
+                            current_run = None
+                        if isinstance(current_run, Mapping):
+                            already_recorded = (
+                                str(current_run.get("status") or "").lower()
+                                not in {"queued", "running"}
                             )
+                    if not already_recorded:
+                        record_failure = getattr(service, "record_run_failure", None)
+                        if callable(record_failure):
+                            try:
+                                await self._maybe_await(
+                                    record_failure(
+                                        resolved_run_id,
+                                        error=(
+                                            "Check cancelled: navigated away "
+                                            "before it finished."
+                                        ),
+                                    )
+                                )
+                            except Exception:
+                                logger.opt(exception=True).warning(
+                                    "Watchlists: could not record the cancellation "
+                                    f"of run {resolved_run_id}."
+                                )
                     raise
                 except Exception as exc:
                     # TASK-1090. `execute_run` records its own fetch failures,

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -128,6 +128,7 @@ from ..Watchlists_Modules.artifacts_pane import (
 from ..Watchlists_Modules.briefing_preset_modal import BriefingPresetModal
 from ..Watchlists_Modules.content_pane import (
     ContentPane,
+    ExpandReaderRequested,
     UnreadToggleRequested,
     ViewSnapshotRequested,
 )
@@ -2094,9 +2095,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         `ContentPane` does not draw its own heading (see `SELF_HEADED_REGIONS`
         in `watchlists_workbench.py`), so `WatchlistsWorkbench` prepends the
         generic "Content" title above whatever this returns.
+
+        Batch-4 review, Qodo Q4. `pane.expanded` is seeded from the live
+        `region_layout` (matching `_build_inspector_pane`'s `selected_entity`
+        seeding note above): this factory reruns on every region rebuild,
+        including the one `handle_expand_reader_requested` itself triggers
+        by calling `_apply_layout`, so the freshly-built pane must be told
+        whether CONTENT is the soloed region or its "Expand"/"Restore" label
+        would go stale the instant the layout that produced it changes.
         """
         pane = ContentPane(id="watchlists-content-pane")
         pane.item = self._selected_content_item
+        pane.expanded = self.region_layout.solo_region == Region.CONTENT
         return pane
 
     def _watchlists_are_empty(self) -> bool:
@@ -4568,6 +4578,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         documents: a cancelled `execute_run` leaves its row at `running`
         forever). `run_worker` below uses a named group instead, so a second,
         DIFFERENT source's check is unaffected by this one either way.
+
+        Args:
+            event: Carries the source entity to check (`event.entity`), or
+                `None` if the pane posting it had nothing selected -- see
+                `SourcesPane`/`InspectorPane`'s own `CheckNowRequested`
+                call sites.
         """
         event.stop()
         entity = event.entity
@@ -8476,6 +8492,37 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         if item_id is None:
             return
         self._dispatch_item_status(item_id, _ItemStatusIntent(status="new", gate=True))
+
+    @on(ExpandReaderRequested)
+    def handle_expand_reader_requested(self, event: ExpandReaderRequested) -> None:
+        """Give the reader the whole centre stack, or give it back (AC#2).
+
+        Batch-4 review, Qodo Q4: this was task-2307's own disclosed gap --
+        `ContentPane` posted `ExpandReaderRequested` and nothing handled it,
+        a dead button. Task-1344 already built the mechanism this needs
+        (`action_solo_region`, bound to `Z`): isolate one centre pane,
+        collapsing the other two around it, and calling `solo` again on the
+        same region restores them (`RegionLayout.solo`'s own docstring).
+        Routed through THAT mechanism rather than a second one -- same
+        `_apply_layout` call `action_solo_region` makes, just with
+        `Region.CONTENT` as the target instead of reading it off
+        `self.focused_region`, since a button press already names its
+        target unambiguously and does not need the focus-tracking
+        indirection a keyboard shortcut does.
+
+        `_refuse_region_gesture_off_read_tab` is consulted anyway, for the
+        same "one source of truth for is a region-layout gesture allowed"
+        reason `action_toggle_region`/`action_solo_region`/`_on_region_
+        toggled` all do (see that method's own docstring) -- in practice
+        this button cannot be pressed off the Read tab at all (CONTENT is
+        unmounted everywhere else), so the refusal is defensive rather than
+        reachable, not a second, independent gate someone could drift out
+        of sync with the other three.
+        """
+        event.stop()
+        if self._refuse_region_gesture_off_read_tab(Region.CONTENT):
+            return
+        self._apply_layout(self.region_layout.solo(Region.CONTENT))
 
     @on(ViewSnapshotRequested)
     def handle_view_snapshot_requested(self, event: ViewSnapshotRequested) -> None:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -599,6 +599,19 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # `_briefing_in_flight_watchlist_id` sibling, so a refusal can name
         # the briefing actually being cast.
         self._cast_in_flight_briefing_id: int | None = None
+        # TASK-2309. The source ids ("id" field -- the namespaced form
+        # `selected_source`/`selected_entity` carry) with a "Check now"
+        # currently running, from EITHER activation site (the Sources pane's
+        # own button and the Inspector's copy of it both post the same
+        # `CheckNowRequested`). This is the debounce state
+        # `handle_check_now_requested` consults to refuse a second press
+        # rather than silently starting a second run, and it is mirrored
+        # onto `SourcesPane.busy_source_ids`/`InspectorPane.busy_source_ids`
+        # (`_set_check_now_busy`) so both buttons show it -- including a
+        # freshly-rebuilt pane (`_build_detail_pane`/`_build_inspector_pane`
+        # re-seed it, the same rebuild-survival reason every other mirror in
+        # this method exists).
+        self._checks_in_flight: set[str] = set()
         # Task 6: the SELECTED briefing's citations -- the rebuild-survival
         # mirror of `pane.citations`, resolved alongside `_selected_briefing`
         # inside `_load_briefings` (see that method). `_citation_item_lookup`
@@ -1946,6 +1959,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # watchlist.
             sources_pane.sources = self.scoped_loaded_sources()
             sources_pane.selected_source = self.selected_source
+            # TASK-2309: re-seed from screen state for the identical
+            # rebuild-survival reason as `selected_source` on the line
+            # above -- a region rebuild (collapse/solo/rail toggle, a tab
+            # switch) constructs a brand new `SourcesPane`, and without this
+            # a check still running would render its Check-now button back
+            # to enabled/"Check now" until the run's own completion repaint
+            # reached this new instance.
+            sources_pane.busy_source_ids = frozenset(self._checks_in_flight)
             # TASK-2302: the destination Select's options and its default,
             # seeded BEFORE `show_create_form` so a form that opens as part
             # of this very rebuild has them. The pane holds no service of its
@@ -2318,6 +2339,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # `Add existing` is the watchlist-side twin of the rail's, so the two
         # must be enabled and disabled by one condition, not two.
         inspector.write_disabled_reason = self._tree_write_disabled_reason()
+        # TASK-2309: same rebuild-survival seeding as `SourcesPane.busy_
+        # source_ids` in `_build_detail_pane`, and for the identical reason
+        # -- this factory builds a brand new `InspectorPane` on every region
+        # rebuild.
+        inspector.busy_source_ids = frozenset(self._checks_in_flight)
         children.append(inspector)
         return Vertical(
             *children,
@@ -4476,13 +4502,97 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             if callable(notify):
                 notify("Failed to preview source.", severity="error")
 
+    @staticmethod
+    def _check_now_entity_name(entity: dict[str, Any]) -> str:
+        """The name a Check now toast should use for `entity`.
+
+        Matches the title fallback chain `_build_inspector_pane`'s
+        `Selected: {title}` line and `_resume_source`'s `name` already use,
+        so a source is never referred to by three different fallbacks across
+        three toasts.
+        """
+        return str(
+            entity.get("name")
+            or entity.get("source_title")
+            or entity.get("title")
+            or "that source"
+        )
+
+    def _set_check_now_busy(self) -> None:
+        """Paint `_checks_in_flight` onto whichever Check-now buttons exist.
+
+        TASK-2309. `_checks_in_flight` is the source of truth; this only
+        pushes it onto panes that happen to be mounted right now -- Sources
+        and the Inspector each host their own copy of this button, and
+        either, both, or neither may be on screen for a given source at a
+        given moment (the active section may not be Sources, or the
+        Inspector's deepest selection may be a different source or none at
+        all). A pane that is not currently mounted needs nothing done to it
+        here: `_build_detail_pane`/`_build_inspector_pane` re-seed
+        `busy_source_ids` from this same set on every rebuild, so a freshly
+        constructed pane never has to be told separately.
+
+        `_dom_is_live`, not `is_mounted` (TASK-2200's mount-window lesson,
+        applied throughout this screen): a check can complete inside the
+        same `on_mount`-adjacent window that lesson documents.
+        """
+        if not self._dom_is_live:
+            return
+        busy_ids = frozenset(self._checks_in_flight)
+        try:
+            sources_pane = self.query_one("#watchlists-sources-pane", SourcesPane)
+        except Exception:
+            pass
+        else:
+            sources_pane.busy_source_ids = busy_ids
+        try:
+            inspector = self.query_one("#watchlists-entity-inspector", InspectorPane)
+        except Exception:
+            pass
+        else:
+            inspector.busy_source_ids = busy_ids
+
     @on(CheckNowRequested)
     def handle_check_now_requested(self, event: CheckNowRequested) -> None:
+        """Start a check, unless this exact source already has one running.
+
+        TASK-2309 (UAT F19). Three things a bare `run_worker(..., exclusive=
+        True)` did not give: an immediate acknowledgment (the toast below,
+        posted before the worker even starts, so the ~5s of dead air the UAT
+        measured has SOMETHING on screen from the first frame), a busy state
+        that outlives the toast (`_set_check_now_busy`, cleared only in
+        `_check_now_source`'s `finally`), and a stated refusal of a second
+        press instead of silently queuing (or, under the old
+        `exclusive=True`, silently CANCELLING the first run mid-write --
+        exactly the unsound cancellation-supersede shape TASK-1541
+        documents: a cancelled `execute_run` leaves its row at `running`
+        forever). `run_worker` below uses a named group instead, so a second,
+        DIFFERENT source's check is unaffected by this one either way.
+        """
         event.stop()
         entity = event.entity
         if entity is None:
             return
-        self.run_worker(self._check_now_source(entity), exclusive=True)
+        source_key = str(entity.get("id") or "")
+        name = self._check_now_entity_name(entity)
+        if source_key and source_key in self._checks_in_flight:
+            # Stated, not silent (AC#2): a second press while this exact
+            # source is mid-check does not queue a duplicate run.
+            self._notify_watchlists(
+                f"Already checking {name}.", severity="warning", markup=False
+            )
+            return
+        if source_key:
+            self._checks_in_flight.add(source_key)
+            self._set_check_now_busy()
+        # Immediate acknowledgment (AC#1), posted before the worker starts.
+        # `markup=False`: `name` is user-entered (the source's Name field).
+        self._notify_watchlists(
+            f"Checking {name}...", severity="information", markup=False
+        )
+        self.run_worker(
+            self._check_now_source(entity, source_key, name), group="wc_check_now"
+        )
 
     #: Run statuses that mean the check did not succeed. `execute_run` catches
     #: the fetch error itself and RETURNS a run in one of these states rather
@@ -4515,8 +4625,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             error_msg = stats.get("error_msg")
         return str(error_msg or "the source reported a failed run")
 
-    async def _check_now_source(self, source: dict[str, Any]) -> None:
+    async def _check_now_source(
+        self,
+        source: dict[str, Any],
+        source_key: str | None = None,
+        name: str | None = None,
+    ) -> None:
         """Run a check for one source and report what actually happened.
+
+        `source_key`/`name` default to `None` and are derived from `source`
+        when omitted (the same derivation `handle_check_now_requested` uses)
+        so a caller that drives this worker directly -- bypassing the
+        message handler entirely, an established pattern in this test suite
+        (`Tests/UI/test_watchlists_rail_counts_and_scope.py`) -- keeps
+        working without knowing about TASK-2309's debounce bookkeeping.
+        `handle_check_now_requested` itself always passes both explicitly,
+        since it already computed them for the immediate-ack toast and the
+        pre-registration in `_checks_in_flight`.
 
         TASK-1090. This wrapped the whole call in `except Exception`, logged at
         **debug** and showed a transient toast, which is the swallow that hid
@@ -4536,7 +4661,23 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         service (see `LocalWatchlistsService.record_run_failure`) -- and the
         source list is reloaded here so the Sources table's Status column
         shows it once the toast is gone.
+
+        TASK-2309: every toast below now names `name` (so a running check is
+        identifiable when more than one source exists) and is `markup=False`
+        (a source's Name field is user-entered free text, and a bracket in it
+        must reach the user verbatim rather than being interpreted -- or
+        swallowed -- as Rich markup, same reasoning as `_resume_source`'s
+        toast). The whole body is now wrapped in `try`/`finally`:
+        `source_key` is cleared from `_checks_in_flight` and the busy state
+        is repainted off unconditionally, on EVERY exit path including an
+        exception this method itself does not expect -- a raise that skipped
+        that cleanup would strand both Check-now buttons permanently
+        disabled for a source no worker is actually still checking.
         """
+        if source_key is None:
+            source_key = str(source.get("id") or "")
+        if name is None:
+            name = self._check_now_entity_name(source)
         notify = getattr(self.app_instance, "notify", None)
         source_id = source.get("id")
         #: Whether this check actually finished and therefore actually produced
@@ -4544,73 +4685,116 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         #: refresh at the end of this method.
         reached_terminal = False
         try:
-            result = await self._controller.check_now(
-                runtime_backend=self.runtime_backend,
-                source_id=source_id,
-            )
-        except Exception as exc:
-            logger.opt(exception=True).warning(
-                f"Check now failed for watchlist source {source_id!r}: {exc}"
-            )
-            if callable(notify):
-                notify(f"Check failed: {exc}", severity="error", timeout=10)
-        else:
-            failure = self._check_failure_message(result)
-            if failure is not None:
-                logger.warning(
-                    f"Check now for watchlist source {source_id!r} finished "
-                    f"failed: {failure}"
+            try:
+                result = await self._controller.check_now(
+                    runtime_backend=self.runtime_backend,
+                    source_id=source_id,
+                )
+            except Exception as exc:
+                logger.opt(exception=True).warning(
+                    f"Check now failed for watchlist source {source_id!r}: {exc}"
                 )
                 if callable(notify):
-                    notify(f"Check failed: {failure}", severity="error", timeout=10)
+                    notify(
+                        f"Check failed: {name} — {exc}",
+                        severity="error",
+                        timeout=10,
+                        markup=False,
+                    )
             else:
-                # Only claim completion for a terminal status. `check_now` on
-                # the server backend delegates to `launch_run`, which triggers
-                # execution asynchronously and returns `queued`/`running` — so
-                # a fixed "Check complete." would tell the user the fetch had
-                # finished while it was still in flight (Qodo #4 on PR #1047).
-                status = str((result or {}).get("status") or "").lower()
-                reached_terminal = status in self._TERMINAL_RUN_STATUSES
-                if callable(notify):
-                    if reached_terminal:
-                        notify("Check complete.", severity="information")
-                    else:
-                        notify("Check started.", severity="information")
-        self._refresh_local_wc_snapshot()
-        self._refresh_overview_data()
-        # Reload the source list so the Status and Last scraped columns carry
-        # the outcome after the toast has gone (AC#2). Same reload
-        # `_delete_source` performs for the same reason.
-        # Preserve the user's selection across the reload. Rebuilding the
-        # table emits a row-0 highlight, which `SourcesPane` treats as a real
-        # selection — so without this the reload silently retargets Preview /
-        # Check now / Delete at the first source (Qodo #3 on PR #1047, and
-        # the defect filed as task-1161).
-        self.run_worker(
-            self._load_sources_preserving_selection(), exclusive=True, group="wc_sources"
-        )
-        # TASK-2304 AC#1. A check is the ONE gesture that manufactures items,
-        # and the rail's numbers are unread item counts -- so this was the
-        # single most visible place they went stale. Measured in the
-        # 2026-08-04 UAT: create a watchlist, assign a source, press Check
-        # now, watch a feed's worth of items arrive in the centre while every
-        # rail count stayed on 0 until the screen was left and re-entered.
-        # `_load_tree_data` publishes through TASK-2200's surface-refresh
-        # drain, so this is a rail rebuild, not a screen recompose.
-        #
-        # Review wave, Minor 4: only once the run has actually FINISHED. The
-        # local backend runs `check_now` to completion and returns
-        # `completed`, so this fires exactly as before there. The server
-        # backend delegates to `launch_run` and returns `queued`/`running`
-        # (the toast three lines up is careful about the same distinction),
-        # so re-reading the counts here would read them before the items it
-        # is meant to be reporting exist -- an authoritative-looking query
-        # against a state the user's own action has not reached yet. A run
-        # that finishes later is picked up by the next refresh, which is the
-        # same guarantee every other server-backend surface on this screen
-        # gives.
-        if reached_terminal:
-            self._load_tree_data()
+                failure = self._check_failure_message(result)
+                if failure is not None:
+                    logger.warning(
+                        f"Check now for watchlist source {source_id!r} finished "
+                        f"failed: {failure}"
+                    )
+                    if callable(notify):
+                        notify(
+                            f"Check failed: {name} — {failure}",
+                            severity="error",
+                            timeout=10,
+                            markup=False,
+                        )
+                else:
+                    # Only claim completion for a terminal status. `check_now`
+                    # on the server backend delegates to `launch_run`, which
+                    # triggers execution asynchronously and returns
+                    # `queued`/`running` — so a fixed "Check complete." would
+                    # tell the user the fetch had finished while it was still
+                    # in flight (Qodo #4 on PR #1047).
+                    status = str((result or {}).get("status") or "").lower()
+                    reached_terminal = status in self._TERMINAL_RUN_STATUSES
+                    if callable(notify):
+                        if reached_terminal:
+                            # The run's own counters (TASK-2309), when the
+                            # result actually carries them -- the local
+                            # backend's `execute_run` always returns a
+                            # normalized run row with both; a completed
+                            # result missing them degrades to the bare
+                            # completion line rather than printing "None".
+                            found = (result or {}).get("found_count")
+                            processed = (result or {}).get("processed_count")
+                            if found is not None or processed is not None:
+                                notify(
+                                    f"Check complete: {name} — "
+                                    f"{found or 0} found, {processed or 0} new.",
+                                    severity="information",
+                                    markup=False,
+                                )
+                            else:
+                                notify(
+                                    f"Check complete: {name}.",
+                                    severity="information",
+                                    markup=False,
+                                )
+                        else:
+                            notify(
+                                f"Check started: {name}.",
+                                severity="information",
+                                markup=False,
+                            )
+            self._refresh_local_wc_snapshot()
+            self._refresh_overview_data()
+            # Reload the source list so the Status and Last scraped columns carry
+            # the outcome after the toast has gone (AC#2). Same reload
+            # `_delete_source` performs for the same reason.
+            # Preserve the user's selection across the reload. Rebuilding the
+            # table emits a row-0 highlight, which `SourcesPane` treats as a real
+            # selection — so without this the reload silently retargets Preview /
+            # Check now / Delete at the first source (Qodo #3 on PR #1047, and
+            # the defect filed as task-1161).
+            self.run_worker(
+                self._load_sources_preserving_selection(), exclusive=True, group="wc_sources"
+            )
+            # TASK-2304 AC#1. A check is the ONE gesture that manufactures items,
+            # and the rail's numbers are unread item counts -- so this was the
+            # single most visible place they went stale. Measured in the
+            # 2026-08-04 UAT: create a watchlist, assign a source, press Check
+            # now, watch a feed's worth of items arrive in the centre while every
+            # rail count stayed on 0 until the screen was left and re-entered.
+            # `_load_tree_data` publishes through TASK-2200's surface-refresh
+            # drain, so this is a rail rebuild, not a screen recompose.
+            #
+            # Review wave, Minor 4: only once the run has actually FINISHED. The
+            # local backend runs `check_now` to completion and returns
+            # `completed`, so this fires exactly as before there. The server
+            # backend delegates to `launch_run` and returns `queued`/`running`
+            # (the toast three lines up is careful about the same distinction),
+            # so re-reading the counts here would read them before the items it
+            # is meant to be reporting exist -- an authoritative-looking query
+            # against a state the user's own action has not reached yet. A run
+            # that finishes later is picked up by the next refresh, which is the
+            # same guarantee every other server-backend surface on this screen
+            # gives.
+            if reached_terminal:
+                self._load_tree_data()
+        finally:
+            # TASK-2309 AC#1 (the failure case): reached whether the `try`
+            # above returned normally, notified a failure, or raised
+            # something neither branch anticipated.
+            if source_key:
+                self._checks_in_flight.discard(source_key)
+            self._set_check_now_busy()
 
     async def _load_sources_preserving_selection(self) -> None:
         """Reload the source list without discarding the current selection."""

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -61,6 +61,7 @@ from ...Subscriptions.briefing_service import (
     STATUS_FAILED,
     STATUS_GENERATING,
 )
+from ...Subscriptions.html_text import strip_control_characters
 from ...Widgets.prune_safe_select import PruneSafeSelect
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
 from .humane_time import humane_timestamp
@@ -1290,7 +1291,7 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                 )
                 audio_status = self.scripts_with_audio.get(row.get("id"))
                 scripts_table.add_row(
-                    Text(str(row.get("preset_name") or "—"), style=style),
+                    Text(strip_control_characters(row.get("preset_name") or "—"), style=style),
                     Text(_script_status_text(row) or "—", style=style),
                     Text(humane_timestamp(row.get("created_at")), style=style),
                     self._audio_cell(audio_status, style),
@@ -1376,10 +1377,13 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
         )
         header.append(" · ")
         header.append(status or "unknown status")
+        # Batch-4 review, I1: stripped for the same reason every other
+        # identity cell touched by this batch is -- `Text.append` protects
+        # only against Rich markup, not a raw control byte.
         model_used = row.get("model_used")
         if model_used:
             header.append(" · ")
-            header.append(str(model_used))
+            header.append(strip_control_characters(model_used))
         header.append("\n")
         header.append(_window_text(row), style="dim")
         header.append("\n")
@@ -1428,13 +1432,16 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
         # would have -- see the compose()-site comment on why there is no
         # separate title `Static` here.
         header.append("Script: ", style="dim")
-        header.append(str(row.get("preset_name") or "Untitled preset"), style="bold")
+        header.append(strip_control_characters(row.get("preset_name") or "Untitled preset"), style="bold")
         header.append(" · ")
         header.append(status or "unknown status")
+        # Batch-4 review, I1: stripped for the same reason every other
+        # identity cell touched by this batch is -- `Text.append` protects
+        # only against Rich markup, not a raw control byte.
         model_used = row.get("model_used")
         if model_used:
             header.append(" · ")
-            header.append(str(model_used))
+            header.append(strip_control_characters(model_used))
         header.append("\n")
         header.append(
             humane_timestamp(row.get("created_at")) if row.get("created_at")

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -63,6 +63,7 @@ from ...Subscriptions.briefing_service import (
 )
 from ...Widgets.prune_safe_select import PruneSafeSelect
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
+from .humane_time import humane_timestamp
 from .table_selection import highlight_is_user_driven
 
 # A briefing body is model output written from remote feed/site content, so
@@ -1189,7 +1190,12 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                 Text(str(row.get("item_count") or 0), style=style),
                 Text(str(row.get("featured_count") or 0), style=style),
                 Text(str(row.get("overflow_count") or 0), style=style),
-                Text(str(row.get("created_at") or "—"), style=style),
+                # TASK-2308. This column is where the UAT found the house
+                # style -- but "2026-08-04 18:22:44" is simply SQLite's
+                # `CURRENT_TIMESTAMP`, i.e. UTC that happens to look humane.
+                # It goes through the same formatter as every other Watchlists
+                # table so the whole screen agrees on one zone.
+                Text(humane_timestamp(row.get("created_at")), style=style),
                 key=row_key,
             )
         if selected_index is not None:
@@ -1286,7 +1292,7 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
                 scripts_table.add_row(
                     Text(str(row.get("preset_name") or "—"), style=style),
                     Text(_script_status_text(row) or "—", style=style),
-                    Text(str(row.get("created_at") or "—"), style=style),
+                    Text(humane_timestamp(row.get("created_at")), style=style),
                     self._audio_cell(audio_status, style),
                     key=row_key,
                 )
@@ -1363,7 +1369,11 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
 
         status = _status_text(row)
         header = Text()
-        header.append(str(row.get("created_at") or "unknown time"), style="bold")
+        header.append(
+            humane_timestamp(row.get("created_at")) if row.get("created_at")
+            else "unknown time",
+            style="bold",
+        )
         header.append(" · ")
         header.append(status or "unknown status")
         model_used = row.get("model_used")
@@ -1426,7 +1436,11 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
             header.append(" · ")
             header.append(str(model_used))
         header.append("\n")
-        header.append(str(row.get("created_at") or "unknown time"), style="dim")
+        header.append(
+            humane_timestamp(row.get("created_at")) if row.get("created_at")
+            else "unknown time",
+            style="dim",
+        )
         header.append("\n")
 
         if status == STATUS_COMPLETE:

--- a/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/content_pane.py
@@ -11,13 +11,15 @@ from typing import Any
 from rich.console import Group, RenderableType
 from rich.markdown import Markdown
 from rich.text import Text
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Button, Static
 
+from ...Subscriptions.html_text import readable_body_text, strip_control_characters
 from ...Subscriptions.item_persist import CONTENT_KIND_CHANGE
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
+from .humane_time import humane_timestamp
 
 # Every item persisted before Phase A carries `content = NULL`, and it cannot
 # be recovered without re-fetching the source. Say so rather than rendering an
@@ -106,6 +108,15 @@ def render_article(item: dict[str, Any]) -> RenderableType:
     genuinely is, and it is defended there rather than upstream -- see
     `_MARKDOWN_HYPERLINKS`.
 
+    TASK-2307: the body additionally goes through `readable_body_text`, which
+    turns a feed's HTML into prose. That is a RENDER step, deliberately the
+    last one before `Text.append`, and it does not weaken anything above:
+    its output is a plain `str` with the markup thrown away and every control
+    character removed, so the "appended, never parsed" property still carries
+    the whole defence. Every other remote-derived field on this path
+    (`title`, `source_name`) is control-stripped for the same reason -- Rich
+    protects against markup, not against a raw ESC.
+
     Args:
         item: A normalized watchlist item. `title`, `source_name`,
             `published_date`, `content` and `content_format` are read; all
@@ -115,15 +126,26 @@ def render_article(item: dict[str, Any]) -> RenderableType:
         A `Text` for a plain-text body, or a `Group` whose body half is a
         `rich.markdown.Markdown` when `content_format` says markdown.
     """
-    body = item.get("content")
+    raw_body = item.get("content")
+    # Markdown bodies keep their source (the `Markdown` renderable is the
+    # parser for them); everything else is made readable here.
+    body = (
+        strip_control_characters(raw_body)
+        if _is_markdown(item)
+        else readable_body_text(raw_body)
+    )
     out = Text()
-    out.append(str(item.get("title") or "Untitled"), style="bold")
+    out.append(strip_control_characters(item.get("title") or "Untitled"), style="bold")
     out.append("\n")
-    meta = [str(item.get("source_name") or "unknown source")]
+    meta = [strip_control_characters(item.get("source_name") or "unknown source")]
     if item.get("published_date"):
-        meta.append(str(item["published_date"]))
+        # TASK-2308: local, human-scale, and the same formatter the Items
+        # table uses -- the byline and the row must not disagree about when
+        # something was published, which is how the UAT noticed the table was
+        # showing ingest time at all.
+        meta.append(humane_timestamp(item["published_date"]))
     if body:
-        meta.append(f"{len(str(body).split())} words")
+        meta.append(f"{len(body.split())} words")
     out.append(" · ".join(meta), style="dim")
     out.append("\n")
     if body and _is_markdown(item):
@@ -131,9 +153,9 @@ def render_article(item: dict[str, Any]) -> RenderableType:
         # `Text` above -- group the two instead. `Markdown` does not evaluate
         # Rich markup either; it parses CommonMark, and `[bold red]x[/]` is
         # just link-shaped text to it.
-        return Group(out, Markdown(str(body), hyperlinks=_MARKDOWN_HYPERLINKS))
+        return Group(out, Markdown(body, hyperlinks=_MARKDOWN_HYPERLINKS))
     out.append("\n")
-    out.append(str(body) if body else _NO_BODY)
+    out.append(body if body else _NO_BODY)
     return out
 
 
@@ -152,7 +174,7 @@ def render_change(item: dict[str, Any]) -> Text:
         item carries no content.
     """
     out = Text()
-    out.append(str(item.get("title") or "Untitled"), style="bold")
+    out.append(strip_control_characters(item.get("title") or "Untitled"), style="bold")
     out.append("\n")
 
     headline: list[str] = []
@@ -172,13 +194,13 @@ def render_change(item: dict[str, Any]) -> Text:
         except (TypeError, ValueError):
             pass
     if item.get("change_type"):
-        headline.append(str(item["change_type"]))
+        headline.append(strip_control_characters(item["change_type"]))
     if item.get("diff_summary"):
         # Whole-branch review (Minor): `diff_summary` was carried through
         # normalization with no consumer at all. It is the monitoring
         # engine's own one-line account of the change ("2 lines changed"),
         # which is exactly what this headline is for.
-        headline.append(str(item["diff_summary"]))
+        headline.append(strip_control_characters(item["diff_summary"]))
     out.append(" · ".join(headline) or "changed", style="dim")
     out.append("\n\n")
 
@@ -189,8 +211,13 @@ def render_change(item: dict[str, Any]) -> Text:
 
     # Colour the diff. These lines are remote content appended to a `Text`,
     # which never parses markup -- see `render_article` on why the former
-    # `escape_markup` call here was corruption without protection.
-    for line in str(body).splitlines():
+    # `escape_markup` call here was corruption without protection. NOT run
+    # through `readable_body_text` (TASK-2307): a diff of an HTML page is
+    # *about* the markup, and converting it to prose would delete the very
+    # characters the diff exists to show. Control characters are still
+    # stripped -- those are never the subject of a diff a person reads, and
+    # they are the one class `Text.append` does not neutralize.
+    for line in strip_control_characters(body).splitlines():
         style = "green" if line.startswith("+") else "red" if line.startswith("-") else None
         out.append(line, style=style)
         out.append("\n")
@@ -245,6 +272,20 @@ class ViewSnapshotRequested(Message):
         super().__init__()
 
 
+class ExpandReaderRequested(Message):
+    """Posted when the reader asks for (or gives back) the whole centre stack.
+
+    TASK-2307 AC#2 (UAT F27). CONTENT is about nine rows on a 52-row terminal
+    and the only ways to enlarge it -- `z` on the sibling regions, `Z` on this
+    one -- are keyboard gestures that require focus to already be inside the
+    region and are advertised nowhere on screen. A reader that cannot say how
+    to make itself readable is the defect; this is the visible affordance.
+
+    Carries no payload: the screen owns `region_layout` and this pane must not
+    hold a second opinion about it (see `ContentPane.expanded`).
+    """
+
+
 class ContentPane(RecomposeCaptureGuard, Vertical):
     """Hosts the reader for the currently selected item.
 
@@ -260,15 +301,29 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
 
     item: reactive[dict[str, Any] | None] = reactive(None, recompose=True)
 
+    #: Whether CONTENT is currently the only expanded centre region, i.e.
+    #: whether the expand button should offer to give the room BACK.
+    #:
+    #: Seeded by `WatchlistsCollectionsScreen._build_content_pane` from the
+    #: live `RegionLayout` and never written here: the layout has exactly one
+    #: owner, and a pane that guessed would show `Restore` over a nine-row
+    #: reader the moment the two drifted. A plain reactive, not
+    #: `recompose=True` -- every layout change rebuilds the whole workbench
+    #: (and therefore this pane) through the region factories anyway, so a
+    #: second recompose would be pure churn.
+    expanded: reactive[bool] = reactive(False)
+
     def compose(self):
         """Build the reader for `item`, or the empty-state placeholder.
 
         Yields:
             A single `#content-empty` `Static` when no item is selected;
-            otherwise the `#content-mark-unread-button`, the `#content-
-            full-page-button`/`#content-previous-snapshot-button` pair on a
-            `change`-kind item only (TASK-1494), and a `#content-body`
-            `Static` holding `render_for(self.item)`.
+            otherwise a one-row `#content-actions` strip holding
+            `#content-mark-unread-button`, `#content-expand-button`
+            (TASK-2307) and, on a `change`-kind item only, the
+            `#content-full-page-button`/`#content-previous-snapshot-button`
+            pair (TASK-1494) -- followed by a `#content-body` `Static`
+            holding `render_for(self.item)`.
         """
         if self.item is None:
             yield Static("Select an item to read it.", id="content-empty")
@@ -285,38 +340,52 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
         # three rows tall (top border, label, bottom border) and CONTENT has
         # only about nine usable ones -- the same third of the pane the
         # tooltip fix above just reclaimed, spent again on a button's chrome.
-        yield Button(
-            "Mark unread",
-            id="content-mark-unread-button",
-            tooltip=_GLOBAL_STATUS_NOTE,
-            compact=True,
-        )
-        if str(self.item.get("content_kind") or "") == CONTENT_KIND_CHANGE:
-            # TASK-1494: the two affordances the design spec promised for a
-            # site change and Phase D never wired up. Article items never
-            # get these -- only `URLMonitor.check_url` (a `change`-kind
-            # producer) ever writes `url_snapshots`, so an article item has
-            # no rows there to show and the buttons would open a modal with
-            # nothing in it. `compact=True`, same footprint as "Mark
-            # unread" above: CONTENT's row budget is genuinely tight (see
-            # that button's own comment), but this is the one place the
-            # stored page these numbers were measured against becomes
-            # reachable at all, and a `change` item's diff body is the
-            # shorter of this pane's two bodies -- the trade favours making
-            # it reachable over a couple of extra lines of diff visible
-            # without scrolling.
+        #
+        # TASK-2307: the buttons share ONE `.destination-filter-strip` row
+        # (`height: 1`, the same chrome every toolbar on this screen uses)
+        # rather than stacking. A `change` item previously spent three of the
+        # pane's nine rows on three stacked buttons; it now spends one, which
+        # is a straight win for the row budget F27 is about -- and it is what
+        # makes room for the expand affordance to be free.
+        with Horizontal(id="content-actions", classes="destination-filter-strip"):
             yield Button(
-                "Full page",
-                id="content-full-page-button",
+                "Mark unread",
+                id="content-mark-unread-button",
+                tooltip=_GLOBAL_STATUS_NOTE,
                 compact=True,
-                tooltip="Open the page this change was measured against.",
             )
+            # AC#2. `Z` does the same thing from the keyboard, and the tooltip
+            # says so -- but only once the user knows the region has to be
+            # focused first, which is exactly the knowledge F27 says nothing
+            # on screen conveys. The button needs no focus at all.
             yield Button(
-                "Previous snapshot",
-                id="content-previous-snapshot-button",
+                "Restore" if self.expanded else "Expand",
+                id="content-expand-button",
                 compact=True,
-                tooltip="Open the page as it was before this change.",
+                tooltip=(
+                    "Give the reader the whole centre pane, and press again "
+                    "to put Feeds and Items back (keyboard: Z)."
+                ),
             )
+            if str(self.item.get("content_kind") or "") == CONTENT_KIND_CHANGE:
+                # TASK-1494: the two affordances the design spec promised for
+                # a site change and Phase D never wired up. Article items
+                # never get these -- only `URLMonitor.check_url` (a
+                # `change`-kind producer) ever writes `url_snapshots`, so an
+                # article item has no rows there to show and the buttons would
+                # open a modal with nothing in it.
+                yield Button(
+                    "Full page",
+                    id="content-full-page-button",
+                    compact=True,
+                    tooltip="Open the page this change was measured against.",
+                )
+                yield Button(
+                    "Previous snapshot",
+                    id="content-previous-snapshot-button",
+                    compact=True,
+                    tooltip="Open the page as it was before this change.",
+                )
         yield Static(render_for(self.item), id="content-body")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
@@ -329,3 +398,6 @@ class ContentPane(RecomposeCaptureGuard, Vertical):
         elif event.button.id == "content-previous-snapshot-button":
             event.stop()
             self.post_message(ViewSnapshotRequested(self.item, "previous"))
+        elif event.button.id == "content-expand-button":
+            event.stop()
+            self.post_message(ExpandReaderRequested())

--- a/tldw_chatbook/UI/Watchlists_Modules/humane_time.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/humane_time.py
@@ -1,0 +1,128 @@
+"""One timestamp format for every Watchlists table.
+
+TASK-2308. Sources ("Last scraped"), Items ("Created") and Runs ("Started")
+each rendered `str(row.get(...))` straight from the database: 32 characters of
+`2026-08-04T18:15:22.123456+00:00` per cell, in UTC, in a table whose other
+columns are a title and a status. The column was the widest thing on screen
+and the least readable.
+
+**There was no house style to reuse.** The Artifacts pane looked humane
+("2026-08-04 18:22:44") purely because SQLite's `CURRENT_TIMESTAMP` has that
+shape -- it is still UTC, and still a raw column value. So the style is
+written down here, once, and every table calls it.
+
+**Naive means UTC.** Every writer behind these columns stores UTC:
+`LocalWatchlistsService._utc_now`, SQLite `CURRENT_TIMESTAMP` defaults, and
+the scrapers' `datetime.now(timezone.utc).isoformat()`. A naive value is
+therefore attached to UTC rather than to the local zone -- assuming local
+would silently shift every pre-existing row by the user's offset.
+
+**Unparseable input passes through.** A backend this app does not control can
+put anything in these fields. Rendering a dash over a value that exists would
+be a lie, and raising inside a `compose()` exits the application, so anything
+this module cannot read is returned unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+__all__ = ["humane_timestamp", "parse_timestamp"]
+
+#: What an empty cell says. The dash every Watchlists table already used for
+#: "no value", kept so this change cannot be mistaken for a new empty state.
+EMPTY_TIMESTAMP = "-"
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    """Parse the timestamp shapes this app actually stores.
+
+    Args:
+        value: A `datetime`, a `date`, or a string. ISO-8601 with or without
+            microseconds, with a `T` or a space separator, with a `Z` suffix,
+            a numeric offset, or nothing at all.
+
+    Returns:
+        A timezone-aware `datetime` in UTC, or `None` when the value is empty
+        or cannot be read. A date with no time component is returned as
+        midnight UTC -- callers that care about the distinction should check
+        the input, not the result.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    text = str(value).strip()
+    if not text:
+        return None
+    # `fromisoformat` accepts `Z` from 3.11, but normalizing it here keeps this
+    # working if the minimum ever moves back down, and costs one comparison.
+    if text.endswith(("Z", "z")):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _is_date_only(value: Any) -> bool:
+    """Whether the stored value carries a date but no clock time.
+
+    A date-only value must NOT be shifted into the local zone: `2026-07-18`
+    means that calendar day, and converting midnight UTC westwards would
+    render it as the 17th.
+    """
+    if isinstance(value, datetime):
+        return False
+    if isinstance(value, date):
+        return True
+    return ":" not in str(value)
+
+
+def humane_timestamp(value: Any, *, now: datetime | None = None) -> str:
+    """Render a stored timestamp for a Watchlists table cell.
+
+    Args:
+        value: The stored value; see `parse_timestamp` for the shapes read.
+        now: The instant to measure "today"/"yesterday" against. Injected so
+            the format is testable without freezing the clock; defaults to
+            the current time.
+
+    Returns:
+        One of, in the viewer's local zone:
+
+        * ``-`` for an empty value;
+        * ``Today 18:15`` / ``Yesterday 18:15`` for the last two days;
+        * ``Aug 04 18:15`` for another day in the same year;
+        * ``2025-12-31`` for an older one;
+        * ``2026-07-18`` for a value that carried no clock time at all;
+        * the original text, unchanged, for anything unparseable.
+    """
+    if value is None:
+        return EMPTY_TIMESTAMP
+    if isinstance(value, str) and not value.strip():
+        return EMPTY_TIMESTAMP
+    parsed = parse_timestamp(value)
+    if parsed is None:
+        return str(value)
+    if _is_date_only(value):
+        return parsed.strftime("%Y-%m-%d")
+
+    local = parsed.astimezone()
+    reference = now if now is not None else datetime.now(timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=timezone.utc)
+    reference_local = reference.astimezone()
+
+    today = reference_local.date()
+    if local.date() == today:
+        return f"Today {local:%H:%M}"
+    if local.date() == today - timedelta(days=1):
+        return f"Yesterday {local:%H:%M}"
+    if local.year == reference_local.year:
+        return f"{local:%b %d %H:%M}"
+    return f"{local:%Y-%m-%d}"

--- a/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
@@ -245,6 +245,18 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
     #: wire path for membership edits, while this button wrote a local
     #: `watchlist_sources` row and reported success.
     write_disabled_reason = reactive[str | None](None, recompose=True)
+    #: TASK-2309. Screen-seeded like the four reactives above (mirrors
+    #: `WatchlistsCollectionsScreen._checks_in_flight`, the same way
+    #: `SourcesPane.busy_source_ids` does): the ids of sources with a check
+    #: currently in flight, so this pane's own "Check now" -- a second
+    #: activation site for the identical write -- can show the same busy
+    #: state rather than inviting a confused second click while the Sources
+    #: pane already shows one greyed out. `recompose=True`, unlike
+    #: `SourcesPane`'s copy: this pane already fully recomposes on every
+    #: selection/scope change, a check starting or ending is rare next to
+    #: that, and there is no live table selection or scroll position here for
+    #: a recompose to disturb.
+    busy_source_ids = reactive[frozenset[str]](frozenset(), recompose=True)
 
     #: TASK-1362 (spec §2). The source types whose checks run through
     #: `URLMonitor.check_url` -- the only ones that extract text from HTML and
@@ -517,7 +529,27 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
         with Vertical(id="inspector-actions"):
             if deepest.kind == "source":
                 yield Button("Preview", id="inspector-preview-button", variant="primary")
-                yield Button("Check now", id="inspector-check-now-button", variant="primary")
+                # TASK-2309: this is a SECOND activation site for the same
+                # `CheckNowRequested` write the Sources pane's own button
+                # posts, so it must show the same busy state the screen is
+                # tracking -- otherwise this copy stays enabled while the
+                # Sources pane shows one greyed out, and a click here queues
+                # a duplicate check the debounce in
+                # `handle_check_now_requested` exists to prevent from ever
+                # looking silent. `deepest.entity` is `None` for a scope-only
+                # "browsing this source" level with nothing selected below
+                # it -- such a level was never sent to `check_now` either, so
+                # it cannot be in `busy_source_ids`, and this reads False.
+                check_now_busy = (
+                    deepest.entity is not None
+                    and str(deepest.entity.get("id") or "") in self.busy_source_ids
+                )
+                yield Button(
+                    "Checking..." if check_now_busy else "Check now",
+                    id="inspector-check-now-button",
+                    variant="primary",
+                    disabled=check_now_busy,
+                )
                 # task-2050 (AC#1/#2): rendered ONLY for a paused local
                 # subscription -- `deepest.entity` can be None here (a
                 # scope-only "browsing this source" level with nothing

--- a/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
@@ -26,6 +26,7 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Button, Static, TextArea
 
+from ...Subscriptions.html_text import strip_control_characters
 from ...Subscriptions.noise_defaults import (
     first_invalid_selector,
     invalid_selector_message,
@@ -509,7 +510,13 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
         deepest = levels[-1]
         if deepest.entity is not None:
             entity = deepest.entity
-            title = (
+            # Batch-4 review, I1. `title` is remote-derived (a source's OPML-
+            # imported name, an item's feed-supplied title) -- the same hole
+            # `sources_pane._source_row_cells` closes, for the same reason:
+            # `Text.append`/`Text(...)` only protects against Rich markup,
+            # not raw control bytes, and this cell is the SAME entity's name
+            # rendered a second place.
+            title = strip_control_characters(
                 entity.get("name")
                 or entity.get("source_title")
                 or entity.get("title")
@@ -523,7 +530,10 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
             if deepest.kind == "source" and self._is_url_family_source(entity):
                 yield from self._noise_selectors_editor(entity)
         else:
-            yield Static(Text(deepest.label), id="inspector-entity-title")
+            yield Static(
+                Text(strip_control_characters(deepest.label)),
+                id="inspector-entity-title",
+            )
             yield Static(Text(f"Type: {deepest.kind.capitalize()}"), id="inspector-entity-type")
 
         with Vertical(id="inspector-actions"):

--- a/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
@@ -141,8 +141,13 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
             )
 
         table = DataTable(id="items-table")
+        # TASK-2308 AC#2: "Published", not "Created". The column used to read
+        # `created_at` -- the INGEST time -- so every row from one check
+        # carried the same value to the microsecond, and the one date a
+        # reader actually wants (when the article was published) was visible
+        # only in the reader's own byline, disagreeing with the table.
         self._column_keys = table.add_columns(
-            "Title", "Source", "Status", "Created", "Queued"
+            "Title", "Source", "Status", "Published", "Queued"
         )
         filtered = self._filtered_items()
         self._rendered_items = filtered
@@ -164,7 +169,7 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
                 # Displayed through `_status_label` (review wave, Minor 1) so
                 # the column and the filter above it use one vocabulary.
                 escape_markup(self._status_label(item.get("status"))),
-                escape_markup(str(item.get("created_at") or "-")),
+                escape_markup(self.item_published_text(item)),
                 self._QUEUED_GLYPH if item.get("queued_for_briefing") else "",
                 key=str(item.get("id") or id(item)),
             )

--- a/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
@@ -14,6 +14,7 @@ from textual.widgets.data_table import CellDoesNotExist, ColumnKey
 
 from ...Widgets.prune_safe_select import PruneSafeSelect
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
+from .humane_time import humane_timestamp
 from .table_selection import highlight_is_user_driven
 
 
@@ -99,6 +100,39 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
         if not text:
             return "-"
         return cls._STATUS_LABELS.get(text.lower(), text)
+
+    @staticmethod
+    def item_published_text(item: dict[str, Any]) -> str:
+        """What the "Published" column says for one item.
+
+        TASK-2308 AC#2 (UAT F20/F24). `created_at` is INGEST time -- every
+        item a single check produces carries the same value to the
+        microsecond -- and it was shown under a column a reader reasonably
+        reads as "when was this published". `content_pane.render_article`'s
+        byline already reads the real field, `published_date`, which is
+        `None` whenever the feed itself omitted a date (RSS/Atom/JSON-Feed
+        parsing in `monitoring_engine.py` returns `None` rather than
+        defaulting to "now" -- see `_parse_date`).
+
+        Args:
+            item: A normalized watchlist item (see `normalize_watchlist_item`).
+                `published_date` and `created_at` are read; both may be
+                missing or `None`.
+
+        Returns:
+            `humane_timestamp(published_date)` when the feed supplied one.
+            Otherwise `"added <humane_timestamp(created_at)>"` -- ingest
+            time, but labelled as ingest time, never presented silently as a
+            publish date under a "Published" heading. `"-"` when the item
+            carries neither.
+        """
+        published = item.get("published_date")
+        if published:
+            return humane_timestamp(published)
+        created = item.get("created_at")
+        if created:
+            return f"added {humane_timestamp(created)}"
+        return "-"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/tldw_chatbook/UI/Watchlists_Modules/notifications_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/notifications_pane.py
@@ -12,6 +12,7 @@ from textual.reactive import reactive
 from textual.widgets import Button, DataTable, Static
 
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
+from .humane_time import humane_timestamp
 from .table_selection import highlight_is_user_driven
 
 
@@ -102,7 +103,9 @@ class NotificationsPane(RecomposeCaptureGuard, Vertical):
                 Text(str(notification.get("title") or "Notification"), style=style),
                 Text(str(notification.get("category") or "-"), style=style),
                 Text(str(notification.get("severity") or "-"), style=style),
-                Text(str(notification.get("created_at") or "-"), style=style),
+                # TASK-2308: one timestamp format across every Watchlists
+                # table, in the viewer's local zone.
+                Text(humane_timestamp(notification.get("created_at")), style=style),
                 key=row_id,
             )
         if selected_index is not None:

--- a/tldw_chatbook/UI/Watchlists_Modules/notifications_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/notifications_pane.py
@@ -11,6 +11,7 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Button, DataTable, Static
 
+from ...Subscriptions.html_text import strip_control_characters
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
 from .humane_time import humane_timestamp
 from .table_selection import highlight_is_user_driven
@@ -98,9 +99,17 @@ class NotificationsPane(RecomposeCaptureGuard, Vertical):
             # somewhere -- including on a row this pane does not consider
             # selected (task-876).
             style = self._SELECTED_ROW_STYLE if row_id == selected_id else ""
+            # Batch-4 review, I1. `title` can carry remote-derived content
+            # (an alert fired against a feed item's own title/snippet), and
+            # `Text(...)` protects only against Rich markup, not a raw
+            # control byte -- the same hole `sources_pane`/`inspector_pane`
+            # close for their own name/title cells.
             table.add_row(
                 Text("Read" if notification.get("is_read") else "Unread", style=style),
-                Text(str(notification.get("title") or "Notification"), style=style),
+                Text(
+                    strip_control_characters(notification.get("title") or "Notification"),
+                    style=style,
+                ),
                 Text(str(notification.get("category") or "-"), style=style),
                 Text(str(notification.get("severity") or "-"), style=style),
                 # TASK-2308: one timestamp format across every Watchlists

--- a/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
@@ -13,6 +13,7 @@ from textual.reactive import reactive
 from textual.widgets import Button, DataTable, Static
 from textual.worker import get_current_worker
 
+from ...Subscriptions.html_text import strip_control_characters
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
 from .humane_time import humane_timestamp
 from .table_selection import highlight_is_user_driven
@@ -150,9 +151,13 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
         `DataTable`'s `default_cell_formatter` runs `Text.from_markup` over any
         plain `str` cell, and an item title is remote content (a feed entry's
         own `<title>`), so these must arrive as `Text` already.
+
+        Batch-4 review, I1: `Text(...)` protects against Rich markup, not a
+        raw control byte -- the title is stripped for the same reason
+        `sources_pane._source_row_cells` strips a source's name.
         """
         return (
-            Text(str(item.get("title") or "Untitled")),
+            Text(strip_control_characters(item.get("title") or "Untitled")),
             Text(str(item.get("status") or "-")),
             Text(str(item.get("alert_count") or "0")),
         )
@@ -201,10 +206,20 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
         # No `job_name` fallback: no normalizer emits that key (review wave,
         # Minor 4), and an unreachable fallback reads as "some backend
         # supplies this" to the next person here.
-        source = str(run.get("source_title") or "").strip()
+        #
+        # Batch-4 review, I1: `source_title`/`watchlist_names` are stripped
+        # of control characters -- `_run_row_cells` wraps this string in a
+        # `Text(...)`, which stops Rich markup but not a raw control byte,
+        # and `source_title` is remote-derived the same way an item's title
+        # is (see `_run_item_row_cells`).
+        source = strip_control_characters(run.get("source_title") or "").strip()
         if not source:
             source = "Untitled"
-        names = [str(name).strip() for name in (run.get("watchlist_names") or []) if str(name).strip()]
+        names = [
+            strip_control_characters(name).strip()
+            for name in (run.get("watchlist_names") or [])
+            if str(name).strip()
+        ]
         if not names:
             return source
         suffix = names[0] if len(names) == 1 else f"{names[0]} +{len(names) - 1}"

--- a/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
@@ -14,6 +14,7 @@ from textual.widgets import Button, DataTable, Static
 from textual.worker import get_current_worker
 
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
+from .humane_time import humane_timestamp
 from .table_selection import highlight_is_user_driven
 
 
@@ -167,7 +168,10 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
         return (
             Text(RunsPane._run_identity(run), style=style),
             Text(str(run.get("status") or "-"), style=style),
-            Text(str(run.get("started_at") or "-"), style=style),
+            # TASK-2308: local, human-scale. The stored value is a UTC ISO
+            # string with microseconds, and it was the widest column in a
+            # table with eight of them.
+            Text(humane_timestamp(run.get("started_at")), style=style),
             Text(str(run.get("duration") or "-"), style=style),
             Text(str(run.get("found_count") or "0"), style=style),
             Text(str(run.get("processed_count") or "0"), style=style),
@@ -225,7 +229,7 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
         base = (
             identity
             + f"Status: {run.get('status', '-')}\n"
-            f"Started: {run.get('started_at', '-')}\n"
+            f"Started: {humane_timestamp(run.get('started_at'))}\n"
             f"Duration: {run.get('duration', '-')}\n"
             f"Found: {run.get('found_count', 0)} | "
             f"Processed: {run.get('processed_count', 0)} | "

--- a/tldw_chatbook/UI/Watchlists_Modules/snapshot_view_modal.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/snapshot_view_modal.py
@@ -29,6 +29,22 @@ not remote content, but they are wrapped through `Text` here too rather
 than an f-string handed to `Static` -- one rendering rule for the whole
 modal is simpler to keep correct than a rule that only applies to one of
 its three fields.
+
+**Batch-4 review round 2, N2.** `Text(str(...))` stops Rich MARKUP; it does
+nothing about a raw control byte, which Rich writes through to the terminal
+untouched (`html_text.strip_control_characters`'s own docstring states the
+same gap for the reader). `_snapshot_body` now runs `content` through
+`readable_body_text` instead of a bare `str()` -- the SAME function
+`content_pane.render_article` uses for a feed item's body, for a reason
+that is not merely consistency: `extracted_content` is not guaranteed to
+already be plain text. `URLMonitor._fetch_url_content` only strips HTML
+when the source's `extraction_method` is `"full"` or `"auto"` (the
+default); a source configured for raw extraction stores the page's literal
+HTML in this column, and `readable_body_text` is what converts that to
+readable prose -- `looks_like_html` gates the conversion, so an
+already-plain-text snapshot (the common case) takes the same
+control-stripped-only path a bare `strip_control_characters` call would
+have, with no behavioural change for it.
 """
 
 from __future__ import annotations
@@ -41,6 +57,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
+from ...Subscriptions.html_text import readable_body_text
 from .humane_time import humane_timestamp
 
 #: `_store_snapshot` never writes a NULL `extracted_content` on its one live
@@ -70,14 +87,22 @@ def _snapshot_header(url: Any, created_at: Any) -> Text:
 
 
 def _snapshot_body(content: Any) -> Text:
-    """The snapshot body, rendered as literal text (AC#3 -- see the module
-    docstring for the full doctrine this restates).
+    """The snapshot body, rendered as literal, readable text (AC#3 -- see
+    the module docstring for the full doctrine this restates, and its N2
+    note for why `readable_body_text` is the right call here).
 
-    `Text(str(...))` never parses Rich markup: a captured page's own
+    `Text(...)` never parses Rich markup: a captured page's own
     `[bold red]x[/]`-shaped fragment, or an HTML-extraction artefact that
     happens to be `[link=...]`-shaped, paints as those exact characters.
+    `readable_body_text` additionally strips control characters on every
+    path (Rich protects against markup, not a raw ESC/C1 byte) and converts
+    genuine HTML to prose when `content` turns out to still be HTML rather
+    than already-extracted text.
     """
-    return Text(str(content) if content else _NO_CONTENT)
+    if not content:
+        return Text(_NO_CONTENT)
+    text = readable_body_text(content)
+    return Text(text if text else _NO_CONTENT)
 
 
 class SnapshotViewModal(ModalScreen[None]):

--- a/tldw_chatbook/UI/Watchlists_Modules/snapshot_view_modal.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/snapshot_view_modal.py
@@ -41,6 +41,8 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
+from .humane_time import humane_timestamp
+
 #: `_store_snapshot` never writes a NULL `extracted_content` on its one live
 #: write path, but a pre-migration or hand-edited row is not ruled out --
 #: degrade honestly rather than showing a blank scroll region.
@@ -48,11 +50,22 @@ _NO_CONTENT = "This snapshot recorded no page text."
 
 
 def _snapshot_header(url: Any, created_at: Any) -> Text:
-    """The modal's header line: the page's URL, then when it was captured."""
+    """The modal's header line: the page's URL, then when it was captured.
+
+    Batch-4 review, I2: task-2308's own scope ("every Watchlists table
+    timestamp") missed this modal -- it opens from the Full page/Previous
+    snapshot buttons in the SAME `#content-actions` row this batch's reader
+    byline already humanizes, so a raw `2026-08-04T18:15:22.123456+00:00`
+    here sat one row below "Today 00:34", the exact "two clocks disagreeing"
+    shape task-2308 exists to eliminate. `created_at` goes through
+    `humane_timestamp`, the same formatter every other Watchlists timestamp
+    uses.
+    """
     header = Text()
     header.append(str(url) if url else "Unknown URL", style="bold")
     header.append("\n")
-    header.append(f"Captured {created_at or 'at an unknown time'}", style="dim")
+    when = humane_timestamp(created_at) if created_at else "at an unknown time"
+    header.append(f"Captured {when}", style="dim")
     return header
 
 

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -646,6 +646,16 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         zone. The stored value is a full UTC ISO-8601 string with
         microseconds -- 32 characters, in a table whose Name column is the
         one people actually read.
+
+        Args:
+            source: A normalized source dict; `last_checked_or_scraped_at`
+                (the current normalizer field) is preferred, falling back to
+                the older `last_scraped` for any hand-built row that still
+                uses it.
+
+        Returns:
+            `humane_timestamp` of whichever of the two fields is present, or
+            `"-"` when neither is.
         """
         return humane_timestamp(
             source.get("last_checked_or_scraped_at") or source.get("last_scraped")
@@ -1256,6 +1266,13 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
 
         TASK-2309. Mirrors `watch_selected_source`'s repaint-not-rebuild
         choice above, for the identical reason.
+
+        Args:
+            _busy_source_ids: The reactive's new value (Textual's watcher
+                convention passes it), unused directly -- `_update_action_
+                buttons`/`_is_check_now_busy` re-read the current value off
+                `self.busy_source_ids` instead, the same indirection
+                `watch_selected_source` already uses for its own reactive.
         """
         self._update_action_buttons()
 

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -20,6 +20,7 @@ from ...Subscriptions.noise_defaults import (
 from ...Utils.input_validation import sanitize_string, validate_text_input, validate_url
 from ...Widgets.prune_safe_select import PruneSafeSelect
 from ...Widgets.recompose_capture_guard import RecomposeCaptureGuard
+from .humane_time import humane_timestamp
 from .inspector_pane import CheckNowRequested, PreviewRequested
 
 
@@ -618,11 +619,15 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
     def source_last_scraped_text(source: dict[str, Any]) -> str:
         """What the Last scraped column says. Same defect as `status` above:
         the normalizers publish `last_checked_or_scraped_at`, so this column
-        read `-` even immediately after a successful check."""
-        return str(
-            source.get("last_checked_or_scraped_at")
-            or source.get("last_scraped")
-            or "-"
+        read `-` even immediately after a successful check.
+
+        TASK-2308: rendered through `humane_timestamp`, in the viewer's local
+        zone. The stored value is a full UTC ISO-8601 string with
+        microseconds -- 32 characters, in a table whose Name column is the
+        one people actually read.
+        """
+        return humane_timestamp(
+            source.get("last_checked_or_scraped_at") or source.get("last_scraped")
         )
 
     @staticmethod

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -116,6 +116,17 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
 
     sources = reactive[list[dict[str, Any]]]([], recompose=True)
     selected_source = reactive[dict[str, Any] | None](None)
+    #: TASK-2309. The source ids ("id" field, the same namespaced form
+    #: `selected_source` carries) with a check currently in flight anywhere
+    #: on the screen -- not just the one selected here, since the Inspector
+    #: can trigger a check for a source that is not this pane's current
+    #: selection. `WatchlistsCollectionsScreen._checks_in_flight` is the
+    #: source of truth; this mirrors it in, the same way `sources` mirrors
+    #: `_loaded_sources`. Deliberately NOT `recompose=True`: a check starting
+    #: or finishing must not rebuild the table under the user (the same
+    #: reason `selected_source` above is not), so `watch_busy_source_ids`
+    #: repaints the one button that can show it, surgically.
+    busy_source_ids = reactive[frozenset[str]](frozenset())
     search_query = reactive("", recompose=True)
     source_type_filter = reactive("all", recompose=True)
     status_filter = reactive("all", recompose=True)
@@ -364,10 +375,19 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
                     id="sources-preview-button",
                     disabled=self.selected_source is None,
                 )
+                # TASK-2309: busy state read at compose time too, not only via
+                # the surgical `_update_action_buttons` repaint below -- this
+                # pane is reconstructed from scratch on every workbench
+                # rebuild (`_build_detail_pane`), and the screen seeds
+                # `busy_source_ids` onto the fresh instance BEFORE it mounts,
+                # so the very first paint has to already reflect an
+                # in-flight check rather than waiting for a watcher that
+                # cannot repaint a widget that does not exist yet.
+                check_now_busy = self._is_check_now_busy(self.selected_source)
                 yield Button(
-                    "Check now",
+                    "Checking..." if check_now_busy else "Check now",
                     id="sources-check-now-button",
-                    disabled=self.selected_source is None,
+                    disabled=self.selected_source is None or check_now_busy,
                 )
                 yield Button("Import OPML", id="sources-import-opml-button")
                 yield Button("Export OPML", id="sources-export-opml-button")
@@ -1215,6 +1235,22 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         self._update_action_buttons()
         self._update_selection_highlight(source)
 
+    def watch_busy_source_ids(self, _busy_source_ids: frozenset[str]) -> None:
+        """Repaint Check now, without a recompose, when a check starts or ends.
+
+        TASK-2309. Mirrors `watch_selected_source`'s repaint-not-rebuild
+        choice above, for the identical reason.
+        """
+        self._update_action_buttons()
+
+    def _is_check_now_busy(self, source: dict[str, Any] | None) -> bool:
+        """Whether `source` (typically `self.selected_source`) has a check
+        in flight right now, per the screen's `busy_source_ids` mirror."""
+        if source is None:
+            return False
+        source_key = str(source.get("id") or "")
+        return bool(source_key) and source_key in self.busy_source_ids
+
     def _update_selection_highlight(self, source: dict[str, Any] | None) -> None:
         """Move the table's selected-row highlight without rebuilding it.
 
@@ -1277,4 +1313,11 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
             return
         disabled = self.selected_source is None
         preview_button.disabled = disabled
-        check_now_button.disabled = disabled
+        # TASK-2309: Check now additionally disables, and relabels, while the
+        # selected source has a check in flight -- the busy state a second,
+        # confused click must see rather than silently queuing a duplicate
+        # run. `Preview` is unaffected: it makes no write and a check running
+        # is no reason to block reading the same feed.
+        check_now_busy = self._is_check_now_busy(self.selected_source)
+        check_now_button.disabled = disabled or check_now_busy
+        check_now_button.label = "Checking..." if check_now_busy else "Check now"

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -12,6 +12,7 @@ from textual.reactive import reactive
 from textual.css.query import NoMatches
 from textual.widgets import Button, DataTable, Input, Select, Static, Switch, TextArea
 
+from ...Subscriptions.html_text import strip_control_characters
 from ...Subscriptions.noise_defaults import (
     default_ignore_selectors_text,
     first_invalid_selector,
@@ -659,8 +660,23 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         which must not rebuild the table) so both draw an identical row.
         """
         style = SourcesPane._SELECTED_ROW_STYLE if highlighted else ""
+        # Batch-4 review, I1. `name` is remote-derived: OPML import
+        # (`WatchlistOpmlService.parse`) hands an `<outline text=...>`
+        # attribute straight to this field with zero sanitization, and a C1
+        # control byte (0x80-0x9F, e.g. a single-byte CSI introducer) is
+        # valid in XML 1.0's character range -- it survives the OPML parse
+        # untouched and would otherwise reach this `Text` cell (and Rich's
+        # real render) verbatim. `Text.append`/`Text(...)` only protects
+        # against Rich MARKUP, not raw control bytes -- see
+        # `html_text.strip_control_characters`'s own docstring, which closed
+        # this exact hole for the reader; it did not extend to this pane.
         return (
-            Text(str(source.get("name") or source.get("title") or "Untitled"), style=style),
+            Text(
+                strip_control_characters(
+                    source.get("name") or source.get("title") or "Untitled"
+                ),
+                style=style,
+            ),
             Text(str(source.get("source_type") or "-"), style=style),
             Text(SourcesPane.source_status_text(source), style=style),
             Text(SourcesPane.source_last_scraped_text(source), style=style),


### PR DESCRIPTION
## What (UAT batch 4 of 5 — tasks 2307, 2308, 2309)

Fourth batch from the 2026-08-04 sr-UX/HCI UAT (findings F19/F20/F24/F26/F27/F41, filed in #1335).

**task-2307 — the reader shows prose, not markup.** Feed bodies were rendered verbatim: `<p>Article URL: <a href="…">…</a></p>` literally on screen. New `Subscriptions/html_text.py` converts HTML to display text at *render* time (the stored body stays the honest capture of what the feed served, and every already-persisted item holds HTML). It **converts rather than sanitizes** — no allow-list that can fail open — and keeps link destinations visible as ordinary text, because a terminal reader who cannot see the address cannot judge it. `strip_control_characters` closes the hole `Text.append` leaves open: Rich writes segment text to the terminal verbatim, so a raw ESC in a feed body would otherwise paint a real OSC-8 hyperlink whose visible label is attacker-chosen.

**task-2308 — humane timestamps and real publish dates.** Sources/Items/Runs showed raw ISO-8601 with microseconds in UTC. Now local, human-scale, via one shared formatter — including the snapshot viewer's `created_at`, which sat next to an already-humanized byline. The Items column also showed *ingest* time (identical to the microsecond on every row from one check) where users need the item's **publish** time; it now shows publish, falling back honestly when a feed omits it.

**task-2309 — check-now has a pulse.** Immediate acknowledgment, a busy state mirrored on both trigger paths (Sources toolbar and Inspector), completion signals covering failure, and a debounce so a second press can't queue duplicate work.

## What review found (and why it mattered)

- **CRITICAL:** switching tabs mid-check cancelled the worker through Textual's unmount path, and since `CancelledError` is a `BaseException` on 3.11+, the pipeline's `except Exception` never saw it — the run row was stranded at `running` **forever**, silently. Fixed by catching it explicitly and recording an honest terminal state before re-raising. Durability was then verified *by construction*, not by observation: Textual delivers exactly one `.cancel()`, and the DB write is a synchronous transaction with no interruptible inner await, so the "cancelled" record cannot itself be cancelled mid-write.
- The two-layer fix then **doubled a side effect** — one cancelled check filed two identical notification rows (the run row was fine; it's an idempotent UPDATE). Redundancy is safe for idempotent writes and unsafe for emitting ones; the outer layer now checks for a terminal status first, with defense-in-depth re-verified by disabling the inner layer.
- Control-stripping stopped at the reader while **OPML import is a live delivery path** for C1 control bytes (a single-byte CSI parses fine through XML where raw ESC does not). Extended to 8 cell sites, then to the snapshot viewer's scraped page body — the highest-risk remote string in the feature, one function away from a line this batch had already edited.
- **Three coverage seams** landed exactly where predicted: this batch was authored by one implementer and tested by another after a rate limit, and mutation-gutting the self-closed-tag handler, the markdown control-strip branch, and the Expand button's pane wiring each left the entire suite green. Code correct, nothing guarding it — now tested.

## Verification

**Whole-branch review + 2 rounds; 18 mutations, all RED, all restores md5 byte-exact.** Counts: 405 passed across the 14 relevant files, 61 on the touched service layer, 25 on the round-2 files; `--collect-only` 9690 collected, zero errors. The one failing case (`_delete_item`) is pre-existing on dev and filed as task-2330. **Live-verified** against a real feed: readable prose with the URL visible, 20 distinct publish dates where one repeated ingest timestamp used to be, "Checking…" mirrored on both buttons, and — with a deliberately slow endpoint — a navigate-away mid-check logging `Check cancelled: navigated away before it finished.` and reaching `failed` instead of hanging at `running`.

**Honest gap:** task-2307's AC#2 (reader Expand affordance) is **unchecked** — the button posts its message but no screen handler exists yet. Recorded rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Watchlists readability and feedback: the reader now renders safe, readable prose (preserving angle‑bracket autolinks), timestamps are humanized with real publish dates, “Check now” shows instant ack, busy state, completion, and debounce, and the Reader’s Expand control now works. Addresses Linear tasks 2307, 2308, and 2309.

- **New Features**
  - Reader converts feed HTML to plain text via `Subscriptions/html_text.py`; links are visible, control bytes are stripped, and `<https://…>` autolinks are preserved; snapshot viewer body uses the same `readable_body_text` (task-2307).
  - Unified `humane_timestamp` in `UI/Watchlists_Modules/humane_time.py`; all Watchlists tables show local, human-scale times; Items prefer `published_date` with an honest “added <time>” fallback; snapshot header is humanized (task-2308).
  - “Check now” posts an immediate ack, shows busy state on both `SourcesPane` and `InspectorPane`, and emits completion/failure toasts; `_checks_in_flight` debounces duplicate presses and workers run in a named group (task-2309).
  - Reader Expand is wired to region solo; the button now toggles the layout and reflects the current state (task-2307).

- **Bug Fixes**
  - Handle `asyncio.CancelledError` in both `LocalWatchlistsService.execute_run` and `WatchlistScopeService.launch_run` so mid-navigation cancels mark runs terminal; prevent duplicate notifications on cancellation (exactly one now) (task-2309).
  - Strip terminal control bytes in identity cells across `sources_pane`, `inspector_pane`, `runs_pane`, `notifications_pane`, and `artifacts_pane`; snapshot bodies now route through `readable_body_text`; CR added to the strip regex (tasks-2307/2309).
  - Fix HTML detection so angle-bracket autolinks aren’t misclassified as tags; they are protected during parse and restored verbatim (task-2307).

<sup>Written for commit 1b4e973ed373fc80310f9297b8c456e0a0b718f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

