### PR TITLE
fix: full-app UAT findings — file + fix tasks 2720-2724, 2726-2727; 2725 profiled

### DIFF
--- a/Tests/App/test_worker_failure_event.py
+++ b/Tests/App/test_worker_failure_event.py
@@ -92,3 +92,75 @@ async def test_successful_worker_records_nothing(monkeypatch):
         if r["event"] in {"worker_failed", "worker_started"}
         and r.get("operation") == "some_worker"
     ], f"the successful worker recorded an event: {recorded}"
+
+
+@pytest.mark.asyncio
+async def test_screen_navigation_worker_transition_does_not_warn_unhandled():
+    """task-2726: every tab switch runs a 'screen-navigation' worker; its
+    transitions must be acknowledged by the registry instead of warning
+    'No handler found' once per navigation."""
+    from loguru import logger as loguru_root_logger
+    from textual.worker import Worker
+
+    from Tests.UI.app_factory import _build_test_app
+
+    warnings: list[str] = []
+    sink_id = loguru_root_logger.add(
+        lambda message: warnings.append(str(message)), level="WARNING"
+    )
+    try:
+        app = _build_test_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            worker = MagicMock(spec=Worker)
+            worker.name = "handle_screen_navigation"
+            worker.group = "screen-navigation"
+            worker.error = None
+            # Real Workers always carry a description; the acknowledging
+            # handler's get_worker_info reads it.
+            worker.description = "handle_screen_navigation=<NavigateToScreen>"
+            await app.on_worker_state_changed(
+                Worker.StateChanged(worker, WorkerState.SUCCESS)
+            )
+            await pilot.pause()
+    finally:
+        loguru_root_logger.remove(sink_id)
+
+    assert not [
+        w
+        for w in warnings
+        if "No handler found" in w and "handle_screen_navigation" in w
+    ], f"navigation worker warned unhandled: {warnings}"
+
+
+@pytest.mark.asyncio
+async def test_unknown_worker_group_still_warns_unhandled():
+    """Guard for task-2726: acknowledging known fire-and-forget groups must not
+    swallow the unhandled-worker warning for genuinely unknown workers."""
+    from loguru import logger as loguru_root_logger
+    from textual.worker import Worker
+
+    from Tests.UI.app_factory import _build_test_app
+
+    warnings: list[str] = []
+    sink_id = loguru_root_logger.add(
+        lambda message: warnings.append(str(message)), level="WARNING"
+    )
+    try:
+        app = _build_test_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            worker = MagicMock(spec=Worker)
+            worker.name = "mystery_worker"
+            worker.group = "task-2726-unknown-group"
+            worker.error = None
+            await app.on_worker_state_changed(
+                Worker.StateChanged(worker, WorkerState.SUCCESS)
+            )
+            await pilot.pause()
+    finally:
+        loguru_root_logger.remove(sink_id)
+
+    assert [
+        w
+        for w in warnings
+        if "No handler found" in w and "mystery_worker" in w
+    ], f"unknown worker did not warn: {warnings}"

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -1596,3 +1596,45 @@ def test_local_notification_adapter_excludes_dismissed_ingest_job():
     )
 
     assert dashboard_input.active_work_items == ()
+
+
+def test_local_notification_adapter_treats_policy_refusal_quietly():
+    """task-2722: in local runtime mode the server feed is refused by policy
+    ("requires server mode"). That is the expected state for a local-only
+    profile — it must not be logged as a warning on every Home visit."""
+    from loguru import logger as loguru_root_logger
+
+    from tldw_chatbook.runtime_policy.types import PolicyDeniedError
+
+    class FakeServerEventService:
+        def list_observed_server_feed(self, *, limit=20, mark_presented=False):
+            raise PolicyDeniedError(
+                action_id="notifications.feed.list.server",
+                reason_code="server_mode_required",
+                user_message="notifications.feed.list.server requires server mode.",
+                effective_source="local",
+                authority_owner="server",
+            )
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        server_event_service=FakeServerEventService()
+    )
+
+    warnings: list[str] = []
+    sink_id = loguru_root_logger.add(
+        lambda message: warnings.append(str(message)), level="WARNING"
+    )
+    try:
+        dashboard_input = adapter.build_dashboard_input(
+            providers_models={"OpenAI": ["gpt-4.1"]},
+            has_recent_work=False,
+        )
+    finally:
+        loguru_root_logger.remove(sink_id)
+
+    assert dashboard_input.server_event_count == 0
+    assert dashboard_input.server_event_state == "unavailable"
+    assert "server mode" in dashboard_input.server_event_recovery
+    assert not [w for w in warnings if "server event feed" in w], (
+        f"policy refusal logged as warning: {warnings}"
+    )

--- a/Tests/Scheduling/test_scheduling_server_client_policy.py
+++ b/Tests/Scheduling/test_scheduling_server_client_policy.py
@@ -1,0 +1,35 @@
+"""task-2722: the scheduling server client must keep policy refusals typed."""
+
+import pytest
+
+from tldw_chatbook.runtime_policy.types import PolicyDeniedError
+from tldw_chatbook.Scheduling.services.server_client import (
+    SchedulingServerClient,
+    ServerClientPolicyError,
+    ServerClientValidationError,
+)
+
+
+def test_policy_error_is_a_validation_error_subtype():
+    # Existing callers catch ServerClientValidationError; the refined type must
+    # not slip past them.
+    assert issubclass(ServerClientPolicyError, ServerClientValidationError)
+
+
+@pytest.mark.asyncio
+async def test_client_translates_policy_denial_to_policy_error():
+    class DenyingService:
+        async def list_reminders(self, **kwargs):
+            raise PolicyDeniedError(
+                action_id="notifications.reminders.list.server",
+                reason_code="server_mode_required",
+                user_message=(
+                    "notifications.reminders.list.server requires server mode."
+                ),
+                effective_source="local",
+                authority_owner="server",
+            )
+
+    client = SchedulingServerClient(DenyingService())
+    with pytest.raises(ServerClientPolicyError):
+        await client.list_reminders()

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -825,3 +825,43 @@ async def test_pull_does_not_push_mutations_or_tombstones(tmp_path):
     assert len(pending) == 1
     tombstones = db.get_tombstones("server:1", primitive="reminder_task")
     assert len(tombstones) == 1
