### PR TITLE
feat(hf): README links resolve — relative paths, #anchors, explicit failures (TASK-1991)

### DIFF
--- a/Tests/UI/test_hf_readme_links_1991.py
+++ b/Tests/UI/test_hf_readme_links_1991.py
@@ -1,0 +1,98 @@
+"""TASK-1991: HF README viewer resolves relative links and #anchors.
+
+Frogmouth-style tiers: absolute URLs open in the browser, relative paths
+join the repo's blob root, #anchors scroll the rendered document, anything
+else notifies instead of failing silently.
+"""
+
+import webbrowser
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Markdown
+
+from tldw_chatbook.Widgets.HuggingFace.model_card_viewer import (
+    ModelCardViewer,
+    resolve_readme_href,
+)
+
+
+def test_resolver_tiers():
+    # Anchors.
+    assert resolve_readme_href("#quickstart", None) == ("anchor", "quickstart")
+    # Absolute URLs and mailto pass through.
+    assert resolve_readme_href("https://x.y/z", None) == ("browser", "https://x.y/z")
+    assert resolve_readme_href("http://x.y", "o/m") == ("browser", "http://x.y")
+    assert resolve_readme_href("mailto:a@b.c", None) == ("browser", "mailto:a@b.c")
+    # Protocol-relative gets https.
+    assert resolve_readme_href("//host/p", None) == ("browser", "https://host/p")
+    # Relative paths join the repo blob root.
+    assert resolve_readme_href("docs/usage.md", "org/model") == (
+        "browser",
+        "https://huggingface.co/org/model/blob/main/docs/usage.md",
+    )
+    assert resolve_readme_href("./assets/img.png", "org/model") == (
+        "browser",
+        "https://huggingface.co/org/model/blob/main/assets/img.png",
+    )
+    # Relative without a known repo is unresolvable, not a guess.
+    assert resolve_readme_href("docs/usage.md", None)[0] == "unresolvable"
+    # Dangerous/unknown schemes never open.
+    assert resolve_readme_href("javascript:alert(1)", "o/m")[0] == "unresolvable"
+    assert resolve_readme_href("file:///etc/passwd", "o/m")[0] == "unresolvable"
+    assert resolve_readme_href("", "o/m")[0] == "unresolvable"
+
+
+class ViewerHarness(App):
+    def compose(self) -> ComposeResult:
+        yield ModelCardViewer(id="viewer")
+
+
+README = "# Title\n\nIntro.\n\n## Quickstart\n\nSteps here.\n"
+
+
+@pytest.mark.asyncio
+async def test_link_clicks_follow_the_tiers(monkeypatch):
+    opened = []
+    monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url))
+    # Keep watch_model_info from hitting the network.
+    monkeypatch.setattr(ModelCardViewer, "load_model_details", lambda self, r: None)
+
+    app = ViewerHarness()
+    async with app.run_test() as pilot:
+        viewer = app.query_one(ModelCardViewer)
+        viewer.model_info = {"id": "test-org/test-model"}
+        viewer.readme_content = README
+        await pilot.pause()
+
+        md = viewer.query_one("#readme-display", Markdown)
+        notices = []
+        monkeypatch.setattr(
+            viewer, "notify", lambda msg, **kw: notices.append((msg, kw))
+        )
+
+        # Absolute URL -> browser.
+        viewer._handle_readme_link(Markdown.LinkClicked(md, "https://example.com"))
+        assert opened == ["https://example.com"]
+
+        # Relative path -> repo blob root.
+        viewer._handle_readme_link(Markdown.LinkClicked(md, "docs/usage.md"))
+        assert opened[-1] == (
+            "https://huggingface.co/test-org/test-model/blob/main/docs/usage.md"
+        )
+
+        # Present anchor -> scrolls, no warning.
+        before = len(notices)
+        viewer._handle_readme_link(Markdown.LinkClicked(md, "#quickstart"))
+        await pilot.pause()
+        assert all("No such section" not in n[0] for n in notices[before:])
+
+        # Missing anchor -> visible warning.
+        viewer._handle_readme_link(Markdown.LinkClicked(md, "#nope"))
+        assert any("No such section" in n[0] for n in notices)
+
+        # Unsupported scheme -> warning, nothing opened.
+        count = len(opened)
+        viewer._handle_readme_link(Markdown.LinkClicked(md, "javascript:alert(1)"))
+        assert len(opened) == count
+        assert any("Cannot handle this link" in n[0] for n in notices)

