### PR TITLE
test: repair the four failures resident on dev's baseline (task 2780)

### DIFF
--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -121,6 +121,10 @@ def _bare_generation_screen(store: ConsoleChatStore) -> ChatScreen:
     screen._pending_console_delete_message_id = None
     screen.app_instance = SimpleNamespace(notify=lambda *a, **k: None)
     screen._sync_native_console_chat_ui = AsyncMock()
+    # `_clear_console_composer_draft` now also syncs the slash-command popup;
+    # on a detached screen (no `_nodes`) that query dies with AttributeError,
+    # not the guarded QueryError — same class of seam as the sync stub above.
+    screen._sync_console_command_popup = lambda: None
     return screen
 
 

--- a/Tests/Library/test_library_ingest_jobs.py
+++ b/Tests/Library/test_library_ingest_jobs.py
@@ -421,6 +421,9 @@ def test_counts_returns_per_state_counts() -> None:
         # counts() is keyed by every IngestJobState, so a state with no jobs
         # still reports zero rather than being absent.
         "cancelled": 0,
+        # SKIPPED joined the lifecycle in 40de4b136 (task-2220:
+        # unsupported-in-folder files record as skipped, not failed).
+        "skipped": 0,
     }
 
 

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1019,13 +1019,17 @@ async def test_conflicts_tab_renders_rows_and_resolves():
         assert table.row_count == 1
         server_button = tab.query_one("#scheduling-use-server", Button)
         local_button = tab.query_one("#scheduling-use-local", Button)
+        # The Lab/Schedules/Logs UX overhaul (9dd2374b5, ADR-031) replaced the
+        # per-button resolve tooltips with one guidance line set by
+        # `_set_actions_enabled` whenever rows exist; this pin tracks that
+        # shipped copy (the old per-version tooltips only exist pre-populate).
         assert (
             str(server_button.tooltip)
-            == "Resolve the selected conflict with the server version."
+            == "Select a conflict above, then choose which version to keep."
         )
         assert (
             str(local_button.tooltip)
-            == "Resolve the selected conflict with the local version."
+            == "Select a conflict above, then choose which version to keep."
         )
         table.cursor_coordinate = (0, 0)
         await pilot.click("#scheduling-use-server")

--- a/Tests/UI/test_ui_responsiveness.py
+++ b/Tests/UI/test_ui_responsiveness.py
@@ -309,6 +309,13 @@ def _make_sync_probe_screen(monitor):
     screen = MagicMock(spec=ChatScreen)
     screen._console_sync_in_progress = False
     screen._console_sync_requested = False