+
+
+@pytest.mark.asyncio
+async def test_policy_refusal_is_not_recorded_as_sync_error(tmp_path):
+    """task-2722: a runtime-mode policy refusal ("requires server mode") is a
+    not-applicable outcome, not a sync failure. The old path persisted it as a
+    standing sync error badge on local-only profiles."""
+    from tldw_chatbook.Scheduling.services.server_client import (
+        ServerClientPolicyError,
+    )
+
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = AsyncMock()
+    server_client.list_reminders.side_effect = ServerClientPolicyError(
+        "notifications.reminders.list.server requires server mode."
+    )
+    engine = SyncEngine(db, server_client, owner_id="local")
+
+    await engine.pull()
+    await engine.sync_now()
+
+    state = db.get_sync_state("local") or {}
+    assert not (state.get("sync_errors") or []), (
+        f"policy refusal was recorded as a sync error: {state.get('sync_errors')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_server_failure_still_records_sync_error(tmp_path):
+    """Guard for task-2722: only policy refusals are exempt — genuine server
+    failures must keep surfacing as sync errors."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = AsyncMock()
+    server_client.list_reminders.side_effect = ServerUnavailableError("offline")
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    await engine.pull()
+
+    state = db.get_sync_state("server:1") or {}
+    assert state.get("sync_errors"), "real failure no longer recorded"

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -701,3 +701,33 @@ async def test_show_conversations_twice_in_same_tick_does_not_crash():
         rows = pilot.app.query(".personas-conversation-row")
         assert len(rows) == 1
         assert _row_text(rows.first(ListItem)) == "Cold trail"
+
+
+async def test_state_pushed_before_children_mount_defers_then_replays():
+    """task-2727: PersonasScreen._load_after_mount races the pane's child
+    mounting; a push landing early crashed with NoMatches and aborted the
+    screen's initial load (pending restore + auto-select silently skipped).
+    Early pushes must defer quietly and be applied once children exist."""
+    pane = PersonasInspectorPane(id="personas-inspector-pane")
+    # Selection state normally arrives via show_selection(), which needs
+    # mounted children itself — set the attributes directly to model the
+    # racing screen-side sync.
+    pane._has_selection = True
+    pane._selected_kind = "character"
+
+    # The exact call observed crashing live, issued pre-mount:
+    pane.set_console_actions_enabled(False, reason="task-2727-probe")
+
+    class LateStateApp(App):
+        def compose(self):
+            yield pane
+
+    app = LateStateApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        readiness = str(
+            pilot.app.query_one("#personas-readiness-console", Static).renderable
+        )
+        assert "task-2727-probe" in readiness, (
+            f"pre-mount push was dropped; readiness reads: {readiness!r}"
+        )

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1096,3 +1096,100 @@ async def test_conflicts_tab_resolve_false_does_not_post_message():
         assert engine.calls == [("c1", "server")]
         assert len(tab.posted_messages) == 0
         assert table.row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_persisted_policy_refusal_is_not_surfaced_as_sync_error():
+    """task-2722: older builds persisted the local-mode policy refusal as a
+    sync error; profiles carrying those rows must not wear the error badge."""
+    app = WorkbenchTestAppWithService()
+    app.scheduling_service.db = _MockSchedulingDB(
+        sync_state={
+            "sync_errors": [
+                {
+                    "message": (
+                        "notifications.reminders.list.server requires server mode."
+                    ),
+                    "timestamp": "2026-08-02T22:36:00+00:00",
+                }
+            ]
+        }
+    )
+
+    async with app.run_test() as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+
+        header_calls: list[tuple[str, str]] = []
+        workbench._sync_header_status = lambda status, label: header_calls.append(
+            (status, label)
+        )
+        workbench._refresh_owner_select()
+        await pilot.pause()
+
+        error_widget = workbench.query_one("#scheduling-sync-error", Static)
+        assert str(error_widget.renderable) == "", (
+            f"refusal shown as sync error: {error_widget.renderable!r}"
+        )
+        assert not [c for c in header_calls if c[0] == "error"], (
+            f"header wears the error badge for a policy refusal: {header_calls}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_real_sync_error_still_surfaces():
+    """Guard for task-2722: only policy refusals are filtered from display."""
+    app = WorkbenchTestAppWithService()
+    app.scheduling_service.db = _MockSchedulingDB(
+        sync_state={
+            "sync_errors": [
+                {
+                    "message": "server unreachable: connection refused",
+                    "timestamp": "2026-08-02T22:36:00+00:00",
+                }
+            ]
+        }
+    )
+
+    async with app.run_test() as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+
+        error_widget = workbench.query_one("#scheduling-sync-error", Static)
+        assert "connection refused" in str(error_widget.renderable)
+
+
+@pytest.mark.asyncio
+async def test_sync_strip_fields_do_not_abut():
+    """task-2723: 'Last pull: —Last push: —<error text>' rendered as one
+    unbroken run. Assert real layout geometry: each field ends at least one
+    cell before the next begins."""
+    app = WorkbenchTestAppWithService()
+    app.scheduling_service.db = _MockSchedulingDB(
+        sync_state={
+            "sync_errors": [
+                {
+                    "message": "server unreachable: connection refused",
+                    "timestamp": "2026-08-02T22:36:00+00:00",
+                }
+            ]
+        }
+    )
+
+    async with app.run_test(size=(200, 40)) as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+
+        pull = workbench.query_one("#scheduling-last-pull", Static)
+        push = workbench.query_one("#scheduling-last-push", Static)
+        error = workbench.query_one("#scheduling-sync-error", Static)
+
+        assert pull.region.right < push.region.x, (
+            f"pull {pull.region} abuts push {push.region}"
+        )
+        assert push.region.right < error.region.x, (
+            f"push {push.region} abuts error {error.region}"
+        )

--- a/Tests/UI/test_screen_navigation_failure_recovery.py
+++ b/Tests/UI/test_screen_navigation_failure_recovery.py
@@ -1,0 +1,179 @@
+"""task-2720: an exception escaping the navigation worker must degrade loudly
+and recoverably.
+
+Live incident (2026-08-06 UAT, dev b0185749c): a transient PermissionError
+inside `handle_screen_navigation` left the app with the nav-bar highlight on
+the destination, the body on the old screen, no user-visible message, and the
+destination unreachable for the rest of the session (the bar's already-active
+check swallowed every retry click).
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+
+from tldw_chatbook.UI.Navigation.main_navigation import (
+    MainNavigationBar,
+    NavigateToScreen,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingBar:
+    def __init__(self):
+        self.restored: list[str] = []
+
+    def restore_active(self, route: str) -> None:
+        self.restored.append(route)
+
+
+class _FakeOutgoingScreen:
+    """Outgoing screen with its own nav bar, like every BaseAppScreen."""
+
+    screen_name = "library"
+
+    def __init__(self, bar: _RecordingBar):
+        self._bar = bar
+
+    def query_one(self, _selector):
+        return self._bar
+
+
+def _wire_failing_navigation(app, monkeypatch, bar: _RecordingBar, fail_flag: dict):
+    """Point the app at fake screens and one injected unguarded failure."""
+
+    class FakeTargetScreen:
+        screen_name = "chat"
+
+        def __init__(self, app_instance):
+            self.app_instance = app_instance
+
+    monkeypatch.setattr(
+        app,
+        "_resolve_screen_navigation_target",
+        lambda target: ("chat", "chat", FakeTargetScreen),
+    )
+
+    switched = []
+
+    async def fake_switch_screen(screen):
+        switched.append(screen)
+
+    monkeypatch.setattr(app, "switch_screen", fake_switch_screen)
+
+    real_identity = type(app)._current_runtime_identity
+
+    def maybe_failing_identity(self):
+        if fail_flag["on"]:
+            raise PermissionError("[Errno 13] injected: task-2720")
+        return real_identity(self)
+
+    # `_current_runtime_identity` is one of the genuinely unguarded steps the
+    # incident's exception class could have escaped from.
+    monkeypatch.setattr(
+        type(app), "_current_runtime_identity", maybe_failing_identity
+    )
+    monkeypatch.setattr(
+        type(app), "screen", property(lambda self: _FakeOutgoingScreen(bar))
+    )
+    app._initial_screen_pushed = True
+    return switched
+
+
+@pytest.mark.asyncio
+async def test_escaped_navigation_exception_notifies_and_rolls_back_nav_bar(
+    monkeypatch,
+):
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    notifications: list[tuple] = []
+    monkeypatch.setattr(
+        app,
+        "notify",
+        lambda message, **kwargs: notifications.append((message, kwargs)),
+    )
+    bar = _RecordingBar()
+    _wire_failing_navigation(app, monkeypatch, bar, {"on": True})
+
+    with pytest.raises(PermissionError):
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+
+    assert notifications, "user got no message about the failed navigation"
+    assert bar.restored == ["library"], (
+        "nav bar was not rolled back to the screen actually on the stack"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatched_navigation_failure_still_records_worker_failed(
+    monkeypatch,
+):
+    """The recovery guard must re-raise so the ADR-029 diagnostics line
+    (`worker_failed operation=handle_screen_navigation`) keeps being written."""
+    from Tests.UI.app_factory import _build_test_app
+
+    recorded: list[dict] = []
+    monkeypatch.setattr(
+        "tldw_chatbook.app.persist_event",
+        lambda component, event, **fields: recorded.append(
+            {"component": component, "event": event, **fields}
+        ),
+    )
+
+    app = _build_test_app()
+    notifications: list[str] = []
+
+    async def failing_locked(message):
+        raise PermissionError("[Errno 13] injected: task-2720")
+
+    monkeypatch.setattr(app, "_handle_screen_navigation_locked", failing_locked)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        monkeypatch.setattr(
+            app, "notify", lambda message, **kwargs: notifications.append(message)
+        )
+        app._initial_screen_pushed = True
+        recorded.clear()
+        app.post_message(NavigateToScreen("library"))
+        await pilot.pause()
+        await pilot.pause()
+
+    assert [
+        r
+        for r in recorded
+        if r["event"] == "worker_failed"
+        and r["operation"] == "handle_screen_navigation"
+        and r["exception_type"] == "PermissionError"
+    ], f"worker_failed line lost, got {recorded}"
+    assert notifications, "dispatched navigation failure showed the user nothing"
+
+
+@pytest.mark.asyncio
+async def test_restore_active_reverts_optimistic_highlight():
+    """Widget-level: restore_active undoes the click-time optimistic state so
+    the destination is re-clickable and the highlight matches reality."""
+
+    class BarApp(App):
+        def compose(self):
+            yield MainNavigationBar(active="library")
+
+    app = BarApp()
+    async with app.run_test(size=(200, 20)) as pilot:
+        bar = app.query_one(MainNavigationBar)
+        chat_button = bar.query_one("#nav-console")
+        assert bar._activate_navigation_button(chat_button) is True
+        assert bar.active_destination_id == "console"
+
+        bar.restore_active("library")
+        await pilot.pause()
+
+        assert bar.active_destination_id == "library"
+        assert not chat_button.has_class("is-active")
+        library_button = bar.query_one("#nav-library")
+        assert library_button.has_class("is-active")
+        # The optimistic state is gone, so a fresh click on the failed
+        # destination must request navigation again instead of no-opping.
+        assert bar._activate_navigation_button(chat_button) is True

--- a/Tests/UI/test_ui_responsiveness.py
+++ b/Tests/UI/test_ui_responsiveness.py
@@ -191,6 +191,58 @@ def test_footer_status_scheduling_records_stable_timer_names():
     assert len(scheduled_periodic) == 2
 
 
+def test_footer_status_scheduling_tolerates_screen_without_footer():
+    """A footer-less active screen (splash, first-run wizard) must not abort
+    timer setup or record an error — the per-tick updates re-resolve the
+    active screen's footer themselves (task-2721)."""
+    from textual.css.query import NoMatches
+
+    from tldw_chatbook import app as app_module
+
+    monitor = UIResponsivenessMonitor(enabled=True)
+    scheduled_once = []
+    scheduled_periodic = []
+    errors = []
+
+    def raising_query_one(_selector):
+        raise NoMatches("No nodes match 'AppFooterStatus'")
+
+    fake_app = SimpleNamespace(
+        ui_responsiveness_monitor=monitor,
+        query_one=raising_query_one,
+        loguru_logger=SimpleNamespace(
+            info=lambda *_args, **_kwargs: None,
+            debug=lambda *_args, **_kwargs: None,
+            error=lambda *args, **kwargs: errors.append(args),
+            opt=lambda **_kwargs: SimpleNamespace(
+                error=lambda *args, **kwargs: errors.append(args)
+            ),
+        ),
+        db_status_manager=SimpleNamespace(
+            start_periodic_updates=lambda interval: scheduled_periodic.append(
+                ("db", interval)
+            )
+        ),
+        update_db_sizes=lambda: None,
+        update_token_count_display=lambda: None,
+        call_after_refresh=lambda callback: callback,
+        set_timer=lambda delay, callback: scheduled_once.append((delay, callback)),
+        set_interval=lambda interval, callback: scheduled_periodic.append(
+            ("token", interval, callback)
+        ),
+        _token_count_update_timer=None,
+        _db_size_status_widget=object(),
+    )
+
+    app_module.TldwCli._schedule_footer_status_updates(fake_app)
+
+    assert errors == []
+    assert fake_app._db_size_status_widget is None
+    assert len(scheduled_once) == 2
+    assert len(scheduled_periodic) == 2
+    assert monitor.snapshot().active_timers == 2
+
+
 def test_app_stops_footer_status_timers_and_diagnostics():
     from tldw_chatbook import app as app_module
 

--- a/Tests/Wizards/test_first_run_setup_state.py
+++ b/Tests/Wizards/test_first_run_setup_state.py
@@ -826,3 +826,72 @@ class TestRerunModelPrefill:
         assert rerun_model_prefill(
             {"chat_defaults": {"provider": "openai", "model": "m"}}, provider_value=""
         ) == ""
+
+
+class TestSummaryTemplateHonesty:
+    """task-2724: a Ctrl+N-only wizard walk (nothing chosen, no credentials)
+    must not earn ✓ rows from template defaults merged in at config load.
+    Observed live: '✗ Provider' directly above '✓ Default model — gpt-5.6-terra'
+    and '✓ RAG — embedding model: e5-small-v2' under a header saying 'RAG off'."""
+
+    _WALKED_TEMPLATE_CFG = {
+        "api_settings": {"openai": {"api_key_env_var": "OPENAI_API_KEY"}},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-5.6-terra"},
+        "embedding_config": {"default_model_id": "e5-small-v2"},
+        "first_run": {"setup_started": True, "setup_completed": True},
+    }
+
+    def test_skipped_walkthrough_earns_no_configured_rows(self):
+        rows = build_summary_rows(
+            self._WALKED_TEMPLATE_CFG, {}, rag_deps_installed=True
+        )
+        configured = [row.label for row in rows if row.ok]
+        assert configured == [], (
+            f"template defaults claimed as user choices: {configured}"
+        )
+
+    def test_template_model_without_provider_reads_as_default(self):
+        from tldw_chatbook.UI.Wizards.first_run_setup_state import ROW_DEFAULT
+
+        rows = {
+            r.label: r
+            for r in build_summary_rows(
+                self._WALKED_TEMPLATE_CFG, {}, rag_deps_installed=True
+            )
+        }
+        assert rows["Default model"].state == ROW_DEFAULT
+        assert rows["Default model"].detail == "not selected"
+
+    def test_template_rag_model_reads_as_off_by_default(self):
+        from tldw_chatbook.UI.Wizards.first_run_setup_state import ROW_DEFAULT
+
+        rows = {
+            r.label: r
+            for r in build_summary_rows(
+                self._WALKED_TEMPLATE_CFG, {}, rag_deps_installed=True
+            )
+        }
+        assert rows["RAG"].state == ROW_DEFAULT
+        assert "off by default" in rows["RAG"].detail
+
+    def test_typed_model_without_provider_is_named_but_not_checked(self):
+        cfg = dict(self._WALKED_TEMPLATE_CFG)
+        cfg["chat_defaults"] = {"provider": "OpenAI", "model": "my-local-model"}
+        rows = {
+            r.label: r
+            for r in build_summary_rows(cfg, {}, rag_deps_installed=True)
+        }
+        row = rows["Default model"]
+        assert row.ok is False
+        assert "my-local-model" in row.detail
+        assert "provider" in row.detail
+
+    def test_user_selected_rag_model_still_earns_configured(self):
+        cfg = dict(self._WALKED_TEMPLATE_CFG)
+        cfg["embedding_config"] = {"default_model_id": "bge-large-en"}
+        rows = {
+            r.label: r
+            for r in build_summary_rows(cfg, {}, rag_deps_installed=True)
+        }
+        assert rows["RAG"].ok is True
+        assert "bge-large-en" in rows["RAG"].detail

--- a/backlog/tasks/task-2720 - Escaped screen-navigation exception silently kills all tab navigation until restart.md
+++ b/backlog/tasks/task-2720 - Escaped screen-navigation exception silently kills all tab navigation until restart.md
@@ -1,0 +1,44 @@
+---
+id: TASK-2720
+title: >-
+  Escaped screen-navigation exception silently kills all tab navigation until
+  restart
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:00'
+labels:
+  - navigation
+  - bug
+  - uat
+  - robustness
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Full-app UAT walkthrough on `origin/dev` `b0185749c` (fresh profile seeded with a copy of real DBs, first-run wizard completed, 235x52 tmux): clicking the Console nav tab raised `worker_failed exception_type=PermissionError operation=handle_screen_navigation` (16:10:16), and a Library click two minutes later failed identically (16:12:17). Both were single sanitized lines in the persistent log; the raising site is unknown (ADR-029 keeps tracebacks off disk, and the escaping exception bypasses the `logger.opt(exception=True)` guards, so nothing reached the in-app Logs buffer either).
+
+The trigger did not reproduce: three faithful replications (same wizard walk, same clicks; one with a fully reset profile, pending v30→v31 migrations, and purged worktree `__pycache__`) all navigated cleanly, and sandbox/write probes at the failing paths passed. Transient cross-process contention is the leading suspect (POSIX `fcntl` lock conflicts surface as `EACCES` → Python `PermissionError`; other app instances run concurrently on this machine), but that is unproven.
+
+What IS proven is how badly the app degrades when any exception escapes the navigation worker, and every piece of it is app-side:
+
+1. **Silent failure.** `_notify_navigation_failure` only covers screen construction and `switch_screen`; an exception at any of the unguarded steps in `_handle_screen_navigation_locked` / `_complete_screen_navigation` (`_resolve_screen_navigation_target`, `_current_runtime_identity`, `screen_state_store.restore`, `acquire_navigation_transition()`) escapes to the worker (`exit_on_error=False`), and the user sees nothing at all.
+2. **Tab-bar desync.** The nav-bar highlight had already moved to the destination, so the bar said Console while the body remained Home.
+3. **No retry.** Because the nav state believed Console was active, re-clicking Console became a no-op — the destination was unreachable for the rest of the session (observed live: second Console click produced no worker attempt at all).
+
+One PermissionError from any transient cause therefore converts to "this tab is dead until app restart", with no message. The nav worker body should be guarded so ANY escaping exception rolls back the tab highlight, surfaces `_notify_navigation_failure`, and leaves the destination re-clickable.
+
+Evidence: scratch-profile persistent log lines at 16:10:16 / 16:12:17 2026-08-06; pane captures showing Console highlighted over Home content.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] An exception raised at any point inside the navigation worker (including target resolution, runtime-identity read, snapshot restore, and transition admission) results in a user-visible failure notification.
+- [ ] After a failed navigation, the nav-bar highlight reflects the screen actually on the stack (no split-brain).
+- [ ] After a failed navigation, clicking the same destination again issues a fresh navigation attempt (no dead tab).
+- [ ] A regression test injects an exception into an unguarded step and verifies notification + highlight rollback + retryability.
+- [ ] The `worker_failed` diagnostics line for navigation failures is preserved (ADR-029 sanitization unchanged).
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2720 - Escaped screen-navigation exception silently kills all tab navigation until restart.md
+++ b/backlog/tasks/task-2720 - Escaped screen-navigation exception silently kills all tab navigation until restart.md
@@ -3,7 +3,7 @@ id: TASK-2720
 title: >-
   Escaped screen-navigation exception silently kills all tab navigation until
   restart
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-06 17:00'
 labels:
@@ -33,12 +33,25 @@ One PermissionError from any transient cause therefore converts to "this tab is 
 Evidence: scratch-profile persistent log lines at 16:10:16 / 16:12:17 2026-08-06; pane captures showing Console highlighted over Home content.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: three tests — escaped exception (injected at `_current_runtime_identity`, an actually-unguarded step) must notify + roll the nav bar back; a dispatched failure must still record `worker_failed` (guard re-raises); widget-level `restore_active` must undo the optimistic highlight and make the destination re-clickable.
+2. GREEN: `MainNavigationBar.restore_active(route)`; `_notify_navigation_failure` additionally rolls the current screen's bar back to the on-stack route; `handle_screen_navigation` wraps the locked body — recover, then re-raise for ADR-029 diagnostics.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] An exception raised at any point inside the navigation worker (including target resolution, runtime-identity read, snapshot restore, and transition admission) results in a user-visible failure notification.
-- [ ] After a failed navigation, the nav-bar highlight reflects the screen actually on the stack (no split-brain).
-- [ ] After a failed navigation, clicking the same destination again issues a fresh navigation attempt (no dead tab).
-- [ ] A regression test injects an exception into an unguarded step and verifies notification + highlight rollback + retryability.
-- [ ] The `worker_failed` diagnostics line for navigation failures is preserved (ADR-029 sanitization unchanged).
+- [x] An exception raised at any point inside the navigation worker (including target resolution, runtime-identity read, snapshot restore, and transition admission) results in a user-visible failure notification.
+- [x] After a failed navigation, the nav-bar highlight reflects the screen actually on the stack (no split-brain).
+- [x] After a failed navigation, clicking the same destination again issues a fresh navigation attempt (no dead tab).
+- [x] A regression test injects an exception into an unguarded step and verifies notification + highlight rollback + retryability.
+- [x] The `worker_failed` diagnostics line for navigation failures is preserved (ADR-029 sanitization unchanged).
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root mechanism (from the live incident): the nav bar activates a destination optimistically at click time, and its already-active check then swallows every retry once the navigation worker dies — one transient exception made a tab unreachable until restart, silently. Fix in three parts: (1) `MainNavigationBar.restore_active(route)` re-points highlight + active ids at the route actually on the stack; (2) `_notify_navigation_failure` now performs that rollback too, which also repairs the pre-existing desync on the already-guarded construction/mount failure paths; (3) `handle_screen_navigation` catches anything escaping the locked body, recovers the user-facing state, and re-raises so the `worker_failed operation=handle_screen_navigation` diagnostics line keeps being written (pinned by test). The transient PermissionError trigger itself remains unreproduced (3 faithful replications); this hardens the degradation path per the ACs. An always-green app-level retry test was deleted during RED verification — app-level retry was never broken; retryability lives in the bar and is pinned at the widget level. Files: tldw_chatbook/app.py, tldw_chatbook/UI/Navigation/main_navigation.py, Tests/UI/test_screen_navigation_failure_recovery.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2721 - Footer-status timer crashes with NoMatches on splash and first-run wizard screens.md
+++ b/backlog/tasks/task-2721 - Footer-status timer crashes with NoMatches on splash and first-run wizard screens.md
@@ -1,0 +1,36 @@
+---
+id: TASK-2721
+title: >-
+  Footer-status timer crashes with NoMatches on splash and first-run wizard
+  screens
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:00'
+labels:
+  - app-shell
+  - bug
+  - uat
+  - first-run
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Full-app UAT on `origin/dev` `b0185749c`: the in-app Logs screen showed "4 errors in buffer" on a fresh first-run session before any user-triggered feature was touched. All four are the same crash, hit twice (chained traceback pairs):
+
+`app.py:8158` in `_schedule_footer_status_updates` does `self._db_size_status_widget = self.query_one(AppFooterStatus)`, which raised `textual.css.query.NoMatches: No nodes match 'AppFooterStatus' on Screen(id='_default')` once during splash and `... on FirstRunSetupWizard()` once while the wizard was up.
+
+The footer-status callback assumes the active screen always mounts an `AppFooterStatus`; the splash screen and the first-run wizard don't. The errors are swallowed into the log buffer (nothing visible breaks), but every fresh install currently starts its session log with two tracebacks, which poisons the "Errors" signal on the Logs screen the very first time a user opens it — and any future consumer of that error count inherits the noise.
+
+Evidence: Logs screen error filter captures, 2026-08-06 UAT session (fresh scratch profile, wizard path).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] `_schedule_footer_status_updates` tolerates an active screen without `AppFooterStatus` (skips quietly, retries on a later tick or next screen).
+- [ ] A fresh first-run session (splash → wizard → main app) reaches the main app with zero errors in the Logs buffer.
+- [ ] A regression test drives the footer-status callback while a screen without the footer widget is active and asserts no error is recorded.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2721 - Footer-status timer crashes with NoMatches on splash and first-run wizard screens.md
+++ b/backlog/tasks/task-2721 - Footer-status timer crashes with NoMatches on splash and first-run wizard screens.md
@@ -3,7 +3,7 @@ id: TASK-2721
 title: >-
   Footer-status timer crashes with NoMatches on splash and first-run wizard
   screens
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-06 17:00'
 labels:
@@ -27,10 +27,24 @@ The footer-status callback assumes the active screen always mounts an `AppFooter
 Evidence: Logs screen error filter captures, 2026-08-06 UAT session (fresh scratch profile, wizard path).
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: extend `Tests/UI/test_ui_responsiveness.py` fake-app pattern — `query_one` raises `QueryError`; assert the timers are still scheduled, the widget cache is `None`, and no error is logged.
+2. GREEN: in `_schedule_footer_status_updates`, catch `QueryError` around only the `AppFooterStatus` acquisition (cache → `None`, debug log) and continue to start the timers; keep the outer guard for genuine timer-setup failures. Per-tick updates already re-resolve the active screen's footer via `_active_footer_status`, so a `None` cache self-heals.
+3. Note: the current behavior is worse than log noise — the aborted setup means the DB-size/token timers never start at all in any session where the deferred timer fires while splash/wizard is active.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] `_schedule_footer_status_updates` tolerates an active screen without `AppFooterStatus` (skips quietly, retries on a later tick or next screen).
-- [ ] A fresh first-run session (splash → wizard → main app) reaches the main app with zero errors in the Logs buffer.
-- [ ] A regression test drives the footer-status callback while a screen without the footer widget is active and asserts no error is recorded.
+- [x] `_schedule_footer_status_updates` tolerates an active screen without `AppFooterStatus` (skips quietly, retries on a later tick or next screen).
+- [x] A fresh first-run session (splash → wizard → main app) reaches the main app with zero errors in the Logs buffer.
+- [x] A regression test drives the footer-status callback while a screen without the footer widget is active and asserts no error is recorded.
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The `AppFooterStatus` acquisition in `_schedule_footer_status_updates` is now tolerant: a `QueryError` (splash/wizard active) sets the cache to `None`, logs at debug, and setup continues. This also fixes the worse latent defect the investigation surfaced: the old `except` aborted the whole method, so the DB-size and token timers never started in any session where the deferred timer fired while a footer-less screen was up. Per-tick updates already resolve the active screen's footer via `_active_footer_status`, so a `None` cache self-heals. Test: `test_footer_status_scheduling_tolerates_screen_without_footer` (Tests/UI/test_ui_responsiveness.py), watched RED (error logged, no timers) then GREEN. Files: tldw_chatbook/app.py, Tests/UI/test_ui_responsiveness.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2722 - Local mode invokes server-only operations and wears their failures as a standing sync error.md
+++ b/backlog/tasks/task-2722 - Local mode invokes server-only operations and wears their failures as a standing sync error.md
@@ -3,7 +3,7 @@ id: TASK-2722
 title: >-
   Local mode invokes server-only operations and wears their failures as a
   standing sync error
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-06 17:00'
 labels:
@@ -29,11 +29,26 @@ A local-mode user who has never configured a server sees a standing error badge 
 Evidence: Schedules pane captures + Logs-screen warning entries, 2026-08-06 UAT session.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. `SyncEngine.pull`/`sync_now`: return early unless the target owner is a server owner (`server:` prefix) — local owners never legitimately sync, and today's attempt is what generates the policy refusal that gets persisted as a sync error.
+2. Schedules workbench `_refresh_owner_select`: for a local owner, server-sync health is not applicable — header shows "Local schedules" and the strip gets no sync errors (also hides refusals persisted before the gate existed).
+3. Home `_server_event_status_fields`: catch `PolicyDeniedError` specifically — return the quiet unavailable state without a warning log.
+4. TDD each layer RED→GREEN with the existing fixtures (Tests/Scheduling/test_sync_engine.py, Tests/UI/test_schedules_workbench.py, Home adapter tests).
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] With runtime source = local and no server configured, the Schedules screen shows no sync-error badge from server-only operations.
-- [ ] Server-only feed/list calls are not issued while in local mode (or their local-mode refusal is classified as "not applicable", never as an error surfaced to the user).
-- [ ] Home renders without logging server-feed failure warnings in local mode.
-- [ ] Switching to server mode restores the current behavior (real failures still surface).
+- [x] With runtime source = local and no server configured, the Schedules screen shows no sync-error badge from server-only operations.
+- [x] Server-only feed/list calls are not issued while in local mode (or their local-mode refusal is classified as "not applicable", never as an error surfaced to the user).
+- [x] Home renders without logging server-feed failure warnings in local mode.
+- [x] Switching to server mode restores the current behavior (real failures still surface).
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The first fix attempt (gate SyncEngine on `server:` owners) was WRONG and reverted: five existing tests proved local-owner sync is the designed local→server push flow (pending mutations). The real defect is classification: `SchedulingServerClient` translated `PolicyDeniedError` into plain `ServerClientValidationError`, erasing the "mode refusal, not failure" signal before the engine recorded it. Fix: (1) new `ServerClientPolicyError(ServerClientValidationError)` + client translation keeps refusals typed without breaking existing catches; (2) `SyncEngine.pull`/`sync_now` treat it as "not applicable" (info log, nothing persisted); (3) the Schedules workbench filters refusal-shaped entries persisted by older builds out of the error surface (badge + strip) — real errors still surface (guard test); (4) Home's `_server_event_status_fields` catches `PolicyDeniedError` before the generic handler: quiet unavailable state, "Server events apply in server mode.", no per-visit warning. Deviation from plan step 1 documented above; plan steps 2-3 shipped as written. Tests: Tests/Scheduling/test_scheduling_server_client_policy.py (new), test_sync_engine.py (+2), test_schedules_workbench.py (+2), test_active_work_adapter.py (+1) — each watched RED first. Note: `test_conflicts_tab_renders_rows_and_resolves` fails on pristine origin/dev (pre-existing copy drift, verified in a throwaway worktree; not addressed here). Files: Scheduling/services/server_client.py, Scheduling/services/sync_engine.py, UI/Screens/scheduling/schedules_workbench.py, Home/active_work_adapter.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2722 - Local mode invokes server-only operations and wears their failures as a standing sync error.md
+++ b/backlog/tasks/task-2722 - Local mode invokes server-only operations and wears their failures as a standing sync error.md
@@ -1,0 +1,39 @@
+---
+id: TASK-2722
+title: >-
+  Local mode invokes server-only operations and wears their failures as a
+  standing sync error
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:00'
+labels:
+  - schedules
+  - home
+  - bug
+  - uat
+  - local-server-split
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Full-app UAT on `origin/dev` `b0185749c`, local-only profile (no server configured, backend "Local"):
+
+- The Schedules screen header wears a persistent **"1 sync error"** badge, and its sync strip shows `notifications.reminders.list.server requires server mode.` — i.e. the screen itself called a `*.server` operation while in local mode and then reports the predictable refusal as a sync error to the user.
+- Home's active-work adapter does the same: `Home.active_work_adapter WARNING Failed to fetch server event feed for Home: notifications.feed.list.server requires server mode.` (twice per visit in the session log buffer).
+
+A local-mode user who has never configured a server sees a standing error badge they cannot clear and did nothing to cause. Server-only feeds should be gated on the active runtime source rather than called-and-caught, and a "requires server mode" refusal in local mode should not be classified as a sync error.
+
+Evidence: Schedules pane captures + Logs-screen warning entries, 2026-08-06 UAT session.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] With runtime source = local and no server configured, the Schedules screen shows no sync-error badge from server-only operations.
+- [ ] Server-only feed/list calls are not issued while in local mode (or their local-mode refusal is classified as "not applicable", never as an error surfaced to the user).
+- [ ] Home renders without logging server-feed failure warnings in local mode.
+- [ ] Switching to server mode restores the current behavior (real failures still surface).
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2723 - Schedules sync strip runs its fields together without separators.md
+++ b/backlog/tasks/task-2723 - Schedules sync strip runs its fields together without separators.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2723
 title: Schedules sync strip runs its fields together without separators
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-06 17:00'
 labels:
@@ -25,9 +25,22 @@ On the Schedules screen (UAT on `origin/dev` `b0185749c`, 235x52) the sync statu
 (The error text itself being shown at all in local mode is TASK-2722; this task is only the layout/separator defect, which would remain visible in genuine server-mode failure states.)
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: layout-geometry test — each sync-strip field's region must end at least one cell before the next begins (was flush: right==x==51).
+2. GREEN: `margin-left: 2` on pull/push/error in `SyncStatusWidget.DEFAULT_CSS`; error additionally `text-wrap: nowrap; text-overflow: ellipsis` so a long message truncates instead of displacing fields.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] Sync-strip fields (mode, server, last pull, last push, error/status message) are visually separated; no field's value abuts the next field's label.
-- [ ] A long error/status message wraps or truncates without displacing the pull/push fields.
+- [x] Sync-strip fields (mode, server, last pull, last push, error/status message) are visually separated; no field's value abuts the next field's label.
+- [x] A long error/status message wraps or truncates without displacing the pull/push fields.
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+CSS-only fix in `SyncStatusWidget.DEFAULT_CSS`: the pull/push/error Statics had `width: auto` and no margins, so they rendered flush ("Last pull: —Last push: —notifications…"). Added `margin-left: 2` to all three; the error Static (already `width: 1fr`) now truncates with ellipsis instead of wrapping/displacing. Regression pinned by real layout geometry (`region.right < next.region.x`), not by style introspection — `test_sync_strip_fields_do_not_abut`, watched RED (51 < 51) then GREEN. Files: tldw_chatbook/UI/Screens/scheduling/sync_status_widget.py, Tests/UI/test_schedules_workbench.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2723 - Schedules sync strip runs its fields together without separators.md
+++ b/backlog/tasks/task-2723 - Schedules sync strip runs its fields together without separators.md
@@ -1,0 +1,33 @@
+---
+id: TASK-2723
+title: Schedules sync strip runs its fields together without separators
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:00'
+labels:
+  - schedules
+  - ux
+  - uat
+  - polish
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+On the Schedules screen (UAT on `origin/dev` `b0185749c`, 235x52) the sync status strip renders as one unbroken run:
+
+`Local       Server (http://127.0.0.1:8000) Last pull: —Last push: —notifications.reminders.list.server requires server mode.`
+
+"Last pull: —", "Last push: —" and the error message have no separators between them, so the em-dash placeholder of one field visually fuses into the label of the next ("—Last push: —notifications…"). Each field needs a separator (·, |, or spacing) and the error message likely belongs on its own line or in the badge's detail, not appended to the pull/push timestamps.
+
+(The error text itself being shown at all in local mode is TASK-2722; this task is only the layout/separator defect, which would remain visible in genuine server-mode failure states.)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] Sync-strip fields (mode, server, last pull, last push, error/status message) are visually separated; no field's value abuts the next field's label.
+- [ ] A long error/status message wraps or truncates without displacing the pull/push fields.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2724 - First-run wizard summary claims choices the user never made.md
+++ b/backlog/tasks/task-2724 - First-run wizard summary claims choices the user never made.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2724
 title: First-run wizard summary claims choices the user never made
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-06 17:00'
 labels:
@@ -30,10 +30,24 @@ Skipped/never-touched steps should render as `–` (like Speech/Tools/Theme alre
 Evidence: wizard Summary pane capture, 2026-08-06 UAT session.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Existing pinned test blesses provider✓+template-model→✓, so the fix targets exactly the observed absurdity: ✗ provider with ✓ model/RAG.
+2. RED: config shaped like the live run (template model + template RAG model + setup_started, no credentials) must produce zero ✓ rows.
+3. GREEN: model row requires `provider_ok` for ✓ (typed-model-without-provider shows the name with –); RAG row gets the same template guard the theme row already has (`_TEMPLATE_DEFAULT_RAG_MODEL`).
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] A wizard walk with no selections shows no ✓ rows; untouched steps render with the – (default/skipped) marker and name the default they fall back to.
-- [ ] The RAG summary row and the recommended-defaults header cannot disagree (single source of truth for the RAG on/off state).
-- [ ] A model row only shows ✓ when the user actually selected or typed a model.
+- [x] A wizard walk with no provider configured shows no ✓ rows: the model and RAG template defaults render with the – marker, naming the default they fall back to.
+- [x] The RAG row never claims ✓ for the untouched template embedding model, so it cannot contradict the header's "RAG off" sentence (AC narrowed from "single source of truth" — the header stays static text; the row is the moving part that lied).
+- [x] The model row never shows ✓ while no provider is configured; a user-typed model without a provider is shown by name with the – marker and a "takes effect once a provider is connected" note (AC narrowed: with a provider configured, the accepted template model keeps its existing pinned ✓ — see test_rows_reflect_persisted_state).
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`build_summary_rows` already had template-poisoning guards for theme/provider/speech but not for model or RAG, so the template defaults merged in at config load (`gpt-5.6-terra`, `e5-small-v2`) earned ✓ on a walk where nothing was chosen. Fix mirrors the existing `_TEMPLATE_DEFAULT_THEME` pattern: `_TEMPLATE_DEFAULT_MODEL` / `_TEMPLATE_DEFAULT_RAG_MODEL` constants; the model row now requires a configured provider for ✓ (a user-typed model without a provider is named with "takes effect once a provider is connected"; the bare template value reads "not selected"); the untouched template RAG model reads "off by default — embedding model e5-small-v2", agreeing with the header sentence instead of contradicting it. ACs were narrowed BEFORE implementation (recorded inline in the AC text) because the existing pinned test `test_rows_reflect_persisted_state` blesses ✓ for provider-configured + accepted-template-model — this task fixes the observed ✗-provider/✓-model absurdity without relitigating that. Tests: `TestSummaryTemplateHonesty` (5 tests, 4 watched RED; the fifth is the user-selected-RAG guard). Files: tldw_chatbook/UI/Wizards/first_run_setup_state.py, Tests/Wizards/test_first_run_setup_state.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2724 - First-run wizard summary claims choices the user never made.md
+++ b/backlog/tasks/task-2724 - First-run wizard summary claims choices the user never made.md
@@ -1,0 +1,39 @@
+---
+id: TASK-2724
+title: First-run wizard summary claims choices the user never made
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:00'
+labels:
+  - first-run
+  - wizard
+  - ux
+  - uat
+  - honesty
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Walking the first-run wizard on `origin/dev` `b0185749c` with Ctrl+N only — no provider picked, no key entered, no model typed — the step-4 Summary reports:
+
+- `✗ Provider — no credentials or saved endpoint` (correct)
+- `✓ Default model — gpt-5.6-terra` (false ✓: nothing was chosen; this is the hard-coded OpenAI default from `config.py`, presented as a completed setup step — with no provider at all)
+- `✓ RAG — embedding model: e5-small-v2` while the header paragraph of the SAME screen says "Left at recommended defaults: tools off, **RAG off**, …" (the two lines contradict each other)
+
+The summary is the wizard's honesty surface — the ✓/✗/– vocabulary implies "what you set up vs skipped". Reporting a config-file fallback as a ✓ "Default model" next to a ✗ provider misstates the state the user will actually land in (Console shows the provider-setup wall), and the RAG line disagrees with the recommended-defaults sentence directly above it.
+
+Skipped/never-touched steps should render as `–` (like Speech/Tools/Theme already do), with defaults labeled as defaults.
+
+Evidence: wizard Summary pane capture, 2026-08-06 UAT session.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] A wizard walk with no selections shows no ✓ rows; untouched steps render with the – (default/skipped) marker and name the default they fall back to.
+- [ ] The RAG summary row and the recommended-defaults header cannot disagree (single source of truth for the RAG on/off state).
+- [ ] A model row only shows ✓ when the user actually selected or typed a model.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2725 - Roleplay screen switch takes 2s where every other screen takes under 1s.md
+++ b/backlog/tasks/task-2725 - Roleplay screen switch takes 2s where every other screen takes under 1s.md
@@ -1,0 +1,41 @@
+---
+id: TASK-2725
+title: Roleplay screen switch takes ~2s where every other screen takes under 1s
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:00'
+labels:
+  - roleplay
+  - performance
+  - uat
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Timed tab-switch latencies during the full-app UAT walkthrough on `origin/dev` `b0185749c` (populated profile: 3 characters, 41 conversations; 235x52; latency = click → nav-highlight move, content follows):
+
+| Screen | Latency |
+|---|---|
+| Workflows, ACP, Artifacts | 0.25s |
+| Logs, Settings | 0.46s |
+| Library | 0.48s |
+| Lab | 0.68s |
+| Watchlists | 0.89s |
+| Schedules, MCP | 1.11s |
+| **Roleplay** | **2.19s / 1.97s (repeat visit)** |
+
+Roleplay is 2–4× slower than every other destination, and the repeat-visit number shows it is recurring screen-construction cost, not one-time module import. Since navigation runs through the FIFO-locked nav worker, those ~2s also delay any queued navigation. Screens are constructed fresh on every visit by design, so whatever Roleplay does in construct/compose (likely synchronous DB loads for characters/personas/dictionaries/lore up front) is paid on every single visit.
+
+Profile before optimizing (per project rules) — the fix is likely deferring per-mode data loads to after first paint, or to the mode actually selected.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] Roleplay tab switch (click → screen interactive) is within 2× the median of the other screens on the same profile, measured before/after with the same method.
+- [ ] The cause is identified by profiling and recorded in the task notes (not guessed).
+- [ ] No functional regression in the four Roleplay modes (Characters, Personas, Dictionaries, Lore all render their data).
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2725 - Roleplay screen switch takes 2s where every other screen takes under 1s.md
+++ b/backlog/tasks/task-2725 - Roleplay screen switch takes 2s where every other screen takes under 1s.md
@@ -36,6 +36,16 @@ Profile before optimizing (per project rules) — the fix is likely deferring pe
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
 - [ ] Roleplay tab switch (click → screen interactive) is within 2× the median of the other screens on the same profile, measured before/after with the same method.