--- a/backlog/tasks/task-1991 - HF-README-viewer-resolve-relative-links-and-anchors.md
+++ b/backlog/tasks/task-1991 - HF-README-viewer-resolve-relative-links-and-anchors.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-1991
 title: 'HF README viewer: resolve relative links and #anchors (Frogmouth-style tiers)'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-02 22:30'
 labels:
   - huggingface
@@ -24,9 +25,19 @@ Scope note: opening resolved links in the system browser is sufficient; in-app r
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Clicking an absolute URL in a rendered README opens it in the browser (current behavior preserved)
-- [ ] #2 Clicking a relative link resolves it against the model repo's base URL and opens the resolved URL in the browser
-- [ ] #3 Clicking a `#anchor` link scrolls the README pane to that heading via goto_anchor
-- [ ] #4 An unresolvable href produces a visible notify with the href — never a silent no-op
-- [ ] #5 No fetch path is added that bypasses the egress policy
+- [x] #1 Clicking an absolute URL in a rendered README opens it in the browser (current behavior preserved)
+- [x] #2 Clicking a relative link resolves it against the model repo's base URL and opens the resolved URL in the browser
+- [x] #3 Clicking a `#anchor` link scrolls the README pane to that heading via goto_anchor
+- [x] #4 An unresolvable href produces a visible notify with the href — never a silent no-op
+- [x] #5 No fetch path is added that bypasses the egress policy
 <!-- AC:END -->
