### PR TITLE
fix(markdown): hygiene batch — About markup, fence-aware reading transforms (TASK-1995)

### DIFF
--- a/Tests/UI/test_markdown_hygiene_1995.py
+++ b/Tests/UI/test_markdown_hygiene_1995.py
@@ -1,0 +1,83 @@
+"""TASK-1995: markdown rendering hygiene.
+
+1. The About pane feeds real markdown (not Rich console markup) to its
+   Markdown widget.
+2. Media reading-mode and search-highlight transforms leave the inside of
+   fenced code blocks untouched.
+"""
+
+from tldw_chatbook.UI.Tools_Settings_Window import ABOUT_MARKDOWN
+from tldw_chatbook.Widgets.Media.media_viewer_panel import (
+    _fenced_ranges,
+    format_reading_text,
+    highlight_match_spans,
+)
+
+FENCED_DOC = (
+    "Intro sentence one. Intro sentence two.\n"
+    "\n"
+    "```python\n"
+    "x = 1. Then more code? No.\n"
+    "1. not a heading\n"
+    "```\n"
+    "\n"
+    "1. a real numbered line\n"
+    "Outro. Done.\n"
+)
+
+
+def test_about_text_is_markdown_not_rich_markup():
+    assert "[bold]" not in ABOUT_MARKDOWN
+    assert "[italic]" not in ABOUT_MARKDOWN
+    assert "[link=" not in ABOUT_MARKDOWN
+    assert "**tldw-chatbook**" in ABOUT_MARKDOWN
+    assert "<https://github.com/rmusser01/tldw>" in ABOUT_MARKDOWN
+    # Bullets are list markers the markdown parser understands.
+    assert "\n- Multi-provider LLM support" in ABOUT_MARKDOWN
+
+
+def test_fenced_ranges_finds_closed_and_unclosed_fences():
+    ranges = _fenced_ranges(FENCED_DOC)
+    assert len(ranges) == 1
+    start, end = ranges[0]
+    assert FENCED_DOC[start:].startswith("```python")
+    assert FENCED_DOC[start:end].rstrip().endswith("```")
+
+    unclosed = "text\n```\ncode to the end"
+    (only,) = _fenced_ranges(unclosed)
+    assert unclosed[only[0] : only[1]] == "```\ncode to the end"
+
+
+def test_reading_mode_leaves_fenced_code_untouched():
+    formatted = format_reading_text(FENCED_DOC)
+    # Code block content is byte-identical.
+    assert "x = 1. Then more code? No.\n" in formatted
+    assert "## 1. not a heading" not in formatted
+    # Prose transforms still apply outside the fence.
+    assert "Intro sentence one.\n\nIntro sentence two." in formatted
+    assert "## 1. a real numbered line" in formatted
+    assert "Outro.\n\nDone." in formatted
+
+
+def test_highlight_skips_matches_inside_fences():
+    target = "code"
+    inside = FENCED_DOC.index("more code")
+    outside = FENCED_DOC.index("Intro")
+    matches = [
+        (outside, outside + 5),  # "Intro" — prose
+        (inside + 5, inside + 9),  # "code" — inside the fence
+    ]
+    highlighted = highlight_match_spans(FENCED_DOC, matches, current_index=0)
+    # Prose match is wrapped as the current match.
+    assert "**`▶ Intro ◀`**" in highlighted
+    # In-fence match is left verbatim — no backticks injected around it.
+    assert "x = 1. Then more code? No.\n" in highlighted
+    assert "`code`" not in highlighted
+
+
+def test_highlight_wraps_non_current_prose_matches():
+    doc = "alpha beta alpha"
+    matches = [(0, 5), (11, 16)]
+    highlighted = highlight_match_spans(doc, matches, current_index=1)
+    assert " `alpha` " in highlighted
+    assert "**`▶ alpha ◀`**" in highlighted

--- a/backlog/tasks/task-1995 - Markdown-rendering-hygiene-batch.md
+++ b/backlog/tasks/task-1995 - Markdown-rendering-hygiene-batch.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-1995
 title: 'Markdown rendering hygiene: About-pane markup, reading-mode mangling, dead CSS'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-02 22:30'
 labels:
   - bug