-- [ ] The cause is identified by profiling and recorded in the task notes (not guessed).
+- [x] The cause is identified by profiling and recorded in the task notes (not guessed).
 - [ ] No functional regression in the four Roleplay modes (Characters, Personas, Dictionaries, Lore all render their data).
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Investigation Notes (2026-08-06, profiling done — fix deferred)
+
+<!-- SECTION:NOTES:BEGIN -->
+Profiled via cProfile around `push_screen(PersonasScreen)` in the standard test-app harness (235x52): **3.2s**, and the cause is NOT DB I/O. The screen mounts **494 widgets, 358 of them inside `#personas-detail-stack`** — every mode's full detail surface is composed eagerly (character card + character editor + persona card + persona editor + dictionary/lore detail + transcript + two try-it panels: 108 Buttons, 21 Inputs, 17 TextAreas), almost all `display: none` on arrival. Cost concentrates in CSS application against the app-wide stylesheet: `stylesheet.apply` 2,644 calls / 2.30s cumulative, 7.77M selector `__hash__` calls, plus ~500 full `update_styles` subtree sweeps triggered by `add_class`/`set_class` mutations during the mount storm (331 + 1,011 calls). Widget count is the lever; per-widget CSS cost is the multiplier.
+
+**Recommended fix (own PR):** defer composition of the non-active mode's detail widgets (mount on first mode activation). NOT landed in the 2720-2726 batch deliberately: 81 in-screen references + 4 external modules address these widgets, and `restore_state` runs before mount — deferral needs a centralized accessor plus an audit of every query site, which is its own reviewable change, not a rider. `textual.lazy.Lazy` alone is insufficient for the same reason (queries during `on_mount`/restore would hit unmounted children).
+
+AC1/AC3 remain unchecked pending that change; AC2 (profiled cause) is satisfied by this note.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2726 - Every navigation logs a No-handler-found warning for the nav worker.md
+++ b/backlog/tasks/task-2726 - Every navigation logs a No-handler-found warning for the nav worker.md
@@ -1,0 +1,33 @@
+---
+id: TASK-2726
+title: Every navigation logs a "No handler found" warning for the nav worker
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:00'
+labels:
+  - navigation
+  - logging
+  - uat
+  - polish
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+During the 2026-08-06 UAT walkthrough on `origin/dev` `b0185749c`, the Logs screen's warning filter was dominated by one line repeated 36 times — once per navigation:
+
+`__main__ WARNING No handler found for worker 'handle_screen_navigation' (Group: screen-navigation)`
+
+`on_worker_state_changed` warns whenever `worker_handler_registry.handle_event` returns unhandled, and the TASK-1230 navigation worker (group `screen-navigation`) has no registered handler, so ordinary tab switching floods the warning channel. With warnings at ~1 per navigation, the Warnings+ filter loses its value as a signal (76 warnings in one browsing session, half of them this line).
+
+Either register a no-op handler for the `screen-navigation` group or exempt known fire-and-forget worker groups from the unhandled-worker warning.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] Tab navigation produces no "No handler found" warnings in the log buffer.
+- [ ] Genuinely unhandled workers (unknown groups) still produce the warning.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2726 - Every navigation logs a No-handler-found warning for the nav worker.md
+++ b/backlog/tasks/task-2726 - Every navigation logs a No-handler-found warning for the nav worker.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2726
 title: Every navigation logs a "No handler found" warning for the nav worker
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-06 17:00'
 labels:
@@ -25,9 +25,22 @@ During the 2026-08-06 UAT walkthrough on `origin/dev` `b0185749c`, the Logs scre
 Either register a no-op handler for the `screen-navigation` group or exempt known fire-and-forget worker groups from the unhandled-worker warning.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: drive `on_worker_state_changed` with a SUCCESS transition for the `screen-navigation` group under a loguru WARNING sink; guard test proves unknown groups still warn.
+2. GREEN: acknowledge known fire-and-forget groups in `MiscWorkerHandler.HANDLED_GROUPS`.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] Tab navigation produces no "No handler found" warnings in the log buffer.
-- [ ] Genuinely unhandled workers (unknown groups) still produce the warning.
+- [x] Tab navigation produces no "No handler found" warnings in the log buffer.
+- [x] Genuinely unhandled workers (unknown groups) still produce the warning.
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `screen-navigation` to `MiscWorkerHandler.HANDLED_GROUPS`, plus three more fire-and-forget groups the RED run itself exposed producing identical startup noise: `scheduling`, `model-catalog-refresh`, `subscriptions-fts-backfill` (each warned 2-3x in a single test-app boot). Failures remain fully recorded: the diagnostics hook persists `worker_failed` before registry delegation. Guard test pins that genuinely unknown groups still warn. Tests: `test_screen_navigation_worker_transition_does_not_warn_unhandled`, `test_unknown_worker_group_still_warns_unhandled` (Tests/App/test_worker_failure_event.py). Files: tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2727 - Personas inspector crashes when console-action state arrives before its children mount.md
+++ b/backlog/tasks/task-2727 - Personas inspector crashes when console-action state arrives before its children mount.md
@@ -1,0 +1,46 @@
+---
+id: TASK-2727
+title: >-
+  Personas inspector crashes when console-action state arrives before its
+  children mount
+status: Done
+assignee: []
+created_date: '2026-08-06 17:20'
+labels:
+  - roleplay
+  - bug
+  - race
+  - uat
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Surfaced by the live verification pass for the 2720-2726 batch: after a first-run walkthrough, one Roleplay visit logged two chained tracebacks — `PersonasScreen._load_after_mount` → `_sync_inspector_console_actions` → `PersonasInspectorPane._apply_action_state` → `NoMatches: '#personas-validation-summary'`.
+
+`_load_after_mount` runs as a worker; when its awaited loads complete before the inspector pane's composed children finish mounting, the five unguarded `query_one` calls in `_apply_action_state` raise. The race is timing-dependent (not reproduced on a pristine `75bc25db3` in one trial; fired on the branch build in one trial — the batch's footer-timer fix changes first-run timer activity, which perturbs the mount window).
+
+The damage is worse than log noise: the exception aborts `_load_after_mount` midway, so `_apply_pending_restore` and `_auto_select_first_library_row` are silently skipped — a lost screen restore and no initial selection. Same defect family as task-2721 (timer/worker callback assuming mounted children).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: call `set_console_actions_enabled` on an unmounted pane (must not raise), then mount and assert the deferred state is replayed onto the readiness line.
+2. GREEN: `_apply_action_state` defers quietly on `QueryError`; `on_mount` replays via `call_after_refresh` so no pushed state is dropped.
+<!-- SECTION:PLAN:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [x] Pushing console-action state to a not-yet-mounted inspector neither raises nor gets lost — the state is applied once the children mount.
+- [x] `PersonasScreen._load_after_mount` can no longer be aborted by this race (the inspector call is exception-free pre-mount).
+- [x] A regression test drives the pre-mount push and the post-mount replay.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two-part fix in `PersonasInspectorPane`: `_apply_action_state` probes its first child query under `QueryError` and defers quietly when the composed children don't exist yet (the pre-mount push window `PersonasScreen._load_after_mount`'s worker can hit), and a new `on_mount` replays the retained state via `call_after_refresh` so an early push is applied rather than dropped — replay reads live attributes, so it cannot clobber newer state. The regression test drives the exact crash observed live (`set_console_actions_enabled` on an unmounted pane with a selection state) and asserts the pushed reason lands on the readiness line after mount; watched RED with the verbatim `NoMatches '#personas-validation-summary'` from the incident. Scope note: `show_selection`/`clear_selection` also query children unguarded but are not reachable in the observed race window; left alone deliberately. Files: tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py, Tests/UI/test_personas_inspector_pane.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py
+++ b/tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py
@@ -20,6 +20,15 @@ class MiscWorkerHandler(BaseWorkerHandler):
     HANDLED_GROUPS = {
         "ollama_api",
         "model_download",
+        # Fire-and-forget groups (task-2726): their failures are already
+        # persisted by the diagnostics hook before registry delegation, so
+        # acknowledging them here only silences the per-transition
+        # "No handler found" warning — one per tab switch for
+        # screen-navigation (TASK-1230), several at startup for the others.
+        "screen-navigation",
+        "scheduling",
+        "model-catalog-refresh",
+        "subscriptions-fts-backfill",
     }
 
     def can_handle(self, worker_name: str, worker_group: Optional[str] = None) -> bool:

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -21,7 +21,7 @@ from tldw_chatbook.Library.library_ingest_state import short_ingest_error
 from tldw_chatbook.Notifications.notifications_scope_service import (
     ServerEventScopeRequiredError,
 )
