### PR TITLE
feat(hf): table of contents for the README pane (TASK-1992)

### DIFF
--- a/Tests/UI/test_hf_readme_toc_1992.py
+++ b/Tests/UI/test_hf_readme_toc_1992.py
@@ -1,0 +1,93 @@
+"""TASK-1992: heading-tree table of contents for the HF README pane.
+
+The TOC is hidden by default (compact layouts stay clean), toggled by the
+toolbar button, populated from the rendered README's headings, and selecting
+an entry scrolls the document to that heading.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Markdown, TabbedContent
+from textual.widgets.markdown import MarkdownTableOfContents
+
+from tldw_chatbook.Widgets.HuggingFace.model_card_viewer import ModelCardViewer
+
+
+class ViewerHarness(App):
+    CSS = "ModelCardViewer { height: 40; }"
+
+    def compose(self) -> ComposeResult:
+        yield ModelCardViewer(id="viewer")
+
+
+LONG_README = "# Title\n\n" + "\n\n".join(
+    f"## Section {i}\n\n" + ("filler line\n" * 8) for i in range(1, 9)
+)
+
+
+@pytest.mark.asyncio
+async def test_toc_hidden_by_default_and_toggles():
+    app = ViewerHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        viewer = app.query_one(ModelCardViewer)
+        toc = viewer.query_one("#readme-toc", MarkdownTableOfContents)
+        assert toc.display is False
+
+        viewer.query_one("#readme-toc-toggle", Button).press()
+        await pilot.pause()
+        assert toc.display is True
+
+        viewer.query_one("#readme-toc-toggle", Button).press()
+        await pilot.pause()
+        assert toc.display is False
+
+
+@pytest.mark.asyncio
+async def test_toc_populates_from_readme_headings():
+    app = ViewerHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        viewer = app.query_one(ModelCardViewer)
+        viewer.readme_content = LONG_README
+        # TableOfContentsUpdated arrives after the markdown finishes parsing.
+        for _ in range(20):
+            await pilot.pause()
+            toc = viewer.query_one("#readme-toc", MarkdownTableOfContents)
+            if toc.table_of_contents:
+                break
+        assert toc.table_of_contents, "TOC never received the heading tree"
+        headings = [entry[1] for entry in toc.table_of_contents]
+        assert "Title" in headings
+        assert "Section 8" in headings
+
+
+@pytest.mark.asyncio
+async def test_toc_selection_scrolls_document():
+    app = ViewerHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        viewer = app.query_one(ModelCardViewer)
+        # The README pane must be the active tab to have scroll geometry.
+        viewer.query_one(TabbedContent).active = "readme-tab"
+        viewer.readme_content = LONG_README
+        for _ in range(20):
+            await pilot.pause()
+            toc = viewer.query_one("#readme-toc", MarkdownTableOfContents)
+            if toc.table_of_contents:
+                break
+        assert toc.table_of_contents
+
+        # Late heading's block id from the TOC payload itself.
+        block_id = next(
+            entry[2] for entry in toc.table_of_contents if entry[1] == "Section 8"
+        )
+        md = viewer.query_one("#readme-display", Markdown)
+        scroll = viewer.query_one("#readme-scroll")
+        assert scroll.scroll_y == 0
+
+        viewer.on_markdown_table_of_contents_selected(
+            Markdown.TableOfContentsSelected(md, block_id)
+        )
+        for _ in range(10):
+            await pilot.pause()
+            if scroll.scroll_y > 0:
+                break
+        assert scroll.scroll_y > 0, "selection did not scroll the README"

--- a/backlog/tasks/task-1992 - Table-of-contents-for-long-markdown-surfaces.md
+++ b/backlog/tasks/task-1992 - Table-of-contents-for-long-markdown-surfaces.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-1992
 title: Table of contents for long markdown surfaces (MarkdownTableOfContents)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-02 22:30'
 labels:
   - ux
@@ -21,8 +22,20 @@ Start with the HF README pane (longest documents, clearest win). Team convention
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The HF README pane offers a heading-tree table of contents for the rendered document
-- [ ] #2 Selecting a TOC entry scrolls the document to that heading
-- [ ] #3 The TOC stays out of the way in tight layouts (collapsed or hidden by default at compact heights; the 32-row contract keeps working)
-- [ ] #4 Live tmux capture recorded showing the TOC populated from a real README and a successful jump
+- [x] #1 The HF README pane offers a heading-tree table of contents for the rendered document
+- [x] #2 Selecting a TOC entry scrolls the document to that heading
+- [x] #3 The TOC stays out of the way in tight layouts (collapsed or hidden by default at compact heights; the 32-row contract keeps working)
+- [x] #4 Live tmux capture recorded showing the TOC populated from a real README and a successful jump
 <!-- AC:END -->
+
+## Implementation Plan (the how)
+
+1. README TabPane becomes toolbar (`☰ Contents` toggle) + horizontal body: `MarkdownTableOfContents` (hidden by default, width 32 / max 40%) beside the existing VerticalScroll+Markdown.
+2. Feed `Markdown.TableOfContentsUpdated` (id-filtered to `#readme-display`) into the TOC; on `TableOfContentsSelected`, `scroll_to_widget(md.query_one(f"#{block_id}"), top=True)` on the README scroll (frogmouth's scroll_to_block).
+3. Tests: hidden-by-default + toggle, population from headings, selection scrolls. Live capture against a real HF README.
+
+## Implementation Notes
+
+`Widgets/HuggingFace/model_card_viewer.py` only. TOC is hidden by default (compact layouts unaffected — AC#3 satisfied by default-hidden + explicit toggle rather than a height threshold). Handlers use explicit `event.markdown.id` filtering, not `@on` selectors — TOC event `control` semantics differ between the Updated/Selected pair. Live-verified (tmux 235x52, real HF API): Lab ▸ Models ▸ Download Models → unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF → README → ☰ Contents shows the real heading tree (Highlights/Model Overview/Quickstart/Agentic Coding/Best Practices▸Citation) → clicking Quickstart scrolled the document to that heading (captures cap_toc_open/cap_toc_jump in session scratchpad). Test gotcha worth keeping: a TabPane that is not active has no scroll geometry — activate `readme-tab` before asserting scroll movement. Live side-observation: the real README renders its YAML front matter as a garbled list at the top — exactly task-1993's target, evidence banked there.
+
+Scope note: filed as "long markdown surfaces"; shipped for the HF README pane (the AC's named surface). Media viewer/note-preview TOCs remain unscoped follow-up work if ever wanted.

--- a/tldw_chatbook/Widgets/HuggingFace/model_card_viewer.py
+++ b/tldw_chatbook/Widgets/HuggingFace/model_card_viewer.py
@@ -9,7 +9,8 @@ from urllib.parse import urljoin
 
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Container, VerticalScroll
+from textual.containers import Container, Horizontal, VerticalScroll
+from textual.widgets.markdown import MarkdownTableOfContents
 from textual.widgets import (
     Label,
     Button,
@@ -158,10 +159,38 @@ class ModelCardViewer(Container):
         padding: 1;
         background: $background;
     }
-    
+
     ModelCardViewer #readme-display {
         height: auto;
         padding: 1;
+    }
+
+    ModelCardViewer .readme-body {
+        height: 1fr;
+        layout: horizontal;
+    }
+
+    ModelCardViewer .readme-toolbar {
+        height: auto;
+        layout: horizontal;
+    }
+
+    ModelCardViewer #readme-toc-toggle {
+        height: 1;
+        min-width: 14;
+        border: none;
+    }
+
+    ModelCardViewer #readme-toc {
+        width: 32;
+        max-width: 40%;
+        height: 1fr;
+        border-right: solid $surface-lighten-1;
+    }
+
+    ModelCardViewer #readme-toc Tree {
+        width: 1fr;
+        padding: 0;
     }
     
     ModelCardViewer .model-card-container {
@@ -247,16 +276,32 @@ class ModelCardViewer(Container):
 
                 # README tab
                 with TabPane("README", id="readme-tab"):
-                    with VerticalScroll(classes="tab-content"):
-                        # open_links=False: link handling goes through the
-                        # tiered resolver below (TASK-1991) — relative links
-                        # and #anchors were dead with the default auto-open.
-                        yield Markdown(
-                            "",
-                            id="readme-display",
-                            classes="readme-content",
-                            open_links=False,
+                    # open_links=False: link handling goes through the
+                    # tiered resolver below (TASK-1991) — relative links
+                    # and #anchors were dead with the default auto-open.
+                    readme_display = Markdown(
+                        "",
+                        id="readme-display",
+                        classes="readme-content",
+                        open_links=False,
+                    )
+                    # TASK-1992: heading-tree TOC for long READMEs. Hidden by
+                    # default (compact layouts stay clean); the toolbar button
+                    # toggles it and selection scrolls the document.
+                    toc = MarkdownTableOfContents(readme_display, id="readme-toc")
+                    toc.display = False
+                    with Horizontal(classes="readme-toolbar"):
+                        yield Button(
+                            "☰ Contents",
+                            id="readme-toc-toggle",
+                            variant="default",
                         )
+                    with Horizontal(classes="readme-body"):
+                        yield toc
+                        with VerticalScroll(
+                            classes="tab-content", id="readme-scroll"
+                        ):
+                            yield readme_display
 
                 # Model Card tab
                 with TabPane("Model Card", id="model-card-tab"):
@@ -349,6 +394,44 @@ class ModelCardViewer(Container):
                 severity="warning",
                 timeout=6,
             )
+
+    def on_markdown_table_of_contents_updated(
+        self, event: Markdown.TableOfContentsUpdated
+    ) -> None:
+        """Feed the README's heading tree into the TOC pane (TASK-1992)."""
+        if getattr(event.markdown, "id", None) != "readme-display":
+            return
+        event.stop()
+        try:
+            toc = self.query_one("#readme-toc", MarkdownTableOfContents)
+        except Exception:
+            return
+        toc.table_of_contents = event.table_of_contents
+
+    def on_markdown_table_of_contents_selected(
+        self, event: Markdown.TableOfContentsSelected
+    ) -> None:
+        """Scroll the README to the heading chosen in the TOC (TASK-1992)."""
+        if getattr(event.markdown, "id", None) != "readme-display":
+            return
+        event.stop()
+        try:
+            scroll = self.query_one("#readme-scroll", VerticalScroll)
+            target = event.markdown.query_one(f"#{event.block_id}")
+        except Exception:
+            logger.warning(f"README TOC target not found: {event.block_id}")
+            return
+        scroll.scroll_to_widget(target, top=True)
+
+    @on(Button.Pressed, "#readme-toc-toggle")
+    def _toggle_readme_toc(self, event: Button.Pressed) -> None:
+        """Show or hide the README table of contents (hidden by default)."""
+        event.stop()
+        try:
+            toc = self.query_one("#readme-toc", MarkdownTableOfContents)
+        except Exception:
+            return
+        toc.display = not toc.display
 
     def watch_selected_file(self, selected: Optional[str]) -> None:
         """Update UI when file selection changes."""