+
+## Implementation Plan (the how)
+
+1. Pure resolver `resolve_readme_href(href, repo_id)` returning ("anchor"|"browser"|"unresolvable", value): anchors strip `#`; http(s)/mailto pass through; `//host` gets https; any other explicit scheme (javascript:, file:, data:…) is unresolvable; relative paths urljoin against `https://huggingface.co/<repo>/blob/main/`; relative with no known repo is unresolvable.
+2. `open_links=False` on `#readme-display`; `@on(Markdown.LinkClicked, "#readme-display")` handler applies the tiers — `goto_anchor()` for anchors (warning notify when the section does not exist), `webbrowser.open` + notify for browser, warning notify otherwise.
+3. Unit tests over the tiers + a mounted-widget test driving real `Markdown.LinkClicked` events.
+
+## Implementation Notes
+
+`Widgets/HuggingFace/model_card_viewer.py`: resolver + handler as planned; no fetch path added anywhere (browser-only), so the egress policy is untouched (AC#5). Repo id comes from the already-displayed `model_info`. Tests: `Tests/UI/test_hf_readme_links_1991.py` (resolver tiers incl. traversal-adjacent cases, browser/anchor/missing-anchor/unsupported-scheme flows with monkeypatched `webbrowser.open`). Consuming suite `test_non_obscuring_focus_contract.py` runs 95/96 — the 1 failure is pre-existing on dev BEFORE this branch (verified at `054cdbd92`; CSS focus-contract assertion unrelated to this change).

--- a/tldw_chatbook/Widgets/HuggingFace/model_card_viewer.py
+++ b/tldw_chatbook/Widgets/HuggingFace/model_card_viewer.py
@@ -3,8 +3,11 @@
 Model card viewer for displaying HuggingFace model details and available files.
 """
 
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 from pathlib import Path
+from urllib.parse import urljoin
+
+from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, VerticalScroll
 from textual.widgets import (
@@ -20,6 +23,39 @@ from textual.widgets import (
 from textual.message import Message
 from textual.reactive import reactive
 from loguru import logger
+
+
+def resolve_readme_href(href: str, repo_id: Optional[str]) -> Tuple[str, str]:
+    """Resolve one README link into an action (TASK-1991, frogmouth tiers).
+
+    Args:
+        href: The clicked link target, exactly as authored in the README.
+        repo_id: The HuggingFace repo the README belongs to (``org/model``),
+            or None when unknown.
+
+    Returns:
+        ``("anchor", name)`` — scroll to the in-document heading;
+        ``("browser", url)`` — open the URL in the system browser;
+        ``("unresolvable", href)`` — tell the user, never fail silently.
+    """
+    href = (href or "").strip()
+    if not href:
+        return ("unresolvable", href)
+    if href.startswith("#"):
+        return ("anchor", href[1:])
+    if href.startswith(("http://", "https://", "mailto:")):
+        return ("browser", href)
+    if href.startswith("//"):
+        return ("browser", f"https:{href}")
+    if ":" in href.split("/", 1)[0].split("?", 1)[0]:
+        # Any other explicit scheme (javascript:, file:, ftp:, data:…).
+        return ("unresolvable", href)
+    if repo_id:
+        # Relative path: resolve against the repo's blob root, like the
+        # links behave on huggingface.co itself.
+        base = f"https://huggingface.co/{repo_id}/blob/main/"
+        return ("browser", urljoin(base, href))
+    return ("unresolvable", href)
 
 
 class DownloadRequestEvent(Message):
@@ -212,8 +248,14 @@ class ModelCardViewer(Container):
                 # README tab
                 with TabPane("README", id="readme-tab"):
                     with VerticalScroll(classes="tab-content"):
+                        # open_links=False: link handling goes through the
+                        # tiered resolver below (TASK-1991) — relative links
+                        # and #anchors were dead with the default auto-open.
                         yield Markdown(
-                            "", id="readme-display", classes="readme-content"
+                            "",
+                            id="readme-display",
+                            classes="readme-content",
+                            open_links=False,
                         )
 
                 # Model Card tab
@@ -276,6 +318,37 @@ class ModelCardViewer(Container):
                 readme_display.update("*No README available*")
         except Exception as e:
             logger.error(f"Error updating README display: {e}")
+
+    @on(Markdown.LinkClicked, "#readme-display")
+    def _handle_readme_link(self, event: Markdown.LinkClicked) -> None:
+        """Resolve README links: anchors scroll, URLs open, junk notifies.
+
+        TASK-1991 (frogmouth tiers): absolute URLs open in the browser;
+        relative paths resolve against the repo's blob root; ``#anchor``
+        scrolls the rendered README; anything else notifies with the href
+        instead of failing silently.
+        """
+        event.stop()
+        repo_id = (self.model_info or {}).get("id")
+        kind, value = resolve_readme_href(event.href, repo_id)
+        if kind == "anchor":
+            if not event.markdown.goto_anchor(value):
+                self.notify(
+                    f"No such section in this README: #{value}",
+                    severity="warning",
+                    timeout=5,
+                )
+        elif kind == "browser":
+            import webbrowser
+
+            webbrowser.open(value)
+            self.notify(f"Opened in browser: {value}", timeout=4)
+        else:
+            self.notify(
+                f"Cannot handle this link: {value or event.href!r}",
+                severity="warning",
+                timeout=6,
+            )
 
     def watch_selected_file(self, selected: Optional[str]) -> None:
         """Update UI when file selection changes."""


### PR DESCRIPTION
Closes TASK-1991 (frogmouth-comparison batch).

The model-card README rendered links dead: relative paths and `#anchors` did nothing useful. Now (`open_links=False` + tiered resolver, ported from Frogmouth's `on_markdown_link_clicked`):

- absolute `http(s)`/`mailto` → system browser + notify
- relative path → `urljoin` against `https://huggingface.co/<repo>/blob/main/` → browser (matches how the links behave on huggingface.co)
- `#anchor` → `Markdown.goto_anchor()`; missing section → visible warning
- `javascript:`/`file:`/any other scheme, or a relative link with no known repo → visible warning, nothing opens

No fetch path added (browser-only) — `Utils/egress.py` policy untouched (AC#5).

Tests: `Tests/UI/test_hf_readme_links_1991.py` — resolver tiers + mounted-widget flows with real `Markdown.LinkClicked` events and monkeypatched `webbrowser.open`. Consuming suite `test_non_obscuring_focus_contract.py`: 95/96 — the 1 failure is **pre-existing on dev before this branch** (verified at `054cdbd92`; CSS focus-contract assertion, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make README links in the Hugging Face model card viewer work: relative paths resolve to the repo, anchors scroll within the doc, and unsupported links show a warning. Absolute URLs open in the system browser, matching huggingface.co behavior and meeting TASK-1991 without adding new network paths.

- **New Features**
  - Added `resolve_readme_href(href, repo_id)` with Frogmouth-style tiers:
    - `#anchor` → scroll via `Markdown.goto_anchor`.
    - `http(s)`, `mailto`, and `//host` → open in browser.
    - Relative paths → `urljoin` against `https://huggingface.co/<repo>/blob/main/`.
    - Unknown schemes or no repo for relative links → warning, no action.
  - Set `open_links=False` on `#readme-display` and handle `Markdown.LinkClicked` to apply tiers; notify on open, missing anchors, or unresolvable links.
  - No new fetch path; egress policy unchanged.
  - Tests cover resolver behavior and real click flows; satisfies TASK-1991 AC 1–5.

<sup>Written for commit 46c0c3a9daa2237fa6bcb790bb5d40eb31080198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