-from tldw_chatbook.runtime_policy.types import RuntimeSourceState
+from tldw_chatbook.runtime_policy.types import PolicyDeniedError, RuntimeSourceState
 from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
 from tldw_chatbook.Utils.path_validation import validate_path
 from .dashboard_state import (
@@ -455,6 +455,16 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                 "server_event_count": 0,
                 "server_event_state": SERVER_EVENT_STATE_RECONNECT_REQUIRED,
                 "server_event_recovery": "Reconnect or select an active server.",
+            }
+        except PolicyDeniedError as exc:
+            # Local runtime mode refuses the server feed by design; that is
+            # the normal state for a local-only profile, not a failure worth
+            # a warning on every Home visit (task-2722).
+            logger.debug(f"Server event feed not applicable for Home: {exc}")
+            return {
+                "server_event_count": 0,
+                "server_event_state": SERVER_EVENT_STATE_UNAVAILABLE,
+                "server_event_recovery": "Server events apply in server mode.",
             }
         except ValueError as exc:
             logger.warning(f"Failed to resolve server event feed scope for Home: {exc}")

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -35,6 +35,16 @@ class ServerClientValidationError(ServerClientError):
     """Server returned 4xx other than 404, or a local policy denied the action."""
 
 
+class ServerClientPolicyError(ServerClientValidationError):
+    """A local runtime-mode policy refused the action before any network I/O.
+
+    Subclass of :class:`ServerClientValidationError` so existing catches keep
+    working; the refined type lets consumers distinguish "not applicable in
+    this runtime mode" from a real failure — the sync engine must not persist
+    a refusal as a sync error (task-2722).
+    """
+
+
 class ServerClientServerError(ServerClientError):
     """Server returned 5xx."""
 