### PR DESCRIPTION
Closes TASK-1992 (frogmouth-comparison batch).

`MarkdownTableOfContents` beside the model-card README: **hidden by default** (compact layouts unaffected), `☰ Contents` toolbar toggle, heading tree fed from `Markdown.TableOfContentsUpdated`, selection scrolls the document to the chosen heading (frogmouth's `scroll_to_block` shape). Handlers filter on `event.markdown.id` rather than `@on` selectors — the Updated/Selected pair's `control` semantics differ.

**Live-verified** (tmux 235x52, real HF API): Lab ▸ Models ▸ Download Models → `unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF` → README → Contents shows the real heading tree → clicking *Quickstart* jumps the document to that section.

Tests: `Tests/UI/test_hf_readme_toc_1992.py` (default-hidden + toggle, population, selection-scrolls; gotcha pinned: an inactive TabPane has no scroll geometry). Live side-observation banked for task-1993: the real README renders its YAML front matter as a garbled list — 1993's exact target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a table of contents beside the Hugging Face README to make long model cards easier to navigate. Hidden by default; toggled via the "☰ Contents" button. Satisfies TASK-1992.

- New Features
  - Renders `MarkdownTableOfContents` next to the README; toggle via `#readme-toc-toggle`.
  - Populates from README headings via `Markdown.TableOfContentsUpdated` scoped to `#readme-display`.
  - Clicking an entry (via `Markdown.TableOfContentsSelected`) scrolls the README to that heading.
  - Tests added for default-hidden + toggle, TOC population, and selection scrolling.

<sup>Written for commit 35b029e5e5e774a6f5fc94f26f3391c28ed09732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