@@ -26,8 +27,21 @@ Three defects found by the 2026-08-02 markdown-rendering audit (all verified on 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The About section renders styled text with no literal bracket tags, verified in a live capture
-- [ ] #2 Reading mode and search highlighting no longer alter the inside of fenced code blocks (test with a code-block-bearing media document)
-- [ ] #3 The dead Markdown#web-search-results CSS rule is gone
-- [ ] #4 Existing tests for the touched surfaces stay green
+- [x] #1 The About markdown source contains no Rich markup tags (verified by test; AMENDED 2026-08-06: the About pane is UNROUTED dead UI since TASK-1346 — `tools_settings` routes to MCPScreen and the F9 Settings screen has no About — so a live capture cannot honestly be produced; reachability gap filed as its own task)
+- [x] #2 Reading mode and search highlighting no longer alter the inside of fenced code blocks (test with a code-block-bearing media document)
+- [x] #3 The dead Markdown#web-search-results CSS rule is gone (already removed by intervening dev churn between filing and implementation; verified absent repo-wide)
+- [x] #4 Existing tests for the touched surfaces stay green
 <!-- AC:END -->
+
+## Implementation Plan (the how)
+
+1. Convert the About pane's Rich-markup text to a real-markdown `ABOUT_MARKDOWN` module constant (bullets to `-` list items, `[link=…]` to autolinks) so the existing `Markdown` widget and LinkClicked handler work unchanged.
+2. Extract the media reading-mode/search-highlight transforms into fence-aware module functions (`format_reading_text`, `highlight_match_spans`, `_fenced_ranges`); an unclosed fence runs to end-of-content (the safe direction).
+3. Unit tests over a fenced document; run the consuming suites.
+
+## Implementation Notes
+
+- `UI/Tools_Settings_Window.py`: `ABOUT_MARKDOWN` constant replaces the inline Rich-markup string. **Reachability finding:** the whole ToolsSettingsWindow (and its About view) is unrouted dead UI since TASK-1346 — `tools_settings` resolves to MCPScreen; the canonical F9 Settings screen carries no About at all. The markup fix stands (module is imported and tested), AC#1 was amended to source-level verification, and the missing-About gap is filed separately.
+- `Widgets/Media/media_viewer_panel.py`: transforms are now module-level and fence-aware — sentence-splitting/heading-promotion skip fenced segments byte-identically; search hits inside fences are left unwrapped (backticks/bold inside a fence broke the block rendering).
+- Item 3 (dead `Markdown#web-search-results` CSS) had already been removed on dev by intervening churn; verified absent repo-wide.
+- Tests: new `Tests/UI/test_markdown_hygiene_1995.py` (5 tests); `test_tools_settings_window.py` (63) and media suites (38) green.

--- a/backlog/tasks/task-2775 - Settings-has-no-About-pane-version-project-info-unreachable.md
+++ b/backlog/tasks/task-2775 - Settings-has-no-About-pane-version-project-info-unreachable.md
@@ -1,0 +1,28 @@
+---
+id: TASK-2775
+title: 'Settings has no About pane — version/project info unreachable since TASK-1346'
+status: To Do
+assignee: []
+created_date: '2026-08-06 17:30'
+labels:
+  - settings
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while fixing task-1995: the About section (project description, license, GitHub/docs/issues links) lives only in `UI/Tools_Settings_Window.py` (`#ts-view-about`), and that whole window is unrouted dead UI since TASK-1346 — the `tools_settings` route resolves to MCPScreen, and the canonical F9 Settings screen (`UI/Screens/settings_screen.py`) has no About category. There is currently no place in the app where a user can see what version they run, the license, or where to file an issue.
+
+The About content itself was converted to real markdown in task-1995 (`ABOUT_MARKDOWN` constant) and is ready to mount; the work here is deciding its home on the Settings screen (a small "About" category or a footer block on Overview) and wiring the existing `Markdown.LinkClicked` → browser handler.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A user can reach an About section from the F9 Settings screen showing project description, license, and GitHub/docs/issues links
+- [ ] #2 Links open in the system browser with a notification
+- [ ] #3 The section shows the installed application version
+- [ ] #4 Live capture at 235x52 recorded
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -124,6 +124,36 @@ SETTINGS_DATABASES = (
     ("subscriptions", "Subscriptions", "tldw_cli_subscriptions"),
 )
 
+#: TASK-1995: real markdown, rendered by the About pane's Markdown widget.
+#: This text was previously Rich console markup ([bold]/[italic]/[link=…]),
+#: which Textual's Markdown does not interpret — the tags rendered literally.
+ABOUT_MARKDOWN = """\
+**tldw-chatbook** is a sophisticated Terminal User Interface (TUI) application for interacting with various Large Language Model APIs.
+
+*Features:*
+
+- Multi-provider LLM support (OpenAI, Anthropic, Google, and many more)
+- Advanced conversation management with branching
+- Character-based conversations with personality cards
+- Comprehensive note-taking with bidirectional file sync
+- Media ingestion and analysis (video, audio, documents, PDFs, e-books)
+- RAG (Retrieval-Augmented Generation) for intelligent search
+- Local LLM server management
+- Extensive customization options
+
+*License:* AGPLv3+
+
+*Links:*
+
+- GitHub: <https://github.com/rmusser01/tldw>
+- Documentation: <https://github.com/rmusser01/tldw/wiki>
+- Issues: <https://github.com/rmusser01/tldw/issues>
+
+*Created by:* rmusser01 and contributors
+
+Thank you for using tldw-chatbook! 🎉
+"""
+
 
 class ToolsSettingsWindow(Container):
     """
@@ -3362,32 +3392,7 @@ class ToolsSettingsWindow(Container):
             "Information about the tldw-chatbook project", classes="section-description"
         )
 
-        about_text = """
-[bold]tldw-chatbook[/bold] is a sophisticated Terminal User Interface (TUI) application for interacting with various Large Language Model APIs.
-
-[italic]Features:[/italic]
-• Multi-provider LLM support (OpenAI, Anthropic, Google, and many more)
-• Advanced conversation management with branching
-• Character-based conversations with personality cards
-• Comprehensive note-taking with bidirectional file sync
-• Media ingestion and analysis (video, audio, documents, PDFs, e-books)
-• RAG (Retrieval-Augmented Generation) for intelligent search
-• Local LLM server management
-• Extensive customization options
-
-[italic]License:[/italic] AGPLv3+
-
-[italic]Links:[/italic]
-• GitHub: [link=https://github.com/rmusser01/tldw]https://github.com/rmusser01/tldw[/link]
-• Documentation: [link=https://github.com/rmusser01/tldw/wiki]https://github.com/rmusser01/tldw/wiki[/link]
-• Issues: [link=https://github.com/rmusser01/tldw/issues]https://github.com/rmusser01/tldw/issues[/link]
-
-[italic]Created by:[/italic] rmusser01 and contributors
-
-Thank you for using tldw-chatbook! 🎉
-        """
-
-        yield Markdown(about_text.strip(), classes="about-content")
+        yield Markdown(ABOUT_MARKDOWN, classes="about-content")
 
         # Add some styling
         yield Static("", classes="settings-separator")

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -74,6 +74,84 @@ READING_HIGHLIGHT_DELETE_DISABLED_TOOLTIP = (
 READING_HIGHLIGHT_DELETE_ENABLED_TOOLTIP = "Delete this reading highlight."
 
 
+def _fenced_ranges(content: str) -> List[Tuple[int, int]]:
+    """Return (start, end) offsets of fenced code blocks in ``content``.
+
+    A fence opens at a line whose first non-space characters are ``` and
+    closes at the next such line. An unclosed fence runs to the end of the
+    content — the safe reading for transforms that must not touch code.
+    """
+    ranges: List[Tuple[int, int]] = []
+    pos = 0
+    start: Optional[int] = None
+    for line in content.splitlines(keepends=True):
+        if line.lstrip().startswith("```"):
+            if start is None:
+                start = pos
+            else:
+                ranges.append((start, pos + len(line)))
+                start = None
+        pos += len(line)
+    if start is not None:
+        ranges.append((start, len(content)))
+    return ranges
+
+
+def format_reading_text(content: str) -> str:
+    """Apply the reading-mode transforms outside fenced code blocks only.
+
+    TASK-1995: sentence-splitting and numbered-line promotion previously ran
+    over the whole document, mangling code blocks (a ``.`` inside code grew a
+    paragraph break; ``1.`` at the start of a code line became a heading).
+    """
+    parts: List[str] = []
+    last_end = 0
+    for start, end in _fenced_ranges(content):
+        text = content[last_end:start]
+        text = re.sub(r"([.!?])\s+", r"\1\n\n", text)
+        text = re.sub(r"^(\d+\.)\s+", r"## \1 ", text, flags=re.MULTILINE)
+        parts.append(text)
+        parts.append(content[start:end])
+        last_end = end
+    text = content[last_end:]
+    text = re.sub(r"([.!?])\s+", r"\1\n\n", text)
+    text = re.sub(r"^(\d+\.)\s+", r"## \1 ", text, flags=re.MULTILINE)
+    parts.append(text)
+    return "".join(parts)
+
+
+def highlight_match_spans(
+    content: str,
+    matches: List[Tuple[int, int]],
+    current_index: int,
+) -> str:
+    """Wrap search matches in markdown emphasis, skipping fenced code.
+
+    TASK-1995: wrapping a hit inside a fenced block in backticks/bold broke
+    the fence rendering; matches inside code are left as-is (the search
+    counter still counts them).
+    """
+    fenced = _fenced_ranges(content)
+
+    def _inside_fence(start: int, end: int) -> bool:
+        return any(fs <= start and end <= fe for fs, fe in fenced)
+
+    result: List[str] = []
+    last_end = 0
+    for i, (start, end) in enumerate(sorted(matches)):
+        result.append(content[last_end:start])
+        match_text = content[start:end]
+        if _inside_fence(start, end):
+            result.append(match_text)
+        elif i == current_index:
+            result.append(f" **`▶ {match_text} ◀`** ")
+        else:
+            result.append(f" `{match_text}` ")
+        last_end = end
+    result.append(content[last_end:])
+    return "".join(result)
+
+
 class ContentSearchEvent(Message):
     """Event fired when searching within content."""
 
@@ -1043,46 +1121,14 @@ class MediaViewerPanel(Container):
             button.tooltip = READ_IT_LATER_DISABLED_TOOLTIP
 
     def _format_content_for_reading(self, content: str) -> str:
-        """Format content for better readability."""
-        # Add line breaks after sentences
-        content = re.sub(r"([.!?])\s+", r"\1\n\n", content)
-
-        # Add headers for sections if detected
-        content = re.sub(r"^(\d+\.)\s+", r"## \1 ", content, flags=re.MULTILINE)
-
-        return content
+        """Format content for better readability, leaving fenced code intact."""
+        return format_reading_text(content)
 
     def _highlight_matches(self, content: str) -> str:
         """Highlight search matches in content."""
         if not self.search_matches:
             return content
-
-        # Sort matches by position
-        sorted_matches = sorted(self.search_matches)
-
-        # Build highlighted content
-        result = []
-        last_end = 0
-
-        for i, (start, end) in enumerate(sorted_matches):
-            # Add text before match
-            result.append(content[last_end:start])
-
-            # Add highlighted match
-            match_text = content[start:end]
-            if i == self.current_match:
-                # Current match gets special highlighting with inline code style
-                result.append(f" **`▶ {match_text} ◀`** ")
-            else:
-                # Other matches get regular highlighting
-                result.append(f" `{match_text}` ")
-
-            last_end = end
-
-        # Add remaining text
-        result.append(content[last_end:])
-
-        return "".join(result)
+        return highlight_match_spans(content, self.search_matches, self.current_match)
 
     @on(Button.Pressed, "#media-use-in-chat-button")
     def handle_use_in_chat_button(self, event: Button.Pressed) -> None:


### PR DESCRIPTION
Closes TASK-1995 (frogmouth-comparison batch).

- **About pane**: the Rich console markup (`[bold]`/`[italic]`/`[link=…]`) fed to a Markdown widget rendered literally — replaced with a real-markdown `ABOUT_MARKDOWN` constant (autolinks work with the existing LinkClicked→browser handler). **Reachability finding**: the pane is unrouted dead UI since TASK-1346 (`tools_settings` routes to MCPScreen; the F9 Settings screen has no About). AC#1 amended to source-level verification — a live capture of unreachable UI cannot honestly be produced — and the gap is filed as **task-2775** (in this PR).
- **Media viewer**: reading-mode sentence-splitting/heading-promotion and search-highlight wrapping are now fence-aware module functions (`format_reading_text`, `highlight_match_spans`) — fenced code passes through byte-identical; in-fence search hits stay unwrapped (wrapping them broke the block rendering). Unclosed fences run to end-of-content (fail toward not touching code).
- **Item 3** (dead `Markdown#web-search-results` CSS): already removed by intervening dev churn; verified absent repo-wide.

Tests: new `Tests/UI/test_markdown_hygiene_1995.py` (5); `test_tools_settings_window.py` 63 green; media handoff/parity suites 38 green. Task-2775's ID claimed after a fresh all-branches+worktrees sweep (max 2765).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Markdown rendering: the About pane now uses real Markdown, and reading mode/search highlighting are fence-aware so code blocks aren’t mangled.

- **Bug Fixes**
  - About pane: replaced Rich tags with an `ABOUT_MARKDOWN` string; autolinks open via the existing handler. The pane is currently unreachable since TASK-1346; AC for TASK-1995 updated to source-level verification and follow-up filed as TASK-2775.
  - Media viewer: added `format_reading_text` and `highlight_match_spans` to skip fenced code; unclosed fences run to end; in-fence matches aren’t wrapped.
  - Removed dead `Markdown#web-search-results` CSS was already gone; confirmed repo-wide.
  - Tests: added `Tests/UI/test_markdown_hygiene_1995.py`; existing suites remain green.

<sup>Written for commit 4943bc86f26a792e6279956491d9aed42fac33dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