@@ -142,7 +152,7 @@ class SchedulingServerClient:
                 coro = method(*args, **kwargs)
                 return await asyncio.wait_for(coro, timeout=timeout)
             except PolicyDeniedError as exc:
-                raise ServerClientValidationError(str(exc)) from exc
+                raise ServerClientPolicyError(str(exc)) from exc
             except ServerClientNotFoundError:
                 raise
             except ServerClientValidationError:

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -12,6 +12,7 @@ from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
     ServerClientError,
     ServerClientNotFoundError,
+    ServerClientPolicyError,
 )
 
 
@@ -62,6 +63,12 @@ class SyncEngine:
             if not isinstance(response, dict):
                 response = {}
             pulled_items = response.get("items", [])
+        except ServerClientPolicyError as exc:
+            # A runtime-mode refusal ("requires server mode") means sync is
+            # not applicable right now — recording it as a sync error put a
+            # standing error badge on local-only profiles (task-2722).
+            logger.info(f"Sync pull not applicable for {target_owner}: {exc}")
+            return
         except ServerClientError as exc:
             self._record_sync_error(str(exc), target_owner)
             return
@@ -117,6 +124,11 @@ class SyncEngine:
                 pending_local_ids,
                 mutations,
             ) = await self._network_phase(target_owner)
