### PR TITLE
refactor(console): decomposition wave 2 — workspace, hands-free, session controllers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -403,3 +403,24 @@ controller's constructor dependencies above; see `ConsoleInspectorRail`'s
 `left_rail.py`) so every `compose()` call mounts a fresh instance built
 from current state, or have the region re-query its own DOM instead of
 caching a reference at all.
+
+**Controller-to-controller traffic goes through named callables the screen
+wires at construction — never a back-door through screen attributes.** Wave 2
+put three controllers on one screen, and clusters genuinely reference each
+other: sessions live inside workspace context, and dictation drives the
+hands-free loop. The temptation is for one controller to reach the other by
+reading a screen attribute (`self._screen._session`, or a live property that
+proxies to it), which reintroduces exactly the coupling the extraction removed
+and hides it behind indirection. Instead the screen owns the wiring: it builds
+both controllers, then passes each the specific callables the other exposes
+(`ConsoleSessionController`'s five seam callables into
+`ConsoleWorkspaceController`, and vice versa; the six that replaced
+`ConsoleDictationController`'s hands-free reach-backs). Two consequences worth
+stating because both cost a review round to establish. First, the lambdas must
+resolve the sibling at CALL time (`lambda: self._session.x()`), never capture
+it at construction, or whichever controller is built second is `None` at
+wiring time. Second, if a proxy property is write-only, its getter must raise
+`RuntimeError` and NOT `AttributeError` — `hasattr()` and
+`getattr(obj, name, default)` swallow `AttributeError` specifically, so a
+defensive read would silently take the default forever with nothing raised
+anywhere.

--- a/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
@@ -188,9 +188,10 @@ of their own. That is the gap.
 |---|---|---|
 | rail + inspector | 958 / 42 | region widgets (left, context, inspector rails) — **(wave 1, done)**: `ConsoleLeftRail` (task 3) and `ConsoleInspectorRail` (task 4), in `UI/Console_Modules/left_rail.py` / `right_rail.py`. The DOM turned out to name two rails, not three — the spec's "context" rail is the left rail's own `console-context-rail-*` id family, not a separate region; see `right_rail.py`'s module docstring |
 | composer | 377 / 18 | controller — the region widget already exists (`ConsoleComposerBar` at `#console-native-composer`); the screen-side lines are orchestration (undo/redo, history navigation, action-state sync), not rendering — wave 2 |
-| workspace | 1,382 / 40 | controller |
-| session | 916 / 31 | controller |
+| workspace | 1,382 / 40 | controller — **(wave 2, done)**: `ConsoleWorkspaceController` in `UI/Console_Modules/workspace.py`. 35 of 45 moved; `on_console_workspace_conversation_search_changed` stays WHOLE on the screen (only 3 of its ~9 mutated fields are workspace state, all reached through proxy properties, so the controller stays the single source of truth without dragging a sibling browser cluster across) |
+| session | 916 / 31 | controller — **(wave 2, done)**: `ConsoleSessionController` in `UI/Console_Modules/session.py`. `_start_character_console_session` (the flagged 215-line risk centre) moved byte-identically; the real entanglement lives in `_apply_console_character_choice_async`, which is not `*session*`-named, was never in scope, and stays coherently |
 | message | 1,027 / 23 | controller |
+| hands-free | 730 / 28 | controller — **(wave 2, done)**: `ConsoleHandsFreeController` in `UI/Console_Modules/hands_free.py`. Absent from this table at plan time because the cluster hid inside dictation's orbit. PR #1350 then made hands-free a TWO-ENGINE abstraction; the controller owns the engine fork and both action entry points (they read both engines, so they are coordination), while the realtime engine stays on the screen reached via two named callables |
 | dictation | 742 / 20 | controller — **(wave 1, done)**: `ConsoleDictationController` (task 5), in `UI/Console_Modules/dictation.py` |
 | agent | 612 / 15 | controller + a region widget for its rail section |
 | character | 708 / 14 | controller + a region widget for its rail section |
@@ -218,6 +219,29 @@ is drawn at the wrong boundary; that is the review signal for this screen.
 `compose_content` (381) splits along the same region lines as the Console.
 `_list_local_source_snapshot` (263) and its siblings are data access with no region and
 become a controller.
+
+## Progress
+
+**Wave 1 (merged, PR #1345)** — geometry baseline, `UI/Console_Modules/` with the
+shared frame helper, `ConsoleLeftRail`, `ConsoleInspectorRail`,
+`ConsoleDictationController`.
+
+**Wave 2 (this branch)** — `ConsoleWorkspaceController`,
+`ConsoleHandsFreeController`, `ConsoleSessionController`.
+
+Measured against dev at the wave-2 close: `chat_screen.py` **24,195 → 20,964
+lines**, `ChatScreen` **680 → 612 methods** (−3,231 / −68). The four controllers
+plus two region widgets total 7,832 lines in `UI/Console_Modules/`. The screen is
+still large, and the success criterion remains ownership rather than a line count:
+it no longer holds those clusters' regions or state. What it legitimately keeps —
+cross-region coordination, Textual lifecycle, and the `action_*`/`@on` entry
+points Textual resolves by name — is why the method count fell by less than the
+line count.
+
+Controller discipline at the close, verified per module rather than asserted:
+**zero** `query_one`/DOM access in any of the four controllers, and `self._screen`
+uses held to 3–6 each, every one either a framework service or a documented
+sibling-state proxy.
 
 ## Migration safety
 

--- a/Tests/Chat/test_chat_conversation_service.py
+++ b/Tests/Chat/test_chat_conversation_service.py
@@ -935,7 +935,8 @@ def test_get_conversation_tree_carries_system_prompt_through_real_db(tmp_path):
     """Full production path: real DB row -> get_conversation_tree()["conversation"].
 
     This is the exact seam Console's resume handler
-    (``ChatScreen._resume_console_workspace_conversation``) reads from. A
+    (``ConsoleWorkspaceController._resume_console_workspace_conversation``)
+    reads from. A
     fake/static conversation-tree service in a UI-level test would hide a
     regression here (``normalize_conversation_row`` silently drops any key
     it doesn't explicitly allow-list), so this exercises the real

--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -115,6 +115,8 @@ def _bare_generation_screen(store: ConsoleChatStore) -> ChatScreen:
     screen = ChatScreen.__new__(ChatScreen)
     screen._console_chat_store = store
     screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
+    screen._session._chat_store_accessor = lambda: screen._console_chat_store
+    screen._session._current_chat_store_accessor = lambda: screen._console_chat_store
     screen._console_message_action_service = ConsoleMessageActionService()
     screen._pending_console_delete_message_id = None
     screen.app_instance = SimpleNamespace(notify=lambda *a, **k: None)

--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -44,6 +44,7 @@ from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSPlaybackEvent,
 )
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 
@@ -113,6 +114,7 @@ def _bare_generation_screen(store: ConsoleChatStore) -> ChatScreen:
     """
     screen = ChatScreen.__new__(ChatScreen)
     screen._console_chat_store = store
+    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._console_message_action_service = ConsoleMessageActionService()
     screen._pending_console_delete_message_id = None
     screen.app_instance = SimpleNamespace(notify=lambda *a, **k: None)
@@ -875,7 +877,7 @@ async def test_generate_image_handler_threads_prepared_fields_into_batch(monkeyp
     def _mock_default_settings():
         return ConsoleSessionSettings(provider="openai")
 
-    screen._default_console_session_settings = _mock_default_settings
+    screen._session._default_console_session_settings = _mock_default_settings
 
     # Stub conversation pairs helper to return a simple test pair
     def _mock_conversation_pairs(store, session_id):
@@ -1090,7 +1092,7 @@ def _wired_generate_image_screen(store, *, batch_calls, batch_data=b"generated_i
     path needs, matching `test_generate_image_handler_threads_prepared_
     fields_into_batch`'s established stubbing style."""
     screen = _bare_generation_screen(store)
-    screen._default_console_session_settings = lambda: ConsoleSessionSettings(
+    screen._session._default_console_session_settings = lambda: ConsoleSessionSettings(
         provider="openai"
     )
     screen._console_composer_or_none = lambda: None
@@ -1165,7 +1167,7 @@ async def test_generate_image_handler_no_prompt_uses_llm_composed_context_end_to
     messages = store.messages_for_session(
         store.ensure_session(
             workspace_id=store.workspace_context.active_workspace_id,
-            settings=screen._default_console_session_settings(),
+            settings=screen._session._default_console_session_settings(),
         ).id
     )
     generation_messages = [m for m in messages if m.content.startswith("[image] ")]
@@ -1410,7 +1412,7 @@ async def test_generate_image_handler_restores_draft_when_batch_raises(monkeypat
 
     from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 
-    screen._default_console_session_settings = lambda: ConsoleSessionSettings(
+    screen._session._default_console_session_settings = lambda: ConsoleSessionSettings(
         provider="openai"
     )
     screen._console_generate_image_conversation_pairs = lambda store, session_id: []

--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -815,8 +815,13 @@ async def test_dispatch_console_command_blocks_generate_image_when_ephemeral():
     store.switch_session(temp.id)
 
     screen = _bare_generation_screen(store)
-    screen._console_initial_session_title_for_workspace = (
-        lambda workspace_id: "Console"
+    # `_bare_generation_screen` bypasses `ChatScreen.__init__` (`__new__`, no
+    # mounted app), so `screen._workspace` -- the real `ConsoleWorkspace
+    # Controller` -- was never constructed. Stub the one method this path
+    # reaches, the same narrow-seam discipline the helper's own docstring
+    # describes for `_sync_native_console_chat_ui`/`app_instance.notify`.
+    screen._workspace = SimpleNamespace(
+        _console_initial_session_title_for_workspace=lambda workspace_id: "Console"
     )
 
     handler_calls: list = []

--- a/Tests/ProductionApp/test_chat_composition_retirement.py
+++ b/Tests/ProductionApp/test_chat_composition_retirement.py
@@ -14,6 +14,7 @@ from tldw_chatbook.config import load_settings
 from tldw_chatbook.Constants import TAB_CHAT
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
 from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
@@ -159,7 +160,7 @@ async def test_native_console_chat_handoff_settles_exact_claim_and_keeps_replace
     continue_first = asyncio.Event()
 
     async def wait_before_native_staging(
-        self: ChatScreen,
+        self: ConsoleSessionController,
         payload: ChatHandoffPayload,
     ) -> bool:
         first_started.set()
@@ -167,7 +168,7 @@ async def test_native_console_chat_handoff_settles_exact_claim_and_keeps_replace
         return False
 
     monkeypatch.setattr(
-        ChatScreen,
+        ConsoleSessionController,
         "_start_character_console_session",
         wait_before_native_staging,
     )
@@ -234,7 +235,7 @@ async def test_native_console_chat_handoff_settles_exact_claim_and_keeps_replace
 
             with monkeypatch.context() as cancellation_patch:
                 cancellation_patch.setattr(
-                    chat,
+                    chat._session,
                     "_start_character_console_session",
                     hold_character_start,
                 )

--- a/Tests/ProductionApp/test_provider_selection_ownership.py
+++ b/Tests/ProductionApp/test_provider_selection_ownership.py
@@ -160,7 +160,7 @@ async def test_real_console_consumes_typed_provider_intents_and_opens_real_picke
                 "notify",
                 lambda message, *args, **kwargs: notifications.append(str(message)),
             )
-            original = screen._ensure_active_console_session_settings()
+            original = screen._session._ensure_active_console_session_settings()
             store = screen._ensure_console_chat_store()
             session_id = store.active_session_id
             assert session_id is not None
@@ -267,7 +267,7 @@ async def test_settings_save_preserves_user_session_then_away_command_hands_off(
         async with app.run_test(size=(140, 48)) as pilot:
             chat = await _wait_for_screen(app, pilot, ChatScreen)
             store = chat._ensure_console_chat_store()
-            initial = chat._ensure_active_console_session_settings()
+            initial = chat._session._ensure_active_console_session_settings()
             session_id = store.active_session_id
             assert session_id is not None
             store.replace_session_settings(

--- a/Tests/UI/test_console_agent_rail.py
+++ b/Tests/UI/test_console_agent_rail.py
@@ -934,7 +934,7 @@ async def test_activate_native_console_session_clears_stale_drilldown():
         store.create_session(title="Other")
         console._console_agent_drilldown_run_id = "run-1"
 
-        await console._activate_native_console_session(first_session.id)
+        await console._session._activate_native_console_session(first_session.id)
 
         assert console._console_agent_drilldown_run_id is None
 

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -38,6 +38,8 @@ def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
     screen = ChatScreen.__new__(ChatScreen)
     screen._console_chat_store = store
     screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
+    screen._session._chat_store_accessor = lambda: screen._console_chat_store
+    screen._session._current_chat_store_accessor = lambda: screen._console_chat_store
     screen._console_visible_draft_session_id = None
     screen._console_composer_or_none = lambda: None
     return screen

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -20,6 +20,7 @@ from textual.widgets import Static
 
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
@@ -36,6 +37,7 @@ def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
     """
     screen = ChatScreen.__new__(ChatScreen)
     screen._console_chat_store = store
+    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._console_visible_draft_session_id = None
     screen._console_composer_or_none = lambda: None
     return screen
@@ -269,7 +271,7 @@ async def console_screen_with_db_avatar_off(avatar_db):
 
 def _set_active_console_character(screen, character_id, character_name) -> None:
     """Bind the active native Console session to a character (or clear it)."""
-    session = screen._active_native_console_session()
+    session = screen._session._active_native_console_session()
     assert session is not None, "no active native Console session"
     session.character_id = character_id
     session.character_name = character_name
@@ -567,7 +569,7 @@ async def test_react_off_pins_idle_even_when_streaming(console_screen_with_db, m
     # the raw status really would say "streaming" (-> "speaking") if react
     # were on.
     controller = screen._ensure_console_chat_controller()
-    session = screen._active_native_console_session()
+    session = screen._session._active_native_console_session()
     message = controller.store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )

--- a/Tests/UI/test_console_command_composer.py
+++ b/Tests/UI/test_console_command_composer.py
@@ -139,7 +139,7 @@ async def test_system_command_rejects_recipe_before_session_or_draft_mutation() 
         _open_console_system_prompt_editor=AsyncMock(),
         _open_console_prompt_picker_for_apply_system=AsyncMock(),
         _append_native_console_system_message=AsyncMock(),
-        _apply_console_session_system_prompt=Mock(),
+        _session=SimpleNamespace(_apply_console_session_system_prompt=Mock()),
         _clear_console_composer_draft=Mock(),
         _is_recipe_prompt_record=ChatScreen._is_recipe_prompt_record,
         _RECIPE_EXECUTION_BLOCKED_COPY=ChatScreen._RECIPE_EXECUTION_BLOCKED_COPY,
@@ -149,7 +149,7 @@ async def test_system_command_rejects_recipe_before_session_or_draft_mutation() 
         screen, SimpleNamespace(args="Outcome first")
     )
 
-    screen._apply_console_session_system_prompt.assert_not_called()
+    screen._session._apply_console_session_system_prompt.assert_not_called()
     screen._clear_console_composer_draft.assert_not_called()
     screen._open_console_prompt_picker_for_apply_system.assert_not_awaited()
     screen._append_native_console_system_message.assert_awaited_once()
@@ -846,7 +846,7 @@ async def test_console_resume_triggered_prompt_insert_survives_stale_session_swi
         # sites (periodic transcript polling, another send/stop cycle, a
         # settings-modal callback) route through this same method. It must
         # not retroactively wipe the insert by reloading the stale draft.
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert "resume-triggered insert" in composer.draft_text()
         assert console._console_visible_draft_session_id == second_session.id
 

--- a/Tests/UI/test_console_composer_collapse.py
+++ b/Tests/UI/test_console_composer_collapse.py
@@ -435,7 +435,7 @@ async def test_replacement_composer_inherits_screen_state_and_active_session_dra
         store = console._ensure_console_chat_store()
         composer.load_draft("canonical session draft")
         console._console_composer_collapsed = True
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
 
         await console.recompose()
         await pilot.pause()

--- a/Tests/UI/test_console_composer_menu.py
+++ b/Tests/UI/test_console_composer_menu.py
@@ -645,7 +645,7 @@ async def test_activate_console_session_for_workspace_keeps_temporary_chip_hones
         assert chip.display is True
 
         # "switch to an existing session in the workspace" branch.
-        console._activate_console_session_for_workspace("workspace-b")
+        console._workspace._activate_console_session_for_workspace("workspace-b")
         await pilot.pause()
         assert store.active_session_id == normal.id
         assert chip.display is False, (
@@ -653,7 +653,7 @@ async def test_activate_console_session_for_workspace_keeps_temporary_chip_hones
         )
 
         # Same branch, opposite direction.
-        console._activate_console_session_for_workspace("workspace-a")
+        console._workspace._activate_console_session_for_workspace("workspace-a")
         await pilot.pause()
         assert store.active_session_id == temp.id
         assert chip.display is True
@@ -663,7 +663,7 @@ async def test_activate_console_session_for_workspace_keeps_temporary_chip_hones
         # workspace with no existing session. `create_session` here never
         # passes `ephemeral=True`, so switching there from the ephemeral
         # session must also hide the chip.
-        console._activate_console_session_for_workspace("workspace-c")
+        console._workspace._activate_console_session_for_workspace("workspace-c")
         await pilot.pause()
         assert store.active_session_id not in (normal.id, temp.id)
         assert chip.display is False

--- a/Tests/UI/test_console_composer_menu.py
+++ b/Tests/UI/test_console_composer_menu.py
@@ -589,10 +589,14 @@ def test_console_active_session_is_ephemeral_reads_the_active_flag():
     other caller has.
     """
     from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+    from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
     screen._console_chat_store = None
+    session = ConsoleSessionController.__new__(ConsoleSessionController)
+    session._current_chat_store_accessor = lambda: screen._console_chat_store
+    screen._session = session
     assert screen._console_active_session_is_ephemeral() is False
 
     store = ConsoleChatStore()
@@ -888,7 +892,15 @@ def _bare_promote_screen(store):
     Shared by the ``_promote_console_temporary_session`` tests below: each
     one only differs in what the fake store does, and in which of the
     captured lists it inspects afterwards.
+
+    ``_promote_console_temporary_session`` moved to ``ConsoleSessionController``
+    (wave-2 console decomposition, task 3); the bare screen now also carries a
+    bare, minimally-wired ``ConsoleSessionController`` (constructed via
+    ``__new__``, bypassing its own ``__init__`` the same way the screen
+    bypasses ``ChatScreen.__init__``) so the real method under test still
+    runs against the same fakes as before.
     """
+    from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
@@ -896,12 +908,8 @@ def _bare_promote_screen(store):
     screen._ensure_console_chat_store = lambda: store
 
     chip_calls: list[bool] = []
-    screen._sync_console_temporary_chip = lambda: chip_calls.append(
-        screen._console_active_session_is_ephemeral()
-    )
 
     invalidated: list[bool] = []
-    screen._invalidate_console_persisted_rows_cache = lambda: invalidated.append(True)
 
     dispatched: list[object] = []
     screen.run_worker = lambda coroutine, **_kwargs: dispatched.append(coroutine)
@@ -913,6 +921,23 @@ def _bare_promote_screen(store):
             notifications.append((message, severity))
 
     screen.app_instance = _App()
+
+    session = ConsoleSessionController.__new__(ConsoleSessionController)
+    session._screen = screen
+    session.app_instance = screen.app_instance
+    session._chat_store_accessor = lambda: store
+    session._current_chat_store_accessor = lambda: store
+    session._sync_temporary_chip_fn = lambda: chip_calls.append(
+        session._console_active_session_is_ephemeral()
+    )
+    session._invalidate_persisted_rows_cache_fn = lambda: invalidated.append(True)
+    # Never awaited in these tests (only the coroutine OBJECT is captured
+    # and closed) -- mirrors the pre-move test, which relied on the real
+    # `ChatScreen._sync_native_console_chat_ui` bound method for the exact
+    # same reason: calling it only creates the coroutine, it never runs.
+    session._sync_native_console_chat_ui_fn = lambda: screen._sync_native_console_chat_ui()
+    screen._session = session
+
     return screen, chip_calls, invalidated, dispatched, notifications
 
 
@@ -957,7 +982,7 @@ def test_promote_console_temporary_session_saves_and_refreshes_the_chip():
         store
     )
 
-    asyncio.run(screen._promote_console_temporary_session())
+    asyncio.run(screen._session._promote_console_temporary_session())
 
     assert store.promote_calls == ["s1"], "the store's promotion must actually run"
     assert store._session.ephemeral is False, "the session must come back non-temporary"
@@ -991,7 +1016,7 @@ def test_promote_console_temporary_session_restores_temporary_state_on_failure()
         store
     )
 
-    asyncio.run(screen._promote_console_temporary_session())
+    asyncio.run(screen._session._promote_console_temporary_session())
 
     assert store._session.ephemeral is True, "must stay temporary after a failed save"
     assert chip_calls == [], "a failed save must not tell the chip to disappear"
@@ -1035,7 +1060,7 @@ def test_promote_console_temporary_session_notifies_when_already_saved():
         store
     )
 
-    asyncio.run(screen._promote_console_temporary_session())
+    asyncio.run(screen._session._promote_console_temporary_session())
 
     assert chip_calls == [False], (
         "already saved -- the chip must still be refreshed so it stops "
@@ -1071,7 +1096,7 @@ def test_promote_console_temporary_session_notifies_when_it_cannot_save():
         store
     )
 
-    asyncio.run(screen._promote_console_temporary_session())
+    asyncio.run(screen._session._promote_console_temporary_session())
 
     assert chip_calls == []
     assert invalidated == []
@@ -1089,11 +1114,15 @@ def test_save_chat_menu_choice_dispatches_to_the_promote_handler():
     """The composer-menu row for ``ACTION_SAVE_CHAT`` reaches the real save
     dispatch path (F5: now a worker-kicking wrapper, not the save coroutine
     itself)."""
+    from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
+    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     calls: list[bool] = []
-    screen._dispatch_promote_console_temporary_session = lambda: calls.append(True)
+    screen._session._dispatch_promote_console_temporary_session = (
+        lambda: calls.append(True)
+    )
 
     screen._handle_console_composer_menu_choice(ACTION_SAVE_CHAT)
 
@@ -1118,14 +1147,18 @@ def test_prompts_menu_choice_opens_exactly_one_browse_modal():
 def test_temporary_chip_save_requested_reaches_the_promote_handler():
     """The chip's activation message (task-7) drives the same save
     dispatch path (F5: now a worker-kicking wrapper)."""
+    from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
     from tldw_chatbook.Widgets.Console.console_status_chips import (
         ConsoleTemporaryChip,
     )
 
     screen = ChatScreen.__new__(ChatScreen)
+    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     calls: list[bool] = []
-    screen._dispatch_promote_console_temporary_session = lambda: calls.append(True)
+    screen._session._dispatch_promote_console_temporary_session = (
+        lambda: calls.append(True)
+    )
 
     event = ConsoleTemporaryChip.SaveRequested()
     stopped: list[bool] = []
@@ -1147,14 +1180,18 @@ def test_dispatch_promote_console_temporary_session_uses_its_own_worker_group():
     already caused a real regression on this branch (Console sends silently
     cancelled by an overlapping sync kick).
     """
+    from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
     calls: list[tuple[object, dict]] = []
     screen.run_worker = lambda coroutine, **kwargs: calls.append((coroutine, kwargs))
-    screen._promote_console_temporary_session = lambda: object()
+    session = ConsoleSessionController.__new__(ConsoleSessionController)
+    session._screen = screen
+    session._promote_console_temporary_session = lambda: object()
+    screen._session = session
 
-    screen._dispatch_promote_console_temporary_session()
+    screen._session._dispatch_promote_console_temporary_session()
 
     assert len(calls) == 1
     _coroutine, kwargs = calls[0]

--- a/Tests/UI/test_console_composer_undo.py
+++ b/Tests/UI/test_console_composer_undo.py
@@ -451,7 +451,7 @@ async def test_console_dictation_insertion_is_undoable():
         composer.move_cursor_end()
         await pilot.pause(0.1)
 
-        console._insert_console_dictation(
+        console._dictation._insert_console_dictation(
             origin_session_id=session_id, transcript="there"
         )
         assert composer.draft_text() == "hello world there"
@@ -718,7 +718,7 @@ async def test_console_background_dictation_drops_stale_session_history():
         assert composer.draft_text() == ""
 
         # Dictation finishes for A while B is visible -- the store-only branch.
-        console._insert_console_dictation(
+        console._dictation._insert_console_dictation(
             origin_session_id=session_a.id, transcript="dictated words"
         )
         assert store.session_draft(session_a.id) == "hello dictated words"

--- a/Tests/UI/test_console_composer_undo.py
+++ b/Tests/UI/test_console_composer_undo.py
@@ -530,7 +530,7 @@ async def test_console_undo_history_scoped_per_session_never_leaks():
         composer.focus()
         await pilot.pause()
         composer.load_draft("")
-        console._sync_console_session_draft()  # settle tracker onto A
+        console._session._sync_console_session_draft()  # settle tracker onto A
 
         for character in "hello":
             composer.insert_text(character)
@@ -538,7 +538,7 @@ async def test_console_undo_history_scoped_per_session_never_leaks():
 
         # Switch to a brand-new session B.
         session_b = store.create_session(title="Session B")
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert store.active_session_id == session_b.id
         assert composer.draft_text() == ""
 
@@ -554,7 +554,7 @@ async def test_console_undo_history_scoped_per_session_never_leaks():
 
         # Switch back to A: its original undo entry must still be intact.
         store.switch_session(session_a.id)
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert composer.draft_text() == "hello"
 
         console._console_composer_undo()
@@ -588,7 +588,7 @@ async def test_console_undo_during_switch_settle_window_does_not_apply_or_corrup
         composer.focus()
         await pilot.pause()
         composer.load_draft("")
-        console._sync_console_session_draft()  # settle tracker onto A
+        console._session._sync_console_session_draft()  # settle tracker onto A
 
         for character in "aaa-secret":
             composer.insert_text(character)
@@ -615,7 +615,7 @@ async def test_console_undo_during_switch_settle_window_does_not_apply_or_corrup
         # Now let the deferred swap actually run: A's real (untouched)
         # draft reaches the store as A's draft, and switching to B shows
         # B's own draft -- never A's leaked text.
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert store.session_draft(session_a.id) == "aaa-secret MORE"
         assert composer.draft_text() == "bbb-b-own-draft"
 
@@ -634,7 +634,7 @@ async def test_console_redo_during_switch_settle_window_does_not_apply():
         composer.focus()
         await pilot.pause()
         composer.load_draft("")
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
 
         composer.insert_text("x")
         composer.undo()  # arm the redo stack
@@ -707,14 +707,14 @@ async def test_console_background_dictation_drops_stale_session_history():
         composer.focus()
         await pilot.pause()
         composer.load_draft("")
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
 
         for character in "hello":
             composer.insert_text(character)
         assert composer.draft_text() == "hello"
 
         store.create_session(title="Session B")
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert composer.draft_text() == ""
 
         # Dictation finishes for A while B is visible -- the store-only branch.
@@ -724,7 +724,7 @@ async def test_console_background_dictation_drops_stale_session_history():
         assert store.session_draft(session_a.id) == "hello dictated words"
 
         store.switch_session(session_a.id)
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert composer.draft_text() == "hello dictated words"
 
         # Nothing to undo: the store-only mutation isn't recorded, and the
@@ -889,7 +889,7 @@ async def test_console_refused_send_preserves_undo_history(monkeypatch):
         composer.focus()
         await pilot.pause()
         composer.load_draft("")
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
 
         for character in "hello":
             composer.insert_text(character)
@@ -897,7 +897,7 @@ async def test_console_refused_send_preserves_undo_history(monkeypatch):
 
         # Switch away, banking A's history.
         store.create_session(title="Session B")
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert composer.draft_text() == ""
         assert session_a.id in console._console_undo_histories
 
@@ -916,7 +916,7 @@ async def test_console_refused_send_preserves_undo_history(monkeypatch):
         assert session_a.id in console._console_undo_histories
 
         store.switch_session(session_a.id)
-        console._sync_console_session_draft()
+        console._session._sync_console_session_draft()
         assert composer.draft_text() == "hello"
 
         console._console_composer_undo()

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -389,7 +389,7 @@ async def test_reverting_system_prompt_edit_with_ttl_remaining_returns_to_warm()
         )
         warm_until_before, _ = controller.cache_ttl_snapshot(session_id)
 
-        console._apply_console_session_system_prompt("You are a pirate.")
+        console._session._apply_console_session_system_prompt("You are a pirate.")
         await console._sync_native_console_chat_ui()
         await pilot.pause()
 
@@ -400,7 +400,7 @@ async def test_reverting_system_prompt_edit_with_ttl_remaining_returns_to_warm()
 
         # Revert to no override -- same session, no new send, no elapsed
         # clock beyond real test-execution time (well under the 300s TTL).
-        console._apply_console_session_system_prompt(None)
+        console._session._apply_console_session_system_prompt(None)
         await console._sync_native_console_chat_ui()
         await pilot.pause()
 
@@ -446,12 +446,12 @@ async def test_system_prompt_revert_after_genuine_ttl_lapse_still_reports_expire
             console, pilot
         )
 
-        console._apply_console_session_system_prompt("You are a pirate.")
+        console._session._apply_console_session_system_prompt("You are a pirate.")
         await console._sync_native_console_chat_ui()
         await pilot.pause()
         assert console._last_console_cost_state.alert is True
 
-        console._apply_console_session_system_prompt(None)
+        console._session._apply_console_session_system_prompt(None)
         # The deadline has genuinely lapsed by the time the revert is
         # observed -- e.g. a slow manual round trip through the editor
         # modal, exactly the real-world scenario the live verification hit.
@@ -718,7 +718,7 @@ async def test_cost_chip_state_isolated_across_session_tabs():
         console = host.screen_stack[-1]
         store = console._ensure_console_chat_store()
 
-        session_a = console._active_native_console_session()
+        session_a = console._session._active_native_console_session()
         assert session_a is not None
         await _send_and_settle(console, pilot, "hello", "priced on A")
         state_a = console._last_console_cost_state
@@ -733,15 +733,15 @@ async def test_cost_chip_state_isolated_across_session_tabs():
         # switch entry point -- proves restoring an EXISTING session's
         # state on the very first real activation isn't a ghost of
         # whatever the chip last happened to show.
-        await console._activate_native_console_session(session_a.id)
+        await console._session._activate_native_console_session(session_a.id)
         await pilot.pause()
-        assert console._active_native_console_session().id == session_a.id
+        assert console._session._active_native_console_session().id == session_a.id
         assert console._last_console_cost_state == state_a
 
         # Hop 2: A -> B -- the "switching TO B shows B's state" case.
-        await console._activate_native_console_session(session_b.id)
+        await console._session._activate_native_console_session(session_b.id)
         await pilot.pause()
-        assert console._active_native_console_session().id == session_b.id
+        assert console._session._active_native_console_session().id == session_b.id
         state_b = console._last_console_cost_state
         assert state_b is not None
         assert state_b != state_a
@@ -752,9 +752,9 @@ async def test_cost_chip_state_isolated_across_session_tabs():
         # Hop 3: B -> A again -- A's state must come back EXACTLY, not a
         # ghost of B's (e.g. a stale single shared memo instead of a
         # per-session one).
-        await console._activate_native_console_session(session_a.id)
+        await console._session._activate_native_console_session(session_a.id)
         await pilot.pause()
-        assert console._active_native_console_session().id == session_a.id
+        assert console._session._active_native_console_session().id == session_a.id
         assert console._last_console_cost_state == state_a
 
         # Fingerprint/revision memos are keyed per session and must not

--- a/Tests/UI/test_console_hands_free_wiring.py
+++ b/Tests/UI/test_console_hands_free_wiring.py
@@ -51,6 +51,7 @@ from tldw_chatbook.Chat.console_voice_input import (
     handsfree_send_delay_seconds as real_handsfree_send_delay_seconds,
     acoustic_barge_in_enabled as real_acoustic_barge_in_enabled,
 )
+from tldw_chatbook.UI.Console_Modules import hands_free as hands_free_module
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
 from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
 
@@ -195,7 +196,7 @@ class _HandsFreeReplyGateway(_ReadyResolutionGateway):
 def _fast_countdown(monkeypatch, seconds: float = 0.3) -> None:
     """Speed up the hands-free countdown so wiring tests don't wait 1.5s+."""
     monkeypatch.setattr(
-        chat_screen_module, "handsfree_send_delay_seconds", lambda: seconds
+        hands_free_module, "handsfree_send_delay_seconds", lambda: seconds
     )
 
 
@@ -688,7 +689,7 @@ async def test_spoken_send_mid_reply_acoustic_mode_ends_capture_and_exits(
         lambda self: fake,
     )
     monkeypatch.setattr(
-        chat_screen_module, "acoustic_barge_in_enabled", lambda: True
+        hands_free_module, "acoustic_barge_in_enabled", lambda: True
     )
     _, host = _ready_host()
 
@@ -706,7 +707,7 @@ async def test_spoken_send_mid_reply_acoustic_mode_ends_capture_and_exits(
         # (acoustic mode's own effect of `on_reply_started`), stubbing
         # `RequestStopAndSend`'s own wiring effect (a real V2 send) --
         # this test targets ONLY the mid-reply spoken-"send" reaction.
-        console._console_hands_free_request_stop_and_send = lambda: None
+        console._hands_free._console_hands_free_request_stop_and_send = lambda: None
         session.controller._begin_awaiting_reply()
         # `_begin_awaiting_reply()`'s own `CloseCapture` is real and async
         # -- `on_reply_started()`'s reopen must wait for it to actually
@@ -751,7 +752,7 @@ def test_silence_speech_posts_stop_unconditionally_even_with_nothing_in_flight()
         controller=object(), sequencer=fake_sequencer
     )
 
-    console._console_hands_free_silence_speech()
+    console._hands_free._console_hands_free_silence_speech()
 
     assert fake_sequencer.flush_calls == 1
     posted.assert_called_once()
@@ -791,7 +792,7 @@ async def test_keypress_in_speaking_silences_and_reopens_capture(monkeypatch):
         # keypress. `RequestStopAndSend`'s own wiring effect is stubbed so
         # this stays a pure unit test of the barge-in reaction, not a live
         # network send.
-        console._console_hands_free_request_stop_and_send = lambda: None
+        console._hands_free._console_hands_free_request_stop_and_send = lambda: None
         session.controller._begin_awaiting_reply()
         session.controller.on_reply_started()
         session.controller.on_first_utterance()
@@ -873,7 +874,7 @@ async def test_barge_in_and_esc_work_with_focus_off_the_composer(monkeypatch):
         console.action_toggle_console_hands_free()
         await _wait_for_mic_label(composer, pilot, "Rec ●")
         session = console._console_hands_free
-        console._console_hands_free_request_stop_and_send = lambda: None
+        console._hands_free._console_hands_free_request_stop_and_send = lambda: None
 
         def _drive_to_speaking() -> None:
             session.controller._begin_awaiting_reply()
@@ -943,7 +944,7 @@ async def test_hands_free_marshal_routes_off_thread_calls_through_call_from_thre
 
         def _from_background_thread() -> None:
             off_thread_id["id"] = threading.get_ident()
-            console._console_hands_free_marshal(_callback, "x", "y")
+            console._hands_free._console_hands_free_marshal(_callback, "x", "y")
 
         worker = threading.Thread(target=_from_background_thread)
         worker.start()
@@ -972,7 +973,7 @@ async def test_hands_free_marshal_calls_directly_when_already_on_ui_thread():
         console.app_instance.call_from_thread = marshal_calls
         direct_calls: list[tuple] = []
 
-        console._console_hands_free_marshal(
+        console._hands_free._console_hands_free_marshal(
             lambda a, b: direct_calls.append((a, b)), "x", "y"
         )
 
@@ -998,7 +999,7 @@ async def test_hands_free_marshal_fast_path_when_loop_is_off():
         console.app_instance.call_from_thread = marshal_calls
         direct_calls: list[tuple] = []
 
-        console._console_hands_free_marshal(
+        console._hands_free._console_hands_free_marshal(
             lambda a, b: direct_calls.append((a, b)), "x", "y"
         )
 
@@ -1031,7 +1032,7 @@ async def test_hands_free_marshal_swallows_call_from_thread_failure():
 
         def _from_background_thread() -> None:
             try:
-                console._console_hands_free_marshal(lambda: None)
+                console._hands_free._console_hands_free_marshal(lambda: None)
             except BaseException as exc:  # noqa: BLE001 - this IS the pin
                 raised.append(exc)
 
@@ -1067,7 +1068,7 @@ async def test_hands_free_marshal_swallows_a_raising_callback_on_the_ui_thread()
             # Called directly, on the UI thread (the test's own async
             # body -- no background thread involved), exercising the
             # UI-thread branch specifically.
-            console._console_hands_free_marshal(_raising_callback)
+            console._hands_free._console_hands_free_marshal(_raising_callback)
         except BaseException as exc:  # noqa: BLE001 - this IS the pin
             raised.append(exc)
 
@@ -1300,24 +1301,24 @@ async def test_reply_identity_same_session_new_id_claims_and_feeds():
         fed: list[str] = []
         session.sequencer.feed = fed.append
 
-        console._on_console_hands_free_delta(real.id, "first chunk. ")
+        console._hands_free._on_console_hands_free_delta(real.id, "first chunk. ")
         assert session.reply_id == real.id
         assert fed == ["first chunk. "]
 
-        console._on_console_hands_free_delta("stale-id", "must not feed")
+        console._hands_free._on_console_hands_free_delta("stale-id", "must not feed")
         assert fed == ["first chunk. "]
 
-        console._on_console_hands_free_delta(real.id, "second chunk. ")
+        console._hands_free._on_console_hands_free_delta(real.id, "second chunk. ")
         assert fed == ["first chunk. ", "second chunk. "]
 
         finished: list[Any] = []
         session.sequencer.reply_completed = lambda: finished.append("sequencer")
         session.controller.on_reply_finished = lambda: finished.append("controller")
 
-        console._on_console_hands_free_terminal("stale-id", False)
+        console._hands_free._on_console_hands_free_terminal("stale-id", False)
         assert finished == []
 
-        console._on_console_hands_free_terminal(real.id, False)
+        console._hands_free._on_console_hands_free_terminal(real.id, False)
         assert finished == ["sequencer", "controller"]
 
 
@@ -1352,7 +1353,7 @@ async def test_reply_identity_rejects_a_concurrent_background_session_reply():
         session.sequencer.feed = fed.append
 
         # The background session's reply id must not claim the slot.
-        console._on_console_hands_free_delta(
+        console._hands_free._on_console_hands_free_delta(
             background_reply.id, "Background tab reply here."
         )
         assert session.reply_id is None
@@ -1362,16 +1363,16 @@ async def test_reply_identity_rejects_a_concurrent_background_session_reply():
         real = store.append_message(
             sending_session_id, role=ConsoleMessageRole.ASSISTANT, content=""
         )
-        console._on_console_hands_free_delta(real.id, "Real reply here.")
+        console._hands_free._on_console_hands_free_delta(real.id, "Real reply here.")
         assert session.reply_id == real.id
         assert fed == ["Real reply here."]
 
         # The background reply's own completion must not resolve THIS turn.
         finished: list[Any] = []
         session.controller.on_reply_finished = lambda: finished.append("controller")
-        console._on_console_hands_free_terminal(background_reply.id, False)
+        console._hands_free._on_console_hands_free_terminal(background_reply.id, False)
         assert finished == []
-        console._on_console_hands_free_terminal(real.id, False)
+        console._hands_free._on_console_hands_free_terminal(real.id, False)
         assert finished == ["controller"]
 
 
@@ -1402,7 +1403,7 @@ async def test_reply_identity_rejects_a_stale_same_session_reply():
         )
         spoken: list[str] = []
         session.sequencer.feed = lambda text: spoken.append(text)
-        console._on_console_hands_free_delta(old_reply.id, "Old reply first sentence.")
+        console._hands_free._on_console_hands_free_delta(old_reply.id, "Old reply first sentence.")
         assert session.reply_id == old_reply.id
         assert spoken == ["Old reply first sentence."]
 
@@ -1418,7 +1419,7 @@ async def test_reply_identity_rejects_a_stale_same_session_reply():
 
         # The OLD reply's generation is still streaming its next sentence
         # -- this must NOT be claimed as turn 2's reply.
-        console._on_console_hands_free_delta(old_reply.id, "Old reply second sentence.")
+        console._hands_free._on_console_hands_free_delta(old_reply.id, "Old reply second sentence.")
         assert session.reply_id is None
         assert spoken == ["Old reply first sentence."]
 
@@ -1426,7 +1427,7 @@ async def test_reply_identity_rejects_a_stale_same_session_reply():
         new_reply = store.append_message(
             sending_session_id, role=ConsoleMessageRole.ASSISTANT, content=""
         )
-        console._on_console_hands_free_delta(new_reply.id, "New reply sentence.")
+        console._hands_free._on_console_hands_free_delta(new_reply.id, "New reply sentence.")
         assert session.reply_id == new_reply.id
         assert spoken == ["Old reply first sentence.", "New reply sentence."]
 
@@ -1491,13 +1492,13 @@ async def test_awaiting_reply_watchdog_disarms_at_row_creation_not_first_token()
         # completes the turn normally -- nothing was abandoned.
         fed: list[str] = []
         session.sequencer.feed = fed.append
-        console._on_console_hands_free_delta(real.id, "Finally, some text. ")
+        console._hands_free._on_console_hands_free_delta(real.id, "Finally, some text. ")
         assert fed == ["Finally, some text. "]
 
         finished: list[Any] = []
         session.sequencer.reply_completed = lambda: finished.append("sequencer")
         session.controller.on_reply_finished = lambda: finished.append("controller")
-        console._on_console_hands_free_terminal(real.id, False)
+        console._hands_free._on_console_hands_free_terminal(real.id, False)
         assert finished == ["sequencer", "controller"]
 
 
@@ -1524,7 +1525,7 @@ async def test_zero_content_reply_completion_still_completes_the_turn():
         session.sequencer.reply_completed = lambda: finished.append("sequencer")
         session.controller.on_reply_finished = lambda: finished.append("controller")
 
-        console._on_console_hands_free_terminal(real.id, False)
+        console._hands_free._on_console_hands_free_terminal(real.id, False)
 
         assert session.reply_id == real.id
         assert finished == ["sequencer", "controller"]
@@ -1560,7 +1561,7 @@ async def test_exit_loop_intent_emits_silence_and_close_capture_itself(monkeypat
         # Drive straight to `speaking`, stubbing `RequestStopAndSend`'s own
         # wiring effect (a real V2 send) -- this test targets ONLY the
         # `ExitLoop` handler's own teardown behavior.
-        console._console_hands_free_request_stop_and_send = lambda: None
+        console._hands_free._console_hands_free_request_stop_and_send = lambda: None
         session.controller._begin_awaiting_reply()
         session.controller.on_reply_started()
         session.controller.on_first_utterance()
@@ -1575,7 +1576,7 @@ async def test_exit_loop_intent_emits_silence_and_close_capture_itself(monkeypat
         post_message = Mock()
         console.app_instance.post_message = post_message
 
-        console._handle_console_hands_free_intent(ExitLoop())
+        console._hands_free._handle_console_hands_free_intent(ExitLoop())
 
         assert session.sequencer._inflight is False
         posted_actions = [
@@ -1605,15 +1606,15 @@ async def test_open_and_close_capture_handlers_are_idempotent_no_ops(monkeypatch
         assert console._console_dictation_state == "idle"
 
         # OpenCapture while idle starts; while ALREADY recording, no-op.
-        console._console_hands_free_open_capture()
+        console._hands_free._console_hands_free_open_capture()
         await _wait_for_mic_label(composer, pilot, "Rec ●")
-        console._console_hands_free_open_capture()
+        console._hands_free._console_hands_free_open_capture()
         await pilot.pause()
         assert fake.start_calls == 1
 
         # CloseCapture is a no-op unless genuinely `recording`.
         console._console_dictation_state = "idle"
-        console._console_hands_free_close_capture()
+        console._hands_free._console_hands_free_close_capture()
         await pilot.pause()
         assert fake.stop_calls == 0
 
@@ -1764,7 +1765,7 @@ async def test_deferred_capture_ended_is_dropped_for_a_replaced_loop():
         console._console_dictation_state = "recording"  # not idle -- blocks the poll
 
         task = asyncio.create_task(
-            console._deliver_console_hands_free_capture_ended(session_a, False)
+            console._hands_free._deliver_console_hands_free_capture_ended(session_a, False)
         )
         await asyncio.sleep(0)  # let the poll loop start and observe "not idle"
 
@@ -1791,7 +1792,7 @@ async def test_acoustic_barge_in_opens_capture_on_reply_started(monkeypatch):
         lambda self: fake,
     )
     monkeypatch.setattr(
-        chat_screen_module, "acoustic_barge_in_enabled", lambda: True
+        hands_free_module, "acoustic_barge_in_enabled", lambda: True
     )
     _, host = _ready_host()
 
@@ -1809,7 +1810,7 @@ async def test_acoustic_barge_in_opens_capture_on_reply_started(monkeypatch):
         # `RequestStopAndSend`'s own wiring effect is stubbed -- this test
         # targets ONLY acoustic mode's reopen-on-`on_reply_started` effect,
         # not a real V2 send. `CloseCapture` (real) still closes the mic.
-        console._console_hands_free_request_stop_and_send = lambda: None
+        console._hands_free._console_hands_free_request_stop_and_send = lambda: None
         session.controller._begin_awaiting_reply()
 
         deadline = time.monotonic() + _ASYNC_SETTLE_TIMEOUT

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -27,6 +27,7 @@ from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
 from tldw_chatbook.UI.Screens.artifacts_screen import ArtifactsScreen
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
@@ -1832,6 +1833,7 @@ def _bare_console_screen_for_restore(app_instance=None) -> ChatScreen:
     screen = ChatScreen.__new__(ChatScreen)
     screen.app_instance = app_instance
     screen._console_chat_store = ConsoleChatStore()
+    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._console_visible_draft_session_id = None
     screen._console_composer_or_none = lambda: None
     screen._task_resume_state = TaskResumeState()

--- a/Tests/UI/test_console_local_server_discovery_card.py
+++ b/Tests/UI/test_console_local_server_discovery_card.py
@@ -220,7 +220,7 @@ async def test_pressing_detected_server_saves_config_and_unlocks_card(
                 },
             }
         ]
-        settings = console._active_console_session_settings()
+        settings = console._session._active_console_session_settings()
         assert settings is not None
         assert settings.provider == "llama_cpp"
         assert settings.model == "srv-model-a"

--- a/Tests/UI/test_console_model_apply_chips.py
+++ b/Tests/UI/test_console_model_apply_chips.py
@@ -80,7 +80,7 @@ async def test_popover_apply_refreshes_the_provider_chip():
 
         await _wait_for(pilot, chip_text, "initial provider chip")
 
-        settings = chat_screen._ensure_active_console_session_settings()
+        settings = chat_screen._session._ensure_active_console_session_settings()
         chat_screen._apply_console_model_popover_result(
             replace(
                 settings,

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -59,6 +59,7 @@ from tldw_chatbook.UI.Screens.chat_screen import (
     ChatScreen,
 )
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
+from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
 from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
 from tldw_chatbook.Widgets.Console import (
@@ -214,7 +215,7 @@ def test_console_workspace_conversation_search_clear_button_stops_pending_timer(
 
 def test_console_workspace_conversation_search_selection_refresh_invalidates_token():
     source = inspect.getsource(
-        ChatScreen._refresh_console_workspace_conversation_search_after_selection
+        ConsoleWorkspaceController._refresh_console_workspace_conversation_search_after_selection
     )
     active_query_branch = source.split("if not query.strip():", 1)[1]
     before_refresh = active_query_branch.split(
@@ -1800,7 +1801,7 @@ def _console_conversation_browser_rows(console):
     always the dataclass default (``""``). Rebuilding the full context state
     is the seam that actually feeds the rendered row label.
     """
-    browser = console._build_console_workspace_context_state().conversation_browser
+    browser = console._workspace._build_console_workspace_context_state().conversation_browser
     rows = []
     for section in browser.sections:
         rows.extend(section.rows)
@@ -7988,7 +7989,7 @@ async def test_console_workspace_conversation_search_ignores_stale_workspace_res
         stale_token = console._console_workspace_conversation_search_token + 1
         console._console_workspace_conversation_search_token = stale_token
         service.set_active_workspace("ws-stale-b")
-        await console._refresh_console_workspace_conversation_search(
+        await console._workspace._refresh_console_workspace_conversation_search(
             active_workspace.workspace_id,
             "Alpha",
             stale_token,
@@ -8133,7 +8134,7 @@ async def test_console_workspace_conversation_search_uses_current_workspace_cont
         service.set_active_workspace("ws-search-b")
 
         assert (
-            console._active_console_workspace_id_for_conversation_search()
+            console._workspace._active_console_workspace_id_for_conversation_search()
             == "ws-search-b"
         )
 
@@ -8584,7 +8585,7 @@ async def test_console_resume_restores_server_character_identity_without_local_l
         console._resolve_resumed_character_name = local_lookup
 
         assert (
-            await console._resume_console_workspace_conversation("server-scoped")
+            await console._workspace._resume_console_workspace_conversation("server-scoped")
             is True
         )
         scoped = store.switch_session(store.active_session_id)
@@ -8598,7 +8599,7 @@ async def test_console_resume_restores_server_character_identity_without_local_l
         assert scoped.settings.character_label == ""
 
         assert (
-            await console._resume_console_workspace_conversation("server-unscoped")
+            await console._workspace._resume_console_workspace_conversation("server-unscoped")
             is True
         )
         unscoped = store.switch_session(store.active_session_id)
@@ -8612,7 +8613,7 @@ async def test_console_resume_restores_server_character_identity_without_local_l
         assert unscoped.settings.character_label == ""
 
         assert (
-            await console._resume_console_workspace_conversation(
+            await console._workspace._resume_console_workspace_conversation(
                 "malformed-local-scalars"
             )
             is True
@@ -8626,7 +8627,7 @@ async def test_console_resume_restores_server_character_identity_without_local_l
         assert malformed.character_ref() is None
 
         assert (
-            await console._resume_console_workspace_conversation(
+            await console._workspace._resume_console_workspace_conversation(
                 "noncanonical-local-id"
             )
             is True
@@ -8684,7 +8685,7 @@ async def test_console_resume_rejects_character_identity_without_valid_source(
         console._resolve_resumed_character_name = local_lookup
 
         assert (
-            await console._resume_console_workspace_conversation("invalid-source")
+            await console._workspace._resume_console_workspace_conversation("invalid-source")
             is True
         )
 
@@ -8729,7 +8730,7 @@ async def test_console_resume_rehydrates_local_character_name_from_local_project
         console._resolve_resumed_character_name = name_lookup
 
         assert (
-            await console._resume_console_workspace_conversation("local-character")
+            await console._workspace._resume_console_workspace_conversation("local-character")
             is True
         )
 
@@ -9075,7 +9076,7 @@ async def test_console_workspace_conversation_resume_hydrates_generation_metadat
             console = host.screen_stack[-1]
             await _wait_for_selector(console, pilot, "#console-native-transcript")
 
-            resumed = await console._resume_console_workspace_conversation(
+            resumed = await console._workspace._resume_console_workspace_conversation(
                 conversation_id
             )
             await pilot.pause()

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -59,6 +59,8 @@ from tldw_chatbook.UI.Screens.chat_screen import (
     ChatScreen,
 )
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
+import tldw_chatbook.UI.Console_Modules.session as session_module
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
 from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
@@ -2033,8 +2035,8 @@ def _select_llamacpp_console(console: ChatScreen) -> None:
     llama_settings.setdefault("model", "test-model")
     console._console_control_provider = "llama_cpp"
     console._console_control_model = "test-model"
-    settings = console._ensure_active_console_session_settings()
-    console._replace_active_console_session_settings(
+    settings = console._session._ensure_active_console_session_settings()
+    console._session._replace_active_console_session_settings(
         replace(
             settings,
             provider="llama_cpp",
@@ -2365,8 +2367,8 @@ def test_console_provider_selection_carries_active_session_system_prompt():
     app = _build_test_app()
     _configure_native_ready_console(app)
     screen = ChatScreen(app)
-    settings = screen._ensure_active_console_session_settings()
-    screen._replace_active_console_session_settings(
+    settings = screen._session._ensure_active_console_session_settings()
+    screen._session._replace_active_console_session_settings(
         replace(settings, system_prompt="Answer only in French.")
     )
 
@@ -4194,7 +4196,7 @@ def _handoff_chat_screen(monkeypatch, app, store: _CharacterHandoffStore) -> Cha
         lambda self: store,
     )
     monkeypatch.setattr(
-        ChatScreen,
+        ConsoleSessionController,
         "_default_console_session_settings",
         lambda self: ConsoleSessionSettings(
             provider="anthropic",
@@ -4217,7 +4219,7 @@ def _handoff_chat_screen(monkeypatch, app, store: _CharacterHandoffStore) -> Cha
 async def _run_character_handoff(monkeypatch, runtime, payload):
     store = _CharacterHandoffStore()
     screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
-    started = await screen._start_character_console_session(payload)
+    started = await screen._session._start_character_console_session(payload)
     return started, store
 
 
@@ -4242,7 +4244,7 @@ def test_character_start_handoff_requires_exact_coherent_envelope(
     payload = _character_start_handoff()
     setattr(payload, field, value)
 
-    assert chat_screen_module._character_session_identity_from_handoff(payload) is None
+    assert session_module._character_session_identity_from_handoff(payload) is None
 
 
 @pytest.mark.parametrize(
@@ -4261,7 +4263,7 @@ def test_character_start_handoff_requires_exact_coherent_metadata(
     payload = _character_start_handoff()
     payload.metadata[metadata_key] = value
 
-    assert chat_screen_module._character_session_identity_from_handoff(payload) is None
+    assert session_module._character_session_identity_from_handoff(payload) is None
 
 
 @pytest.mark.parametrize(
@@ -4285,7 +4287,7 @@ def test_character_start_handoff_requires_canonical_positive_numeric_wire_id(
 ):
     payload = _character_start_handoff(character_id=character_id)
 
-    assert chat_screen_module._character_session_identity_from_handoff(payload) is None
+    assert session_module._character_session_identity_from_handoff(payload) is None
 
 
 @pytest.mark.parametrize(
@@ -4304,7 +4306,7 @@ def test_character_start_handoff_requires_matching_record_and_target_ids(
     payload.metadata["selected_record_id"] = record_id
     payload.metadata["selected_target_id"] = target_id
 
-    assert chat_screen_module._character_session_identity_from_handoff(payload) is None
+    assert session_module._character_session_identity_from_handoff(payload) is None
 
 
 @pytest.mark.asyncio
@@ -4776,11 +4778,11 @@ async def test_server_authenticated_context_change_immediately_before_commit_abo
         )
 
     monkeypatch.setattr(
-        screen,
+        screen._session,
         "_default_console_session_settings",
         _settings_then_change_context,
     )
-    started = await screen._start_character_console_session(
+    started = await screen._session._start_character_console_session(
         _character_start_handoff(
             runtime_backend="server",
             active_server_profile_id=expected_server_id,
@@ -9571,6 +9573,19 @@ def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
     """
     screen = ChatScreen.__new__(ChatScreen)
     screen._console_chat_store = store
+    # A bare, uninitialized `ConsoleSessionController` -- `__init__` was
+    # never run, so every OTHER dependency is unset by default. Only the
+    # two chat-store accessors are wired (reading back `screen._console_
+    # chat_store`, which several tests using this helper reassign later):
+    # `_console_session_to_state`/`_console_session_from_state` (this
+    # helper's original whole point) tolerate a missing accessor via their
+    # own `getattr`/staticmethod shape, but sibling staying methods this
+    # file also drives through a bare screen (e.g. `_current_console_rail_
+    # character_id` -> `_active_native_console_session`) read `self.
+    # _console_chat_store` directly, with no such tolerance.
+    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
+    screen._session._chat_store_accessor = lambda: screen._console_chat_store
+    screen._session._current_chat_store_accessor = lambda: screen._console_chat_store
     screen._console_visible_draft_session_id = None
     screen._console_composer_or_none = lambda: None
     screen._task_resume_state = TaskResumeState()
@@ -10089,7 +10104,7 @@ async def test_console_setup_modal_retains_collapsed_layout_and_restores_expand_
         await pilot.pause()
 
         _configure_openai_missing_api_key(app)
-        console._replace_active_console_session_settings(
+        console._session._replace_active_console_session_settings(
             ConsoleSessionSettings(
                 provider="openai",
                 model="gpt-4o",
@@ -10108,7 +10123,7 @@ async def test_console_setup_modal_retains_collapsed_layout_and_restores_expand_
         assert console.check_action("expand_collapsed_console_composer", ()) is False
 
         _configure_native_ready_console(app)
-        console._replace_active_console_session_settings(
+        console._session._replace_active_console_session_settings(
             ConsoleSessionSettings(
                 provider="llama_cpp",
                 model="local-model",
@@ -11549,25 +11564,26 @@ def test_console_screen_state_round_trips_the_temporary_flag():
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
+    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
 
     # A REAL round trip: the serializer's own output feeds the restorer.
     # Asserting on a hand-built dict would test neither half.
     temporary = ConsoleChatSession(title="Temporary chat", ephemeral=True)
-    payload = screen._console_session_to_state(temporary)
+    payload = screen._session._console_session_to_state(temporary)
     assert payload["ephemeral"] is True
-    assert screen._console_session_from_state(payload).ephemeral is True
+    assert screen._session._console_session_from_state(payload).ephemeral is True
 
     normal = ConsoleChatSession(title="Normal chat")
     assert (
-        screen._console_session_from_state(
-            screen._console_session_to_state(normal)
+        screen._session._console_session_from_state(
+            screen._session._console_session_to_state(normal)
         ).ephemeral
         is False
     )
 
     # Legacy payloads predate the key entirely.
     assert (
-        screen._console_session_from_state(
+        screen._session._console_session_from_state(
             {"id": normal.id, "title": normal.title}
         ).ephemeral
         is False

--- a/Tests/UI/test_console_new_workspace.py
+++ b/Tests/UI/test_console_new_workspace.py
@@ -97,7 +97,7 @@ async def test_browser_row_click_announces_workspace_switch() -> None:
             (str(message), kwargs)
         )
 
-        console._activate_console_workspace_for_browser_row(
+        console._workspace._activate_console_workspace_for_browser_row(
             _row("workspace-local-9", "Workspace 9")
         )
         messages = [message for message, _ in notifications]
@@ -107,7 +107,7 @@ async def test_browser_row_click_announces_workspace_switch() -> None:
 
         # A row already in the active workspace must not re-announce.
         notifications.clear()
-        console._activate_console_workspace_for_browser_row(
+        console._workspace._activate_console_workspace_for_browser_row(
             _row("workspace-local-9", "Workspace 9")
         )
         assert notifications == []

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -461,12 +461,14 @@ def test_source_scope_survives_a_screen_state_round_trip():
         ConsoleChatSession,
         ConsoleChatStore,
     )
+    from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
     from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 
     def _bare_screen(store: ConsoleChatStore) -> ChatScreen:
         screen = ChatScreen.__new__(ChatScreen)
         screen._console_chat_store = store
+        screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
         screen._console_visible_draft_session_id = None
         screen._console_composer_or_none = lambda: None
         screen._task_resume_state = TaskResumeState()

--- a/Tests/UI/test_console_realtime_wiring.py
+++ b/Tests/UI/test_console_realtime_wiring.py
@@ -40,6 +40,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
 
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.message_metadata import MessageMetadata
+from tldw_chatbook.UI.Console_Modules import hands_free as hands_free_module
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
 from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
 
@@ -343,12 +344,25 @@ def _patch_realtime_config(
     `api_key` included: the wiring refuses to dispatch a connect without
     one (there is nothing to authenticate with), so every mounted test
     needs a configured key even though the injected session never uses it.
+
+    `resolve_handsfree_engine`/`realtime_enabled` are pinned on `hands_free_
+    module`, not `chat_screen_module`: the engine fork that reads them moved
+    to `ConsoleHandsFreeController` (wave-2 console decomposition, task 1),
+    and it holds its own separate copy of this import -- pinning only
+    `chat_screen_module`'s (now nonexistent) copy would silently stop
+    governing the fork's actual behaviour. `acoustic_barge_in_enabled` is
+    pinned on BOTH modules: the realtime engine's own `_enter_console_
+    realtime_loop` reads `chat_screen_module`'s copy, and a pipeline
+    fallback (`_console_realtime_fallback_to_pipeline` -> `Console
+    HandsFreeController._enter_console_hands_free_pipeline_loop`) reads
+    `hands_free_module`'s separate copy -- a test exercising the fallback
+    path needs both to agree.
     """
     monkeypatch.setattr(chat_screen_module, "get_api_key", lambda _name: api_key)
     monkeypatch.setattr(
-        chat_screen_module, "resolve_handsfree_engine", lambda: engine
+        hands_free_module, "resolve_handsfree_engine", lambda: engine
     )
-    monkeypatch.setattr(chat_screen_module, "realtime_enabled", lambda: enabled)
+    monkeypatch.setattr(hands_free_module, "realtime_enabled", lambda: enabled)
     monkeypatch.setattr(chat_screen_module, "realtime_provider", lambda: provider)
     monkeypatch.setattr(chat_screen_module, "realtime_model", lambda: "gpt-realtime")
     monkeypatch.setattr(chat_screen_module, "realtime_voice", lambda: "marin")
@@ -359,6 +373,9 @@ def _patch_realtime_config(
     )
     monkeypatch.setattr(
         chat_screen_module, "acoustic_barge_in_enabled", lambda: acoustic
+    )
+    monkeypatch.setattr(
+        hands_free_module, "acoustic_barge_in_enabled", lambda: acoustic
     )
 
 
@@ -1594,13 +1611,13 @@ async def test_double_failure_toast_carries_the_install_remedy(monkeypatch):
     and the toast that reports it is the only place the user sees it."""
     _patch_realtime_config(monkeypatch)
     monkeypatch.setattr(
-        chat_screen_module.console_voice_input,
+        hands_free_module.console_voice_input,
         "probe",
-        lambda: chat_screen_module.console_voice_input.Availability(
+        lambda: hands_free_module.console_voice_input.Availability(
             ok=False,
             kind="missing-capture",
-            reason=chat_screen_module.console_voice_input.CAPTURE_REASON,
-            remedy=chat_screen_module.console_voice_input.CAPTURE_REMEDY,
+            reason=hands_free_module.console_voice_input.CAPTURE_REASON,
+            remedy=hands_free_module.console_voice_input.CAPTURE_REMEDY,
         ),
     )
     app = _build_test_app()
@@ -1675,9 +1692,9 @@ async def test_realtime_lifecycle_is_persistently_logged(monkeypatch):
     connect-failure must both be reconstructable from the log alone."""
     _patch_realtime_config(monkeypatch)
     monkeypatch.setattr(
-        chat_screen_module.console_voice_input,
+        hands_free_module.console_voice_input,
         "probe",
-        lambda: chat_screen_module.console_voice_input.Availability(
+        lambda: hands_free_module.console_voice_input.Availability(
             ok=False, kind="missing-capture", reason="No microphone.", remedy=""
         ),
     )
@@ -1869,9 +1886,9 @@ async def test_close_before_ready_fails_the_connect_instead_of_hanging(monkeypat
     """
     _patch_realtime_config(monkeypatch)
     monkeypatch.setattr(
-        chat_screen_module.console_voice_input,
+        hands_free_module.console_voice_input,
         "probe",
-        lambda: chat_screen_module.console_voice_input.Availability(
+        lambda: hands_free_module.console_voice_input.Availability(
             ok=False, kind="missing-capture", reason="No microphone.", remedy=""
         ),
     )
@@ -1916,9 +1933,9 @@ async def test_error_before_ready_fails_the_connect(monkeypatch):
     ends the dead entry a beat sooner -- and with the same reason."""
     _patch_realtime_config(monkeypatch)
     monkeypatch.setattr(
-        chat_screen_module.console_voice_input,
+        hands_free_module.console_voice_input,
         "probe",
-        lambda: chat_screen_module.console_voice_input.Availability(
+        lambda: hands_free_module.console_voice_input.Availability(
             ok=False, kind="missing-capture", reason="No microphone.", remedy=""
         ),
     )
@@ -1950,9 +1967,9 @@ async def test_ready_that_never_arrives_times_out_instead_of_hanging(monkeypatch
         chat_screen_module, "CONSOLE_REALTIME_READY_TIMEOUT_SECONDS", 0.05
     )
     monkeypatch.setattr(
-        chat_screen_module.console_voice_input,
+        hands_free_module.console_voice_input,
         "probe",
-        lambda: chat_screen_module.console_voice_input.Availability(
+        lambda: hands_free_module.console_voice_input.Availability(
             ok=False, kind="missing-capture", reason="No microphone.", remedy=""
         ),
     )

--- a/Tests/UI/test_console_rename_persistence.py
+++ b/Tests/UI/test_console_rename_persistence.py
@@ -53,7 +53,7 @@ async def test_rename_modal_persists_saved_conversation_title():
             active_leaf_persisted_id=None,
         )
 
-        console._open_console_session_rename_modal(session.id)
+        console._session._open_console_session_rename_modal(session.id)
         await pilot.pause()
         modal = host.screen_stack[-1]
         assert isinstance(modal, ConsoleRenameSessionModal)

--- a/Tests/UI/test_console_scope_row.py
+++ b/Tests/UI/test_console_scope_row.py
@@ -703,7 +703,7 @@ async def test_resume_console_workspace_conversation_refreshes_row_and_chip():
             )
             assert console.query_one(f"#{SCOPE_CHIP_ID}").display is False
 
-            resumed = await console._resume_console_workspace_conversation(
+            resumed = await console._workspace._resume_console_workspace_conversation(
                 conversation_id
             )
             await pilot.pause()
@@ -778,7 +778,7 @@ async def test_initial_mount_of_restored_persisted_scoped_session_warms_row_and_
         saved_state: dict | None = None
         async with host.run_test(size=(240, 64)) as pilot:
             console = host.screen_stack[-1]
-            resumed = await console._resume_console_workspace_conversation(
+            resumed = await console._workspace._resume_console_workspace_conversation(
                 conversation_id
             )
             assert resumed is True
@@ -1096,7 +1096,7 @@ async def test_workspace_rag_scope_save_persists_via_registry():
             items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"
         )
 
-        await console._apply_console_workspace_scope_save(active.workspace_id, scope)
+        await console._workspace._apply_console_workspace_scope_save(active.workspace_id, scope)
         await pilot.pause()
 
         assert registry.get_workspace_scope(active.workspace_id) == scope
@@ -1124,7 +1124,7 @@ async def test_workspace_rag_scope_save_catches_workspace_not_found():
             items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"
         )
 
-        await console._apply_console_workspace_scope_save("workspace-default", scope)
+        await console._workspace._apply_console_workspace_scope_save("workspace-default", scope)
         await pilot.pause()
 
         assert notifications, "expected an honest notify on WorkspaceNotFound"

--- a/Tests/UI/test_console_scope_row.py
+++ b/Tests/UI/test_console_scope_row.py
@@ -171,7 +171,7 @@ async def test_retrieval_scope_row_reflects_held_scope_for_unpersisted_session()
         console = host.screen_stack[-1]
         row = await _open_inspector_and_get_row(console, pilot)
 
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         assert session is not None
         session.rag_scope_holder.set(
             RagScope(
@@ -216,7 +216,7 @@ async def test_retrieval_scope_row_zero_db_on_forced_recompose():
         assert _static_plain_text(row.query_one(f"#{LABEL_ID}", Static)) == "Scope: everything"
         assert console.query_one(f"#{SCOPE_CHIP_ID}").display is False
 
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         session.persisted_conversation_id = "conv-not-cached"
         raising_db = _RaisingDB()
         app.chachanotes_db = raising_db
@@ -320,7 +320,7 @@ async def test_edit_button_seeds_modal_from_held_scope():
     async with host.run_test(size=(240, 64)) as pilot:
         console = host.screen_stack[-1]
         await _open_inspector_and_get_row(console, pilot)
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         session.rag_scope_holder.set(
             RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z")
         )
@@ -346,7 +346,7 @@ async def test_save_unpersisted_stores_in_holder_and_refreshes_row():
     async with host.run_test(size=(240, 64)) as pilot:
         console = host.screen_stack[-1]
         row = await _open_inspector_and_get_row(console, pilot)
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         assert session.persisted_conversation_id is None
         scope = RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z")
 
@@ -386,7 +386,7 @@ async def test_scope_saved_unpersisted_then_first_send_flush_refreshes_row():
             console = host.screen_stack[-1]
             row = await _open_inspector_and_get_row(console, pilot)
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             assert session.persisted_conversation_id is None
             scope = RagScope(
                 items=(ScopeItem("media", "m1"), ScopeItem("note", note_id)),
@@ -440,7 +440,7 @@ async def test_save_persisted_writes_through_refreshes_row_and_run_recipe():
             console = host.screen_stack[-1]
             await _open_inspector_and_get_row(console, pilot)
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             conversation_id = store.persist_session_if_needed(session.id)
             assert conversation_id is not None
             scope = RagScope(
@@ -475,7 +475,7 @@ async def test_save_persisted_corrupt_metadata_surfaces_honest_notify():
             console = host.screen_stack[-1]
             await _open_inspector_and_get_row(console, pilot)
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             conversation_id = store.persist_session_if_needed(session.id)
             record = db.get_conversation_by_id(conversation_id)
             db.update_conversation(
@@ -524,7 +524,7 @@ async def test_save_persisted_conflict_error_surfaces_specific_notify():
             console = host.screen_stack[-1]
             await _open_inspector_and_get_row(console, pilot)
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             conversation_id = store.persist_session_if_needed(session.id)
 
             def _raise_conflict(*args, **kwargs):
@@ -565,7 +565,7 @@ async def test_save_persisted_conversation_not_found_surfaces_specific_notify():
             console = host.screen_stack[-1]
             await _open_inspector_and_get_row(console, pilot)
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             conversation_id = store.persist_session_if_needed(session.id)
             db.soft_delete_conversation(conversation_id, expected_version=1)
             scope = RagScope(
@@ -590,7 +590,7 @@ async def test_clear_button_unpersisted_session():
     async with host.run_test(size=(240, 64)) as pilot:
         console = host.screen_stack[-1]
         row = await _open_inspector_and_get_row(console, pilot)
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         session.rag_scope_holder.set(
             RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z")
         )
@@ -620,7 +620,7 @@ async def test_clear_button_persisted_session():
             console = host.screen_stack[-1]
             await _open_inspector_and_get_row(console, pilot)
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             conversation_id = store.persist_session_if_needed(session.id)
             scope = RagScope(
                 items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"
@@ -709,7 +709,7 @@ async def test_resume_console_workspace_conversation_refreshes_row_and_chip():
             await pilot.pause()
 
             assert resumed is True
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             assert session is not None
             assert session.persisted_conversation_id == conversation_id
 
@@ -792,7 +792,7 @@ async def test_initial_mount_of_restored_persisted_scoped_session_warms_row_and_
             console = restored_host.screen_stack[-1]
             await _wait_for_selector(console, pilot, "#console-native-composer")
 
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             assert session is not None
             assert session.persisted_conversation_id == conversation_id
 
@@ -849,7 +849,7 @@ async def test_scope_chip_shows_count_and_tooltip_when_scoped():
         console = host.screen_stack[-1]
         await _open_console_inspector(console, pilot)
 
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         assert session is not None
         session.rag_scope_holder.set(
             RagScope(
@@ -879,7 +879,7 @@ async def test_scope_chip_refreshes_on_modal_save():
     async with host.run_test(size=(240, 64)) as pilot:
         console = host.screen_stack[-1]
         await _open_console_inspector(console, pilot)
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         assert session.persisted_conversation_id is None
         scope = RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z")
 
@@ -908,7 +908,7 @@ async def test_scope_chip_refreshes_on_persist_transition_flush():
             console = host.screen_stack[-1]
             await _open_console_inspector(console, pilot)
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             scope = RagScope(
                 items=(ScopeItem("media", "m1"), ScopeItem("note", note_id)),
                 updated_at="2026-01-01T00:00:00Z",
@@ -948,7 +948,7 @@ async def test_scope_chip_click_opens_picker_modal():
     async with host.run_test(size=(240, 64)) as pilot:
         console = host.screen_stack[-1]
         await _open_console_inspector(console, pilot)
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         session.rag_scope_holder.set(
             RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z")
         )
@@ -1190,7 +1190,7 @@ async def test_chip_tooltip_shows_intersection_breakdown_when_both_levels_set():
                 ),
             )
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             store.persist_session_if_needed(session.id)
             conv_scope = RagScope(
                 items=(ScopeItem("media", "m1"), ScopeItem("note", note_id)),
@@ -1225,7 +1225,7 @@ async def test_chip_tooltip_shows_workspace_only_breakdown():
             active.workspace_id,
             RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"),
         )
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
 
         await console._resolve_console_effective_scope_state(session)
         console._sync_console_retrieval_scope_row()
@@ -1261,7 +1261,7 @@ async def test_no_workspace_overlap_renders_empty_state_on_row_and_chip():
                 ),
             )
             store = console._ensure_console_chat_store()
-            session = console._active_native_console_session()
+            session = console._session._active_native_console_session()
             store.persist_session_if_needed(session.id)
             conv_scope = RagScope(
                 items=(ScopeItem("media", "m-conv"),), updated_at="2026-01-01T00:00:00Z"
@@ -1312,7 +1312,7 @@ async def test_switch_between_resumed_sessions_refreshes_stale_workspace_scope()
         active = registry.get_active_workspace()
         store = console._ensure_console_chat_store()
 
-        first_session = console._active_native_console_session()
+        first_session = console._session._active_native_console_session()
         assert first_session is not None
         second_session = store.create_session(title="Second")
         assert second_session.workspace_id == first_session.workspace_id
@@ -1346,10 +1346,10 @@ async def test_switch_between_resumed_sessions_refreshes_stale_workspace_scope()
             ),
         )
 
-        await console._activate_native_console_session(first_session.id)
+        await console._session._activate_native_console_session(first_session.id)
         await pilot.pause()
 
-        assert console._active_native_console_session().id == first_session.id
+        assert console._session._active_native_console_session().id == first_session.id
         row = console.query_one(f"#{ROW_ID}")
         assert (
             _static_plain_text(row.query_one(f"#{LABEL_ID}", Static))

--- a/Tests/UI/test_console_session_controller.py
+++ b/Tests/UI/test_console_session_controller.py
@@ -1,0 +1,416 @@
+"""Characterisation tests for the Console session cluster, written BEFORE the
+wave-2 Task 3 extraction of `ConsoleSessionController`
+(`tldw_chatbook/UI/Console_Modules/session.py`) lands.
+
+Drives `_activate_native_console_session`, `_apply_console_switcher_choice`,
+and `_promote_console_temporary_session` through REAL interactions against
+the still-monolithic `ChatScreen` -- the same "real production coroutine, not
+a rebuilt double" discipline `test_console_native_chat_flow.py`'s own resume
+coverage and `test_console_workspace_controller.py` (wave-2 Task 2's own
+characterisation file) use. No method under test is monkeypatched.
+
+Two things this file exists specifically to pin, per the wave-2 Task 3 brief:
+
+1. **Session activation's workspace-alignment seam**
+   (`_activate_native_console_session` -> `_set_active_workspace_for_console_
+   session`, which after the extraction becomes a session-controller ->
+   workspace-controller named-callable call): activating a session that
+   belongs to a DIFFERENT workspace than the currently active one must also
+   switch the active workspace. Existing coverage
+   (`test_console_cost_chip_screen.py::test_cost_chip_state_isolated_across_
+   session_tabs`, `test_console_agent_rail.py::test_activate_native_console_
+   session_clears_stale_drilldown`, `test_console_scope_row.py`) exercises the
+   SAME entry point but never with two DIFFERENT workspaces in play, so none
+   of it would catch a snapshot-vs-live binding bug in that one call.
+2. **Temporary-session promotion writes a DURABLE database row.** Every
+   existing `_promote_console_temporary_session` test
+   (`Tests/UI/test_console_composer_menu.py`) stubs `store.
+   promote_ephemeral_session` outright and asserts only chip/widget state --
+   none of them ever let a real write reach `chachanotes_db`. The brief is
+   explicit: assert the DATABASE, not widget state.
+
+Method calls below (`console._activate_native_console_session(...)`,
+`console._promote_console_temporary_session()`,
+`console._apply_console_switcher_choice(...)`, etc.) move to
+`console._session.<method>(...)` once the extraction lands.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_switcher_state import ConsoleSwitcherEntry
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Widgets.Console.console_rename_session_modal import (
+    ConsoleRenameSessionModal,
+)
+from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (
+    ConsoleSwitcherChoice,
+)
+
+
+def _real_chachanotes_db(tmp_path) -> CharactersRAGDB:
+    """A real (temp-file-backed) ChaChaNotes DB.
+
+    `_build_test_app` deliberately leaves `app.chachanotes_db` unset (its
+    `notes_service` is faked with no real `.db`) -- fine for the vast
+    majority of Console tests, which never touch persistence, but exactly
+    the gap the promotion tests below exist to close. Assigned to
+    `app.chachanotes_db` BEFORE the screen mounts: `_ensure_console_chat_
+    store` reads it lazily on first call and memoizes the result, so
+    setting it any later would be silently ignored.
+    """
+    return CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+
+
+def _switcher_entry(
+    *,
+    native_session_id: str | None = None,
+    conversation_id: str | None = None,
+    row_key: str = "row",
+    title: str = "Entry",
+    scope_type: str = "workspace",
+    workspace_id: str | None = None,
+    is_active: bool = False,
+) -> ConsoleSwitcherEntry:
+    return ConsoleSwitcherEntry(
+        row_key=row_key,
+        title=title,
+        subtitle="",
+        native_session_id=native_session_id,
+        conversation_id=conversation_id,
+        scope_type=scope_type,
+        workspace_id=workspace_id,
+        is_active=is_active,
+    )
+
+
+# -- Session activation: workspace-alignment seam ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_activate_native_console_session_realigns_active_workspace():
+    """Activating a session in a DIFFERENT workspace switches the active one.
+
+    This is the one call `_activate_native_console_session` makes into the
+    workspace cluster (`_set_active_workspace_for_console_session`) --
+    exactly the seam the wave-2 Task 3 brief calls out as needing a deliberate
+    named callable between the session and workspace controllers rather than
+    a screen back-door. Two real workspaces, two real sessions, one real
+    registry service.
+    """
+    app = _build_test_app()
+    registry_service = app.workspace_registry_service
+    default_workspace = registry_service.get_active_workspace()
+    registry_service.create_workspace(
+        workspace_id="ws-other",
+        name="Other workspace",
+        description="Second workspace for the activation test.",
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        store = console._ensure_console_chat_store()
+        home_session = console._active_native_console_session()
+        assert home_session is not None
+        assert registry_service.get_active_workspace().workspace_id == (
+            default_workspace.workspace_id
+        )
+
+        # `create_session` activates what it creates (same trap
+        # `test_cost_chip_state_isolated_across_session_tabs` documents), so
+        # right after this call `other_session` -- not `home_session` -- is
+        # the active one and the active workspace has already followed it
+        # via THIS call's own real-time context sync. The two real
+        # transitions this test needs both go through the shared entry
+        # point below: hop back home first, THEN hop to `other_session`, so
+        # the interesting assertion is against a genuine activation call,
+        # not residue from creation.
+        other_session = store.create_session(
+            title="Other workspace chat", workspace_id="ws-other"
+        )
+        assert other_session.workspace_id == "ws-other"
+        assert store.active_session_id == other_session.id
+
+        await console._activate_native_console_session(home_session.id)
+        await pilot.pause()
+        assert store.active_session_id == home_session.id
+        assert registry_service.get_active_workspace().workspace_id == (
+            default_workspace.workspace_id
+        )
+
+        await console._activate_native_console_session(other_session.id)
+        await pilot.pause()
+
+        assert store.active_session_id == other_session.id
+        assert registry_service.get_active_workspace().workspace_id == "ws-other"
+
+        # Hop back: the home session's own workspace must be restored too,
+        # not just left on "ws-other" because nothing re-checks it.
+        await console._activate_native_console_session(home_session.id)
+        await pilot.pause()
+
+        assert store.active_session_id == home_session.id
+        assert registry_service.get_active_workspace().workspace_id == (
+            default_workspace.workspace_id
+        )
+
+
+@pytest.mark.asyncio
+async def test_activate_native_console_session_noop_still_focuses_composer(
+    monkeypatch,
+):
+    """Activating the ALREADY-active session skips the switch but still
+    calls the composer-focus step (the guard is `store.active_session_id !=
+    session_id`, not an early return from the whole method) -- spies on the
+    dependency rather than asserting real Textual focus state, which is not
+    reliable to observe headlessly for this compound widget."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        session = console._active_native_console_session()
+        assert session is not None
+
+        focus_calls: list[bool] = []
+        real_focus = type(console)._focus_console_composer_if_needed
+
+        def _spy_focus(self, *, force: bool = False) -> None:
+            focus_calls.append(force)
+            return real_focus(self, force=force)
+
+        monkeypatch.setattr(
+            type(console), "_focus_console_composer_if_needed", _spy_focus
+        )
+
+        await console._activate_native_console_session(session.id)
+        await pilot.pause()
+
+        assert console._active_native_console_session().id == session.id
+        assert focus_calls == [True]
+
+
+# -- Ctrl+K switcher callback (`_apply_console_switcher_choice`) ------------
+
+
+@pytest.mark.asyncio
+async def test_apply_console_switcher_choice_activate_uses_shared_activation_path():
+    """The switcher's "activate" result reaches the same shared entry point
+    as the tab click / Alt+1..9 -- verified here through a real workspace
+    switch, not just an active-session-id flip."""
+    app = _build_test_app()
+    registry_service = app.workspace_registry_service
+    registry_service.create_workspace(
+        workspace_id="ws-switcher",
+        name="Switcher workspace",
+        description="Workspace for the switcher-choice test.",
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        store = console._ensure_console_chat_store()
+        home = console._active_native_console_session()
+        assert home is not None
+        target = store.create_session(
+            title="Switcher target", workspace_id="ws-switcher"
+        )
+        assert home.id != target.id
+        # `create_session` activates what it creates -- go back home first so
+        # the switcher choice below is a real transition, not a no-op.
+        await console._activate_native_console_session(home.id)
+        await pilot.pause()
+        assert store.active_session_id == home.id
+
+        choice = ConsoleSwitcherChoice(
+            kind="activate",
+            entry=_switcher_entry(native_session_id=target.id, title=target.title),
+        )
+        await console._apply_console_switcher_choice(choice)
+        await pilot.pause()
+
+        assert store.active_session_id == target.id
+        assert registry_service.get_active_workspace().workspace_id == (
+            "ws-switcher"
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_console_switcher_choice_rename_opens_rename_modal():
+    """The switcher's "rename" result opens the rename modal for that tab,
+    seeded with its CURRENT title."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        store = console._ensure_console_chat_store()
+        session = store.create_session(title="Rename me")
+
+        choice = ConsoleSwitcherChoice(
+            kind="rename",
+            entry=_switcher_entry(native_session_id=session.id, title=session.title),
+        )
+        await console._apply_console_switcher_choice(choice)
+        await pilot.pause()
+
+        top = host.screen_stack[-1]
+        assert isinstance(top, ConsoleRenameSessionModal)
+        assert top._title == "Rename me"
+
+
+@pytest.mark.asyncio
+async def test_apply_console_switcher_choice_none_is_a_noop():
+    """A cancelled switcher (`choice is None`) leaves the active session and
+    screen stack untouched."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        store = console._ensure_console_chat_store()
+        active_before = store.active_session_id
+        depth_before = len(host.screen_stack)
+
+        await console._apply_console_switcher_choice(None)
+        await pilot.pause()
+
+        assert store.active_session_id == active_before
+        assert len(host.screen_stack) == depth_before
+
+
+# -- Temporary-session promotion: assert the DATABASE, not widget state -----
+
+
+@pytest.mark.asyncio
+async def test_promote_console_temporary_session_writes_durable_rows_to_the_database(
+    tmp_path,
+):
+    """Saving a temporary chat must produce a REAL, readable conversation row
+    (and its messages) in `chachanotes_db` -- not just an in-memory flag flip.
+
+    Every existing `_promote_console_temporary_session` test
+    (`test_console_composer_menu.py`) stubs the store's own
+    `promote_ephemeral_session` and only asserts chip/notification state;
+    none of them let a write reach a real database. This is the gap the
+    wave-2 Task 3 brief calls out by name.
+    """
+    app = _build_test_app()
+    db = _real_chachanotes_db(tmp_path)
+    app.chachanotes_db = db
+    host = ConsoleHarness(app)
+
+    try:
+        async with host.run_test(size=(160, 44)) as pilot:
+            console = host.screen_stack[-1]
+            await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+            store = console._ensure_console_chat_store()
+            session = store.create_session(title="Temp chat to save", ephemeral=True)
+            store.switch_session(session.id)
+            store.append_message(
+                session.id, role=ConsoleMessageRole.USER, content="hello", persist=True
+            )
+            store.append_message(
+                session.id,
+                role=ConsoleMessageRole.ASSISTANT,
+                content="hi there",
+                persist=True,
+            )
+            assert session.persisted_conversation_id is None
+
+            await console._promote_console_temporary_session()
+            await pilot.pause()
+
+            assert session.ephemeral is False
+            conversation_id = session.persisted_conversation_id
+            assert conversation_id is not None
+
+            conversation = db.get_conversation_by_id(conversation_id)
+            assert conversation is not None
+            assert conversation["title"] == "Temp chat to save"
+
+            messages = db.get_messages_for_conversation(conversation_id)
+            assert [m["content"] for m in messages] == ["hello", "hi there"]
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_promote_console_temporary_session_second_call_does_not_duplicate_the_row(
+    tmp_path,
+):
+    """Promoting an already-saved session again must not write a second
+    conversation row -- `promote_ephemeral_session` is idempotent, and the
+    screen-level wrapper must not paper over a regression there by, say,
+    creating a fresh conversation on every click."""
+    app = _build_test_app()
+    db = _real_chachanotes_db(tmp_path)
+    app.chachanotes_db = db
+    host = ConsoleHarness(app)
+
+    try:
+        async with host.run_test(size=(160, 44)) as pilot:
+            console = host.screen_stack[-1]
+            await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+            store = console._ensure_console_chat_store()
+            session = store.create_session(title="Save twice", ephemeral=True)
+            store.switch_session(session.id)
+            store.append_message(
+                session.id, role=ConsoleMessageRole.USER, content="hi", persist=True
+            )
+
+            await console._promote_console_temporary_session()
+            await pilot.pause()
+            conversation_id = session.persisted_conversation_id
+            assert conversation_id is not None
+            assert db.get_conversation_by_id(conversation_id) is not None
+
+            await console._promote_console_temporary_session()
+            await pilot.pause()
+
+            assert session.persisted_conversation_id == conversation_id
+            assert session.ephemeral is False
+            # Still exactly the one conversation row this session's messages
+            # belong to; a duplicate-write regression would mint a second one.
+            assert db.get_conversation_by_id(conversation_id) is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_promote_console_temporary_session_no_active_session_touches_nothing():
+    """With no active session (a bare/never-mounted store edge), promotion is
+    a pure no-op -- no notification, no DB access attempted."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        store = console._ensure_console_chat_store()
+        store.active_session_id = None
+
+        # Must not raise even though there is nothing to promote.
+        await console._promote_console_temporary_session()
+        await pilot.pause()

--- a/Tests/UI/test_console_session_controller.py
+++ b/Tests/UI/test_console_session_controller.py
@@ -1,38 +1,39 @@
-"""Characterisation tests for the Console session cluster, written BEFORE the
-wave-2 Task 3 extraction of `ConsoleSessionController`
-(`tldw_chatbook/UI/Console_Modules/session.py`) lands.
+"""Characterisation tests for the Console session cluster.
+
+Originally written BEFORE the wave-2 Task 3 extraction of
+`ConsoleSessionController` (`tldw_chatbook/UI/Console_Modules/session.py`)
+landed -- all 8 tests below passed against the unmodified, still-monolithic
+`ChatScreen` (commit `08f0f5479`) before the extraction touched any
+production file. Call sites were then retargeted from `console.<method>(...)`
+to `console._session.<method>(...)` to follow the move; every assertion is
+byte-for-byte unchanged from the pre-move version.
 
 Drives `_activate_native_console_session`, `_apply_console_switcher_choice`,
-and `_promote_console_temporary_session` through REAL interactions against
-the still-monolithic `ChatScreen` -- the same "real production coroutine, not
-a rebuilt double" discipline `test_console_native_chat_flow.py`'s own resume
+and `_promote_console_temporary_session` through REAL interactions against a
+real mounted `ChatScreen` -- the same "real production coroutine, not a
+rebuilt double" discipline `test_console_native_chat_flow.py`'s own resume
 coverage and `test_console_workspace_controller.py` (wave-2 Task 2's own
 characterisation file) use. No method under test is monkeypatched.
 
 Two things this file exists specifically to pin, per the wave-2 Task 3 brief:
 
 1. **Session activation's workspace-alignment seam**
-   (`_activate_native_console_session` -> `_set_active_workspace_for_console_
-   session`, which after the extraction becomes a session-controller ->
-   workspace-controller named-callable call): activating a session that
-   belongs to a DIFFERENT workspace than the currently active one must also
-   switch the active workspace. Existing coverage
-   (`test_console_cost_chip_screen.py::test_cost_chip_state_isolated_across_
-   session_tabs`, `test_console_agent_rail.py::test_activate_native_console_
-   session_clears_stale_drilldown`, `test_console_scope_row.py`) exercises the
-   SAME entry point but never with two DIFFERENT workspaces in play, so none
-   of it would catch a snapshot-vs-live binding bug in that one call.
+   (`_activate_native_console_session` -> `_set_active_workspace_for_
+   session`, a session-controller -> workspace-controller named-callable
+   call): activating a session that belongs to a DIFFERENT workspace than
+   the currently active one must also switch the active workspace. Existing
+   coverage (`test_console_cost_chip_screen.py::test_cost_chip_state_
+   isolated_across_session_tabs`, `test_console_agent_rail.py::test_
+   activate_native_console_session_clears_stale_drilldown`, `test_console_
+   scope_row.py`) exercises the SAME entry point but never with two
+   DIFFERENT workspaces in play, so none of it would have caught a
+   snapshot-vs-live binding bug in that one call.
 2. **Temporary-session promotion writes a DURABLE database row.** Every
    existing `_promote_console_temporary_session` test
    (`Tests/UI/test_console_composer_menu.py`) stubs `store.
    promote_ephemeral_session` outright and asserts only chip/widget state --
    none of them ever let a real write reach `chachanotes_db`. The brief is
    explicit: assert the DATABASE, not widget state.
-
-Method calls below (`console._activate_native_console_session(...)`,
-`console._promote_console_temporary_session()`,
-`console._apply_console_switcher_choice(...)`, etc.) move to
-`console._session.<method>(...)` once the extraction lands.
 """
 
 from __future__ import annotations
@@ -120,7 +121,7 @@ async def test_activate_native_console_session_realigns_active_workspace():
         await _wait_for_selector(console, pilot, "#console-native-transcript")
 
         store = console._ensure_console_chat_store()
-        home_session = console._active_native_console_session()
+        home_session = console._session._active_native_console_session()
         assert home_session is not None
         assert registry_service.get_active_workspace().workspace_id == (
             default_workspace.workspace_id
@@ -141,14 +142,14 @@ async def test_activate_native_console_session_realigns_active_workspace():
         assert other_session.workspace_id == "ws-other"
         assert store.active_session_id == other_session.id
 
-        await console._activate_native_console_session(home_session.id)
+        await console._session._activate_native_console_session(home_session.id)
         await pilot.pause()
         assert store.active_session_id == home_session.id
         assert registry_service.get_active_workspace().workspace_id == (
             default_workspace.workspace_id
         )
 
-        await console._activate_native_console_session(other_session.id)
+        await console._session._activate_native_console_session(other_session.id)
         await pilot.pause()
 
         assert store.active_session_id == other_session.id
@@ -156,7 +157,7 @@ async def test_activate_native_console_session_realigns_active_workspace():
 
         # Hop back: the home session's own workspace must be restored too,
         # not just left on "ws-other" because nothing re-checks it.
-        await console._activate_native_console_session(home_session.id)
+        await console._session._activate_native_console_session(home_session.id)
         await pilot.pause()
 
         assert store.active_session_id == home_session.id
@@ -181,7 +182,7 @@ async def test_activate_native_console_session_noop_still_focuses_composer(
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-transcript")
 
-        session = console._active_native_console_session()
+        session = console._session._active_native_console_session()
         assert session is not None
 
         focus_calls: list[bool] = []
@@ -195,10 +196,10 @@ async def test_activate_native_console_session_noop_still_focuses_composer(
             type(console), "_focus_console_composer_if_needed", _spy_focus
         )
 
-        await console._activate_native_console_session(session.id)
+        await console._session._activate_native_console_session(session.id)
         await pilot.pause()
 
-        assert console._active_native_console_session().id == session.id
+        assert console._session._active_native_console_session().id == session.id
         assert focus_calls == [True]
 
 
@@ -224,7 +225,7 @@ async def test_apply_console_switcher_choice_activate_uses_shared_activation_pat
         await _wait_for_selector(console, pilot, "#console-native-transcript")
 
         store = console._ensure_console_chat_store()
-        home = console._active_native_console_session()
+        home = console._session._active_native_console_session()
         assert home is not None
         target = store.create_session(
             title="Switcher target", workspace_id="ws-switcher"
@@ -232,7 +233,7 @@ async def test_apply_console_switcher_choice_activate_uses_shared_activation_pat
         assert home.id != target.id
         # `create_session` activates what it creates -- go back home first so
         # the switcher choice below is a real transition, not a no-op.
-        await console._activate_native_console_session(home.id)
+        await console._session._activate_native_console_session(home.id)
         await pilot.pause()
         assert store.active_session_id == home.id
 
@@ -240,7 +241,7 @@ async def test_apply_console_switcher_choice_activate_uses_shared_activation_pat
             kind="activate",
             entry=_switcher_entry(native_session_id=target.id, title=target.title),
         )
-        await console._apply_console_switcher_choice(choice)
+        await console._session._apply_console_switcher_choice(choice)
         await pilot.pause()
 
         assert store.active_session_id == target.id
@@ -267,7 +268,7 @@ async def test_apply_console_switcher_choice_rename_opens_rename_modal():
             kind="rename",
             entry=_switcher_entry(native_session_id=session.id, title=session.title),
         )
-        await console._apply_console_switcher_choice(choice)
+        await console._session._apply_console_switcher_choice(choice)
         await pilot.pause()
 
         top = host.screen_stack[-1]
@@ -290,7 +291,7 @@ async def test_apply_console_switcher_choice_none_is_a_noop():
         active_before = store.active_session_id
         depth_before = len(host.screen_stack)
 
-        await console._apply_console_switcher_choice(None)
+        await console._session._apply_console_switcher_choice(None)
         await pilot.pause()
 
         assert store.active_session_id == active_before
@@ -337,7 +338,7 @@ async def test_promote_console_temporary_session_writes_durable_rows_to_the_data
             )
             assert session.persisted_conversation_id is None
 
-            await console._promote_console_temporary_session()
+            await console._session._promote_console_temporary_session()
             await pilot.pause()
 
             assert session.ephemeral is False
@@ -379,13 +380,13 @@ async def test_promote_console_temporary_session_second_call_does_not_duplicate_
                 session.id, role=ConsoleMessageRole.USER, content="hi", persist=True
             )
 
-            await console._promote_console_temporary_session()
+            await console._session._promote_console_temporary_session()
             await pilot.pause()
             conversation_id = session.persisted_conversation_id
             assert conversation_id is not None
             assert db.get_conversation_by_id(conversation_id) is not None
 
-            await console._promote_console_temporary_session()
+            await console._session._promote_console_temporary_session()
             await pilot.pause()
 
             assert session.persisted_conversation_id == conversation_id
@@ -412,5 +413,5 @@ async def test_promote_console_temporary_session_no_active_session_touches_nothi
         store.active_session_id = None
 
         # Must not raise even though there is nothing to promote.
-        await console._promote_console_temporary_session()
+        await console._session._promote_console_temporary_session()
         await pilot.pause()

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -25,6 +25,7 @@ from tldw_chatbook.Chat.console_session_settings import (
     build_console_settings_summary_state,
     validate_console_session_settings,
 )
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import (
     CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL,
     ChatScreen,
@@ -836,12 +837,12 @@ def test_legacy_identity_settings_helper_ignores_unknown_keys_without_mutation()
         "user_profile_label": "Legacy B",
     }
     source_before = dict(source)
-    restored = ChatScreen._restore_console_settings(source)
+    restored = ConsoleSessionController._restore_console_settings(source)
 
     assert restored is not None
     assert source == source_before
     assert not hasattr(restored, "user_profile_label")
-    serialized = ChatScreen._serialize_console_settings(restored)
+    serialized = ConsoleSessionController._serialize_console_settings(restored)
     assert serialized is not None
     assert {"persona_label", "user_profile_label"}.isdisjoint(serialized)
 
@@ -3512,7 +3513,7 @@ def test_console_default_settings_keep_configured_model_without_legacy_model() -
     }
     screen = ChatScreen(app)
 
-    settings = screen._default_console_session_settings()
+    settings = screen._session._default_console_session_settings()
 
     assert settings.provider == "llama_cpp"
     assert settings.model == "configured-model"
@@ -3574,7 +3575,7 @@ def test_console_control_state_reads_persona_label_without_storing_it_on_session
     store = screen._ensure_console_chat_store()
     session = store.ensure_session()
     monkeypatch.setattr(
-        screen,
+        screen._session,
         "_active_native_console_session",
         lambda: SimpleNamespace(
             assistant_kind="persona",
@@ -4411,11 +4412,11 @@ def test_console_stale_default_refresh_respects_user_marked_settings() -> None:
         provider="openai", model="gpt-4o", source="user"
     )
     store.replace_session_settings(session.id, user_choice)
-    assert console._ensure_active_console_session_settings() == user_choice
+    assert console._session._ensure_active_console_session_settings() == user_choice
 
     stale_derived = ConsoleSessionSettings(provider="openai", model="gpt-4o")
     store.replace_session_settings(session.id, stale_derived)
-    refreshed = console._ensure_active_console_session_settings()
+    refreshed = console._session._ensure_active_console_session_settings()
     assert refreshed.provider == "llama_cpp"
     assert refreshed.source == "derived"
 
@@ -4449,7 +4450,7 @@ def test_console_stale_default_refresh_preserves_applied_system_prompt() -> None
     )
     store.replace_session_settings(session.id, stale_derived_with_system_prompt)
 
-    refreshed = console._ensure_active_console_session_settings()
+    refreshed = console._session._ensure_active_console_session_settings()
 
     assert refreshed.provider == "llama_cpp", (
         "the provider/model default refresh must still happen"

--- a/Tests/UI/test_console_shell_chip_actions.py
+++ b/Tests/UI/test_console_shell_chip_actions.py
@@ -132,6 +132,7 @@ def test_swap_seeds_greeting_only_into_an_empty_chat():
     """
     from dataclasses import dataclass, replace as dc_replace
 
+    from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     @dataclass
@@ -169,14 +170,14 @@ def test_swap_seeds_greeting_only_into_an_empty_chat():
     screen = ChatScreen.__new__(ChatScreen)
 
     empty = _Store([])
-    assert ChatScreen._swap_console_session_character(
+    assert ConsoleSessionController._swap_console_session_character(
         screen, empty, 7, "Lana", "SYS", "Hello!"
     )
     assert [a["content"] for a in empty.appended] == ["Hello!"]
     assert empty.settings.system_prompt == "SYS"
 
     busy = _Store(["an existing message"])
-    assert ChatScreen._swap_console_session_character(
+    assert ConsoleSessionController._swap_console_session_character(
         screen, busy, 7, "Lana", "SYS", "Hello!"
     )
     assert busy.appended == [], "greeting must not interrupt a live chat"

--- a/Tests/UI/test_console_staged_evidence_strip.py
+++ b/Tests/UI/test_console_staged_evidence_strip.py
@@ -690,7 +690,7 @@ async def test_console_rail_badge_and_chip_report_the_same_staged_count() -> Non
         screen._stage_console_library_rag_launch(_launch(4))
         await pilot.pause()
 
-        workspace_context = screen._current_console_workspace_context()
+        workspace_context = screen._workspace._current_console_workspace_context()
         assert len(workspace_context.staged_sources) == 4
         assert [source.label for source in workspace_context.staged_sources] == [
             "Source 1",
@@ -716,7 +716,9 @@ def test_workspace_context_falls_back_to_one_row_for_a_bundleless_launch() -> No
         _pending_console_launch_context=launch,
         app_instance=SimpleNamespace(),
     )
-    context = chat_screen_module.ChatScreen._current_console_workspace_context(screen)
+    context = chat_screen_module.ConsoleWorkspaceController._current_console_workspace_context(
+        screen
+    )
     assert len(context.staged_sources) == 1
     assert context.staged_sources[0].label == "Daily papers"
     assert console_staged_source_count(launch) == 1

--- a/Tests/UI/test_console_switch_draft_integrity.py
+++ b/Tests/UI/test_console_switch_draft_integrity.py
@@ -30,13 +30,13 @@ async def _settle_window_swap(console, pilot, *, type_during_window: str):
     await pilot.pause()
 
     composer.load_draft("old draft")
-    console._sync_console_session_draft()  # settle tracker onto A
+    console._session._sync_console_session_draft()  # settle tracker onto A
 
     # Hold the coalescing guard: the new-tab path's inline sync defers, so
     # the draft swap runs only on a LATER pass — the real settle window.
     console._console_sync_in_progress = True
     try:
-        await console._create_native_console_session_from_active_context()
+        await console._session._create_native_console_session_from_active_context()
         if type_during_window:
             composer.insert_text(type_during_window)
     finally:
@@ -44,7 +44,7 @@ async def _settle_window_swap(console, pilot, *, type_during_window: str):
 
     session_b_id = store.active_session_id
     assert session_b_id != session_a.id
-    console._sync_console_session_draft()
+    console._session._sync_console_session_draft()
     return store, session_a, session_b_id, composer
 
 

--- a/Tests/UI/test_console_system_prompt.py
+++ b/Tests/UI/test_console_system_prompt.py
@@ -210,11 +210,11 @@ async def test_console_system_prompt_chip_label_reflects_applied_prompt():
         await _wait_for_selector(console, pilot, "#console-system-prompt-chip")
         assert _system_prompt_chip_text(console) == CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
 
-        console._apply_console_session_system_prompt("Be concise.")
+        console._session._apply_console_session_system_prompt("Be concise.")
         await pilot.pause(0.2)
         assert _system_prompt_chip_text(console) == CONSOLE_SYSTEM_PROMPT_LABEL_SET
 
-        console._apply_console_session_system_prompt(None)
+        console._session._apply_console_session_system_prompt(None)
         await pilot.pause(0.2)
         assert _system_prompt_chip_text(console) == CONSOLE_SYSTEM_PROMPT_LABEL_UNSET
 
@@ -234,7 +234,7 @@ async def test_console_system_bare_command_opens_editor_with_current_text():
         console = host.screen_stack[-1]
         baseline_depth = len(host.screen_stack)
         await _wait_for_selector(console, pilot, "#console-native-composer")
-        console._apply_console_session_system_prompt("Answer tersely.")
+        console._session._apply_console_session_system_prompt("Answer tersely.")
         await pilot.pause(0.1)
 
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
@@ -276,7 +276,7 @@ async def test_console_system_prompt_modal_apply_updates_settings_and_rail_previ
         modal.query_one(f"#{APPLY_BUTTON_ID}", Button).press()
         await pilot.pause(0.2)
 
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt == "Be concise."
         assert _rail_system_line_text(console) == "System: Be concise."
         assert not _rail_system_line_is_dim(console)
@@ -291,7 +291,7 @@ async def test_console_system_prompt_modal_clear_resets_settings_and_rail_to_non
     async with host.run_test(size=(180, 48)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
-        console._apply_console_session_system_prompt("Be terse.")
+        console._session._apply_console_session_system_prompt("Be terse.")
         await pilot.pause(0.1)
         assert _rail_system_line_text(console) == "System: Be terse."
 
@@ -304,7 +304,7 @@ async def test_console_system_prompt_modal_clear_resets_settings_and_rail_to_non
         modal.query_one(f"#{CLEAR_BUTTON_ID}", Button).press()
         await pilot.pause(0.2)
 
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt is None
         assert _rail_system_line_text(console) == "System: none"
         assert _rail_system_line_is_dim(console)
@@ -320,7 +320,7 @@ async def test_console_system_prompt_modal_cancel_leaves_settings_untouched():
         console = host.screen_stack[-1]
         baseline_depth = len(host.screen_stack)
         await _wait_for_selector(console, pilot, "#console-native-composer")
-        console._apply_console_session_system_prompt("Keep me.")
+        console._session._apply_console_session_system_prompt("Keep me.")
         await pilot.pause(0.1)
 
         console.run_worker(
@@ -333,7 +333,7 @@ async def test_console_system_prompt_modal_cancel_leaves_settings_untouched():
         await pilot.pause(0.2)
 
         assert len(host.screen_stack) == baseline_depth
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt == "Keep me."
 
 
@@ -352,10 +352,10 @@ async def test_apply_console_session_system_prompt_preserves_formatting_verbatim
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
 
-        console._apply_console_session_system_prompt(formatted_prompt)
+        console._session._apply_console_session_system_prompt(formatted_prompt)
         await pilot.pause(0.1)
 
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt == formatted_prompt
 
 
@@ -395,7 +395,7 @@ async def test_console_system_command_unique_name_applies_and_updates_rail_previ
         assert len(host.screen_stack) == baseline_depth, (
             "a unique match must not open the picker"
         )
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt == "Answer tersely."
         assert _rail_system_line_text(console) == "System: Answer tersely."
         # Finding 2 (final review): a successful named `/system` apply must
@@ -440,7 +440,7 @@ async def test_console_system_command_unique_prefix_match_resolves(tmp_path):
         await pilot.pause(0.2)
 
         assert len(host.screen_stack) == baseline_depth
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt == "Be terse."
 
 
@@ -475,7 +475,7 @@ async def test_console_system_command_empty_system_part_shows_exact_inline_error
         assert len(host.screen_stack) == baseline_depth, (
             "no picker/modal should open on this error"
         )
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt is None
         assert _rail_system_line_text(console) == "System: none"
         # Finding 2 (final review): the empty-system-part ERROR path must
@@ -575,7 +575,7 @@ async def test_console_system_command_picker_selection_applies_system_prompt(tmp
         assert len(host.screen_stack) == baseline_depth, (
             "the picker must have dismissed"
         )
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt == "Sunny system."
 
 
@@ -617,7 +617,7 @@ async def test_console_system_command_picker_escape_leaves_settings_untouched(tm
         await pilot.pause(0.2)
 
         assert len(host.screen_stack) == baseline_depth
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt is None
 
 
@@ -734,13 +734,13 @@ async def test_console_system_prompt_apply_persists_when_conversation_already_sa
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
         store = console._ensure_console_chat_store()
-        console._ensure_active_console_session_settings()
+        console._session._ensure_active_console_session_settings()
         session_id = store.active_session_id
         fake_persistence = FakeConsolePersistence()
         store.persistence = fake_persistence
         store.persist_session_if_needed(session_id)
 
-        console._apply_console_session_system_prompt("Persisted prompt.")
+        console._session._apply_console_session_system_prompt("Persisted prompt.")
         await pilot.pause(0.1)
 
         assert fake_persistence.updated_system_prompts == [
@@ -769,7 +769,7 @@ async def test_console_system_prompt_apply_notifies_on_persistence_failure():
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
         store = console._ensure_console_chat_store()
-        console._ensure_active_console_session_settings()
+        console._session._ensure_active_console_session_settings()
         session_id = store.active_session_id
         store.persistence = FakeConsolePersistence()
         store.persist_session_if_needed(session_id)
@@ -780,10 +780,10 @@ async def test_console_system_prompt_apply_notifies_on_persistence_failure():
             notifications.append((message, severity))
         )
 
-        console._apply_console_session_system_prompt("New prompt")
+        console._session._apply_console_session_system_prompt("New prompt")
         await pilot.pause(0.1)
 
-        settings = console._ensure_active_console_session_settings()
+        settings = console._session._ensure_active_console_session_settings()
         assert settings.system_prompt == "New prompt"
         assert any(severity == "warning" for _message, severity in notifications)
 
@@ -805,7 +805,7 @@ async def test_console_context_estimate_counts_system_prompt_after_apply():
         baseline = console._active_console_settings_context_estimate()
         assert baseline.used_tokens is not None
 
-        console._apply_console_session_system_prompt(
+        console._session._apply_console_session_system_prompt(
             "Answer using formal English at all times, citing sources where possible."
         )
         await pilot.pause(0.1)

--- a/Tests/UI/test_console_tick_gating.py
+++ b/Tests/UI/test_console_tick_gating.py
@@ -261,7 +261,7 @@ async def test_console_workspace_context_legacy_alias_kick_skipped_when_state_un
         # Pin the built state to one fixed (but distinct-object-each-call)
         # value so two consecutive syncs are a genuine "state unchanged"
         # comparison rather than incidentally differing mount-time state.
-        original_build = console._build_console_workspace_context_state
+        original_build = console._workspace._build_console_workspace_context_state
 
         def pinned_build(*args, **kwargs):
             return replace(original_build(*args, **kwargs), heading="Pinned heading")
@@ -269,7 +269,7 @@ async def test_console_workspace_context_legacy_alias_kick_skipped_when_state_un
         with (
             patch.object(console, "run_worker", counting_run_worker),
             patch.object(
-                console, "_build_console_workspace_context_state", pinned_build
+                console._workspace, "_build_console_workspace_context_state", pinned_build
             ),
         ):
             console._sync_console_workspace_context()
@@ -378,7 +378,7 @@ async def test_console_streaming_message_excerpt_is_static_placeholder():
 def _pin_workspace_state(console):
     """Patch the state build to a fixed (distinct-object) value so syncs are
     a genuine "state unchanged" comparison, and count tray recomposes."""
-    original_build = console._build_console_workspace_context_state
+    original_build = console._workspace._build_console_workspace_context_state
 
     def pinned_build(*args, **kwargs):
         return replace(original_build(*args, **kwargs), heading="Pinned heading")
@@ -414,7 +414,7 @@ async def test_console_workspace_context_tray_not_recomposed_when_state_unchange
         )
         with (
             patch.object(
-                console, "_build_console_workspace_context_state", pinned_build
+                console._workspace, "_build_console_workspace_context_state", pinned_build
             ),
             patch.object(ConsoleWorkspaceContextTray, "refresh", counting_refresh),
         ):
@@ -454,7 +454,7 @@ async def test_console_workspace_context_fresh_tray_still_synced_mid_run():
         )
         with (
             patch.object(
-                console, "_build_console_workspace_context_state", pinned_build
+                console._workspace, "_build_console_workspace_context_state", pinned_build
             ),
             patch.object(ConsoleWorkspaceContextTray, "refresh", counting_refresh),
         ):

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -3245,7 +3245,7 @@ async def test_console_conversation_row_click_shows_loading_until_resume_finishe
             )
             return False
 
-        console._resume_console_workspace_conversation = _fake_resume
+        console._workspace._resume_console_workspace_conversation = _fake_resume
 
         await console.on_button_pressed(Button.Pressed(row))
 
@@ -3283,7 +3283,7 @@ async def test_console_conversation_row_loading_cleared_when_resume_raises() -> 
         async def _raising_resume(conversation_id, **kwargs):
             raise RuntimeError("resume boom")
 
-        console._resume_console_workspace_conversation = _raising_resume
+        console._workspace._resume_console_workspace_conversation = _raising_resume
 
         with pytest.raises(RuntimeError):
             await console.on_button_pressed(Button.Pressed(row))

--- a/Tests/UI/test_console_workspace_controller.py
+++ b/Tests/UI/test_console_workspace_controller.py
@@ -1,0 +1,277 @@
+"""Characterisation + boundary tests for the Console workspace cluster.
+
+Written before the wave-2 Task 2 extraction of `ConsoleWorkspaceController`
+(`tldw_chatbook/UI/Console_Modules/workspace.py`) lands, driving the resume
+flow and the conversation-search debounce through REAL interactions against
+the pre-move `ChatScreen` -- the same "real production coroutine, not a
+rebuilt double" discipline `test_console_native_chat_flow.py`'s own resume
+coverage uses. Search-token/error state is exactly where a
+snapshot-vs-live binding bug would hide (see wave 1's
+`ConsoleDictationController` review history), so these assert the
+token/error lifecycle explicitly, not just the visible rows.
+
+Method calls below (`console._resume_console_workspace_conversation(...)`,
+`console._refresh_console_workspace_conversation_search(...)`, etc.) move to
+`console._workspace.<method>(...)` once the extraction lands; the six
+`_console_workspace_conversation_*` state reads/writes below are expected to
+keep working completely unchanged -- `ChatScreen` keeps get/set proxy
+properties for them, exactly as `ConsoleDictationController`'s cluster did in
+wave 1 (see that module's docstring).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from textual.widgets import Input
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+
+
+class _InputChangedEvent:
+    """Minimal stand-in for `Input.Changed` -- matches what the handler reads
+    (`event.value`, `event.input.disabled`, and `event.stop()`)."""
+
+    def __init__(self, value: str, *, input_widget=None) -> None:
+        self.value = value
+        self.input = input_widget
+
+    def stop(self) -> None:
+        return None
+
+
+def _set_workspace_search(console, query: str) -> None:
+    """Drive the real search-changed handler, mirroring a real keystroke."""
+    search = console.query_one("#console-workspace-conversation-search", Input)
+    search.value = query
+    console.on_console_workspace_conversation_search_changed(
+        _InputChangedEvent(query, input_widget=search)
+    )
+
+
+def _conversation_tree_payload(
+    conversation_id: str,
+    *,
+    title: str = "Resumed chat",
+    workspace_id: str | None = None,
+) -> dict:
+    conversation: dict = {"id": conversation_id, "title": title}
+    if workspace_id is not None:
+        conversation["workspace_id"] = workspace_id
+    return {"conversation": conversation, "root_threads": []}
+
+
+@pytest.mark.asyncio
+async def test_search_debounce_mirrors_query_and_bumps_token_and_timer():
+    """Typing into the rail search mirrors into workspace state and arms a timer."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(
+            console, pilot, "#console-workspace-conversation-search"
+        )
+
+        _set_workspace_search(console, "alpha")
+        await pilot.pause()
+
+        assert console._console_workspace_conversation_query == "alpha"
+        # `_console_workspace_conversation_search_token` is a pure mirror of
+        # `_console_conversation_browser_search_token` inside this handler
+        # (see the handler's own docstring / the module docstring for this
+        # test file) -- not an independently incrementing counter, so the
+        # only thing worth asserting is that the mirror is faithful.
+        assert (
+            console._console_workspace_conversation_search_token
+            == console._console_conversation_browser_search_token
+        )
+        assert console._console_workspace_conversation_search_timer is not None
+
+
+@pytest.mark.asyncio
+async def test_search_debounce_empty_query_clears_state_synchronously():
+    """Clearing the search box resets workspace search state with no pending timer."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(
+            console, pilot, "#console-workspace-conversation-search"
+        )
+
+        _set_workspace_search(console, "alpha")
+        await pilot.pause()
+        assert console._console_workspace_conversation_query == "alpha"
+
+        _set_workspace_search(console, "")
+        await pilot.pause()
+
+        assert console._console_workspace_conversation_query == ""
+        assert console._console_workspace_conversation_search_timer is None
+
+
+@pytest.mark.asyncio
+async def test_search_refresh_populates_rows_from_scope_service():
+    """`_refresh_console_workspace_conversation_search` fills workspace rows
+    from the scope service.
+
+    Driven directly (the same "real production coroutine, not a rebuilt
+    double" pattern `test_console_native_chat_flow.py`'s resume coverage
+    uses) rather than through the live search-input handler: that handler
+    only mirrors THREE fields onto workspace state (see this file's module
+    docstring) and drives the sibling conversation-browser's own search --
+    `_refresh_console_workspace_conversation_search` itself is reached (in
+    production) only via `_refresh_console_workspace_conversation_search_
+    after_selection`, so this exercises it the same way the existing
+    characterisation in `test_console_native_chat_flow.py` does.
+    """
+    app = _build_test_app()
+    active_workspace = app.workspace_registry_service.get_active_workspace()
+    app.chat_conversation_scope_service = SimpleNamespace(
+        list_conversations=lambda **kwargs: {
+            "items": [
+                {
+                    "id": "conv-alpha",
+                    "title": "Alpha project",
+                    "state": "workspace-thread",
+                }
+            ],
+            "total": 1,
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(
+            console, pilot, "#console-workspace-conversation-search"
+        )
+
+        console._console_workspace_conversation_query = "alpha"
+        token = console._console_workspace_conversation_search_token
+        await console._refresh_console_workspace_conversation_search(
+            active_workspace.workspace_id, "alpha", token
+        )
+        await pilot.pause()
+
+        rows = console._console_workspace_conversation_search_rows
+        assert any(row.conversation_id == "conv-alpha" for row in rows), rows
+        assert console._console_workspace_conversation_search_error == ""
+
+
+@pytest.mark.asyncio
+async def test_search_refresh_ignores_stale_token():
+    """A refresh whose token no longer matches current state is a no-op.
+
+    Simulates a slow in-flight refresh (token N-1) that lands after a newer
+    keystroke already bumped the token to N -- exactly the race the token
+    guard exists to close.
+    """
+    app = _build_test_app()
+    active_workspace = app.workspace_registry_service.get_active_workspace()
+    app.chat_conversation_scope_service = SimpleNamespace(
+        list_conversations=lambda **kwargs: {
+            "items": [
+                {
+                    "id": "conv-late",
+                    "title": "Late arrival",
+                    "state": "workspace-thread",
+                }
+            ],
+            "total": 1,
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(
+            console, pilot, "#console-workspace-conversation-search"
+        )
+
+        console._console_workspace_conversation_query = "late"
+        current_token = console._console_workspace_conversation_search_token + 1
+        console._console_workspace_conversation_search_token = current_token
+
+        await console._refresh_console_workspace_conversation_search(
+            active_workspace.workspace_id, "late", current_token - 1
+        )
+
+        assert console._console_workspace_conversation_search_rows == ()
+
+
+@pytest.mark.asyncio
+async def test_resume_workspace_conversation_restores_native_session():
+    """Resuming a real persisted conversation creates a matching native session."""
+    app = _build_test_app()
+    active_workspace = app.workspace_registry_service.get_active_workspace()
+    app.chat_conversation_scope_service = SimpleNamespace(
+        get_conversation_tree=lambda conversation_id, **kwargs: (
+            _conversation_tree_payload(
+                conversation_id,
+                title="Resumed alpha",
+                workspace_id=active_workspace.workspace_id,
+            )
+        )
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        resumed = await console._resume_console_workspace_conversation(
+            "conv-resume-1"
+        )
+        await pilot.pause()
+
+        assert resumed is True
+        store = console._ensure_console_chat_store()
+        active_session = store.switch_session(store.active_session_id)
+        assert active_session.persisted_conversation_id == "conv-resume-1"
+        assert active_session.workspace_id == active_workspace.workspace_id
+
+
+@pytest.mark.asyncio
+async def test_resume_workspace_conversation_missing_record_returns_false():
+    """A missing conversation record is reported honestly as False."""
+    app = _build_test_app()
+    app.chat_conversation_scope_service = SimpleNamespace(
+        get_conversation_tree=lambda *args, **kwargs: {}
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        resumed = await console._resume_console_workspace_conversation(
+            "conv-missing"
+        )
+        await pilot.pause()
+
+        assert resumed is False
+
+
+@pytest.mark.asyncio
+async def test_active_workspace_id_for_conversation_search_reads_registry():
+    """Falls back to the registry's active workspace when none is staged."""
+    app = _build_test_app()
+    active_workspace = app.workspace_registry_service.get_active_workspace()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        assert (
+            console._active_console_workspace_id_for_conversation_search()
+            == active_workspace.workspace_id
+        )

--- a/Tests/UI/test_console_workspace_controller.py
+++ b/Tests/UI/test_console_workspace_controller.py
@@ -1,22 +1,21 @@
 """Characterisation + boundary tests for the Console workspace cluster.
 
-Written before the wave-2 Task 2 extraction of `ConsoleWorkspaceController`
-(`tldw_chatbook/UI/Console_Modules/workspace.py`) lands, driving the resume
-flow and the conversation-search debounce through REAL interactions against
-the pre-move `ChatScreen` -- the same "real production coroutine, not a
-rebuilt double" discipline `test_console_native_chat_flow.py`'s own resume
-coverage uses. Search-token/error state is exactly where a
-snapshot-vs-live binding bug would hide (see wave 1's
-`ConsoleDictationController` review history), so these assert the
+Originally written before the wave-2 Task 2 extraction of `ConsoleWorkspace
+Controller` (`tldw_chatbook/UI/Console_Modules/workspace.py`) landed, driving
+the resume flow and the conversation-search debounce through REAL
+interactions against the (at the time) still-monolithic `ChatScreen` -- the
+same "real production coroutine, not a rebuilt double" discipline
+`test_console_native_chat_flow.py`'s own resume coverage uses. Search-token/
+error state is exactly where a snapshot-vs-live binding bug would hide (see
+wave 1's `ConsoleDictationController` review history), so these assert the
 token/error lifecycle explicitly, not just the visible rows.
 
-Method calls below (`console._resume_console_workspace_conversation(...)`,
-`console._refresh_console_workspace_conversation_search(...)`, etc.) move to
-`console._workspace.<method>(...)` once the extraction lands; the six
-`_console_workspace_conversation_*` state reads/writes below are expected to
-keep working completely unchanged -- `ChatScreen` keeps get/set proxy
-properties for them, exactly as `ConsoleDictationController`'s cluster did in
-wave 1 (see that module's docstring).
+Now that the extraction has landed, the moved-method calls below go through
+`console._workspace.<method>(...)`; the six `_console_workspace_conversation_
+*` state reads/writes stay exactly as they were pre-move -- `ChatScreen`
+keeps get/set proxy properties for them, exactly as `ConsoleDictation
+Controller`'s cluster did in wave 1 (see that module's docstring), so no
+test here needed to change for the state accesses, only the method calls.
 """
 
 from __future__ import annotations
@@ -156,7 +155,7 @@ async def test_search_refresh_populates_rows_from_scope_service():
 
         console._console_workspace_conversation_query = "alpha"
         token = console._console_workspace_conversation_search_token
-        await console._refresh_console_workspace_conversation_search(
+        await console._workspace._refresh_console_workspace_conversation_search(
             active_workspace.workspace_id, "alpha", token
         )
         await pilot.pause()
@@ -200,7 +199,7 @@ async def test_search_refresh_ignores_stale_token():
         current_token = console._console_workspace_conversation_search_token + 1
         console._console_workspace_conversation_search_token = current_token
 
-        await console._refresh_console_workspace_conversation_search(
+        await console._workspace._refresh_console_workspace_conversation_search(
             active_workspace.workspace_id, "late", current_token - 1
         )
 
@@ -227,7 +226,7 @@ async def test_resume_workspace_conversation_restores_native_session():
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-transcript")
 
-        resumed = await console._resume_console_workspace_conversation(
+        resumed = await console._workspace._resume_console_workspace_conversation(
             "conv-resume-1"
         )
         await pilot.pause()
@@ -252,7 +251,7 @@ async def test_resume_workspace_conversation_missing_record_returns_false():
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-transcript")
 
-        resumed = await console._resume_console_workspace_conversation(
+        resumed = await console._workspace._resume_console_workspace_conversation(
             "conv-missing"
         )
         await pilot.pause()
@@ -272,6 +271,6 @@ async def test_active_workspace_id_for_conversation_search_reads_registry():
         await _wait_for_selector(console, pilot, "#console-native-transcript")
 
         assert (
-            console._active_console_workspace_id_for_conversation_search()
+            console._workspace._active_console_workspace_id_for_conversation_search()
             == active_workspace.workspace_id
         )

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -57,6 +57,7 @@ from tldw_chatbook.tldw_api.character_persona_schemas import (
     PersonaProfileUpdate,
 )
 from tldw_chatbook.UI.Navigation.shortcut_context import ShortcutAction, ShortcutContext
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
@@ -8650,7 +8651,7 @@ class TestPersonaHumanIdentityRemoval:
             lambda self: store,
         )
         monkeypatch.setattr(
-            ChatScreen,
+            ConsoleSessionController,
             "_default_console_session_settings",
             lambda self: baseline,
         )
@@ -8685,7 +8686,7 @@ class TestPersonaHumanIdentityRemoval:
             },
         )
 
-        assert await screen._start_character_console_session(payload) is True
+        assert await screen._session._start_character_console_session(payload) is True
         assert store.session is not None
         assert not hasattr(store.session.settings, "user_profile_label")
         assert [message["content"] for message in store.messages] == [

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1214,7 +1214,7 @@ class ConsoleChatController:
         #: outcome`` by ``_ensure_console_chat_controller``, mirroring
         #: ``park_pending_approval``'s wiring and reusing its exact
         #: session-title/workspace-name resolution
-        #: (``ChatScreen._console_workspace_display_name``). ``None`` in
+        #: (``ConsoleWorkspaceController._console_workspace_display_name``). ``None`` in
         #: most controller-only tests, matching every other UI bridge slot
         #: here.
         self.notify_run_outcome: Callable[[str, ConsoleRunStatus], None] | None = None
@@ -1858,7 +1858,7 @@ class ConsoleChatController:
                 )
         else:
             # Task 4 (D2 fix wave, "bonus race"): mirror the mount-time
-            # creator (`ChatScreen._ensure_active_console_session_settings`),
+            # creator (`ConsoleSessionController._ensure_active_console_session_settings`),
             # which always passes `settings=` -- without this, a session
             # bootstrapped from THIS branch (no dispatch-captured session id
             # at all) got `settings=None` while every other creator gave the

--- a/tldw_chatbook/UI/Console_Modules/dictation.py
+++ b/tldw_chatbook/UI/Console_Modules/dictation.py
@@ -893,8 +893,16 @@ class ConsoleDictationController:
     @property
     def _console_hands_free_vad_degraded(self) -> bool:
         """Write-only: see `__init__`'s docstring for
-        `set_hands_free_vad_degraded`."""
-        raise AttributeError(
+        `set_hands_free_vad_degraded`.
+
+        Raises `RuntimeError`, deliberately NOT `AttributeError`: this is a
+        property, and `hasattr()`/`getattr(obj, name, default)` swallow
+        `AttributeError` specifically. A defensive
+        `getattr(self._dictation, "_console_hands_free_vad_degraded", False)`
+        would then read False forever regardless of the real flag, with no
+        error ever surfacing. `RuntimeError` propagates instead.
+        """
+        raise RuntimeError(
             "_console_hands_free_vad_degraded is write-only on "
             "ConsoleDictationController"
         )

--- a/tldw_chatbook/UI/Console_Modules/dictation.py
+++ b/tldw_chatbook/UI/Console_Modules/dictation.py
@@ -40,36 +40,52 @@ live on the class that receives the message). Every other one of the 20
 moves with no residue left on the screen.
 
 The controller boundary is the state attribute, not the file: dictation's
-own methods stay entangled with the hands-free loop (`ChatScreen._console_
-hands_free` and friends -- a sibling cluster this wave does not touch; the
-design spec's decomposition table does not yet give "hands-free" its own
-row) and with two not-yet-extracted composer/workspace attributes
+own methods stay entangled with the hands-free loop (`_console_hands_free`
+and friends) and with two not-yet-extracted composer/workspace attributes
 (`_console_undo_histories`, `_console_visible_draft_session_id`). Rather
 than reach through a bare screen handle ad hoc at each of those call
-sites, this module's constructor binds a property or a bound method for
-each, under the SAME name the original `ChatScreen` method used. That is
-what lets every one of the 20 method bodies below be a byte-for-byte copy
-of the pre-extraction source: no internal line needed to change, because
-every name a body references still resolves -- either to this
-controller's own moved state, or to one of these bound names.
+sites, this module's constructor binds a NAMED CALLABLE for each, under
+the SAME name the original `ChatScreen` method or attribute used, exposed
+back to the 20 method bodies below as a thin property. That is what lets
+every one of those bodies be a byte-for-byte copy of the pre-extraction
+source: no internal line needed to change, because every name a body
+references still resolves -- either to this controller's own moved state,
+or to one of these bound names.
 
-Conversely, eleven `ChatScreen` methods that are NOT part of this cluster
-(general voice-status/hands-free/composer-sync/dispatch code:
-`_speak_status`, `_deliver_console_hands_free_capture_ended`, `_console_
-read_last_response_back`, `action_toggle_console_hands_free`, `_teardown_
-console_hands_free_loop`, `_console_hands_free_request_stop_and_send`,
-`_console_hands_free_open_capture`, `_console_hands_free_close_capture`,
-`_repaint_console_hands_free_chip`, `_sync_console_composer_action_state`,
-`on_button_pressed`) read `_console_dictation_state` (or, in one case,
-write/read `_console_pending_voice_action` / `_console_dictation_origin_
-session_id`). None of them are dictation-shaped -- they own hands-free's
-FSM, the giant screen-level button dispatcher, or general composer sync --
-so none of them moved. `ChatScreen` keeps a small set of read/write
-properties under the original attribute names (see `ChatScreen`'s own
-"Dictation state (owned by `ConsoleDictationController`)" section) so
-those eleven method bodies also needed zero edits: the attribute now
-lives on `self._dictation`, but `self._console_dictation_state` still
-reads and writes it transparently.
+Wave 1 shipped six of these bindings (`_console_hands_free` and its
+`_console_hands_free_vad_degraded` sibling, `_enter_console_hands_free_
+loop`, `_console_hands_free_force_immediate_send`, `_deliver_console_
+hands_free_capture_ended`, and `_run_pending_console_voice_action`) as
+live `@property`s reaching straight through `screen`, explicitly disclosed
+as a temporary exception: hands-free had no controller of its own yet to
+hand a named dependency to. It does now (`ConsoleHandsFreeController`,
+`hands_free.py`, wave-2 console decomposition task 1). That exception is
+over -- every one of those, plus `_console_realtime_adopt_transcript`
+(same shape, same reason, even though its target -- the realtime engine --
+stays screen-owned) and the two composer/workspace accessors above, is a
+named keyword-only constructor callable now, wired by `ChatScreen.__init__`
+as a late-binding lambda, matching this file's `composer_accessor`/`chat_
+store_accessor`/`speak_status` from wave 1. See each parameter's own
+docstring below for exactly which of these are read-only, write-only
+(`set_hands_free_vad_degraded`, since no moved body here ever reads it),
+or call-through.
+
+Eleven `ChatScreen` methods are NOT part of this cluster but still read
+`_console_dictation_state` (general voice-status/composer-sync/dispatch
+code: `_speak_status`, `_console_read_last_response_back`, `_sync_console_
+composer_action_state`, `on_button_pressed`, plus seven now living on
+`ConsoleHandsFreeController` instead of `ChatScreen` -- `action_toggle_
+console_hands_free`, `_teardown_console_hands_free_loop`, `_console_hands_
+free_request_stop_and_send`, `_console_hands_free_open_capture`, `_console_
+hands_free_close_capture`, `_repaint_console_hands_free_chip`, and
+`_deliver_console_hands_free_capture_ended`). None of them are
+dictation-shaped -- they own hands-free's FSM, the giant screen-level
+button dispatcher, or general composer sync -- so none of them moved.
+`ChatScreen` keeps a small set of read/write properties under the original
+attribute names (see `ChatScreen`'s own "Dictation state (owned by
+`ConsoleDictationController`)" section) so those eleven method bodies also
+needed zero edits: the attribute now lives on `self._dictation`, but
+`self._console_dictation_state` still reads and writes it transparently.
 """
 
 from __future__ import annotations
@@ -625,6 +641,15 @@ class ConsoleDictationController:
         composer_accessor: Callable[[], ConsoleComposerBar | None],
         chat_store_accessor: Callable[[], Any],
         speak_status: Callable[[str], None],
+        hands_free_session_accessor: Callable[[], Any],
+        set_hands_free_vad_degraded: Callable[[bool], None],
+        enter_hands_free_loop: Callable[..., None],
+        hands_free_force_immediate_send: Callable[[], None],
+        deliver_hands_free_capture_ended: Callable[[Any, bool], Any],
+        realtime_adopt_transcript: Callable[[str], bool],
+        run_pending_voice_action: Callable[[str | None], Any],
+        undo_histories_accessor: Callable[[], dict[str, Any]],
+        visible_draft_session_id_accessor: Callable[[], str | None],
     ) -> None:
         """Build the controller and bind everything its moved bodies need.
 
@@ -635,8 +660,9 @@ class ConsoleDictationController:
         that is not this controller's own state, under the SAME name the
         original method used.
 
-        Three kinds of binding, one rule each, not one rule for
-        everything:
+        Two kinds of binding, one rule each (a wave-1 third kind, "reach
+        through `screen` because the target has no controller of its own
+        yet," is retired as of wave 2 -- see the module docstring):
 
         1. **Framework services** (`run_worker`, `post_message`,
            `set_timer`, `set_interval`, `is_mounted`) live-read from
@@ -646,49 +672,37 @@ class ConsoleDictationController:
            over) goes stale the instant a test replaces the attribute on
            the SCREEN INSTANCE afterward, confirmed for `set_timer`/
            `set_interval` by this cluster's own test suite.
-        2. **Hands-free's reach-backs** (`_console_hands_free` and its
-           siblings, `_enter_console_hands_free_loop`,
-           `_console_hands_free_force_immediate_send`,
-           `_deliver_console_hands_free_capture_ended`) and one general
-           screen-orchestration method (`_run_pending_console_voice_
-           action`) are the SAME live-`@property`-through-`screen` shape,
-           for the same staleness reason -- but they are a disclosed,
-           temporary exception, not a controller dependency: they belong
-           to sibling clusters this wave does not touch (hands-free is
-           not yet its own controller), so there is no named-parameter
-           home for them yet. `screen` is the only handle that reaches
-           them.
-        3. **Everything else dictation genuinely depends on that is not
-           its own state** -- the composer accessor, the chat-store
-           accessor, and the speak-status gate -- is a NAMED constructor
-           dependency (`composer_accessor`/`chat_store_accessor`/
-           `speak_status` below), matching the design spec's rule that
-           "a controller's dependencies are its signature": discoverable
-           by reading the constructor, not by reading every `@property`
-           on the class. Each is a zero-arg callable the CALLER
-           constructs to close over the screen's own attribute lookup at
-           CALL time, not at construction time -- see `ChatScreen.
-           __init__`'s `lambda: self._console_composer_or_none()` (not
-           `composer_accessor=self._console_composer_or_none`, which
-           would freeze the bound method the same way `run_worker` used
-           to) -- so the same staleness guarantee kind 1 gets from a
-           property, kind 3 gets from the lambda's own late attribute
-           lookup. The controller's own `_console_composer_or_none`/
-           `_ensure_console_chat_store`/`_speak_status` properties below
-           are thin returns of these stored callables, kept under their
-           original names so every one of the 20 moved method bodies
-           still calls `self._console_composer_or_none()` etc. unchanged.
+        2. **Everything else dictation genuinely depends on that is not
+           its own state** is a NAMED constructor dependency, matching the
+           design spec's rule that "a controller's dependencies are its
+           signature": discoverable by reading the constructor, not by
+           reading every `@property` on the class. Each is a callable the
+           CALLER constructs to close over the screen's own attribute
+           lookup at CALL time, not at construction time -- see
+           `ChatScreen.__init__`'s `lambda: self._console_composer_or_
+           none()` (not `composer_accessor=self._console_composer_or_
+           none`, which would freeze the bound method the same way
+           `run_worker` used to) -- so the same staleness guarantee kind 1
+           gets from a property, kind 2 gets from the lambda's own late
+           attribute lookup. The controller's own properties below are
+           thin wrappers around these stored callables, kept under the
+           ORIGINAL attribute/method names so every one of the 20 moved
+           method bodies still reads/calls `self._console_composer_or_
+           none()`, `self._console_hands_free`, etc. unchanged. Most
+           return the callable itself, for bodies that already called it
+           with `()`; `_console_undo_histories`/`_console_visible_draft_
+           session_id` were bare-attribute reads in the pre-move source,
+           so those two properties CALL the stored accessor internally and
+           return the value instead.
 
-        `app_instance` is the one plain-attribute exception to all three
-        rules above: see its own line below for why.
+        `app_instance` is the one plain-attribute exception to both rules
+        above: see its own line below for why.
 
         Args:
             screen: The Console screen. Used ONLY for the framework
-                services in binding kind 1 above and the disclosed,
-                temporary hands-free/orchestration reach-backs in kind 2.
-                None of this is `query_one` traffic -- dictation owns no
-                DOM of its own, so there is no region boundary for it to
-                cross.
+                services in binding kind 1 above. None of this is
+                `query_one` traffic -- dictation owns no DOM of its own,
+                so there is no region boundary for it to cross.
             app_instance: For `notify()`, posting TTS events, and the
                 once-per-app-run notification latches the moved event
                 handler stores on it (`_console_dictation_override_
@@ -713,12 +727,65 @@ class ConsoleDictationController:
                 non-dictation voice paths too (hands-free's queued-send
                 ack, "read that back"), so it stays screen-owned;
                 dictation only calls it.
+            hands_free_session_accessor: Reads `ConsoleHandsFreeController.
+                _console_hands_free`, the pipeline loop's live session (or
+                None). Wave 1's disclosed, temporary exception, closed out
+                now that hands-free has its own controller (wave-2 console
+                decomposition, task 1) -- see the module docstring.
+            set_hands_free_vad_degraded: Writes `ConsoleHandsFreeController.
+                _console_hands_free_vad_degraded`. Setter-only: only
+                `_handle_console_dictation_event`'s `VoiceVadUnavailable`
+                branch touches this attribute, and it only ever assigns to
+                it, never reads it.
+            enter_hands_free_loop: `ConsoleHandsFreeController._enter_
+                console_hands_free_loop`, the engine fork -- reached by a
+                spoken "Console, hands free." mid-capture.
+            hands_free_force_immediate_send: `ConsoleHandsFreeController.
+                _console_hands_free_force_immediate_send`, reached by a
+                spoken "send" mid-loop.
+            deliver_hands_free_capture_ended: `ConsoleHandsFreeController.
+                _deliver_console_hands_free_capture_ended`, scheduled (not
+                awaited) by `_handle_console_dictation_limit` when a
+                limit-triggered stop finds nothing captured.
+            realtime_adopt_transcript: `ChatScreen._console_realtime_adopt_
+                transcript` -- the realtime engine's own entry point. Same
+                shape and staleness reason as the five hands-free callables
+                above, but its target stays screen-owned (not extracted
+                this wave): the realtime loop (V4) owns whether a capture's
+                transcript becomes its first spoken turn instead of
+                composer text.
+            run_pending_voice_action: `ChatScreen._run_pending_console_
+                voice_action` -- general screen-orchestration (chat store,
+                send button, tab creation, TTS read-back), well beyond a
+                controller's "handful of well-known ids," so it stays
+                screen-owned; only `_stop_console_dictation`'s tail calls
+                it, unconditionally (a no-op when nothing was queued).
+                `ConsoleHandsFreeController` has an identically-shaped,
+                identically-named dependency pointed at the SAME screen
+                method.
+            undo_histories_accessor: Reads `ChatScreen._console_undo_
+                histories` -- per-session composer undo history, screen-
+                owned (not extracted this wave). Returns the actual dict
+                (not a copy): `_insert_console_dictation` mutates it in
+                place via `.pop(...)`.
+            visible_draft_session_id_accessor: Reads `ChatScreen._console_
+                visible_draft_session_id` -- the session id the mounted
+                composer's draft currently reflects, screen-owned.
         """
         self._screen = screen
         self.app_instance = app_instance
         self._composer_accessor = composer_accessor
         self._chat_store_accessor = chat_store_accessor
         self._speak_status_fn = speak_status
+        self._hands_free_session_accessor = hands_free_session_accessor
+        self._set_hands_free_vad_degraded_fn = set_hands_free_vad_degraded
+        self._enter_hands_free_loop_fn = enter_hands_free_loop
+        self._hands_free_force_immediate_send_fn = hands_free_force_immediate_send
+        self._deliver_hands_free_capture_ended_fn = deliver_hands_free_capture_ended
+        self._realtime_adopt_transcript_fn = realtime_adopt_transcript
+        self._run_pending_voice_action_fn = run_pending_voice_action
+        self._undo_histories_accessor = undo_histories_accessor
+        self._visible_draft_session_id_accessor = visible_draft_session_id_accessor
 
         # Dictation's own state, moved verbatim from `ChatScreen.__init__`.
         self._console_dictation_session: Any | None = None
@@ -783,70 +850,71 @@ class ConsoleDictationController:
 
     @property
     def _enter_console_hands_free_loop(self) -> Any:
-        """Hands-free's own entry point (sibling cluster). See `__init__`."""
-        return self._screen._enter_console_hands_free_loop
+        """The injected `enter_hands_free_loop`. See `__init__`'s docstring."""
+        return self._enter_hands_free_loop_fn
 
     @property
     def _console_hands_free_force_immediate_send(self) -> Any:
-        """Hands-free's own entry point (sibling cluster). See `__init__`."""
-        return self._screen._console_hands_free_force_immediate_send
+        """The injected `hands_free_force_immediate_send`. See `__init__`'s
+        docstring."""
+        return self._hands_free_force_immediate_send_fn
 
     @property
     def _deliver_console_hands_free_capture_ended(self) -> Any:
-        """Hands-free's own entry point (sibling cluster). See `__init__`."""
-        return self._screen._deliver_console_hands_free_capture_ended
+        """The injected `deliver_hands_free_capture_ended`. See `__init__`'s
+        docstring."""
+        return self._deliver_hands_free_capture_ended_fn
 
     @property
     def _console_realtime_adopt_transcript(self) -> Any:
-        """Realtime's own entry point (sibling cluster). See `__init__`.
-
-        Live `@property` through `screen`, never snapshotted, for the same
-        staleness reason as the hands-free reach-backs above: the realtime
-        loop (V4) owns whether a capture's transcript becomes its first
-        spoken turn instead of composer text.
+        """The injected `realtime_adopt_transcript`. See `__init__`'s
+        docstring: the realtime loop (V4) owns whether a capture's
+        transcript becomes its first spoken turn instead of composer text.
         """
-        return self._screen._console_realtime_adopt_transcript
+        return self._realtime_adopt_transcript_fn
 
     @property
     def _run_pending_console_voice_action(self) -> Any:
-        """Fire a capture-ending `VoiceCommand`'s queued action.
-
-        `ChatScreen`'s own, not dictation's: its body reaches the chat
-        store, the send button, tab creation, and TTS read-back -- well
-        beyond a controller's "handful of well-known ids." Only
+        """The injected `run_pending_voice_action`. See `__init__`'s
+        docstring: `ChatScreen`'s own, not dictation's -- its body reaches
+        the chat store, the send button, tab creation, and TTS read-back,
+        well beyond a controller's "handful of well-known ids." Only
         `_stop_console_dictation`'s tail calls it, unconditionally (a
         no-op when nothing was queued).
         """
-        return self._screen._run_pending_console_voice_action
+        return self._run_pending_voice_action_fn
 
     @property
     def _console_hands_free(self) -> Any:
-        """The hands-free loop's live session, or None. Screen-owned."""
-        return self._screen._console_hands_free
+        """Calls the injected `hands_free_session_accessor`. The pipeline
+        loop's live session, or None. See `__init__`'s docstring."""
+        return self._hands_free_session_accessor()
 
     @property
     def _console_hands_free_vad_degraded(self) -> bool:
-        """Whether VAD is unavailable, degrading the hands-free loop.
-
-        Screen-owned state; the moved `_handle_console_dictation_event`
-        writes it (the VAD-unavailable notice arrives mid-capture), so
-        this needs a setter, unlike the read-only properties below.
-        """
-        return self._screen._console_hands_free_vad_degraded
+        """Write-only: see `__init__`'s docstring for
+        `set_hands_free_vad_degraded`."""
+        raise AttributeError(
+            "_console_hands_free_vad_degraded is write-only on "
+            "ConsoleDictationController"
+        )
 
     @_console_hands_free_vad_degraded.setter
     def _console_hands_free_vad_degraded(self, value: bool) -> None:
-        self._screen._console_hands_free_vad_degraded = value
+        self._set_hands_free_vad_degraded_fn(value)
 
     @property
     def _console_undo_histories(self) -> Any:
-        """Per-session composer undo history. Screen-owned (not extracted this wave)."""
-        return self._screen._console_undo_histories
+        """Calls the injected `undo_histories_accessor`. See `__init__`'s
+        docstring: per-session composer undo history, screen-owned (not
+        extracted this wave)."""
+        return self._undo_histories_accessor()
 
     @property
     def _console_visible_draft_session_id(self) -> Any:
-        """The session id the mounted composer's draft currently reflects."""
-        return self._screen._console_visible_draft_session_id
+        """Calls the injected `visible_draft_session_id_accessor`. See
+        `__init__`'s docstring."""
+        return self._visible_draft_session_id_accessor()
 
     async def teardown(self) -> None:
         """Release dictation's own resources during screen unmount.

--- a/tldw_chatbook/UI/Console_Modules/hands_free.py
+++ b/tldw_chatbook/UI/Console_Modules/hands_free.py
@@ -1,0 +1,1331 @@
+"""Console hands-free controller.
+
+Extracted out of `ChatScreen` (wave-2 console decomposition, task 1): the
+V3 pipeline hands-free conversation loop -- speak, it sends, the reply is
+spoken, speak again -- plus the two-engine coordination points shared with
+the V4 realtime loop added by PR #1350. `Chat/console_hands_free.py`
+(`HandsFreeController`, the headless FSM) and `Chat/reply_sentence_
+sequencer.py` (`SentenceSequencer`, the speech splitter) are pure/headless;
+this module is their thin Console-screen wiring, matching `dictation.py`'s
+own "controller, a plain object that owns state and behaviour with no
+region of its own" shape
+(`Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`).
+
+TWO-ENGINE BOUNDARY (the load-bearing design decision this file makes):
+
+`_enter_console_hands_free_loop` is an engine FORK, not a pipeline-only
+entry point -- PR #1350 (realtime voice V4) added a second engine,
+`ChatScreen._console_realtime` (+ `_console_realtime_close_worker`),
+mutually exclusive with this module's own `_console_hands_free` pipeline
+session by construction (the fork picks exactly one per loop entry).
+`ConsoleHandsFreeController` owns the FORK and both cross-engine action
+entry points (`action_toggle_console_hands_free`/`action_exit_console_
+hands_free`, moved here as-is, plus `check_action`'s availability check,
+moved as `console_hands_free_exit_available`) because all three read BOTH
+engines -- that is coordination logic, not pipeline-only logic. "Esc from
+any point in the loop" is a promise the docs make about hands-free, not
+about one engine's implementation of it, so `action_exit_console_hands_
+free` exits both unconditionally.
+
+The realtime engine's own state and ~60-method implementation
+(`ConsoleRealtimeSession` and every `_console_realtime_*`/`_on_console_
+realtime_*` method) deliberately did NOT move here and stay on `ChatScreen`
+exactly as PR #1350 wrote them -- dragging that whole stack across the
+boundary was never this task's job, only the fork and the two action entry
+points were. This module reaches the realtime engine through exactly two
+named constructor callables, `realtime_session_accessor` and
+`enter_realtime_loop` (see `__init__`'s docstring, binding kind 3) -- never
+a bare screen handle. The reverse direction (realtime code on `ChatScreen`
+calling into the PIPELINE engine moved here, e.g. `_console_realtime_
+fallback_to_pipeline`'s loud fallback) is ordinary screen-calls-its-own-
+controller traffic: `ChatScreen` holds `self._hands_free` the same way it
+holds `self._dictation`/`self._workspace`, and calls its methods directly
+by their ORIGINAL private names -- no injection needed for that direction,
+matching the established convention throughout this decomposition.
+
+Moved verbatim (byte-for-byte, mechanically diffable against the pre-move
+source):
+
+- The module-level vocabulary this loop's own wiring needs:
+  `CONSOLE_HANDS_FREE_DEGRADED_MESSAGE`, `ConsoleHandsFreeSession` (the
+  per-loop-entry dataclass), and `CONSOLE_REALTIME_FORCED_UNCONFIGURED_
+  MESSAGE` (realtime-labeled but consumed ONLY by the fork below -- it
+  stayed textually inside `ChatScreen`'s realtime-constants block since
+  wave 1 for no reason beyond neighboring code; the fork is the only
+  reader, so it moved with its one caller rather than staying behind for a
+  circular re-import).
+- Every `ChatScreen` method matching `*hands_free*` whose body was
+  pipeline-shaped: the engine fork itself, plus all 26 methods between
+  `_enter_console_hands_free_pipeline_loop` and `_on_console_hands_free_
+  sequencer_drained` in the pre-move source's "Hands-free conversation
+  loop" section, plus `_deliver_console_hands_free_capture_ended` (a
+  dictation-cluster-adjacent async helper the pre-move source placed near
+  `ChatScreen.on_unmount` rather than in that section, but whose own
+  docstring names it "Console hands-free" throughout) and `_console_
+  pipeline_hands_free_blocker` (the fallback-availability check the
+  realtime engine's own loud-fallback method calls). 28 methods, ~730
+  lines -- both counts confirmed against the pre-move source. Plus the two
+  action entry points and the `check_action` branch described above.
+- `_CONSOLE_HANDS_FREE_CAPTURE_ENDED_WAIT_SECONDS`, the class constant
+  `_deliver_console_hands_free_capture_ended` is bound on.
+
+Three kinds of binding, same rule as `dictation.py`'s own (see that
+module's `ConsoleDictationController.__init__` docstring for the full
+rationale; restated briefly here):
+
+1. **Framework services** (`run_worker`, `set_interval`, `is_mounted`)
+   live-read from `screen` via `@property` on every access.
+2. **App-level dependencies that are not this controller's own state** are
+   NAMED keyword-only constructor callables (`composer_accessor`, `chat_
+   store_accessor`, dictation's state/actions, `run_pending_voice_action`,
+   and the two realtime callables above) -- each exposed back to the 28
+   moved bodies as a thin property under the SAME original name the
+   pre-move source used, so none of those bodies needed an internal edit.
+   A handful of these (`_console_dictation_state`, `_console_dictation_
+   origin_session_id`, `_console_pending_voice_action`) were bare-attribute
+   reads/writes in the original, not calls -- their properties therefore
+   invoke the stored callable internally and return/accept the VALUE,
+   unlike `_console_composer_or_none` and friends, whose properties return
+   the callable itself because the original bodies already called it with
+   `()`. `_console_pending_voice_action` is write-only (the 28 bodies never
+   read it, only `_console_hands_free_request_stop_and_send` writes it) --
+   its getter raises rather than silently returning a stale/wrong value.
+3. `app_instance` is the one plain-attribute exception, for the same
+   reason `dictation.py` snapshots it: `notify()`/`post_message()` calls
+   read it as a bare attribute in the pre-move source, never through a
+   call that could go stale.
+
+There is no more "kind 2, disclosed temporary exception" bucket here, and
+`dictation.py`'s no longer has one either (see that module's docstring):
+wave 1 left FOUR of dictation's reach-backs (`_console_hands_free` and its
+`_console_hands_free_vad_degraded` sibling, `_enter_console_hands_free_
+loop`, `_console_hands_free_force_immediate_send`, `_deliver_console_
+hands_free_capture_ended`) as live properties straight through `screen`,
+explicitly disclosed as temporary because hands-free had no controller of
+its own yet to hand a named dependency to. It does now: `ChatScreen.
+__init__` wires all four (plus `_console_realtime_adopt_transcript` and
+`_run_pending_console_voice_action`, which were the same shape for the
+same reason even though their targets are screen-owned, not moved here) as
+named callables pointed at THIS controller, exactly like every other
+app-level dependency in this decomposition. That exception is over.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import asyncio
+import threading
+import time
+from typing import Any, TYPE_CHECKING
+
+from loguru import logger
+
+from ...Chat import console_voice_input
+from ...Chat.console_voice_input import (
+    acoustic_barge_in_enabled,
+    handsfree_send_delay_seconds,
+    resolve_handsfree_engine,
+    realtime_enabled,
+)
+from ...Chat.console_chat_models import ConsoleMessageRole
+from ...Chat.console_hands_free import (
+    CloseCapture,
+    CountdownTick,
+    ExitLoop,
+    HandsFreeController,
+    HandsFreeIntent,
+    ModeChanged,
+    OpenCapture,
+    RequestStopAndSend,
+    SilenceSpeech,
+    SuppressReplySpeech,
+)
+from ...Chat.reply_sentence_sequencer import SentenceSequencer
+from ...Widgets.Console import ConsoleComposerBar
+
+if TYPE_CHECKING:
+    from ..Screens.chat_screen import ChatScreen
+
+logger = logger.bind(module="ChatScreen")
+
+
+#: Task 5 (VAD-degraded honesty carrier): shown once per hands-free ENTRY
+#: (not once per app run, unlike `VAD_UNAVAILABLE_MESSAGE` -- entering the
+#: loop is the moment this limitation actually starts to matter) when
+#: `webrtcvad` is unavailable. Reuses `VAD_UNAVAILABLE_MESSAGE`'s own
+#: framing (see `console_voice_input.VoiceVadUnavailable`'s docstring):
+#: without it, the silence gate that drives auto-send/barge-in never fires.
+CONSOLE_HANDS_FREE_DEGRADED_MESSAGE = (
+    "Hands-free is degraded: voice-activity detection (webrtcvad) is not "
+    "installed, so it cannot auto-send on a pause or hear a spoken barge-in. "
+    "Use the mic button, \"Console, stop.\", or Esc/ctrl+shift+h to end a turn."
+)
+
+
+#: Realtime-labeled but consumed only by the engine fork below -- see the
+#: module docstring's "moved verbatim" section for why this lives here now
+#: instead of in `ChatScreen`'s own realtime-constants block.
+CONSOLE_REALTIME_FORCED_UNCONFIGURED_MESSAGE = (
+    "Hands-free is set to the realtime engine, but [realtime] enabled is "
+    'false. Turn it on in config, or set dictation.handsfree_engine to "auto" '
+    'or "pipeline".'
+)
+
+
+@dataclass
+class ConsoleHandsFreeSession:
+    """Everything the hands-free conversation loop needs while it runs.
+
+    Constructed once per loop entry (`ChatScreen._enter_console_hands_free_
+    loop`) and torn down on `ExitLoop` (`ChatScreen._teardown_console_hands_
+    free_loop`) -- never reused across loop entries, unlike the one-shot
+    dictation session, so a fresh `HandsFreeController`/`SentenceSequencer`
+    pair with clean state is guaranteed for every "hands free" invocation.
+
+    Attributes:
+        controller: The headless FSM driving the loop.
+        sequencer: The headless sentence-boundary speech sequencer, reused
+            across every reply in this loop (`begin_reply()` resets its
+            per-reply state -- see that method's docstring).
+        tick_timer: The `set_interval(0.1, ...)` handle driving both
+            `controller.tick(now)` and the chip repaint. Stopped on
+            teardown.
+        reply_id: The outstanding reply's assistant-message id, or None
+            when no reply is outstanding. Claimed by the first delta/
+            completion tap call that passes the reply-identity guard (see
+            `pending_session_id`/`pending_existing_assistant_ids` below and
+            `_console_hands_free_try_claim_reply`'s docstring) while
+            `controller.state == "awaiting_reply"`.
+        toast_shown_for_reply: Policy state for `speak_utterance`'s `quiet`
+            parameter -- at most one failure toast per reply; every
+            subsequent utterance in the same reply passes `quiet=True`
+            once this is True. Reset in `_begin_console_hands_free_reply`.
+        countdown_remaining: The most recent `CountdownTick.remaining`,
+            painted into the chip by the 0.1 s tick (see `_repaint_console_
+            hands_free_chip`). Meaningless outside `controller.state ==
+            "countdown"`.
+        pending_session_id: The Console session `RequestStopAndSend`
+            recorded this send as going into (`_console_dictation_origin_
+            session_id` at that moment -- the SAME value the existing V2
+            wrong-session-refusal already uses, not `store.active_session_
+            id` re-read later, which a tab switch could have moved on from
+            by dispatch time). `None` until the first send. Part of the
+            reply-identity guard (task-5 review B1/M7).
+        pending_existing_assistant_ids: A snapshot of every assistant
+            message id already present in `pending_session_id` at the
+            moment `RequestStopAndSend` fired -- taken BEFORE the send
+            creates its own new assistant row, so any id in this set can
+            only be a PRE-EXISTING (therefore stale/foreign) reply, never
+            the new one. Part of the reply-identity guard (task-5 review
+            B1).
+    """
+
+    controller: HandsFreeController
+    sequencer: SentenceSequencer
+    tick_timer: Any = None
+    reply_id: str | None = None
+    toast_shown_for_reply: bool = False
+    countdown_remaining: float = 0.0
+    pending_session_id: str | None = None
+    pending_existing_assistant_ids: frozenset[str] = frozenset()
+
+
+class ConsoleHandsFreeController:
+    """Owns the Console shell's V3 pipeline hands-free loop, plus the
+    engine-fork/action coordination shared with the V4 realtime loop.
+
+    Wave 2's first controller extraction to sit alongside a still-on-screen
+    sibling engine (see the module docstring's two-engine boundary
+    section). `ChatScreen` constructs exactly one of these, in `__init__`,
+    and keeps a `self._hands_free` reference plus thin delegations for the
+    two Textual `action_*` entry points and the `check_action` branch (all
+    three call straight through to this controller -- see their own
+    docstrings on `ChatScreen`).
+    """
+
+    #: Bound on how long `_deliver_console_hands_free_capture_ended` waits
+    #: for a limit-triggered stop to actually reach `idle` before giving up
+    #: -- generous relative to `dictation.stop_join_timeout_seconds`'s own
+    #: 30s default (that timeout is the transcription-thread join `_stop_
+    #: console_dictation` itself is bounded by; this only needs to exceed
+    #: it, not match it exactly). Giving up here is a safe failure mode: no
+    #: `on_capture_ended` is delivered at all, so the FSM's own bookkeeping
+    #: is never told something that did not (yet) happen, and the user can
+    #: still exit manually (Esc/mic/ctrl+shift+h/spoken "stop").
+    _CONSOLE_HANDS_FREE_CAPTURE_ENDED_WAIT_SECONDS: float = 40.0
+
+    def __init__(
+        self,
+        screen: "ChatScreen",
+        *,
+        app_instance: Any,
+        composer_accessor: Callable[[], ConsoleComposerBar | None],
+        chat_store_accessor: Callable[[], Any],
+        dictation_state_accessor: Callable[[], str],
+        dictation_origin_session_id_accessor: Callable[[], str | None],
+        set_pending_voice_action: Callable[[str | None], None],
+        request_dictation_start: Callable[[], None],
+        request_dictation_stop: Callable[[], None],
+        run_pending_voice_action: Callable[[str | None], Any],
+        realtime_session_accessor: Callable[[], Any],
+        enter_realtime_loop: Callable[..., None],
+    ) -> None:
+        """Build the controller and bind everything its moved bodies need.
+
+        Every moved method body below is a byte-for-byte copy of the
+        pre-extraction `ChatScreen` method (see the module docstring's
+        "moved verbatim" section) -- no internal line was edited to
+        retarget a call or an attribute. That is possible because this
+        constructor binds every name those bodies reference that is not
+        this controller's own state, under the SAME name the original
+        method used. See the module docstring for the three binding kinds.
+
+        Args:
+            screen: The Console screen. Used ONLY for the framework
+                services in binding kind 1 (`run_worker`/`set_interval`/
+                `is_mounted`). No `query_one` traffic -- this controller
+                owns no DOM of its own, so there is no region boundary for
+                it to cross.
+            app_instance: For `notify()` and posting TTS events -- unchanged
+                from how the pre-extraction methods used `self.app_
+                instance`. Snapshotted as a plain attribute; see the module
+                docstring's binding-kind-3 paragraph for why that is
+                correct here (every pre-move use was a bare-attribute read,
+                never a call that could go stale).
+            composer_accessor: `ChatScreen._console_composer_or_none`,
+                late-binding lambda -- same rationale as `dictation.py`'s
+                identical parameter.
+            chat_store_accessor: `ChatScreen._ensure_console_chat_store`,
+                same rationale.
+            dictation_state_accessor: Reads `ChatScreen._console_dictation_
+                state` (itself a proxy onto `ConsoleDictationController`'s
+                own state) at call time. The property exposing this below
+                CALLS the accessor and returns the value, unlike `_console_
+                composer_or_none`'s property -- the pre-move bodies read
+                `self._console_dictation_state` bare, never with `()`.
+            dictation_origin_session_id_accessor: Same shape, for
+                `ChatScreen._console_dictation_origin_session_id`. Read-only
+                -- only `_console_hands_free_request_stop_and_send` reads
+                it, and it never writes it.
+            set_pending_voice_action: Writes `ChatScreen._console_pending_
+                voice_action` (itself a proxy onto dictation's own state).
+                Setter-only: `_console_hands_free_request_stop_and_send` is
+                the ONLY pre-move body that touches this attribute, and it
+                only ever assigns to it, never reads it -- the property
+                below is therefore write-only too (its getter raises),
+                rather than silently exposing a read no moved body needs.
+            request_dictation_start: `ChatScreen._request_console_dictation_
+                start`, itself already a one-line delegation onto
+                `ConsoleDictationController`.
+            request_dictation_stop: `ChatScreen._request_console_dictation_
+                stop`, same shape.
+            run_pending_voice_action: `ChatScreen._run_pending_console_
+                voice_action` -- general screen-orchestration (chat store,
+                send button, tab creation, TTS read-back), shared with
+                `ConsoleDictationController`'s OWN identically-named
+                dependency; both point at the same screen method.
+            realtime_session_accessor: Reads `ChatScreen._console_realtime`
+                -- the ONLY way this controller ever touches the realtime
+                engine's live session. See the module docstring's
+                two-engine boundary section.
+            enter_realtime_loop: `ChatScreen._enter_console_realtime_loop`,
+                the realtime engine's own entry point -- called only from
+                the fork (`_enter_console_hands_free_loop`), which picks
+                exactly one engine per loop entry.
+        """
+        self._screen = screen
+        self.app_instance = app_instance
+        self._composer_accessor = composer_accessor
+        self._chat_store_accessor = chat_store_accessor
+        self._dictation_state_accessor = dictation_state_accessor
+        self._dictation_origin_session_id_accessor = (
+            dictation_origin_session_id_accessor
+        )
+        self._set_pending_voice_action_fn = set_pending_voice_action
+        self._request_dictation_start_fn = request_dictation_start
+        self._request_dictation_stop_fn = request_dictation_stop
+        self._run_pending_voice_action_fn = run_pending_voice_action
+        self._realtime_session_accessor = realtime_session_accessor
+        self._enter_realtime_loop_fn = enter_realtime_loop
+
+        # The pipeline engine's own state, moved verbatim from
+        # `ChatScreen.__init__`.
+        self._console_hands_free: ConsoleHandsFreeSession | None = None
+        #: True once `_install_console_hands_free_store_tap` has wrapped the
+        #: store's `append_stream_chunk`/`mark_message_*` methods. The store
+        #: itself is a lazily-created singleton for this screen instance
+        #: (`_ensure_console_chat_store`), so this only ever needs doing once.
+        self._console_hands_free_store_tap_installed = False
+        #: Set once (per app run) by a `VoiceVadUnavailable` event, via
+        #: dictation's injected `set_hands_free_vad_degraded` callable. Read
+        #: by `_enter_console_hands_free_pipeline_loop`, which shows a
+        #: dedicated warning naming exactly what auto-send/barge-in cannot
+        #: do in degraded mode, and by `_console_pipeline_hands_free_
+        #: blocker`, the realtime engine's own loud-fallback check.
+        self._console_hands_free_vad_degraded = False
+
+    @property
+    def is_mounted(self) -> bool:
+        """Whether the Console screen is currently mounted.
+
+        A live check: mount state changes over the controller's life, so
+        this has to re-read `screen.is_mounted` on every access.
+        """
+        return self._screen.is_mounted
+
+    @property
+    def run_worker(self) -> Any:
+        """`Screen.run_worker`, bound. See `__init__`'s docstring for why
+        this is a property rather than a value snapshotted once."""
+        return self._screen.run_worker
+
+    @property
+    def set_interval(self) -> Any:
+        """`Screen.set_interval`, bound. See `__init__`'s docstring."""
+        return self._screen.set_interval
+
+    @property
+    def _console_composer_or_none(self) -> Any:
+        """The injected `composer_accessor`. Kept under this name so the
+        moved method bodies below still call `self._console_composer_or_
+        none()` unchanged. See `__init__`'s docstring (binding kind 3)."""
+        return self._composer_accessor
+
+    @property
+    def _ensure_console_chat_store(self) -> Any:
+        """The injected `chat_store_accessor`. See `_console_composer_or_
+        none`'s docstring immediately above."""
+        return self._chat_store_accessor
+
+    @property
+    def _console_dictation_state(self) -> str:
+        """Calls the injected `dictation_state_accessor` and returns the
+        value -- the pre-move bodies read this bare, never with `()`."""
+        return self._dictation_state_accessor()
+
+    @property
+    def _console_dictation_origin_session_id(self) -> str | None:
+        """Calls the injected `dictation_origin_session_id_accessor`."""
+        return self._dictation_origin_session_id_accessor()
+
+    @property
+    def _console_pending_voice_action(self) -> str | None:
+        """Write-only: see `__init__`'s docstring for
+        `set_pending_voice_action`."""
+        raise AttributeError(
+            "_console_pending_voice_action is write-only on "
+            "ConsoleHandsFreeController"
+        )
+
+    @_console_pending_voice_action.setter
+    def _console_pending_voice_action(self, value: str | None) -> None:
+        self._set_pending_voice_action_fn(value)
+
+    @property
+    def _request_console_dictation_start(self) -> Any:
+        """The injected `request_dictation_start`. See `_console_composer_
+        or_none`'s docstring."""
+        return self._request_dictation_start_fn
+
+    @property
+    def _request_console_dictation_stop(self) -> Any:
+        """The injected `request_dictation_stop`. See `_console_composer_
+        or_none`'s docstring."""
+        return self._request_dictation_stop_fn
+
+    @property
+    def _run_pending_console_voice_action(self) -> Any:
+        """The injected `run_pending_voice_action`. See `_console_composer_
+        or_none`'s docstring."""
+        return self._run_pending_voice_action_fn
+
+    @property
+    def _console_realtime(self) -> Any:
+        """Calls the injected `realtime_session_accessor`. The realtime
+        engine's live session, or None -- screen-owned; see the module
+        docstring's two-engine boundary section."""
+        return self._realtime_session_accessor()
+
+    @property
+    def _enter_console_realtime_loop(self) -> Any:
+        """The injected `enter_realtime_loop`. See `_console_composer_or_
+        none`'s docstring."""
+        return self._enter_realtime_loop_fn
+
+    def action_toggle_console_hands_free(self) -> None:
+        """`ctrl+shift+h`: enter the hands-free loop, or exit it if already running.
+
+        Both engines exit through their own controller's `on_exit_request()`
+        -- the toggle never tears state down directly, so the exit runs the
+        same reasoned `ExitLoop` path every other exit route uses.
+        """
+        if self._console_hands_free is not None:
+            self._console_hands_free.controller.on_exit_request()
+            return
+        if self._console_realtime is not None:
+            self._console_realtime.controller.on_exit_request()
+            return
+        self._enter_console_hands_free_loop(
+            capture_live=self._console_dictation_state == "recording"
+        )
+
+    def _enter_console_hands_free_loop(self, *, capture_live: bool) -> None:
+        """Pick the hands-free engine, then start that engine's loop.
+
+        The fork (V4 task 5, rule 1) is deliberately the ONLY place engine
+        selection happens, and it happens once per loop entry -- never
+        mid-loop. A loop that is already running keeps the engine it was
+        started with: `resolve_handsfree_engine()` reads live config, and
+        re-resolving it on a re-entry (a spoken "hands free" mid-loop, say)
+        could otherwise hand a running V3 loop's re-entry to the realtime
+        engine and leave two loops fighting over the microphone.
+
+        `"realtime"` selected while `[realtime] enabled` is false is a
+        FORCED-but-unconfigured selection, not a mistake to paper over:
+        `resolve_handsfree_engine()`'s docstring is explicit that it never
+        silently downgrades an explicit `dictation.handsfree_engine =
+        "realtime"` to the pipeline, and that being honest about it is the
+        caller's job. So it is refused here, loudly, rather than starting
+        an engine the user disabled or a fallback they did not ask for.
+
+        Args:
+            capture_live: True when an existing one-shot dictation capture
+                is already open and should be adopted as the loop's first
+                turn; forwarded verbatim to whichever engine is selected.
+        """
+        if self._console_hands_free is not None:
+            self._enter_console_hands_free_pipeline_loop(capture_live=capture_live)
+            return
+        if self._console_realtime is not None:
+            # `RealtimeLoopController.enter()` is itself idempotent, so a
+            # stray re-entry has nothing to re-confirm here (unlike V3,
+            # whose `enter()` carries capture bookkeeping).
+            return
+        if resolve_handsfree_engine() == "realtime":
+            if not realtime_enabled():
+                self.app_instance.notify(
+                    CONSOLE_REALTIME_FORCED_UNCONFIGURED_MESSAGE, severity="warning"
+                )
+                return
+            self._enter_console_realtime_loop(capture_live=capture_live)
+            return
+        self._enter_console_hands_free_pipeline_loop(capture_live=capture_live)
+
+    def _enter_console_hands_free_pipeline_loop(self, *, capture_live: bool) -> None:
+        """Start (or re-confirm) the V3 pipeline hands-free loop.
+
+        Reached from the engine fork above, and directly from the realtime
+        engine's loud fallback (`_console_realtime_fallback_to_pipeline`),
+        which must NOT re-run the fork -- it would resolve straight back to
+        the realtime engine that just failed.
+
+        Args:
+            capture_live: True when an existing one-shot dictation capture
+                is already open and should be adopted as the loop's first
+                turn (spoken "hands free" mid-capture, or the key binding
+                pressed while already recording); False opens a fresh
+                capture (the key binding pressed from idle). Ignored on
+                re-entry -- `HandsFreeController.enter()`'s own re-entry
+                semantics trust its own `capture_open` bookkeeping instead
+                of a possibly-stale argument (see that method's docstring).
+        """
+        existing = self._console_hands_free
+        if existing is not None:
+            existing.controller.enter(capture_live=capture_live)
+            return
+        if self._console_hands_free_vad_degraded:
+            self.app_instance.notify(
+                CONSOLE_HANDS_FREE_DEGRADED_MESSAGE, severity="warning"
+            )
+        controller = HandsFreeController(
+            emit=self._handle_console_hands_free_intent,
+            send_delay_seconds=handsfree_send_delay_seconds(),
+            acoustic_barge_in=acoustic_barge_in_enabled(),
+        )
+        sequencer = SentenceSequencer(
+            speak=self._dispatch_console_hands_free_speak,
+            stop_speech=self._stop_console_hands_free_speech,
+        )
+        session = ConsoleHandsFreeSession(controller=controller, sequencer=sequencer)
+        sequencer.on_drained = self._on_console_hands_free_sequencer_drained
+        self._console_hands_free = session
+        self._install_console_hands_free_store_tap()
+        session.tick_timer = self.set_interval(0.1, self._tick_console_hands_free)
+        controller.enter(capture_live=capture_live)
+
+    def _teardown_console_hands_free_loop(self) -> None:
+        """Drop the loop session and repaint the chip back to normal.
+
+        Only ever called from `_console_hands_free_exit_loop` (`ExitLoop`'s
+        handler), after that method has already silenced any reply audio
+        and closed the capture -- this just stops the tick timer and clears
+        the composer's borrowed hands-free chip state.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        if session.tick_timer is not None:
+            session.tick_timer.stop()
+        self._console_hands_free = None
+        composer = self._console_composer_or_none()
+        if composer is not None:
+            # Repaints over whatever hands-free's own `set_voice_status`
+            # calls last left on screen (`countdown`/`awaiting-reply`/
+            # `speaking` are not lifecycle states `sync_dictation_state`
+            # knows, so only a fresh call with the REAL current one-shot
+            # state clears them).
+            composer.sync_dictation_state(self._console_dictation_state)
+
+    def _tick_console_hands_free(self) -> None:
+        """`set_interval(0.1, ...)`: the controller's only clock input."""
+        session = self._console_hands_free
+        if session is None:
+            return
+        session.controller.tick(time.monotonic())
+        self._repaint_console_hands_free_chip()
+
+    def _handle_console_hands_free_intent(self, intent: HandsFreeIntent) -> None:
+        """Route one `HandsFreeIntent`, emitted synchronously by the
+        controller, to the wiring machinery that acts on it."""
+        if isinstance(intent, RequestStopAndSend):
+            self._console_hands_free_request_stop_and_send()
+        elif isinstance(intent, (SilenceSpeech, SuppressReplySpeech)):
+            self._console_hands_free_silence_speech()
+        elif isinstance(intent, OpenCapture):
+            self._console_hands_free_open_capture()
+        elif isinstance(intent, CloseCapture):
+            self._console_hands_free_close_capture()
+        elif isinstance(intent, CountdownTick):
+            self._console_hands_free_countdown_tick(intent.remaining)
+        elif isinstance(intent, ModeChanged):
+            self._console_hands_free_mode_changed(intent.state)
+        elif isinstance(intent, ExitLoop):
+            self._console_hands_free_exit_loop()
+
+    def _console_hands_free_request_stop_and_send(self) -> None:
+        """`RequestStopAndSend`: drive the existing V2 pending-send seam.
+
+        Queues the send exactly like a spoken "Console, send." does
+        (`_console_pending_voice_action = "send"`), then either stops the
+        still-open capture -- the common case; `_stop_console_dictation`'s
+        own success tail runs `_run_pending_console_voice_action`, which
+        dispatches the queued send once the transcript has actually landed
+        -- or, if the capture has ALREADY ended by the time this intent
+        lands (a service-side capture limit reached `on_capture_ended`
+        before this ran, so `_console_dictation_state` is already back at
+        `idle`), dispatches the queued send directly, since there is
+        nothing left to stop. There is no second send path either way --
+        both branches ultimately run `_run_pending_console_voice_action`,
+        the same method a spoken "send" already uses.
+
+        Task-5 review B1/M7: records `pending_session_id` (from
+        `_console_dictation_origin_session_id` -- the SAME value V2's own
+        wrong-session-refusal already uses, NOT a fresh `store.active_
+        session_id` read, which a tab switch could have moved on from by
+        the time a deferred idle-branch dispatch actually runs) and a
+        snapshot of every assistant message id already in that session
+        (`pending_existing_assistant_ids`), both consumed by the
+        reply-identity guard (`_console_hands_free_try_claim_reply`) to
+        decide which later delta/completion tap call is really THIS send's
+        reply.
+        """
+        session = self._console_hands_free
+        sending_session_id = self._console_dictation_origin_session_id
+        if session is not None:
+            session.pending_session_id = sending_session_id
+            session.pending_existing_assistant_ids = (
+                self._console_hands_free_assistant_ids(sending_session_id)
+            )
+        self._console_pending_voice_action = "send"
+        if self._console_dictation_state == "recording":
+            self._request_console_dictation_stop()
+            return
+        if self._console_dictation_state == "idle":
+            self.run_worker(
+                self._run_pending_console_voice_action(sending_session_id),
+                exclusive=True,
+                group="console-hands-free-send",
+                exit_on_error=False,
+            )
+        # else ("starting"/"transcribing"): a stop is already in flight for
+        # this same capture; its own tail will pick up the queued action.
+
+    def _console_hands_free_assistant_ids(self, session_id: str | None) -> frozenset[str]:
+        """Return every assistant message id currently in `session_id`.
+
+        Used to snapshot "pre-existing" reply ids before a send, so the
+        reply-identity guard can tell a brand-new reply from a stale one
+        that already existed (task-5 review B1).
+        """
+        if not session_id:
+            return frozenset()
+        store = self._ensure_console_chat_store()
+        try:
+            messages = store.messages_for_session(session_id)
+        except KeyError:
+            return frozenset()
+        return frozenset(m.id for m in messages if m.role == "assistant")
+
+    def _console_hands_free_force_immediate_send(self) -> None:
+        """Spoken "send" mid-loop: drive the SAME countdown-expiry path
+        `RequestStopAndSend` uses, collapsed to (near) zero wall time
+        (task-5 review I3).
+
+        Only the controller's OWN public inputs are used here (`on_voice_
+        final()` then two `tick()` calls) -- no reach into its private
+        `_begin_awaiting_reply()`/`_send_delay_seconds` -- so this is
+        exactly the path a real countdown expiry takes, just compressed:
+        from `listening`, `on_voice_final()` arms the countdown; from
+        `countdown` already (a prior segment's own final already armed
+        one -- e.g. "hello there" dictated, then "Console, send." spoken
+        immediately after, before that countdown would have expired on its
+        own), the existing arming is reused as-is rather than re-armed.
+        Either way, the first `tick()` adopts/re-confirms `now` as the
+        anchor (elapsed 0 relative to a same-call anchor, never expires on
+        its own); the second, with `now` pushed far enough into the future
+        that `remaining` clamps to 0 regardless of the configured
+        `dictation.handsfree_send_delay_seconds`, expires it -- which is
+        what actually emits `RequestStopAndSend` and moves the controller
+        into `awaiting_reply`, so the reply that follows is genuinely
+        spoken instead of streaming into a `listening` loop that silently
+        drops it. A no-op in every other state (`awaiting_reply`/
+        `speaking`/`idle`) -- nothing to send yet, or a send is already
+        outstanding.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        controller = session.controller
+        if controller.state == "listening":
+            controller.on_voice_final()
+        elif controller.state != "countdown":
+            return
+        now = time.monotonic()
+        controller.tick(now)
+        controller.tick(now + 3600.0)
+
+    def _console_hands_free_silence_speech(self) -> None:
+        """`SilenceSpeech`/`SuppressReplySpeech`: stop any playing speech and
+        flush the sequencer.
+
+        Two things, unconditionally: (1) the both-ways TTS stop routine
+        (`TTSPlaybackEvent(action="stop")`) fires directly here too, not
+        only through `flush()`'s conditional `stop_speech()` -- a `_speak_
+        status` ack ("Sent.", "Discarded.", ...) bypasses the sequencer
+        entirely, so without this a barge-in mid-ack would leave it
+        playing (task-5 review M9); (2) `SentenceSequencer.flush()` clears
+        the queue, calls `stop_speech()` (redundant with (1) when
+        something is in flight -- harmless, matches the existing "post a
+        bare stop before every capture-open" idiom this file already
+        uses) exactly iff an utterance is in flight, and latches
+        suppression so nothing from this reply speaks again.
+        `SilenceSpeech` (a barge-in mid-`speaking`, or re-`enter()`
+        catching a still-speaking reply) typically has something in
+        flight to stop; `SuppressReplySpeech` (a keypress during
+        `awaiting_reply`, or `on_reply_failed()`'s recovery) typically
+        does not -- the suppression latch still needs setting either way,
+        which is why both intents route here.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+            TTSPlaybackEvent,
+        )
+
+        self.app_instance.post_message(TTSPlaybackEvent(action="stop"))
+        session.sequencer.flush()
+
+    def _console_hands_free_open_capture(self) -> None:
+        """`OpenCapture`: idempotent-safe via `_request_console_dictation_
+        start`'s own guard -- a no-op unless `_console_dictation_state`
+        is genuinely `idle`."""
+        if self._console_dictation_state == "idle":
+            self._request_console_dictation_start()
+
+    def _console_hands_free_close_capture(self) -> None:
+        """`CloseCapture`: idempotent-safe via `_request_console_dictation_
+        stop`'s own guard -- a no-op unless genuinely `recording`."""
+        if self._console_dictation_state == "recording":
+            self._request_console_dictation_stop()
+
+    def _console_hands_free_countdown_tick(self, remaining: float) -> None:
+        """`CountdownTick`: record the remaining seconds for the chip."""
+        session = self._console_hands_free
+        if session is None:
+            return
+        session.countdown_remaining = remaining
+
+    def _console_hands_free_mode_changed(self, state: str) -> None:
+        """`ModeChanged`: reset per-reply state on entering `awaiting_reply`,
+        seed the countdown's first-paint value on entering `countdown`,
+        then repaint the chip for whatever state this is."""
+        if state == "awaiting_reply":
+            self._begin_console_hands_free_reply()
+        elif state == "countdown":
+            session = self._console_hands_free
+            if session is not None:
+                # Task-5 final review I1: `ModeChanged("countdown")` fires
+                # from `_transition`, itself called from `on_voice_final()`
+                # -- BEFORE the first real `CountdownTick` (which only
+                # arrives on the next `tick()` call) ever writes `session.
+                # countdown_remaining`. Without this, the repaint below
+                # would show the dataclass default `0.0` on turn 1 ("sending
+                # in 0.0s…", reading as "sending NOW") or the PREVIOUS
+                # countdown's last value on later turns. Seeded from the
+                # controller's own configured delay -- exactly what the
+                # first tick would compute anyway (`remaining = send_delay
+                # - 0`).
+                session.countdown_remaining = (
+                    session.controller._send_delay_seconds
+                )
+        self._repaint_console_hands_free_chip()
+
+    def _begin_console_hands_free_reply(self) -> None:
+        """Reset per-reply state at `ModeChanged("awaiting_reply")`.
+
+        `SentenceSequencer.begin_reply()` is REQUIRED before feeding a
+        second (or later) reply's deltas on this reused sequencer instance
+        -- without it, the suppression latch/fence/buffer state from the
+        PRIOR reply survives, and `on_drained` never fires again, so the
+        loop never reopens the microphone (see that method's docstring).
+        Also clears `reply_id` (a fresh reply claims a fresh id -- see
+        `_on_console_hands_free_delta`) and the per-reply toast policy.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        session.sequencer.begin_reply()
+        session.reply_id = None
+        session.toast_shown_for_reply = False
+
+    def _console_hands_free_exit_loop(self) -> None:
+        """`ExitLoop`: the controller deliberately does NOT emit
+        `SilenceSpeech`/`CloseCapture` alongside this intent (see
+        `HandsFreeController._exit`'s callers) -- this handler performs
+        both itself, in that order, before tearing the session down."""
+        self._console_hands_free_silence_speech()
+        self._console_hands_free_close_capture()
+        self._teardown_console_hands_free_loop()
+
+    def _repaint_console_hands_free_chip(self) -> None:
+        """Paint the hands-free loop's mode into the composer's voice chip.
+
+        `listening` RESTORES the ordinary dictation chip rather than being
+        left untouched (task-5 final review I1): the ordinary pipeline
+        (`VoicePartial`/`VoiceFinal`/the elapsed ticker) does paint an
+        accurate "recording" chip for it on its OWN -- but only the very
+        first time, before this loop has ever borrowed the chip for
+        `countdown`/`awaiting_reply`/`speaking`. By the time control
+        returns HERE to `listening` (a cancelled countdown, a barge-in, a
+        drained reply), the chip is showing whatever borrowed text was
+        painted last, and nothing else was going to overwrite it -- a
+        cancelled countdown kept reading "sending in 0.0s…" for the
+        user's entire next utterance (PROBE A). `composer.sync_dictation_
+        state(...)`, re-applied with the composer's OWN currently-tracked
+        partial/elapsed/segment-transcribing values (not this loop's),
+        is the same idiom `_teardown_console_hands_free_loop` already uses
+        to clear a borrowed chip on exit -- safe to call redundantly (the
+        widget's own `entering_recording`/`state_changed` guards no-op
+        when nothing actually changed), so calling it on every 0.1s tick
+        while `listening` is cheap. The other three states either close
+        the mic (default mode) or otherwise have nothing else painting
+        the chip, so they are driven directly through `ConsoleComposerBar.
+        set_voice_status`, which -- unlike `set_voice_partial`/`sync_
+        dictation_state` -- is not gated on the one-shot dictation
+        lifecycle state, so it keeps painting correctly even once
+        `_console_dictation_state` has already reached `idle`.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        composer = self._console_composer_or_none()
+        if composer is None:
+            return
+        state = session.controller.state
+        if state == "listening":
+            composer.sync_dictation_state(self._console_dictation_state)
+            return
+        if state == "countdown":
+            composer.set_voice_status(
+                "countdown",
+                message=(
+                    f"hands-free · sending in {session.countdown_remaining:.1f}s…"
+                ),
+            )
+        elif state == "awaiting_reply":
+            composer.set_voice_status(
+                "awaiting-reply", message="hands-free · thinking…"
+            )
+        elif state == "speaking":
+            composer.set_voice_status("speaking", message="hands-free · speaking")
+
+    def _install_console_hands_free_store_tap(self) -> None:
+        """Wrap the store's creation/delta/completion seams, once, for this
+        screen's life.
+
+        `Chat/console_agent_bridge.py`'s streaming adapter (and
+        `ConsoleChatController`'s own non-agent streaming path) both call
+        `store.append_message`/`store.append_stream_chunk`/`store.mark_
+        message_complete`/`store.mark_message_failed`/`store.mark_message_
+        stopped` directly -- there is no existing observer/subscription
+        mechanism on the store, so this wraps the bound methods on the
+        store itself (a lazily-created singleton for this screen instance
+        -- `_ensure_console_chat_store` only ever builds one). Read-only:
+        every wrapper calls the original method FIRST and returns its
+        result unchanged; the tap only observes. Idempotent -- installed at
+        most once per screen instance, and stays installed across loop
+        exit/re-entry (uninstalling would need to reach back into a store
+        that outlives any one loop session). `append_message` is the
+        EARLIEST of the five seams -- it fires the instant the assistant
+        row is created, before any streaming (task-5 final review I3).
+        """
+        if self._console_hands_free_store_tap_installed:
+            return
+        store = self._ensure_console_chat_store()
+        original_append_message = store.append_message
+        original_append = store.append_stream_chunk
+        original_complete = store.mark_message_complete
+        original_failed = store.mark_message_failed
+        original_stopped = store.mark_message_stopped
+
+        def _append_message(*args: Any, **kwargs: Any):
+            result = original_append_message(*args, **kwargs)
+            # Task-5 final review I3: the EARLIEST observable "generation
+            # truly begins" signal -- filtered to ASSISTANT rows here,
+            # before the marshal, so a user/system append (far more
+            # frequent) never pays a cross-thread round trip for nothing.
+            # See `_on_console_hands_free_assistant_row_created`.
+            if result.role is ConsoleMessageRole.ASSISTANT:
+                self._console_hands_free_marshal(
+                    self._on_console_hands_free_assistant_row_created,
+                    result.id,
+                )
+            return result
+
+        def _append_stream_chunk(message_id: str, chunk: str):
+            result = original_append(message_id, chunk)
+            self._console_hands_free_marshal(
+                self._on_console_hands_free_delta, message_id, chunk
+            )
+            return result
+
+        def _mark_message_complete(message_id: str):
+            result = original_complete(message_id)
+            self._console_hands_free_marshal(
+                self._on_console_hands_free_terminal, message_id, False
+            )
+            return result
+
+        def _mark_message_failed(message_id: str):
+            result = original_failed(message_id)
+            self._console_hands_free_marshal(
+                self._on_console_hands_free_terminal, message_id, True
+            )
+            return result
+
+        def _mark_message_stopped(message_id: str):
+            result = original_stopped(message_id)
+            self._console_hands_free_marshal(
+                self._on_console_hands_free_terminal, message_id, True
+            )
+            return result
+
+        store.append_message = _append_message
+        store.append_stream_chunk = _append_stream_chunk
+        store.mark_message_complete = _mark_message_complete
+        store.mark_message_failed = _mark_message_failed
+        store.mark_message_stopped = _mark_message_stopped
+        self._console_hands_free_store_tap_installed = True
+
+    def _console_hands_free_marshal(
+        self, callback: Callable[..., None], *args: Any
+    ) -> None:
+        """Run `callback(*args)` on the UI thread (task-5 review I1).
+
+        The tap wraps store methods reachable from TWO contexts: the
+        async, on-the-app-loop direct-provider send path, and -- the
+        DEFAULT production path, `[console] agent_runtime` on by default
+        -- a WORKER THREAD running its own event loop
+        (`ConsoleChatController._run_agent_reply` ->
+        `asyncio.to_thread(bridge.run_reply)` ->
+        `console_agent_bridge.py`'s `_StreamingModelAdapter.chat_call` ->
+        `store.append_stream_chunk`/etc, all on that thread). Everything
+        downstream of this tap touches widgets (`ConsoleComposerBar.set_
+        voice_status` via the chip repaint) or calls `run_worker`/`post_
+        message` (which themselves require -- or at least assume -- the
+        app's own thread), so every call must land back there. `self.app`
+        itself is UNSAFE to read off-thread (it resolves via a context
+        var with no active app on a bare worker thread -- `NoActiveAppError`)
+        -- `self.app_instance` (the stored `TldwCli` reference, plain
+        attribute access, safe from any thread) is used for both the
+        thread-identity check and the marshal call.
+
+        Task-5 review round 2, D1: the tap is installed once and never
+        uninstalled (see `_install_console_hands_free_store_tap`), so
+        EVERY streamed chunk of EVERY message pays for this call, hands-
+        free running or not -- the fast path below (bail out before the
+        thread-identity check, let alone a real `call_from_thread` round
+        trip, when the loop is not running) is what keeps the common
+        case (hands-free never entered this session) cheap: measured
+        ~60us/chunk down to near-zero. Also: `App.call_from_thread` raises
+        `RuntimeError("App is not running")` when the app has no running
+        event loop (e.g. the standard test harness, where `app_instance`
+        is a `TldwCli` that was never `run()`) -- wrapped in `except
+        Exception` so a hands-free plumbing/timing issue can NEVER escape
+        into `store.append_message`/`append_stream_chunk`/`mark_message_
+        *`, which every reply -- hands-free or not -- streams through.
+
+        Task-5 final review I2: the UI-thread branch used to call
+        `callback(*args)` bare -- the "NEVER escape" claim two paragraphs
+        up was therefore false on the (also supported, non-agent-runtime)
+        direct-provider path, which calls this tap from the UI thread
+        directly. Both branches now share the identical guarantee.
+        """
+        if self._console_hands_free is None:
+            return
+        if threading.get_ident() == self.app_instance._thread_id:
+            try:
+                callback(*args)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Console hands-free: tap callback failed on the UI "
+                    "thread; dropping this callback"
+                )
+            return
+        try:
+            self.app_instance.call_from_thread(callback, *args)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Console hands-free: tap marshal failed off-thread; "
+                "dropping this callback"
+            )
+
+    def _console_hands_free_try_claim_reply(
+        self, session: "ConsoleHandsFreeSession", message_id: str
+    ) -> bool:
+        """Claim `message_id` as the outstanding reply's id, if eligible.
+
+        REPLY IDENTITY (binding carrier, task-5 review B1): eligible means
+        ALL of:
+          (a) `controller.state == "awaiting_reply"` -- nothing has been
+              claimed yet, and a reply is genuinely outstanding;
+          (b) `message_id` belongs to the SAME session `RequestStopAndSend`
+              recorded this send as going into (`session.pending_session_
+              id`) -- rules out a concurrently-streaming BACKGROUND
+              session's reply (parallel per-session runs are a supported
+              feature, `console_chat_controller.py`'s `send_refusal_copy`
+              gates on `max_parallel_runs`, not "only one run app-wide");
+          (c) `message_id` was NOT already present in that session before
+              this send (`session.pending_existing_assistant_ids`) -- rules
+              out a STALE reply in the SAME session: a keyboard barge-in
+              during `awaiting_reply` suppresses speech but never cancels
+              generation, so that reply's message id already exists (and
+              keeps streaming) by the time the NEXT turn's send fires; without
+              this check the next turn would claim the OLD reply's id (it is
+              the first one still streaming) and speak its leftover sentences
+              into the new turn -- reopening exactly the hazard task-3's
+              `on_reply_started` docstring warns about
+              (`console_hands_free.py`'s `_reply_abandoned_by_watchdog`
+              framing is the same class of "a suppressed reply must not
+              resurrect" issue, one layer up).
+
+        There is still no independent ground truth beyond "new, in the
+        right session" -- there is no earlier synchronous "reply started,
+        here is its id" signal reachable without touching
+        `console_chat_controller.py` (out of this task's file list) -- but
+        that pair of checks is exactly what the brief's reply-identity
+        constraint requires: a wrong id can no longer win the slot.
+        """
+        if session.controller.state != "awaiting_reply":
+            return False
+        if session.pending_session_id is None:
+            return False
+        store = self._ensure_console_chat_store()
+        try:
+            owner_session_id = store.session_id_for_message(message_id)
+        except KeyError:
+            return False
+        if owner_session_id != session.pending_session_id:
+            return False
+        if message_id in session.pending_existing_assistant_ids:
+            return False
+        session.reply_id = message_id
+        return True
+
+    def _on_console_hands_free_assistant_row_created(self, message_id: str) -> None:
+        """`store.append_message`'s ASSISTANT-role tap (task-5 final review
+        I3): the EARLIEST observable "generation truly begins" signal.
+
+        Before this, the only `on_reply_started()` call sites were the
+        first streamed delta and the terminal tap -- both downstream of
+        the model actually producing VISIBLE output. On the DEFAULT
+        agent-runtime path, `console_agent_bridge.py`'s streaming adapter
+        only forwards fence-gated PRIMARY-turn output, so a run that does
+        tool round-trips first (or opens with a fenced code block the
+        sequencer skips by design, or is a sealed/non-streaming turn)
+        could blow the `awaiting_reply` watchdog's `AWAITING_REPLY_
+        DEADLINE_SECONDS` before a single visible token arrived -- the
+        FSM's own docstring calls that "routine," not exceptional, and
+        promises the watchdog does not punish it. `store.append_message`
+        creates the assistant row ONCE, synchronously, before any
+        streaming (agent or not) begins -- reusing it here makes the
+        watchdog measure what its docstring actually says it measures
+        (send -> `on_reply_started()`), not send -> first visible token.
+
+        Reuses the SAME reply-identity guard the delta/completion taps
+        use (`_console_hands_free_try_claim_reply`): a claim made here
+        for the WRONG session or a pre-existing id is refused exactly
+        like a claim from a delta would be, so this cannot weaken the B1
+        guarantee -- a non-assistant append never reaches here at all
+        (filtered in the wrapper, before the marshal), and an assistant
+        append for an unrelated/background session's OWN reply fails the
+        SAME session+novelty checks a delta for it would.
+        """
+        session = self._console_hands_free
+        if session is None or session.reply_id is not None:
+            return
+        if self._console_hands_free_try_claim_reply(session, message_id):
+            session.controller.on_reply_started()
+
+    def _on_console_hands_free_delta(self, message_id: str, chunk: str) -> None:
+        """Delta tap: feed one streamed chunk into the loop's sentence sequencer.
+
+        UI-thread only -- always reached via `_console_hands_free_marshal`
+        (task-5 review I1). The FIRST delta that passes `_console_hands_
+        free_try_claim_reply` (see its docstring for the full reply-identity
+        contract) claims `session.reply_id` for this turn, and doubles as
+        the earliest available `on_reply_started()` signal. Every later
+        delta is fed ONLY when its `message_id` matches `session.reply_id`;
+        anything else is dropped before it can reach the sequencer.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        if session.reply_id is None:
+            if not self._console_hands_free_try_claim_reply(session, message_id):
+                return
+            session.controller.on_reply_started()
+        elif message_id != session.reply_id:
+            return
+        session.sequencer.feed(chunk)
+
+    def _on_console_hands_free_terminal(self, message_id: str, failed: bool) -> None:
+        """Completion tap: `mark_message_complete`/`mark_message_failed`/
+        `mark_message_stopped`.
+
+        UI-thread only -- always reached via `_console_hands_free_marshal`
+        (task-5 review I1; `failed` is positional here, not keyword-only,
+        for that same call site's benefit -- `call_from_thread`/direct
+        dispatch both pass it positionally). Claims `session.reply_id` via
+        `_console_hands_free_try_claim_reply` the same way the delta tap
+        does when it has not already been claimed -- a reply that streams
+        ZERO chunks (a zero-speakable reply, or a failure before any
+        content arrived) still needs its completion recognized, or the
+        loop hangs in `awaiting_reply` until the 30s watchdog gives up on
+        it. Dropped when `message_id` does not match the outstanding reply.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        if session.reply_id is None:
+            if not self._console_hands_free_try_claim_reply(session, message_id):
+                return
+        elif session.reply_id != message_id:
+            return
+        if failed:
+            session.sequencer.flush()
+            session.controller.on_reply_failed()
+            return
+        session.controller.on_reply_started()
+        session.sequencer.reply_completed()
+        session.controller.on_reply_finished()
+
+    def _dispatch_console_hands_free_speak(self, text: str) -> None:
+        """`SentenceSequencer`'s `speak` callable: dispatch one utterance.
+
+        Synchronous (the sequencer's contract) -- schedules the actual
+        async `speak_utterance` call as a worker. Also this wiring's only
+        call site for `HandsFreeController.on_first_utterance()`: safe on
+        EVERY dispatch (idempotent -- a no-op outside `awaiting_reply`, see
+        that method's docstring), so no separate first-utterance flag is
+        needed here.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        session.controller.on_first_utterance()
+        token = session.sequencer.current_utterance_token
+        self.run_worker(
+            self._speak_console_hands_free_utterance(text, token),
+            exclusive=False,
+            group="console-hands-free-speech",
+            exit_on_error=False,
+        )
+
+    async def _speak_console_hands_free_utterance(
+        self, text: str, token: int | None
+    ) -> None:
+        """Speak one utterance via the cooldown-free `speak_utterance` entry.
+
+        `token` is `session.sequencer.current_utterance_token`, captured
+        synchronously at dispatch time (binding carrier: production callers
+        MUST thread it through into `utterance_finished(ok, token=...)` --
+        see that method's docstring). `quiet` implements the "at most one
+        failure toast per reply" policy: the first failed utterance in a
+        reply shows its toast and latches `toast_shown_for_reply`; every
+        later utterance in the SAME reply then passes `quiet=True` and only
+        logs.
+        """
+        session = self._console_hands_free
+        if session is None:
+            return
+        handler = await self.app_instance._ensure_tts_handler()
+        if handler is None:
+            session.sequencer.utterance_finished(False, token=token)
+            return
+        quiet = session.toast_shown_for_reply
+
+        def _on_finished(ok: bool) -> None:
+            current = self._console_hands_free
+            if current is not session:
+                # A different loop entry (or none at all) owns the screen's
+                # hands-free state now; this utterance's own sequencer/token
+                # bookkeeping is no longer live to report back into.
+                return
+            if not ok:
+                session.toast_shown_for_reply = True
+            session.sequencer.utterance_finished(ok, token=token)
+
+        await handler.speak_utterance(text, on_finished=_on_finished, quiet=quiet)
+
+    def _stop_console_hands_free_speech(self) -> None:
+        """`SentenceSequencer`'s `stop_speech` callable: the existing
+        both-ways stop routine (silences BOTH the streaming sink and the
+        legacy player) -- see `_request_console_dictation_start`'s
+        identical use for the mic/speaker exclusion invariant."""
+        from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+            TTSPlaybackEvent,
+        )
+
+        self.app_instance.post_message(TTSPlaybackEvent(action="stop"))
+
+    def _on_console_hands_free_sequencer_drained(self) -> None:
+        """`SentenceSequencer.on_drained`: nothing left queued or in flight."""
+        session = self._console_hands_free
+        if session is None:
+            return
+        session.controller.on_sequencer_drained()
+
+    async def _deliver_console_hands_free_capture_ended(
+        self, scheduled_for: "ConsoleHandsFreeSession", had_segments: bool
+    ) -> None:
+        """Wait for a limit-triggered stop to actually release the
+        microphone, THEN deliver `on_capture_ended` (task-5 review B2).
+
+        Polls `_console_dictation_state` rather than hooking `_stop_
+        console_dictation`'s own internals directly, so this stays a
+        self-contained addition next to the ONE call site that needs it
+        instead of threading a new "was this a limit stop" flag through
+        that already-delicate method.
+
+        Task-5 review round 2, D4: `scheduled_for` is the session object
+        captured by the CALLER at schedule time (while the limit-hit
+        capture was still live), not re-read from `self._console_hands_
+        free` after the wait. Re-reading was wrong: if the user exits and
+        re-enters hands-free during the (up to 40s) wait, `self._console_
+        hands_free` now points at a brand-new session/controller for a
+        DIFFERENT loop -- delivering this stale capture-ended to it would
+        silently burn the new loop's own one-time reopen ceiling for an
+        ending that has nothing to do with it. Delivered only when the
+        CURRENT session is still identically the one this was scheduled
+        for.
+        """
+        deadline = (
+            time.monotonic() + self._CONSOLE_HANDS_FREE_CAPTURE_ENDED_WAIT_SECONDS
+        )
+        while self._console_dictation_state != "idle":
+            if not self.is_mounted or time.monotonic() >= deadline:
+                logger.warning(
+                    "Console hands-free: capture-ended delivery gave up "
+                    "waiting for the limit-triggered stop to reach idle"
+                )
+                return
+            await asyncio.sleep(0.05)
+        if self._console_hands_free is not scheduled_for:
+            return
+        scheduled_for.controller.on_capture_ended(
+            had_segments=had_segments, limit_hit=True
+        )
+
+
+    def _console_pipeline_hands_free_blocker(self) -> str | None:
+        """Why the V3 pipeline loop is not a usable fallback, or None.
+
+        Two blockers, both already defined elsewhere in this screen: a
+        degraded VAD (the pipeline loop cannot auto-send at all -- see
+        `_console_hands_free_vad_degraded`), and dictation being
+        unavailable outright (no capture backend or no speech provider).
+
+        `Availability.remedy` is included when there is one (final review
+        M7): this string ends up in the toast that reports BOTH engines
+        failing, which is the only place the user is told what to install
+        -- dropping it left them with a diagnosis and no fix.
+        """
+        if self._console_hands_free_vad_degraded:
+            return "voice-activity detection is unavailable, so auto-send cannot work"
+        try:
+            availability = console_voice_input.probe()
+        except Exception:  # noqa: BLE001 - a probe crash is not a refusal
+            logger.opt(exception=True).debug(
+                "Console realtime: dictation availability probe crashed"
+            )
+            return None
+        if not availability.ok:
+            reason = availability.reason or "dictation is unavailable"
+            remedy = str(availability.remedy or "").strip()
+            return f"{reason} {remedy}".strip() if remedy else reason
+        return None
+
+
+    def action_exit_console_hands_free(self) -> None:
+        """Priority Esc: exit the hands-free loop from any point (task-5
+        review I2) -- see `check_action`'s gate and the `BINDINGS` entry's
+        docstring-comment for why this needs to be `priority=True` rather
+        than relying on `on_key`'s own (bubbling-order) branch alone.
+
+        Covers BOTH engines (V4 task 5): "Esc from any point in the loop"
+        is a promise the docs make about hands-free, not about one
+        engine's implementation of it.
+        """
+        hands_free = self._console_hands_free
+        if hands_free is not None:
+            hands_free.controller.on_exit_request()
+        realtime = self._console_realtime
+        if realtime is not None:
+            realtime.controller.on_exit_request()
+
+    def console_hands_free_exit_available(self) -> bool:
+        """`ChatScreen.check_action`'s `exit_console_hands_free` branch,
+        moved: whether EITHER engine is running, so the priority-Esc
+        binding (`action_exit_console_hands_free` above) only lights up
+        while there is something for it to exit."""
+        return self._console_hands_free is not None or self._console_realtime is not None
+
+    def teardown(self) -> None:
+        """Abandon the pipeline loop's timer during screen unmount.
+
+        Moved out of `ChatScreen.on_unmount` (wave-2 console decomposition,
+        task 1), where this was two inline statements; `on_unmount` now
+        calls this as one line, mirroring `ConsoleDictationController.
+        teardown`'s own precedent. Direct timer stop + state drop, not the
+        full `ExitLoop` intent path: unmount is abandon teardown (V2-style,
+        per the design doc's error-handling section), not a graceful exit --
+        no further TTS/dictation calls are safe to issue against a screen
+        that is being torn down.
+        """
+        hands_free = self._console_hands_free
+        if hands_free is not None and hands_free.tick_timer is not None:
+            hands_free.tick_timer.stop()
+        self._console_hands_free = None

--- a/tldw_chatbook/UI/Console_Modules/hands_free.py
+++ b/tldw_chatbook/UI/Console_Modules/hands_free.py
@@ -412,8 +412,16 @@ class ConsoleHandsFreeController:
     @property
     def _console_pending_voice_action(self) -> str | None:
         """Write-only: see `__init__`'s docstring for
-        `set_pending_voice_action`."""
-        raise AttributeError(
+        `set_pending_voice_action`.
+
+        Raises `RuntimeError`, deliberately NOT `AttributeError`: this is a
+        property, and `hasattr()`/`getattr(obj, name, default)` swallow
+        `AttributeError` specifically. A defensive
+        `getattr(self._hands_free, "_console_pending_voice_action", None)`
+        would then read None forever regardless of the real value, with no
+        error ever surfacing. `RuntimeError` propagates instead.
+        """
+        raise RuntimeError(
             "_console_pending_voice_action is write-only on "
             "ConsoleHandsFreeController"
         )

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -1,0 +1,1805 @@
+"""Console session controller.
+
+Extracted out of `ChatScreen` (wave-2 console decomposition, task 3): native
+Console session lifecycle -- start/activate/swap/promote/rename -- plus
+per-session settings, the Ctrl+K switcher's own choice handling, draft sync,
+and screen-state (de)serialization for one `ConsoleChatSession`.
+
+This module follows the SAME binding rule wave 1's `ConsoleDictationController`
+established and wave 2's `ConsoleWorkspaceController`/`ConsoleHandsFreeController`
+already applied (see `dictation.py`'s own docstring for the canonical
+statement; restated briefly here):
+
+1. **Framework services** (`run_worker`, `push_screen`) live-read from the
+   screen via `@property` on every access -- never snapshotted.
+2. **A sibling cluster's own attribute, not this cluster's business** is a
+   disclosed, temporary live `@property` straight through `screen`:
+   `_console_agent_drilldown_run_id` (the sub-agent drill-in cluster's own
+   attribute, read+write -- same shape `ConsoleWorkspaceController` already
+   uses for the identical attribute).
+3. **Everything else this cluster depends on that is not its own state** is a
+   NAMED keyword-only constructor callable, matching the design spec's rule
+   that "a controller's dependencies are its signature". Each is a
+   zero-arg (or narrowly-typed) callable the CALLER (`ChatScreen.__init__`)
+   constructs as a late-binding lambda closing over `self` -- never a bound
+   method passed directly, for the same instance-patch staleness reason
+   `ConsoleDictationController.__init__`'s docstring gives in full. The
+   controller's own property of the SAME NAME as the original private
+   method/attribute is a thin wrapper around the stored callable.
+
+**Controller-to-controller seam (session <-> workspace), the one new binding
+shape this cluster needed**: five of the moved bodies below called straight
+into `ConsoleWorkspaceController` in the pre-move source
+(`self._workspace._set_active_workspace_for_console_session(...)`,
+`.._resume_console_workspace_conversation(...)`,
+`.._console_initial_session_title_for_workspace(...)` x3,
+`.._merge_console_workspace_rows(...)`,
+`.._console_session_id_for_workspace_conversation(...)`). Per the wave-2
+Task 3 brief ("the two controllers may need a named callable between them;
+design it deliberately, never a back-door through the screen"), those seven
+call sites are the only INTENTIONAL, documented deviation from "byte-for-byte
+moved" in this module: each drops its `self._workspace.` prefix in favour of
+a same-named property here (`_set_active_workspace_for_console_session`,
+`_resume_console_workspace_conversation`,
+`_console_initial_session_title_for_workspace`, `_merge_console_workspace_
+rows`, `_console_session_id_for_workspace_conversation`), each wrapping a
+constructor-injected callable `ChatScreen.__init__` points at
+`self._workspace.<same method>` -- Python resolves `self._workspace` at
+CALL time inside that lambda, so construction order between the two
+controllers does not matter. `ChatScreen` itself keeps calling both
+controllers' methods directly by their original private names (ordinary
+screen-calls-its-own-controller traffic, unchanged).
+
+Moved: every `ChatScreen` method matching `*session*` whose body touched
+only session-lifecycle state (or one of the callables above) and no DOM --
+27 methods, plus four small module-level pure helpers only those methods (or
+this cluster's own remaining screen-side callers) use:
+`_has_selected_text`/`_is_empty_select_value` (Select-value predicates
+`_default_console_session_settings` needs; `ChatScreen` imports both back --
+`_is_empty_select_value` has its own independent `@on(Select.Changed)`
+consumer, `_has_selected_text` a dozen more, none of them session-shaped),
+and the character-handoff quartet `_canonical_card_character_id`/
+`_canonical_character_id_text`/`_character_session_identity_from_handoff`/
+`_character_session_prompt_seed`/`_SERVER_CHARACTER_AUTHORITY_PATTERN`
+(`_start_character_console_session`'s own dependencies; `ChatScreen` imports
+back the two of those its own character-PICKER cluster --
+`_console_character_picker_options`/`_apply_console_character_choice_async`,
+which stay screen-side, see below -- still needs).
+
+`_console_active_session_is_ephemeral` is the one exception to "moved for
+real": its IMPLEMENTATION lives here, but `ChatScreen` keeps a one-line
+delegation under the original name, because
+`Widgets/Console/console_transcript.py`'s `_console_ephemeral_active` reaches
+it by BARE NAME off `self.screen` (`getattr(screen,
+"_console_active_session_is_ephemeral", None)`, failing toward "not
+ephemeral" -- the unsafe direction -- when the name is missing). That is an
+external, non-controller consumer probing the screen by name, not a sibling
+controller's business, so it gets the same treatment as `ConsoleWorkspace
+Controller`'s own DOM-reached members: a thin screen-side delegation.
+
+`ChatScreen` also keeps these members this cluster's name pattern would
+otherwise suggest belong here, for the reasons noted:
+
+- Two `action_*` entry points: `action_open_console_session_switcher`
+  (builds rows from THREE conversation-browser-cluster methods, not this
+  cluster's state, before pushing the switcher modal) and
+  `action_open_console_session_settings` (a bare guarded delegation to
+  `_open_console_settings`, not part of this cluster at all).
+- `_ensure_console_session_surface` (DOM: constructs/returns the
+  `ConsoleSessionSurface` widget instance the screen owns -- "never store a
+  widget instance the screen may replace").
+- `_sync_console_native_session_tabs` (DOM: `query_one` for that surface).
+- The seven `ConsoleRealtimeSession`-shaped `*session*` methods
+  (`_start_console_realtime_tap`, `_build_console_realtime_session`,
+  `_start_console_realtime_connect`, `_on_console_realtime_ready`,
+  `_on_console_realtime_reply_done`, `_console_realtime_played_ms`,
+  `_close_console_realtime_session`) -- the V4 realtime engine's own state,
+  which `hands_free.py`'s own docstring already documents as staying
+  screen-owned; a DIFFERENT meaning of "session" than this cluster's
+  `ConsoleChatSession`.
+- `_console_imagegen_inflight_sessions`/`_park_console_approval`/
+  `_remember_console_impersonate` -- name-pattern false positives: in-flight
+  image-generation bookkeeping, background-approval parking, and the
+  impersonate-suggestion cache, none of which touch `ConsoleChatSession`
+  state.
+- `_serialize_native_console_state`/`_restore_native_console_state` -- the
+  WHOLE native-Console screen-state (de)serializers (image view modes,
+  library RAG source types, the pending live-work launch, task-resume
+  state...), which call this cluster's own `_console_session_to_state`/
+  `_console_session_from_state` per-session helpers directly by name rather
+  than owning the per-session shape themselves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, replace
+from typing import Any, Optional, TYPE_CHECKING
+import asyncio
+import re
+import uuid
+
+from loguru import logger
+from textual.widgets import Select
+
+from ...Chat.chat_handoff_models import ChatHandoffPayload
+from ...Chat.console_chat_models import (
+    CONSOLE_GLOBAL_WORKSPACE_ID,
+    DEFAULT_CONSOLE_SESSION_TITLE,
+    ConsoleMessageRole,
+)
+from ...Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
+from ...Chat.console_prefill import pinned_prefill_from_conversation_metadata
+from ...Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    build_console_settings_readiness,
+    build_default_console_session_settings,
+)
+from ...Chat.provider_readiness import provider_config_key
+from ...Widgets.Console import ConsoleComposerUndoHistory, ConsoleRenameSessionModal
+from ...Widgets.Console.console_session_switcher_modal import ConsoleSwitcherChoice
+from ...Workspaces import ConsoleConversationBrowserRow
+from ...Workspaces.display_state import (
+    ConsoleWorkspaceContextState,
+    ConsoleWorkspaceConversationRow,
+)
+
+if TYPE_CHECKING:
+    from ..Screens.chat_screen import ChatScreen
+
+logger = logger.bind(module="ChatScreen")
+
+
+# -- Module-level pure helpers this cluster owns (see module docstring) -----
+
+
+def _is_empty_select_value(value: Any) -> bool:
+    """Return True for Textual's blank/null select sentinels."""
+    return value is None or value == Select.BLANK or str(value).startswith("Select.")
+
+
+def _has_selected_text(value: Any) -> bool:
+    """Return whether a provider/model value is meaningfully selected.
+
+    Args:
+        value: Value from Textual select state or app/default configuration.
+
+    Returns:
+        True when the value is not an empty Textual select sentinel and has
+        non-whitespace text.
+    """
+    return not _is_empty_select_value(value) and bool(str(value).strip())
+
+
+_MAX_CANONICAL_CHARACTER_ID = (1 << 63) - 1
+_MAX_CANONICAL_CHARACTER_ID_TEXT = str(_MAX_CANONICAL_CHARACTER_ID)
+_CANONICAL_CHARACTER_ID_PATTERN = re.compile(r"[1-9][0-9]{0,18}")
+_SERVER_CHARACTER_AUTHORITY_PATTERN = re.compile(r"server-user-v1:[0-9a-f]{64}")
+
+
+def _canonical_character_id_text(value: Any) -> str | None:
+    """Return an exact signed-64 positive decimal wire ID."""
+    if type(value) is not str:
+        return None
+    if _CANONICAL_CHARACTER_ID_PATTERN.fullmatch(value) is None:
+        return None
+    if (
+        len(value) == len(_MAX_CANONICAL_CHARACTER_ID_TEXT)
+        and value > _MAX_CANONICAL_CHARACTER_ID_TEXT
+    ):
+        return None
+    return value
+
+
+def _canonical_card_character_id(value: Any) -> int | None:
+    """Return a canonical signed-64 positive ID from a card response."""
+    if type(value) is int:
+        return value if 1 <= value <= _MAX_CANONICAL_CHARACTER_ID else None
+    value_text = _canonical_character_id_text(value)
+    return int(value_text) if value_text is not None else None
+
+
+def _character_session_identity_from_handoff(
+    payload: ChatHandoffPayload,
+) -> tuple[str, int, str, str] | None:
+    """Return character session identity for Personas Start Chat handoffs.
+
+    Args:
+        payload: Handoff payload staged by a source screen.
+
+    Returns:
+        A tuple of `(runtime_backend, character_id, character_name,
+        assistant_id)` when the payload represents a source-aware Personas
+        character Start Chat handoff; otherwise `None`.
+    """
+    metadata = payload.metadata
+    if not isinstance(metadata, Mapping):
+        return None
+    if (
+        payload.source != "personas"
+        or payload.item_type != "character-card"
+        or metadata.get("intent") != "start_chat"
+        or metadata.get("selected_kind") != "character"
+    ):
+        return None
+    runtime_backend = payload.runtime_backend
+    if runtime_backend not in {"local", "server"}:
+        return None
+    if (
+        payload.source_owner != runtime_backend
+        or payload.source_selector_state != runtime_backend
+        or metadata.get("backend") != runtime_backend
+    ):
+        return None
+
+    character_id_text = _canonical_character_id_text(metadata.get("selected_record_id"))
+    if character_id_text is None:
+        return None
+    if (
+        metadata.get("selected_target_id")
+        != f"{runtime_backend}:character:{character_id_text}"
+    ):
+        return None
+
+    character_id = int(character_id_text)
+    character_name = str(metadata.get("selected_name") or payload.title or "").strip()
+    return runtime_backend, character_id, character_name, character_id_text
+
+
+def _character_session_prompt_seed(
+    card: Mapping[str, Any], name_hint: str = ""
+) -> tuple[str, str, str]:
+    """Return ``(name, system_prompt, greeting)`` seeded from a character card.
+
+    Joins the card's prompt-bearing fields into the Console session's system
+    prompt and picks the seeded greeting from ``first_message``.
+
+    task-1744: the join itself (field order, labels, and macro resolution)
+    is ``Character_Chat_Lib.compose_character_card_text`` -- the same
+    function the character-probe eval engine uses
+    (``Evals.character_probe.prompt.compose_system_prompt``), so a probe run
+    predicts exactly what this seeds into a real Console session. This
+    includes ``message_example`` and ``post_history_instructions``, which
+    Console did not send before task-1744; that is a deliberate,
+    user-visible change to every character session's system prompt, not an
+    incidental refactor.
+
+    Args:
+        card: The character card record.
+        name_hint: Fallback display name when the card has none.
+
+    Returns:
+        The character name, session system prompt, and greeting text.
+    """
+    # Local import matches this module's existing convention of deferring
+    # Character_Chat submodule imports (they pull in Pillow and
+    # CharactersRAGDB) rather than importing them at module scope.
+    from ...Character_Chat.Character_Chat_Lib import (
+        compose_character_card_text,
+        replace_placeholders,
+    )
+
+    name = str(card.get("name") or name_hint or "").strip() or "Character"
+    # Cards are written against SillyTavern-style macros; compose_character_card_text
+    # resolves {{char}}/{{user}} (and aliases) before the text reaches
+    # session settings, or they leak verbatim into every provider payload
+    # (task-1530). "User" matches the greeting-display substitution used
+    # across the Personas surfaces. A card with no prompt-bearing text at
+    # all falls back to a fixed instruction -- Console, not the shared
+    # composer, owns that fallback, since it is not meaningful to the eval
+    # engine's own empty-card handling (an intentionally blank system
+    # message, see compose_system_prompt).
+    system_prompt = (
+        compose_character_card_text(
+            name=name,
+            system_prompt=str(card.get("system_prompt") or ""),
+            personality=str(card.get("personality") or ""),
+            description=str(card.get("description") or ""),
+            scenario=str(card.get("scenario") or ""),
+            message_example=str(card.get("message_example") or ""),
+            post_history_instructions=str(card.get("post_history_instructions") or ""),
+            user_name="User",
+        )
+        or "Stay in character."
+    )
+    greeting = replace_placeholders(str(card.get("first_message") or ""), name, "User")
+    return name, system_prompt, greeting
+
+
+class ConsoleSessionController:
+    """Owns the Console shell's native session lifecycle: start/activate/
+    swap/promote/rename, per-session settings, the Ctrl+K switcher's choice
+    handling, draft sync, and one-session (de)serialization.
+
+    `ChatScreen` constructs exactly one of these, in `__init__`, and keeps a
+    `self._session` reference plus the stay-behind members described in the
+    module docstring.
+    """
+
+    # Readiness labels that stale-default session refresh may recover from:
+    # credential/endpoint gaps a Settings save can fix. Provider-identity
+    # blockers (Unknown/Pending WIP providers) are deliberate choices and are
+    # never auto-replaced.
+    _CONSOLE_REFRESHABLE_BLOCKED_LABELS = frozenset(
+        {"Missing key", "Not ready", "Invalid URL", "Endpoint not saved"}
+    )
+
+    def __init__(
+        self,
+        screen: "ChatScreen",
+        *,
+        app_instance: Any,
+        chat_store_accessor: Callable[[], ConsoleChatStore],
+        current_chat_store_accessor: Callable[[], ConsoleChatStore | None],
+        ensure_console_chat_controller: Callable[[], Any],
+        composer_accessor: Callable[[], Any],
+        effective_console_provider_model: Callable[[], tuple[Any, Any]],
+        provider_readiness_app_config: Callable[[], Any],
+        sync_native_console_chat_ui: Callable[[], Any],
+        sync_chat_core_state: Callable[[], Any],
+        sync_temporary_chip: Callable[[], None],
+        sync_settings_summary: Callable[[], None],
+        sync_control_bar: Callable[[], None],
+        sync_command_popup: Callable[[], None],
+        note_follow_intent: Callable[[], None],
+        focus_composer_if_needed: Callable[..., None],
+        invalidate_persisted_rows_cache: Callable[[], None],
+        mark_conversation_row_broken: Callable[[str], None],
+        refresh_effective_scope_and_sync: Callable[[Any], Any],
+        set_active_workspace_for_session: Callable[[str], None],
+        resume_workspace_conversation: Callable[..., Any],
+        workspace_initial_session_title: Callable[[str | None], str],
+        merge_workspace_rows: Callable[[list, tuple], list],
+        session_id_for_workspace_conversation: Callable[[str], str | None],
+    ) -> None:
+        """Build the controller and bind everything its moved bodies need.
+
+        Every one of the 27 method bodies below is a byte-for-byte copy of
+        the pre-extraction `ChatScreen` method, EXCEPT the seven documented
+        `self._workspace.X(...)` call sites (see the module docstring's
+        "Controller-to-controller seam" section), which drop their
+        `_workspace.` prefix in favour of a same-named property on this
+        controller instead.
+
+        Args:
+            screen: The Console screen. Used ONLY for the framework
+                services (`run_worker`, `push_screen`) and the one disclosed
+                sibling-cluster reach-back (`_console_agent_drilldown_
+                run_id`). Zero `query_one`/`query` traffic reaches through
+                `screen` here.
+            app_instance: For `notify()` and the character/handoff service
+                lookups `_start_character_console_session` makes --
+                unchanged from how the pre-extraction methods used
+                `self.app_instance`. Snapshotted as a plain attribute: it
+                does not change identity over the controller's life, and
+                the pre-extraction methods never called it, only read it.
+            chat_store_accessor: `ChatScreen._ensure_console_chat_store`
+                (lazily creates the store) -- used where the original body
+                called it as a method.
+            current_chat_store_accessor: A DIFFERENT accessor for the SAME
+                store, `lambda: self._console_chat_store` -- a bare
+                attribute read that must NOT create the store as a side
+                effect (several moved bodies branch on it still being
+                `None`). Kept distinct from `chat_store_accessor` for the
+                same reason `ConsoleWorkspaceController` keeps its own pair
+                distinct.
+            ensure_console_chat_controller: `ChatScreen._ensure_console_
+                chat_controller` -- the (much larger-scoped) chat
+                orchestration controller, used only by
+                `_activate_native_console_session` for its shared
+                `controller.store`/`controller.switch_session` sequence.
+            composer_accessor: `ChatScreen._console_composer_or_none` (DOM);
+                same shape as `dictation.py`'s/`hands_free.py`'s own
+                `composer_accessor`.
+            effective_console_provider_model: `ChatScreen._effective_
+                console_provider_model`, used by `_default_console_session_
+                settings`.
+            provider_readiness_app_config: `ChatScreen._provider_readiness_
+                app_config`.
+            sync_native_console_chat_ui: `ChatScreen._sync_native_console_
+                chat_ui` -- a coroutine FUNCTION, called (not awaited
+                directly) by every moved body exactly as the original did.
+            sync_chat_core_state: `ChatScreen._sync_console_chat_core_
+                state`.
+            sync_temporary_chip: `ChatScreen._sync_console_temporary_chip`
+                (DOM).
+            sync_settings_summary: `ChatScreen._sync_console_settings_
+                summary` (DOM).
+            sync_control_bar: `ChatScreen._sync_console_control_bar` (DOM);
+                the moved body calls it with no arguments, matching the
+                original `self._sync_console_control_bar()` call shape.
+            sync_command_popup: `ChatScreen._sync_console_command_popup`
+                (DOM).
+            note_follow_intent: `ChatScreen._note_console_follow_intent`
+                (DOM); same name `ConsoleWorkspaceController` already binds
+                independently.
+            focus_composer_if_needed: `ChatScreen._focus_console_composer_
+                if_needed`; the moved bodies call it with `force=True`
+                exactly as before -- the stored callable accepts the same
+                keyword, not a value baked in here.
+            invalidate_persisted_rows_cache: `ChatScreen._invalidate_
+                console_persisted_rows_cache` -- the conversation-browser
+                cluster's own cache, not this cluster's state.
+            mark_conversation_row_broken: `ChatScreen._mark_console_
+                conversation_row_broken` -- same sibling cluster, used by
+                `_apply_console_switcher_choice`'s TASK-717 branch.
+            refresh_effective_scope_and_sync: `ChatScreen._refresh_console_
+                effective_scope_and_sync`, async; same name
+                `ConsoleWorkspaceController` already binds independently.
+            set_active_workspace_for_session: `ConsoleWorkspaceController.
+                _set_active_workspace_for_console_session` -- the
+                session<->workspace seam (see module docstring); the ORIGINAL
+                body called `self._workspace._set_active_workspace_for_
+                console_session(...)`, dropped to `self._set_active_
+                workspace_for_session(...)` here.
+            resume_workspace_conversation: `ConsoleWorkspaceController.
+                _resume_console_workspace_conversation` -- same seam,
+                `_apply_console_switcher_choice`'s conversation-id branch.
+            workspace_initial_session_title: `ConsoleWorkspaceController.
+                _console_initial_session_title_for_workspace` -- same seam,
+                used by three moved bodies
+                (`_ensure_active_console_session_settings`, `_replace_
+                active_console_session_settings`, `_sync_console_session_
+                draft`).
+            merge_workspace_rows: `ConsoleWorkspaceController._merge_
+                console_workspace_rows` -- same seam, `_with_native_
+                console_session_rows`.
+            session_id_for_workspace_conversation: `ConsoleWorkspace
+                Controller._console_session_id_for_workspace_conversation`
+                -- same seam, `_console_session_id_for_browser_row`.
+        """
+        self._screen = screen
+        self.app_instance = app_instance
+        self._chat_store_accessor = chat_store_accessor
+        self._current_chat_store_accessor = current_chat_store_accessor
+        self._ensure_console_chat_controller_fn = ensure_console_chat_controller
+        self._composer_accessor = composer_accessor
+        self._effective_console_provider_model_fn = effective_console_provider_model
+        self._provider_readiness_app_config_fn = provider_readiness_app_config
+        self._sync_native_console_chat_ui_fn = sync_native_console_chat_ui
+        self._sync_chat_core_state_fn = sync_chat_core_state
+        self._sync_temporary_chip_fn = sync_temporary_chip
+        self._sync_settings_summary_fn = sync_settings_summary
+        self._sync_control_bar_fn = sync_control_bar
+        self._sync_command_popup_fn = sync_command_popup
+        self._note_follow_intent_fn = note_follow_intent
+        self._focus_composer_if_needed_fn = focus_composer_if_needed
+        self._invalidate_persisted_rows_cache_fn = invalidate_persisted_rows_cache
+        self._mark_conversation_row_broken_fn = mark_conversation_row_broken
+        self._refresh_effective_scope_and_sync_fn = refresh_effective_scope_and_sync
+        self._set_active_workspace_for_session_fn = set_active_workspace_for_session
+        self._resume_workspace_conversation_fn = resume_workspace_conversation
+        self._workspace_initial_session_title_fn = workspace_initial_session_title
+        self._merge_workspace_rows_fn = merge_workspace_rows
+        self._session_id_for_workspace_conversation_fn = (
+            session_id_for_workspace_conversation
+        )
+
+        # This cluster's own state, moved verbatim from `ChatScreen.__init__`.
+        self._console_visible_draft_session_id: str | None = None
+        self._console_undo_histories: dict[str, ConsoleComposerUndoHistory] = {}
+        self._console_draft_switch_snapshot: tuple[str | None, str, int] | None = None
+
+    # -- Framework services (live-read via `@property`) --------------------
+
+    @property
+    def run_worker(self) -> Any:
+        """`Screen.run_worker`, bound. See `__init__`'s docstring for why
+        this is a property rather than a value snapshotted once."""
+        return self._screen.run_worker
+
+    @property
+    def push_screen(self) -> Any:
+        """`Screen.app.push_screen`, bound. See `__init__`'s docstring."""
+        return self._screen.app.push_screen
+
+    # -- Sibling cluster's reach-back (disclosed) ---------------------------
+
+    @property
+    def _console_agent_drilldown_run_id(self) -> str | None:
+        """The sub-agent drill-in cluster's own attribute. Read+write: the
+        moved activation body clears it unconditionally on every switch.
+        Same shape `ConsoleWorkspaceController` binds independently for the
+        identical attribute."""
+        return self._screen._console_agent_drilldown_run_id
+
+    @_console_agent_drilldown_run_id.setter
+    def _console_agent_drilldown_run_id(self, value: str | None) -> None:
+        self._screen._console_agent_drilldown_run_id = value
+
+    # -- Named constructor dependencies -------------------------------------
+    #
+    # Each property below is a thin wrapper around a stored callable, kept
+    # under the SAME name the original `ChatScreen` method/attribute used --
+    # see `__init__`'s docstring. `_console_chat_store` is the one
+    # bare-attribute-read shape (calls the accessor immediately and returns
+    # the value); every other property returns the callable itself.
+
+    @property
+    def _ensure_console_chat_store(self) -> Any:
+        return self._chat_store_accessor
+
+    @property
+    def _console_chat_store(self) -> ConsoleChatStore | None:
+        return self._current_chat_store_accessor()
+
+    @property
+    def _ensure_console_chat_controller(self) -> Any:
+        return self._ensure_console_chat_controller_fn
+
+    @property
+    def _console_composer_or_none(self) -> Any:
+        return self._composer_accessor
+
+    @property
+    def _effective_console_provider_model(self) -> Any:
+        return self._effective_console_provider_model_fn
+
+    @property
+    def _provider_readiness_app_config(self) -> Any:
+        return self._provider_readiness_app_config_fn
+
+    @property
+    def _sync_native_console_chat_ui(self) -> Any:
+        return self._sync_native_console_chat_ui_fn
+
+    @property
+    def _sync_console_chat_core_state(self) -> Any:
+        return self._sync_chat_core_state_fn
+
+    @property
+    def _sync_console_temporary_chip(self) -> Any:
+        return self._sync_temporary_chip_fn
+
+    @property
+    def _sync_console_settings_summary(self) -> Any:
+        return self._sync_settings_summary_fn
+
+    @property
+    def _sync_console_control_bar(self) -> Any:
+        return self._sync_control_bar_fn
+
+    @property
+    def _sync_console_command_popup(self) -> Any:
+        return self._sync_command_popup_fn
+
+    @property
+    def _note_console_follow_intent(self) -> Any:
+        return self._note_follow_intent_fn
+
+    @property
+    def _focus_console_composer_if_needed(self) -> Any:
+        return self._focus_composer_if_needed_fn
+
+    @property
+    def _invalidate_console_persisted_rows_cache(self) -> Any:
+        return self._invalidate_persisted_rows_cache_fn
+
+    @property
+    def _mark_console_conversation_row_broken(self) -> Any:
+        return self._mark_conversation_row_broken_fn
+
+    @property
+    def _refresh_console_effective_scope_and_sync(self) -> Any:
+        return self._refresh_effective_scope_and_sync_fn
+
+    # -- Session<->workspace seam (see module docstring) --------------------
+
+    @property
+    def _set_active_workspace_for_session(self) -> Any:
+        """`ConsoleWorkspaceController._set_active_workspace_for_console_
+        session`. The pre-move body called `self._workspace._set_active_
+        workspace_for_console_session(...)`; the moved body drops the
+        `_workspace.` prefix in favour of this property."""
+        return self._set_active_workspace_for_session_fn
+
+    @property
+    def _resume_workspace_conversation(self) -> Any:
+        """`ConsoleWorkspaceController._resume_console_workspace_
+        conversation`. Same prefix-drop as above."""
+        return self._resume_workspace_conversation_fn
+
+    @property
+    def _workspace_initial_session_title(self) -> Any:
+        """`ConsoleWorkspaceController._console_initial_session_title_for_
+        workspace`. Same prefix-drop as above."""
+        return self._workspace_initial_session_title_fn
+
+    @property
+    def _merge_workspace_rows(self) -> Any:
+        """`ConsoleWorkspaceController._merge_console_workspace_rows`. Same
+        prefix-drop as above."""
+        return self._merge_workspace_rows_fn
+
+    @property
+    def _session_id_for_workspace_conversation(self) -> Any:
+        """`ConsoleWorkspaceController._console_session_id_for_workspace_
+        conversation`. Same prefix-drop as above."""
+        return self._session_id_for_workspace_conversation_fn
+
+    # -- Session switcher / rename -------------------------------------------
+
+    def _open_console_session_rename_modal(self, session_id: str) -> None:
+        """Open a modal for viewing and editing the active Console tab title."""
+        store = self._ensure_console_chat_store()
+        session = next(
+            (candidate for candidate in store.sessions() if candidate.id == session_id),
+            None,
+        )
+        if session is None:
+            self.app_instance.notify(
+                "Console tab is no longer available.", severity="error"
+            )
+            return
+
+        def _apply_rename(result: str | None) -> None:
+            if result is None:
+                return
+            try:
+                _renamed, persisted = store.rename_session(session_id, result)
+            except ValueError as exc:
+                self.app_instance.notify(str(exc), severity="warning")
+                return
+            except KeyError:
+                self.app_instance.notify(
+                    "Console tab is no longer available.", severity="error"
+                )
+                return
+            if not persisted:
+                self.app_instance.notify(
+                    "Renamed this tab, but saving the conversation title "
+                    "failed — the stored conversation keeps its old name.",
+                    severity="warning",
+                )
+            # TASK-251: a renamed session's persisted conversation title
+            # must appear in the browser on the very next sync.
+            self._invalidate_console_persisted_rows_cache()
+            self.run_worker(
+                self._sync_native_console_chat_ui(),
+                exclusive=True,
+                group="console-sync",
+            )
+
+        self.push_screen(
+            ConsoleRenameSessionModal(title=session.title),
+            callback=_apply_rename,
+        )
+
+    async def _activate_native_console_session(self, session_id: str) -> None:
+        """Activate a native Console session through the shared activation sequence.
+
+        Set the active workspace, switch the native session, refresh the
+        retrieval-scope display, await the UI sync, then force composer
+        focus. Shared by the session-tab click handler, the Ctrl+K switcher
+        callback, and Alt+1..9 tab-jump so all three entry points follow
+        one activation path.
+
+        Args:
+            session_id: Native Console session id to activate.
+        """
+        controller = self._ensure_console_chat_controller()
+        if controller.store.active_session_id != session_id:
+            self._capture_console_draft_switch_snapshot()
+            self._note_console_follow_intent()
+            self._set_active_workspace_for_session(session_id)
+            controller.switch_session(session_id)
+            # Finding C: a sub-agent drill-in is scoped to the conversation
+            # active when the user drilled in -- clear it immediately on
+            # switch here (the shared activation path for tab clicks,
+            # Ctrl+K, and Alt+1..9) rather than rely solely on the rail
+            # render path's own defensive re-check on the next sync.
+            self._console_agent_drilldown_run_id = None
+            # Task-13 review finding 2: this path activates an ALREADY-
+            # resumed native session (unlike `_resume_console_workspace_
+            # conversation`, which warms the cache itself), so `_console_
+            # effective_scope_cache` may hold a stale entry -- e.g. a
+            # workspace-scope edit made via `_apply_console_workspace_
+            # scope_save` while a DIFFERENT session's tab was active only
+            # refreshes that other (active) session's row/chip. Without
+            # this call the row/chip would keep rendering the stale
+            # snapshot indefinitely: recompose reads the cache, never the
+            # DB (`_build_console_retrieval_scope_state`'s own contract).
+            new_session = self._active_native_console_session()
+            if new_session is not None:
+                try:
+                    await self._refresh_console_effective_scope_and_sync(new_session)
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Failed to refresh retrieval scope display on session "
+                        "activation: {}",
+                        session_id,
+                    )
+            await self._sync_native_console_chat_ui()
+        self._focus_console_composer_if_needed(force=True)
+
+    async def _apply_console_switcher_choice(
+        self, choice: ConsoleSwitcherChoice | None
+    ) -> None:
+        """Apply a switcher selection through the shared native-session activation helper.
+
+        Mirrors the session-tab click handler and Alt+1..9 tab-jump: all three
+        call ``_activate_native_console_session`` so there is one activation
+        sequence (set workspace, switch, sync UI, focus composer) shared
+        across Console session-selection entry points.
+
+        Args:
+            choice: Switcher result, or ``None`` if the switcher was cancelled.
+        """
+        if choice is None:
+            return
+        entry = choice.entry
+        if choice.kind == "rename" and entry.native_session_id:
+            self._open_console_session_rename_modal(entry.native_session_id)
+            return
+        if choice.kind != "activate":
+            return
+        if entry.native_session_id:
+            await self._activate_native_console_session(entry.native_session_id)
+            return
+        if entry.conversation_id:
+            resumed = await self._resume_workspace_conversation(
+                entry.conversation_id,
+                target_scope_type=entry.scope_type or None,
+                target_workspace_id=entry.workspace_id,
+            )
+            if resumed is False:
+                # TASK-717: record missing - same honest feedback and broken
+                # marking as the rail row path (resume no longer self-toasts
+                # for this failure class).
+                self._mark_console_conversation_row_broken(entry.conversation_id)
+                self.app_instance.notify(
+                    "This saved conversation could not be loaded - "
+                    "its record is missing.",
+                    severity="warning",
+                )
+
+    async def _create_native_console_session_from_active_context(
+        self, *, ephemeral: bool = False
+    ) -> None:
+        """Create and focus a native Console session in the active workspace context.
+
+        Args:
+            ephemeral: Create the session temporary (never saved locally).
+        """
+        # TASK-339: new_session activates the fresh session inline; snapshot
+        # first so the deferred draft swap attributes settle-window typing
+        # to the new tab instead of clobbering it.
+        self._capture_console_draft_switch_snapshot()
+        self._ensure_console_chat_controller().new_session(
+            settings=(
+                self._active_console_session_settings()
+                or self._default_console_session_settings()
+            ),
+            ephemeral=ephemeral,
+        )
+        # TASK-251: new-chat-tab handler -- invalidate so the browser's
+        # "selected" row indicator picks up the new active session promptly.
+        self._invalidate_console_persisted_rows_cache()
+        await self._sync_native_console_chat_ui()
+        # Task-7: this is the shared activation path for every "new session"
+        # entry point (plain Ctrl+T, "New Temporary" via the palette/tab-strip
+        # button, and the other internal callers below) --
+        # `_sync_native_console_chat_ui()` above
+        # never touches `#console-temporary-chip` (same reason it never
+        # touches the scope chip; see `_sync_console_retrieval_scope_row`).
+        # Without this push a freshly created temporary tab would render
+        # with no marker at all until some unrelated event (a tab switch
+        # away and back) happened to resync it -- the chip's entire purpose
+        # is to be visible the moment the tab exists. It also clears a
+        # stale "Temporary" chip left over when a new ordinary chat is
+        # created right after a temporary one.
+        self._sync_console_temporary_chip()
+        self._focus_console_composer_if_needed(force=True)
+
+    # -- Per-session settings -------------------------------------------------
+
+    def _active_console_session_settings(self) -> ConsoleSessionSettings | None:
+        """Return settings for the active native Console session, if one exists."""
+        store = self._console_chat_store
+        if store is None or store.active_session_id is None:
+            return None
+        try:
+            return store.session_settings(store.active_session_id)
+        except KeyError:
+            return None
+
+    def _default_console_session_settings(self) -> ConsoleSessionSettings:
+        """Build the default settings snapshot for a new native Console session."""
+        provider, model = self._effective_console_provider_model()
+        settings = build_default_console_session_settings(
+            self._provider_readiness_app_config(),
+            str(provider).strip() if _has_selected_text(provider) else None,
+            str(model).strip() if _has_selected_text(model) else None,
+        )
+        provider_key = provider_config_key(settings.provider)
+        return replace(
+            settings,
+            base_url=None
+            if provider_key in {"llama_cpp", "local_llamacpp"}
+            else settings.base_url,
+        )
+
+    def _ensure_active_console_session_settings(self) -> ConsoleSessionSettings:
+        """Ensure the active native Console session owns a settings snapshot."""
+        store = self._ensure_console_chat_store()
+        workspace_id = store.workspace_context.active_workspace_id
+        session = store.ensure_session(
+            title=self._workspace_initial_session_title(workspace_id),
+            workspace_id=workspace_id,
+            settings=self._default_console_session_settings(),
+        )
+        if session.settings is None:
+            settings = self._default_console_session_settings()
+            store.replace_session_settings(session.id, settings)
+            return settings
+        return self._maybe_refresh_stale_default_console_settings(store, session)
+
+    def _maybe_refresh_stale_default_console_settings(
+        self,
+        store: ConsoleChatStore,
+        session: ConsoleChatSession,
+    ) -> ConsoleSessionSettings:
+        """Re-derive default-sourced settings for blocked, never-used sessions.
+
+        First-run sessions snapshot template defaults (e.g. OpenAI without a
+        key) and that snapshot survives navigation via screen-state restore.
+        When the user then configures a working provider in Settings, an empty
+        session the user never explicitly configured must converge on the new
+        defaults instead of keeping the setup card blocked until restart
+        (task-177 live regression). Explicit selections (``source == "user"``),
+        sessions with any messages, and already-sendable settings are never
+        touched; stale defaults are only replaced when the re-derived defaults
+        are actually send-capable.
+        """
+        settings = session.settings
+        if settings is None:
+            settings = self._default_console_session_settings()
+            store.replace_session_settings(session.id, settings)
+            return settings
+        if getattr(settings, "source", "derived") == "user":
+            return settings
+        try:
+            if store.messages_for_session(session.id):
+                return settings
+        except KeyError:
+            return settings
+        app_config = self._provider_readiness_app_config()
+        current_readiness = build_console_settings_readiness(
+            settings, app_config=app_config
+        )
+        if current_readiness.native_send_supported:
+            return settings
+        if current_readiness.label not in self._CONSOLE_REFRESHABLE_BLOCKED_LABELS:
+            # Unknown/WIP providers are a provider *choice* problem, not a
+            # config-fixable credential/endpoint gap; never override choice.
+            return settings
+        fresh_defaults = self._default_console_session_settings()
+        if fresh_defaults == settings:
+            return settings
+        fresh_readiness = build_console_settings_readiness(
+            fresh_defaults,
+            app_config=app_config,
+        )
+        if not fresh_readiness.native_send_supported:
+            return settings
+        if settings.system_prompt:
+            # Carry forward an already-applied `/system` prompt across this
+            # config-driven refresh -- it is explicit user intent, not part
+            # of the provider/model "default" this refresh re-derives.
+            # `fresh_defaults.system_prompt` is always ``None`` (defaults
+            # never seed it), so without this guard a message-less session
+            # where the user ran `/system` before fixing a blocked provider
+            # in Settings would have its applied system prompt silently
+            # discarded on the very next settings read.
+            fresh_defaults = replace(
+                fresh_defaults, system_prompt=settings.system_prompt
+            )
+        store.replace_session_settings(session.id, fresh_defaults)
+        return fresh_defaults
+
+    def _replace_active_console_session_settings(
+        self,
+        settings: ConsoleSessionSettings,
+    ) -> None:
+        """Replace settings for only the active native Console session."""
+        store = self._ensure_console_chat_store()
+        workspace_id = store.workspace_context.active_workspace_id
+        session = store.ensure_session(
+            title=self._workspace_initial_session_title(workspace_id),
+            workspace_id=workspace_id,
+            settings=self._default_console_session_settings(),
+        )
+        store.replace_session_settings(session.id, settings)
+        self._sync_console_chat_core_state()
+        self._sync_console_settings_summary()
+
+    def _console_session_settings_for_resume(
+        self,
+        conversation: Mapping[str, Any],
+    ) -> ConsoleSessionSettings:
+        """Return settings for a resumed session, restoring its system prompt.
+
+        Every other field is inherited from the currently active session's
+        settings (or the config-derived defaults when there is none yet);
+        only ``system_prompt`` is overridden from the persisted conversation
+        row so a saved system prompt survives close/resume even though it is
+        never seeded from ``[chat_defaults]``.
+        """
+        settings = (
+            self._active_console_session_settings()
+            or self._default_console_session_settings()
+        )
+        raw_system_prompt = conversation.get("system_prompt")
+        # Only blank/whitespace-only text collapses to "no system prompt";
+        # anything else is restored verbatim (leading/trailing whitespace
+        # and internal formatting included) rather than stripped, so a
+        # formatting-sensitive prompt survives close/resume unchanged.
+        system_prompt = (
+            raw_system_prompt
+            if isinstance(raw_system_prompt, str) and raw_system_prompt.strip()
+            else None
+        )
+        pinned_prefill = pinned_prefill_from_conversation_metadata(
+            conversation.get("metadata")
+        )
+        return replace(
+            settings, system_prompt=system_prompt, pinned_prefill=pinned_prefill
+        )
+
+    def _apply_console_session_system_prompt(
+        self, system_prompt: Optional[str]
+    ) -> None:
+        """Apply (or, for a blank/``None`` value, clear) the active session's
+        system prompt, persisting the change if the conversation is already
+        saved (Task 13's ``ConsoleChatStore.set_session_system_prompt``), and
+        refresh the rail preview + context-estimate surfaces in place.
+
+        The in-memory session is always updated even when the durable write
+        fails -- ``set_session_system_prompt`` never rolls that back (see
+        its docstring) -- so a persistence failure only means the change may
+        not survive a reload; it is surfaced here as an honest warning
+        rather than silently swallowed or crashing this callback.
+        """
+        self._ensure_active_console_session_settings()
+        store = self._ensure_console_chat_store()
+        session_id = store.active_session_id
+        if session_id is None:
+            return
+        _session, persisted = store.set_session_system_prompt(session_id, system_prompt)
+        if not persisted:
+            self.app_instance.notify(
+                "System prompt applied for this session, but the change "
+                "could not be saved -- it may not survive a reload.",
+                severity="warning",
+            )
+        self._sync_console_chat_core_state()
+        self._sync_console_settings_summary()
+        self._sync_console_control_bar()
+
+    # -- Temporary-session promotion ------------------------------------------
+
+    def _dispatch_promote_console_temporary_session(self) -> None:
+        """Kick off the temporary-chat save as its own worker (F5, final review).
+
+        Both entry points (the composer menu row and the Temporary chip)
+        land here, so the save behaves identically however it was reached,
+        and both stay non-blocking: ``promote_ephemeral_session`` runs one
+        DB transaction over every tree node including attachment BLOBs,
+        which can visibly freeze the TUI for a temporary chat with several
+        pasted images. ``group="console-promote"`` is its own family,
+        distinct from ``console-sync``/``console-run-*``/``console-
+        impersonate`` -- see ``Tests/UI/test_chat_screen_worker_groups.py``
+        for why an ungrouped (or wrongly-grouped) exclusive worker is not a
+        cosmetic bug on this screen: one already cancelled in-flight
+        Console sends on this branch. ``exclusive=True`` collapses a
+        double-activation (menu row AND chip clicked before the first save
+        lands) into one save rather than two overlapping transactions on
+        the same session.
+        """
+        self.run_worker(
+            self._promote_console_temporary_session(),
+            exclusive=True,
+            group="console-promote",
+        )
+
+    async def _promote_console_temporary_session(self) -> None:
+        """Save the active temporary chat, then refresh its marker and chip.
+
+        The actual store call is offloaded to a thread
+        (``asyncio.to_thread``) rather than run inline on the event loop --
+        see ``_dispatch_promote_console_temporary_session`` for why blocking
+        here is a real, user-visible freeze, not a theoretical one.
+        """
+        store = self._ensure_console_chat_store()
+        session_id = getattr(store, "active_session_id", None)
+        if not session_id:
+            return
+        try:
+            conversation_id = await asyncio.to_thread(
+                store.promote_ephemeral_session, session_id
+            )
+        except Exception:
+            logger.opt(exception=True).warning("Saving the temporary chat failed")
+            self.app_instance.notify(
+                "Could not save this chat. It is still temporary.",
+                severity="error",
+            )
+            return
+        if conversation_id is None:
+            # F6 (final review): every other outcome notifies -- a silent
+            # return here left the user with no feedback at all on "Save
+            # this chat". `promote_ephemeral_session` returns `None` for
+            # two different reasons (its own docstring): the session was
+            # already saved (idempotent, genuinely fine), or no
+            # persistence adapter is configured at all (the chat is still
+            # temporary and nothing happened) -- these read very
+            # differently to the user, so distinguish them rather than
+            # picking one generic sentence.
+            session = next((s for s in store.sessions() if s.id == session_id), None)
+            if session is not None and not session.ephemeral:
+                # A cancelled-then-retried promote worker lands here: the
+                # first (cancelled) run's `asyncio.to_thread` DB write still
+                # completed, so the session really is saved, but that first
+                # coroutine never reached the `_sync_console_temporary_chip()`
+                # call below. Without refreshing here too, the chip and the
+                # `◌` tab marker keep reading "Temporary" about a chat
+                # that is, in fact, saved -- exactly the mismatch this
+                # marker exists to prevent.
+                self._sync_console_temporary_chip()
+                self.app_instance.notify(
+                    "This chat is already saved.", severity="information"
+                )
+            else:
+                self.app_instance.notify(
+                    "Could not save this chat right now. It is still temporary.",
+                    severity="warning",
+                )
+            return
+        self._invalidate_console_persisted_rows_cache()
+        # `_sync_native_console_chat_ui()` below never touches the Temporary
+        # chip (see `_sync_console_temporary_chip`'s docstring: it is pushed
+        # explicitly at every session-creation/switch point, not folded into
+        # the general sync tick), so without this call the chip would keep
+        # showing "Temporary" on an already-saved conversation.
+        self._sync_console_temporary_chip()
+        self.run_worker(
+            self._sync_native_console_chat_ui(), exclusive=False, group="console-sync"
+        )
+        self.app_instance.notify("Chat saved.", severity="information")
+
+    # -- Character sessions -----------------------------------------------------
+
+    def _swap_console_session_character(
+        self,
+        store: Any,
+        character_id: int,
+        name: str,
+        system_prompt: str,
+        greeting: str,
+    ) -> bool:
+        """Rebind the active session to ``character_id`` in place.
+
+        The greeting is only seeded into an EMPTY chat (user decision,
+        2026-07-31): interrupting a conversation in progress with a
+        greeting reads as the model talking to itself.
+
+        Args:
+            store: The Console chat store.
+            character_id: The picked character's local id.
+            name: Display name for the session/chip.
+            system_prompt: The card's macro-resolved system prompt, which
+                must reach the session settings or the model keeps talking
+                as the previous character (cubic PR #1153 P1).
+            greeting: The card's greeting, seeded only into an empty chat.
+
+        Returns:
+            True when the active session was rebound.
+        """
+        session_id = getattr(store, "active_session_id", None)
+        session = None
+        if session_id:
+            session = next((s for s in store.sessions() if s.id == session_id), None)
+        if session is None:
+            return False
+        for field, value in (
+            ("runtime_backend", "local"),
+            ("assistant_kind", "character"),
+            ("assistant_id", str(character_id)),
+            ("assistant_authority_id", None),
+            ("character_id", character_id),
+            ("character_name", name),
+        ):
+            try:
+                object.__setattr__(session, field, value)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Character swap: could not set {}.", field
+                )
+                return False
+        current_settings = store.session_settings(session_id)
+        if current_settings is not None:
+            store.replace_session_settings(
+                session_id, replace(current_settings, system_prompt=system_prompt)
+            )
+        if greeting and not store.messages_for_session(session_id):
+            try:
+                store.append_message(
+                    session_id,
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content=greeting,
+                    persist=True,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Character swap: greeting seed failed; continuing."
+                )
+        # cubic PR #1153 P2: an already-saved conversation kept the old
+        # prompt after reload because the swap only touched memory.
+        conversation_id = getattr(session, "persisted_conversation_id", None)
+        if conversation_id:
+            try:
+                store.update_conversation_system_prompt(
+                    conversation_id=conversation_id, system_prompt=system_prompt
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Character swap: persisting the system prompt failed."
+                )
+        return True
+
+    async def _start_character_console_session(
+        self, payload: ChatHandoffPayload
+    ) -> bool:
+        """Build a dedicated character conversation from a Start-Chat handoff.
+
+        Args:
+            payload: The Personas Start-Chat handoff staged into the native
+                Console (its metadata carries the character identity).
+
+        Returns:
+            ``True`` when a character session was created (the caller then
+            marks the handoff consumed); ``False`` to let the caller fall back
+            to the staged-context path (task-427).
+        """
+        identity = _character_session_identity_from_handoff(payload)
+        if identity is None:
+            return False
+        runtime_backend, character_id, name_hint, assistant_id = identity
+        scope_service = getattr(
+            self.app_instance,
+            "character_persona_scope_service",
+            None,
+        )
+        get_character = getattr(scope_service, "get_character", None)
+        if not callable(get_character):
+            return False
+
+        assistant_authority_id: str | None
+        local_character_id: int | None
+        server_context_capture: object | None = None
+        server_context_is_current: Callable[[object], bool] | None = None
+
+        def exact_server_context_is_current() -> bool:
+            if server_context_capture is None or server_context_is_current is None:
+                return False
+            try:
+                return server_context_is_current(server_context_capture) is True
+            except Exception:
+                return False
+
+        if runtime_backend == "local":
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            get_local_authority_id = getattr(db, "get_local_authority_id", None)
+            if not callable(get_local_authority_id):
+                return False
+            try:
+                local_authority_id = get_local_authority_id()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            if (
+                type(local_authority_id) is not str
+                or not local_authority_id
+                or local_authority_id != local_authority_id.strip()
+            ):
+                return False
+            assistant_authority_id = local_authority_id
+            local_character_id = character_id
+        else:
+            expected_server_id = payload.active_server_profile_id
+            if (
+                type(expected_server_id) is not str
+                or not expected_server_id
+                or expected_server_id != expected_server_id.strip()
+            ):
+                return False
+            if (
+                getattr(self.app_instance, "active_server_id", None)
+                != expected_server_id
+            ):
+                return False
+
+            assistant_authority_id = None
+            provider = getattr(self.app_instance, "server_context_provider", None)
+            capture_context = getattr(
+                provider,
+                "capture_character_authority_context",
+                None,
+            )
+            server_context_is_current = getattr(
+                provider,
+                "is_character_authority_context_current",
+                None,
+            )
+            resolver = getattr(provider, "resolve_character_authority_id", None)
+            if not callable(capture_context) or not callable(server_context_is_current):
+                return False
+            try:
+                server_context_capture = capture_context(
+                    expected_server_id=expected_server_id
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            if not exact_server_context_is_current():
+                return False
+            if callable(resolver):
+                try:
+                    resolved_authority_id = await resolver(
+                        expected_server_id=expected_server_id,
+                        context_capture=server_context_capture,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    resolved_authority_id = None
+                if (
+                    type(resolved_authority_id) is str
+                    and _SERVER_CHARACTER_AUTHORITY_PATTERN.fullmatch(
+                        resolved_authority_id
+                    )
+                    is not None
+                ):
+                    assistant_authority_id = resolved_authority_id
+
+            # This is both the post-resolver fence and the immediately
+            # pre-card-fetch fence. No card from a newly active target may be
+            # used for the ID carried by the handoff.
+            if (
+                not exact_server_context_is_current()
+                or getattr(self.app_instance, "active_server_id", None)
+                != expected_server_id
+            ):
+                return False
+            local_character_id = None
+
+        try:
+            card = await get_character(character_id, mode=runtime_backend)
+            if hasattr(card, "model_dump"):
+                card = card.model_dump(mode="json")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Start Chat: character card unavailable; staging context instead "
+                "(source={}).",
+                runtime_backend,
+            )
+            return False
+        if not isinstance(card, Mapping) or not card:
+            return False
+        card = dict(card)
+        if _canonical_card_character_id(card.get("id")) != character_id:
+            return False
+
+        if runtime_backend == "server":
+            expected_server_id = payload.active_server_profile_id
+            if (
+                not exact_server_context_is_current()
+                or getattr(self.app_instance, "active_server_id", None)
+                != expected_server_id
+            ):
+                return False
+
+        name, system_prompt, greeting = _character_session_prompt_seed(
+            card, name_hint=str(name_hint or "")
+        )
+
+        store = self._ensure_console_chat_store()
+        settings = replace(
+            self._default_console_session_settings(),
+            system_prompt=system_prompt,
+            character_label=name,
+        )
+        if runtime_backend == "server" and (
+            not exact_server_context_is_current()
+            or getattr(self.app_instance, "active_server_id", None)
+            != payload.active_server_profile_id
+        ):
+            return False
+        session = store.create_session(
+            title=f"Chat with {name}",
+            workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
+            settings=settings,
+            runtime_backend=runtime_backend,
+            assistant_kind="character",
+            assistant_id=assistant_id,
+            assistant_authority_id=assistant_authority_id,
+            character_id=local_character_id,
+            character_name=name,
+        )
+        if greeting:
+            try:
+                store.append_message(
+                    session.id,
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content=greeting,
+                    persist=True,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Start Chat: greeting seed/persist failed; continuing."
+                )
+        try:
+            await self._sync_native_console_chat_ui()
+            self._focus_console_composer_if_needed(force=True)
+        except asyncio.CancelledError:
+            # The durable commit boundary is above. Report success so the
+            # caller acknowledges this handoff instead of replaying it.
+            return True
+        except Exception:
+            # The character session (and its greeting) is already durably
+            # created above -- a UI-sync/focus failure here must not
+            # propagate, or the caller would never clear
+            # ``pending_chat_handoff`` and a later re-consume (e.g. a
+            # screen re-mount timer) would build a SECOND durable
+            # character session.
+            logger.opt(exception=True).warning(
+                "Start Chat: post-seed console sync/focus failed; character "
+                "session was already created and the handoff is still "
+                "considered consumed."
+            )
+        return True
+
+    # -- Draft sync ---------------------------------------------------------
+
+    def _capture_console_draft_switch_snapshot(self) -> None:
+        """Record the composer state at the moment a session switch begins.
+
+        TASK-339: the draft swap in ``_sync_console_session_draft`` can run
+        a settle-window later (coalesced syncs, slow resume loads). Anything
+        the user types in that window is intended for the NEW session; this
+        snapshot lets the swap attribute it correctly instead of saving it
+        to the old session and wiping it from the composer.
+        """
+        composer = self._console_composer_or_none()
+        if composer is None:
+            self._console_draft_switch_snapshot = None
+            return
+        self._console_draft_switch_snapshot = (
+            self._console_visible_draft_session_id,
+            composer.draft_text(),
+            composer.edit_serial,
+        )
+
+    def _sync_console_session_draft(self) -> None:
+        """Reconcile the composer draft with the active runtime Console session.
+
+        Saves the visible draft back to the session that owns it, then loads
+        the active session's draft when the active session changed. Runs
+        inside the native Console sync pass so session transitions cannot
+        lose drafts. Keystrokes typed between switch initiation (see
+        ``_capture_console_draft_switch_snapshot``) and this swap carry
+        forward into the new session, in order (TASK-339).
+        """
+        store = self._ensure_console_chat_store()
+        session = store.ensure_session(
+            title=self._workspace_initial_session_title(
+                store.workspace_context.active_workspace_id
+            ),
+            workspace_id=store.workspace_context.active_workspace_id,
+            settings=self._default_console_session_settings(),
+        )
+        active_session_id = session.id
+        composer = self._console_composer_or_none()
+        if composer is None:
+            return
+        visible_session_id = self._console_visible_draft_session_id
+        if visible_session_id == active_session_id:
+            if visible_session_id is not None:
+                try:
+                    store.set_session_draft(visible_session_id, composer.draft_text())
+                except KeyError:
+                    pass
+            return
+        snapshot = self._console_draft_switch_snapshot
+        self._console_draft_switch_snapshot = None
+        live_text = composer.draft_text()
+        save_text = live_text
+        typed_suffix = ""
+        if snapshot is not None and snapshot[0] == visible_session_id:
+            snap_text, snap_serial = snapshot[1], snapshot[2]
+            if composer.edit_serial != snap_serial and live_text.startswith(snap_text):
+                # User typed during the settle window: the old session keeps
+                # what it actually had at the keypress; the new typing rides
+                # into the new session below. (Non-append edits — e.g.
+                # backspacing into the old draft — fall back to today's
+                # save-the-live-text semantics.)
+                save_text = snap_text
+                typed_suffix = live_text[len(snap_text) :]
+        if visible_session_id is not None:
+            try:
+                store.set_session_draft(visible_session_id, save_text)
+            except KeyError:
+                pass
+            # TASK-1281: this composer is about to start showing a DIFFERENT
+            # session's draft -- bank its undo/redo history under the
+            # session it actually belongs to before the swap below discards
+            # it, so a later switch back can restore it.
+            self._console_undo_histories[visible_session_id] = (
+                composer.export_undo_history()
+            )
+        try:
+            composer.load_draft(store.session_draft(active_session_id))
+        except KeyError:
+            composer.clear_draft()
+        # TASK-1281: restore (or start fresh) BEFORE re-inserting any
+        # settle-window keystrokes below, so those keystrokes land in --
+        # and are recorded onto -- the session they actually typed into.
+        composer.restore_undo_history(
+            self._console_undo_histories.get(active_session_id)
+        )
+        if typed_suffix:
+            composer.insert_text(typed_suffix)
+        self._sync_console_command_popup()
+        self._console_visible_draft_session_id = active_session_id
+
+    # -- Session identity / state -------------------------------------------
+
+    def _active_native_console_session(self) -> Any | None:
+        """Return the active native Console session without creating the store."""
+        console_store = self._console_chat_store
+        active_session_id = (
+            console_store.active_session_id if console_store is not None else None
+        )
+        if console_store is None or active_session_id is None:
+            return None
+        for console_session in console_store.sessions():
+            if console_session.id == active_session_id:
+                return console_session
+        return None
+
+    def _current_console_conversation_id(self) -> Optional[str]:
+        """Return the active conversation id for Console context highlighting."""
+        console_store = self._console_chat_store
+        active_session_id = (
+            console_store.active_session_id if console_store is not None else None
+        )
+        if console_store is not None and active_session_id is not None:
+            for console_session in console_store.sessions():
+                if console_session.id == active_session_id:
+                    conversation_id = console_session.persisted_conversation_id
+                    if conversation_id:
+                        return str(conversation_id)
+                    break
+        return None
+
+    def _current_console_session_id(self) -> Optional[str]:
+        """Return a durable external Console session scope when one is available."""
+        session_id = getattr(self.app_instance, "console_rail_session_id", None)
+        if session_id:
+            return str(session_id)
+        console_store = self._console_chat_store
+        if console_store is not None and console_store.active_session_id is not None:
+            return str(console_store.active_session_id)
+        return None
+
+    def _console_active_session_is_ephemeral(self) -> bool:
+        """Return whether the active Console session is temporary.
+
+        Public-API only (`sessions()` + `active_session_id`): the store has
+        no single-session getter that is not private. The scan is over open
+        tabs, so it is a handful of items.
+        """
+        store = self._console_chat_store
+        if store is None:
+            return False
+        active_id = store.active_session_id
+        if not active_id:
+            return False
+        return any(
+            session.id == active_id and session.ephemeral
+            for session in store.sessions()
+        )
+
+    def _console_session_id_for_browser_row(
+        self,
+        row: ConsoleConversationBrowserRow,
+    ) -> str | None:
+        """Return an open session matching a grouped browser row's identity."""
+        store = self._console_chat_store
+        if store is None:
+            return None
+        native_session_id = str(row.native_session_id or "").strip()
+        if native_session_id:
+            if any(session.id == native_session_id for session in store.sessions()):
+                return native_session_id
+            return None
+        row_key = str(row.row_key or "").strip()
+        if row_key.startswith("native:"):
+            return self._session_id_for_workspace_conversation(row_key)
+        conversation_id = str(row.conversation_id or "").strip()
+        if not conversation_id:
+            return None
+        scope_type = str(row.scope_type or "").strip()
+        expected_workspace_id = (
+            CONSOLE_GLOBAL_WORKSPACE_ID
+            if scope_type == "global"
+            else str(row.workspace_id or "").strip()
+        )
+        fallback_session_id: str | None = None
+        for session in store.sessions():
+            if str(session.persisted_conversation_id or "").strip() != conversation_id:
+                continue
+            session_workspace_id = str(session.workspace_id or "").strip()
+            if expected_workspace_id and session_workspace_id == expected_workspace_id:
+                return session.id
+            if fallback_session_id is None:
+                fallback_session_id = session.id
+        if str(row.source_kind or "").strip() == "membership" and expected_workspace_id:
+            return None
+        return fallback_session_id
+
+    def _with_native_console_session_rows(
+        self,
+        state: ConsoleWorkspaceContextState,
+    ) -> ConsoleWorkspaceContextState:
+        """Include active native Console sessions in the workspace rail.
+
+        The workspace registry only knows about conversations after durable
+        persistence links them. Native Console sessions are still user-visible
+        conversations and need to remain reachable from the rail while they are
+        open, including before the first persisted message exists.
+        """
+        store = self._console_chat_store
+        if store is None:
+            return state
+
+        active_workspace_id = str(
+            store.workspace_context.active_workspace_id or ""
+        ).strip()
+        active_session_id = store.active_session_id
+        rows = list(state.conversation_rows)
+        existing_ids = {str(row.conversation_id) for row in rows}
+        native_rows: list[ConsoleWorkspaceConversationRow] = []
+        for session in store.sessions():
+            session_workspace_id = str(session.workspace_id or "").strip()
+            selected = session.id == active_session_id
+            if (
+                active_workspace_id
+                and active_workspace_id != CONSOLE_GLOBAL_WORKSPACE_ID
+                and session_workspace_id != active_workspace_id
+                and not selected
+            ):
+                continue
+
+            conversation_id = (
+                str(session.persisted_conversation_id)
+                if session.persisted_conversation_id
+                else f"native:{session.id}"
+            )
+            if conversation_id in existing_ids:
+                continue
+
+            native_rows.append(
+                ConsoleWorkspaceConversationRow(
+                    conversation_id=conversation_id,
+                    title=session.title,
+                    status="active" if selected else "open",
+                    selected=selected,
+                )
+            )
+            existing_ids.add(conversation_id)
+
+        if not native_rows:
+            return state
+        native_rows.sort(key=lambda row: 0 if row.selected else 1)
+        return replace(
+            state,
+            conversation_rows=tuple(
+                self._merge_workspace_rows(native_rows, rows)
+            ),
+        )
+
+    # -- Screen-state (de)serialization for one session ----------------------
+
+    @staticmethod
+    def _console_session_to_state(session: ConsoleChatSession) -> dict[str, Any]:
+        """Serialize one ConsoleChatSession for screen-state restoration.
+
+        Extracted from `_serialize_native_console_state` so the round trip
+        is testable without a running app. This is an explicit field list:
+        a field missing from it is silently dropped on the way back.
+        """
+        return {
+            "id": session.id,
+            "title": session.title,
+            "workspace_id": session.workspace_id,
+            "persisted_conversation_id": session.persisted_conversation_id,
+            "draft": session.draft,
+            "settings": ConsoleSessionController._serialize_console_settings(
+                session.settings
+            ),
+            "updated_at": session.updated_at,
+            "runtime_backend": session.runtime_backend,
+            "assistant_kind": session.assistant_kind,
+            "assistant_id": session.assistant_id,
+            "assistant_authority_id": session.assistant_authority_id,
+            "character_id": session.local_character_id(),
+            "character_name": session.character_name,
+            # Temporary conversations: without this key a temporary chat
+            # comes back as a persisting one after any screen navigation,
+            # and the next send writes it to the DB.
+            "ephemeral": session.ephemeral,
+        }
+
+    def _console_session_from_state(
+        self, raw_session: dict[str, Any]
+    ) -> ConsoleChatSession:
+        """Rebuild one ConsoleChatSession from its serialized screen state.
+
+        The mirror of `_console_session_to_state`. Every legacy-payload
+        branch below exists because older saved states omit keys that newer
+        ones carry -- keep them.
+        """
+        # `getattr` (not `self._ensure_console_chat_store()`) tolerates a
+        # bare controller that never ran `__init__` (unit-level
+        # serialize/restore round trips build one via `__new__`, same as
+        # `ChatScreen.__new__` did pre-move). In the real restore path,
+        # `_restore_native_console_state` already ensured the store before
+        # this per-session helper runs, so this is the same object either way.
+        store = getattr(self, "_console_chat_store", None)
+        session_id = str(raw_session.get("id") or uuid.uuid4())
+        session_kwargs: dict[str, Any] = dict(
+            id=session_id,
+            title=str(raw_session.get("title") or DEFAULT_CONSOLE_SESSION_TITLE),
+            workspace_id=str(
+                raw_session.get("workspace_id")
+                or (
+                    store.workspace_context.active_workspace_id
+                    if store is not None
+                    else None
+                )
+                or CONSOLE_GLOBAL_WORKSPACE_ID
+            ),
+            persisted_conversation_id=(
+                str(raw_session["persisted_conversation_id"])
+                if raw_session.get("persisted_conversation_id") is not None
+                else None
+            ),
+            settings=self._restore_console_settings(raw_session.get("settings")),
+            draft=str(raw_session.get("draft") or ""),
+        )
+        # Legacy payloads saved before `updated_at` was serialized omit the
+        # key entirely; keep the ConsoleChatSession factory default (now)
+        # for those instead of forcing an empty/invalid timestamp.
+        raw_updated_at = raw_session.get("updated_at")
+        if raw_updated_at:
+            session_kwargs["updated_at"] = str(raw_updated_at)
+        identity_keys = (
+            "runtime_backend",
+            "assistant_kind",
+            "assistant_id",
+            "assistant_authority_id",
+        )
+        has_source_aware_identity = any(key in raw_session for key in identity_keys)
+        if has_source_aware_identity:
+            raw_runtime_backend = raw_session.get("runtime_backend")
+            session_kwargs["runtime_backend"] = (
+                raw_runtime_backend if type(raw_runtime_backend) is str else ""
+            )
+            for key in (
+                "assistant_kind",
+                "assistant_id",
+                "assistant_authority_id",
+            ):
+                value = raw_session.get(key)
+                session_kwargs[key] = value if type(value) is str else None
+
+        raw_character_id = raw_session.get("character_id")
+        character_id: int | None = None
+        if type(raw_character_id) is int and raw_character_id > 0:
+            if not has_source_aware_identity:
+                character_id = raw_character_id
+            elif (
+                session_kwargs.get("runtime_backend") == "local"
+                and session_kwargs.get("assistant_kind") == "character"
+                and session_kwargs.get("assistant_id") == str(raw_character_id)
+            ):
+                character_id = raw_character_id
+        if character_id is not None:
+            session_kwargs["character_id"] = character_id
+        if not has_source_aware_identity and character_id is not None:
+            # Pre-provenance screen state used the numeric local character
+            # projection as its direct-chat routing marker. Preserve that
+            # behavior without inventing a proven authority.
+            session_kwargs.update(
+                runtime_backend="local",
+                assistant_kind="character",
+                assistant_id=str(character_id),
+                assistant_authority_id=None,
+            )
+        raw_character_name = raw_session.get("character_name")
+        if raw_character_name is not None:
+            session_kwargs["character_name"] = str(raw_character_name)
+        # Legacy payloads predate the key; absent means saved, never temporary.
+        session_kwargs["ephemeral"] = raw_session.get("ephemeral") is True
+        return ConsoleChatSession(**session_kwargs)
+
+    @staticmethod
+    def _serialize_console_settings(
+        settings: ConsoleSessionSettings | None,
+    ) -> dict[str, Any] | None:
+        """Return a JSON-safe snapshot of per-session Console settings."""
+        if settings is None:
+            return None
+        return asdict(settings)
+
+    @staticmethod
+    def _restore_console_settings(
+        payload: Any,
+    ) -> ConsoleSessionSettings | None:
+        """Return per-session Console settings from a saved state payload."""
+        if not isinstance(payload, dict):
+            return None
+        values = dict(payload)
+        values.pop("persona_label", None)
+        values.pop("user_profile_label", None)
+        valid_fields = set(ConsoleSessionSettings.__dataclass_fields__)
+        values = {key: value for key, value in values.items() if key in valid_fields}
+        provider = str(values.get("provider") or "").strip()
+        if not provider:
+            return None
+        values["provider"] = provider
+        try:
+            return ConsoleSessionSettings(**values)
+        except TypeError:
+            logger.opt(exception=True).debug(
+                "Skipping invalid Console session settings payload"
+            )
+            return None
+
+    # -- Composer/session-draft coherence guard -------------------------------
+
+    def _console_composer_history_session_synced(self) -> bool:
+        """Return whether the composer's visible session matches the active one.
+
+        TASK-1281 review F1 (HIGH): mirrors the guard `_insert_console_
+        dictation` already carries for exactly this reason. During the
+        session-switch settle window (TASK-339) -- `controller.switch_
+        session(...)` runs synchronously and `store.active_session_id`
+        changes immediately, but `_console_visible_draft_session_id` only
+        catches up later, inside `_sync_console_session_draft`, once the
+        deferred sync actually runs -- the composer can still be showing
+        session A's draft while the store already considers session B
+        active. Undo/redo must never run while that window is open: doing
+        so would apply session A's history against the composer, then
+        (via the re-persist below) write A's resulting text into the STORE
+        under session B's id -- permanently destroying B's own draft the
+        moment the deferred swap finally lands.
+
+        Returns:
+            True only when the composer is not None, an active session
+            exists, and the composer is provably showing that exact
+            session's draft right now.
+        """
+        composer = self._console_composer_or_none()
+        if composer is None:
+            return False
+        store = self._ensure_console_chat_store()
+        return (
+            store.active_session_id is not None
+            and self._console_visible_draft_session_id == store.active_session_id
+        )

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -1649,26 +1649,6 @@ class ConsoleWorkspaceController:
             )
         return rows, total_count, ""
 
-    def _refresh_console_workspace_conversation_search_if_current(
-        self,
-        workspace_id: str,
-        query: str,
-        token: int,
-        *,
-        restore_focus: bool = False,
-    ) -> bool:
-        """Refresh search results when workspace, query, and token still match."""
-        if token != self._console_workspace_conversation_search_token:
-            return False
-        if workspace_id != self._active_console_workspace_id_for_conversation_search():
-            return False
-        if query != self._console_workspace_conversation_query:
-            return False
-        self._sync_console_workspace_context()
-        if restore_focus:
-            self.call_after_refresh(self._focus_console_workspace_conversation_search)
-        return True
-
     async def _refresh_console_workspace_conversation_search(
         self,
         workspace_id: str,

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -1,0 +1,1879 @@
+"""Console workspace controller.
+
+Extracted out of `ChatScreen` (wave-2 console decomposition, task 2): the
+largest single cluster in wave 2 -- 35 moved methods, ~1,341 lines of method
+bodies -- covering workspace policy context, the workspace switcher/rename/
+archive/create lifecycle, the workspace RAG-scope picker, workspace-scoped
+Console session activation, resuming a persisted conversation into a native
+Console session, and the (largely legacy, still-tested) workspace
+conversation search rows.
+
+This module follows the SAME binding rule wave 1's `ConsoleDictationController`
+established (see that module's own docstring for the canonical statement):
+
+1. **Framework services** (`run_worker`, `push_screen`, `call_after_refresh`)
+   live-read from the screen via `@property` on every access -- never
+   snapshotted, because a bound method captured once at construction goes
+   stale the instant a test replaces the attribute on the SCREEN INSTANCE
+   afterward.
+2. **Sibling clusters' own state/entry points, not yet given a named-
+   accessor home** are the same live-`@property`-through-`screen` shape, for
+   the same staleness reason, but are a disclosed, temporary exception, not
+   a controller dependency: `_pending_console_launch_context` (the staged-
+   evidence cluster's own attribute) and `_console_agent_drilldown_run_id`
+   (the sub-agent drill-in cluster's own attribute, read+write).
+3. **Everything else this cluster genuinely depends on that is not its own
+   state** is a NAMED constructor dependency, matching the design spec's
+   rule that "a controller's dependencies are its signature". Each is a
+   zero-arg (or narrowly-typed) callable the CALLER constructs to close over
+   the screen's own attribute lookup at CALL time (a late-binding lambda,
+   never a bound method passed directly -- see `ChatScreen.__init__`'s
+   wiring for why). The controller's own property of the SAME NAME as the
+   original `ChatScreen` method/attribute is a thin wrapper around the
+   stored callable, so every moved method body below is a byte-for-byte
+   copy of the pre-extraction source: no internal line needed to change,
+   because every name a body references still resolves.
+
+   This cluster adds ONE variant kind 3 wave 1 did not need: two of this
+   cluster's OWN original members -- `_sync_console_workspace_context` and
+   `_focus_console_workspace_conversation_search` -- read/write the DOM
+   (`query_one`/`query`/`mount`), so per the "zero DOM in the controller"
+   rule they stay behind on `ChatScreen` as real implementations. The
+   controller still reaches them, but as ordinary named constructor
+   callables (`sync_workspace_context`/`focus_conversation_search`) rather
+   than as screen properties -- they are not a sibling cluster's business,
+   they are this cluster's own DOM-shaped edge, staying behind for a
+   documented reason.
+
+   A second variant: where the ORIGINAL name was a plain attribute read
+   (`self._console_chat_store`, `self._pending_console_launch_context`),
+   not a method call, the wrapper property CALLS the stored accessor (or
+   the screen attribute) immediately and returns the value, rather than
+   returning the callable itself -- matching the bare-read call shape the
+   moved body uses.
+
+`app_instance` is the one plain-attribute exception to all three rules
+above, exactly as in `ConsoleDictationController`: it does not change
+identity over the controller's life, and the pre-extraction methods already
+read it as a plain attribute, never as a call.
+
+Moved verbatim: every `ChatScreen` method matching `*workspace*` whose body
+touched only `_console_workspace_conversation_*` state (or one of its
+sibling attributes) and the callables above -- 35 methods in total. `Chat
+Screen` keeps SIX get/set proxy properties for this cluster's state
+(`_console_workspace_conversation_query`/`_search_timer`/`_search_token`/
+`_search_rows`/`_search_total`/`_search_error` -- NOT `_workspace_id`, which
+is read and written only inside `_with_console_workspace_conversation_
+section`, itself moved, so it never needed a proxy) under the ORIGINAL
+attribute names, each routing straight through to `self._workspace`, so
+`on_console_workspace_conversation_search_changed` (a sibling
+conversation-browser handler that only mirrors THREE of these six fields --
+see that handler's own docstring) and `on_button_pressed`'s workspace-search
+branches (the giant screen-level button dispatcher, staying on the screen
+for the same reason wave 1's dictation branches stayed there) needed zero
+changes.
+
+`ChatScreen` also keeps ten methods this cluster's name pattern matches but
+whose bodies do not belong here:
+
+- Five ``@on``/``action_*`` one-line delegations Textual's own dispatch
+  requires to live on the class that receives the event/command:
+  `on_console_change_workspace`, `action_open_console_workspace_switcher`,
+  `on_console_new_workspace`, `action_new_console_workspace`,
+  `on_console_workspace_rag_scope_open`.
+- `on_console_workspace_conversation_search_changed` (see above).
+- Three DOM-touching methods (`_sync_console_workspace_context`,
+  `_sync_console_legacy_workspace_context_aliases`,
+  `_on_console_workspace_context_relabeled`) -- the "zero DOM in the
+  controller" rule; the first two are reached via the named accessors
+  described above, the third needed no change (it already only calls
+  `run_worker`+the second, both screen-owned either way).
+- `_focus_console_workspace_conversation_search` (DOM; see above).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+from typing import Any, Optional, TYPE_CHECKING
+import asyncio
+import inspect
+
+from loguru import logger
+
+from ...Chat.console_chat_models import (
+    CONSOLE_GLOBAL_WORKSPACE_ID,
+    DEFAULT_CONSOLE_SESSION_TITLE,
+    ConsoleStagedSource,
+    ConsoleWorkspaceContext,
+)
+from ...Chat.console_display_state import evidence_bundle_from_launch
+from ...Chat.console_live_work import ConsoleLiveWorkLaunch
+from ...Chat.rag_scope import RagScope
+from ...Widgets.confirmation_dialog import ConfirmationDialog
+from ...Widgets.Console import (
+    ConsoleWorkspaceContextTray,
+    ConsoleWorkspaceRenameModal,
+    ConsoleWorkspaceSwitcherModal,
+)
+from ...Widgets.Console.console_scope_picker_modal import ConsoleScopePickerModal
+from ...Workspaces import (
+    ConsoleConversationBrowserRow,
+    DEFAULT_WORKSPACE_ID,
+    WorkspaceRecord,
+)
+from ...Workspaces.display_state import (
+    CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT,
+    ConsoleWorkspaceContextState,
+    ConsoleWorkspaceConversationRow,
+    ConsoleWorkspaceConversationSectionState,
+    build_console_workspace_state,
+    console_workspace_conversation_result_copy,
+)
+from ...Workspaces.registry_service import (
+    WorkspaceNotFound,
+    WorkspaceRegistryServiceError,
+    next_local_workspace_identity,
+)
+
+if TYPE_CHECKING:
+    from ...Chat.console_chat_controller import ConsoleChatController
+    from ..Screens.chat_screen import ChatScreen
+
+logger = logger.bind(module="ChatScreen")
+
+
+class ConsoleWorkspaceController:
+    """Owns the Console shell's workspace policy context, lifecycle, and
+    the workspace-scoped conversation search/resume flows.
+
+    Wave 2's largest cluster. Holds every attribute the pre-extraction
+    `ChatScreen` named `_console_workspace_conversation_*` (six of the
+    seven -- see the module docstring for why `_workspace_id` needed no
+    proxy), plus the 35 methods whose bodies touched only that state and
+    the constructor-supplied callables below. `ChatScreen` constructs
+    exactly one of these, in `__init__`, and keeps a `self._workspace`
+    reference plus the ten stay-behind methods described in the module
+    docstring.
+    """
+
+    def __init__(
+        self,
+        screen: "ChatScreen",
+        *,
+        app_instance: Any,
+        chat_store_accessor: Callable[[], Any],
+        current_chat_store_accessor: Callable[[], Any],
+        current_conversation_id_accessor: Callable[[], str | None],
+        native_session_rows_accessor: Callable[
+            [ConsoleWorkspaceContextState], ConsoleWorkspaceContextState
+        ],
+        conversation_browser_state_accessor: Callable[
+            ..., ConsoleWorkspaceContextState
+        ],
+        capture_draft_switch_snapshot: Callable[[], None],
+        sync_chat_core_state: Callable[[], None],
+        sync_native_console_chat_ui: Callable[[], Any],
+        sync_temporary_chip: Callable[[], None],
+        default_session_settings_accessor: Callable[[], Any],
+        scope_picker_listers_accessor: Callable[[], tuple[Any, Any, Any]],
+        active_native_session_accessor: Callable[[], Any],
+        refresh_effective_scope_and_sync: Callable[[Any], Any],
+        messages_from_conversation_tree_accessor: Callable[[dict], list],
+        session_settings_for_resume_accessor: Callable[[Any], Any],
+        resolve_resumed_character_name: Callable[[int], Any],
+        inject_resume_agent_markers_accessor: Callable[[list, str], list],
+        resolve_effective_scope_state: Callable[[Any], Any],
+        sync_retrieval_scope_row: Callable[[], None],
+        note_follow_intent: Callable[[], None],
+        focus_composer_if_needed: Callable[..., None],
+        conversation_section_config_accessor: Callable[[], dict],
+        focus_conversation_search: Callable[[], None],
+        sync_workspace_context: Callable[[], None],
+    ) -> None:
+        """Build the controller and bind everything its moved bodies need.
+
+        Every one of the 35 method bodies below is a byte-for-byte copy of
+        the pre-extraction `ChatScreen` method. That is possible because
+        this constructor binds every name those bodies reference that is
+        not this controller's own state, under the SAME name the original
+        method/attribute used -- see the module docstring for the three
+        (plus one cluster-specific variant) binding kinds this follows.
+
+        Args:
+            screen: The Console screen. Used ONLY for the framework
+                services (`run_worker`, `push_screen`, `call_after_
+                refresh`) and the two disclosed, temporary sibling-cluster
+                reach-backs (`_pending_console_launch_context`,
+                `_console_agent_drilldown_run_id`). Zero `query_one`/
+                `query` traffic reaches through `screen` here -- this
+                cluster's two DOM-touching members stayed on `ChatScreen`
+                and are reached via the named accessors below instead.
+            app_instance: For `notify()` and the workspace/scope-service
+                registry lookups every lifecycle method makes -- unchanged
+                from how the pre-extraction methods used
+                `self.app_instance`. Snapshotted as a plain attribute, not
+                a property: it does not change identity over the
+                controller's life, and the pre-extraction methods never
+                called it, only read it.
+            chat_store_accessor: `ChatScreen._ensure_console_chat_store`
+                (lazily creates the store) -- used where the original body
+                called it as a method (`self._ensure_console_chat_store()`).
+            current_chat_store_accessor: A DIFFERENT accessor for the SAME
+                store, `lambda: self._console_chat_store` -- a bare
+                attribute read that must NOT create the store as a side
+                effect (several moved bodies branch on it still being
+                `None`). Kept distinct from `chat_store_accessor` on
+                purpose: collapsing them would change behavior (an
+                eager-create side effect where the original had none).
+            current_conversation_id_accessor: `ChatScreen._current_console_
+                conversation_id`, a general screen helper.
+            native_session_rows_accessor: `ChatScreen._with_native_console_
+                session_rows`, the sibling conversation-browser cluster's
+                own state builder (native, unpersisted sessions).
+            conversation_browser_state_accessor: `ChatScreen._with_console_
+                conversation_browser_state`, same sibling cluster.
+            capture_draft_switch_snapshot: `ChatScreen._capture_console_
+                draft_switch_snapshot`, the composer's own pre-switch
+                snapshot hook.
+            sync_chat_core_state: `ChatScreen._sync_console_chat_core_
+                state`.
+            sync_native_console_chat_ui: `ChatScreen._sync_native_console_
+                chat_ui` -- a coroutine FUNCTION, called (not awaited
+                directly) by every moved body exactly as the original did,
+                either wrapped in `self.run_worker(...)` or `await`ed.
+            sync_temporary_chip: `ChatScreen._sync_console_temporary_chip`.
+            default_session_settings_accessor: `ChatScreen._default_
+                console_session_settings`.
+            scope_picker_listers_accessor: `ChatScreen._console_scope_
+                picker_listers`, shared with the non-workspace retrieval-
+                scope picker too, so it stays screen-owned.
+            active_native_session_accessor: `ChatScreen._active_native_
+                console_session`.
+            refresh_effective_scope_and_sync: `ChatScreen._refresh_console_
+                effective_scope_and_sync`, async.
+            messages_from_conversation_tree_accessor: `ChatScreen._console_
+                messages_from_conversation_tree`, the resume flow's tree
+                flattener.
+            session_settings_for_resume_accessor: `ChatScreen._console_
+                session_settings_for_resume`.
+            resolve_resumed_character_name: `ChatScreen._resolve_resumed_
+                character_name`, async.
+            inject_resume_agent_markers_accessor: `ChatScreen._inject_
+                resume_agent_markers`.
+            resolve_effective_scope_state: `ChatScreen._resolve_console_
+                effective_scope_state`, async.
+            sync_retrieval_scope_row: `ChatScreen._sync_console_retrieval_
+                scope_row`.
+            note_follow_intent: `ChatScreen._note_console_follow_intent`.
+            focus_composer_if_needed: `ChatScreen._focus_console_composer_
+                if_needed`; the moved resume body calls it with
+                `force=True` exactly as before -- the stored callable
+                accepts the same keyword, not a value baked in here.
+            conversation_section_config_accessor: `ChatScreen._console_
+                conversation_section_config`.
+            focus_conversation_search: `ChatScreen._focus_console_
+                workspace_conversation_search` -- stays on the screen (DOM:
+                `query_one`), reached as a named callable rather than a
+                screen property because it belongs to THIS cluster (see
+                the module docstring), not a sibling one.
+            sync_workspace_context: `ChatScreen._sync_console_workspace_
+                context` -- stays on the screen for the same DOM reason;
+                the single most-called external dependency in this
+                cluster (every lifecycle mutation ends by pushing a
+                refresh through it).
+        """
+        self._screen = screen
+        self.app_instance = app_instance
+        self._chat_store_accessor = chat_store_accessor
+        self._current_chat_store_accessor = current_chat_store_accessor
+        self._current_conversation_id_accessor = current_conversation_id_accessor
+        self._native_session_rows_accessor = native_session_rows_accessor
+        self._conversation_browser_state_accessor = (
+            conversation_browser_state_accessor
+        )
+        self._capture_draft_switch_snapshot_fn = capture_draft_switch_snapshot
+        self._sync_chat_core_state_fn = sync_chat_core_state
+        self._sync_native_console_chat_ui_fn = sync_native_console_chat_ui
+        self._sync_temporary_chip_fn = sync_temporary_chip
+        self._default_session_settings_accessor = default_session_settings_accessor
+        self._scope_picker_listers_accessor = scope_picker_listers_accessor
+        self._active_native_session_accessor = active_native_session_accessor
+        self._refresh_effective_scope_and_sync_fn = refresh_effective_scope_and_sync
+        self._messages_from_conversation_tree_accessor = (
+            messages_from_conversation_tree_accessor
+        )
+        self._session_settings_for_resume_accessor = (
+            session_settings_for_resume_accessor
+        )
+        self._resolve_resumed_character_name_fn = resolve_resumed_character_name
+        self._inject_resume_agent_markers_accessor = (
+            inject_resume_agent_markers_accessor
+        )
+        self._resolve_effective_scope_state_fn = resolve_effective_scope_state
+        self._sync_retrieval_scope_row_fn = sync_retrieval_scope_row
+        self._note_follow_intent_fn = note_follow_intent
+        self._focus_composer_if_needed_fn = focus_composer_if_needed
+        self._conversation_section_config_accessor = (
+            conversation_section_config_accessor
+        )
+        self._focus_conversation_search_fn = focus_conversation_search
+        self._sync_workspace_context_fn = sync_workspace_context
+
+        # This cluster's own state, moved verbatim from `ChatScreen.__init__`.
+        self._console_workspace_conversation_query = ""
+        self._console_workspace_conversation_search_timer: Any | None = None
+        self._console_workspace_conversation_search_token = 0
+        self._console_workspace_conversation_search_rows: tuple[
+            ConsoleWorkspaceConversationRow, ...
+        ] = ()
+        self._console_workspace_conversation_search_total: int | None = None
+        self._console_workspace_conversation_search_error = ""
+        self._console_workspace_conversation_workspace_id: str | None = None
+
+    # -- Framework services (kind 1: live-read via `@property`) ------------
+
+    @property
+    def run_worker(self) -> Any:
+        """`Screen.run_worker`, bound. See `__init__`'s docstring for why
+        this is a property rather than a value snapshotted once."""
+        return self._screen.run_worker
+
+    @property
+    def push_screen(self) -> Any:
+        """`Screen.app.push_screen`, bound. See `__init__`'s docstring."""
+        return self._screen.app.push_screen
+
+    @property
+    def call_after_refresh(self) -> Any:
+        """`Screen.call_after_refresh`, bound. See `__init__`'s docstring."""
+        return self._screen.call_after_refresh
+
+    # -- Sibling clusters' reach-backs (kind 2) -----------------------------
+
+    @property
+    def _pending_console_launch_context(self) -> Optional[ConsoleLiveWorkLaunch]:
+        """The staged-evidence cluster's own attribute (not extracted this
+        wave). Live `@property` through `screen`, never snapshotted."""
+        return self._screen._pending_console_launch_context
+
+    @property
+    def _console_agent_drilldown_run_id(self) -> str | None:
+        """The sub-agent drill-in cluster's own attribute. Read+write:
+        the moved resume body clears it unconditionally on every resume."""
+        return self._screen._console_agent_drilldown_run_id
+
+    @_console_agent_drilldown_run_id.setter
+    def _console_agent_drilldown_run_id(self, value: str | None) -> None:
+        self._screen._console_agent_drilldown_run_id = value
+
+    # -- Named constructor dependencies (kind 3) ----------------------------
+    #
+    # Each property below is a thin wrapper around a stored callable, kept
+    # under the SAME name the original `ChatScreen` method/attribute used --
+    # see `__init__`'s docstring. Two shapes:
+    #
+    # - The original was a METHOD CALL (`self._name(...)`): the property
+    #   returns the stored callable itself, unbound-called by the moved
+    #   body exactly as before (`self._name(...)` still resolves, and a
+    #   bare reference like `self.call_after_refresh(self._name)` also
+    #   still works, since the property hands back the same callable
+    #   object either way).
+    # - The original was a PLAIN ATTRIBUTE READ (`self._name`, no `()`):
+    #   the property CALLS the stored accessor immediately and returns the
+    #   value, matching the bare-read call shape (`_console_chat_store`
+    #   only).
+
+    @property
+    def _ensure_console_chat_store(self) -> Any:
+        return self._chat_store_accessor
+
+    @property
+    def _console_chat_store(self) -> Any:
+        return self._current_chat_store_accessor()
+
+    @property
+    def _current_console_conversation_id(self) -> Any:
+        return self._current_conversation_id_accessor
+
+    @property
+    def _with_native_console_session_rows(self) -> Any:
+        return self._native_session_rows_accessor
+
+    @property
+    def _with_console_conversation_browser_state(self) -> Any:
+        return self._conversation_browser_state_accessor
+
+    @property
+    def _capture_console_draft_switch_snapshot(self) -> Any:
+        return self._capture_draft_switch_snapshot_fn
+
+    @property
+    def _sync_console_chat_core_state(self) -> Any:
+        return self._sync_chat_core_state_fn
+
+    @property
+    def _sync_native_console_chat_ui(self) -> Any:
+        return self._sync_native_console_chat_ui_fn
+
+    @property
+    def _sync_console_temporary_chip(self) -> Any:
+        return self._sync_temporary_chip_fn
+
+    @property
+    def _default_console_session_settings(self) -> Any:
+        return self._default_session_settings_accessor
+
+    @property
+    def _console_scope_picker_listers(self) -> Any:
+        return self._scope_picker_listers_accessor
+
+    @property
+    def _active_native_console_session(self) -> Any:
+        return self._active_native_session_accessor
+
+    @property
+    def _refresh_console_effective_scope_and_sync(self) -> Any:
+        return self._refresh_effective_scope_and_sync_fn
+
+    @property
+    def _console_messages_from_conversation_tree(self) -> Any:
+        return self._messages_from_conversation_tree_accessor
+
+    @property
+    def _console_session_settings_for_resume(self) -> Any:
+        return self._session_settings_for_resume_accessor
+
+    @property
+    def _resolve_resumed_character_name(self) -> Any:
+        return self._resolve_resumed_character_name_fn
+
+    @property
+    def _inject_resume_agent_markers(self) -> Any:
+        return self._inject_resume_agent_markers_accessor
+
+    @property
+    def _resolve_console_effective_scope_state(self) -> Any:
+        return self._resolve_effective_scope_state_fn
+
+    @property
+    def _sync_console_retrieval_scope_row(self) -> Any:
+        return self._sync_retrieval_scope_row_fn
+
+    @property
+    def _note_console_follow_intent(self) -> Any:
+        return self._note_follow_intent_fn
+
+    @property
+    def _focus_console_composer_if_needed(self) -> Any:
+        return self._focus_composer_if_needed_fn
+
+    @property
+    def _console_conversation_section_config(self) -> Any:
+        return self._conversation_section_config_accessor
+
+    @property
+    def _focus_console_workspace_conversation_search(self) -> Any:
+        """Stays on `ChatScreen` (DOM: `query_one`). See module docstring."""
+        return self._focus_conversation_search_fn
+
+    @property
+    def _sync_console_workspace_context(self) -> Any:
+        """Stays on `ChatScreen` (DOM: `query_one`/`query`). See module
+        docstring."""
+        return self._sync_workspace_context_fn
+
+    # -- Workspace policy context -------------------------------------------
+
+    def _current_console_workspace_context(self) -> ConsoleWorkspaceContext:
+        """Return explicit workspace policy context for native Console sends."""
+        workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is not None:
+            try:
+                ensure_default_workspace = getattr(
+                    registry_service,
+                    "ensure_default_workspace",
+                    None,
+                )
+                active_workspace = (
+                    ensure_default_workspace()
+                    if callable(ensure_default_workspace)
+                    else registry_service.get_active_workspace()
+                )
+                candidate = getattr(active_workspace, "workspace_id", None)
+                if candidate:
+                    workspace_id = str(candidate)
+            except Exception:
+                logger.debug(
+                    "Console workspace registry was unavailable for send context"
+                )
+
+        staged_sources: list[ConsoleStagedSource] = []
+        pending_launch = self._pending_console_launch_context
+        if pending_launch is not None:
+            payload = pending_launch.payload
+            source_workspace = payload.get("workspace_id")
+            launch_workspace_id = (
+                str(source_workspace) if source_workspace else None
+            )
+            # RAG UX v2 PR-4: this builder is the SINGLE seam feeding both
+            # the Inspector rail badge ("{n} staged") and the settings
+            # context estimate, and it used to append exactly ONE staged
+            # source per launch -- so the status chip could read "Sources: 4
+            # staged" while its two siblings read 1. One row per bundle
+            # reference puts all three in the same vocabulary (and gives the
+            # workspace policy check a real per-source id to gate on).
+            bundle = evidence_bundle_from_launch(pending_launch)
+            references = bundle.references if bundle is not None else ()
+            for reference in references:
+                chunk_id = reference.metadata.get("chunk_id")
+                # Two chunks of one document share a source_id; qualify with
+                # the chunk id (exactly as the capture adapter does) so
+                # `allowed_sources`' source_id dedupe cannot collapse them.
+                staged_sources.append(
+                    ConsoleStagedSource(
+                        source_id=str(
+                            chunk_id
+                            if isinstance(chunk_id, str) and chunk_id
+                            else reference.source_id
+                        ),
+                        label=reference.title,
+                        source_type=reference.source_type,
+                        workspace_id=reference.workspace_id or launch_workspace_id,
+                    )
+                )
+            if not staged_sources:
+                # A launch with no (or an empty) evidence bundle is still one
+                # staged item -- the same fallback `console_staged_source_count`
+                # and the strip use, so all three surfaces still agree.
+                source_id = (
+                    payload.get("source_id")
+                    or payload.get("target_id")
+                    or payload.get("run_id")
+                    or pending_launch.title
+                )
+                staged_sources.append(
+                    ConsoleStagedSource(
+                        source_id=str(source_id),
+                        label=pending_launch.title,
+                        source_type=str(pending_launch.source),
+                        workspace_id=launch_workspace_id,
+                    )
+                )
+
+        return ConsoleWorkspaceContext(
+            active_workspace_id=workspace_id,
+            staged_sources=tuple(staged_sources),
+        )
+
+    def _active_console_workspace_id_for_conversation_search(self) -> str:
+        """Return the current active workspace id for Console conversation search."""
+        try:
+            workspace_id = str(
+                self._current_console_workspace_context().active_workspace_id or ""
+            ).strip()
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Unable to read current workspace context for conversation search",
+            )
+            workspace_id = ""
+        if workspace_id:
+            return workspace_id
+        service = getattr(self.app_instance, "workspace_registry_service", None)
+        get_active_workspace = getattr(service, "get_active_workspace", None)
+        if callable(get_active_workspace):
+            try:
+                workspace = get_active_workspace()
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Unable to read active workspace for conversation search"
+                )
+                workspace = None
+            workspace_id = str(getattr(workspace, "workspace_id", "") or "").strip()
+            if workspace_id:
+                return workspace_id
+        store = self._console_chat_store
+        if store is not None and store.workspace_context.active_workspace_id:
+            return str(store.workspace_context.active_workspace_id)
+        return ""
+
+    # -- Workspace switcher / rename / archive / create ---------------------
+
+    def _open_console_workspace_switcher(self) -> None:
+        """Open the active Console workspace switcher."""
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Workspace service is not ready.", severity="warning"
+            )
+            return
+        try:
+            workspaces = tuple(registry_service.list_workspaces())
+            active_workspace = registry_service.get_active_workspace()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unable to open Console workspace switcher"
+            )
+            self.app_instance.notify(
+                "Workspace registry could not be read.",
+                severity="error",
+            )
+            return
+        if not workspaces:
+            self.app_instance.notify(
+                "Create one with the rail's New button or in Settings > Workspaces.",
+                severity="warning",
+            )
+            return
+
+        active_workspace_id = (
+            active_workspace.workspace_id if active_workspace is not None else None
+        )
+
+        def _switch_to(workspace_id: str) -> None:
+            try:
+                registry_service.set_active_workspace(workspace_id)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Unable to switch Console workspace",
+                )
+                self.app_instance.notify(
+                    "Workspace could not be selected.",
+                    severity="error",
+                )
+                return
+            self._sync_console_chat_core_state()
+            self._activate_console_session_for_workspace(workspace_id)
+            self._sync_console_workspace_context()
+            self.run_worker(
+                self._sync_native_console_chat_ui(),
+                exclusive=True,
+                group="console-sync",
+            )
+
+        def _apply_workspace_switch(
+            result: tuple[str, str] | None,
+        ) -> None:
+            if not result:
+                return
+            action, workspace_id = result
+            if action == "switch":
+                _switch_to(workspace_id)
+            elif action == "rename":
+                self._open_console_workspace_rename(workspace_id)
+            elif action == "archive":
+                self._confirm_console_workspace_archive(workspace_id)
+
+        self.push_screen(
+            ConsoleWorkspaceSwitcherModal(
+                workspaces=workspaces,
+                active_workspace_id=active_workspace_id,
+            ),
+            callback=_apply_workspace_switch,
+        )
+
+    def _open_console_workspace_rename(self, workspace_id: str) -> None:
+        """Prompt for and apply a new workspace name (TASK-714)."""
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Workspace service is not ready.", severity="warning"
+            )
+            return
+        record = registry_service.get_workspace(workspace_id)
+        if record is None:
+            self.app_instance.notify(
+                "Workspace is no longer available.", severity="warning"
+            )
+            return
+
+        def _apply_rename(new_name: str | None) -> None:
+            if not new_name:
+                return
+            try:
+                renamed = registry_service.rename_workspace(workspace_id, new_name)
+            except WorkspaceRegistryServiceError as exc:
+                self.app_instance.notify(str(exc), severity="warning")
+                return
+            except Exception:
+                logger.opt(exception=True).warning("Unable to rename Console workspace")
+                self.app_instance.notify(
+                    "Workspace could not be renamed.", severity="error"
+                )
+                return
+            self._sync_console_chat_core_state()
+            self._sync_console_workspace_context()
+            self.run_worker(
+                self._sync_native_console_chat_ui(),
+                exclusive=True,
+                group="console-sync",
+            )
+            self.app_instance.notify(
+                f"Renamed workspace to {renamed.name}.", severity="information"
+            )
+
+        self.push_screen(
+            ConsoleWorkspaceRenameModal(current_name=record.name),
+            callback=_apply_rename,
+        )
+
+    def _confirm_console_workspace_archive(self, workspace_id: str) -> None:
+        """Confirm and archive a workspace (TASK-714)."""
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Workspace service is not ready.", severity="warning"
+            )
+            return
+        record = registry_service.get_workspace(workspace_id)
+        if record is None:
+            self.app_instance.notify(
+                "Workspace is no longer available.", severity="warning"
+            )
+            return
+        was_active = bool(record.active)
+
+        # ConfirmationDialog awaits its confirm callback, so this must be a
+        # coroutine function.
+        async def _archive() -> None:
+            try:
+                registry_service.archive_workspace(workspace_id)
+            except WorkspaceRegistryServiceError as exc:
+                self.app_instance.notify(str(exc), severity="warning")
+                return
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Unable to archive Console workspace"
+                )
+                self.app_instance.notify(
+                    "Workspace could not be archived.", severity="error"
+                )
+                return
+            self._sync_console_chat_core_state()
+            if was_active:
+                self._activate_console_session_for_workspace(DEFAULT_WORKSPACE_ID)
+            self._sync_console_workspace_context()
+            self.run_worker(
+                self._sync_native_console_chat_ui(),
+                exclusive=True,
+                group="console-sync",
+            )
+            suffix = " Console switched to the Default workspace." if was_active else ""
+            self.app_instance.notify(
+                f"Archived {record.name}. Its conversations stay saved in "
+                f"Library.{suffix}",
+                severity="information",
+            )
+
+        self.push_screen(
+            ConfirmationDialog(
+                title="Archive workspace?",
+                message=(
+                    f"Archive {record.name}? Its conversations stay saved and "
+                    "remain visible in Library; the workspace disappears from "
+                    "the switcher and the Console browser."
+                ),
+                confirm_label="Archive",
+                confirm_callback=_archive,
+            )
+        )
+
+    def _create_console_workspace(self) -> None:
+        """Create a new local workspace and activate it."""
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Workspace service is not ready.", severity="warning"
+            )
+            return
+        try:
+            workspace_id, workspace_name = next_local_workspace_identity(
+                registry_service
+            )
+            registry_service.create_workspace(
+                workspace_id=workspace_id,
+                name=workspace_name,
+                description="Local workspace created from Console.",
+            )
+            registry_service.set_active_workspace(workspace_id)
+        except WorkspaceRegistryServiceError:
+            logger.opt(exception=True).warning("Unable to create Console workspace")
+            self.app_instance.notify(
+                "Workspace could not be created.", severity="error"
+            )
+            return
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unexpected error creating Console workspace"
+            )
+            self.app_instance.notify(
+                "Workspace could not be created.", severity="error"
+            )
+            return
+        self._sync_console_chat_core_state()
+        self._activate_console_session_for_workspace(workspace_id)
+        self._sync_console_workspace_context()
+        self.run_worker(
+            self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"
+        )
+        # TASK-713: creation also activates the workspace and opens a tab;
+        # without a notification the whole sequence is invisible when the
+        # Workspace status row is scrolled out of view.
+        self.app_instance.notify(
+            f"Created {workspace_name} and switched Console to it.",
+            severity="information",
+        )
+
+    # -- Workspace RAG-scope picker ------------------------------------------
+
+    async def _open_console_workspace_scope_picker(self) -> None:
+        """Open the RAG retrieval-scope picker for the ACTIVE workspace.
+
+        Task-13 workspace entry point (design spec section 4, "Workspace
+        entry: Scope button beside the workspace row in the Session area").
+        ``universe=None`` -- the workspace picker offers the full library,
+        unlike the conversation-target picker, which restricts to the
+        workspace's own items once one is set (D3, see
+        ``_open_console_retrieval_scope_picker``).
+
+        Only a REAL registry workspace can be scoped -- gated the same way
+        the mounted button itself is gated
+        (``ConsoleWorkspaceContextState.rag_scope_enabled``): the built-in
+        Default workspace has a real ``workspace_id`` row
+        (``DEFAULT_WORKSPACE_ID``) once ``ensure_default_workspace`` has
+        run, so it IS scopable; only the "Local Default"/error/no-registry
+        sentinel states (no real workspace row at all) are refused here.
+        """
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Workspace service is not ready.", severity="warning"
+            )
+            return
+        try:
+            active_workspace = registry_service.get_active_workspace()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unable to read active workspace for the scope picker"
+            )
+            self.app_instance.notify(
+                "Workspace registry could not be read.", severity="error"
+            )
+            return
+        if active_workspace is None:
+            self.app_instance.notify(
+                "Create or select a workspace before setting a RAG scope.",
+                severity="warning",
+            )
+            return
+        workspace_id = active_workspace.workspace_id
+
+        try:
+            initial = await self._read_console_workspace_scope(
+                registry_service, workspace_id
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unable to read workspace scope for {}", workspace_id
+            )
+            initial = None
+
+        target_label = f"workspace '{active_workspace.name}'"
+        media_lister, notes_lister, tag_lister = self._console_scope_picker_listers()
+
+        def _on_save(scope: Optional[RagScope]) -> None:
+            self.run_worker(
+                self._apply_console_workspace_scope_save(workspace_id, scope),
+                exclusive=True,
+                group="console-workspace-scope-save",
+            )
+
+        self.push_screen(
+            ConsoleScopePickerModal(
+                target_label,
+                None,
+                initial,
+                _on_save,
+                media_lister=media_lister,
+                notes_lister=notes_lister,
+                tag_lister=tag_lister,
+            )
+        )
+
+    async def _apply_console_workspace_scope_save(
+        self,
+        workspace_id: str,
+        scope: Optional[RagScope],
+    ) -> None:
+        """Persist (or clear) a workspace's RAG retrieval scope (task-13).
+
+        ``WorkspaceNotFound`` is caught deliberately -- the workspace may
+        have been archived/deleted (e.g. from Library > Workspaces) between
+        opening the picker and saving. Refreshes the ACTIVE Console
+        session's effective-scope display afterward: a workspace-scope
+        change can widen or narrow retrieval for every conversation linked
+        to it, but only the currently active session's row/chip are
+        mounted to refresh.
+
+        Args:
+            workspace_id: The workspace whose scope was just chosen.
+            scope: The new scope, or ``None`` to clear it.
+        """
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Couldn't save scope: workspace service is not ready.",
+                severity="error",
+            )
+            return
+        try:
+            await self._write_console_workspace_scope(
+                registry_service, workspace_id, scope
+            )
+        except WorkspaceNotFound:
+            logger.opt(exception=True).warning(
+                "Workspace scope save target missing: {}", workspace_id
+            )
+            self.app_instance.notify(
+                "Couldn't save scope: this workspace no longer exists.",
+                severity="error",
+            )
+            return
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to write workspace scope for {}", workspace_id
+            )
+            self.app_instance.notify("Couldn't save workspace scope.", severity="error")
+            return
+        session = self._active_native_console_session()
+        if session is not None:
+            await self._refresh_console_effective_scope_and_sync(session)
+
+    # -- Workspace-scoped Console session activation -------------------------
+
+    def _activate_console_session_for_workspace(self, workspace_id: str) -> None:
+        """Activate or create the Console session for the selected workspace."""
+        target_workspace_id = str(workspace_id).strip()
+        if not target_workspace_id:
+            return
+        store = self._ensure_console_chat_store()
+        inherited_settings = None
+        if store.active_session_id is not None:
+            try:
+                inherited_settings = store.session_settings(store.active_session_id)
+            except KeyError:
+                inherited_settings = None
+        if store.active_session_id is not None:
+            for session in store.sessions():
+                if (
+                    session.id == store.active_session_id
+                    and session.workspace_id == target_workspace_id
+                ):
+                    return
+        for session in store.sessions():
+            if session.workspace_id == target_workspace_id:
+                self._capture_console_draft_switch_snapshot()
+                store.switch_session(session.id)
+                # task-7 review: this switches the active session with no
+                # other chip-refresh call anywhere in the caller chain (all
+                # three callers only run `_sync_native_console_chat_ui()`
+                # afterward, which never touches the temporary chip -- see
+                # `_sync_console_temporary_chip`). Without this the chip
+                # could keep reading "Temporary" on a workspace's saved
+                # session, or stay hidden on one that is actually temporary.
+                self._sync_console_temporary_chip()
+                return
+        self._capture_console_draft_switch_snapshot()
+        store.create_session(
+            title=self._console_workspace_session_title(target_workspace_id),
+            workspace_id=target_workspace_id,
+            settings=inherited_settings or self._default_console_session_settings(),
+        )
+        # task-7 review: `create_session` activates the new (never
+        # ephemeral -- no `ephemeral=` passed) session inline; same
+        # staleness risk as the switch branch above if the workspace's
+        # previous session was temporary.
+        self._sync_console_temporary_chip()
+
+    def _console_workspace_session_title(self, workspace_id: str) -> str:
+        """Return a readable title for an auto-created workspace Console tab."""
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        workspace_name = str(workspace_id).strip()
+        if registry_service is not None:
+            try:
+                workspace = registry_service.get_workspace(workspace_id)
+                if workspace is not None:
+                    workspace_name = workspace.name
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Unable to read Console workspace title"
+                )
+        if not workspace_name:
+            workspace_name = "Workspace"
+        return f"{workspace_name} Chat"
+
+    def _console_initial_session_title_for_workspace(
+        self, workspace_id: str | None
+    ) -> str:
+        """Return the first Console tab title for the active workspace."""
+        target_workspace_id = str(workspace_id or "").strip()
+        if not target_workspace_id or target_workspace_id in {
+            CONSOLE_GLOBAL_WORKSPACE_ID,
+            DEFAULT_WORKSPACE_ID,
+        }:
+            return DEFAULT_CONSOLE_SESSION_TITLE
+        return self._console_workspace_session_title(target_workspace_id)
+
+    def _set_active_workspace_for_console_session(self, session_id: str) -> None:
+        """Keep workspace context aligned when switching Console tabs."""
+        store = self._ensure_console_chat_store()
+        target_session = next(
+            (session for session in store.sessions() if session.id == session_id),
+            None,
+        )
+        if target_session is None:
+            return
+        workspace_id = str(target_session.workspace_id or "").strip()
+        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
+            return
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            return
+        try:
+            active_workspace = registry_service.get_active_workspace()
+            if (
+                active_workspace is not None
+                and active_workspace.workspace_id == workspace_id
+            ):
+                return
+            registry_service.set_active_workspace(workspace_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unable to align Console workspace with selected tab",
+            )
+
+    # -- Workspace-scope persistence primitives ------------------------------
+
+    @staticmethod
+    async def _read_console_workspace_scope(
+        registry_service: Any, workspace_id: str
+    ) -> Optional[RagScope]:
+        """Read a workspace's stored scope, off-loop for a file-backed registry.
+
+        Mirrors ``_read_console_retrieval_scope``'s in-memory-DB guard
+        (task-13): ``LocalWorkspaceRegistryService.db`` is never actually
+        ``:memory:``-backed in production (``WorkspaceDB`` opens a brand-new
+        connection per call, incompatible with SQLite's ``:memory:``
+        semantics beyond a single call), but the guard is applied anyway
+        for the same defensive discipline the conversation-scope read uses.
+        """
+        db = getattr(registry_service, "db", None)
+        if getattr(db, "is_memory_db", False):
+            return registry_service.get_workspace_scope(workspace_id)
+        return await asyncio.to_thread(
+            registry_service.get_workspace_scope, workspace_id
+        )
+
+    @staticmethod
+    async def _write_console_workspace_scope(
+        registry_service: Any, workspace_id: str, scope: Optional[RagScope]
+    ) -> None:
+        """Write (or clear) a workspace's stored scope; see the read twin's
+        in-memory-registry-DB guard docstring for why this isn't
+        unconditionally ``asyncio.to_thread``."""
+        db = getattr(registry_service, "db", None)
+        if getattr(db, "is_memory_db", False):
+            registry_service.set_workspace_scope(workspace_id, scope)
+        else:
+            await asyncio.to_thread(
+                registry_service.set_workspace_scope, workspace_id, scope
+            )
+
+    # -- Resuming a persisted conversation ------------------------------------
+
+    def _console_session_id_for_workspace_conversation(
+        self,
+        conversation_id: str,
+    ) -> str | None:
+        """Return an open Console session id for a workspace conversation row."""
+        target = str(conversation_id or "").strip()
+        if not target:
+            return None
+        store = self._console_chat_store
+        if store is None:
+            return None
+        if target.startswith("native:"):
+            session_id = target.removeprefix("native:")
+            if any(session.id == session_id for session in store.sessions()):
+                return session_id
+            return None
+        for session in store.sessions():
+            if str(session.persisted_conversation_id or "") == target:
+                return session.id
+        return None
+
+    async def _resume_console_workspace_conversation(
+        self,
+        conversation_id: str,
+        *,
+        target_scope_type: str | None = None,
+        target_workspace_id: str | None = None,
+    ) -> bool | None:
+        """Load a persisted saved conversation into a native Console session.
+
+        Returns:
+            True on success; None on a transient failure this method already
+            notified about (service unavailable / load error); False when the
+            conversation record is missing - the caller owns that failure's
+            feedback (TASK-717).
+        """
+        target = str(conversation_id or "").strip()
+        if not target:
+            return None
+        # TASK-339: keystrokes typed while the conversation tree loads
+        # belong to the resumed session — snapshot the composer now.
+        self._capture_console_draft_switch_snapshot()
+        conversation_service = getattr(
+            self.app_instance,
+            "chat_conversation_scope_service",
+            None,
+        )
+        get_conversation_tree = getattr(
+            conversation_service, "get_conversation_tree", None
+        )
+        if not callable(get_conversation_tree):
+            self.app_instance.notify(
+                "Saved conversation resume is unavailable in this build.",
+                severity="warning",
+            )
+            return None
+
+        try:
+            # Task 8: raise the depth/root caps well past the service defaults
+            # (50) so a long or branchy conversation's full tree -- every
+            # branch, not just the latest -- is loaded intact, not truncated.
+            maybe_tree = get_conversation_tree(
+                target, mode="local", depth_cap=10_000, root_limit=10_000
+            )
+            tree = await maybe_tree if inspect.isawaitable(maybe_tree) else maybe_tree
+        except Exception:
+            logger.exception(
+                f"Unable to resume Console saved conversation: conversation_id={target}"
+            )
+            self.app_instance.notify(
+                "Unable to load this saved conversation.",
+                severity="error",
+            )
+            return None
+
+        if not isinstance(tree, dict) or not tree.get("conversation"):
+            # TASK-717: missing record - the caller owns this failure's UX
+            # (honest toast + marking the row visibly broken), so do not
+            # stack a second notification here.
+            return False
+
+        conversation = tree.get("conversation")
+        if not isinstance(conversation, dict):
+            conversation = {}
+        store = self._ensure_console_chat_store()
+        active_workspace_id = str(
+            store.workspace_context.active_workspace_id or ""
+        ).strip()
+        persisted_workspace_id = (
+            str(conversation.get("workspace_id")).strip()
+            if conversation.get("workspace_id") is not None
+            else ""
+        )
+        target_scope = str(target_scope_type or "").strip()
+        requested_workspace_id = (
+            str(target_workspace_id).strip() if target_workspace_id is not None else ""
+        )
+        if target_scope == "global":
+            workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
+        else:
+            workspace_id = (
+                persisted_workspace_id
+                or requested_workspace_id
+                or active_workspace_id
+                or None
+            )
+        title = str(conversation.get("title") or "Saved conversation").strip()
+        if not title:
+            title = "Saved conversation"
+        # Task 8: load the WHOLE persisted tree (every branch), then reconstruct
+        # the active branch from the stored active-leaf pointer. Loading all
+        # branches (not just the latest) is what makes off-path siblings
+        # navigable (swipe) right after resume.
+        all_nodes = self._console_messages_from_conversation_tree(tree)
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        active_leaf_id = getattr(db, "get_conversation_active_leaf", lambda _c: None)(
+            target
+        )
+        raw_runtime_backend = conversation.get("runtime_backend")
+        if type(raw_runtime_backend) is str:
+            runtime_backend = raw_runtime_backend
+        else:
+            runtime_backend = ""
+        raw_assistant_kind = conversation.get("assistant_kind")
+        assistant_kind = raw_assistant_kind if type(raw_assistant_kind) is str else None
+        raw_assistant_id = conversation.get("assistant_id")
+        assistant_id = raw_assistant_id if type(raw_assistant_id) is str else None
+        raw_assistant_authority_id = conversation.get("assistant_authority_id")
+        assistant_authority_id = (
+            raw_assistant_authority_id
+            if type(raw_assistant_authority_id) is str
+            else None
+        )
+        raw_character_id = conversation.get("character_id")
+        character_id = (
+            raw_character_id
+            if (
+                runtime_backend == "local"
+                and assistant_kind == "character"
+                and type(raw_character_id) is int
+                and raw_character_id > 0
+                and assistant_id == str(raw_character_id)
+            )
+            else None
+        )
+        session = store.restore_persisted_session(
+            title=title,
+            workspace_id=workspace_id,
+            persisted_conversation_id=target,
+            all_nodes=all_nodes,
+            active_leaf_persisted_id=active_leaf_id,
+            settings=self._console_session_settings_for_resume(conversation),
+            runtime_backend=runtime_backend,
+            assistant_kind=assistant_kind,
+            assistant_id=assistant_id,
+            assistant_authority_id=assistant_authority_id,
+            character_id=character_id,
+        )
+        # Re-derive display-only agent TOOL markers from AgentRunsDB and overlay
+        # them onto the restored active-path VIEW (markers are never tree nodes;
+        # the next tree mutation's recompute rebuilds the view from live nodes
+        # and drops them, matching how live markers are ephemeral in Phase A).
+        store.apply_resume_marker_overlay(
+            session.id,
+            self._inject_resume_agent_markers(
+                store.messages_for_session(session.id), target
+            ),
+        )
+        # Local presentation remains keyed only by the numeric local
+        # projection. Opaque server identity never enters local card/avatar/
+        # dictionary lookup paths.
+        if (
+            session.runtime_backend == "local"
+            and session.assistant_kind == "character"
+            and session.character_id is not None
+        ):
+            character_name = await self._resolve_resumed_character_name(
+                session.character_id
+            )
+            if character_name:
+                session.character_name = character_name
+            # Always (re)set the label on a local character resume -- to the
+            # resolved name, or clear it when unresolved. ``settings`` are
+            # otherwise inherited from the currently active session, so
+            # leaving an inherited ``character_label`` in place would make
+            # a card-less resume show a *different* character's name.
+            if session.settings is not None:
+                session.settings = replace(
+                    session.settings, character_label=character_name
+                )
+        elif session.settings is not None:
+            session.settings = replace(session.settings, character_label="")
+        self._set_active_workspace_for_console_session(session.id)
+        # task-9/task-13: warm the EFFECTIVE (conversation ∩ workspace)
+        # scope cache for this session now (off-loop) so the Inspector row
+        # reflects reality immediately on resume, rather than defaulting to
+        # "everything" until the user opens Edit or saves a change (the
+        # picker's other two read triggers).
+        try:
+            await self._resolve_console_effective_scope_state(session)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to resolve retrieval scope for conversation {}", target
+            )
+        # task-10 review finding 2: warming the cache above is not enough
+        # by itself -- neither `_sync_native_console_chat_ui()` below nor
+        # its own `_sync_console_control_bar()` call ever touches the
+        # retrieval-scope row or `ConsoleStatusChips.sync_scope_chip`
+        # (`sync_scope_chip` is deliberately its own method, kept off the
+        # general control-bar sync tick -- see its docstring). Without this
+        # explicit call the MOUNTED row/chip stayed on whatever state they
+        # last rendered until the user opened Edit/Narrow or saved a
+        # change, even though the cache above already had the right
+        # answer. This is the same helper (and the same one-state,
+        # two-renderers push) the scope-picker save path already uses.
+        self._sync_console_retrieval_scope_row()
+        # Finding C: resuming a saved conversation switches the active
+        # conversation just as much as a tab switch does -- clear any
+        # sub-agent drill-in immediately rather than rely solely on the
+        # rail render path's defensive re-check on the next sync.
+        self._console_agent_drilldown_run_id = None
+        self._note_console_follow_intent()
+        self._sync_console_chat_core_state()
+        await self._sync_native_console_chat_ui()
+        self._focus_console_composer_if_needed(force=True)
+        return True
+
+    # -- Workspace context state / grouped conversation rows -----------------
+
+    def _build_console_workspace_context_state(self) -> ConsoleWorkspaceContextState:
+        current_conversation = self._current_console_conversation_id()
+        state = build_console_workspace_state(
+            registry_service=getattr(
+                self.app_instance, "workspace_registry_service", None
+            ),
+            current_conversation=current_conversation,
+            server_adapter_state=getattr(
+                self.app_instance,
+                "workspace_server_adapter_state",
+                None,
+            ),
+            acp_handoff_state=getattr(
+                self.app_instance,
+                "workspace_acp_handoff_state",
+                None,
+            ),
+        )
+        state = self._with_native_console_session_rows(state)
+        return self._with_console_conversation_browser_state(
+            state,
+            current_conversation_id=current_conversation,
+        )
+
+    @staticmethod
+    def _console_workspace_row_key(row: ConsoleWorkspaceConversationRow) -> str:
+        return str(row.conversation_id or "").strip()
+
+    def _activate_console_workspace_for_browser_row(
+        self,
+        row: ConsoleConversationBrowserRow,
+    ) -> None:
+        """Align active workspace context before opening a browser row."""
+        scope_type = str(row.scope_type or "").strip()
+        if scope_type == "global":
+            return
+        workspace_id = str(row.workspace_id or "").strip()
+        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
+            return
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            return
+        try:
+            active_workspace = registry_service.get_active_workspace()
+            if (
+                active_workspace is None
+                or active_workspace.workspace_id != workspace_id
+            ):
+                registry_service.set_active_workspace(workspace_id)
+                # TASK-713: opening a row from another workspace's group
+                # retargets the whole Console context; the Workspace status
+                # row is usually scrolled out of view at that moment, so the
+                # side effect needs an explicit announcement.
+                switched = registry_service.get_active_workspace()
+                switched_name = switched.name if switched is not None else workspace_id
+                self.app_instance.notify(
+                    f"Switched Console to {switched_name}.",
+                    severity="information",
+                )
+            self._ensure_console_chat_store().set_workspace_context(
+                self._current_console_workspace_context()
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unable to activate Console workspace for browser row",
+            )
+
+    def _console_browser_workspace_records(self) -> tuple[WorkspaceRecord, ...]:
+        """Return all local workspace records visible to the Console browser."""
+        service = getattr(self.app_instance, "workspace_registry_service", None)
+        if service is None:
+            return ()
+        ensure_default = getattr(service, "ensure_default_workspace", None)
+        if callable(ensure_default):
+            try:
+                ensure_default()
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Unable to ensure default workspace for Console browser"
+                )
+        list_workspaces = getattr(service, "list_workspaces", None)
+        if not callable(list_workspaces):
+            return ()
+        try:
+            return tuple(list_workspaces())
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Unable to list Console browser workspaces"
+            )
+            return ()
+
+    def _console_browser_workspace_labels(self) -> dict[str, str]:
+        """Return workspace labels keyed by workspace id for browser rows."""
+        labels: dict[str, str] = {}
+        for record in self._console_browser_workspace_records():
+            workspace_id = str(record.workspace_id or "").strip()
+            if not workspace_id:
+                continue
+            labels[workspace_id] = (
+                "Chats"
+                if workspace_id == DEFAULT_WORKSPACE_ID
+                else str(record.name or workspace_id)
+            )
+        labels.setdefault(DEFAULT_WORKSPACE_ID, "Chats")
+        return labels
+
+    def _console_browser_workspace_label(
+        self,
+        workspace_id: str | None,
+        labels: dict[str, str] | None = None,
+    ) -> str:
+        """Return display label for a workspace/global browser row."""
+        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
+            return "Chats"
+        if workspace_id == DEFAULT_WORKSPACE_ID:
+            return "Chats"
+        workspace_labels = (
+            labels if labels is not None else self._console_browser_workspace_labels()
+        )
+        return workspace_labels.get(workspace_id, workspace_id)
+
+    def _selected_console_workspace_conversation_summary(
+        self,
+        rows: list[ConsoleWorkspaceConversationRow],
+    ) -> str:
+        selected = next((row for row in rows if row.selected), None)
+        if selected is None:
+            return "No active conversation."
+        title = ConsoleWorkspaceContextTray._conversation_title(selected.title)
+        detail = ConsoleWorkspaceContextTray._conversation_detail_status(
+            selected.status
+        )
+        return f"{title} - {detail or 'conversation'}"
+
+    def _merge_console_workspace_rows(
+        self,
+        primary: list[ConsoleWorkspaceConversationRow],
+        secondary: list[ConsoleWorkspaceConversationRow],
+    ) -> list[ConsoleWorkspaceConversationRow]:
+        merged: list[ConsoleWorkspaceConversationRow] = []
+        seen: set[str] = set()
+        for row in primary + secondary:
+            key = self._console_workspace_row_key(row)
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            merged.append(row)
+        return merged
+
+    def _native_console_rows_for_workspace_search(
+        self,
+        workspace_id: str,
+        query: str,
+    ) -> list[ConsoleWorkspaceConversationRow]:
+        """Return matching open native sessions for the active workspace search."""
+        store = self._console_chat_store
+        if store is None:
+            return []
+        needle = str(query or "").strip().lower()
+        rows: list[ConsoleWorkspaceConversationRow] = []
+        active_session_id = store.active_session_id
+        for session in store.sessions():
+            selected = session.id == active_session_id
+            session_workspace_id = str(session.workspace_id or "").strip()
+            if (
+                workspace_id
+                and workspace_id != CONSOLE_GLOBAL_WORKSPACE_ID
+                and session_workspace_id != workspace_id
+                and not selected
+            ):
+                continue
+            title = str(session.title or "Untitled conversation")
+            if needle and needle not in title.lower():
+                continue
+            conversation_id = (
+                str(session.persisted_conversation_id)
+                if session.persisted_conversation_id
+                else f"native:{session.id}"
+            )
+            rows.append(
+                ConsoleWorkspaceConversationRow(
+                    conversation_id=conversation_id,
+                    title=title,
+                    status="active" if selected else "open",
+                    selected=selected,
+                )
+            )
+        return rows
+
+    def _membership_console_rows_for_workspace_search(
+        self,
+        workspace_id: str,
+        query: str,
+    ) -> list[ConsoleWorkspaceConversationRow]:
+        """Return matching workspace conversation membership rows."""
+        service = getattr(self.app_instance, "workspace_registry_service", None)
+        list_conversations = getattr(service, "list_workspace_conversations", None)
+        if not callable(list_conversations) or not workspace_id:
+            return []
+        needle = str(query or "").strip().lower()
+        try:
+            memberships = list_conversations(workspace_id)
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Unable to search workspace conversation memberships"
+            )
+            return []
+        rows: list[ConsoleWorkspaceConversationRow] = []
+        current_conversation = self._current_console_conversation_id()
+        for membership in memberships:
+            title = str(
+                getattr(membership, "title", "") or getattr(membership, "item_id", "")
+            )
+            if needle and needle not in title.lower():
+                continue
+            conversation_id = str(getattr(membership, "item_id", "") or "")
+            rows.append(
+                ConsoleWorkspaceConversationRow(
+                    conversation_id=conversation_id,
+                    title=title,
+                    status=str(getattr(membership, "role", "") or "workspace-thread"),
+                    selected=bool(
+                        current_conversation and conversation_id == current_conversation
+                    ),
+                )
+            )
+        return rows
+
+    async def _persisted_console_rows_for_workspace_search(
+        self,
+        workspace_id: str,
+        query: str,
+    ) -> tuple[list[ConsoleWorkspaceConversationRow], int | None, str]:
+        """Return persisted workspace conversation search rows, total, and error copy."""
+        scope_service = getattr(
+            self.app_instance,
+            "chat_conversation_scope_service",
+            None,
+        )
+        list_conversations = getattr(scope_service, "list_conversations", None)
+        if not callable(list_conversations) or not workspace_id:
+            return [], None, ""
+        if (
+            hasattr(scope_service, "local_service")
+            and getattr(scope_service, "local_service", None) is None
+        ):
+            return [], None, ""
+        try:
+            result = list_conversations(
+                mode="local",
+                query=query,
+                scope_type="workspace",
+                workspace_id=workspace_id,
+                limit=CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT,
+                offset=0,
+            )
+            result = await result if inspect.isawaitable(result) else result
+        except Exception as exc:
+            if (
+                isinstance(exc, ValueError)
+                and "service is unavailable" in str(exc).lower()
+            ):
+                logger.debug(
+                    "Local persisted conversation search service is unavailable"
+                )
+                return [], None, ""
+            logger.exception("Unable to search Console workspace conversations")
+            return [], None, "Workspace conversation search is unavailable."
+        if not isinstance(result, dict):
+            return [], 0, ""
+        items = result.get("items")
+        if not isinstance(items, list):
+            items = []
+        total = result.get("total")
+        if total is None:
+            pagination = result.get("pagination")
+            if isinstance(pagination, dict):
+                total = pagination.get("total")
+        try:
+            total_count = int(total)
+        except (TypeError, ValueError):
+            total_count = len(items)
+        current_conversation = self._current_console_conversation_id()
+        rows: list[ConsoleWorkspaceConversationRow] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            conversation_id = str(item.get("id") or "").strip()
+            if not conversation_id:
+                continue
+            rows.append(
+                ConsoleWorkspaceConversationRow(
+                    conversation_id=conversation_id,
+                    title=str(item.get("title") or "Untitled conversation"),
+                    status=str(item.get("state") or "workspace-thread"),
+                    selected=bool(
+                        current_conversation and current_conversation == conversation_id
+                    ),
+                )
+            )
+        return rows, total_count, ""
+
+    def _refresh_console_workspace_conversation_search_if_current(
+        self,
+        workspace_id: str,
+        query: str,
+        token: int,
+        *,
+        restore_focus: bool = False,
+    ) -> bool:
+        """Refresh search results when workspace, query, and token still match."""
+        if token != self._console_workspace_conversation_search_token:
+            return False
+        if workspace_id != self._active_console_workspace_id_for_conversation_search():
+            return False
+        if query != self._console_workspace_conversation_query:
+            return False
+        self._sync_console_workspace_context()
+        if restore_focus:
+            self.call_after_refresh(self._focus_console_workspace_conversation_search)
+        return True
+
+    async def _refresh_console_workspace_conversation_search(
+        self,
+        workspace_id: str,
+        query: str,
+        token: int,
+    ) -> None:
+        """Refresh search results only if workspace and query are still current."""
+        if token != self._console_workspace_conversation_search_token:
+            return
+        if workspace_id != self._active_console_workspace_id_for_conversation_search():
+            return
+        if query != self._console_workspace_conversation_query:
+            return
+        if not str(query or "").strip():
+            self._console_workspace_conversation_search_rows = ()
+            self._console_workspace_conversation_search_total = None
+            self._console_workspace_conversation_search_error = ""
+            self._sync_console_workspace_context()
+            self.call_after_refresh(self._focus_console_workspace_conversation_search)
+            return
+        native_rows = self._native_console_rows_for_workspace_search(
+            workspace_id,
+            query,
+        )
+        membership_rows = self._membership_console_rows_for_workspace_search(
+            workspace_id,
+            query,
+        )
+        local_rows = self._merge_console_workspace_rows(native_rows, membership_rows)
+        self._console_workspace_conversation_search_rows = tuple(local_rows)
+        self._console_workspace_conversation_search_total = len(local_rows)
+        self._console_workspace_conversation_search_error = ""
+        self._sync_console_workspace_context()
+        self.call_after_refresh(self._focus_console_workspace_conversation_search)
+        (
+            persisted_rows,
+            persisted_total,
+            error_copy,
+        ) = await self._persisted_console_rows_for_workspace_search(
+            workspace_id,
+            query,
+        )
+        if token != self._console_workspace_conversation_search_token:
+            return
+        if workspace_id != self._active_console_workspace_id_for_conversation_search():
+            return
+        if query != self._console_workspace_conversation_query:
+            return
+        merged = self._merge_console_workspace_rows(
+            local_rows,
+            persisted_rows,
+        )
+        result_total = persisted_total
+        if result_total is None or result_total < len(merged):
+            result_total = len(merged)
+        self._console_workspace_conversation_search_rows = tuple(merged)
+        self._console_workspace_conversation_search_total = result_total
+        self._console_workspace_conversation_search_error = error_copy
+        self._sync_console_workspace_context()
+        self.call_after_refresh(self._focus_console_workspace_conversation_search)
+
+    async def _refresh_console_workspace_conversation_search_after_selection(
+        self,
+    ) -> None:
+        """Refresh active search rows after a conversation row changes selection."""
+        query = self._console_workspace_conversation_query
+        if not query.strip():
+            return
+        if self._console_workspace_conversation_search_timer is not None:
+            self._console_workspace_conversation_search_timer.stop()
+            self._console_workspace_conversation_search_timer = None
+        self._console_workspace_conversation_search_token += 1
+        token = self._console_workspace_conversation_search_token
+        await self._refresh_console_workspace_conversation_search(
+            self._active_console_workspace_id_for_conversation_search(),
+            query,
+            token,
+        )
+
+    def _with_console_workspace_conversation_section(
+        self,
+        state: ConsoleWorkspaceContextState,
+    ) -> ConsoleWorkspaceContextState:
+        """Attach renderable Conversations subsection state to workspace context."""
+        workspace_id = ""
+        try:
+            workspace_id = str(
+                self._current_console_workspace_context().active_workspace_id or ""
+            ).strip()
+        except Exception:
+            workspace_id = ""
+        store = self._console_chat_store
+        if not workspace_id:
+            if store is not None and store.workspace_context.active_workspace_id:
+                workspace_id = str(store.workspace_context.active_workspace_id)
+            elif state.workspace_label.startswith("Workspace: "):
+                workspace_id = state.workspace_label.removeprefix("Workspace: ").strip()
+
+        if self._console_workspace_conversation_workspace_id != workspace_id:
+            self._console_workspace_conversation_query = ""
+            self._console_workspace_conversation_search_token += 1
+            self._console_workspace_conversation_search_rows = ()
+            self._console_workspace_conversation_search_total = None
+            self._console_workspace_conversation_search_error = ""
+            self._console_workspace_conversation_workspace_id = workspace_id
+
+        rows = list(state.conversation_rows)
+        if self._console_workspace_conversation_query.strip():
+            rows = list(self._console_workspace_conversation_search_rows)
+        selected_summary = self._selected_console_workspace_conversation_summary(rows)
+        query = self._console_workspace_conversation_query
+        result_total = (
+            self._console_workspace_conversation_search_total if query.strip() else None
+        )
+        if (
+            query.strip()
+            and result_total is None
+            and not self._console_workspace_conversation_search_error
+        ):
+            result_total = len(rows)
+        status_copy = console_workspace_conversation_result_copy(
+            query=query,
+            result_total_count=result_total,
+            result_limit=CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT,
+        )
+        section = ConsoleWorkspaceConversationSectionState(
+            workspace_id=workspace_id,
+            collapsed=self._console_workspace_conversations_collapsed(workspace_id),
+            query=query,
+            selected_summary=selected_summary,
+            rows=tuple(rows),
+            workspace_total_count=len(rows),
+            result_total_count=result_total,
+            status_copy=status_copy,
+            empty_copy=(
+                "No matches in this workspace."
+                if query.strip()
+                else state.conversation_empty_copy
+            ),
+            search_enabled=True,
+            new_conversation_enabled=state.new_conversation_enabled,
+            error_copy=self._console_workspace_conversation_search_error,
+        )
+        return replace(state, conversation_section=section)
+
+    def _console_workspace_conversations_collapsed(
+        self,
+        workspace_id: str | None,
+    ) -> bool:
+        """Return stored collapse preference for one workspace."""
+        key = str(workspace_id or "global").strip() or "global"
+        app_config = getattr(self.app_instance, "app_config", None)
+        if not isinstance(app_config, dict):
+            return False
+        console_config = app_config.get("console")
+        if not isinstance(console_config, dict):
+            return False
+        section_config = console_config.get("conversation_section")
+        if not isinstance(section_config, dict):
+            return False
+        value = section_config.get(key)
+        return bool(value.get("collapsed")) if isinstance(value, dict) else False
+
+    def _set_console_workspace_conversations_collapsed(
+        self,
+        workspace_id: str | None,
+        collapsed: bool,
+    ) -> None:
+        """Store collapse preference for one workspace in memory."""
+        key = str(workspace_id or "global").strip() or "global"
+        section_config = self._console_conversation_section_config()
+        section_config[key] = {"collapsed": bool(collapsed)}
+
+    # -- Misc toast helpers ----------------------------------------------------
+
+    def _console_session_title_and_workspace_name(
+        self, controller: "ConsoleChatController", session_id: str
+    ) -> tuple[str, str]:
+        """Return ``(session_title, workspace_name)`` for a fleet toast.
+
+        Fix wave (rider 6, final review): shared by ``_park_console_
+        approval`` and ``_notify_console_run_outcome``, which previously
+        duplicated this exact lookup byte-for-byte. Falls back to the raw
+        ``session_id``/workspace id when the session has already closed or
+        the workspace can't be resolved -- a toast about a session that
+        vanished microseconds ago must still say SOMETHING coherent rather
+        than raise.
+        """
+        session_title = session_id
+        workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
+        for session in controller.store.sessions():
+            if session.id == session_id:
+                session_title = session.title
+                workspace_id = session.workspace_id
+                break
+        return session_title, self._console_workspace_display_name(workspace_id)
+
+    def _console_workspace_display_name(self, workspace_id: str) -> str:
+        """Return ``workspace_id``'s display name via the registry, falling
+        back to the raw id when the service is unavailable or the
+        workspace can't be resolved (PA-T9 toast copy)."""
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is not None:
+            try:
+                workspace = registry_service.get_workspace(workspace_id)
+                if workspace is not None and workspace.name:
+                    return workspace.name
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Unable to resolve Console workspace name for approval toast"
+                )
+        return str(workspace_id)

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -57,9 +57,15 @@ above, exactly as in `ConsoleDictationController`: it does not change
 identity over the controller's life, and the pre-extraction methods already
 read it as a plain attribute, never as a call.
 
-Moved verbatim: every `ChatScreen` method matching `*workspace*` whose body
-touched only `_console_workspace_conversation_*` state (or one of its
-sibling attributes) and the callables above -- 35 methods in total. `Chat
+Moved: every `ChatScreen` method matching `*workspace*` whose body touched
+only `_console_workspace_conversation_*` state (or one of its sibling
+attributes) and the callables above -- 35 methods in total. Thirty of the
+35 bodies are byte-identical to their pre-move source; the other five carry
+one mechanical edit each, all inert: four swap `self.app.push_screen(` for
+`self.push_screen(` (this class's own framework-service property, same
+call), and one requotes a type annotation to dodge an import cycle. Stated
+precisely because "verbatim" is the claim a later reader will lean on when
+deciding whether a behaviour change could have slipped in here. `Chat
 Screen` keeps SIX get/set proxy properties for this cluster's state
 (`_console_workspace_conversation_query`/`_search_timer`/`_search_token`/
 `_search_rows`/`_search_total`/`_search_error` -- NOT `_workspace_id`, which

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -65,6 +65,10 @@ from ..Console_Modules.dictation import (
     _VOICE_ACK_NOT_SENT,
     _VOICE_ACK_SESSION_CHANGED,
 )
+from ..Console_Modules.hands_free import (
+    ConsoleHandsFreeController,
+    ConsoleHandsFreeSession,
+)
 from ..Console_Modules.left_rail import ConsoleLeftRail
 from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ..Console_Modules.workspace import ConsoleWorkspaceController
@@ -204,20 +208,6 @@ from ...Chat.console_provider_endpoints import (
     safe_endpoint_display,
 )
 
-# Import-safe at module scope: `console_voice_input` reaches the optional
-# speech stack only through `importlib.util.find_spec` and a function-body
-# import inside `default_service_factory`, so nothing here drags
-# `tldw_chatbook.Audio` (and with it faster-whisper and NeMo) into app start.
-#
-# The module itself is imported (not just the names below) so
-# `_sync_console_dictation_availability` can call `console_voice_input.probe()`
-# through the module's own namespace at call time -- the same target tests
-# already monkeypatch (`_patch_availability` in
-# `Tests/UI/test_console_dictation_streaming.py`) to make the controller's own
-# internal `probe()` call deterministic. Binding `probe` as a bare name here
-# instead would capture the unpatched function at import time and silently
-# stop tracking that monkeypatch.
-from ...Chat import console_voice_input
 from ...Chat.console_voice_input import (
     NO_CAPTURE_MESSAGE,
     NO_SPEECH_MESSAGE,
@@ -238,10 +228,13 @@ from ...Chat.console_voice_input import (
     VoiceSegmentTranscribing,
     VoiceSpeechResumed,
     VoiceVadUnavailable,
+    # `acoustic_barge_in_enabled` is dual-use: the realtime engine's own
+    # `_enter_console_realtime_loop` reads it directly, in addition to
+    # `ConsoleHandsFreeController`'s own separate copy of this import for
+    # the pipeline engine's `_enter_console_hands_free_pipeline_loop`
+    # (wave-2 console decomposition, task 1) -- see that module's docstring.
     acoustic_barge_in_enabled,
     default_service_factory,
-    handsfree_send_delay_seconds,
-    realtime_enabled,
     realtime_idle_timeout_seconds,
     realtime_model,
     realtime_provider,
@@ -249,11 +242,11 @@ from ...Chat.console_voice_input import (
     realtime_vad_silence_ms,
     realtime_vad_threshold,
     realtime_voice,
-    resolve_handsfree_engine,
 )
 from ...Chat.console_realtime_loop import RealtimeLoopController
 
-# Import-safe at module scope for the same reason `console_voice_input` is:
+# Import-safe at module scope, same discipline as `console_voice_input`'s
+# own optional-stack avoidance (see `dictation.py`'s module docstring):
 # `LLM_Calls/realtime/__init__.py` re-exports pure dataclasses/typing only
 # and is documented never to import `websockets` (or any provider transport)
 # at package-import time. The provider session itself
@@ -261,19 +254,21 @@ from ...Chat.console_realtime_loop import RealtimeLoopController
 # lazily, in `_build_console_realtime_session`, exactly like
 # `default_service_factory` defers the speech stack.
 from ...LLM_Calls.realtime import RealtimeCallbacks, RealtimeSessionConfig
+# `ExitLoop`/`ModeChanged`/`SilenceSpeech` are dual-use: the realtime engine's
+# own `_handle_console_realtime_intent` reads them directly (V4's FSM emits a
+# strict subset of the pipeline engine's own intent vocabulary, "imported
+# from `console_hands_free.py` rather than redefined" per that method's
+# docstring), in addition to `ConsoleHandsFreeController`'s own separate copy
+# of this import for the pipeline engine (wave-2 console decomposition, task
+# 1) -- see that module's docstring. The rest of this vocabulary
+# (`CloseCapture`/`CountdownTick`/`HandsFreeController`/`HandsFreeIntent`/
+# `OpenCapture`/`RequestStopAndSend`/`SuppressReplySpeech`) is pipeline-only
+# and moved there entirely.
 from ...Chat.console_hands_free import (
-    CloseCapture,
-    CountdownTick,
     ExitLoop,
-    HandsFreeController,
-    HandsFreeIntent,
     ModeChanged,
-    OpenCapture,
-    RequestStopAndSend,
     SilenceSpeech,
-    SuppressReplySpeech,
 )
-from ...Chat.reply_sentence_sequencer import SentenceSequencer
 from ...Chat.console_display_state import (
     CONSOLE_INSPECTOR_NO_APPROVAL_REASON,
     CONSOLE_INSPECTOR_NO_TOOL_CALLS_REASON,
@@ -706,80 +701,11 @@ CONSOLE_FOCUS_TARGETS_BY_PANE = {
 #: dictation.py` (wave-1 console decomposition, task 5), imported back
 #: above for the `@on(...)` decorators below and for the handful of
 #: tests that still construct them via `chat_screen_module.<name>`.
-#: `CONSOLE_HANDS_FREE_DEGRADED_MESSAGE` and `ConsoleHandsFreeSession`
-#: stayed: both belong to the hands-free loop, a sibling cluster this
-#: wave does not touch (see `dictation.py`'s module docstring).
-
-
-#: Task 5 (VAD-degraded honesty carrier): shown once per hands-free ENTRY
-#: (not once per app run, unlike `VAD_UNAVAILABLE_MESSAGE` -- entering the
-#: loop is the moment this limitation actually starts to matter) when
-#: `webrtcvad` is unavailable. Reuses `VAD_UNAVAILABLE_MESSAGE`'s own
-#: framing (see `console_voice_input.VoiceVadUnavailable`'s docstring):
-#: without it, the silence gate that drives auto-send/barge-in never fires.
-CONSOLE_HANDS_FREE_DEGRADED_MESSAGE = (
-    "Hands-free is degraded: voice-activity detection (webrtcvad) is not "
-    "installed, so it cannot auto-send on a pause or hear a spoken barge-in. "
-    "Use the mic button, \"Console, stop.\", or Esc/ctrl+shift+h to end a turn."
-)
-
-
-@dataclass
-class ConsoleHandsFreeSession:
-    """Everything the hands-free conversation loop needs while it runs.
-
-    Constructed once per loop entry (`ChatScreen._enter_console_hands_free_
-    loop`) and torn down on `ExitLoop` (`ChatScreen._teardown_console_hands_
-    free_loop`) -- never reused across loop entries, unlike the one-shot
-    dictation session, so a fresh `HandsFreeController`/`SentenceSequencer`
-    pair with clean state is guaranteed for every "hands free" invocation.
-
-    Attributes:
-        controller: The headless FSM driving the loop.
-        sequencer: The headless sentence-boundary speech sequencer, reused
-            across every reply in this loop (`begin_reply()` resets its
-            per-reply state -- see that method's docstring).
-        tick_timer: The `set_interval(0.1, ...)` handle driving both
-            `controller.tick(now)` and the chip repaint. Stopped on
-            teardown.
-        reply_id: The outstanding reply's assistant-message id, or None
-            when no reply is outstanding. Claimed by the first delta/
-            completion tap call that passes the reply-identity guard (see
-            `pending_session_id`/`pending_existing_assistant_ids` below and
-            `_console_hands_free_try_claim_reply`'s docstring) while
-            `controller.state == "awaiting_reply"`.
-        toast_shown_for_reply: Policy state for `speak_utterance`'s `quiet`
-            parameter -- at most one failure toast per reply; every
-            subsequent utterance in the same reply passes `quiet=True`
-            once this is True. Reset in `_begin_console_hands_free_reply`.
-        countdown_remaining: The most recent `CountdownTick.remaining`,
-            painted into the chip by the 0.1 s tick (see `_repaint_console_
-            hands_free_chip`). Meaningless outside `controller.state ==
-            "countdown"`.
-        pending_session_id: The Console session `RequestStopAndSend`
-            recorded this send as going into (`_console_dictation_origin_
-            session_id` at that moment -- the SAME value the existing V2
-            wrong-session-refusal already uses, not `store.active_session_
-            id` re-read later, which a tab switch could have moved on from
-            by dispatch time). `None` until the first send. Part of the
-            reply-identity guard (task-5 review B1/M7).
-        pending_existing_assistant_ids: A snapshot of every assistant
-            message id already present in `pending_session_id` at the
-            moment `RequestStopAndSend` fired -- taken BEFORE the send
-            creates its own new assistant row, so any id in this set can
-            only be a PRE-EXISTING (therefore stale/foreign) reply, never
-            the new one. Part of the reply-identity guard (task-5 review
-            B1).
-    """
-
-    controller: HandsFreeController
-    sequencer: SentenceSequencer
-    tick_timer: Any = None
-    reply_id: str | None = None
-    toast_shown_for_reply: bool = False
-    countdown_remaining: float = 0.0
-    pending_session_id: str | None = None
-    pending_existing_assistant_ids: frozenset[str] = frozenset()
+#: `CONSOLE_HANDS_FREE_DEGRADED_MESSAGE` and `ConsoleHandsFreeSession` moved
+#: to `UI/Console_Modules/hands_free.py` (wave-2 console decomposition, task
+#: 1) along with the rest of the V3 pipeline hands-free loop; `Console
+#: HandsFreeController`/`ConsoleHandsFreeSession` are imported back above
+#: for the same two reasons dictation's types are.
 
 
 # ---------------------------------------------------------------------------
@@ -907,11 +833,10 @@ CONSOLE_REALTIME_CHIP_MESSAGES: dict[str, str] = {
     "reconnecting": "realtime · reconnecting…",
 }
 
-CONSOLE_REALTIME_FORCED_UNCONFIGURED_MESSAGE = (
-    "Hands-free is set to the realtime engine, but [realtime] enabled is "
-    'false. Turn it on in config, or set dictation.handsfree_engine to "auto" '
-    'or "pipeline".'
-)
+#: `CONSOLE_REALTIME_FORCED_UNCONFIGURED_MESSAGE` moved to
+#: `UI/Console_Modules/hands_free.py` (wave-2 console decomposition, task 1)
+#: -- realtime-labeled but consumed only by the engine fork, which moved
+#: with it; see that module's docstring.
 CONSOLE_REALTIME_UNSUPPORTED_PROVIDER_TEMPLATE = (
     "Realtime voice provider '{provider}' is not supported. Only "
     "'{supported}' is implemented; hands-free did not start."
@@ -1774,10 +1699,10 @@ class ChatScreen(BaseAppScreen):
                 and not self._console_setup_modal_blocking()
             )
         if action == "exit_console_hands_free":
-            return (
-                self._console_hands_free is not None
-                or self._console_realtime is not None
-            )
+            # One-line delegation (wave-2 console decomposition, task 1).
+            # See `ConsoleHandsFreeController.console_hands_free_exit_
+            # available` for the real implementation.
+            return self._hands_free.console_hands_free_exit_available()
         return super().check_action(action, parameters)
 
     def action_exit_console_hands_free(self) -> None:
@@ -1786,16 +1711,15 @@ class ChatScreen(BaseAppScreen):
         docstring-comment for why this needs to be `priority=True` rather
         than relying on `on_key`'s own (bubbling-order) branch alone.
 
-        Covers BOTH engines (V4 task 5): "Esc from any point in the loop"
-        is a promise the docs make about hands-free, not about one
-        engine's implementation of it.
+        One-line delegation (wave-2 console decomposition, task 1); the
+        `action_*` method has to stay on this class for Textual's action
+        dispatch to find it. See `ConsoleHandsFreeController.action_exit_
+        console_hands_free` for the real implementation, which covers BOTH
+        engines (V4 task 5): "Esc from any point in the loop" is a promise
+        the docs make about hands-free, not about one engine's
+        implementation of it.
         """
-        hands_free = self._console_hands_free
-        if hands_free is not None:
-            hands_free.controller.on_exit_request()
-        realtime = self._console_realtime
-        if realtime is not None:
-            realtime.controller.on_exit_request()
+        self._hands_free.action_exit_console_hands_free()
 
     def action_expand_collapsed_console_composer(self) -> None:
         """Expand the hidden Console composer and return keyboard focus to it.
@@ -2986,11 +2910,91 @@ class ChatScreen(BaseAppScreen):
             composer_accessor=lambda: self._console_composer_or_none(),
             chat_store_accessor=lambda: self._ensure_console_chat_store(),
             speak_status=lambda reason: self._speak_status(reason),
+            # The four reach-backs wave 1 left as a disclosed, temporary
+            # exception (bare `self._screen.X` properties) now that hands-
+            # free has a controller of its own to hand a named dependency
+            # to (wave-2 console decomposition, task 1) -- late-binding
+            # lambdas onto `self._hands_free`, constructed just below.
+            # Python resolves `self._hands_free` at CALL time, not here, so
+            # construction order between the two controllers does not
+            # matter.
+            hands_free_session_accessor=lambda: self._hands_free._console_hands_free,
+            set_hands_free_vad_degraded=(
+                lambda value: setattr(
+                    self._hands_free, "_console_hands_free_vad_degraded", value
+                )
+            ),
+            enter_hands_free_loop=(
+                lambda **kwargs: self._hands_free._enter_console_hands_free_loop(
+                    **kwargs
+                )
+            ),
+            hands_free_force_immediate_send=(
+                lambda: self._hands_free._console_hands_free_force_immediate_send()
+            ),
+            deliver_hands_free_capture_ended=(
+                lambda session, had_segments: (
+                    self._hands_free._deliver_console_hands_free_capture_ended(
+                        session, had_segments
+                    )
+                )
+            ),
+            # Realtime stays screen-owned (not extracted this wave); this
+            # was the same "temporary exception" shape as the four above,
+            # for the same staleness reason, now closed out the same way.
+            realtime_adopt_transcript=(
+                lambda transcript: self._console_realtime_adopt_transcript(
+                    transcript
+                )
+            ),
+            run_pending_voice_action=(
+                lambda session_id: self._run_pending_console_voice_action(
+                    session_id
+                )
+            ),
+            undo_histories_accessor=lambda: self._console_undo_histories,
+            visible_draft_session_id_accessor=(
+                lambda: self._console_visible_draft_session_id
+            ),
         )
-        #: The hands-free conversation loop's live session, or None when the
-        #: loop is not running. See `ConsoleHandsFreeSession` and
-        #: `_enter_console_hands_free_loop`/`_teardown_console_hands_free_loop`.
-        self._console_hands_free: ConsoleHandsFreeSession | None = None
+        #: The V3 pipeline hands-free loop's state and lifecycle, plus the
+        #: two-engine fork/action coordination it shares with the V4
+        #: realtime loop, moved to `ConsoleHandsFreeController` (wave-2
+        #: console decomposition, task 1). `self._console_hands_free`/
+        #: `_console_hands_free_vad_degraded` stay readable/writable via
+        #: the properties defined near `_console_composer_or_none`, so
+        #: nothing outside this cluster (`on_key`, `on_button_pressed`,
+        #: `on_unmount`, the realtime engine's own loud fallback, tests)
+        #: had to change. See `hands_free.py`'s module docstring for the
+        #: full map of what moved and why, including the two-engine
+        #: boundary this controller draws around the still-on-screen
+        #: realtime engine.
+        self._hands_free = ConsoleHandsFreeController(
+            self,
+            app_instance=self.app_instance,
+            composer_accessor=lambda: self._console_composer_or_none(),
+            chat_store_accessor=lambda: self._ensure_console_chat_store(),
+            dictation_state_accessor=lambda: self._console_dictation_state,
+            dictation_origin_session_id_accessor=(
+                lambda: self._console_dictation_origin_session_id
+            ),
+            set_pending_voice_action=(
+                lambda value: setattr(self, "_console_pending_voice_action", value)
+            ),
+            request_dictation_start=lambda: self._request_console_dictation_start(),
+            request_dictation_stop=lambda: self._request_console_dictation_stop(),
+            run_pending_voice_action=(
+                lambda session_id: self._run_pending_console_voice_action(
+                    session_id
+                )
+            ),
+            realtime_session_accessor=lambda: self._console_realtime,
+            enter_realtime_loop=(
+                lambda capture_live: self._enter_console_realtime_loop(
+                    capture_live=capture_live
+                )
+            ),
+        )
         #: The realtime (V4) hands-free loop's live session, or None when
         #: that loop is not running. Mutually exclusive with
         #: `_console_hands_free` by construction: the engine fork in
@@ -3003,19 +3007,6 @@ class ChatScreen(BaseAppScreen):
         #: sink, or None. Retained only so `on_unmount` can wait for it --
         #: see `_teardown_console_realtime_loop`.
         self._console_realtime_close_worker: Any | None = None
-        #: True once `_install_console_hands_free_store_tap` has wrapped the
-        #: store's `append_stream_chunk`/`mark_message_*` methods. The store
-        #: itself is a lazily-created singleton for this screen instance
-        #: (`_ensure_console_chat_store`), so this only ever needs doing once.
-        self._console_hands_free_store_tap_installed = False
-        #: Set once (per app run) by a `VoiceVadUnavailable` event -- see that
-        #: dataclass's docstring. Read by `_enter_console_hands_free_loop`,
-        #: which shows a dedicated warning naming exactly what auto-send/
-        #: barge-in cannot do in degraded mode (task-5 review M1: this
-        #: comment used to claim the chip repaint reads it -- it does not;
-        #: the entry toast alone is what satisfies the "never promise
-        #: silence detection it can't deliver" constraint).
-        self._console_hands_free_vad_degraded = False
         self._console_provider_gateway: Any | None = None
         self._console_prompt_history: Any | None = None
         self._console_chat_controller: ConsoleChatController | None = None
@@ -5229,6 +5220,40 @@ class ChatScreen(BaseAppScreen):
         """
         self._dictation._sync_console_dictation_availability()
 
+    # V3 pipeline hands-free loop state moved to `ConsoleHandsFreeController`
+    # (wave-2 console decomposition, task 1). These two properties keep
+    # `self._console_hands_free`/`_console_hands_free_vad_degraded`/
+    # `_console_hands_free_store_tap_installed` readable AND writable
+    # exactly as before, for the several screen methods that are not part
+    # of the hands-free cluster but still touch this state (`on_key`,
+    # `on_button_pressed`, `on_unmount`, the realtime engine's own loud
+    # fallback) and for tests that poke it directly -- each proxies
+    # straight through to `self._hands_free`, so none of those call sites
+    # needed to change.
+    @property
+    def _console_hands_free(self) -> ConsoleHandsFreeSession | None:
+        return self._hands_free._console_hands_free
+
+    @_console_hands_free.setter
+    def _console_hands_free(self, value: ConsoleHandsFreeSession | None) -> None:
+        self._hands_free._console_hands_free = value
+
+    @property
+    def _console_hands_free_vad_degraded(self) -> bool:
+        return self._hands_free._console_hands_free_vad_degraded
+
+    @_console_hands_free_vad_degraded.setter
+    def _console_hands_free_vad_degraded(self, value: bool) -> None:
+        self._hands_free._console_hands_free_vad_degraded = value
+
+    @property
+    def _console_hands_free_store_tap_installed(self) -> bool:
+        return self._hands_free._console_hands_free_store_tap_installed
+
+    @_console_hands_free_store_tap_installed.setter
+    def _console_hands_free_store_tap_installed(self, value: bool) -> None:
+        self._hands_free._console_hands_free_store_tap_installed = value
+
     # Workspace conversation-search state moved to `ConsoleWorkspaceController`
     # (wave-2 console decomposition, task 2). These six properties keep
     # `self._console_workspace_conversation_query`/`_search_timer`/
@@ -5359,59 +5384,12 @@ class ChatScreen(BaseAppScreen):
         """
         self._dictation._handle_console_dictation_buffer_limit(message)
 
-
-    #: Bound on how long `_deliver_console_hands_free_capture_ended` waits
-    #: for a limit-triggered stop to actually reach `idle` before giving up
-    #: -- generous relative to `dictation.stop_join_timeout_seconds`'s own
-    #: 30s default (that timeout is the transcription-thread join `_stop_
-    #: console_dictation` itself is bounded by; this only needs to exceed
-    #: it, not match it exactly). Giving up here is a safe failure mode: no
-    #: `on_capture_ended` is delivered at all, so the FSM's own bookkeeping
-    #: is never told something that did not (yet) happen, and the user can
-    #: still exit manually (Esc/mic/ctrl+shift+h/spoken "stop").
-    _CONSOLE_HANDS_FREE_CAPTURE_ENDED_WAIT_SECONDS: float = 40.0
-
-    async def _deliver_console_hands_free_capture_ended(
-        self, scheduled_for: "ConsoleHandsFreeSession", had_segments: bool
-    ) -> None:
-        """Wait for a limit-triggered stop to actually release the
-        microphone, THEN deliver `on_capture_ended` (task-5 review B2).
-
-        Polls `_console_dictation_state` rather than hooking `_stop_
-        console_dictation`'s own internals directly, so this stays a
-        self-contained addition next to the ONE call site that needs it
-        instead of threading a new "was this a limit stop" flag through
-        that already-delicate method.
-
-        Task-5 review round 2, D4: `scheduled_for` is the session object
-        captured by the CALLER at schedule time (while the limit-hit
-        capture was still live), not re-read from `self._console_hands_
-        free` after the wait. Re-reading was wrong: if the user exits and
-        re-enters hands-free during the (up to 40s) wait, `self._console_
-        hands_free` now points at a brand-new session/controller for a
-        DIFFERENT loop -- delivering this stale capture-ended to it would
-        silently burn the new loop's own one-time reopen ceiling for an
-        ending that has nothing to do with it. Delivered only when the
-        CURRENT session is still identically the one this was scheduled
-        for.
-        """
-        deadline = (
-            time.monotonic() + self._CONSOLE_HANDS_FREE_CAPTURE_ENDED_WAIT_SECONDS
-        )
-        while self._console_dictation_state != "idle":
-            if not self.is_mounted or time.monotonic() >= deadline:
-                logger.warning(
-                    "Console hands-free: capture-ended delivery gave up "
-                    "waiting for the limit-triggered stop to reach idle"
-                )
-                return
-            await asyncio.sleep(0.05)
-        if self._console_hands_free is not scheduled_for:
-            return
-        scheduled_for.controller.on_capture_ended(
-            had_segments=had_segments, limit_hit=True
-        )
-
+    #: `_deliver_console_hands_free_capture_ended` (and the wait bound it
+    #: used to be attached to as a sibling class constant) moved to
+    #: `ConsoleHandsFreeController` (wave-2 console decomposition, task 1).
+    #: `ConsoleDictationController._handle_console_dictation_limit` reaches
+    #: it through the injected `deliver_hands_free_capture_ended` callable;
+    #: see `hands_free.py`'s module docstring.
 
     #: task-1683: the exact Impersonate text last inserted into the draft,
     #: so a second click REPLACES it instead of stacking drafts. Keyed by
@@ -6287,778 +6265,42 @@ class ChatScreen(BaseAppScreen):
         await self._sync_native_console_chat_ui()
 
     # ------------------------------------------------------------------
-    # Hands-free conversation loop: speak -> it sends -> the reply is
-    # spoken -> speak again. `Chat/console_hands_free.py` (`HandsFreeController`,
-    # the headless FSM) and `Chat/reply_sentence_sequencer.py`
-    # (`SentenceSequencer`, the speech splitter) are pure/headless; this
-    # section is their thin Console-screen wiring. See
-    # `Docs/superpowers/specs/2026-08-02-hands-free-loop-design.md`.
+    # V3 pipeline hands-free conversation loop: moved to
+    # `ConsoleHandsFreeController` (wave-2 console decomposition, task 1),
+    # along with the engine fork and both cross-engine action entry points
+    # it shares with the V4 realtime loop below (`action_toggle_console_
+    # hands_free` here is the one-line delegation Textual's action dispatch
+    # needs to find on this class; `action_exit_console_hands_free` and
+    # `check_action`'s `exit_console_hands_free` branch are the same shape,
+    # above). `_enter_console_hands_free_loop` is kept as a one-line
+    # delegation too, under its ORIGINAL private name -- it is reached from
+    # outside this cluster (a spoken "Console, hands free." mid-capture,
+    # via `ConsoleDictationController`'s own injected `enter_hands_free_
+    # loop` callable, which points straight at `self._hands_free` and does
+    # NOT go through this delegation; this one exists for the handful of
+    # OTHER call sites, chiefly tests, that reach the fork directly on the
+    # screen instance). See `hands_free.py`'s module docstring for the full
+    # map of what moved and the two-engine boundary it draws.
     # ------------------------------------------------------------------
 
     def action_toggle_console_hands_free(self) -> None:
-        """`ctrl+shift+h`: enter the hands-free loop, or exit it if already running.
+        """`ctrl+shift+h`: enter the hands-free loop, or exit it if already
+        running.
 
-        Both engines exit through their own controller's `on_exit_request()`
-        -- the toggle never tears state down directly, so the exit runs the
-        same reasoned `ExitLoop` path every other exit route uses.
+        One-line delegation (wave-2 console decomposition, task 1). See
+        `ConsoleHandsFreeController.action_toggle_console_hands_free` for
+        the real implementation.
         """
-        if self._console_hands_free is not None:
-            self._console_hands_free.controller.on_exit_request()
-            return
-        if self._console_realtime is not None:
-            self._console_realtime.controller.on_exit_request()
-            return
-        self._enter_console_hands_free_loop(
-            capture_live=self._console_dictation_state == "recording"
-        )
+        self._hands_free.action_toggle_console_hands_free()
 
     def _enter_console_hands_free_loop(self, *, capture_live: bool) -> None:
         """Pick the hands-free engine, then start that engine's loop.
 
-        The fork (V4 task 5, rule 1) is deliberately the ONLY place engine
-        selection happens, and it happens once per loop entry -- never
-        mid-loop. A loop that is already running keeps the engine it was
-        started with: `resolve_handsfree_engine()` reads live config, and
-        re-resolving it on a re-entry (a spoken "hands free" mid-loop, say)
-        could otherwise hand a running V3 loop's re-entry to the realtime
-        engine and leave two loops fighting over the microphone.
-
-        `"realtime"` selected while `[realtime] enabled` is false is a
-        FORCED-but-unconfigured selection, not a mistake to paper over:
-        `resolve_handsfree_engine()`'s docstring is explicit that it never
-        silently downgrades an explicit `dictation.handsfree_engine =
-        "realtime"` to the pipeline, and that being honest about it is the
-        caller's job. So it is refused here, loudly, rather than starting
-        an engine the user disabled or a fallback they did not ask for.
-
-        Args:
-            capture_live: True when an existing one-shot dictation capture
-                is already open and should be adopted as the loop's first
-                turn; forwarded verbatim to whichever engine is selected.
+        One-line delegation (wave-2 console decomposition, task 1). See
+        `ConsoleHandsFreeController._enter_console_hands_free_loop` for the
+        real implementation (the engine fork).
         """
-        if self._console_hands_free is not None:
-            self._enter_console_hands_free_pipeline_loop(capture_live=capture_live)
-            return
-        if self._console_realtime is not None:
-            # `RealtimeLoopController.enter()` is itself idempotent, so a
-            # stray re-entry has nothing to re-confirm here (unlike V3,
-            # whose `enter()` carries capture bookkeeping).
-            return
-        if resolve_handsfree_engine() == "realtime":
-            if not realtime_enabled():
-                self.app_instance.notify(
-                    CONSOLE_REALTIME_FORCED_UNCONFIGURED_MESSAGE, severity="warning"
-                )
-                return
-            self._enter_console_realtime_loop(capture_live=capture_live)
-            return
-        self._enter_console_hands_free_pipeline_loop(capture_live=capture_live)
-
-    def _enter_console_hands_free_pipeline_loop(self, *, capture_live: bool) -> None:
-        """Start (or re-confirm) the V3 pipeline hands-free loop.
-
-        Reached from the engine fork above, and directly from the realtime
-        engine's loud fallback (`_console_realtime_fallback_to_pipeline`),
-        which must NOT re-run the fork -- it would resolve straight back to
-        the realtime engine that just failed.
-
-        Args:
-            capture_live: True when an existing one-shot dictation capture
-                is already open and should be adopted as the loop's first
-                turn (spoken "hands free" mid-capture, or the key binding
-                pressed while already recording); False opens a fresh
-                capture (the key binding pressed from idle). Ignored on
-                re-entry -- `HandsFreeController.enter()`'s own re-entry
-                semantics trust its own `capture_open` bookkeeping instead
-                of a possibly-stale argument (see that method's docstring).
-        """
-        existing = self._console_hands_free
-        if existing is not None:
-            existing.controller.enter(capture_live=capture_live)
-            return
-        if self._console_hands_free_vad_degraded:
-            self.app_instance.notify(
-                CONSOLE_HANDS_FREE_DEGRADED_MESSAGE, severity="warning"
-            )
-        controller = HandsFreeController(
-            emit=self._handle_console_hands_free_intent,
-            send_delay_seconds=handsfree_send_delay_seconds(),
-            acoustic_barge_in=acoustic_barge_in_enabled(),
-        )
-        sequencer = SentenceSequencer(
-            speak=self._dispatch_console_hands_free_speak,
-            stop_speech=self._stop_console_hands_free_speech,
-        )
-        session = ConsoleHandsFreeSession(controller=controller, sequencer=sequencer)
-        sequencer.on_drained = self._on_console_hands_free_sequencer_drained
-        self._console_hands_free = session
-        self._install_console_hands_free_store_tap()
-        session.tick_timer = self.set_interval(0.1, self._tick_console_hands_free)
-        controller.enter(capture_live=capture_live)
-
-    def _teardown_console_hands_free_loop(self) -> None:
-        """Drop the loop session and repaint the chip back to normal.
-
-        Only ever called from `_console_hands_free_exit_loop` (`ExitLoop`'s
-        handler), after that method has already silenced any reply audio
-        and closed the capture -- this just stops the tick timer and clears
-        the composer's borrowed hands-free chip state.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        if session.tick_timer is not None:
-            session.tick_timer.stop()
-        self._console_hands_free = None
-        composer = self._console_composer_or_none()
-        if composer is not None:
-            # Repaints over whatever hands-free's own `set_voice_status`
-            # calls last left on screen (`countdown`/`awaiting-reply`/
-            # `speaking` are not lifecycle states `sync_dictation_state`
-            # knows, so only a fresh call with the REAL current one-shot
-            # state clears them).
-            composer.sync_dictation_state(self._console_dictation_state)
-
-    def _tick_console_hands_free(self) -> None:
-        """`set_interval(0.1, ...)`: the controller's only clock input."""
-        session = self._console_hands_free
-        if session is None:
-            return
-        session.controller.tick(time.monotonic())
-        self._repaint_console_hands_free_chip()
-
-    def _handle_console_hands_free_intent(self, intent: HandsFreeIntent) -> None:
-        """Route one `HandsFreeIntent`, emitted synchronously by the
-        controller, to the wiring machinery that acts on it."""
-        if isinstance(intent, RequestStopAndSend):
-            self._console_hands_free_request_stop_and_send()
-        elif isinstance(intent, (SilenceSpeech, SuppressReplySpeech)):
-            self._console_hands_free_silence_speech()
-        elif isinstance(intent, OpenCapture):
-            self._console_hands_free_open_capture()
-        elif isinstance(intent, CloseCapture):
-            self._console_hands_free_close_capture()
-        elif isinstance(intent, CountdownTick):
-            self._console_hands_free_countdown_tick(intent.remaining)
-        elif isinstance(intent, ModeChanged):
-            self._console_hands_free_mode_changed(intent.state)
-        elif isinstance(intent, ExitLoop):
-            self._console_hands_free_exit_loop()
-
-    def _console_hands_free_request_stop_and_send(self) -> None:
-        """`RequestStopAndSend`: drive the existing V2 pending-send seam.
-
-        Queues the send exactly like a spoken "Console, send." does
-        (`_console_pending_voice_action = "send"`), then either stops the
-        still-open capture -- the common case; `_stop_console_dictation`'s
-        own success tail runs `_run_pending_console_voice_action`, which
-        dispatches the queued send once the transcript has actually landed
-        -- or, if the capture has ALREADY ended by the time this intent
-        lands (a service-side capture limit reached `on_capture_ended`
-        before this ran, so `_console_dictation_state` is already back at
-        `idle`), dispatches the queued send directly, since there is
-        nothing left to stop. There is no second send path either way --
-        both branches ultimately run `_run_pending_console_voice_action`,
-        the same method a spoken "send" already uses.
-
-        Task-5 review B1/M7: records `pending_session_id` (from
-        `_console_dictation_origin_session_id` -- the SAME value V2's own
-        wrong-session-refusal already uses, NOT a fresh `store.active_
-        session_id` read, which a tab switch could have moved on from by
-        the time a deferred idle-branch dispatch actually runs) and a
-        snapshot of every assistant message id already in that session
-        (`pending_existing_assistant_ids`), both consumed by the
-        reply-identity guard (`_console_hands_free_try_claim_reply`) to
-        decide which later delta/completion tap call is really THIS send's
-        reply.
-        """
-        session = self._console_hands_free
-        sending_session_id = self._console_dictation_origin_session_id
-        if session is not None:
-            session.pending_session_id = sending_session_id
-            session.pending_existing_assistant_ids = (
-                self._console_hands_free_assistant_ids(sending_session_id)
-            )
-        self._console_pending_voice_action = "send"
-        if self._console_dictation_state == "recording":
-            self._request_console_dictation_stop()
-            return
-        if self._console_dictation_state == "idle":
-            self.run_worker(
-                self._run_pending_console_voice_action(sending_session_id),
-                exclusive=True,
-                group="console-hands-free-send",
-                exit_on_error=False,
-            )
-        # else ("starting"/"transcribing"): a stop is already in flight for
-        # this same capture; its own tail will pick up the queued action.
-
-    def _console_hands_free_assistant_ids(self, session_id: str | None) -> frozenset[str]:
-        """Return every assistant message id currently in `session_id`.
-
-        Used to snapshot "pre-existing" reply ids before a send, so the
-        reply-identity guard can tell a brand-new reply from a stale one
-        that already existed (task-5 review B1).
-        """
-        if not session_id:
-            return frozenset()
-        store = self._ensure_console_chat_store()
-        try:
-            messages = store.messages_for_session(session_id)
-        except KeyError:
-            return frozenset()
-        return frozenset(m.id for m in messages if m.role == "assistant")
-
-    def _console_hands_free_force_immediate_send(self) -> None:
-        """Spoken "send" mid-loop: drive the SAME countdown-expiry path
-        `RequestStopAndSend` uses, collapsed to (near) zero wall time
-        (task-5 review I3).
-
-        Only the controller's OWN public inputs are used here (`on_voice_
-        final()` then two `tick()` calls) -- no reach into its private
-        `_begin_awaiting_reply()`/`_send_delay_seconds` -- so this is
-        exactly the path a real countdown expiry takes, just compressed:
-        from `listening`, `on_voice_final()` arms the countdown; from
-        `countdown` already (a prior segment's own final already armed
-        one -- e.g. "hello there" dictated, then "Console, send." spoken
-        immediately after, before that countdown would have expired on its
-        own), the existing arming is reused as-is rather than re-armed.
-        Either way, the first `tick()` adopts/re-confirms `now` as the
-        anchor (elapsed 0 relative to a same-call anchor, never expires on
-        its own); the second, with `now` pushed far enough into the future
-        that `remaining` clamps to 0 regardless of the configured
-        `dictation.handsfree_send_delay_seconds`, expires it -- which is
-        what actually emits `RequestStopAndSend` and moves the controller
-        into `awaiting_reply`, so the reply that follows is genuinely
-        spoken instead of streaming into a `listening` loop that silently
-        drops it. A no-op in every other state (`awaiting_reply`/
-        `speaking`/`idle`) -- nothing to send yet, or a send is already
-        outstanding.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        controller = session.controller
-        if controller.state == "listening":
-            controller.on_voice_final()
-        elif controller.state != "countdown":
-            return
-        now = time.monotonic()
-        controller.tick(now)
-        controller.tick(now + 3600.0)
-
-    def _console_hands_free_silence_speech(self) -> None:
-        """`SilenceSpeech`/`SuppressReplySpeech`: stop any playing speech and
-        flush the sequencer.
-
-        Two things, unconditionally: (1) the both-ways TTS stop routine
-        (`TTSPlaybackEvent(action="stop")`) fires directly here too, not
-        only through `flush()`'s conditional `stop_speech()` -- a `_speak_
-        status` ack ("Sent.", "Discarded.", ...) bypasses the sequencer
-        entirely, so without this a barge-in mid-ack would leave it
-        playing (task-5 review M9); (2) `SentenceSequencer.flush()` clears
-        the queue, calls `stop_speech()` (redundant with (1) when
-        something is in flight -- harmless, matches the existing "post a
-        bare stop before every capture-open" idiom this file already
-        uses) exactly iff an utterance is in flight, and latches
-        suppression so nothing from this reply speaks again.
-        `SilenceSpeech` (a barge-in mid-`speaking`, or re-`enter()`
-        catching a still-speaking reply) typically has something in
-        flight to stop; `SuppressReplySpeech` (a keypress during
-        `awaiting_reply`, or `on_reply_failed()`'s recovery) typically
-        does not -- the suppression latch still needs setting either way,
-        which is why both intents route here.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
-            TTSPlaybackEvent,
-        )
-
-        self.app_instance.post_message(TTSPlaybackEvent(action="stop"))
-        session.sequencer.flush()
-
-    def _console_hands_free_open_capture(self) -> None:
-        """`OpenCapture`: idempotent-safe via `_request_console_dictation_
-        start`'s own guard -- a no-op unless `_console_dictation_state`
-        is genuinely `idle`."""
-        if self._console_dictation_state == "idle":
-            self._request_console_dictation_start()
-
-    def _console_hands_free_close_capture(self) -> None:
-        """`CloseCapture`: idempotent-safe via `_request_console_dictation_
-        stop`'s own guard -- a no-op unless genuinely `recording`."""
-        if self._console_dictation_state == "recording":
-            self._request_console_dictation_stop()
-
-    def _console_hands_free_countdown_tick(self, remaining: float) -> None:
-        """`CountdownTick`: record the remaining seconds for the chip."""
-        session = self._console_hands_free
-        if session is None:
-            return
-        session.countdown_remaining = remaining
-
-    def _console_hands_free_mode_changed(self, state: str) -> None:
-        """`ModeChanged`: reset per-reply state on entering `awaiting_reply`,
-        seed the countdown's first-paint value on entering `countdown`,
-        then repaint the chip for whatever state this is."""
-        if state == "awaiting_reply":
-            self._begin_console_hands_free_reply()
-        elif state == "countdown":
-            session = self._console_hands_free
-            if session is not None:
-                # Task-5 final review I1: `ModeChanged("countdown")` fires
-                # from `_transition`, itself called from `on_voice_final()`
-                # -- BEFORE the first real `CountdownTick` (which only
-                # arrives on the next `tick()` call) ever writes `session.
-                # countdown_remaining`. Without this, the repaint below
-                # would show the dataclass default `0.0` on turn 1 ("sending
-                # in 0.0s…", reading as "sending NOW") or the PREVIOUS
-                # countdown's last value on later turns. Seeded from the
-                # controller's own configured delay -- exactly what the
-                # first tick would compute anyway (`remaining = send_delay
-                # - 0`).
-                session.countdown_remaining = (
-                    session.controller._send_delay_seconds
-                )
-        self._repaint_console_hands_free_chip()
-
-    def _begin_console_hands_free_reply(self) -> None:
-        """Reset per-reply state at `ModeChanged("awaiting_reply")`.
-
-        `SentenceSequencer.begin_reply()` is REQUIRED before feeding a
-        second (or later) reply's deltas on this reused sequencer instance
-        -- without it, the suppression latch/fence/buffer state from the
-        PRIOR reply survives, and `on_drained` never fires again, so the
-        loop never reopens the microphone (see that method's docstring).
-        Also clears `reply_id` (a fresh reply claims a fresh id -- see
-        `_on_console_hands_free_delta`) and the per-reply toast policy.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        session.sequencer.begin_reply()
-        session.reply_id = None
-        session.toast_shown_for_reply = False
-
-    def _console_hands_free_exit_loop(self) -> None:
-        """`ExitLoop`: the controller deliberately does NOT emit
-        `SilenceSpeech`/`CloseCapture` alongside this intent (see
-        `HandsFreeController._exit`'s callers) -- this handler performs
-        both itself, in that order, before tearing the session down."""
-        self._console_hands_free_silence_speech()
-        self._console_hands_free_close_capture()
-        self._teardown_console_hands_free_loop()
-
-    def _repaint_console_hands_free_chip(self) -> None:
-        """Paint the hands-free loop's mode into the composer's voice chip.
-
-        `listening` RESTORES the ordinary dictation chip rather than being
-        left untouched (task-5 final review I1): the ordinary pipeline
-        (`VoicePartial`/`VoiceFinal`/the elapsed ticker) does paint an
-        accurate "recording" chip for it on its OWN -- but only the very
-        first time, before this loop has ever borrowed the chip for
-        `countdown`/`awaiting_reply`/`speaking`. By the time control
-        returns HERE to `listening` (a cancelled countdown, a barge-in, a
-        drained reply), the chip is showing whatever borrowed text was
-        painted last, and nothing else was going to overwrite it -- a
-        cancelled countdown kept reading "sending in 0.0s…" for the
-        user's entire next utterance (PROBE A). `composer.sync_dictation_
-        state(...)`, re-applied with the composer's OWN currently-tracked
-        partial/elapsed/segment-transcribing values (not this loop's),
-        is the same idiom `_teardown_console_hands_free_loop` already uses
-        to clear a borrowed chip on exit -- safe to call redundantly (the
-        widget's own `entering_recording`/`state_changed` guards no-op
-        when nothing actually changed), so calling it on every 0.1s tick
-        while `listening` is cheap. The other three states either close
-        the mic (default mode) or otherwise have nothing else painting
-        the chip, so they are driven directly through `ConsoleComposerBar.
-        set_voice_status`, which -- unlike `set_voice_partial`/`sync_
-        dictation_state` -- is not gated on the one-shot dictation
-        lifecycle state, so it keeps painting correctly even once
-        `_console_dictation_state` has already reached `idle`.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        composer = self._console_composer_or_none()
-        if composer is None:
-            return
-        state = session.controller.state
-        if state == "listening":
-            composer.sync_dictation_state(self._console_dictation_state)
-            return
-        if state == "countdown":
-            composer.set_voice_status(
-                "countdown",
-                message=(
-                    f"hands-free · sending in {session.countdown_remaining:.1f}s…"
-                ),
-            )
-        elif state == "awaiting_reply":
-            composer.set_voice_status(
-                "awaiting-reply", message="hands-free · thinking…"
-            )
-        elif state == "speaking":
-            composer.set_voice_status("speaking", message="hands-free · speaking")
-
-    def _install_console_hands_free_store_tap(self) -> None:
-        """Wrap the store's creation/delta/completion seams, once, for this
-        screen's life.
-
-        `Chat/console_agent_bridge.py`'s streaming adapter (and
-        `ConsoleChatController`'s own non-agent streaming path) both call
-        `store.append_message`/`store.append_stream_chunk`/`store.mark_
-        message_complete`/`store.mark_message_failed`/`store.mark_message_
-        stopped` directly -- there is no existing observer/subscription
-        mechanism on the store, so this wraps the bound methods on the
-        store itself (a lazily-created singleton for this screen instance
-        -- `_ensure_console_chat_store` only ever builds one). Read-only:
-        every wrapper calls the original method FIRST and returns its
-        result unchanged; the tap only observes. Idempotent -- installed at
-        most once per screen instance, and stays installed across loop
-        exit/re-entry (uninstalling would need to reach back into a store
-        that outlives any one loop session). `append_message` is the
-        EARLIEST of the five seams -- it fires the instant the assistant
-        row is created, before any streaming (task-5 final review I3).
-        """
-        if self._console_hands_free_store_tap_installed:
-            return
-        store = self._ensure_console_chat_store()
-        original_append_message = store.append_message
-        original_append = store.append_stream_chunk
-        original_complete = store.mark_message_complete
-        original_failed = store.mark_message_failed
-        original_stopped = store.mark_message_stopped
-
-        def _append_message(*args: Any, **kwargs: Any):
-            result = original_append_message(*args, **kwargs)
-            # Task-5 final review I3: the EARLIEST observable "generation
-            # truly begins" signal -- filtered to ASSISTANT rows here,
-            # before the marshal, so a user/system append (far more
-            # frequent) never pays a cross-thread round trip for nothing.
-            # See `_on_console_hands_free_assistant_row_created`.
-            if result.role is ConsoleMessageRole.ASSISTANT:
-                self._console_hands_free_marshal(
-                    self._on_console_hands_free_assistant_row_created,
-                    result.id,
-                )
-            return result
-
-        def _append_stream_chunk(message_id: str, chunk: str):
-            result = original_append(message_id, chunk)
-            self._console_hands_free_marshal(
-                self._on_console_hands_free_delta, message_id, chunk
-            )
-            return result
-
-        def _mark_message_complete(message_id: str):
-            result = original_complete(message_id)
-            self._console_hands_free_marshal(
-                self._on_console_hands_free_terminal, message_id, False
-            )
-            return result
-
-        def _mark_message_failed(message_id: str):
-            result = original_failed(message_id)
-            self._console_hands_free_marshal(
-                self._on_console_hands_free_terminal, message_id, True
-            )
-            return result
-
-        def _mark_message_stopped(message_id: str):
-            result = original_stopped(message_id)
-            self._console_hands_free_marshal(
-                self._on_console_hands_free_terminal, message_id, True
-            )
-            return result
-
-        store.append_message = _append_message
-        store.append_stream_chunk = _append_stream_chunk
-        store.mark_message_complete = _mark_message_complete
-        store.mark_message_failed = _mark_message_failed
-        store.mark_message_stopped = _mark_message_stopped
-        self._console_hands_free_store_tap_installed = True
-
-    def _console_hands_free_marshal(
-        self, callback: Callable[..., None], *args: Any
-    ) -> None:
-        """Run `callback(*args)` on the UI thread (task-5 review I1).
-
-        The tap wraps store methods reachable from TWO contexts: the
-        async, on-the-app-loop direct-provider send path, and -- the
-        DEFAULT production path, `[console] agent_runtime` on by default
-        -- a WORKER THREAD running its own event loop
-        (`ConsoleChatController._run_agent_reply` ->
-        `asyncio.to_thread(bridge.run_reply)` ->
-        `console_agent_bridge.py`'s `_StreamingModelAdapter.chat_call` ->
-        `store.append_stream_chunk`/etc, all on that thread). Everything
-        downstream of this tap touches widgets (`ConsoleComposerBar.set_
-        voice_status` via the chip repaint) or calls `run_worker`/`post_
-        message` (which themselves require -- or at least assume -- the
-        app's own thread), so every call must land back there. `self.app`
-        itself is UNSAFE to read off-thread (it resolves via a context
-        var with no active app on a bare worker thread -- `NoActiveAppError`)
-        -- `self.app_instance` (the stored `TldwCli` reference, plain
-        attribute access, safe from any thread) is used for both the
-        thread-identity check and the marshal call.
-
-        Task-5 review round 2, D1: the tap is installed once and never
-        uninstalled (see `_install_console_hands_free_store_tap`), so
-        EVERY streamed chunk of EVERY message pays for this call, hands-
-        free running or not -- the fast path below (bail out before the
-        thread-identity check, let alone a real `call_from_thread` round
-        trip, when the loop is not running) is what keeps the common
-        case (hands-free never entered this session) cheap: measured
-        ~60us/chunk down to near-zero. Also: `App.call_from_thread` raises
-        `RuntimeError("App is not running")` when the app has no running
-        event loop (e.g. the standard test harness, where `app_instance`
-        is a `TldwCli` that was never `run()`) -- wrapped in `except
-        Exception` so a hands-free plumbing/timing issue can NEVER escape
-        into `store.append_message`/`append_stream_chunk`/`mark_message_
-        *`, which every reply -- hands-free or not -- streams through.
-
-        Task-5 final review I2: the UI-thread branch used to call
-        `callback(*args)` bare -- the "NEVER escape" claim two paragraphs
-        up was therefore false on the (also supported, non-agent-runtime)
-        direct-provider path, which calls this tap from the UI thread
-        directly. Both branches now share the identical guarantee.
-        """
-        if self._console_hands_free is None:
-            return
-        if threading.get_ident() == self.app_instance._thread_id:
-            try:
-                callback(*args)
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Console hands-free: tap callback failed on the UI "
-                    "thread; dropping this callback"
-                )
-            return
-        try:
-            self.app_instance.call_from_thread(callback, *args)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Console hands-free: tap marshal failed off-thread; "
-                "dropping this callback"
-            )
-
-    def _console_hands_free_try_claim_reply(
-        self, session: "ConsoleHandsFreeSession", message_id: str
-    ) -> bool:
-        """Claim `message_id` as the outstanding reply's id, if eligible.
-
-        REPLY IDENTITY (binding carrier, task-5 review B1): eligible means
-        ALL of:
-          (a) `controller.state == "awaiting_reply"` -- nothing has been
-              claimed yet, and a reply is genuinely outstanding;
-          (b) `message_id` belongs to the SAME session `RequestStopAndSend`
-              recorded this send as going into (`session.pending_session_
-              id`) -- rules out a concurrently-streaming BACKGROUND
-              session's reply (parallel per-session runs are a supported
-              feature, `console_chat_controller.py`'s `send_refusal_copy`
-              gates on `max_parallel_runs`, not "only one run app-wide");
-          (c) `message_id` was NOT already present in that session before
-              this send (`session.pending_existing_assistant_ids`) -- rules
-              out a STALE reply in the SAME session: a keyboard barge-in
-              during `awaiting_reply` suppresses speech but never cancels
-              generation, so that reply's message id already exists (and
-              keeps streaming) by the time the NEXT turn's send fires; without
-              this check the next turn would claim the OLD reply's id (it is
-              the first one still streaming) and speak its leftover sentences
-              into the new turn -- reopening exactly the hazard task-3's
-              `on_reply_started` docstring warns about
-              (`console_hands_free.py`'s `_reply_abandoned_by_watchdog`
-              framing is the same class of "a suppressed reply must not
-              resurrect" issue, one layer up).
-
-        There is still no independent ground truth beyond "new, in the
-        right session" -- there is no earlier synchronous "reply started,
-        here is its id" signal reachable without touching
-        `console_chat_controller.py` (out of this task's file list) -- but
-        that pair of checks is exactly what the brief's reply-identity
-        constraint requires: a wrong id can no longer win the slot.
-        """
-        if session.controller.state != "awaiting_reply":
-            return False
-        if session.pending_session_id is None:
-            return False
-        store = self._ensure_console_chat_store()
-        try:
-            owner_session_id = store.session_id_for_message(message_id)
-        except KeyError:
-            return False
-        if owner_session_id != session.pending_session_id:
-            return False
-        if message_id in session.pending_existing_assistant_ids:
-            return False
-        session.reply_id = message_id
-        return True
-
-    def _on_console_hands_free_assistant_row_created(self, message_id: str) -> None:
-        """`store.append_message`'s ASSISTANT-role tap (task-5 final review
-        I3): the EARLIEST observable "generation truly begins" signal.
-
-        Before this, the only `on_reply_started()` call sites were the
-        first streamed delta and the terminal tap -- both downstream of
-        the model actually producing VISIBLE output. On the DEFAULT
-        agent-runtime path, `console_agent_bridge.py`'s streaming adapter
-        only forwards fence-gated PRIMARY-turn output, so a run that does
-        tool round-trips first (or opens with a fenced code block the
-        sequencer skips by design, or is a sealed/non-streaming turn)
-        could blow the `awaiting_reply` watchdog's `AWAITING_REPLY_
-        DEADLINE_SECONDS` before a single visible token arrived -- the
-        FSM's own docstring calls that "routine," not exceptional, and
-        promises the watchdog does not punish it. `store.append_message`
-        creates the assistant row ONCE, synchronously, before any
-        streaming (agent or not) begins -- reusing it here makes the
-        watchdog measure what its docstring actually says it measures
-        (send -> `on_reply_started()`), not send -> first visible token.
-
-        Reuses the SAME reply-identity guard the delta/completion taps
-        use (`_console_hands_free_try_claim_reply`): a claim made here
-        for the WRONG session or a pre-existing id is refused exactly
-        like a claim from a delta would be, so this cannot weaken the B1
-        guarantee -- a non-assistant append never reaches here at all
-        (filtered in the wrapper, before the marshal), and an assistant
-        append for an unrelated/background session's OWN reply fails the
-        SAME session+novelty checks a delta for it would.
-        """
-        session = self._console_hands_free
-        if session is None or session.reply_id is not None:
-            return
-        if self._console_hands_free_try_claim_reply(session, message_id):
-            session.controller.on_reply_started()
-
-    def _on_console_hands_free_delta(self, message_id: str, chunk: str) -> None:
-        """Delta tap: feed one streamed chunk into the loop's sentence sequencer.
-
-        UI-thread only -- always reached via `_console_hands_free_marshal`
-        (task-5 review I1). The FIRST delta that passes `_console_hands_
-        free_try_claim_reply` (see its docstring for the full reply-identity
-        contract) claims `session.reply_id` for this turn, and doubles as
-        the earliest available `on_reply_started()` signal. Every later
-        delta is fed ONLY when its `message_id` matches `session.reply_id`;
-        anything else is dropped before it can reach the sequencer.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        if session.reply_id is None:
-            if not self._console_hands_free_try_claim_reply(session, message_id):
-                return
-            session.controller.on_reply_started()
-        elif message_id != session.reply_id:
-            return
-        session.sequencer.feed(chunk)
-
-    def _on_console_hands_free_terminal(self, message_id: str, failed: bool) -> None:
-        """Completion tap: `mark_message_complete`/`mark_message_failed`/
-        `mark_message_stopped`.
-
-        UI-thread only -- always reached via `_console_hands_free_marshal`
-        (task-5 review I1; `failed` is positional here, not keyword-only,
-        for that same call site's benefit -- `call_from_thread`/direct
-        dispatch both pass it positionally). Claims `session.reply_id` via
-        `_console_hands_free_try_claim_reply` the same way the delta tap
-        does when it has not already been claimed -- a reply that streams
-        ZERO chunks (a zero-speakable reply, or a failure before any
-        content arrived) still needs its completion recognized, or the
-        loop hangs in `awaiting_reply` until the 30s watchdog gives up on
-        it. Dropped when `message_id` does not match the outstanding reply.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        if session.reply_id is None:
-            if not self._console_hands_free_try_claim_reply(session, message_id):
-                return
-        elif session.reply_id != message_id:
-            return
-        if failed:
-            session.sequencer.flush()
-            session.controller.on_reply_failed()
-            return
-        session.controller.on_reply_started()
-        session.sequencer.reply_completed()
-        session.controller.on_reply_finished()
-
-    def _dispatch_console_hands_free_speak(self, text: str) -> None:
-        """`SentenceSequencer`'s `speak` callable: dispatch one utterance.
-
-        Synchronous (the sequencer's contract) -- schedules the actual
-        async `speak_utterance` call as a worker. Also this wiring's only
-        call site for `HandsFreeController.on_first_utterance()`: safe on
-        EVERY dispatch (idempotent -- a no-op outside `awaiting_reply`, see
-        that method's docstring), so no separate first-utterance flag is
-        needed here.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        session.controller.on_first_utterance()
-        token = session.sequencer.current_utterance_token
-        self.run_worker(
-            self._speak_console_hands_free_utterance(text, token),
-            exclusive=False,
-            group="console-hands-free-speech",
-            exit_on_error=False,
-        )
-
-    async def _speak_console_hands_free_utterance(
-        self, text: str, token: int | None
-    ) -> None:
-        """Speak one utterance via the cooldown-free `speak_utterance` entry.
-
-        `token` is `session.sequencer.current_utterance_token`, captured
-        synchronously at dispatch time (binding carrier: production callers
-        MUST thread it through into `utterance_finished(ok, token=...)` --
-        see that method's docstring). `quiet` implements the "at most one
-        failure toast per reply" policy: the first failed utterance in a
-        reply shows its toast and latches `toast_shown_for_reply`; every
-        later utterance in the SAME reply then passes `quiet=True` and only
-        logs.
-        """
-        session = self._console_hands_free
-        if session is None:
-            return
-        handler = await self.app_instance._ensure_tts_handler()
-        if handler is None:
-            session.sequencer.utterance_finished(False, token=token)
-            return
-        quiet = session.toast_shown_for_reply
-
-        def _on_finished(ok: bool) -> None:
-            current = self._console_hands_free
-            if current is not session:
-                # A different loop entry (or none at all) owns the screen's
-                # hands-free state now; this utterance's own sequencer/token
-                # bookkeeping is no longer live to report back into.
-                return
-            if not ok:
-                session.toast_shown_for_reply = True
-            session.sequencer.utterance_finished(ok, token=token)
-
-        await handler.speak_utterance(text, on_finished=_on_finished, quiet=quiet)
-
-    def _stop_console_hands_free_speech(self) -> None:
-        """`SentenceSequencer`'s `stop_speech` callable: the existing
-        both-ways stop routine (silences BOTH the streaming sink and the
-        legacy player) -- see `_request_console_dictation_start`'s
-        identical use for the mic/speaker exclusion invariant."""
-        from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
-            TTSPlaybackEvent,
-        )
-
-        self.app_instance.post_message(TTSPlaybackEvent(action="stop"))
-
-    def _on_console_hands_free_sequencer_drained(self) -> None:
-        """`SentenceSequencer.on_drained`: nothing left queued or in flight."""
-        session = self._console_hands_free
-        if session is None:
-            return
-        session.controller.on_sequencer_drained()
+        self._hands_free._enter_console_hands_free_loop(capture_live=capture_live)
 
     # ------------------------------------------------------------------
     # Realtime (V4) hands-free loop: one live provider session for the
@@ -8901,13 +8143,20 @@ class ChatScreen(BaseAppScreen):
         for a fault that is really a missing microphone or speech model.
         """
         reason = failure or "the realtime session could not be opened"
-        pipeline_reason = self._console_pipeline_hands_free_blocker()
+        # `_console_pipeline_hands_free_blocker`/`_enter_console_hands_free_
+        # pipeline_loop` moved to `ConsoleHandsFreeController` (wave-2
+        # console decomposition, task 1) -- called directly on
+        # `self._hands_free`, the same as `self._dictation`/`self._workspace`
+        # elsewhere on this screen; no injection needed for this direction
+        # (see `hands_free.py`'s module docstring, two-engine boundary
+        # section).
+        pipeline_reason = self._hands_free._console_pipeline_hands_free_blocker()
         if pipeline_reason is None:
             self.app_instance.notify(
                 CONSOLE_REALTIME_FALLBACK_TEMPLATE.format(reason=reason),
                 severity="warning",
             )
-            self._enter_console_hands_free_pipeline_loop(
+            self._hands_free._enter_console_hands_free_pipeline_loop(
                 capture_live=self._console_dictation_state == "recording"
             )
             return
@@ -8917,34 +8166,6 @@ class ChatScreen(BaseAppScreen):
             ),
             severity="error",
         )
-
-    def _console_pipeline_hands_free_blocker(self) -> str | None:
-        """Why the V3 pipeline loop is not a usable fallback, or None.
-
-        Two blockers, both already defined elsewhere in this screen: a
-        degraded VAD (the pipeline loop cannot auto-send at all -- see
-        `_console_hands_free_vad_degraded`), and dictation being
-        unavailable outright (no capture backend or no speech provider).
-
-        `Availability.remedy` is included when there is one (final review
-        M7): this string ends up in the toast that reports BOTH engines
-        failing, which is the only place the user is told what to install
-        -- dropping it left them with a diagnosis and no fix.
-        """
-        if self._console_hands_free_vad_degraded:
-            return "voice-activity detection is unavailable, so auto-send cannot work"
-        try:
-            availability = console_voice_input.probe()
-        except Exception:  # noqa: BLE001 - a probe crash is not a refusal
-            logger.opt(exception=True).debug(
-                "Console realtime: dictation availability probe crashed"
-            )
-            return None
-        if not availability.ok:
-            reason = availability.reason or "dictation is unavailable"
-            remedy = str(availability.remedy or "").strip()
-            return f"{reason} {remedy}".strip() if remedy else reason
-        return None
 
     # -- chip, clock and teardown -------------------------------------------
 
@@ -15414,15 +14635,11 @@ class ChatScreen(BaseAppScreen):
         """Release Console-native resources owned by this screen."""
         self._stop_console_transcript_sync_timer()
         self._stop_console_cost_ttl_timer()
-        hands_free = self._console_hands_free
-        if hands_free is not None and hands_free.tick_timer is not None:
-            # Direct timer stop + state drop, not the full `ExitLoop` intent
-            # path: unmount is abandon teardown (V2-style, per the design
-            # doc's error-handling section), not a graceful exit -- no
-            # further TTS/dictation calls are safe to issue against a
-            # screen that is being torn down.
-            hands_free.tick_timer.stop()
-        self._console_hands_free = None
+        # The pipeline hands-free loop's own two-statement abandon teardown
+        # now lives in the decomposed controller (wave-2 console
+        # decomposition, task 1); calling it here keeps this method one line
+        # per subsystem, matching `_dictation.teardown()` below.
+        self._hands_free.teardown()
         # Same abandon-teardown discipline for the realtime loop, one step
         # further: its resources are OS-level (an open microphone, a live
         # WebSocket, an audio device stream), so they are actually released

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass, replace
+from dataclasses import dataclass, replace
 import asyncio
 from functools import partial
 import inspect
@@ -72,6 +72,13 @@ from ..Console_Modules.hands_free import (
 from ..Console_Modules.left_rail import ConsoleLeftRail
 from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ..Console_Modules.workspace import ConsoleWorkspaceController
+from ..Console_Modules.session import (
+    ConsoleSessionController,
+    _canonical_card_character_id,
+    _character_session_prompt_seed,
+    _has_selected_text,
+    _is_empty_select_value,
+)
 from ...Chat.chat_persistence_service import ChatPersistenceService
 from ...Chat.citation_trace_repository import ActiveCitationTraceState
 from ...Chat.console_chat_controller import ConsoleChatController
@@ -144,7 +151,6 @@ from ...Chat.console_prefill import (
     ACTION_STATUS,
     describe_prefill_preview,
     parse_prefill_args,
-    pinned_prefill_from_conversation_metadata,
 )
 from ...Chat.console_generate_image import (
     GenerationRefusal,
@@ -169,7 +175,6 @@ from ...Chat.console_skill_resolver import (
 from ...Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
     CONSOLE_RUN_MARKER_GLYPHS,
-    DEFAULT_CONSOLE_SESSION_TITLE,
     ConsoleChatMessage,
     ConsoleContextSnapshot,
     ConsoleMessageRole,
@@ -411,7 +416,6 @@ from ...Widgets.Console import (
     ConsoleEditMessageModal,
     ConsoleEditResult,
     ConsoleRailHandle,
-    ConsoleRenameSessionModal,
     ConsoleRetrievalScopeRow,
     ConsoleRunInspector,
     ConsoleSaveAsModal,
@@ -516,7 +520,6 @@ from ...Widgets.destination_rail import (
 )
 from ...Widgets.Console.console_session_switcher_modal import (
     ConsoleSessionSwitcherModal,
-    ConsoleSwitcherChoice,
 )
 from ...Widgets.Console.console_rewind_modal import (
     ConsoleRewindChoice,
@@ -1153,146 +1156,6 @@ def _console_workbench_agents_notes(max_parallel_runs: int) -> tuple[str, ...]:
     )
 
 
-def _is_empty_select_value(value: Any) -> bool:
-    """Return True for Textual's blank/null select sentinels."""
-    return value is None or value == Select.BLANK or str(value).startswith("Select.")
-
-
-_MAX_CANONICAL_CHARACTER_ID = (1 << 63) - 1
-_MAX_CANONICAL_CHARACTER_ID_TEXT = str(_MAX_CANONICAL_CHARACTER_ID)
-_CANONICAL_CHARACTER_ID_PATTERN = re.compile(r"[1-9][0-9]{0,18}")
-_SERVER_CHARACTER_AUTHORITY_PATTERN = re.compile(r"server-user-v1:[0-9a-f]{64}")
-
-
-def _canonical_character_id_text(value: Any) -> str | None:
-    """Return an exact signed-64 positive decimal wire ID."""
-    if type(value) is not str:
-        return None
-    if _CANONICAL_CHARACTER_ID_PATTERN.fullmatch(value) is None:
-        return None
-    if (
-        len(value) == len(_MAX_CANONICAL_CHARACTER_ID_TEXT)
-        and value > _MAX_CANONICAL_CHARACTER_ID_TEXT
-    ):
-        return None
-    return value
-
-
-def _canonical_card_character_id(value: Any) -> int | None:
-    """Return a canonical signed-64 positive ID from a card response."""
-    if type(value) is int:
-        return value if 1 <= value <= _MAX_CANONICAL_CHARACTER_ID else None
-    value_text = _canonical_character_id_text(value)
-    return int(value_text) if value_text is not None else None
-
-
-def _character_session_identity_from_handoff(
-    payload: ChatHandoffPayload,
-) -> tuple[str, int, str, str] | None:
-    """Return character session identity for Personas Start Chat handoffs.
-
-    Args:
-        payload: Handoff payload staged by a source screen.
-
-    Returns:
-        A tuple of `(runtime_backend, character_id, character_name,
-        assistant_id)` when the payload represents a source-aware Personas
-        character Start Chat handoff; otherwise `None`.
-    """
-    metadata = payload.metadata
-    if not isinstance(metadata, Mapping):
-        return None
-    if (
-        payload.source != "personas"
-        or payload.item_type != "character-card"
-        or metadata.get("intent") != "start_chat"
-        or metadata.get("selected_kind") != "character"
-    ):
-        return None
-    runtime_backend = payload.runtime_backend
-    if runtime_backend not in {"local", "server"}:
-        return None
-    if (
-        payload.source_owner != runtime_backend
-        or payload.source_selector_state != runtime_backend
-        or metadata.get("backend") != runtime_backend
-    ):
-        return None
-
-    character_id_text = _canonical_character_id_text(metadata.get("selected_record_id"))
-    if character_id_text is None:
-        return None
-    if (
-        metadata.get("selected_target_id")
-        != f"{runtime_backend}:character:{character_id_text}"
-    ):
-        return None
-
-    character_id = int(character_id_text)
-    character_name = str(metadata.get("selected_name") or payload.title or "").strip()
-    return runtime_backend, character_id, character_name, character_id_text
-
-
-def _character_session_prompt_seed(
-    card: Mapping[str, Any], name_hint: str = ""
-) -> tuple[str, str, str]:
-    """Return ``(name, system_prompt, greeting)`` seeded from a character card.
-
-    Joins the card's prompt-bearing fields into the Console session's system
-    prompt and picks the seeded greeting from ``first_message``.
-
-    task-1744: the join itself (field order, labels, and macro resolution)
-    is ``Character_Chat_Lib.compose_character_card_text`` -- the same
-    function the character-probe eval engine uses
-    (``Evals.character_probe.prompt.compose_system_prompt``), so a probe run
-    predicts exactly what this seeds into a real Console session. This
-    includes ``message_example`` and ``post_history_instructions``, which
-    Console did not send before task-1744; that is a deliberate,
-    user-visible change to every character session's system prompt, not an
-    incidental refactor.
-
-    Args:
-        card: The character card record.
-        name_hint: Fallback display name when the card has none.
-
-    Returns:
-        The character name, session system prompt, and greeting text.
-    """
-    # Local import matches this module's existing convention of deferring
-    # Character_Chat submodule imports (they pull in Pillow and
-    # CharactersRAGDB) rather than importing them at module scope.
-    from ...Character_Chat.Character_Chat_Lib import (
-        compose_character_card_text,
-        replace_placeholders,
-    )
-
-    name = str(card.get("name") or name_hint or "").strip() or "Character"
-    # Cards are written against SillyTavern-style macros; compose_character_card_text
-    # resolves {{char}}/{{user}} (and aliases) before the text reaches
-    # session settings, or they leak verbatim into every provider payload
-    # (task-1530). "User" matches the greeting-display substitution used
-    # across the Personas surfaces. A card with no prompt-bearing text at
-    # all falls back to a fixed instruction -- Console, not the shared
-    # composer, owns that fallback, since it is not meaningful to the eval
-    # engine's own empty-card handling (an intentionally blank system
-    # message, see compose_system_prompt).
-    system_prompt = (
-        compose_character_card_text(
-            name=name,
-            system_prompt=str(card.get("system_prompt") or ""),
-            personality=str(card.get("personality") or ""),
-            description=str(card.get("description") or ""),
-            scenario=str(card.get("scenario") or ""),
-            message_example=str(card.get("message_example") or ""),
-            post_history_instructions=str(card.get("post_history_instructions") or ""),
-            user_name="User",
-        )
-        or "Stay in character."
-    )
-    greeting = replace_placeholders(str(card.get("first_message") or ""), name, "User")
-    return name, system_prompt, greeting
-
-
 def character_avatar_box(available_cols: int) -> tuple[int, int]:
     """Avatar box (cols, lines) for a rail of ``available_cols`` width.
 
@@ -1500,19 +1363,6 @@ def _apply_console_message_attachments(
     message.attachment_label = (
         first.display_name if first and first.display_name else None
     )
-
-
-def _has_selected_text(value: Any) -> bool:
-    """Return whether a provider/model value is meaningfully selected.
-
-    Args:
-        value: Value from Textual select state or app/default configuration.
-
-    Returns:
-        True when the value is not an empty Textual select sentinel and has
-        non-whitespace text.
-    """
-    return not _is_empty_select_value(value) and bool(str(value).strip())
 
 
 def _run_dictionary_summary_off_thread(
@@ -1930,7 +1780,7 @@ class ChatScreen(BaseAppScreen):
 
     async def _open_console_settings(self, *, focus_model: bool = False) -> None:
         """Open Console session settings for the active native session."""
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
         controller = self._ensure_console_chat_controller()
         modal = ConsoleSettingsModal(
             settings=settings,
@@ -1949,7 +1799,7 @@ class ChatScreen(BaseAppScreen):
                 return
             # Modal results are explicit user selections; mark them so stale
             # default refresh never overrides them.
-            self._replace_active_console_session_settings(
+            self._session._replace_active_console_session_settings(
                 replace(result, source="user")
             )
             self.run_worker(
@@ -1984,7 +1834,7 @@ class ChatScreen(BaseAppScreen):
         event.stop()
         action_id = event.action_id
         if action_id == "new-tab":
-            await self._create_native_console_session_from_active_context()
+            await self._session._create_native_console_session_from_active_context()
         elif action_id == "settings":
             await self._open_console_settings(focus_model=False)
         elif action_id == "attach-context":
@@ -2176,51 +2026,6 @@ class ChatScreen(BaseAppScreen):
         """Clear Console Workbench shortcuts from this screen's own footer."""
         self.clear_footer_shortcuts(source="console")
 
-    def _open_console_session_rename_modal(self, session_id: str) -> None:
-        """Open a modal for viewing and editing the active Console tab title."""
-        store = self._ensure_console_chat_store()
-        session = next(
-            (candidate for candidate in store.sessions() if candidate.id == session_id),
-            None,
-        )
-        if session is None:
-            self.app_instance.notify(
-                "Console tab is no longer available.", severity="error"
-            )
-            return
-
-        def _apply_rename(result: str | None) -> None:
-            if result is None:
-                return
-            try:
-                _renamed, persisted = store.rename_session(session_id, result)
-            except ValueError as exc:
-                self.app_instance.notify(str(exc), severity="warning")
-                return
-            except KeyError:
-                self.app_instance.notify(
-                    "Console tab is no longer available.", severity="error"
-                )
-                return
-            if not persisted:
-                self.app_instance.notify(
-                    "Renamed this tab, but saving the conversation title "
-                    "failed — the stored conversation keeps its old name.",
-                    severity="warning",
-                )
-            # TASK-251: a renamed session's persisted conversation title
-            # must appear in the browser on the very next sync.
-            self._invalidate_console_persisted_rows_cache()
-            self.run_worker(
-                self._sync_native_console_chat_ui(),
-                exclusive=True,
-                group="console-sync",
-            )
-
-        self.app.push_screen(
-            ConsoleRenameSessionModal(title=session.title),
-            callback=_apply_rename,
-        )
 
     def action_open_console_session_switcher(self) -> None:
         """Open the Ctrl+K fuzzy session switcher."""
@@ -2234,14 +2039,14 @@ class ChatScreen(BaseAppScreen):
         rows.extend(persisted_rows)
         self.app.push_screen(
             ConsoleSessionSwitcherModal(rows=tuple(rows)),
-            callback=self._apply_console_switcher_choice,
+            callback=self._session._apply_console_switcher_choice,
         )
 
     async def action_open_console_model_popover(self) -> None:
         """Open the Alt+M quick provider/model/temperature/streaming popover."""
         if self._console_setup_modal_blocking():
             return
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
         providers_models = await self._providers_models_for_console_settings(
             settings.provider,
             current_model=settings.model,
@@ -2265,7 +2070,7 @@ class ChatScreen(BaseAppScreen):
             self.run_worker(self._open_console_settings(), exclusive=False)
             return
         # Popover results are explicit user selections; protect from refresh.
-        self._replace_active_console_session_settings(replace(result, source="user"))
+        self._session._replace_active_console_session_settings(replace(result, source="user"))
 
     def action_focus_console_composer_home(self) -> None:
         """Return keyboard focus to the Console composer (Escape, non-priority).
@@ -2288,7 +2093,7 @@ class ChatScreen(BaseAppScreen):
         if self._console_setup_modal_blocking():
             return
         self.run_worker(
-            self._create_native_console_session_from_active_context(), exclusive=False
+            self._session._create_native_console_session_from_active_context(), exclusive=False
         )
 
     def action_new_temporary_console_tab(self) -> None:
@@ -2308,7 +2113,7 @@ class ChatScreen(BaseAppScreen):
         if self._console_setup_modal_blocking():
             return
         self.run_worker(
-            self._create_native_console_session_from_active_context(ephemeral=True),
+            self._session._create_native_console_session_from_active_context(ephemeral=True),
             exclusive=False,
         )
 
@@ -2451,133 +2256,8 @@ class ChatScreen(BaseAppScreen):
         sessions = store.sessions()
         if not (1 <= number <= len(sessions)):
             return
-        await self._activate_native_console_session(sessions[number - 1].id)
+        await self._session._activate_native_console_session(sessions[number - 1].id)
 
-    async def _activate_native_console_session(self, session_id: str) -> None:
-        """Activate a native Console session through the shared activation sequence.
-
-        Set the active workspace, switch the native session, refresh the
-        retrieval-scope display, await the UI sync, then force composer
-        focus. Shared by the session-tab click handler, the Ctrl+K switcher
-        callback, and Alt+1..9 tab-jump so all three entry points follow
-        one activation path.
-
-        Args:
-            session_id: Native Console session id to activate.
-        """
-        controller = self._ensure_console_chat_controller()
-        if controller.store.active_session_id != session_id:
-            self._capture_console_draft_switch_snapshot()
-            self._note_console_follow_intent()
-            self._workspace._set_active_workspace_for_console_session(session_id)
-            controller.switch_session(session_id)
-            # Finding C: a sub-agent drill-in is scoped to the conversation
-            # active when the user drilled in -- clear it immediately on
-            # switch here (the shared activation path for tab clicks,
-            # Ctrl+K, and Alt+1..9) rather than rely solely on the rail
-            # render path's own defensive re-check on the next sync.
-            self._console_agent_drilldown_run_id = None
-            # Task-13 review finding 2: this path activates an ALREADY-
-            # resumed native session (unlike `_resume_console_workspace_
-            # conversation`, which warms the cache itself), so `_console_
-            # effective_scope_cache` may hold a stale entry -- e.g. a
-            # workspace-scope edit made via `_apply_console_workspace_
-            # scope_save` while a DIFFERENT session's tab was active only
-            # refreshes that other (active) session's row/chip. Without
-            # this call the row/chip would keep rendering the stale
-            # snapshot indefinitely: recompose reads the cache, never the
-            # DB (`_build_console_retrieval_scope_state`'s own contract).
-            new_session = self._active_native_console_session()
-            if new_session is not None:
-                try:
-                    await self._refresh_console_effective_scope_and_sync(new_session)
-                except Exception:
-                    logger.opt(exception=True).warning(
-                        "Failed to refresh retrieval scope display on session "
-                        "activation: {}",
-                        session_id,
-                    )
-            await self._sync_native_console_chat_ui()
-        self._focus_console_composer_if_needed(force=True)
-
-    async def _apply_console_switcher_choice(
-        self, choice: ConsoleSwitcherChoice | None
-    ) -> None:
-        """Apply a switcher selection through the shared native-session activation helper.
-
-        Mirrors the session-tab click handler and Alt+1..9 tab-jump: all three
-        call ``_activate_native_console_session`` so there is one activation
-        sequence (set workspace, switch, sync UI, focus composer) shared
-        across Console session-selection entry points.
-
-        Args:
-            choice: Switcher result, or ``None`` if the switcher was cancelled.
-        """
-        if choice is None:
-            return
-        entry = choice.entry
-        if choice.kind == "rename" and entry.native_session_id:
-            self._open_console_session_rename_modal(entry.native_session_id)
-            return
-        if choice.kind != "activate":
-            return
-        if entry.native_session_id:
-            await self._activate_native_console_session(entry.native_session_id)
-            return
-        if entry.conversation_id:
-            resumed = await self._workspace._resume_console_workspace_conversation(
-                entry.conversation_id,
-                target_scope_type=entry.scope_type or None,
-                target_workspace_id=entry.workspace_id,
-            )
-            if resumed is False:
-                # TASK-717: record missing - same honest feedback and broken
-                # marking as the rail row path (resume no longer self-toasts
-                # for this failure class).
-                self._mark_console_conversation_row_broken(entry.conversation_id)
-                self.app_instance.notify(
-                    "This saved conversation could not be loaded - "
-                    "its record is missing.",
-                    severity="warning",
-                )
-
-    async def _create_native_console_session_from_active_context(
-        self, *, ephemeral: bool = False
-    ) -> None:
-        """Create and focus a native Console session in the active workspace context.
-
-        Args:
-            ephemeral: Create the session temporary (never saved locally).
-        """
-        # TASK-339: new_session activates the fresh session inline; snapshot
-        # first so the deferred draft swap attributes settle-window typing
-        # to the new tab instead of clobbering it.
-        self._capture_console_draft_switch_snapshot()
-        self._ensure_console_chat_controller().new_session(
-            settings=(
-                self._active_console_session_settings()
-                or self._default_console_session_settings()
-            ),
-            ephemeral=ephemeral,
-        )
-        # TASK-251: new-chat-tab handler -- invalidate so the browser's
-        # "selected" row indicator picks up the new active session promptly.
-        self._invalidate_console_persisted_rows_cache()
-        await self._sync_native_console_chat_ui()
-        # Task-7: this is the shared activation path for every "new session"
-        # entry point (plain Ctrl+T, "New Temporary" via the palette/tab-strip
-        # button, and the other internal callers below) --
-        # `_sync_native_console_chat_ui()` above
-        # never touches `#console-temporary-chip` (same reason it never
-        # touches the scope chip; see `_sync_console_retrieval_scope_row`).
-        # Without this push a freshly created temporary tab would render
-        # with no marker at all until some unrelated event (a tab switch
-        # away and back) happened to resync it -- the chip's entire purpose
-        # is to be visible the moment the tab exists. It also clears a
-        # stale "Temporary" chip left over when a new ordinary chat is
-        # created right after a temporary one.
-        self._sync_console_temporary_chip()
-        self._focus_console_composer_if_needed(force=True)
 
     @on(Button.Pressed, "#console-change-workspace")
     def on_console_change_workspace(self, event: Button.Pressed) -> None:
@@ -2705,9 +2385,6 @@ class ChatScreen(BaseAppScreen):
         #: on the SAME task) can resolve which session's stash entry above
         #: is its own, without changing that hook's public no-arg contract.
         self._console_submit_session_by_task: dict[asyncio.Task, str] = {}
-        # TASK-339: (visible session id, draft text, edit serial) captured at
-        # switch initiation; consumed by the deferred draft swap.
-        self._console_draft_switch_snapshot: tuple[str | None, str, int] | None = None
         self._console_agent_bridge: Any | None = None
         # TASK-1141: round/request ids (namespaced "mcp:<round_id>" /
         # "install:<request_id>" / "script:<request_id>") this screen has
@@ -2797,10 +2474,10 @@ class ChatScreen(BaseAppScreen):
             chat_store_accessor=lambda: self._ensure_console_chat_store(),
             current_chat_store_accessor=lambda: self._console_chat_store,
             current_conversation_id_accessor=(
-                lambda: self._current_console_conversation_id()
+                lambda: self._session._current_console_conversation_id()
             ),
             native_session_rows_accessor=(
-                lambda state: self._with_native_console_session_rows(state)
+                lambda state: self._session._with_native_console_session_rows(state)
             ),
             conversation_browser_state_accessor=(
                 lambda state, current_conversation_id: (
@@ -2810,19 +2487,19 @@ class ChatScreen(BaseAppScreen):
                 )
             ),
             capture_draft_switch_snapshot=(
-                lambda: self._capture_console_draft_switch_snapshot()
+                lambda: self._session._capture_console_draft_switch_snapshot()
             ),
             sync_chat_core_state=lambda: self._sync_console_chat_core_state(),
             sync_native_console_chat_ui=lambda: self._sync_native_console_chat_ui(),
             sync_temporary_chip=lambda: self._sync_console_temporary_chip(),
             default_session_settings_accessor=(
-                lambda: self._default_console_session_settings()
+                lambda: self._session._default_console_session_settings()
             ),
             scope_picker_listers_accessor=(
                 lambda: self._console_scope_picker_listers()
             ),
             active_native_session_accessor=(
-                lambda: self._active_native_console_session()
+                lambda: self._session._active_native_console_session()
             ),
             refresh_effective_scope_and_sync=(
                 lambda session: self._refresh_console_effective_scope_and_sync(
@@ -2833,7 +2510,7 @@ class ChatScreen(BaseAppScreen):
                 lambda tree: self._console_messages_from_conversation_tree(tree)
             ),
             session_settings_for_resume_accessor=(
-                lambda conversation: self._console_session_settings_for_resume(
+                lambda conversation: self._session._console_session_settings_for_resume(
                     conversation
                 )
             ),
@@ -2873,19 +2550,97 @@ class ChatScreen(BaseAppScreen):
         ] = ()
         self._console_conversation_browser_total: int | None = None
         self._console_conversation_browser_error = ""
-        self._console_visible_draft_session_id: str | None = None
-        # TASK-1281: composer undo/redo history, scoped per Console session.
-        # Exported (`ConsoleComposerBar.export_undo_history`) on switch-away
-        # and restored on switch-in inside `_sync_console_session_draft`, so
-        # Ctrl+Z/Ctrl+Shift+Z in one session's tab never sees or touches
-        # another session's edits. Entries are dropped when a tab is
-        # explicitly closed (see the `console-close-session-tab-` button
-        # handler); a session that goes away some other way (e.g. a full
-        # `restore_state` rehydration) leaves a stale, unreachable entry
-        # here rather than being actively pruned -- bounded by how many
-        # distinct session ids this screen instance has ever shown a
-        # composer for, same tradeoff as the other per-session caches above.
-        self._console_undo_histories: dict[str, ConsoleComposerUndoHistory] = {}
+        #: Native session lifecycle -- start/activate/swap/promote/rename,
+        #: per-session settings, the Ctrl+K switcher's choice handling,
+        #: draft sync, and one-session (de)serialization -- moved to
+        #: `ConsoleSessionController` (wave-2 console decomposition, task 3).
+        #: `self._console_visible_draft_session_id`/`_console_undo_histories`
+        #: stay readable/writable via the two proxy properties defined near
+        #: `_console_composer_or_none`, so nothing outside this cluster
+        #: (screen-state (de)serialization, the submit path, `on_button_
+        #: pressed`'s tab-close branch, tests) had to change.
+        #: `_console_active_session_is_ephemeral` keeps a one-line
+        #: delegation instead of a proxy property (see that method's own
+        #: docstring: an external, non-controller consumer reaches it by
+        #: bare name off `self.screen`). See `session.py`'s module
+        #: docstring for the full map of what moved and why.
+        self._session = ConsoleSessionController(
+            self,
+            app_instance=self.app_instance,
+            chat_store_accessor=lambda: self._ensure_console_chat_store(),
+            current_chat_store_accessor=lambda: self._console_chat_store,
+            ensure_console_chat_controller=(
+                lambda: self._ensure_console_chat_controller()
+            ),
+            composer_accessor=lambda: self._console_composer_or_none(),
+            effective_console_provider_model=(
+                lambda: self._effective_console_provider_model()
+            ),
+            provider_readiness_app_config=(
+                lambda: self._provider_readiness_app_config()
+            ),
+            sync_native_console_chat_ui=lambda: self._sync_native_console_chat_ui(),
+            sync_chat_core_state=lambda: self._sync_console_chat_core_state(),
+            sync_temporary_chip=lambda: self._sync_console_temporary_chip(),
+            sync_settings_summary=lambda: self._sync_console_settings_summary(),
+            sync_control_bar=lambda: self._sync_console_control_bar(),
+            sync_command_popup=lambda: self._sync_console_command_popup(),
+            note_follow_intent=lambda: self._note_console_follow_intent(),
+            focus_composer_if_needed=(
+                lambda **kwargs: self._focus_console_composer_if_needed(**kwargs)
+            ),
+            invalidate_persisted_rows_cache=(
+                lambda: self._invalidate_console_persisted_rows_cache()
+            ),
+            mark_conversation_row_broken=(
+                lambda conversation_id: self._mark_console_conversation_row_broken(
+                    conversation_id
+                )
+            ),
+            refresh_effective_scope_and_sync=(
+                lambda session: self._refresh_console_effective_scope_and_sync(
+                    session
+                )
+            ),
+            # Session<->workspace seam (design spec: "a named callable
+            # between them; design it deliberately, never a back-door
+            # through the screen"). `self._workspace` was constructed just
+            # above; Python resolves it at CALL time inside these lambdas,
+            # so construction order does not matter.
+            set_active_workspace_for_session=(
+                lambda session_id: (
+                    self._workspace._set_active_workspace_for_console_session(
+                        session_id
+                    )
+                )
+            ),
+            resume_workspace_conversation=(
+                lambda conversation_id, **kwargs: (
+                    self._workspace._resume_console_workspace_conversation(
+                        conversation_id, **kwargs
+                    )
+                )
+            ),
+            workspace_initial_session_title=(
+                lambda workspace_id: (
+                    self._workspace._console_initial_session_title_for_workspace(
+                        workspace_id
+                    )
+                )
+            ),
+            merge_workspace_rows=(
+                lambda native_rows, rows: self._workspace._merge_console_workspace_rows(
+                    native_rows, rows
+                )
+            ),
+            session_id_for_workspace_conversation=(
+                lambda row_key: (
+                    self._workspace._console_session_id_for_workspace_conversation(
+                        row_key
+                    )
+                )
+            ),
+        )
         #: Dictation's own state and lifecycle moved to
         #: `ConsoleDictationController` (wave-1 console decomposition,
         #: task 5) -- this is wave 1's proof of the controller collaborator
@@ -3168,14 +2923,6 @@ class ChatScreen(BaseAppScreen):
     # never takes the fresh branch.
     _CONSOLE_LIVE_CONFIG_MARKER_SECTIONS = ("general", "logging")
 
-    # Readiness labels that stale-default session refresh may recover from:
-    # credential/endpoint gaps a Settings save can fix. Provider-identity
-    # blockers (Unknown/Pending WIP providers) are deliberate choices and are
-    # never auto-replaced.
-    _CONSOLE_REFRESHABLE_BLOCKED_LABELS = frozenset(
-        {"Missing key", "Not ready", "Invalid URL", "Endpoint not saved"}
-    )
-
     def _provider_readiness_app_config(self) -> Any:
         """Return the freshest app config for provider-readiness checks.
 
@@ -3424,15 +3171,6 @@ class ChatScreen(BaseAppScreen):
         value = config.get(key, {})
         return value if isinstance(value, dict) else {}
 
-    def _active_console_session_settings(self) -> ConsoleSessionSettings | None:
-        """Return settings for the active native Console session, if one exists."""
-        store = self._console_chat_store
-        if store is None or store.active_session_id is None:
-            return None
-        try:
-            return store.session_settings(store.active_session_id)
-        except KeyError:
-            return None
 
     def _providers_models(self) -> dict[str, list[str]]:
         """Return configured provider/model options for Console settings."""
@@ -3523,115 +3261,6 @@ class ChatScreen(BaseAppScreen):
             "",
         )
 
-    def _default_console_session_settings(self) -> ConsoleSessionSettings:
-        """Build the default settings snapshot for a new native Console session."""
-        provider, model = self._effective_console_provider_model()
-        settings = build_default_console_session_settings(
-            self._provider_readiness_app_config(),
-            str(provider).strip() if _has_selected_text(provider) else None,
-            str(model).strip() if _has_selected_text(model) else None,
-        )
-        provider_key = provider_config_key(settings.provider)
-        return replace(
-            settings,
-            base_url=None
-            if provider_key in {"llama_cpp", "local_llamacpp"}
-            else settings.base_url,
-        )
-
-    def _ensure_active_console_session_settings(self) -> ConsoleSessionSettings:
-        """Ensure the active native Console session owns a settings snapshot."""
-        store = self._ensure_console_chat_store()
-        workspace_id = store.workspace_context.active_workspace_id
-        session = store.ensure_session(
-            title=self._workspace._console_initial_session_title_for_workspace(workspace_id),
-            workspace_id=workspace_id,
-            settings=self._default_console_session_settings(),
-        )
-        if session.settings is None:
-            settings = self._default_console_session_settings()
-            store.replace_session_settings(session.id, settings)
-            return settings
-        return self._maybe_refresh_stale_default_console_settings(store, session)
-
-    def _maybe_refresh_stale_default_console_settings(
-        self,
-        store: ConsoleChatStore,
-        session: ConsoleChatSession,
-    ) -> ConsoleSessionSettings:
-        """Re-derive default-sourced settings for blocked, never-used sessions.
-
-        First-run sessions snapshot template defaults (e.g. OpenAI without a
-        key) and that snapshot survives navigation via screen-state restore.
-        When the user then configures a working provider in Settings, an empty
-        session the user never explicitly configured must converge on the new
-        defaults instead of keeping the setup card blocked until restart
-        (task-177 live regression). Explicit selections (``source == "user"``),
-        sessions with any messages, and already-sendable settings are never
-        touched; stale defaults are only replaced when the re-derived defaults
-        are actually send-capable.
-        """
-        settings = session.settings
-        if settings is None:
-            settings = self._default_console_session_settings()
-            store.replace_session_settings(session.id, settings)
-            return settings
-        if getattr(settings, "source", "derived") == "user":
-            return settings
-        try:
-            if store.messages_for_session(session.id):
-                return settings
-        except KeyError:
-            return settings
-        app_config = self._provider_readiness_app_config()
-        current_readiness = build_console_settings_readiness(
-            settings, app_config=app_config
-        )
-        if current_readiness.native_send_supported:
-            return settings
-        if current_readiness.label not in self._CONSOLE_REFRESHABLE_BLOCKED_LABELS:
-            # Unknown/WIP providers are a provider *choice* problem, not a
-            # config-fixable credential/endpoint gap; never override choice.
-            return settings
-        fresh_defaults = self._default_console_session_settings()
-        if fresh_defaults == settings:
-            return settings
-        fresh_readiness = build_console_settings_readiness(
-            fresh_defaults,
-            app_config=app_config,
-        )
-        if not fresh_readiness.native_send_supported:
-            return settings
-        if settings.system_prompt:
-            # Carry forward an already-applied `/system` prompt across this
-            # config-driven refresh -- it is explicit user intent, not part
-            # of the provider/model "default" this refresh re-derives.
-            # `fresh_defaults.system_prompt` is always ``None`` (defaults
-            # never seed it), so without this guard a message-less session
-            # where the user ran `/system` before fixing a blocked provider
-            # in Settings would have its applied system prompt silently
-            # discarded on the very next settings read.
-            fresh_defaults = replace(
-                fresh_defaults, system_prompt=settings.system_prompt
-            )
-        store.replace_session_settings(session.id, fresh_defaults)
-        return fresh_defaults
-
-    def _replace_active_console_session_settings(
-        self,
-        settings: ConsoleSessionSettings,
-    ) -> None:
-        """Replace settings for only the active native Console session."""
-        store = self._ensure_console_chat_store()
-        workspace_id = store.workspace_context.active_workspace_id
-        session = store.ensure_session(
-            title=self._workspace._console_initial_session_title_for_workspace(workspace_id),
-            workspace_id=workspace_id,
-            settings=self._default_console_session_settings(),
-        )
-        store.replace_session_settings(session.id, settings)
-        self._sync_console_chat_core_state()
-        self._sync_console_settings_summary()
 
     def _configured_console_provider(
         self,
@@ -3734,7 +3363,7 @@ class ChatScreen(BaseAppScreen):
         """Consume one typed provider intent after the Console session is ready."""
         try:
             store = self._ensure_console_chat_store()
-            settings = self._ensure_active_console_session_settings()
+            settings = self._session._ensure_active_console_session_settings()
             session_id = store.active_session_id
             if session_id is None:
                 return False
@@ -3778,7 +3407,7 @@ class ChatScreen(BaseAppScreen):
 
     def current_console_provider_for_command(self) -> str | None:
         """Return the active session provider without creating a session."""
-        settings = self._active_console_session_settings()
+        settings = self._session._active_console_session_settings()
         if settings is None:
             return None
         return str(settings.provider or "").strip() or None
@@ -3787,7 +3416,7 @@ class ChatScreen(BaseAppScreen):
         self,
     ) -> ConsoleSettingsContextEstimate:
         """Return context usage for the active native Console settings snapshot."""
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
         workspace_context = self._workspace._current_console_workspace_context()
         staged_context_state = self._build_console_staged_context_state(
             self._pending_console_launch_context
@@ -3849,7 +3478,7 @@ class ChatScreen(BaseAppScreen):
             Tuple of ``(line_text, is_dim)`` -- ``is_dim`` is ``True`` for
             the unset ``"System: none"`` sentinel state.
         """
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
         line_text = build_console_rail_system_line(settings.system_prompt)
         # TASK-365: this rail line is clickable (opens the system-prompt editor)
         # but otherwise reads as inert label text like the Provider/Model lines
@@ -4356,7 +3985,7 @@ class ChatScreen(BaseAppScreen):
     def _build_console_provider_selection(self) -> ConsoleProviderSelection:
         """Return the effective native Console provider selection for sends."""
         app_config = self._provider_readiness_app_config()
-        selection_settings = self._ensure_active_console_session_settings()
+        selection_settings = self._session._ensure_active_console_session_settings()
         _legacy_provider, legacy_model = self._effective_console_provider_model()
         provider = provider_config_key(selection_settings.provider) or "llama_cpp"
         explicit_model = (
@@ -4425,7 +4054,7 @@ class ChatScreen(BaseAppScreen):
         self,
     ) -> tuple[str, str | None, ConsoleSessionSettings]:
         """Return provider/model labels backed by active session settings."""
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
         selection = self._build_console_provider_selection()
         legacy_provider, _legacy_model = self._effective_console_provider_model()
         provider_display = selection.provider
@@ -4441,7 +4070,7 @@ class ChatScreen(BaseAppScreen):
         self,
     ) -> tuple[ConsoleSessionSettings, ConsoleSettingsReadiness]:
         """Return effective settings plus Console-native readiness for display/send surfaces."""
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
         selection = self._build_console_provider_selection()
         selected_model = selection.explicit_model or selection.configured_model
         effective_settings = replace(
@@ -4893,7 +4522,7 @@ class ChatScreen(BaseAppScreen):
                 chat_dictionary_applier=self._console_chat_dictionary_applier,
                 world_info_applier=self._console_world_info_applier,
                 rag_capture_provider=self._capture_console_staged_rag,
-                default_session_settings=self._default_console_session_settings,
+                default_session_settings=self._session._default_console_session_settings,
             )
         self._console_chat_controller.on_submission_accepted = (
             self._on_console_submission_accepted
@@ -5319,6 +4948,25 @@ class ChatScreen(BaseAppScreen):
     def _console_workspace_conversation_search_error(self, value: str) -> None:
         self._workspace._console_workspace_conversation_search_error = value
 
+    #: Per-session draft bookkeeping moved to `ConsoleSessionController`
+    #: (wave-2 console decomposition, task 3). `self._console_visible_draft_
+    #: session_id`/`_console_undo_histories` stay readable/writable via
+    #: these two proxy properties under the ORIGINAL attribute names, so
+    #: `_serialize_native_console_state`/`_restore_native_console_state`,
+    #: `_submit_console_native_draft`/`_on_console_submission_accepted`, and
+    #: `on_button_pressed`'s tab-close branch -- none of them this
+    #: cluster's own -- needed no changes.
+    @property
+    def _console_visible_draft_session_id(self) -> str | None:
+        return self._session._console_visible_draft_session_id
+
+    @_console_visible_draft_session_id.setter
+    def _console_visible_draft_session_id(self, value: str | None) -> None:
+        self._session._console_visible_draft_session_id = value
+
+    @property
+    def _console_undo_histories(self) -> dict[str, ConsoleComposerUndoHistory]:
+        return self._session._console_undo_histories
 
     def _speak_status(self, text: str) -> None:
         """Speak a status/ack/error via TTS when spoken feedback is on and idle.
@@ -5447,7 +5095,7 @@ class ChatScreen(BaseAppScreen):
         if not action_id:
             return
         if action_id == ACTION_SAVE_CHAT:
-            self._dispatch_promote_console_temporary_session()
+            self._session._dispatch_promote_console_temporary_session()
             return
         if action_id == ACTION_PROMPTS:
             self._open_console_prompts_modal()
@@ -5497,7 +5145,7 @@ class ChatScreen(BaseAppScreen):
         composer = self._console_composer_or_none()
         if composer is None:
             return
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
         store = self._ensure_console_chat_store()
         session_id = store.active_session_id
         if session_id is None:
@@ -5559,7 +5207,7 @@ class ChatScreen(BaseAppScreen):
             return await method(mode=source, **payload)
 
         def _active_system_fingerprint() -> str:
-            live_settings = self._ensure_active_console_session_settings()
+            live_settings = self._session._ensure_active_console_session_settings()
             return fingerprint_text(str(live_settings.system_prompt or ""))
 
         def _resolution_identity(resolution: Any) -> tuple[str, str, str, str, str]:
@@ -5850,7 +5498,7 @@ class ChatScreen(BaseAppScreen):
                 return ConsolePromptsApplyOutcome(
                     "stale", "The active Console session changed."
                 )
-            live_settings = self._ensure_active_console_session_settings()
+            live_settings = self._session._ensure_active_console_session_settings()
             if str(live_settings.system_prompt or "") != str(result.system_text or ""):
                 return ConsolePromptsApplyOutcome(
                     "stale", "The live System prompt changed."
@@ -5889,94 +5537,6 @@ class ChatScreen(BaseAppScreen):
             callback=restore_focus,
         )
 
-    def _dispatch_promote_console_temporary_session(self) -> None:
-        """Kick off the temporary-chat save as its own worker (F5, final review).
-
-        Both entry points (the composer menu row and the Temporary chip)
-        land here, so the save behaves identically however it was reached,
-        and both stay non-blocking: ``promote_ephemeral_session`` runs one
-        DB transaction over every tree node including attachment BLOBs,
-        which can visibly freeze the TUI for a temporary chat with several
-        pasted images. ``group="console-promote"`` is its own family,
-        distinct from ``console-sync``/``console-run-*``/``console-
-        impersonate`` -- see ``Tests/UI/test_chat_screen_worker_groups.py``
-        for why an ungrouped (or wrongly-grouped) exclusive worker is not a
-        cosmetic bug on this screen: one already cancelled in-flight
-        Console sends on this branch. ``exclusive=True`` collapses a
-        double-activation (menu row AND chip clicked before the first save
-        lands) into one save rather than two overlapping transactions on
-        the same session.
-        """
-        self.run_worker(
-            self._promote_console_temporary_session(),
-            exclusive=True,
-            group="console-promote",
-        )
-
-    async def _promote_console_temporary_session(self) -> None:
-        """Save the active temporary chat, then refresh its marker and chip.
-
-        The actual store call is offloaded to a thread
-        (``asyncio.to_thread``) rather than run inline on the event loop --
-        see ``_dispatch_promote_console_temporary_session`` for why blocking
-        here is a real, user-visible freeze, not a theoretical one.
-        """
-        store = self._ensure_console_chat_store()
-        session_id = getattr(store, "active_session_id", None)
-        if not session_id:
-            return
-        try:
-            conversation_id = await asyncio.to_thread(
-                store.promote_ephemeral_session, session_id
-            )
-        except Exception:
-            logger.opt(exception=True).warning("Saving the temporary chat failed")
-            self.app_instance.notify(
-                "Could not save this chat. It is still temporary.",
-                severity="error",
-            )
-            return
-        if conversation_id is None:
-            # F6 (final review): every other outcome notifies -- a silent
-            # return here left the user with no feedback at all on "Save
-            # this chat". `promote_ephemeral_session` returns `None` for
-            # two different reasons (its own docstring): the session was
-            # already saved (idempotent, genuinely fine), or no
-            # persistence adapter is configured at all (the chat is still
-            # temporary and nothing happened) -- these read very
-            # differently to the user, so distinguish them rather than
-            # picking one generic sentence.
-            session = next((s for s in store.sessions() if s.id == session_id), None)
-            if session is not None and not session.ephemeral:
-                # A cancelled-then-retried promote worker lands here: the
-                # first (cancelled) run's `asyncio.to_thread` DB write still
-                # completed, so the session really is saved, but that first
-                # coroutine never reached the `_sync_console_temporary_chip()`
-                # call below. Without refreshing here too, the chip and the
-                # `◌` tab marker keep reading "Temporary" about a chat
-                # that is, in fact, saved -- exactly the mismatch this
-                # marker exists to prevent.
-                self._sync_console_temporary_chip()
-                self.app_instance.notify(
-                    "This chat is already saved.", severity="information"
-                )
-            else:
-                self.app_instance.notify(
-                    "Could not save this chat right now. It is still temporary.",
-                    severity="warning",
-                )
-            return
-        self._invalidate_console_persisted_rows_cache()
-        # `_sync_native_console_chat_ui()` below never touches the Temporary
-        # chip (see `_sync_console_temporary_chip`'s docstring: it is pushed
-        # explicitly at every session-creation/switch point, not folded into
-        # the general sync tick), so without this call the chip would keep
-        # showing "Temporary" on an already-saved conversation.
-        self._sync_console_temporary_chip()
-        self.run_worker(
-            self._sync_native_console_chat_ui(), exclusive=False, group="console-sync"
-        )
-        self.app_instance.notify("Chat saved.", severity="information")
 
     @on(ConsoleTemporaryChip.SaveRequested)
     def on_console_temporary_chip_save(
@@ -5984,7 +5544,7 @@ class ChatScreen(BaseAppScreen):
     ) -> None:
         """Save the temporary chat from its status chip."""
         event.stop()
-        self._dispatch_promote_console_temporary_session()
+        self._session._dispatch_promote_console_temporary_session()
 
     async def _open_console_generate_image_modal(self) -> None:
         """Collect image options, then paste the command into the draft."""
@@ -6355,7 +5915,7 @@ class ChatScreen(BaseAppScreen):
         # Bind the Console session ONCE, here: every continuity row this
         # loop writes goes to this id, never to a re-read `active_session_
         # id` (see `ConsoleRealtimeSession.console_session_id`).
-        self._ensure_active_console_session_settings()
+        self._session._ensure_active_console_session_settings()
         store = self._ensure_console_chat_store()
         console_session_id = store.active_session_id
         if not console_session_id:
@@ -6465,7 +6025,7 @@ class ChatScreen(BaseAppScreen):
         persona the moment the transport blips.
         """
         try:
-            settings = self._ensure_active_console_session_settings()
+            settings = self._session._ensure_active_console_session_settings()
         except Exception:  # noqa: BLE001 - a settings failure must not block voice
             logger.opt(exception=True).debug(
                 "Console realtime: could not read the session system prompt"
@@ -8414,24 +7974,6 @@ class ChatScreen(BaseAppScreen):
         """
         self._dictation._request_console_dictation_start()
 
-    def _capture_console_draft_switch_snapshot(self) -> None:
-        """Record the composer state at the moment a session switch begins.
-
-        TASK-339: the draft swap in ``_sync_console_session_draft`` can run
-        a settle-window later (coalesced syncs, slow resume loads). Anything
-        the user types in that window is intended for the NEW session; this
-        snapshot lets the swap attribute it correctly instead of saving it
-        to the old session and wiping it from the composer.
-        """
-        composer = self._console_composer_or_none()
-        if composer is None:
-            self._console_draft_switch_snapshot = None
-            return
-        self._console_draft_switch_snapshot = (
-            self._console_visible_draft_session_id,
-            composer.draft_text(),
-            composer.edit_serial,
-        )
 
     def _capture_console_transcript_reading_state(
         self,
@@ -8521,77 +8063,6 @@ class ChatScreen(BaseAppScreen):
         else:
             self._focus_console_workbench_target("console-native-composer")
 
-    def _sync_console_session_draft(self) -> None:
-        """Reconcile the composer draft with the active runtime Console session.
-
-        Saves the visible draft back to the session that owns it, then loads
-        the active session's draft when the active session changed. Runs
-        inside the native Console sync pass so session transitions cannot
-        lose drafts. Keystrokes typed between switch initiation (see
-        ``_capture_console_draft_switch_snapshot``) and this swap carry
-        forward into the new session, in order (TASK-339).
-        """
-        store = self._ensure_console_chat_store()
-        session = store.ensure_session(
-            title=self._workspace._console_initial_session_title_for_workspace(
-                store.workspace_context.active_workspace_id
-            ),
-            workspace_id=store.workspace_context.active_workspace_id,
-            settings=self._default_console_session_settings(),
-        )
-        active_session_id = session.id
-        composer = self._console_composer_or_none()
-        if composer is None:
-            return
-        visible_session_id = self._console_visible_draft_session_id
-        if visible_session_id == active_session_id:
-            if visible_session_id is not None:
-                try:
-                    store.set_session_draft(visible_session_id, composer.draft_text())
-                except KeyError:
-                    pass
-            return
-        snapshot = self._console_draft_switch_snapshot
-        self._console_draft_switch_snapshot = None
-        live_text = composer.draft_text()
-        save_text = live_text
-        typed_suffix = ""
-        if snapshot is not None and snapshot[0] == visible_session_id:
-            snap_text, snap_serial = snapshot[1], snapshot[2]
-            if composer.edit_serial != snap_serial and live_text.startswith(snap_text):
-                # User typed during the settle window: the old session keeps
-                # what it actually had at the keypress; the new typing rides
-                # into the new session below. (Non-append edits — e.g.
-                # backspacing into the old draft — fall back to today's
-                # save-the-live-text semantics.)
-                save_text = snap_text
-                typed_suffix = live_text[len(snap_text) :]
-        if visible_session_id is not None:
-            try:
-                store.set_session_draft(visible_session_id, save_text)
-            except KeyError:
-                pass
-            # TASK-1281: this composer is about to start showing a DIFFERENT
-            # session's draft -- bank its undo/redo history under the
-            # session it actually belongs to before the swap below discards
-            # it, so a later switch back can restore it.
-            self._console_undo_histories[visible_session_id] = (
-                composer.export_undo_history()
-            )
-        try:
-            composer.load_draft(store.session_draft(active_session_id))
-        except KeyError:
-            composer.clear_draft()
-        # TASK-1281: restore (or start fresh) BEFORE re-inserting any
-        # settle-window keystrokes below, so those keystrokes land in --
-        # and are recorded onto -- the session they actually typed into.
-        composer.restore_undo_history(
-            self._console_undo_histories.get(active_session_id)
-        )
-        if typed_suffix:
-            composer.insert_text(typed_suffix)
-        self._sync_console_command_popup()
-        self._console_visible_draft_session_id = active_session_id
 
     def _build_console_control_state(
         self,
@@ -8599,7 +8070,7 @@ class ChatScreen(BaseAppScreen):
     ) -> ConsoleControlState:
         """Build Console-owned control/readiness labels."""
         provider, model, settings = self._active_console_provider_model_display()
-        active_session = self._active_native_console_session()
+        active_session = self._session._active_native_console_session()
         source = pending_launch.source if pending_launch else None
         return ConsoleControlState.from_values(
             provider=provider,
@@ -8639,7 +8110,7 @@ class ChatScreen(BaseAppScreen):
         missing chip is fine, a broken send is not.
         """
         try:
-            session = self._active_native_console_session()
+            session = self._session._active_native_console_session()
             store = self._console_chat_store
             if session is None or store is None:
                 self._console_cost_cache_state = ConsoleCacheState.NONE
@@ -8873,7 +8344,7 @@ class ChatScreen(BaseAppScreen):
             effective state yet, or a persisted session whose conversation
             id has not yet been resolved into the cache.
         """
-        session = self._active_native_console_session()
+        session = self._session._active_native_console_session()
         if session is None:
             return ConsoleRetrievalScopeState.unscoped()
         cache_key = session.persisted_conversation_id or session.id
@@ -9024,7 +8495,7 @@ class ChatScreen(BaseAppScreen):
         the same one-time guard every other warmer relies on -- so this
         adds no repeated DB work.
         """
-        session = self._active_native_console_session()
+        session = self._session._active_native_console_session()
         if session is None or session.persisted_conversation_id is None:
             return
         cache_key = session.persisted_conversation_id
@@ -9099,7 +8570,7 @@ class ChatScreen(BaseAppScreen):
         workspace's scope. No workspace scope set -> ``universe=None``
         (today's full-library behavior, byte-identical).
         """
-        session = self._active_native_console_session()
+        session = self._session._active_native_console_session()
         if session is None:
             return
         conversation_id = session.persisted_conversation_id
@@ -9161,7 +8632,7 @@ class ChatScreen(BaseAppScreen):
 
     async def _clear_console_retrieval_scope(self) -> None:
         """Clear the active Console session's RAG retrieval scope."""
-        session = self._active_native_console_session()
+        session = self._session._active_native_console_session()
         if session is None:
             return
         await self._apply_console_retrieval_scope_save(session, None)
@@ -9512,7 +8983,7 @@ class ChatScreen(BaseAppScreen):
             # discarded, leaving the new chat on the default prompt. Mirror
             # the Start-Chat path, which seeds it into the session settings.
             settings = replace(
-                self._default_console_session_settings(),
+                self._session._default_console_session_settings(),
                 system_prompt=system_prompt,
             )
             session = store.create_session(
@@ -9546,7 +9017,7 @@ class ChatScreen(BaseAppScreen):
             self._sync_console_temporary_chip()
             self.app.notify(f"Started a new chat with {name}.")
         else:
-            if not self._swap_console_session_character(
+            if not self._session._swap_console_session_character(
                 store, choice.character_id, name, system_prompt, greeting
             ):
                 return
@@ -9556,83 +9027,6 @@ class ChatScreen(BaseAppScreen):
         await self._sync_native_console_chat_ui()
         await self._refresh_active_character_avatar_if_scope_changed()
 
-    def _swap_console_session_character(
-        self,
-        store: Any,
-        character_id: int,
-        name: str,
-        system_prompt: str,
-        greeting: str,
-    ) -> bool:
-        """Rebind the active session to ``character_id`` in place.
-
-        The greeting is only seeded into an EMPTY chat (user decision,
-        2026-07-31): interrupting a conversation in progress with a
-        greeting reads as the model talking to itself.
-
-        Args:
-            store: The Console chat store.
-            character_id: The picked character's local id.
-            name: Display name for the session/chip.
-            system_prompt: The card's macro-resolved system prompt, which
-                must reach the session settings or the model keeps talking
-                as the previous character (cubic PR #1153 P1).
-            greeting: The card's greeting, seeded only into an empty chat.
-
-        Returns:
-            True when the active session was rebound.
-        """
-        session_id = getattr(store, "active_session_id", None)
-        session = None
-        if session_id:
-            session = next((s for s in store.sessions() if s.id == session_id), None)
-        if session is None:
-            return False
-        for field, value in (
-            ("runtime_backend", "local"),
-            ("assistant_kind", "character"),
-            ("assistant_id", str(character_id)),
-            ("assistant_authority_id", None),
-            ("character_id", character_id),
-            ("character_name", name),
-        ):
-            try:
-                object.__setattr__(session, field, value)
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Character swap: could not set {}.", field
-                )
-                return False
-        current_settings = store.session_settings(session_id)
-        if current_settings is not None:
-            store.replace_session_settings(
-                session_id, replace(current_settings, system_prompt=system_prompt)
-            )
-        if greeting and not store.messages_for_session(session_id):
-            try:
-                store.append_message(
-                    session_id,
-                    role=ConsoleMessageRole.ASSISTANT,
-                    content=greeting,
-                    persist=True,
-                )
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Character swap: greeting seed failed; continuing."
-                )
-        # cubic PR #1153 P2: an already-saved conversation kept the old
-        # prompt after reload because the swap only touched memory.
-        conversation_id = getattr(session, "persisted_conversation_id", None)
-        if conversation_id:
-            try:
-                store.update_conversation_system_prompt(
-                    conversation_id=conversation_id, system_prompt=system_prompt
-                )
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Character swap: persisting the system prompt failed."
-                )
-        return True
 
     @on(ConsoleScopeChip.OpenRequested)
     async def _console_scope_chip_activated(
@@ -9647,37 +9041,10 @@ class ChatScreen(BaseAppScreen):
         event.stop()
         await self._open_console_retrieval_scope_picker()
 
-    def _current_console_conversation_id(self) -> Optional[str]:
-        """Return the active conversation id for Console context highlighting."""
-        console_store = self._console_chat_store
-        active_session_id = (
-            console_store.active_session_id if console_store is not None else None
-        )
-        if console_store is not None and active_session_id is not None:
-            for console_session in console_store.sessions():
-                if console_session.id == active_session_id:
-                    conversation_id = console_session.persisted_conversation_id
-                    if conversation_id:
-                        return str(conversation_id)
-                    break
-        return None
-
-    def _active_native_console_session(self) -> Any | None:
-        """Return the active native Console session without creating the store."""
-        console_store = self._console_chat_store
-        active_session_id = (
-            console_store.active_session_id if console_store is not None else None
-        )
-        if console_store is None or active_session_id is None:
-            return None
-        for console_session in console_store.sessions():
-            if console_session.id == active_session_id:
-                return console_session
-        return None
 
     def _current_console_rail_conversation_id(self) -> Optional[str]:
         """Return the conversation scope used only for Console rail persistence."""
-        native_session = self._active_native_console_session()
+        native_session = self._session._active_native_console_session()
         if native_session is not None:
             conversation_id = getattr(
                 native_session,
@@ -9685,7 +9052,7 @@ class ChatScreen(BaseAppScreen):
                 None,
             )
             return str(conversation_id) if conversation_id else None
-        return self._current_console_conversation_id()
+        return self._session._current_console_conversation_id()
 
     def _current_console_rail_character_id(self) -> Optional[int]:
         """Active native Console session's character id (int), or None.
@@ -9694,14 +9061,14 @@ class ChatScreen(BaseAppScreen):
         DB-resume, and on screen-state restore); never from legacy
         ``app.current_chat_*`` reactives. None for a generic session.
         """
-        native_session = self._active_native_console_session()
+        native_session = self._session._active_native_console_session()
         if native_session is None:
             return None
         return native_session.local_character_id()
 
     def _current_console_rail_character_name(self) -> Optional[str]:
         """Active native Console session's character name, or None."""
-        native_session = self._active_native_console_session()
+        native_session = self._session._active_native_console_session()
         if native_session is None:
             return None
         name = getattr(native_session, "character_name", None)
@@ -10200,38 +9567,6 @@ class ChatScreen(BaseAppScreen):
                 message, list(message.attachments) + extras
             )
 
-    def _console_session_settings_for_resume(
-        self,
-        conversation: Mapping[str, Any],
-    ) -> ConsoleSessionSettings:
-        """Return settings for a resumed session, restoring its system prompt.
-
-        Every other field is inherited from the currently active session's
-        settings (or the config-derived defaults when there is none yet);
-        only ``system_prompt`` is overridden from the persisted conversation
-        row so a saved system prompt survives close/resume even though it is
-        never seeded from ``[chat_defaults]``.
-        """
-        settings = (
-            self._active_console_session_settings()
-            or self._default_console_session_settings()
-        )
-        raw_system_prompt = conversation.get("system_prompt")
-        # Only blank/whitespace-only text collapses to "no system prompt";
-        # anything else is restored verbatim (leading/trailing whitespace
-        # and internal formatting included) rather than stripped, so a
-        # formatting-sensitive prompt survives close/resume unchanged.
-        system_prompt = (
-            raw_system_prompt
-            if isinstance(raw_system_prompt, str) and raw_system_prompt.strip()
-            else None
-        )
-        pinned_prefill = pinned_prefill_from_conversation_metadata(
-            conversation.get("metadata")
-        )
-        return replace(
-            settings, system_prompt=system_prompt, pinned_prefill=pinned_prefill
-        )
 
     async def _resolve_resumed_character_name(self, character_id: int) -> str:
         """Return a resumed character's display name from its card, or ``""``.
@@ -10341,7 +9676,7 @@ class ChatScreen(BaseAppScreen):
             return
         self._sync_console_retrieval_scope_row()
         self._sync_console_control_bar()
-        session = self._active_native_console_session()
+        session = self._session._active_native_console_session()
         if session is not None and session.persisted_conversation_id == conversation_id:
             self.run_worker(
                 self._refresh_console_effective_scope_and_sync(session),
@@ -10434,43 +9769,6 @@ class ChatScreen(BaseAppScreen):
                         fallback = row
         return fallback
 
-    def _console_session_id_for_browser_row(
-        self,
-        row: ConsoleConversationBrowserRow,
-    ) -> str | None:
-        """Return an open session matching a grouped browser row's identity."""
-        store = self._console_chat_store
-        if store is None:
-            return None
-        native_session_id = str(row.native_session_id or "").strip()
-        if native_session_id:
-            if any(session.id == native_session_id for session in store.sessions()):
-                return native_session_id
-            return None
-        row_key = str(row.row_key or "").strip()
-        if row_key.startswith("native:"):
-            return self._workspace._console_session_id_for_workspace_conversation(row_key)
-        conversation_id = str(row.conversation_id or "").strip()
-        if not conversation_id:
-            return None
-        scope_type = str(row.scope_type or "").strip()
-        expected_workspace_id = (
-            CONSOLE_GLOBAL_WORKSPACE_ID
-            if scope_type == "global"
-            else str(row.workspace_id or "").strip()
-        )
-        fallback_session_id: str | None = None
-        for session in store.sessions():
-            if str(session.persisted_conversation_id or "").strip() != conversation_id:
-                continue
-            session_workspace_id = str(session.workspace_id or "").strip()
-            if expected_workspace_id and session_workspace_id == expected_workspace_id:
-                return session.id
-            if fallback_session_id is None:
-                fallback_session_id = session.id
-        if str(row.source_kind or "").strip() == "membership" and expected_workspace_id:
-            return None
-        return fallback_session_id
 
     @staticmethod
     def _console_browser_display_identity(
@@ -10589,9 +9887,9 @@ class ChatScreen(BaseAppScreen):
         labels = self._workspace._console_browser_workspace_labels()
         starred_ids = self._starred_console_conversation_ids()
         current_conversation = (
-            current_conversation_id or self._current_console_conversation_id()
+            current_conversation_id or self._session._current_console_conversation_id()
         )
-        active_session = self._active_native_console_session()
+        active_session = self._session._active_native_console_session()
         active_workspace_id = (
             str(active_session.workspace_id or "").strip()
             if active_session is not None
@@ -10686,7 +9984,7 @@ class ChatScreen(BaseAppScreen):
             total_count = 0
             saw_total = False
             saw_result = False
-            current_conversation = self._current_console_conversation_id()
+            current_conversation = self._session._current_console_conversation_id()
             starred_ids = self._starred_console_conversation_ids()
             for scope_type, workspace_id in scopes:
                 list_kwargs: dict[str, Any] = {
@@ -10898,7 +10196,7 @@ class ChatScreen(BaseAppScreen):
             saw_total = False
             saw_sync_result = False
             current_conversation = (
-                current_conversation_id or self._current_console_conversation_id()
+                current_conversation_id or self._session._current_console_conversation_id()
             )
             starred_ids = self._starred_console_conversation_ids()
             for scope_type, workspace_id in scopes:
@@ -11118,66 +10416,6 @@ class ChatScreen(BaseAppScreen):
         token = self._console_conversation_browser_search_token
         await self._refresh_console_conversation_browser_search(query, token)
 
-    def _with_native_console_session_rows(
-        self,
-        state: ConsoleWorkspaceContextState,
-    ) -> ConsoleWorkspaceContextState:
-        """Include active native Console sessions in the workspace rail.
-
-        The workspace registry only knows about conversations after durable
-        persistence links them. Native Console sessions are still user-visible
-        conversations and need to remain reachable from the rail while they are
-        open, including before the first persisted message exists.
-        """
-        store = self._console_chat_store
-        if store is None:
-            return state
-
-        active_workspace_id = str(
-            store.workspace_context.active_workspace_id or ""
-        ).strip()
-        active_session_id = store.active_session_id
-        rows = list(state.conversation_rows)
-        existing_ids = {str(row.conversation_id) for row in rows}
-        native_rows: list[ConsoleWorkspaceConversationRow] = []
-        for session in store.sessions():
-            session_workspace_id = str(session.workspace_id or "").strip()
-            selected = session.id == active_session_id
-            if (
-                active_workspace_id
-                and active_workspace_id != CONSOLE_GLOBAL_WORKSPACE_ID
-                and session_workspace_id != active_workspace_id
-                and not selected
-            ):
-                continue
-
-            conversation_id = (
-                str(session.persisted_conversation_id)
-                if session.persisted_conversation_id
-                else f"native:{session.id}"
-            )
-            if conversation_id in existing_ids:
-                continue
-
-            native_rows.append(
-                ConsoleWorkspaceConversationRow(
-                    conversation_id=conversation_id,
-                    title=session.title,
-                    status="active" if selected else "open",
-                    selected=selected,
-                )
-            )
-            existing_ids.add(conversation_id)
-
-        if not native_rows:
-            return state
-        native_rows.sort(key=lambda row: 0 if row.selected else 1)
-        return replace(
-            state,
-            conversation_rows=tuple(
-                self._workspace._merge_console_workspace_rows(native_rows, rows)
-            ),
-        )
 
     def _console_subagent_counts_refresh_needed(self, row_ids: frozenset) -> bool:
         """Decide whether the sub-agent badge-count cache needs a DB round trip.
@@ -11711,33 +10949,18 @@ class ChatScreen(BaseAppScreen):
         rail_state_config.pop(fallback_key, None)
         self._delete_console_rail_preference_keys([fallback_key])
 
-    def _current_console_session_id(self) -> Optional[str]:
-        """Return a durable external Console session scope when one is available."""
-        session_id = getattr(self.app_instance, "console_rail_session_id", None)
-        if session_id:
-            return str(session_id)
-        console_store = self._console_chat_store
-        if console_store is not None and console_store.active_session_id is not None:
-            return str(console_store.active_session_id)
-        return None
-
     def _console_active_session_is_ephemeral(self) -> bool:
         """Return whether the active Console session is temporary.
 
-        Public-API only (`sessions()` + `active_session_id`): the store has
-        no single-session getter that is not private. The scan is over open
-        tabs, so it is a handful of items.
+        One-line delegation (wave-2 console decomposition, task 3): kept on
+        `ChatScreen` under the original name because `Widgets/Console/
+        console_transcript.py`'s `_console_ephemeral_active` reaches it by
+        BARE NAME off `self.screen` (`getattr(screen,
+        "_console_active_session_is_ephemeral", None)`), not through this
+        controller. See `ConsoleSessionController._console_active_session_is_
+        ephemeral` for the real implementation.
         """
-        store = self._console_chat_store
-        if store is None:
-            return False
-        active_id = store.active_session_id
-        if not active_id:
-            return False
-        return any(
-            session.id == active_id and session.ephemeral
-            for session in store.sessions()
-        )
+        return self._session._console_active_session_is_ephemeral()
 
     def _sync_console_temporary_chip(self) -> None:
         """Push the active session's temporary flag to the status-strip chip.
@@ -11814,7 +11037,7 @@ class ChatScreen(BaseAppScreen):
         preference_key = build_console_rail_preference_key(
             workspace_id=workspace_context.active_workspace_id,
             conversation_id=self._current_console_rail_conversation_id(),
-            session_id=self._current_console_session_id(),
+            session_id=self._session._current_console_session_id(),
         )
         self._migrate_console_rail_fallback_preferences(
             preference_key.value,
@@ -12065,7 +11288,7 @@ class ChatScreen(BaseAppScreen):
         preference_key = build_console_rail_preference_key(
             workspace_id=workspace_context.active_workspace_id,
             conversation_id=self._current_console_rail_conversation_id(),
-            session_id=self._current_console_session_id(),
+            session_id=self._session._current_console_session_id(),
         )
         self._migrate_console_rail_fallback_preferences(
             preference_key.value,
@@ -13660,7 +12883,7 @@ class ChatScreen(BaseAppScreen):
         )
         if provider_config_key(settings.provider) in {"llama_cpp", "local_llamacpp"}:
             settings = replace(settings, base_url=None)
-        self._replace_active_console_session_settings(replace(settings, source="user"))
+        self._session._replace_active_console_session_settings(replace(settings, source="user"))
         self._sync_console_transcript_guidance()
         self.run_worker(
             self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"
@@ -14695,38 +13918,6 @@ class ChatScreen(BaseAppScreen):
         self._console_chat_controller = None
         super().on_unmount()
 
-    @staticmethod
-    def _serialize_console_settings(
-        settings: ConsoleSessionSettings | None,
-    ) -> dict[str, Any] | None:
-        """Return a JSON-safe snapshot of per-session Console settings."""
-        if settings is None:
-            return None
-        return asdict(settings)
-
-    @staticmethod
-    def _restore_console_settings(
-        payload: Any,
-    ) -> ConsoleSessionSettings | None:
-        """Return per-session Console settings from a saved state payload."""
-        if not isinstance(payload, dict):
-            return None
-        values = dict(payload)
-        values.pop("persona_label", None)
-        values.pop("user_profile_label", None)
-        valid_fields = set(ConsoleSessionSettings.__dataclass_fields__)
-        values = {key: value for key, value in values.items() if key in valid_fields}
-        provider = str(values.get("provider") or "").strip()
-        if not provider:
-            return None
-        values["provider"] = provider
-        try:
-            return ConsoleSessionSettings(**values)
-        except TypeError:
-            logger.opt(exception=True).debug(
-                "Skipping invalid Console session settings payload"
-            )
-            return None
 
     @staticmethod
     def _serialize_console_variants(
@@ -14944,33 +14135,6 @@ class ChatScreen(BaseAppScreen):
                 if not store.add_pending_attachment(session_id, pending):
                     break  # staging cap reached — matches live staging semantics
 
-    @staticmethod
-    def _console_session_to_state(session: ConsoleChatSession) -> dict[str, Any]:
-        """Serialize one ConsoleChatSession for screen-state restoration.
-
-        Extracted from `_serialize_native_console_state` so the round trip
-        is testable without a running app. This is an explicit field list:
-        a field missing from it is silently dropped on the way back.
-        """
-        return {
-            "id": session.id,
-            "title": session.title,
-            "workspace_id": session.workspace_id,
-            "persisted_conversation_id": session.persisted_conversation_id,
-            "draft": session.draft,
-            "settings": ChatScreen._serialize_console_settings(session.settings),
-            "updated_at": session.updated_at,
-            "runtime_backend": session.runtime_backend,
-            "assistant_kind": session.assistant_kind,
-            "assistant_id": session.assistant_id,
-            "assistant_authority_id": session.assistant_authority_id,
-            "character_id": session.local_character_id(),
-            "character_name": session.character_name,
-            # Temporary conversations: without this key a temporary chat
-            # comes back as a persisting one after any screen navigation,
-            # and the next send writes it to the DB.
-            "ephemeral": session.ephemeral,
-        }
 
     def _serialize_native_console_state(self) -> dict[str, Any] | None:
         """Return the native Console in-session state for screen restoration."""
@@ -15003,7 +14167,7 @@ class ChatScreen(BaseAppScreen):
             "active_session_id": store.active_session_id,
             "task_resume_state": self._task_resume_state.to_dict(),
             "sessions": [
-                self._console_session_to_state(session) for session in store.sessions()
+                self._session._console_session_to_state(session) for session in store.sessions()
             ],
             "messages_by_session": {
                 session.id: [
@@ -15041,97 +14205,6 @@ class ChatScreen(BaseAppScreen):
             "console_evidence_sent_notice": sent_notice,
         }
 
-    def _console_session_from_state(
-        self, raw_session: dict[str, Any]
-    ) -> ConsoleChatSession:
-        """Rebuild one ConsoleChatSession from its serialized screen state.
-
-        The mirror of `_console_session_to_state`. Every legacy-payload
-        branch below exists because older saved states omit keys that newer
-        ones carry -- keep them.
-        """
-        # `getattr` (not `self._ensure_console_chat_store()`) tolerates bare
-        # screen shells that never ran `ChatScreen.__init__` (unit-level
-        # serialize/restore round trips). In the real restore path,
-        # `_restore_native_console_state` already ensured the store before
-        # this per-session helper runs, so this is the same object either way.
-        store = getattr(self, "_console_chat_store", None)
-        session_id = str(raw_session.get("id") or uuid.uuid4())
-        session_kwargs: dict[str, Any] = dict(
-            id=session_id,
-            title=str(raw_session.get("title") or DEFAULT_CONSOLE_SESSION_TITLE),
-            workspace_id=str(
-                raw_session.get("workspace_id")
-                or (
-                    store.workspace_context.active_workspace_id
-                    if store is not None
-                    else None
-                )
-                or CONSOLE_GLOBAL_WORKSPACE_ID
-            ),
-            persisted_conversation_id=(
-                str(raw_session["persisted_conversation_id"])
-                if raw_session.get("persisted_conversation_id") is not None
-                else None
-            ),
-            settings=self._restore_console_settings(raw_session.get("settings")),
-            draft=str(raw_session.get("draft") or ""),
-        )
-        # Legacy payloads saved before `updated_at` was serialized omit the
-        # key entirely; keep the ConsoleChatSession factory default (now)
-        # for those instead of forcing an empty/invalid timestamp.
-        raw_updated_at = raw_session.get("updated_at")
-        if raw_updated_at:
-            session_kwargs["updated_at"] = str(raw_updated_at)
-        identity_keys = (
-            "runtime_backend",
-            "assistant_kind",
-            "assistant_id",
-            "assistant_authority_id",
-        )
-        has_source_aware_identity = any(key in raw_session for key in identity_keys)
-        if has_source_aware_identity:
-            raw_runtime_backend = raw_session.get("runtime_backend")
-            session_kwargs["runtime_backend"] = (
-                raw_runtime_backend if type(raw_runtime_backend) is str else ""
-            )
-            for key in (
-                "assistant_kind",
-                "assistant_id",
-                "assistant_authority_id",
-            ):
-                value = raw_session.get(key)
-                session_kwargs[key] = value if type(value) is str else None
-
-        raw_character_id = raw_session.get("character_id")
-        character_id: int | None = None
-        if type(raw_character_id) is int and raw_character_id > 0:
-            if not has_source_aware_identity:
-                character_id = raw_character_id
-            elif (
-                session_kwargs.get("runtime_backend") == "local"
-                and session_kwargs.get("assistant_kind") == "character"
-                and session_kwargs.get("assistant_id") == str(raw_character_id)
-            ):
-                character_id = raw_character_id
-        if character_id is not None:
-            session_kwargs["character_id"] = character_id
-        if not has_source_aware_identity and character_id is not None:
-            # Pre-provenance screen state used the numeric local character
-            # projection as its direct-chat routing marker. Preserve that
-            # behavior without inventing a proven authority.
-            session_kwargs.update(
-                runtime_backend="local",
-                assistant_kind="character",
-                assistant_id=str(character_id),
-                assistant_authority_id=None,
-            )
-        raw_character_name = raw_session.get("character_name")
-        if raw_character_name is not None:
-            session_kwargs["character_name"] = str(raw_character_name)
-        # Legacy payloads predate the key; absent means saved, never temporary.
-        session_kwargs["ephemeral"] = raw_session.get("ephemeral") is True
-        return ConsoleChatSession(**session_kwargs)
 
     def _restore_native_console_state(self, payload: Any) -> None:
         """Restore native Console in-session state saved by ``save_state``."""
@@ -15151,7 +14224,7 @@ class ChatScreen(BaseAppScreen):
         for raw_session in raw_sessions:
             if not isinstance(raw_session, dict):
                 continue
-            session = self._console_session_from_state(raw_session)
+            session = self._session._console_session_from_state(raw_session)
             restored_sessions.append(session)
             restored_messages_by_session[session.id] = []
             raw_messages = messages_by_session.get(session.id, [])
@@ -15410,221 +14483,6 @@ class ChatScreen(BaseAppScreen):
             self._restore_native_console_state(native_console_state)
         self.sync_task_resume_state()
 
-    async def _start_character_console_session(
-        self, payload: ChatHandoffPayload
-    ) -> bool:
-        """Build a dedicated character conversation from a Start-Chat handoff.
-
-        Args:
-            payload: The Personas Start-Chat handoff staged into the native
-                Console (its metadata carries the character identity).
-
-        Returns:
-            ``True`` when a character session was created (the caller then
-            marks the handoff consumed); ``False`` to let the caller fall back
-            to the staged-context path (task-427).
-        """
-        identity = _character_session_identity_from_handoff(payload)
-        if identity is None:
-            return False
-        runtime_backend, character_id, name_hint, assistant_id = identity
-        scope_service = getattr(
-            self.app_instance,
-            "character_persona_scope_service",
-            None,
-        )
-        get_character = getattr(scope_service, "get_character", None)
-        if not callable(get_character):
-            return False
-
-        assistant_authority_id: str | None
-        local_character_id: int | None
-        server_context_capture: object | None = None
-        server_context_is_current: Callable[[object], bool] | None = None
-
-        def exact_server_context_is_current() -> bool:
-            if server_context_capture is None or server_context_is_current is None:
-                return False
-            try:
-                return server_context_is_current(server_context_capture) is True
-            except Exception:
-                return False
-
-        if runtime_backend == "local":
-            db = getattr(self.app_instance, "chachanotes_db", None)
-            get_local_authority_id = getattr(db, "get_local_authority_id", None)
-            if not callable(get_local_authority_id):
-                return False
-            try:
-                local_authority_id = get_local_authority_id()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                return False
-            if (
-                type(local_authority_id) is not str
-                or not local_authority_id
-                or local_authority_id != local_authority_id.strip()
-            ):
-                return False
-            assistant_authority_id = local_authority_id
-            local_character_id = character_id
-        else:
-            expected_server_id = payload.active_server_profile_id
-            if (
-                type(expected_server_id) is not str
-                or not expected_server_id
-                or expected_server_id != expected_server_id.strip()
-            ):
-                return False
-            if (
-                getattr(self.app_instance, "active_server_id", None)
-                != expected_server_id
-            ):
-                return False
-
-            assistant_authority_id = None
-            provider = getattr(self.app_instance, "server_context_provider", None)
-            capture_context = getattr(
-                provider,
-                "capture_character_authority_context",
-                None,
-            )
-            server_context_is_current = getattr(
-                provider,
-                "is_character_authority_context_current",
-                None,
-            )
-            resolver = getattr(provider, "resolve_character_authority_id", None)
-            if not callable(capture_context) or not callable(server_context_is_current):
-                return False
-            try:
-                server_context_capture = capture_context(
-                    expected_server_id=expected_server_id
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                return False
-            if not exact_server_context_is_current():
-                return False
-            if callable(resolver):
-                try:
-                    resolved_authority_id = await resolver(
-                        expected_server_id=expected_server_id,
-                        context_capture=server_context_capture,
-                    )
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    resolved_authority_id = None
-                if (
-                    type(resolved_authority_id) is str
-                    and _SERVER_CHARACTER_AUTHORITY_PATTERN.fullmatch(
-                        resolved_authority_id
-                    )
-                    is not None
-                ):
-                    assistant_authority_id = resolved_authority_id
-
-            # This is both the post-resolver fence and the immediately
-            # pre-card-fetch fence. No card from a newly active target may be
-            # used for the ID carried by the handoff.
-            if (
-                not exact_server_context_is_current()
-                or getattr(self.app_instance, "active_server_id", None)
-                != expected_server_id
-            ):
-                return False
-            local_character_id = None
-
-        try:
-            card = await get_character(character_id, mode=runtime_backend)
-            if hasattr(card, "model_dump"):
-                card = card.model_dump(mode="json")
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.warning(
-                "Start Chat: character card unavailable; staging context instead "
-                "(source={}).",
-                runtime_backend,
-            )
-            return False
-        if not isinstance(card, Mapping) or not card:
-            return False
-        card = dict(card)
-        if _canonical_card_character_id(card.get("id")) != character_id:
-            return False
-
-        if runtime_backend == "server":
-            expected_server_id = payload.active_server_profile_id
-            if (
-                not exact_server_context_is_current()
-                or getattr(self.app_instance, "active_server_id", None)
-                != expected_server_id
-            ):
-                return False
-
-        name, system_prompt, greeting = _character_session_prompt_seed(
-            card, name_hint=str(name_hint or "")
-        )
-
-        store = self._ensure_console_chat_store()
-        settings = replace(
-            self._default_console_session_settings(),
-            system_prompt=system_prompt,
-            character_label=name,
-        )
-        if runtime_backend == "server" and (
-            not exact_server_context_is_current()
-            or getattr(self.app_instance, "active_server_id", None)
-            != payload.active_server_profile_id
-        ):
-            return False
-        session = store.create_session(
-            title=f"Chat with {name}",
-            workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
-            settings=settings,
-            runtime_backend=runtime_backend,
-            assistant_kind="character",
-            assistant_id=assistant_id,
-            assistant_authority_id=assistant_authority_id,
-            character_id=local_character_id,
-            character_name=name,
-        )
-        if greeting:
-            try:
-                store.append_message(
-                    session.id,
-                    role=ConsoleMessageRole.ASSISTANT,
-                    content=greeting,
-                    persist=True,
-                )
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Start Chat: greeting seed/persist failed; continuing."
-                )
-        try:
-            await self._sync_native_console_chat_ui()
-            self._focus_console_composer_if_needed(force=True)
-        except asyncio.CancelledError:
-            # The durable commit boundary is above. Report success so the
-            # caller acknowledges this handoff instead of replaying it.
-            return True
-        except Exception:
-            # The character session (and its greeting) is already durably
-            # created above -- a UI-sync/focus failure here must not
-            # propagate, or the caller would never clear
-            # ``pending_chat_handoff`` and a later re-consume (e.g. a
-            # screen re-mount timer) would build a SECOND durable
-            # character session.
-            logger.opt(exception=True).warning(
-                "Start Chat: post-seed console sync/focus failed; character "
-                "session was already created and the handoff is still "
-                "considered consumed."
-            )
-        return True
 
     async def _consume_pending_chat_handoff(self) -> None:
         """Claim one Chat handoff and stage it directly in native Console."""
@@ -15647,7 +14505,7 @@ class ChatScreen(BaseAppScreen):
             # failed to build -- stages into the Console live-work lane
             # so the context lands in Staged Context instead of being
             # dropped with a warning.
-            if await self._start_character_console_session(payload):
+            if await self._session._start_character_console_session(payload):
                 store.acknowledge(claim)
                 return
             self._stage_handoff_as_console_live_work(payload)
@@ -15779,11 +14637,11 @@ class ChatScreen(BaseAppScreen):
                 # non-default title, so the send-time auto-titler
                 # (``_maybe_auto_title_session``) leaves it as-is rather than
                 # renaming it after the prefilled instruction.
-                self._capture_console_draft_switch_snapshot()
+                self._session._capture_console_draft_switch_snapshot()
                 session = store.create_session(
                     title=title,
                     workspace_id=store.workspace_context.active_workspace_id,
-                    settings=self._default_console_session_settings(),
+                    settings=self._session._default_console_session_settings(),
                 )
                 store.set_session_draft(session.id, suggested_prompt)
             else:
@@ -15792,7 +14650,7 @@ class ChatScreen(BaseAppScreen):
                         store.workspace_context.active_workspace_id
                     ),
                     workspace_id=store.workspace_context.active_workspace_id,
-                    settings=self._default_console_session_settings(),
+                    settings=self._session._default_console_session_settings(),
                 )
                 if not store.session_draft(session.id).strip():
                     store.set_session_draft(session.id, suggested_prompt)
@@ -16384,7 +15242,7 @@ class ChatScreen(BaseAppScreen):
         self._record_ui_worker_started("console-sync")
         try:
             self._sync_console_chat_core_state()
-            self._sync_console_session_draft()
+            self._session._sync_console_session_draft()
             # PR#757 review (comment 4): warm the effective-scope cache for
             # an already-active persisted session before anything below
             # reads it -- see `_warm_console_effective_scope_cache_if_stale`
@@ -16453,9 +15311,9 @@ class ChatScreen(BaseAppScreen):
                 store.workspace_context.active_workspace_id
             ),
             workspace_id=store.workspace_context.active_workspace_id,
-            settings=self._default_console_session_settings(),
+            settings=self._session._default_console_session_settings(),
         )
-        self._ensure_active_console_session_settings()
+        self._session._ensure_active_console_session_settings()
         controller = getattr(self, "_console_chat_controller", None)
         streaming_session_id = (
             controller.streaming_session_id() if controller is not None else None
@@ -17022,7 +15880,7 @@ class ChatScreen(BaseAppScreen):
         # synchronous call (no `await` before `target_session_id` is read),
         # so there is no scheduling gap for the store's active session to
         # change out from under it.
-        self._ensure_active_console_session_settings()
+        self._session._ensure_active_console_session_settings()
         # Fix round 1 (minor): normalize the same way the controller side
         # already does (`store.active_session_id or ""`) -- `None` is a
         # valid (if unlikely, post-mount) dict key, but every other
@@ -17461,7 +16319,7 @@ class ChatScreen(BaseAppScreen):
         # the no-op fast path instead of clobbering what we're about to
         # insert.
         try:
-            self._sync_console_session_draft()
+            self._session._sync_console_session_draft()
             inserted = self._insert_prompt_text_into_composer(text, replace=False)
         except asyncio.CancelledError:
             store.release(claim)
@@ -17527,7 +16385,7 @@ class ChatScreen(BaseAppScreen):
                     CONSOLE_SYSTEM_PROMPT_NO_SYSTEM_PART_TEMPLATE.format(name=name)
                 )
                 return
-            self._apply_console_session_system_prompt(system_prompt)
+            self._session._apply_console_session_system_prompt(system_prompt)
             self._clear_console_composer_draft()
             return
         await self._open_console_prompt_picker_for_apply_system(args)
@@ -17546,7 +16404,7 @@ class ChatScreen(BaseAppScreen):
         store = self._ensure_console_chat_store()
         session = store.ensure_session(
             workspace_id=store.workspace_context.active_workspace_id,
-            settings=self._default_console_session_settings(),
+            settings=self._session._default_console_session_settings(),
         )
         if session.settings is None:
             # `ensure_session` only applies `settings=` when it CREATES the
@@ -17555,7 +16413,7 @@ class ChatScreen(BaseAppScreen):
             # silent no-op in `set_session_pinned_prefill` (PR #729 Qodo
             # finding 3), so seed defaults before any pin/clear below.
             session = store.replace_session_settings(
-                session.id, self._default_console_session_settings()
+                session.id, self._session._default_console_session_settings()
             )
         if action.kind == ACTION_ERROR:
             await self._append_native_console_system_message(action.error)
@@ -17796,7 +16654,7 @@ class ChatScreen(BaseAppScreen):
         store = self._ensure_console_chat_store()
         session = store.ensure_session(
             workspace_id=store.workspace_context.active_workspace_id,
-            settings=self._default_console_session_settings(),
+            settings=self._session._default_console_session_settings(),
         )
         conversation_pairs = self._console_generate_image_conversation_pairs(
             store, session.id
@@ -18193,7 +17051,7 @@ class ChatScreen(BaseAppScreen):
             )
             if not system_prompt.strip():
                 return
-            self._apply_console_session_system_prompt(system_prompt)
+            self._session._apply_console_session_system_prompt(system_prompt)
 
         self.app.push_screen(
             ConsolePromptPickerModal(
@@ -18204,45 +17062,16 @@ class ChatScreen(BaseAppScreen):
             callback=_apply_picker_choice,
         )
 
-    def _apply_console_session_system_prompt(
-        self, system_prompt: Optional[str]
-    ) -> None:
-        """Apply (or, for a blank/``None`` value, clear) the active session's
-        system prompt, persisting the change if the conversation is already
-        saved (Task 13's ``ConsoleChatStore.set_session_system_prompt``), and
-        refresh the rail preview + context-estimate surfaces in place.
-
-        The in-memory session is always updated even when the durable write
-        fails -- ``set_session_system_prompt`` never rolls that back (see
-        its docstring) -- so a persistence failure only means the change may
-        not survive a reload; it is surfaced here as an honest warning
-        rather than silently swallowed or crashing this callback.
-        """
-        self._ensure_active_console_session_settings()
-        store = self._ensure_console_chat_store()
-        session_id = store.active_session_id
-        if session_id is None:
-            return
-        _session, persisted = store.set_session_system_prompt(session_id, system_prompt)
-        if not persisted:
-            self.app_instance.notify(
-                "System prompt applied for this session, but the change "
-                "could not be saved -- it may not survive a reload.",
-                severity="warning",
-            )
-        self._sync_console_chat_core_state()
-        self._sync_console_settings_summary()
-        self._sync_console_control_bar()
 
     async def _open_console_system_prompt_editor(self) -> None:
         """Open the system prompt editor modal for the active Console session."""
-        settings = self._ensure_active_console_session_settings()
+        settings = self._session._ensure_active_console_session_settings()
 
         def _apply_modal_result(result: Optional[str]) -> None:
             self._focus_console_composer_if_needed(force=True)
             if result is None:
                 return
-            self._apply_console_session_system_prompt(result)
+            self._session._apply_console_session_system_prompt(result)
 
         self.app.push_screen(
             ConsoleSystemPromptModal(
@@ -19510,7 +18339,7 @@ class ChatScreen(BaseAppScreen):
 
     def _console_save_source_title(self) -> str:
         """Return the active Console conversation title for save-as derivations."""
-        session = self._active_native_console_session()
+        session = self._session._active_native_console_session()
         return str(getattr(session, "title", "") or "").strip()
 
     async def _save_console_message_image(self, message_id: str) -> None:
@@ -19871,7 +18700,7 @@ class ChatScreen(BaseAppScreen):
             title=derive_console_save_title(self._console_save_source_title()),
             message_text=content,
             message_role=self._console_message_role_label(message),
-            conversation_id=self._current_console_conversation_id(),
+            conversation_id=self._session._current_console_conversation_id(),
             message_id=message_id,
             provider=provider,
             model=model,
@@ -20408,36 +19237,6 @@ class ChatScreen(BaseAppScreen):
         if popup is not None and popup.is_open:
             popup.reposition()
 
-    def _console_composer_history_session_synced(self) -> bool:
-        """Return whether the composer's visible session matches the active one.
-
-        TASK-1281 review F1 (HIGH): mirrors the guard `_insert_console_
-        dictation` already carries for exactly this reason. During the
-        session-switch settle window (TASK-339) -- `controller.switch_
-        session(...)` runs synchronously and `store.active_session_id`
-        changes immediately, but `_console_visible_draft_session_id` only
-        catches up later, inside `_sync_console_session_draft`, once the
-        deferred sync actually runs -- the composer can still be showing
-        session A's draft while the store already considers session B
-        active. Undo/redo must never run while that window is open: doing
-        so would apply session A's history against the composer, then
-        (via the re-persist below) write A's resulting text into the STORE
-        under session B's id -- permanently destroying B's own draft the
-        moment the deferred swap finally lands.
-
-        Returns:
-            True only when the composer is not None, an active session
-            exists, and the composer is provably showing that exact
-            session's draft right now.
-        """
-        composer = self._console_composer_or_none()
-        if composer is None:
-            return False
-        store = self._ensure_console_chat_store()
-        return (
-            store.active_session_id is not None
-            and self._console_visible_draft_session_id == store.active_session_id
-        )
 
     def _persist_console_composer_draft_after_history_navigation(
         self, composer: ConsoleComposerBar
@@ -20476,7 +19275,7 @@ class ChatScreen(BaseAppScreen):
         composer showing content that belongs to neither the session it
         still visibly reflects nor the one the store now considers active.
         """
-        if not self._console_composer_history_session_synced():
+        if not self._session._console_composer_history_session_synced():
             return
         composer = self._console_composer_or_none()
         if composer is None or not composer.undo():
@@ -20489,7 +19288,7 @@ class ChatScreen(BaseAppScreen):
         See `_console_composer_undo` -- the same settle-window guard (F1)
         applies here.
         """
-        if not self._console_composer_history_session_synced():
+        if not self._session._console_composer_history_session_synced():
             return
         composer = self._console_composer_or_none()
         if composer is None or not composer.redo():
@@ -21157,7 +19956,7 @@ class ChatScreen(BaseAppScreen):
             return
 
         try:
-            settings = self._ensure_active_console_session_settings()
+            settings = self._session._ensure_active_console_session_settings()
             next_settings = settings
             if provider is not None or model is not None:
                 app_config = getattr(self.app_instance, "app_config", {}) or {}
@@ -21209,7 +20008,7 @@ class ChatScreen(BaseAppScreen):
                 except (TypeError, ValueError):
                     logger.debug("Ignoring invalid Console temperature sync value")
             if next_settings != settings:
-                self._replace_active_console_session_settings(next_settings)
+                self._session._replace_active_console_session_settings(next_settings)
         except Exception as e:
             logger.debug(
                 f"Unable to sync compact controls into Console session settings: {e}"
@@ -21673,7 +20472,7 @@ class ChatScreen(BaseAppScreen):
             return
         if button_id == "console-new-chat-tab":
             event.stop()
-            await self._create_native_console_session_from_active_context()
+            await self._session._create_native_console_session_from_active_context()
             return
         if button_id and button_id.startswith(
             "console-conversation-browser-section-toggle-"
@@ -21823,7 +20622,7 @@ class ChatScreen(BaseAppScreen):
             return
         if button_id == "console-new-workspace-conversation":
             event.stop()
-            await self._create_native_console_session_from_active_context()
+            await self._session._create_native_console_session_from_active_context()
             return
         if button_id == "console-workspace-conversation-search-clear":
             event.stop()
@@ -21859,7 +20658,7 @@ class ChatScreen(BaseAppScreen):
             if browser_row is not None:
                 self._workspace._activate_console_workspace_for_browser_row(browser_row)
                 row_conversation_id = str(browser_row.conversation_id or "").strip()
-                session_id = self._console_session_id_for_browser_row(browser_row)
+                session_id = self._session._console_session_id_for_browser_row(browser_row)
             else:
                 row_conversation_id = conversation_id
                 session_id = self._workspace._console_session_id_for_workspace_conversation(
@@ -21971,9 +20770,9 @@ class ChatScreen(BaseAppScreen):
             session_id = button_id.removeprefix("console-session-tab-")
             controller = self._ensure_console_chat_controller()
             if controller.store.active_session_id == session_id:
-                self._open_console_session_rename_modal(session_id)
+                self._session._open_console_session_rename_modal(session_id)
                 return
-            await self._activate_native_console_session(session_id)
+            await self._session._activate_native_console_session(session_id)
             return
         if button_id and button_id.startswith("console-message-action-"):
             handled = await self.handle_console_message_action(event)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -67,6 +67,7 @@ from ..Console_Modules.dictation import (
 )
 from ..Console_Modules.left_rail import ConsoleLeftRail
 from ..Console_Modules.right_rail import ConsoleInspectorRail
+from ..Console_Modules.workspace import ConsoleWorkspaceController
 from ...Chat.chat_persistence_service import ChatPersistenceService
 from ...Chat.citation_trace_repository import ActiveCitationTraceState
 from ...Chat.console_chat_controller import ConsoleChatController
@@ -172,8 +173,6 @@ from ...Chat.console_chat_models import (
     ConsoleRunStatus,
     ConsoleVariant,
     ConsoleVariantSet,
-    ConsoleWorkspaceContext,
-    ConsoleStagedSource,
     MessageAttachment,
     derive_console_session_title,
 )
@@ -293,7 +292,6 @@ from ...Chat.console_display_state import (
     console_prompted_evidence_text,
     console_prompted_source_count,
     console_staged_source_count,
-    evidence_bundle_from_launch,
 )
 from ...Chat.console_onboarding_state import (
     ConsoleSetupCardState,
@@ -430,8 +428,6 @@ from ...Widgets.Console import (
     ConsoleStagedEvidenceStrip,
     ConsoleTranscript,
     ConsoleWorkspaceContextTray,
-    ConsoleWorkspaceRenameModal,
-    ConsoleWorkspaceSwitcherModal,
 )
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.Console.console_image_viewer_modal import (
@@ -535,24 +531,14 @@ from ...Widgets.Console.console_rewind_modal import (
 from ...Widgets.Console.console_workspace_details import ConsoleWorkspaceDetailsTray
 from ...Widgets.Console.console_workbench_state import build_console_workbench_state
 from ...Workspaces.display_state import (
-    CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT,
     ConsoleWorkspaceConversationRow,
-    ConsoleWorkspaceConversationSectionState,
     ConsoleWorkspaceContextState,
-    build_console_workspace_state,
-    console_workspace_conversation_result_copy,
-)
-from ...Workspaces.registry_service import (
-    WorkspaceNotFound,
-    WorkspaceRegistryServiceError,
-    next_local_workspace_identity,
 )
 from ...Workspaces import (
     CONSOLE_CONVERSATION_BROWSER_RESULT_LIMIT,
     ConsoleConversationBrowserInputRow,
     ConsoleConversationBrowserRow,
     DEFAULT_WORKSPACE_ID,
-    WorkspaceRecord,
     build_console_conversation_browser_state,
     console_persisted_row_updated_sort,
 )
@@ -2559,7 +2545,7 @@ class ChatScreen(BaseAppScreen):
         if controller.store.active_session_id != session_id:
             self._capture_console_draft_switch_snapshot()
             self._note_console_follow_intent()
-            self._set_active_workspace_for_console_session(session_id)
+            self._workspace._set_active_workspace_for_console_session(session_id)
             controller.switch_session(session_id)
             # Finding C: a sub-agent drill-in is scoped to the conversation
             # active when the user drilled in -- clear it immediately on
@@ -2615,7 +2601,7 @@ class ChatScreen(BaseAppScreen):
             await self._activate_native_console_session(entry.native_session_id)
             return
         if entry.conversation_id:
-            resumed = await self._resume_console_workspace_conversation(
+            resumed = await self._workspace._resume_console_workspace_conversation(
                 entry.conversation_id,
                 target_scope_type=entry.scope_type or None,
                 target_workspace_id=entry.workspace_id,
@@ -2673,7 +2659,7 @@ class ChatScreen(BaseAppScreen):
     def on_console_change_workspace(self, event: Button.Pressed) -> None:
         """Open the active Console workspace switcher."""
         event.stop()
-        self._open_console_workspace_switcher()
+        self._workspace._open_console_workspace_switcher()
 
     @on(Button.Pressed, "#console-new-temporary-tab")
     def on_console_new_temporary_tab(self, event: Button.Pressed) -> None:
@@ -2689,250 +2675,17 @@ class ChatScreen(BaseAppScreen):
 
     def action_open_console_workspace_switcher(self) -> None:
         """Open the workspace switcher (Alt+W / command palette, TASK-722)."""
-        self._open_console_workspace_switcher()
-
-    def _open_console_workspace_switcher(self) -> None:
-        """Open the active Console workspace switcher."""
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            self.app_instance.notify(
-                "Workspace service is not ready.", severity="warning"
-            )
-            return
-        try:
-            workspaces = tuple(registry_service.list_workspaces())
-            active_workspace = registry_service.get_active_workspace()
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Unable to open Console workspace switcher"
-            )
-            self.app_instance.notify(
-                "Workspace registry could not be read.",
-                severity="error",
-            )
-            return
-        if not workspaces:
-            self.app_instance.notify(
-                "Create one with the rail's New button or in Settings > Workspaces.",
-                severity="warning",
-            )
-            return
-
-        active_workspace_id = (
-            active_workspace.workspace_id if active_workspace is not None else None
-        )
-
-        def _switch_to(workspace_id: str) -> None:
-            try:
-                registry_service.set_active_workspace(workspace_id)
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Unable to switch Console workspace",
-                )
-                self.app_instance.notify(
-                    "Workspace could not be selected.",
-                    severity="error",
-                )
-                return
-            self._sync_console_chat_core_state()
-            self._activate_console_session_for_workspace(workspace_id)
-            self._sync_console_workspace_context()
-            self.run_worker(
-                self._sync_native_console_chat_ui(),
-                exclusive=True,
-                group="console-sync",
-            )
-
-        def _apply_workspace_switch(
-            result: tuple[str, str] | None,
-        ) -> None:
-            if not result:
-                return
-            action, workspace_id = result
-            if action == "switch":
-                _switch_to(workspace_id)
-            elif action == "rename":
-                self._open_console_workspace_rename(workspace_id)
-            elif action == "archive":
-                self._confirm_console_workspace_archive(workspace_id)
-
-        self.app.push_screen(
-            ConsoleWorkspaceSwitcherModal(
-                workspaces=workspaces,
-                active_workspace_id=active_workspace_id,
-            ),
-            callback=_apply_workspace_switch,
-        )
-
-    def _open_console_workspace_rename(self, workspace_id: str) -> None:
-        """Prompt for and apply a new workspace name (TASK-714)."""
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            self.app_instance.notify(
-                "Workspace service is not ready.", severity="warning"
-            )
-            return
-        record = registry_service.get_workspace(workspace_id)
-        if record is None:
-            self.app_instance.notify(
-                "Workspace is no longer available.", severity="warning"
-            )
-            return
-
-        def _apply_rename(new_name: str | None) -> None:
-            if not new_name:
-                return
-            try:
-                renamed = registry_service.rename_workspace(workspace_id, new_name)
-            except WorkspaceRegistryServiceError as exc:
-                self.app_instance.notify(str(exc), severity="warning")
-                return
-            except Exception:
-                logger.opt(exception=True).warning("Unable to rename Console workspace")
-                self.app_instance.notify(
-                    "Workspace could not be renamed.", severity="error"
-                )
-                return
-            self._sync_console_chat_core_state()
-            self._sync_console_workspace_context()
-            self.run_worker(
-                self._sync_native_console_chat_ui(),
-                exclusive=True,
-                group="console-sync",
-            )
-            self.app_instance.notify(
-                f"Renamed workspace to {renamed.name}.", severity="information"
-            )
-
-        self.app.push_screen(
-            ConsoleWorkspaceRenameModal(current_name=record.name),
-            callback=_apply_rename,
-        )
-
-    def _confirm_console_workspace_archive(self, workspace_id: str) -> None:
-        """Confirm and archive a workspace (TASK-714)."""
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            self.app_instance.notify(
-                "Workspace service is not ready.", severity="warning"
-            )
-            return
-        record = registry_service.get_workspace(workspace_id)
-        if record is None:
-            self.app_instance.notify(
-                "Workspace is no longer available.", severity="warning"
-            )
-            return
-        was_active = bool(record.active)
-
-        # ConfirmationDialog awaits its confirm callback, so this must be a
-        # coroutine function.
-        async def _archive() -> None:
-            try:
-                registry_service.archive_workspace(workspace_id)
-            except WorkspaceRegistryServiceError as exc:
-                self.app_instance.notify(str(exc), severity="warning")
-                return
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Unable to archive Console workspace"
-                )
-                self.app_instance.notify(
-                    "Workspace could not be archived.", severity="error"
-                )
-                return
-            self._sync_console_chat_core_state()
-            if was_active:
-                self._activate_console_session_for_workspace(DEFAULT_WORKSPACE_ID)
-            self._sync_console_workspace_context()
-            self.run_worker(
-                self._sync_native_console_chat_ui(),
-                exclusive=True,
-                group="console-sync",
-            )
-            suffix = " Console switched to the Default workspace." if was_active else ""
-            self.app_instance.notify(
-                f"Archived {record.name}. Its conversations stay saved in "
-                f"Library.{suffix}",
-                severity="information",
-            )
-
-        self.app.push_screen(
-            ConfirmationDialog(
-                title="Archive workspace?",
-                message=(
-                    f"Archive {record.name}? Its conversations stay saved and "
-                    "remain visible in Library; the workspace disappears from "
-                    "the switcher and the Console browser."
-                ),
-                confirm_label="Archive",
-                confirm_callback=_archive,
-            )
-        )
+        self._workspace._open_console_workspace_switcher()
 
     @on(Button.Pressed, "#console-new-workspace")
     def on_console_new_workspace(self, event: Button.Pressed) -> None:
         """Create a new local workspace from the Console rail and activate it."""
         event.stop()
-        self._create_console_workspace()
+        self._workspace._create_console_workspace()
 
     def action_new_console_workspace(self) -> None:
         """Create a local workspace from the command palette (TASK-722)."""
-        self._create_console_workspace()
-
-    def _create_console_workspace(self) -> None:
-        """Create a new local workspace and activate it."""
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            self.app_instance.notify(
-                "Workspace service is not ready.", severity="warning"
-            )
-            return
-        try:
-            workspace_id, workspace_name = next_local_workspace_identity(
-                registry_service
-            )
-            registry_service.create_workspace(
-                workspace_id=workspace_id,
-                name=workspace_name,
-                description="Local workspace created from Console.",
-            )
-            registry_service.set_active_workspace(workspace_id)
-        except WorkspaceRegistryServiceError:
-            logger.opt(exception=True).warning("Unable to create Console workspace")
-            self.app_instance.notify(
-                "Workspace could not be created.", severity="error"
-            )
-            return
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Unexpected error creating Console workspace"
-            )
-            self.app_instance.notify(
-                "Workspace could not be created.", severity="error"
-            )
-            return
-        self._sync_console_chat_core_state()
-        self._activate_console_session_for_workspace(workspace_id)
-        self._sync_console_workspace_context()
-        self.run_worker(
-            self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"
-        )
-        # TASK-713: creation also activates the workspace and opens a tab;
-        # without a notification the whole sequence is invisible when the
-        # Workspace status row is scrolled out of view.
-        self.app_instance.notify(
-            f"Created {workspace_name} and switched Console to it.",
-            severity="information",
-        )
+        self._workspace._create_console_workspace()
 
     @on(Button.Pressed, "#console-workspace-rag-scope-open")
     def on_console_workspace_rag_scope_open(self, event: Button.Pressed) -> None:
@@ -2944,137 +2697,10 @@ class ChatScreen(BaseAppScreen):
         """
         event.stop()
         self.run_worker(
-            self._open_console_workspace_scope_picker(),
+            self._workspace._open_console_workspace_scope_picker(),
             exclusive=True,
             group="console-workspace-scope-open",
         )
-
-    async def _open_console_workspace_scope_picker(self) -> None:
-        """Open the RAG retrieval-scope picker for the ACTIVE workspace.
-
-        Task-13 workspace entry point (design spec section 4, "Workspace
-        entry: Scope button beside the workspace row in the Session area").
-        ``universe=None`` -- the workspace picker offers the full library,
-        unlike the conversation-target picker, which restricts to the
-        workspace's own items once one is set (D3, see
-        ``_open_console_retrieval_scope_picker``).
-
-        Only a REAL registry workspace can be scoped -- gated the same way
-        the mounted button itself is gated
-        (``ConsoleWorkspaceContextState.rag_scope_enabled``): the built-in
-        Default workspace has a real ``workspace_id`` row
-        (``DEFAULT_WORKSPACE_ID``) once ``ensure_default_workspace`` has
-        run, so it IS scopable; only the "Local Default"/error/no-registry
-        sentinel states (no real workspace row at all) are refused here.
-        """
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            self.app_instance.notify(
-                "Workspace service is not ready.", severity="warning"
-            )
-            return
-        try:
-            active_workspace = registry_service.get_active_workspace()
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Unable to read active workspace for the scope picker"
-            )
-            self.app_instance.notify(
-                "Workspace registry could not be read.", severity="error"
-            )
-            return
-        if active_workspace is None:
-            self.app_instance.notify(
-                "Create or select a workspace before setting a RAG scope.",
-                severity="warning",
-            )
-            return
-        workspace_id = active_workspace.workspace_id
-
-        try:
-            initial = await self._read_console_workspace_scope(
-                registry_service, workspace_id
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Unable to read workspace scope for {}", workspace_id
-            )
-            initial = None
-
-        target_label = f"workspace '{active_workspace.name}'"
-        media_lister, notes_lister, tag_lister = self._console_scope_picker_listers()
-
-        def _on_save(scope: Optional[RagScope]) -> None:
-            self.run_worker(
-                self._apply_console_workspace_scope_save(workspace_id, scope),
-                exclusive=True,
-                group="console-workspace-scope-save",
-            )
-
-        self.app.push_screen(
-            ConsoleScopePickerModal(
-                target_label,
-                None,
-                initial,
-                _on_save,
-                media_lister=media_lister,
-                notes_lister=notes_lister,
-                tag_lister=tag_lister,
-            )
-        )
-
-    async def _apply_console_workspace_scope_save(
-        self,
-        workspace_id: str,
-        scope: Optional[RagScope],
-    ) -> None:
-        """Persist (or clear) a workspace's RAG retrieval scope (task-13).
-
-        ``WorkspaceNotFound`` is caught deliberately -- the workspace may
-        have been archived/deleted (e.g. from Library > Workspaces) between
-        opening the picker and saving. Refreshes the ACTIVE Console
-        session's effective-scope display afterward: a workspace-scope
-        change can widen or narrow retrieval for every conversation linked
-        to it, but only the currently active session's row/chip are
-        mounted to refresh.
-
-        Args:
-            workspace_id: The workspace whose scope was just chosen.
-            scope: The new scope, or ``None`` to clear it.
-        """
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            self.app_instance.notify(
-                "Couldn't save scope: workspace service is not ready.",
-                severity="error",
-            )
-            return
-        try:
-            await self._write_console_workspace_scope(
-                registry_service, workspace_id, scope
-            )
-        except WorkspaceNotFound:
-            logger.opt(exception=True).warning(
-                "Workspace scope save target missing: {}", workspace_id
-            )
-            self.app_instance.notify(
-                "Couldn't save scope: this workspace no longer exists.",
-                severity="error",
-            )
-            return
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Failed to write workspace scope for {}", workspace_id
-            )
-            self.app_instance.notify("Couldn't save workspace scope.", severity="error")
-            return
-        session = self._active_native_console_session()
-        if session is not None:
-            await self._refresh_console_effective_scope_and_sync(session)
 
     # Reactive property for sidebar state persistence
     sidebar_state = reactive({}, layout=False)
@@ -3225,15 +2851,96 @@ class ChatScreen(BaseAppScreen):
         self._agent_section_user_dismissed_while_busy = False
         self._console_rail_system_line_last: tuple[str, bool] | None = None
         self._console_rail_prune_dispatched = False
-        self._console_workspace_conversation_query = ""
-        self._console_workspace_conversation_search_timer: Any | None = None
-        self._console_workspace_conversation_search_token = 0
-        self._console_workspace_conversation_search_rows: tuple[
-            ConsoleWorkspaceConversationRow, ...
-        ] = ()
-        self._console_workspace_conversation_search_total: int | None = None
-        self._console_workspace_conversation_search_error = ""
-        self._console_workspace_conversation_workspace_id: str | None = None
+        #: Workspace policy context, lifecycle, and resume-flow state and
+        #: behaviour moved to `ConsoleWorkspaceController` (wave-2 console
+        #: decomposition, task 2) -- the largest cluster in wave 2.
+        #: `self._console_workspace_conversation_query`/`_search_timer`/
+        #: `_search_token`/`_search_rows`/`_search_total`/`_search_error`
+        #: stay readable/writable via the six proxy properties defined near
+        #: `_console_composer_or_none`, so `on_console_workspace_
+        #: conversation_search_changed` (a sibling conversation-browser
+        #: handler that only mirrors three of them) and `on_button_pressed`'s
+        #: workspace-search branches needed no change. See `workspace.py`'s
+        #: module docstring for the full map of what moved and why.
+        self._workspace = ConsoleWorkspaceController(
+            self,
+            app_instance=self.app_instance,
+            # Late-binding lambdas, not the bound methods directly -- same
+            # staleness reason as `ConsoleDictationController`'s own wiring
+            # just below: a bound method captured here would freeze the
+            # CURRENT screen method, invisible to a later
+            # `monkeypatch.setattr` on this screen instance.
+            chat_store_accessor=lambda: self._ensure_console_chat_store(),
+            current_chat_store_accessor=lambda: self._console_chat_store,
+            current_conversation_id_accessor=(
+                lambda: self._current_console_conversation_id()
+            ),
+            native_session_rows_accessor=(
+                lambda state: self._with_native_console_session_rows(state)
+            ),
+            conversation_browser_state_accessor=(
+                lambda state, current_conversation_id: (
+                    self._with_console_conversation_browser_state(
+                        state, current_conversation_id=current_conversation_id
+                    )
+                )
+            ),
+            capture_draft_switch_snapshot=(
+                lambda: self._capture_console_draft_switch_snapshot()
+            ),
+            sync_chat_core_state=lambda: self._sync_console_chat_core_state(),
+            sync_native_console_chat_ui=lambda: self._sync_native_console_chat_ui(),
+            sync_temporary_chip=lambda: self._sync_console_temporary_chip(),
+            default_session_settings_accessor=(
+                lambda: self._default_console_session_settings()
+            ),
+            scope_picker_listers_accessor=(
+                lambda: self._console_scope_picker_listers()
+            ),
+            active_native_session_accessor=(
+                lambda: self._active_native_console_session()
+            ),
+            refresh_effective_scope_and_sync=(
+                lambda session: self._refresh_console_effective_scope_and_sync(
+                    session
+                )
+            ),
+            messages_from_conversation_tree_accessor=(
+                lambda tree: self._console_messages_from_conversation_tree(tree)
+            ),
+            session_settings_for_resume_accessor=(
+                lambda conversation: self._console_session_settings_for_resume(
+                    conversation
+                )
+            ),
+            resolve_resumed_character_name=(
+                lambda character_id: self._resolve_resumed_character_name(
+                    character_id
+                )
+            ),
+            inject_resume_agent_markers_accessor=(
+                lambda messages, conversation_id: self._inject_resume_agent_markers(
+                    messages, conversation_id
+                )
+            ),
+            resolve_effective_scope_state=(
+                lambda session: self._resolve_console_effective_scope_state(session)
+            ),
+            sync_retrieval_scope_row=(
+                lambda: self._sync_console_retrieval_scope_row()
+            ),
+            note_follow_intent=lambda: self._note_console_follow_intent(),
+            focus_composer_if_needed=(
+                lambda **kwargs: self._focus_console_composer_if_needed(**kwargs)
+            ),
+            conversation_section_config_accessor=(
+                lambda: self._console_conversation_section_config()
+            ),
+            focus_conversation_search=(
+                lambda: self._focus_console_workspace_conversation_search()
+            ),
+            sync_workspace_context=lambda: self._sync_console_workspace_context(),
+        )
         self._console_conversation_browser_query = ""
         self._console_conversation_browser_search_timer: Any | None = None
         self._console_conversation_browser_search_token = 0
@@ -3846,7 +3553,7 @@ class ChatScreen(BaseAppScreen):
         store = self._ensure_console_chat_store()
         workspace_id = store.workspace_context.active_workspace_id
         session = store.ensure_session(
-            title=self._console_initial_session_title_for_workspace(workspace_id),
+            title=self._workspace._console_initial_session_title_for_workspace(workspace_id),
             workspace_id=workspace_id,
             settings=self._default_console_session_settings(),
         )
@@ -3927,7 +3634,7 @@ class ChatScreen(BaseAppScreen):
         store = self._ensure_console_chat_store()
         workspace_id = store.workspace_context.active_workspace_id
         session = store.ensure_session(
-            title=self._console_initial_session_title_for_workspace(workspace_id),
+            title=self._workspace._console_initial_session_title_for_workspace(workspace_id),
             workspace_id=workspace_id,
             settings=self._default_console_session_settings(),
         )
@@ -4090,7 +3797,7 @@ class ChatScreen(BaseAppScreen):
     ) -> ConsoleSettingsContextEstimate:
         """Return context usage for the active native Console settings snapshot."""
         settings = self._ensure_active_console_session_settings()
-        workspace_context = self._current_console_workspace_context()
+        workspace_context = self._workspace._current_console_workspace_context()
         staged_context_state = self._build_console_staged_context_state(
             self._pending_console_launch_context
         )
@@ -4647,121 +4354,6 @@ class ChatScreen(BaseAppScreen):
             group="console-sync",
         )
 
-    def _current_console_workspace_context(self) -> ConsoleWorkspaceContext:
-        """Return explicit workspace policy context for native Console sends."""
-        workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is not None:
-            try:
-                ensure_default_workspace = getattr(
-                    registry_service,
-                    "ensure_default_workspace",
-                    None,
-                )
-                active_workspace = (
-                    ensure_default_workspace()
-                    if callable(ensure_default_workspace)
-                    else registry_service.get_active_workspace()
-                )
-                candidate = getattr(active_workspace, "workspace_id", None)
-                if candidate:
-                    workspace_id = str(candidate)
-            except Exception:
-                logger.debug(
-                    "Console workspace registry was unavailable for send context"
-                )
-
-        staged_sources: list[ConsoleStagedSource] = []
-        pending_launch = self._pending_console_launch_context
-        if pending_launch is not None:
-            payload = pending_launch.payload
-            source_workspace = payload.get("workspace_id")
-            launch_workspace_id = (
-                str(source_workspace) if source_workspace else None
-            )
-            # RAG UX v2 PR-4: this builder is the SINGLE seam feeding both
-            # the Inspector rail badge ("{n} staged") and the settings
-            # context estimate, and it used to append exactly ONE staged
-            # source per launch -- so the status chip could read "Sources: 4
-            # staged" while its two siblings read 1. One row per bundle
-            # reference puts all three in the same vocabulary (and gives the
-            # workspace policy check a real per-source id to gate on).
-            bundle = evidence_bundle_from_launch(pending_launch)
-            references = bundle.references if bundle is not None else ()
-            for reference in references:
-                chunk_id = reference.metadata.get("chunk_id")
-                # Two chunks of one document share a source_id; qualify with
-                # the chunk id (exactly as the capture adapter does) so
-                # `allowed_sources`' source_id dedupe cannot collapse them.
-                staged_sources.append(
-                    ConsoleStagedSource(
-                        source_id=str(
-                            chunk_id
-                            if isinstance(chunk_id, str) and chunk_id
-                            else reference.source_id
-                        ),
-                        label=reference.title,
-                        source_type=reference.source_type,
-                        workspace_id=reference.workspace_id or launch_workspace_id,
-                    )
-                )
-            if not staged_sources:
-                # A launch with no (or an empty) evidence bundle is still one
-                # staged item -- the same fallback `console_staged_source_count`
-                # and the strip use, so all three surfaces still agree.
-                source_id = (
-                    payload.get("source_id")
-                    or payload.get("target_id")
-                    or payload.get("run_id")
-                    or pending_launch.title
-                )
-                staged_sources.append(
-                    ConsoleStagedSource(
-                        source_id=str(source_id),
-                        label=pending_launch.title,
-                        source_type=str(pending_launch.source),
-                        workspace_id=launch_workspace_id,
-                    )
-                )
-
-        return ConsoleWorkspaceContext(
-            active_workspace_id=workspace_id,
-            staged_sources=tuple(staged_sources),
-        )
-
-    def _active_console_workspace_id_for_conversation_search(self) -> str:
-        """Return the current active workspace id for Console conversation search."""
-        try:
-            workspace_id = str(
-                self._current_console_workspace_context().active_workspace_id or ""
-            ).strip()
-        except Exception:
-            logger.opt(exception=True).debug(
-                "Unable to read current workspace context for conversation search",
-            )
-            workspace_id = ""
-        if workspace_id:
-            return workspace_id
-        service = getattr(self.app_instance, "workspace_registry_service", None)
-        get_active_workspace = getattr(service, "get_active_workspace", None)
-        if callable(get_active_workspace):
-            try:
-                workspace = get_active_workspace()
-            except Exception:
-                logger.opt(exception=True).debug(
-                    "Unable to read active workspace for conversation search"
-                )
-                workspace = None
-            workspace_id = str(getattr(workspace, "workspace_id", "") or "").strip()
-            if workspace_id:
-                return workspace_id
-        store = self._console_chat_store
-        if store is not None and store.workspace_context.active_workspace_id:
-            return str(store.workspace_context.active_workspace_id)
-        return ""
-
     def _focus_console_workspace_conversation_search(self) -> None:
         """Restore focus to the conversation search input when it is mounted."""
         try:
@@ -4835,7 +4427,7 @@ class ChatScreen(BaseAppScreen):
             thinking_budget_tokens=selection_settings.thinking_budget_tokens,
             streaming=selection_settings.streaming,
             system_prompt=selection_settings.system_prompt,
-            workspace_context=self._current_console_workspace_context(),
+            workspace_context=self._workspace._current_console_workspace_context(),
         )
 
     def _active_console_provider_model_display(
@@ -4916,7 +4508,7 @@ class ChatScreen(BaseAppScreen):
                 )
             self._console_chat_store = ConsoleChatStore(
                 persistence=persistence,
-                workspace_context=self._current_console_workspace_context(),
+                workspace_context=self._workspace._current_console_workspace_context(),
                 on_scope_flushed=self._on_console_scope_flushed,
             )
         return self._console_chat_store
@@ -5545,111 +5137,6 @@ class ChatScreen(BaseAppScreen):
                 )
         return selection
 
-    def _activate_console_session_for_workspace(self, workspace_id: str) -> None:
-        """Activate or create the Console session for the selected workspace."""
-        target_workspace_id = str(workspace_id).strip()
-        if not target_workspace_id:
-            return
-        store = self._ensure_console_chat_store()
-        inherited_settings = None
-        if store.active_session_id is not None:
-            try:
-                inherited_settings = store.session_settings(store.active_session_id)
-            except KeyError:
-                inherited_settings = None
-        if store.active_session_id is not None:
-            for session in store.sessions():
-                if (
-                    session.id == store.active_session_id
-                    and session.workspace_id == target_workspace_id
-                ):
-                    return
-        for session in store.sessions():
-            if session.workspace_id == target_workspace_id:
-                self._capture_console_draft_switch_snapshot()
-                store.switch_session(session.id)
-                # task-7 review: this switches the active session with no
-                # other chip-refresh call anywhere in the caller chain (all
-                # three callers only run `_sync_native_console_chat_ui()`
-                # afterward, which never touches the temporary chip -- see
-                # `_sync_console_temporary_chip`). Without this the chip
-                # could keep reading "Temporary" on a workspace's saved
-                # session, or stay hidden on one that is actually temporary.
-                self._sync_console_temporary_chip()
-                return
-        self._capture_console_draft_switch_snapshot()
-        store.create_session(
-            title=self._console_workspace_session_title(target_workspace_id),
-            workspace_id=target_workspace_id,
-            settings=inherited_settings or self._default_console_session_settings(),
-        )
-        # task-7 review: `create_session` activates the new (never
-        # ephemeral -- no `ephemeral=` passed) session inline; same
-        # staleness risk as the switch branch above if the workspace's
-        # previous session was temporary.
-        self._sync_console_temporary_chip()
-
-    def _console_workspace_session_title(self, workspace_id: str) -> str:
-        """Return a readable title for an auto-created workspace Console tab."""
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        workspace_name = str(workspace_id).strip()
-        if registry_service is not None:
-            try:
-                workspace = registry_service.get_workspace(workspace_id)
-                if workspace is not None:
-                    workspace_name = workspace.name
-            except Exception:
-                logger.opt(exception=True).debug(
-                    "Unable to read Console workspace title"
-                )
-        if not workspace_name:
-            workspace_name = "Workspace"
-        return f"{workspace_name} Chat"
-
-    def _console_initial_session_title_for_workspace(
-        self, workspace_id: str | None
-    ) -> str:
-        """Return the first Console tab title for the active workspace."""
-        target_workspace_id = str(workspace_id or "").strip()
-        if not target_workspace_id or target_workspace_id in {
-            CONSOLE_GLOBAL_WORKSPACE_ID,
-            DEFAULT_WORKSPACE_ID,
-        }:
-            return DEFAULT_CONSOLE_SESSION_TITLE
-        return self._console_workspace_session_title(target_workspace_id)
-
-    def _set_active_workspace_for_console_session(self, session_id: str) -> None:
-        """Keep workspace context aligned when switching Console tabs."""
-        store = self._ensure_console_chat_store()
-        target_session = next(
-            (session for session in store.sessions() if session.id == session_id),
-            None,
-        )
-        if target_session is None:
-            return
-        workspace_id = str(target_session.workspace_id or "").strip()
-        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
-            return
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            return
-        try:
-            active_workspace = registry_service.get_active_workspace()
-            if (
-                active_workspace is not None
-                and active_workspace.workspace_id == workspace_id
-            ):
-                return
-            registry_service.set_active_workspace(workspace_id)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Unable to align Console workspace with selected tab",
-            )
-
     def _console_composer_or_none(self) -> ConsoleComposerBar | None:
         """Return the native Console composer when it is mounted."""
         composers = list(self.query("#console-native-composer"))
@@ -5741,6 +5228,71 @@ class ChatScreen(BaseAppScreen):
         availability` for the real implementation.
         """
         self._dictation._sync_console_dictation_availability()
+
+    # Workspace conversation-search state moved to `ConsoleWorkspaceController`
+    # (wave-2 console decomposition, task 2). These six properties keep
+    # `self._console_workspace_conversation_query`/`_search_timer`/
+    # `_search_token`/`_search_rows`/`_search_total`/`_search_error` readable
+    # AND writable exactly as before, for the two screen methods that are
+    # not part of the workspace cluster but still touch this state
+    # (`on_console_workspace_conversation_search_changed`, a sibling
+    # conversation-browser handler that mirrors three of them, and
+    # `on_button_pressed`'s workspace-search branches) and for tests that
+    # poke it directly -- each proxies straight through to `self._workspace`,
+    # so none of those call sites needed to change. `_console_workspace_
+    # conversation_workspace_id` needs no proxy: it is read and written only
+    # inside `_with_console_workspace_conversation_section`, itself moved.
+    @property
+    def _console_workspace_conversation_query(self) -> str:
+        return self._workspace._console_workspace_conversation_query
+
+    @_console_workspace_conversation_query.setter
+    def _console_workspace_conversation_query(self, value: str) -> None:
+        self._workspace._console_workspace_conversation_query = value
+
+    @property
+    def _console_workspace_conversation_search_timer(self) -> Any:
+        return self._workspace._console_workspace_conversation_search_timer
+
+    @_console_workspace_conversation_search_timer.setter
+    def _console_workspace_conversation_search_timer(self, value: Any) -> None:
+        self._workspace._console_workspace_conversation_search_timer = value
+
+    @property
+    def _console_workspace_conversation_search_token(self) -> int:
+        return self._workspace._console_workspace_conversation_search_token
+
+    @_console_workspace_conversation_search_token.setter
+    def _console_workspace_conversation_search_token(self, value: int) -> None:
+        self._workspace._console_workspace_conversation_search_token = value
+
+    @property
+    def _console_workspace_conversation_search_rows(
+        self,
+    ) -> tuple[ConsoleWorkspaceConversationRow, ...]:
+        return self._workspace._console_workspace_conversation_search_rows
+
+    @_console_workspace_conversation_search_rows.setter
+    def _console_workspace_conversation_search_rows(
+        self, value: tuple[ConsoleWorkspaceConversationRow, ...]
+    ) -> None:
+        self._workspace._console_workspace_conversation_search_rows = value
+
+    @property
+    def _console_workspace_conversation_search_total(self) -> int | None:
+        return self._workspace._console_workspace_conversation_search_total
+
+    @_console_workspace_conversation_search_total.setter
+    def _console_workspace_conversation_search_total(self, value: int | None) -> None:
+        self._workspace._console_workspace_conversation_search_total = value
+
+    @property
+    def _console_workspace_conversation_search_error(self) -> str:
+        return self._workspace._console_workspace_conversation_search_error
+
+    @_console_workspace_conversation_search_error.setter
+    def _console_workspace_conversation_search_error(self, value: str) -> None:
+        self._workspace._console_workspace_conversation_search_error = value
 
 
     def _speak_status(self, text: str) -> None:
@@ -9760,7 +9312,7 @@ class ChatScreen(BaseAppScreen):
         """
         store = self._ensure_console_chat_store()
         session = store.ensure_session(
-            title=self._console_initial_session_title_for_workspace(
+            title=self._workspace._console_initial_session_title_for_workspace(
                 store.workspace_context.active_workspace_id
             ),
             workspace_id=store.workspace_context.active_workspace_id,
@@ -10298,41 +9850,6 @@ class ChatScreen(BaseAppScreen):
                 write_conversation_scope, db, conversation_id, scope
             )
 
-    @staticmethod
-    async def _read_console_workspace_scope(
-        registry_service: Any, workspace_id: str
-    ) -> Optional[RagScope]:
-        """Read a workspace's stored scope, off-loop for a file-backed registry.
-
-        Mirrors ``_read_console_retrieval_scope``'s in-memory-DB guard
-        (task-13): ``LocalWorkspaceRegistryService.db`` is never actually
-        ``:memory:``-backed in production (``WorkspaceDB`` opens a brand-new
-        connection per call, incompatible with SQLite's ``:memory:``
-        semantics beyond a single call), but the guard is applied anyway
-        for the same defensive discipline the conversation-scope read uses.
-        """
-        db = getattr(registry_service, "db", None)
-        if getattr(db, "is_memory_db", False):
-            return registry_service.get_workspace_scope(workspace_id)
-        return await asyncio.to_thread(
-            registry_service.get_workspace_scope, workspace_id
-        )
-
-    @staticmethod
-    async def _write_console_workspace_scope(
-        registry_service: Any, workspace_id: str, scope: Optional[RagScope]
-    ) -> None:
-        """Write (or clear) a workspace's stored scope; see the read twin's
-        in-memory-registry-DB guard docstring for why this isn't
-        unconditionally ``asyncio.to_thread``."""
-        db = getattr(registry_service, "db", None)
-        if getattr(db, "is_memory_db", False):
-            registry_service.set_workspace_scope(workspace_id, scope)
-        else:
-            await asyncio.to_thread(
-                registry_service.set_workspace_scope, workspace_id, scope
-            )
-
     def _console_scope_picker_listers(
         self,
     ) -> tuple[Any, Any, Any]:
@@ -10383,7 +9900,7 @@ class ChatScreen(BaseAppScreen):
         )
         if workspace_id and registry_service is not None:
             try:
-                ws_scope = await self._read_console_workspace_scope(
+                ws_scope = await self._workspace._read_console_workspace_scope(
                     registry_service, workspace_id
                 )
             except Exception:
@@ -11266,27 +10783,6 @@ class ChatScreen(BaseAppScreen):
             logger.opt(exception=True).debug("avatar: pixels build failed")
             return Static("no avatar", id="console-character-avatar-empty")
 
-    def _console_session_id_for_workspace_conversation(
-        self,
-        conversation_id: str,
-    ) -> str | None:
-        """Return an open Console session id for a workspace conversation row."""
-        target = str(conversation_id or "").strip()
-        if not target:
-            return None
-        store = self._console_chat_store
-        if store is None:
-            return None
-        if target.startswith("native:"):
-            session_id = target.removeprefix("native:")
-            if any(session.id == session_id for session in store.sessions()):
-                return session_id
-            return None
-        for session in store.sessions():
-            if str(session.persisted_conversation_id or "") == target:
-                return session.id
-        return None
-
     @staticmethod
     def _console_message_role_from_persisted(
         message: dict[str, Any],
@@ -11588,212 +11084,6 @@ class ChatScreen(BaseAppScreen):
         broken.add(target)
         self._sync_console_workspace_context()
 
-    async def _resume_console_workspace_conversation(
-        self,
-        conversation_id: str,
-        *,
-        target_scope_type: str | None = None,
-        target_workspace_id: str | None = None,
-    ) -> bool | None:
-        """Load a persisted saved conversation into a native Console session.
-
-        Returns:
-            True on success; None on a transient failure this method already
-            notified about (service unavailable / load error); False when the
-            conversation record is missing - the caller owns that failure's
-            feedback (TASK-717).
-        """
-        target = str(conversation_id or "").strip()
-        if not target:
-            return None
-        # TASK-339: keystrokes typed while the conversation tree loads
-        # belong to the resumed session — snapshot the composer now.
-        self._capture_console_draft_switch_snapshot()
-        conversation_service = getattr(
-            self.app_instance,
-            "chat_conversation_scope_service",
-            None,
-        )
-        get_conversation_tree = getattr(
-            conversation_service, "get_conversation_tree", None
-        )
-        if not callable(get_conversation_tree):
-            self.app_instance.notify(
-                "Saved conversation resume is unavailable in this build.",
-                severity="warning",
-            )
-            return None
-
-        try:
-            # Task 8: raise the depth/root caps well past the service defaults
-            # (50) so a long or branchy conversation's full tree -- every
-            # branch, not just the latest -- is loaded intact, not truncated.
-            maybe_tree = get_conversation_tree(
-                target, mode="local", depth_cap=10_000, root_limit=10_000
-            )
-            tree = await maybe_tree if inspect.isawaitable(maybe_tree) else maybe_tree
-        except Exception:
-            logger.exception(
-                f"Unable to resume Console saved conversation: conversation_id={target}"
-            )
-            self.app_instance.notify(
-                "Unable to load this saved conversation.",
-                severity="error",
-            )
-            return None
-
-        if not isinstance(tree, dict) or not tree.get("conversation"):
-            # TASK-717: missing record - the caller owns this failure's UX
-            # (honest toast + marking the row visibly broken), so do not
-            # stack a second notification here.
-            return False
-
-        conversation = tree.get("conversation")
-        if not isinstance(conversation, dict):
-            conversation = {}
-        store = self._ensure_console_chat_store()
-        active_workspace_id = str(
-            store.workspace_context.active_workspace_id or ""
-        ).strip()
-        persisted_workspace_id = (
-            str(conversation.get("workspace_id")).strip()
-            if conversation.get("workspace_id") is not None
-            else ""
-        )
-        target_scope = str(target_scope_type or "").strip()
-        requested_workspace_id = (
-            str(target_workspace_id).strip() if target_workspace_id is not None else ""
-        )
-        if target_scope == "global":
-            workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
-        else:
-            workspace_id = (
-                persisted_workspace_id
-                or requested_workspace_id
-                or active_workspace_id
-                or None
-            )
-        title = str(conversation.get("title") or "Saved conversation").strip()
-        if not title:
-            title = "Saved conversation"
-        # Task 8: load the WHOLE persisted tree (every branch), then reconstruct
-        # the active branch from the stored active-leaf pointer. Loading all
-        # branches (not just the latest) is what makes off-path siblings
-        # navigable (swipe) right after resume.
-        all_nodes = self._console_messages_from_conversation_tree(tree)
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        active_leaf_id = getattr(db, "get_conversation_active_leaf", lambda _c: None)(
-            target
-        )
-        raw_runtime_backend = conversation.get("runtime_backend")
-        if type(raw_runtime_backend) is str:
-            runtime_backend = raw_runtime_backend
-        else:
-            runtime_backend = ""
-        raw_assistant_kind = conversation.get("assistant_kind")
-        assistant_kind = raw_assistant_kind if type(raw_assistant_kind) is str else None
-        raw_assistant_id = conversation.get("assistant_id")
-        assistant_id = raw_assistant_id if type(raw_assistant_id) is str else None
-        raw_assistant_authority_id = conversation.get("assistant_authority_id")
-        assistant_authority_id = (
-            raw_assistant_authority_id
-            if type(raw_assistant_authority_id) is str
-            else None
-        )
-        raw_character_id = conversation.get("character_id")
-        character_id = (
-            raw_character_id
-            if (
-                runtime_backend == "local"
-                and assistant_kind == "character"
-                and type(raw_character_id) is int
-                and raw_character_id > 0
-                and assistant_id == str(raw_character_id)
-            )
-            else None
-        )
-        session = store.restore_persisted_session(
-            title=title,
-            workspace_id=workspace_id,
-            persisted_conversation_id=target,
-            all_nodes=all_nodes,
-            active_leaf_persisted_id=active_leaf_id,
-            settings=self._console_session_settings_for_resume(conversation),
-            runtime_backend=runtime_backend,
-            assistant_kind=assistant_kind,
-            assistant_id=assistant_id,
-            assistant_authority_id=assistant_authority_id,
-            character_id=character_id,
-        )
-        # Re-derive display-only agent TOOL markers from AgentRunsDB and overlay
-        # them onto the restored active-path VIEW (markers are never tree nodes;
-        # the next tree mutation's recompute rebuilds the view from live nodes
-        # and drops them, matching how live markers are ephemeral in Phase A).
-        store.apply_resume_marker_overlay(
-            session.id,
-            self._inject_resume_agent_markers(
-                store.messages_for_session(session.id), target
-            ),
-        )
-        # Local presentation remains keyed only by the numeric local
-        # projection. Opaque server identity never enters local card/avatar/
-        # dictionary lookup paths.
-        if (
-            session.runtime_backend == "local"
-            and session.assistant_kind == "character"
-            and session.character_id is not None
-        ):
-            character_name = await self._resolve_resumed_character_name(
-                session.character_id
-            )
-            if character_name:
-                session.character_name = character_name
-            # Always (re)set the label on a local character resume -- to the
-            # resolved name, or clear it when unresolved. ``settings`` are
-            # otherwise inherited from the currently active session, so
-            # leaving an inherited ``character_label`` in place would make
-            # a card-less resume show a *different* character's name.
-            if session.settings is not None:
-                session.settings = replace(
-                    session.settings, character_label=character_name
-                )
-        elif session.settings is not None:
-            session.settings = replace(session.settings, character_label="")
-        self._set_active_workspace_for_console_session(session.id)
-        # task-9/task-13: warm the EFFECTIVE (conversation ∩ workspace)
-        # scope cache for this session now (off-loop) so the Inspector row
-        # reflects reality immediately on resume, rather than defaulting to
-        # "everything" until the user opens Edit or saves a change (the
-        # picker's other two read triggers).
-        try:
-            await self._resolve_console_effective_scope_state(session)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Failed to resolve retrieval scope for conversation {}", target
-            )
-        # task-10 review finding 2: warming the cache above is not enough
-        # by itself -- neither `_sync_native_console_chat_ui()` below nor
-        # its own `_sync_console_control_bar()` call ever touches the
-        # retrieval-scope row or `ConsoleStatusChips.sync_scope_chip`
-        # (`sync_scope_chip` is deliberately its own method, kept off the
-        # general control-bar sync tick -- see its docstring). Without this
-        # explicit call the MOUNTED row/chip stayed on whatever state they
-        # last rendered until the user opened Edit/Narrow or saved a
-        # change, even though the cache above already had the right
-        # answer. This is the same helper (and the same one-state,
-        # two-renderers push) the scope-picker save path already uses.
-        self._sync_console_retrieval_scope_row()
-        # Finding C: resuming a saved conversation switches the active
-        # conversation just as much as a tab switch does -- clear any
-        # sub-agent drill-in immediately rather than rely solely on the
-        # rail render path's defensive re-check on the next sync.
-        self._console_agent_drilldown_run_id = None
-        self._note_console_follow_intent()
-        self._sync_console_chat_core_state()
-        await self._sync_native_console_chat_ui()
-        self._focus_console_composer_if_needed(force=True)
-        return True
-
     def _on_console_scope_flushed(
         self, conversation_id: str, scope: Optional[RagScope]
     ) -> None:
@@ -11837,34 +11127,6 @@ class ChatScreen(BaseAppScreen):
                 exclusive=True,
                 group="console-effective-scope-refresh",
             )
-
-    def _build_console_workspace_context_state(self) -> ConsoleWorkspaceContextState:
-        current_conversation = self._current_console_conversation_id()
-        state = build_console_workspace_state(
-            registry_service=getattr(
-                self.app_instance, "workspace_registry_service", None
-            ),
-            current_conversation=current_conversation,
-            server_adapter_state=getattr(
-                self.app_instance,
-                "workspace_server_adapter_state",
-                None,
-            ),
-            acp_handoff_state=getattr(
-                self.app_instance,
-                "workspace_acp_handoff_state",
-                None,
-            ),
-        )
-        state = self._with_native_console_session_rows(state)
-        return self._with_console_conversation_browser_state(
-            state,
-            current_conversation_id=current_conversation,
-        )
-
-    @staticmethod
-    def _console_workspace_row_key(row: ConsoleWorkspaceConversationRow) -> str:
-        return str(row.conversation_id or "").strip()
 
     @staticmethod
     def _console_browser_row_key(row: ConsoleConversationBrowserInputRow) -> str:
@@ -11921,7 +11183,7 @@ class ChatScreen(BaseAppScreen):
         target_conversation_id = str(conversation_id or "").strip()
         if not target_row_key and not target_conversation_id:
             return None
-        state = self._build_console_workspace_context_state()
+        state = self._workspace._build_console_workspace_context_state()
         browser = state.conversation_browser
         if browser is None:
             return None
@@ -11951,47 +11213,6 @@ class ChatScreen(BaseAppScreen):
                         fallback = row
         return fallback
 
-    def _activate_console_workspace_for_browser_row(
-        self,
-        row: ConsoleConversationBrowserRow,
-    ) -> None:
-        """Align active workspace context before opening a browser row."""
-        scope_type = str(row.scope_type or "").strip()
-        if scope_type == "global":
-            return
-        workspace_id = str(row.workspace_id or "").strip()
-        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
-            return
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            return
-        try:
-            active_workspace = registry_service.get_active_workspace()
-            if (
-                active_workspace is None
-                or active_workspace.workspace_id != workspace_id
-            ):
-                registry_service.set_active_workspace(workspace_id)
-                # TASK-713: opening a row from another workspace's group
-                # retargets the whole Console context; the Workspace status
-                # row is usually scrolled out of view at that moment, so the
-                # side effect needs an explicit announcement.
-                switched = registry_service.get_active_workspace()
-                switched_name = switched.name if switched is not None else workspace_id
-                self.app_instance.notify(
-                    f"Switched Console to {switched_name}.",
-                    severity="information",
-                )
-            self._ensure_console_chat_store().set_workspace_context(
-                self._current_console_workspace_context()
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Unable to activate Console workspace for browser row",
-            )
-
     def _console_session_id_for_browser_row(
         self,
         row: ConsoleConversationBrowserRow,
@@ -12007,7 +11228,7 @@ class ChatScreen(BaseAppScreen):
             return None
         row_key = str(row.row_key or "").strip()
         if row_key.startswith("native:"):
-            return self._console_session_id_for_workspace_conversation(row_key)
+            return self._workspace._console_session_id_for_workspace_conversation(row_key)
         conversation_id = str(row.conversation_id or "").strip()
         if not conversation_id:
             return None
@@ -12043,60 +11264,6 @@ class ChatScreen(BaseAppScreen):
             )
             return ("conversation", scope_type, workspace_id, conversation_id)
         return ("row", ChatScreen._console_browser_row_key(row))
-
-    def _console_browser_workspace_records(self) -> tuple[WorkspaceRecord, ...]:
-        """Return all local workspace records visible to the Console browser."""
-        service = getattr(self.app_instance, "workspace_registry_service", None)
-        if service is None:
-            return ()
-        ensure_default = getattr(service, "ensure_default_workspace", None)
-        if callable(ensure_default):
-            try:
-                ensure_default()
-            except Exception:
-                logger.opt(exception=True).debug(
-                    "Unable to ensure default workspace for Console browser"
-                )
-        list_workspaces = getattr(service, "list_workspaces", None)
-        if not callable(list_workspaces):
-            return ()
-        try:
-            return tuple(list_workspaces())
-        except Exception:
-            logger.opt(exception=True).debug(
-                "Unable to list Console browser workspaces"
-            )
-            return ()
-
-    def _console_browser_workspace_labels(self) -> dict[str, str]:
-        """Return workspace labels keyed by workspace id for browser rows."""
-        labels: dict[str, str] = {}
-        for record in self._console_browser_workspace_records():
-            workspace_id = str(record.workspace_id or "").strip()
-            if not workspace_id:
-                continue
-            labels[workspace_id] = (
-                "Chats"
-                if workspace_id == DEFAULT_WORKSPACE_ID
-                else str(record.name or workspace_id)
-            )
-        labels.setdefault(DEFAULT_WORKSPACE_ID, "Chats")
-        return labels
-
-    def _console_browser_workspace_label(
-        self,
-        workspace_id: str | None,
-        labels: dict[str, str] | None = None,
-    ) -> str:
-        """Return display label for a workspace/global browser row."""
-        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
-            return "Chats"
-        if workspace_id == DEFAULT_WORKSPACE_ID:
-            return "Chats"
-        workspace_labels = (
-            labels if labels is not None else self._console_browser_workspace_labels()
-        )
-        return workspace_labels.get(workspace_id, workspace_id)
 
     def _starred_console_conversation_ids(self) -> set[str]:
         """Return locally starred durable conversation ids."""
@@ -12140,7 +11307,7 @@ class ChatScreen(BaseAppScreen):
         store = self._console_chat_store
         if store is None:
             return []
-        labels = self._console_browser_workspace_labels()
+        labels = self._workspace._console_browser_workspace_labels()
         starred_ids = self._starred_console_conversation_ids()
         active_session_id = store.active_session_id
         controller = getattr(self, "_console_chat_controller", None)
@@ -12177,7 +11344,7 @@ class ChatScreen(BaseAppScreen):
                 title=str(session.title or "Untitled conversation"),
                 scope_type=scope_type,
                 workspace_id=workspace_id,
-                workspace_label=self._console_browser_workspace_label(
+                workspace_label=self._workspace._console_browser_workspace_label(
                     workspace_id, labels
                 ),
                 status="active session" if selected else "open session",
@@ -12198,7 +11365,7 @@ class ChatScreen(BaseAppScreen):
         list_conversations = getattr(service, "list_workspace_conversations", None)
         if not callable(list_conversations):
             return []
-        labels = self._console_browser_workspace_labels()
+        labels = self._workspace._console_browser_workspace_labels()
         starred_ids = self._starred_console_conversation_ids()
         current_conversation = (
             current_conversation_id or self._current_console_conversation_id()
@@ -12208,11 +11375,11 @@ class ChatScreen(BaseAppScreen):
             str(active_session.workspace_id or "").strip()
             if active_session is not None
             else str(
-                self._current_console_workspace_context().active_workspace_id or ""
+                self._workspace._current_console_workspace_context().active_workspace_id or ""
             ).strip()
         )
         rows: list[ConsoleConversationBrowserInputRow] = []
-        for record in self._console_browser_workspace_records():
+        for record in self._workspace._console_browser_workspace_records():
             workspace_id = str(record.workspace_id or "").strip()
             if not workspace_id:
                 continue
@@ -12237,7 +11404,7 @@ class ChatScreen(BaseAppScreen):
                     title=title,
                     scope_type="workspace",
                     workspace_id=workspace_id,
-                    workspace_label=self._console_browser_workspace_label(
+                    workspace_label=self._workspace._console_browser_workspace_label(
                         workspace_id, labels
                     ),
                     status=str(getattr(membership, "role", "") or "workspace-thread"),
@@ -12282,11 +11449,11 @@ class ChatScreen(BaseAppScreen):
         if not services:
             return [], None, ""
 
-        labels = self._console_browser_workspace_labels()
+        labels = self._workspace._console_browser_workspace_labels()
         scopes: list[tuple[str, str | None]] = [("global", None)]
         scopes.extend(
             ("workspace", str(record.workspace_id))
-            for record in self._console_browser_workspace_records()
+            for record in self._workspace._console_browser_workspace_records()
             if str(record.workspace_id or "").strip()
         )
         last_error = ""
@@ -12396,7 +11563,7 @@ class ChatScreen(BaseAppScreen):
                         title=str(item.get("title") or "Untitled conversation"),
                         scope_type=item_scope_type,
                         workspace_id=normalized_workspace_id,
-                        workspace_label=self._console_browser_workspace_label(
+                        workspace_label=self._workspace._console_browser_workspace_label(
                             normalized_workspace_id,
                             labels,
                         ),
@@ -12493,11 +11660,11 @@ class ChatScreen(BaseAppScreen):
         if not services:
             return [], None, ""
 
-        labels = self._console_browser_workspace_labels()
+        labels = self._workspace._console_browser_workspace_labels()
         scopes: list[tuple[str, str | None]] = [("global", None)]
         scopes.extend(
             ("workspace", str(record.workspace_id))
-            for record in self._console_browser_workspace_records()
+            for record in self._workspace._console_browser_workspace_records()
             if str(record.workspace_id or "").strip()
         )
         last_error = ""
@@ -12593,7 +11760,7 @@ class ChatScreen(BaseAppScreen):
                         title=str(item.get("title") or "Untitled conversation"),
                         scope_type=item_scope_type,
                         workspace_id=normalized_workspace_id,
-                        workspace_label=self._console_browser_workspace_label(
+                        workspace_label=self._workspace._console_browser_workspace_label(
                             normalized_workspace_id,
                             labels,
                         ),
@@ -12660,286 +11827,6 @@ class ChatScreen(BaseAppScreen):
         else:
             total = None
         return rows, total, self._console_conversation_browser_error or sync_error
-
-    def _selected_console_workspace_conversation_summary(
-        self,
-        rows: list[ConsoleWorkspaceConversationRow],
-    ) -> str:
-        selected = next((row for row in rows if row.selected), None)
-        if selected is None:
-            return "No active conversation."
-        title = ConsoleWorkspaceContextTray._conversation_title(selected.title)
-        detail = ConsoleWorkspaceContextTray._conversation_detail_status(
-            selected.status
-        )
-        return f"{title} - {detail or 'conversation'}"
-
-    def _merge_console_workspace_rows(
-        self,
-        primary: list[ConsoleWorkspaceConversationRow],
-        secondary: list[ConsoleWorkspaceConversationRow],
-    ) -> list[ConsoleWorkspaceConversationRow]:
-        merged: list[ConsoleWorkspaceConversationRow] = []
-        seen: set[str] = set()
-        for row in primary + secondary:
-            key = self._console_workspace_row_key(row)
-            if not key or key in seen:
-                continue
-            seen.add(key)
-            merged.append(row)
-        return merged
-
-    def _native_console_rows_for_workspace_search(
-        self,
-        workspace_id: str,
-        query: str,
-    ) -> list[ConsoleWorkspaceConversationRow]:
-        """Return matching open native sessions for the active workspace search."""
-        store = self._console_chat_store
-        if store is None:
-            return []
-        needle = str(query or "").strip().lower()
-        rows: list[ConsoleWorkspaceConversationRow] = []
-        active_session_id = store.active_session_id
-        for session in store.sessions():
-            selected = session.id == active_session_id
-            session_workspace_id = str(session.workspace_id or "").strip()
-            if (
-                workspace_id
-                and workspace_id != CONSOLE_GLOBAL_WORKSPACE_ID
-                and session_workspace_id != workspace_id
-                and not selected
-            ):
-                continue
-            title = str(session.title or "Untitled conversation")
-            if needle and needle not in title.lower():
-                continue
-            conversation_id = (
-                str(session.persisted_conversation_id)
-                if session.persisted_conversation_id
-                else f"native:{session.id}"
-            )
-            rows.append(
-                ConsoleWorkspaceConversationRow(
-                    conversation_id=conversation_id,
-                    title=title,
-                    status="active" if selected else "open",
-                    selected=selected,
-                )
-            )
-        return rows
-
-    def _membership_console_rows_for_workspace_search(
-        self,
-        workspace_id: str,
-        query: str,
-    ) -> list[ConsoleWorkspaceConversationRow]:
-        """Return matching workspace conversation membership rows."""
-        service = getattr(self.app_instance, "workspace_registry_service", None)
-        list_conversations = getattr(service, "list_workspace_conversations", None)
-        if not callable(list_conversations) or not workspace_id:
-            return []
-        needle = str(query or "").strip().lower()
-        try:
-            memberships = list_conversations(workspace_id)
-        except Exception:
-            logger.opt(exception=True).debug(
-                "Unable to search workspace conversation memberships"
-            )
-            return []
-        rows: list[ConsoleWorkspaceConversationRow] = []
-        current_conversation = self._current_console_conversation_id()
-        for membership in memberships:
-            title = str(
-                getattr(membership, "title", "") or getattr(membership, "item_id", "")
-            )
-            if needle and needle not in title.lower():
-                continue
-            conversation_id = str(getattr(membership, "item_id", "") or "")
-            rows.append(
-                ConsoleWorkspaceConversationRow(
-                    conversation_id=conversation_id,
-                    title=title,
-                    status=str(getattr(membership, "role", "") or "workspace-thread"),
-                    selected=bool(
-                        current_conversation and conversation_id == current_conversation
-                    ),
-                )
-            )
-        return rows
-
-    async def _persisted_console_rows_for_workspace_search(
-        self,
-        workspace_id: str,
-        query: str,
-    ) -> tuple[list[ConsoleWorkspaceConversationRow], int | None, str]:
-        """Return persisted workspace conversation search rows, total, and error copy."""
-        scope_service = getattr(
-            self.app_instance,
-            "chat_conversation_scope_service",
-            None,
-        )
-        list_conversations = getattr(scope_service, "list_conversations", None)
-        if not callable(list_conversations) or not workspace_id:
-            return [], None, ""
-        if (
-            hasattr(scope_service, "local_service")
-            and getattr(scope_service, "local_service", None) is None
-        ):
-            return [], None, ""
-        try:
-            result = list_conversations(
-                mode="local",
-                query=query,
-                scope_type="workspace",
-                workspace_id=workspace_id,
-                limit=CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT,
-                offset=0,
-            )
-            result = await result if inspect.isawaitable(result) else result
-        except Exception as exc:
-            if (
-                isinstance(exc, ValueError)
-                and "service is unavailable" in str(exc).lower()
-            ):
-                logger.debug(
-                    "Local persisted conversation search service is unavailable"
-                )
-                return [], None, ""
-            logger.exception("Unable to search Console workspace conversations")
-            return [], None, "Workspace conversation search is unavailable."
-        if not isinstance(result, dict):
-            return [], 0, ""
-        items = result.get("items")
-        if not isinstance(items, list):
-            items = []
-        total = result.get("total")
-        if total is None:
-            pagination = result.get("pagination")
-            if isinstance(pagination, dict):
-                total = pagination.get("total")
-        try:
-            total_count = int(total)
-        except (TypeError, ValueError):
-            total_count = len(items)
-        current_conversation = self._current_console_conversation_id()
-        rows: list[ConsoleWorkspaceConversationRow] = []
-        for item in items:
-            if not isinstance(item, dict):
-                continue
-            conversation_id = str(item.get("id") or "").strip()
-            if not conversation_id:
-                continue
-            rows.append(
-                ConsoleWorkspaceConversationRow(
-                    conversation_id=conversation_id,
-                    title=str(item.get("title") or "Untitled conversation"),
-                    status=str(item.get("state") or "workspace-thread"),
-                    selected=bool(
-                        current_conversation and current_conversation == conversation_id
-                    ),
-                )
-            )
-        return rows, total_count, ""
-
-    def _refresh_console_workspace_conversation_search_if_current(
-        self,
-        workspace_id: str,
-        query: str,
-        token: int,
-        *,
-        restore_focus: bool = False,
-    ) -> bool:
-        """Refresh search results when workspace, query, and token still match."""
-        if token != self._console_workspace_conversation_search_token:
-            return False
-        if workspace_id != self._active_console_workspace_id_for_conversation_search():
-            return False
-        if query != self._console_workspace_conversation_query:
-            return False
-        self._sync_console_workspace_context()
-        if restore_focus:
-            self.call_after_refresh(self._focus_console_workspace_conversation_search)
-        return True
-
-    async def _refresh_console_workspace_conversation_search(
-        self,
-        workspace_id: str,
-        query: str,
-        token: int,
-    ) -> None:
-        """Refresh search results only if workspace and query are still current."""
-        if token != self._console_workspace_conversation_search_token:
-            return
-        if workspace_id != self._active_console_workspace_id_for_conversation_search():
-            return
-        if query != self._console_workspace_conversation_query:
-            return
-        if not str(query or "").strip():
-            self._console_workspace_conversation_search_rows = ()
-            self._console_workspace_conversation_search_total = None
-            self._console_workspace_conversation_search_error = ""
-            self._sync_console_workspace_context()
-            self.call_after_refresh(self._focus_console_workspace_conversation_search)
-            return
-        native_rows = self._native_console_rows_for_workspace_search(
-            workspace_id,
-            query,
-        )
-        membership_rows = self._membership_console_rows_for_workspace_search(
-            workspace_id,
-            query,
-        )
-        local_rows = self._merge_console_workspace_rows(native_rows, membership_rows)
-        self._console_workspace_conversation_search_rows = tuple(local_rows)
-        self._console_workspace_conversation_search_total = len(local_rows)
-        self._console_workspace_conversation_search_error = ""
-        self._sync_console_workspace_context()
-        self.call_after_refresh(self._focus_console_workspace_conversation_search)
-        (
-            persisted_rows,
-            persisted_total,
-            error_copy,
-        ) = await self._persisted_console_rows_for_workspace_search(
-            workspace_id,
-            query,
-        )
-        if token != self._console_workspace_conversation_search_token:
-            return
-        if workspace_id != self._active_console_workspace_id_for_conversation_search():
-            return
-        if query != self._console_workspace_conversation_query:
-            return
-        merged = self._merge_console_workspace_rows(
-            local_rows,
-            persisted_rows,
-        )
-        result_total = persisted_total
-        if result_total is None or result_total < len(merged):
-            result_total = len(merged)
-        self._console_workspace_conversation_search_rows = tuple(merged)
-        self._console_workspace_conversation_search_total = result_total
-        self._console_workspace_conversation_search_error = error_copy
-        self._sync_console_workspace_context()
-        self.call_after_refresh(self._focus_console_workspace_conversation_search)
-
-    async def _refresh_console_workspace_conversation_search_after_selection(
-        self,
-    ) -> None:
-        """Refresh active search rows after a conversation row changes selection."""
-        query = self._console_workspace_conversation_query
-        if not query.strip():
-            return
-        if self._console_workspace_conversation_search_timer is not None:
-            self._console_workspace_conversation_search_timer.stop()
-            self._console_workspace_conversation_search_timer = None
-        self._console_workspace_conversation_search_token += 1
-        token = self._console_workspace_conversation_search_token
-        await self._refresh_console_workspace_conversation_search(
-            self._active_console_workspace_id_for_conversation_search(),
-            query,
-            token,
-        )
 
     async def _refresh_console_conversation_browser_search(
         self,
@@ -13067,75 +11954,9 @@ class ChatScreen(BaseAppScreen):
         return replace(
             state,
             conversation_rows=tuple(
-                self._merge_console_workspace_rows(native_rows, rows)
+                self._workspace._merge_console_workspace_rows(native_rows, rows)
             ),
         )
-
-    def _with_console_workspace_conversation_section(
-        self,
-        state: ConsoleWorkspaceContextState,
-    ) -> ConsoleWorkspaceContextState:
-        """Attach renderable Conversations subsection state to workspace context."""
-        workspace_id = ""
-        try:
-            workspace_id = str(
-                self._current_console_workspace_context().active_workspace_id or ""
-            ).strip()
-        except Exception:
-            workspace_id = ""
-        store = self._console_chat_store
-        if not workspace_id:
-            if store is not None and store.workspace_context.active_workspace_id:
-                workspace_id = str(store.workspace_context.active_workspace_id)
-            elif state.workspace_label.startswith("Workspace: "):
-                workspace_id = state.workspace_label.removeprefix("Workspace: ").strip()
-
-        if self._console_workspace_conversation_workspace_id != workspace_id:
-            self._console_workspace_conversation_query = ""
-            self._console_workspace_conversation_search_token += 1
-            self._console_workspace_conversation_search_rows = ()
-            self._console_workspace_conversation_search_total = None
-            self._console_workspace_conversation_search_error = ""
-            self._console_workspace_conversation_workspace_id = workspace_id
-
-        rows = list(state.conversation_rows)
-        if self._console_workspace_conversation_query.strip():
-            rows = list(self._console_workspace_conversation_search_rows)
-        selected_summary = self._selected_console_workspace_conversation_summary(rows)
-        query = self._console_workspace_conversation_query
-        result_total = (
-            self._console_workspace_conversation_search_total if query.strip() else None
-        )
-        if (
-            query.strip()
-            and result_total is None
-            and not self._console_workspace_conversation_search_error
-        ):
-            result_total = len(rows)
-        status_copy = console_workspace_conversation_result_copy(
-            query=query,
-            result_total_count=result_total,
-            result_limit=CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT,
-        )
-        section = ConsoleWorkspaceConversationSectionState(
-            workspace_id=workspace_id,
-            collapsed=self._console_workspace_conversations_collapsed(workspace_id),
-            query=query,
-            selected_summary=selected_summary,
-            rows=tuple(rows),
-            workspace_total_count=len(rows),
-            result_total_count=result_total,
-            status_copy=status_copy,
-            empty_copy=(
-                "No matches in this workspace."
-                if query.strip()
-                else state.conversation_empty_copy
-            ),
-            search_enabled=True,
-            new_conversation_enabled=state.new_conversation_enabled,
-            error_copy=self._console_workspace_conversation_search_error,
-        )
-        return replace(state, conversation_section=section)
 
     def _console_subagent_counts_refresh_needed(self, row_ids: frozenset) -> bool:
         """Decide whether the sub-agent badge-count cache needs a DB round trip.
@@ -13230,7 +12051,7 @@ class ChatScreen(BaseAppScreen):
         subagent_counts = self._console_subagent_counts_for_rows(bridge, rows)
         browser = build_console_conversation_browser_state(
             rows=rows,
-            active_workspace_id=self._current_console_workspace_context().active_workspace_id,
+            active_workspace_id=self._workspace._current_console_workspace_context().active_workspace_id,
             group_collapse_preferences=(
                 self._console_conversation_browser_collapse_preferences()
             ),
@@ -13241,7 +12062,7 @@ class ChatScreen(BaseAppScreen):
             result_limit=CONSOLE_CONVERSATION_BROWSER_RESULT_LIMIT,
             subagent_counts=subagent_counts,
         )
-        legacy_state = self._with_console_workspace_conversation_section(state)
+        legacy_state = self._workspace._with_console_workspace_conversation_section(state)
         return replace(
             state,
             conversation_browser=browser,
@@ -13315,34 +12136,6 @@ class ChatScreen(BaseAppScreen):
             collapsed_groups = {}
             browser_config["collapsed_groups"] = collapsed_groups
         collapsed_groups[normalized_group_id] = bool(collapsed)
-
-    def _console_workspace_conversations_collapsed(
-        self,
-        workspace_id: str | None,
-    ) -> bool:
-        """Return stored collapse preference for one workspace."""
-        key = str(workspace_id or "global").strip() or "global"
-        app_config = getattr(self.app_instance, "app_config", None)
-        if not isinstance(app_config, dict):
-            return False
-        console_config = app_config.get("console")
-        if not isinstance(console_config, dict):
-            return False
-        section_config = console_config.get("conversation_section")
-        if not isinstance(section_config, dict):
-            return False
-        value = section_config.get(key)
-        return bool(value.get("collapsed")) if isinstance(value, dict) else False
-
-    def _set_console_workspace_conversations_collapsed(
-        self,
-        workspace_id: str | None,
-        collapsed: bool,
-    ) -> None:
-        """Store collapse preference for one workspace in memory."""
-        key = str(workspace_id or "global").strip() or "global"
-        section_config = self._console_conversation_section_config()
-        section_config[key] = {"collapsed": bool(collapsed)}
 
     def _console_rail_state_config(self) -> dict[str, Any]:
         """Return mutable Console rail-state config, initializing it if needed."""
@@ -13785,7 +12578,7 @@ class ChatScreen(BaseAppScreen):
         workspace_context_state: ConsoleWorkspaceContextState,
     ) -> ConsoleRailState:
         """Build the effective Console rail state for the current composition."""
-        workspace_context = self._current_console_workspace_context()
+        workspace_context = self._workspace._current_console_workspace_context()
         active_session_id = (
             self._console_chat_store.active_session_id
             if self._console_chat_store is not None
@@ -13970,7 +12763,7 @@ class ChatScreen(BaseAppScreen):
         pending_launch = self._pending_console_launch_context
         staged_context_state = self._build_console_staged_context_state(pending_launch)
         inspector_state = self._build_console_inspector_state(pending_launch)
-        workspace_context_state = self._build_console_workspace_context_state()
+        workspace_context_state = self._workspace._build_console_workspace_context_state()
         rail_state = self._build_console_rail_state(
             staged_context_state=staged_context_state,
             inspector_state=inspector_state,
@@ -14047,7 +12840,7 @@ class ChatScreen(BaseAppScreen):
         notify_on_failure: bool = True,
     ) -> ConsoleRailState:
         """Persist requested Console rail preference changes and return new state."""
-        workspace_context = self._current_console_workspace_context()
+        workspace_context = self._workspace._current_console_workspace_context()
         preference_key = build_console_rail_preference_key(
             workspace_id=workspace_context.active_workspace_id,
             conversation_id=self._current_console_rail_conversation_id(),
@@ -14130,7 +12923,7 @@ class ChatScreen(BaseAppScreen):
                 "#console-workspace-context",
                 ConsoleWorkspaceContextTray,
             )
-            state = self._build_console_workspace_context_state()
+            state = self._workspace._build_console_workspace_context_state()
             # TASK-251: read the widget's OWN current state before it's
             # overwritten -- this is intentionally not a screen-level cache
             # (which would go stale across a full-screen recompose); the
@@ -14213,7 +13006,7 @@ class ChatScreen(BaseAppScreen):
         except (NoMatches, QueryError):
             return
 
-        state = self._build_console_workspace_context_state()
+        state = self._workspace._build_console_workspace_context_state()
 
         if not self.query("#console-new-workspace-conversation"):
             new_button = Button(
@@ -15022,7 +13815,7 @@ class ChatScreen(BaseAppScreen):
                 ConsoleDisplayRow("Conversation source", "none"),
             )
 
-        workspace_state = self._build_console_workspace_context_state()
+        workspace_state = self._workspace._build_console_workspace_context_state()
         workspace_label = str(workspace_state.workspace_label or "").strip()
         if workspace_label.startswith("Workspace: "):
             workspace_label = workspace_label.removeprefix("Workspace: ").strip()
@@ -16166,7 +14959,7 @@ class ChatScreen(BaseAppScreen):
         control_state = self._build_console_control_state(pending_launch)
         staged_context_state = self._build_console_staged_context_state(pending_launch)
         inspector_state = self._build_console_inspector_state(pending_launch)
-        workspace_context_state = self._build_console_workspace_context_state()
+        workspace_context_state = self._workspace._build_console_workspace_context_state()
         # task-10: built once, shared verbatim by the header's "Scope" chip
         # and the Inspector's retrieval-scope row below -- one zero-DB
         # state, two renderers.
@@ -17778,7 +16571,7 @@ class ChatScreen(BaseAppScreen):
                 store.set_session_draft(session.id, suggested_prompt)
             else:
                 session = store.ensure_session(
-                    title=self._console_initial_session_title_for_workspace(
+                    title=self._workspace._console_initial_session_title_for_workspace(
                         store.workspace_context.active_workspace_id
                     ),
                     workspace_id=store.workspace_context.active_workspace_id,
@@ -18439,7 +17232,7 @@ class ChatScreen(BaseAppScreen):
             return
         store = self._ensure_console_chat_store()
         store.ensure_session(
-            title=self._console_initial_session_title_for_workspace(
+            title=self._workspace._console_initial_session_title_for_workspace(
                 store.workspace_context.active_workspace_id
             ),
             workspace_id=store.workspace_context.active_workspace_id,
@@ -18509,7 +17302,7 @@ class ChatScreen(BaseAppScreen):
                 pass
         else:
             session = store.ensure_session(
-                title=self._console_initial_session_title_for_workspace(
+                title=self._workspace._console_initial_session_title_for_workspace(
                     store.workspace_context.active_workspace_id
                 ),
                 workspace_id=store.workspace_context.active_workspace_id,
@@ -23417,7 +22210,7 @@ class ChatScreen(BaseAppScreen):
                 and last_round_ids <= self._console_toasted_park_round_ids
             ):
                 return
-        session_title, workspace_name = self._console_session_title_and_workspace_name(
+        session_title, workspace_name = self._workspace._console_session_title_and_workspace_name(
             controller, session_id
         )
         self.app_instance.notify(
@@ -23468,46 +22261,6 @@ class ChatScreen(BaseAppScreen):
                 ids.add(f"script:{request_id}")
         return frozenset(ids)
 
-    def _console_session_title_and_workspace_name(
-        self, controller: ConsoleChatController, session_id: str
-    ) -> tuple[str, str]:
-        """Return ``(session_title, workspace_name)`` for a fleet toast.
-
-        Fix wave (rider 6, final review): shared by ``_park_console_
-        approval`` and ``_notify_console_run_outcome``, which previously
-        duplicated this exact lookup byte-for-byte. Falls back to the raw
-        ``session_id``/workspace id when the session has already closed or
-        the workspace can't be resolved -- a toast about a session that
-        vanished microseconds ago must still say SOMETHING coherent rather
-        than raise.
-        """
-        session_title = session_id
-        workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
-        for session in controller.store.sessions():
-            if session.id == session_id:
-                session_title = session.title
-                workspace_id = session.workspace_id
-                break
-        return session_title, self._console_workspace_display_name(workspace_id)
-
-    def _console_workspace_display_name(self, workspace_id: str) -> str:
-        """Return ``workspace_id``'s display name via the registry, falling
-        back to the raw id when the service is unavailable or the
-        workspace can't be resolved (PA-T9 toast copy)."""
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is not None:
-            try:
-                workspace = registry_service.get_workspace(workspace_id)
-                if workspace is not None and workspace.name:
-                    return workspace.name
-            except Exception:
-                logger.opt(exception=True).debug(
-                    "Unable to resolve Console workspace name for approval toast"
-                )
-        return str(workspace_id)
-
     def _notify_console_run_outcome(
         self, session_id: str, status: ConsoleRunStatus
     ) -> None:
@@ -23537,7 +22290,7 @@ class ChatScreen(BaseAppScreen):
         controller = self._console_chat_controller
         if controller is None:
             return
-        session_title, workspace_name = self._console_session_title_and_workspace_name(
+        session_title, workspace_name = self._workspace._console_session_title_and_workspace_name(
             controller, session_id
         )
         verb = "finished" if status is ConsoleRunStatus.COMPLETED else "failed"
@@ -23710,7 +22463,7 @@ class ChatScreen(BaseAppScreen):
         ):
             event.stop()
             group_id = str(getattr(event.button, "group_id", "") or "").strip()
-            state = self._build_console_workspace_context_state()
+            state = self._workspace._build_console_workspace_context_state()
             section_id = group_id.removeprefix("section:")
             section = None
             browser = state.conversation_browser
@@ -23732,7 +22485,7 @@ class ChatScreen(BaseAppScreen):
         ):
             event.stop()
             group_id = str(getattr(event.button, "group_id", "") or "").strip()
-            state = self._build_console_workspace_context_state()
+            state = self._workspace._build_console_workspace_context_state()
             group = None
             browser = state.conversation_browser
             if browser is not None:
@@ -23835,7 +22588,7 @@ class ChatScreen(BaseAppScreen):
                 if section is None:
                     return
                 collapsed = not bool(section.collapsed)
-                self._set_console_workspace_conversations_collapsed(
+                self._workspace._set_console_workspace_conversations_collapsed(
                     section.workspace_id,
                     collapsed,
                 )
@@ -23887,12 +22640,12 @@ class ChatScreen(BaseAppScreen):
                 conversation_id=conversation_id,
             )
             if browser_row is not None:
-                self._activate_console_workspace_for_browser_row(browser_row)
+                self._workspace._activate_console_workspace_for_browser_row(browser_row)
                 row_conversation_id = str(browser_row.conversation_id or "").strip()
                 session_id = self._console_session_id_for_browser_row(browser_row)
             else:
                 row_conversation_id = conversation_id
-                session_id = self._console_session_id_for_workspace_conversation(
+                session_id = self._workspace._console_session_id_for_workspace_conversation(
                     conversation_id
                 )
             if session_id is None:
@@ -23909,7 +22662,7 @@ class ChatScreen(BaseAppScreen):
                 # flag; the finally covers the not-resumable/error return).
                 self._set_console_conversation_row_loading(row_conversation_id, True)
                 try:
-                    resumed = await self._resume_console_workspace_conversation(
+                    resumed = await self._workspace._resume_console_workspace_conversation(
                         row_conversation_id,
                         target_scope_type=(
                             browser_row.scope_type if browser_row is not None else None
@@ -23943,7 +22696,7 @@ class ChatScreen(BaseAppScreen):
             controller = self._ensure_console_chat_controller()
             if controller.store.active_session_id != session_id:
                 if browser_row is None:
-                    self._set_active_workspace_for_console_session(session_id)
+                    self._workspace._set_active_workspace_for_console_session(session_id)
                 controller.switch_session(session_id)
                 await self._sync_native_console_chat_ui()
                 # task-7 review: an already-open native tab for this


### PR DESCRIPTION
Wave 2 of the Console decomposition, per the plan merged in #1347. **Pure refactor — zero behaviour change is the contract**, and the whole-branch review *measured* that rather than asserting it.

Spec: `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`. Plan: `Docs/superpowers/plans/2026-08-04-console-decomposition-wave2.md`. Follows wave 1 (#1345).

## What moved

| New module | Cluster |
|---|---|
| `UI/Console_Modules/workspace.py` | `ConsoleWorkspaceController` — 35 of 45 `*workspace*` methods, incl. the 205-line `_resume_console_workspace_conversation` |
| `UI/Console_Modules/hands_free.py` | `ConsoleHandsFreeController` — 28 methods, the engine fork, and both cross-engine action entry points |
| `UI/Console_Modules/session.py` | `ConsoleSessionController` — 27 methods, incl. the 215-line `_start_character_console_session` |

**`chat_screen.py`: 24,195 → 20,964 lines. `ChatScreen`: 680 → 612 methods** (−3,231 / −68). The screen is still large, deliberately: it keeps cross-region coordination, the Textual lifecycle, and the `action_*`/`@on` entry points Textual resolves by name. The criterion is ownership, not line count.

## Evidence the contract held

The whole-branch review ran a normalized AST diff (docstrings/comments stripped, controller prefixes collapsed) over **all 612 retained `ChatScreen` methods**: exactly **6 changed**, every one a pure delegation. `on_button_pressed`, `on_key` and `compose_content` are byte-identical. Of 89 moved methods, all 89 landed in a controller with identical bodies modulo seam renames. Worker group names *and counts* identical to base (25 names). pyflakes on `chat_screen.py`: 31 findings before, 31 after, set-identical.

Controller discipline, verified per module: **zero `query_one`/DOM access** in any of the four controllers; `self._screen` uses held to 3–6 each, every one a framework service or a documented sibling proxy; **zero** sibling reach-through (`self._screen._session|_workspace|_hands_free|_dictation`).

## The seam rule this wave established (now in DESIGN.md §7)

Three controllers on one screen forced the question wave 1 didn't face. Controller-to-controller traffic goes through **named callables the screen wires at construction** — never a back-door through screen attributes. Two consequences, each of which cost a review round:

- The lambdas must resolve the sibling **at call time**; a construction-time capture leaves whichever controller is built second as `None`.
- A write-only proxy getter must raise `RuntimeError`, **not** `AttributeError` — `hasattr()` and `getattr(obj, name, default)` swallow exactly that exception, so a defensive read would silently take the default forever.

## PR #1350 (realtime voice) preservation

Hands-free is a two-engine abstraction since #1350. The controller owns the fork and both action entry points (they read *both* engines, so they are coordination); the realtime engine's ~60 methods stay on the screen, reached via two named callables. Verified: the fork is the only engine-selection point, `action_exit_console_hands_free` hits both engines with no early return, and the realtime close-worker is still awaited on unmount.

## Also fixed here

Two tests in `test_console_composer_undo.py` have been failing on **dev** since wave 1 merged — `_insert_console_dictation` moved to the dictation controller but two call sites kept calling it on the screen. Our extraction shipped that gap, so this wave fixes it rather than filing it.

## Testing

Per-task gates >1,400 passing. Close-out gates: **90 passed** (geometry baseline + all three new controller suites) and **641 passed** (dictation streaming, native chat flow, internals decomposition, composer undo, realtime wiring). Reviewer confirmations added 161 more.

Characterisation tests were committed **before** each extraction for workspace and session; hands-free's baseline was recovered retroactively via a disposable worktree at the pre-move commit — disclosed, and its real safety comes from 30/30 byte-identical moved bodies plus a receiver-only test diff, both independently verified.

## Not in wave 2

The message cluster and the remaining visual surfaces (main column, mode/control bars, transcript) go together in wave 3, plus the agent/character/image clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored Console by extracting workspace, hands-free, and session logic from `ChatScreen` into `ConsoleWorkspaceController`, `ConsoleHandsFreeController`, and `ConsoleSessionController` with no behavior changes. `ChatScreen` is slimmer and keeps lifecycle/DOM; controllers are wired via named callables, and the hands-free/realtime engine fork remains intact.

- **Refactors**
  - Added `UI/Console_Modules/workspace.py`, `hands_free.py`, and `session.py`; the hands-free controller owns the pipeline↔realtime fork and both action entry points, while the realtime engine stays on the screen behind callables.
  - Reduced `tldw_chatbook/UI/Screens/chat_screen.py` from 24,195→20,964 lines and `ChatScreen` methods from 680→612; kept entry points and thin delegations (workspace search state, hands-free flags).
  - Retired dictation’s temporary hands-free reach-backs; `UI/Console_Modules/dictation.py` now uses injected callables.
  - Updated `DESIGN.md` and the spec to document the controller seam rule; write-only proxy getters raise `RuntimeError`. Removed dead `_refresh_console_workspace_conversation_search_if_current`.
  - Added characterization suites for `ConsoleWorkspaceController` and `ConsoleSessionController`.

- **Bug Fixes**
  - Fixed two failing tests by calling `_insert_console_dictation` on `ConsoleDictationController` in `test_console_composer_undo.py`.

<sup>Written for commit 779b409987d6f4e91624a5ca4a77c8b1c4d5a602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