+    # Console decomposition wave 2 (PR #1381) moved stages onto instance-held
+    # delegate objects created in __init__ (`_session`, `_workspace`).
+    # `spec=ChatScreen` auto-stubs only CLASS attributes, so these fall
+    # outside the spec treadmill this factory exists to avoid and must be
+    # stubbed by hand; every delegate call in the sync path is synchronous.
+    screen._session = MagicMock()
+    screen._workspace = MagicMock()
     screen.app_instance = SimpleNamespace(ui_responsiveness_monitor=monitor)
     screen._ui_responsiveness_monitor = partial(
         ChatScreen._ui_responsiveness_monitor, screen

--- a/backlog/tasks/task-2780 - Repair the four test failures resident on dev's baseline.md
+++ b/backlog/tasks/task-2780 - Repair the four test failures resident on dev's baseline.md
@@ -1,0 +1,38 @@
+---
+id: TASK-2780
+title: Repair the four test failures resident on dev's baseline
+status: Done
+assignee: []
+created_date: '2026-08-07 01:00'
+labels:
+  - tests
+  - dev-baseline
+  - uat
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The full-app UAT batch (PR #1378) catalogued four test failures that reproduce on pristine `origin/dev` — every future PR inherits them as red noise, which is exactly how the Lab ▸ Speech crash hid for weeks ("pre-existing noise" that was a real crash). Each was diagnosed to its introducing change; in all four cases the production behavior was a deliberate, merged change and the TEST encoded the stale expectation:
+
+1. `test_console_sync_records_worker_lifecycle` — broke in the console-decomposition wave 2 merge (#1381): stages moved onto instance-held delegates (`_session`, `_workspace`) created in `__init__`, which `MagicMock(spec=ChatScreen)` cannot auto-stub (spec covers class attributes only). The task-1469 probe factory was built to survive delegation growth; this is delegation growth in a shape it couldn't see.
+2. `test_conflicts_tab_renders_rows_and_resolves` — the Lab/Schedules/Logs UX overhaul (`9dd2374b5`, ADR-031) deliberately replaced per-button resolve tooltips with one guidance line; the test pinned the pre-overhaul copy.
+3. `test_counts_returns_per_state_counts` — `IngestJobState.SKIPPED` joined the lifecycle (`40de4b136`, task-2220); `counts()` honors its documented every-state contract, the expected dict didn't.
+4. `test_generate_image_handler_restores_draft_when_batch_raises` — `_clear_console_composer_draft` grew a `_sync_console_command_popup()` call after the `_bare_generation_screen` factory was written; on a detached screen that query dies with AttributeError past the QueryError guard.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [x] All four tests pass on the branch, and their containing files pass in full.
+- [x] Each repair follows the introducing change's documented intent (recorded inline at the fix site), never reverting shipped behavior.
+- [x] No production code changed.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Test-only changes, one per failure: (1) the sync-probe factory stubs the two instance-held delegates with a comment explaining the spec-mock blind spot; (2) the conflicts test pins the shipped ADR-031 guidance copy; (3) the counts expectation gains `"skipped": 0` citing task-2220; (4) the bare-screen factory stubs `_sync_console_command_popup` alongside its existing sync stub. Full files green: 15 + 39 + 66 + 35. Files: Tests/UI/test_ui_responsiveness.py, Tests/UI/test_schedules_workbench.py, Tests/Library/test_library_ingest_jobs.py, Tests/Chat/test_console_generation_actions.py.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

PR #1378's verification catalogued four test failures that reproduce on **pristine origin/dev** — standing red that poisons every PR's CI signal (the same 'pre-existing noise' pattern that hid the Lab ▸ Speech crash for weeks). Each is now diagnosed to its introducing change; in all four the production behavior was deliberate and merged, and the **test** encoded the stale expectation. Test-only diff.

| Test | Introduced by | Repair |
|---|---|---|
| `test_console_sync_records_worker_lifecycle` | #1381 console decomposition wave 2 — stages moved onto instance-held `_session`/`_workspace` delegates, invisible to `MagicMock(spec=ChatScreen)` (spec covers class attributes only) | probe factory stubs the delegates, comment documents the spec-mock blind spot |
| `test_conflicts_tab_renders_rows_and_resolves` | `9dd2374b5` ADR-031 UX overhaul — per-button resolve tooltips deliberately replaced with one guidance line | test pins the shipped copy |
| `test_counts_returns_per_state_counts` | `40de4b136` task-2220 — `IngestJobState.SKIPPED` added; `counts()` honors its every-state contract | expectation gains `"skipped": 0` |
| `test_generate_image_handler_restores_draft_when_batch_raises` | `_clear_console_composer_draft` grew a popup-sync call post-dating the bare-screen factory; detached-screen query dies with AttributeError past the QueryError guard | factory stubs `_sync_console_command_popup` beside its existing sync stub |

## Verification
- All four containing files green in one run: **155 passed**.
- `--collect-only` sweep clean: 31,556 collected.
- No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four failing tests on the dev baseline (task-2780) to restore a clean CI signal. Test-only updates align expectations with shipped behavior; no production code changes.

- **Bug Fixes**
  - Console sync lifecycle: stub `_session` and `_workspace` delegates in the probe factory since spec-mocked `ChatScreen` doesn’t cover instance delegates after console decomposition wave 2.
  - Conflicts tab: update tooltip expectations to the single guidance line from ADR-031.
  - Ingest counts: include `"skipped": 0` for the new `SKIPPED` state per the every-state contract.
  - Image generation draft restore: stub `_sync_console_command_popup` in the bare screen to avoid AttributeError on a detached screen.

<sup>Written for commit 90d666882ac9ab849806a9dd1a1a5e320546f769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

