### PR TITLE
chore: mark UAT batch-5 tasks Done — Watchlists UAT complete (PR #1373 merged)

### DIFF
--- a/backlog/tasks/task-2310 - Label the Watchlists toolbar Selects and stage the Artifacts toolbar.md
+++ b/backlog/tasks/task-2310 - Label the Watchlists toolbar Selects and stage the Artifacts toolbar.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2310
 title: Label the Watchlists toolbar Selects and stage the Artifacts toolbar
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2311 - Briefing failures surface their reason proactively.md
+++ b/backlog/tasks/task-2311 - Briefing failures surface their reason proactively.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2311
 title: Briefing failures surface their reason proactively
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2312 - Stable tab strip and status line across Watchlists sections.md
+++ b/backlog/tasks/task-2312 - Stable tab strip and status line across Watchlists sections.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2312
 title: Stable tab strip and status line across Watchlists sections
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2313 - Watchlists copy terminology and empty-state sweep.md
+++ b/backlog/tasks/task-2313 - Watchlists copy terminology and empty-state sweep.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2313
 title: Watchlists copy terminology and empty-state sweep
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:

--- a/backlog/tasks/task-2314 - First-run wizard honors early Escape.md
+++ b/backlog/tasks/task-2314 - First-run wizard honors early Escape.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2314
 title: First-run wizard honors early Escape
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-04'
 labels:


### PR DESCRIPTION
Final bookkeeping for the 2026-08-04 Watchlists sr-UX/HCI UAT: 41 findings → 15 tasks → 5 PRs (#1342, #1348, #1355, #1370, #1373), all merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked Watchlists UAT batch‑5 tasks as Done to close the UAT and align the backlog with merged changes. Updated `backlog/tasks` items TASK‑2310–TASK‑2314 from “In Progress” to “Done”.

<sup>Written for commit 93a0b35fcc9a94b122345c525b871cd058b13a58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