+        except ServerClientPolicyError as exc:
+            # Same rule as `pull`: a runtime-mode refusal is "not applicable",
+            # never a persisted sync error (task-2722).
+            logger.info(f"Sync not applicable for {target_owner}: {exc}")
+            return
         except ServerClientError as exc:
             self._record_sync_error(str(exc), target_owner)
             return

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -394,3 +394,27 @@ class MainNavigationBar(Container):
 
         logger.info(f"Navigation requested to screen: {screen_name}")
         return True
+
+    def restore_active(self, route: str) -> None:
+        """Reset the highlight to ``route``, undoing a click's optimism.
+
+        A click activates its destination here before the navigation worker
+        has run; when that navigation fails, the app calls this with the
+        route still on the screen stack so the highlight matches reality and
+        the failed destination stays re-clickable — the already-active check
+        in `_activate_navigation_button` would otherwise swallow every retry
+        (task-2720, observed live: one transient error made a tab
+        unreachable for the rest of the session).
+
+        Args:
+            route: Screen or destination route actually on the screen stack.
+        """
+        resolved = resolve_shell_route(route)
+        self.active_destination_id = resolved.destination_id
+        self.active_route = resolved.canonical_route
+        self.active_screen = self.active_destination_id
+        for nav_button in self.query(".nav-button"):
+            nav_button.set_class(
+                nav_button.id == f"nav-{self.active_destination_id}",
+                "is-active",
+            )

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -592,6 +592,16 @@ class SchedulesWorkbench(BaseAppScreen):
         status.set_owner_state(service.owner_id, active_server_id, server_available)
         state = service.db.get_sync_state(service.owner_id) or {}
         sync_errors = state.get("sync_errors") or []
+        # A runtime-mode refusal is "sync not applicable", never a failure.
+        # New refusals are no longer recorded (task-2722, SyncEngine), but
+        # profiles that synced on older builds still carry persisted ones —
+        # keep them off the error surface instead of badging local-only
+        # profiles with an error the user did nothing to cause.
+        sync_errors = [
+            entry
+            for entry in sync_errors
+            if "requires server mode" not in str(entry.get("message", ""))
+        ]
         status.update_status(
             last_pull_at=state.get("last_pull_at"),
             last_push_at=state.get("last_push_at"),

--- a/tldw_chatbook/UI/Screens/scheduling/sync_status_widget.py
+++ b/tldw_chatbook/UI/Screens/scheduling/sync_status_widget.py
@@ -17,12 +17,18 @@ class SyncStatusWidget(Horizontal):
     #scheduling-owner-local, #scheduling-owner-server {
         width: auto;
     }
+    /* task-2723: without margins these Statics render flush against each
+       other — "Last pull: —Last push: —<error text>" read as one run. */
     #scheduling-last-pull, #scheduling-last-push {
         width: auto;
+        margin-left: 2;
     }
     #scheduling-sync-error {
         width: 1fr;
         color: $error;
+        margin-left: 2;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
     }
     #scheduling-clear-error {
         width: auto;

--- a/tldw_chatbook/UI/Wizards/first_run_setup_state.py
+++ b/tldw_chatbook/UI/Wizards/first_run_setup_state.py
@@ -579,6 +579,13 @@ ROW_ATTENTION = "attention"
 
 _TEMPLATE_DEFAULT_THEME = "textual-dark"
 
+#: Shipped template defaults that get merged into app_config at load time.
+#: Like `_TEMPLATE_DEFAULT_THEME`, their mere presence is not a user choice
+#: (task-2724: a Ctrl+N-only walk rendered "✓ Default model — gpt-5.6-terra"
+#: and "✓ RAG — embedding model: e5-small-v2" beneath "✗ Provider").
+_TEMPLATE_DEFAULT_RAG_MODEL = "e5-small-v2"
+_TEMPLATE_DEFAULT_MODEL = "gpt-5.6-terra"
+
 
 @dataclass(frozen=True)
 class SummaryRow:
@@ -718,17 +725,33 @@ def build_summary_rows(
 
     if not rag_deps_installed:
         rag_row = SummaryRow("RAG", ROW_DEFAULT, "optional — embeddings deps not installed")
-    elif rag_model:
+    elif rag_model and rag_model != _TEMPLATE_DEFAULT_RAG_MODEL:
         rag_row = SummaryRow("RAG", ROW_CONFIGURED, f"embedding model: {rag_model}")
+    elif rag_model:
+        # The untouched template value — matches the header's "RAG off"
+        # sentence instead of contradicting it (task-2724).
+        rag_row = SummaryRow(
+            "RAG", ROW_DEFAULT, f"off by default — embedding model {rag_model}"
+        )
     else:
         rag_row = SummaryRow("RAG", ROW_DEFAULT, "no embedding model selected")
 
-    if prefill.model_id:
+    if prefill.model_id and provider_ok:
         model_row = SummaryRow("Default model", ROW_CONFIGURED, prefill.model_id)
     elif provider_ok:
         # A provider without a model is half-finished — worth flagging.
         model_row = SummaryRow("Default model", ROW_ATTENTION, "not selected")
+    elif prefill.model_id and prefill.model_id != _TEMPLATE_DEFAULT_MODEL:
+        # Typed/selected by the user, but with no provider it cannot take
+        # effect — name it honestly without claiming a finished setup.
+        model_row = SummaryRow(
+            "Default model",
+            ROW_DEFAULT,
+            f"{prefill.model_id} — takes effect once a provider is connected",
+        )
     else:
+        # With no provider, whatever sits in chat_defaults.model is the
+        # merged template default, not a choice (task-2724).
         model_row = SummaryRow("Default model", ROW_DEFAULT, "not selected")
 
     theme_is_custom = bool(

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -7,6 +7,7 @@ import re
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
+from textual.css.query import QueryError
 from textual.widgets import Button, Checkbox, ListItem, ListView, Static
 
 from ..Console.console_image_viewer_modal import ClickableAvatarBox
@@ -417,10 +418,27 @@ class PersonasInspectorPane(Vertical):
         if items:
             await list_view.extend(items)
 
+    def on_mount(self) -> None:
+        """Replay any state pushed before the composed children existed.
+
+        task-2727: `PersonasScreen._load_after_mount` runs as a worker and can
+        push console-action state while this pane's children are still
+        mounting; `_apply_action_state` defers quietly in that window, and
+        this replay (after the first refresh, so the children are queryable)
+        makes sure nothing pushed early is dropped.
+        """
+        self.call_after_refresh(self._apply_action_state)
+
     def _apply_action_state(self) -> None:
         selected = self._has_selection
         unsaved = self._is_unsaved
         kind = self._selected_kind
+        try:
+            self.query_one("#personas-validation-summary", Static)
+        except QueryError:
+            # Children not composed yet (pre-mount push) — the on_mount
+            # replay applies the retained state once they exist (task-2727).
+            return
         # F-031: pre-selection the inspector is one guidance line only. The
         # section chrome (Validation, Conversations, Readiness header) and
         # the action stack stay hidden until there is something to act on;

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -369,7 +369,7 @@ from tldw_chatbook.config import (
     settings,
     get_chachanotes_db_lazy,
 )
-from .UI.Navigation.main_navigation import NavigateToScreen
+from .UI.Navigation.main_navigation import MainNavigationBar, NavigateToScreen
 from .UI.Navigation.pending_handoff_store import (
     ConsoleProviderIntent,
     HandoffChannel,
@@ -6506,7 +6506,18 @@ class TldwCli(
     async def handle_screen_navigation(self, message: NavigateToScreen) -> None:
         """Handle navigation to a different screen using switch_screen for better performance."""
         async with self._screen_navigation_lock():
-            await self._handle_screen_navigation_locked(message)
+            try:
+                await self._handle_screen_navigation_locked(message)
+            except Exception:
+                # task-2720: several steps in the locked body are legitimately
+                # unguarded (target resolution, runtime identity, snapshot
+                # restore, transition admission) and a transient error in any
+                # of them used to fail SILENTLY: no message, nav-bar highlight
+                # stuck on the destination, retry clicks no-opped. Recover the
+                # user-facing state, then re-raise so the worker hook still
+                # writes the `worker_failed` diagnostics line (ADR-029).
+                self._notify_navigation_failure(message.screen_name)
+                raise
 
     async def _handle_screen_navigation_locked(self, message: NavigateToScreen) -> None:
         """Body of `handle_screen_navigation`, run under its FIFO lock."""
@@ -6725,6 +6736,23 @@ class TldwCli(
             )
         except Exception:
             logger.debug(f"Could not surface navigation failure for {screen_name!r}.")
+        # task-2720: the nav bar highlighted the destination the moment it was
+        # clicked, before the navigation worker ran. Roll it back to the screen
+        # actually on the stack — otherwise the bar shows a destination that
+        # never loaded AND its already-active check swallows every retry click,
+        # leaving the destination unreachable until restart.
+        try:
+            current_screen = self.screen
+            current_route = getattr(current_screen, "screen_name", None)
+            if isinstance(current_route, str) and current_route.strip():
+                current_screen.query_one(MainNavigationBar).restore_active(
+                    current_route
+                )
+        except Exception:
+            logger.debug(
+                f"Could not roll back nav-bar state after failing to open "
+                f"{screen_name!r}."
+            )
 
     async def _complete_screen_navigation(
         self,
@@ -8191,8 +8219,21 @@ class TldwCli(
                 return
 
         try:
-            self._db_size_status_widget = self.query_one(AppFooterStatus)
-            self.loguru_logger.info("AppFooterStatus widget instance acquired.")
+            # The cache is only a pre-first-screen fallback: per-tick updates
+            # resolve the ACTIVE screen's footer via `_active_footer_status`.
+            # Splash and the first-run wizard mount no AppFooterStatus, so a
+            # miss here must not abort timer setup (task-2721: it previously
+            # logged two tracebacks per fresh install and left the DB-size and
+            # token timers never started for the whole session).
+            try:
+                self._db_size_status_widget = self.query_one(AppFooterStatus)
+                self.loguru_logger.info("AppFooterStatus widget instance acquired.")
+            except QueryError:
+                self._db_size_status_widget = None
+                self.loguru_logger.debug(
+                    "Active screen has no AppFooterStatus; footer timers start "
+                    "anyway and each tick resolves the active screen's footer."
+                )
 
             self.set_timer(
                 DEFERRED_DB_SIZE_UPDATE_DELAY_SECONDS,


### PR DESCRIPTION
## Summary

Findings from a full-app UAT walkthrough (crashes, slowness, general-browsing bugs) run live in tmux against `origin/dev` `b0185749c`, on a scratch profile seeded with a copy of the real DBs (v30→v31 migration exercised), through the first-run wizard and every nav destination: Home, Console, Library, Artifacts, Roleplay, Watchlists, Schedules, Workflows, MCP, ACP, Lab (Models/Speech/Evals), Logs, Settings — plus in-screen browsing (Library notes open, Watchlists subtabs, Roleplay modes, Home cross-nav, command palette).

## Tasks filed

| Task | Sev | Finding |
|---|---|---|
| 2720 | high | Escaped nav-worker exception (PermissionError, observed 2×) silently kills ALL tab navigation until restart: no notification, tab-bar desync, same-tab retry no-ops. Trigger transient (3 faithful replications clean); degradation mechanism fully app-side. |
| 2721 | medium | `_schedule_footer_status_updates` crashes `NoMatches: AppFooterStatus` on splash + first-run wizard — every fresh install starts with 4 buffered error tracebacks. |
| 2722 | medium | Local mode invokes `*.server` ops and reports the refusal as a standing **"1 sync error"** badge on Schedules (+ Home feed warnings). |
| 2723 | low | Schedules sync strip runs fields together: `Last pull: —Last push: —notifications.reminders.list.server requires server mode.` |
| 2724 | medium | Wizard Summary claims `✓ Default model — gpt-5.6-terra` (config fallback, nothing chosen, no provider) and `✓ RAG` contradicting "RAG off" in the same screen. |
| 2725 | medium | Roleplay tab switch ~2s recurring (2.19s / 1.97s repeat) vs 0.25–1.1s for all other screens. |
| 2726 | low | Every navigation logs `No handler found for worker 'handle_screen_navigation'` — 36× in one browsing session. |

## Verified, not filed

- **Lab ▸ Speech app-fatal crash (TASK-2610)**: reproduced at `b0185749c` (`DuplicateIds: lab-speech-row-playground`, `lab_frame.py _populate_regions` double-mount — took the whole app down, not just the pane). PR #1377 merged the fix mid-walkthrough; **verified fixed live at `75bc25db3`** (TTS Playground renders, app stays up).
- Everything else browsed clean: zero buffered errors across the full 13-destination sweep in the main session.

## Observations (no task)

- 6 failed Watchlists drafts + 3 RSS sources in the real DB all carry the literal name "Draft Name" — some creation flow persists the placeholder as the real name; adjacent to the open Watchlists follow-ups.
- Cold start ~6s warm on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened navigation and cleaned up UAT regressions: failures now surface properly, local‑mode no longer shows bogus sync errors, footer timers are safe on splash/wizard, and UI polish and logging noise are addressed. 2725 (Roleplay perf) was profiled; fix deferred.

- **Bug Fixes**
  - 2720: Navigation worker failures notify the user and roll back the tab highlight; `MainNavigationBar.restore_active` added; diagnostics still recorded.
  - 2721: Footer status timers tolerate screens without `AppFooterStatus`; no errors on splash/wizard and timers still start.
  - 2722: Treat policy refusals as “not applicable,” not errors—introduce `ServerClientPolicyError`; `SyncEngine` skips persisting refusals; Home adapter handles `PolicyDeniedError` quietly; Schedules filters old “requires server mode” entries from the error surface.
  - 2723: Sync strip fields spaced and truncated (`SyncStatusWidget` margins/ellipsis) so labels don’t run together.
  - 2724: Wizard Summary stops claiming template defaults as ✓; model requires a provider; RAG default reads as off with the template model named.
  - 2726: Silence “No handler found” warnings for known fire‑and‑forget groups (`screen-navigation`, `scheduling`, `model-catalog-refresh`, `subscriptions-fts-backfill`); unknown groups still warn.
  - 2727: Personas inspector defers pre‑mount action‑state pushes and replays on mount to avoid `NoMatches` crashes.

<sup>Written for commit adb015664781e897b77ead8386e87bf58e17c4a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

