### PR TITLE
feat(settings): About category — version, license, and project links (TASK-2775)

### DIFF
--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -107,6 +107,7 @@ unless you run Manual sync from Overview yourself.
 | Data & Privacy | **Workspaces** | Create, rename, archive, and bind folders for agent file tools. | Applies immediately |
 | Data & Privacy | **Privacy & Security** (view) | Secrets, encryption, redaction, and local privacy boundaries. | Read-only here |
 | Troubleshooting | **Diagnostics** (view) | Config validation, logs, and troubleshooting signals. | Read-only here |
+| Troubleshooting | **About** (view) | Version, license, and project links. | Read-only here |
 | Expert | **Internal Prompts** | The system prompts the app uses internally (RAG, web search, agents, summarization, more). | Per-item Save/Reset |
 | Expert | **Advanced Config** | Raw TOML view and expert configuration editing. | Validate, then Save |
 | Domain Defaults | **RAG** → [own page](settings/rag.md) | Source search, retrieval, citations, snippets, and Console evidence defaults. | Draft — save with s |
@@ -290,6 +291,13 @@ Three buttons, no fields. Pressing **t** runs the first two together.
 | **Validate Config** | Parses your configuration file strictly and reports "valid" or "invalid - \<error\>", with secrets redacted out of the error. |
 | **Reload Config** | Validates, then loads the file into the running app. |
 | **Run Setup Wizard** | Re-runs the guided first-run setup — see [First run setup](First_Run_Setup.md). |
+
+### Troubleshooting — About
+
+The installed version, the license (AGPLv3+), a short feature list, and the
+project links (GitHub, documentation, issues). Read-only. Clicking a link
+opens it in your system browser and confirms with a notification; nothing on
+this page writes config.
 
 ### Expert — Internal Prompts
 
@@ -484,4 +492,4 @@ not open an editor.
   inspector" at the bottom means there is more below.
 
 —
-*Verified against dev @ e7b9ebabd — 2026-08-06*
+*Verified against dev @ 39232202b — 2026-08-06*

--- a/Tests/UI/test_settings_about_2775.py
+++ b/Tests/UI/test_settings_about_2775.py
@@ -1,0 +1,90 @@
+"""TASK-2775: the F9 Settings screen has an About category.
+
+Version/license/links were unreachable since TASK-1346 retired the legacy
+ToolsSettingsWindow. About is a read-only ("view") category under
+Troubleshooting: it shows the installed version, renders the real-markdown
+About text, and opens http(s) links in the system browser with a notify.
+"""
+
+import webbrowser
+from types import SimpleNamespace
+
+import pytest
+from textual.widgets import Markdown
+
+from Tests.UI.test_destination_shells import DestinationHarness, _build_test_app
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+from tldw_chatbook.Utils.about_text import ABOUT_MARKDOWN, get_app_version
+
+
+def test_about_category_registered_read_only():
+    screen = SettingsScreen(_build_test_app())
+    summaries = {s.category: s for s in screen._category_summaries()}
+    assert SettingsCategoryId.ABOUT in summaries
+    assert summaries[SettingsCategoryId.ABOUT].title == "About"
+
+    groups = dict(screen._category_groups())
+    assert SettingsCategoryId.ABOUT in groups["Troubleshooting"]
+
+    record = screen._ownership_record(SettingsCategoryId.ABOUT)
+    assert record.writes_allowed is False
+    # Explicit record, not the missing-record fallback.
+    assert "matrix" not in record.boundary_copy.lower()
+
+    assert screen._inspector_guidance(SettingsCategoryId.ABOUT)
+
+
+def test_about_text_and_version_are_presentable():
+    assert "[bold]" not in ABOUT_MARKDOWN and "[link=" not in ABOUT_MARKDOWN
+    version = get_app_version()
+    assert isinstance(version, str) and version
+
+
+@pytest.mark.asyncio
+async def test_about_pane_renders_version_and_markdown():
+    app = DestinationHarness(_build_test_app(), "settings")
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen_stack[-1]
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        screen.active_category = SettingsCategoryId.ABOUT.value
+        await pilot.pause()
+        await pilot.pause()
+
+        card = screen.query_one("#settings-about-card")
+        assert card is not None
+        md = screen.query_one("#settings-about-markdown", Markdown)
+        assert md.source == ABOUT_MARKDOWN
+        visible = " ".join(
+            str(getattr(w, "renderable", "")) for w in card.query("Static")
+        )
+        assert get_app_version() in visible
+        assert "AGPLv3+" in visible
+
+
+@pytest.mark.asyncio
+async def test_about_link_policy(monkeypatch):
+    opened = []
+    monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url))
+    app = DestinationHarness(_build_test_app(), "settings")
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen_stack[-1]
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        notices = []
+        monkeypatch.setattr(
+            screen, "notify", lambda msg, **kw: notices.append((msg, kw))
+        )
+        screen._handle_about_link(
+            SimpleNamespace(href="https://github.com/rmusser01/tldw", stop=lambda: None)
+        )
+        assert opened == ["https://github.com/rmusser01/tldw"]
+        assert any("Opened in browser" in n[0] for n in notices)
+
+        screen._handle_about_link(
+            SimpleNamespace(href="file:///etc/passwd", stop=lambda: None)
+        )
+        assert opened == ["https://github.com/rmusser01/tldw"]
+        assert any("unsupported scheme" in n[0] for n in notices)

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -181,14 +181,14 @@ def test_settings_category_summaries_cover_every_category_id_exactly_once():
     Adding Internal Prompts brought the total from 19 to 20; adding Image Gen
     (Settings > Image Gen task 4) brought it to 21; adding Workspaces
     (settings-workspaces-folder-roots task 8) brought it to 22; Speech & TTS
-    (TASK-1984) brought it to 23. This pins
+    (TASK-1984) brought it to 23; About (TASK-2775) brought it to 24. This pins
     the literal count so the next addition must touch this assertion
     deliberately, and cross-checks that summaries neither miss nor duplicate
     an enum member.
     """
     screen = SettingsScreen(_build_test_app())
     summaries = screen._category_summaries()
-    assert len(summaries) == len(list(SettingsCategoryId)) == 23
+    assert len(summaries) == len(list(SettingsCategoryId)) == 24
     assert {s.category for s in summaries} == set(SettingsCategoryId)
 
 

--- a/backlog/tasks/task-2775 - Settings-has-no-About-pane-version-project-info-unreachable.md
+++ b/backlog/tasks/task-2775 - Settings-has-no-About-pane-version-project-info-unreachable.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-2775
 title: 'Settings has no About pane — version/project info unreachable since TASK-1346'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-06 17:30'
 labels:
   - settings
@@ -21,8 +22,18 @@ The About content itself was converted to real markdown in task-1995 (`ABOUT_MAR
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A user can reach an About section from the F9 Settings screen showing project description, license, and GitHub/docs/issues links
-- [ ] #2 Links open in the system browser with a notification
-- [ ] #3 The section shows the installed application version
-- [ ] #4 Live capture at 235x52 recorded
+- [x] #1 A user can reach an About section from the F9 Settings screen showing project description, license, and GitHub/docs/issues links
+- [x] #2 Links open in the system browser with a notification
+- [x] #3 The section shows the installed application version
+- [x] #4 Live capture at 235x52 recorded
 <!-- AC:END -->
+
+## Implementation Plan (the how)
+
+1. Move ABOUT_MARKDOWN to `Utils/about_text.py` (+ `get_app_version()` via importlib.metadata; deprecated window re-imports for back-compat).
+2. New read-only `SettingsCategoryId.ABOUT` under Troubleshooting, taught to EVERY per-category surface: summaries, rail group, _INSPECTOR_GUIDANCE (compose-critical), ownership record (writes_allowed=False → automatic "(view)" badge), guided-edits hint, detail-pane branch (version row, license row, Markdown with open_links=False), link handler (http(s)→browser+notify, else warning — same policy as Console/HF links).
+3. Update the pinned category-count guard (23→24) deliberately; tests; live capture; User Guide section + stamp.
+
+## Implementation Notes
+
+`settings_config_models.py` (enum), `settings_screen.py` (six per-category surfaces + render branch + `_handle_about_link`), `Utils/about_text.py` (new), `Tools_Settings_Window.py` (re-import), `Docs/User_Guide/settings.md` (category row, About section, stamp), tests: `Tests/UI/test_settings_about_2775.py` (4) + the count-pin update in `test_settings_configuration_hub.py`. Full hub suite green (315 passed) — including the exhaustiveness guards this addition was required to satisfy. Live tmux capture at 235x52: rail shows "About (view)" under Troubleshooting; pane shows Version: 0.1.8.0 (real installed metadata), License AGPLv3+, rendered markdown links; inspector shows the About guidance.

--- a/tldw_chatbook/UI/Screens/settings_config_models.py
+++ b/tldw_chatbook/UI/Screens/settings_config_models.py
@@ -30,6 +30,7 @@ class SettingsCategoryId(StrEnum):
     MCP_DEFAULTS = "mcp-defaults"
     ACP_DEFAULTS = "acp-defaults"
     DIAGNOSTICS = "diagnostics"
+    ABOUT = "about"
     ADVANCED_CONFIG = "advanced-config"
     INTERNAL_PROMPTS = "internal-prompts"
     IMAGE_GENERATION = "image_generation"

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -35,12 +35,15 @@ from textual.widgets import (
     Checkbox,
     Collapsible,
     Input,
+    Markdown,
     Rule,
     Select,
     SelectionList,
     Static,
     TextArea,
 )
+
+from tldw_chatbook.Utils.about_text import ABOUT_MARKDOWN, get_app_version
 
 from ...Chat.console_chat_models import CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
 from ...Chat.console_provider_endpoints import URL_BASED_PROVIDER_KEYS
@@ -1173,6 +1176,11 @@ _INSPECTOR_GUIDANCE: dict[SettingsCategoryId, tuple[tuple[str, str], ...]] = {
             "Boundary",
             "Library owns indexing, query execution, source browse, Collections, and staging",
         ),
+    ),
+    SettingsCategoryId.ABOUT: (
+        ("Affected config", "nothing — version, license, and links are read-only"),
+        ("Recovery", "no recovery needed; links open in the system browser"),
+        ("Boundary", "informational only; no runtime or config surface"),
     ),
     SettingsCategoryId.DIAGNOSTICS: (
         (
@@ -2473,6 +2481,12 @@ class SettingsScreen(BaseAppScreen):
                 "Validate",
             ),
             SettingsCategorySummary(
+                SettingsCategoryId.ABOUT,
+                "About",
+                "Version, license, and project links.",
+                "Local",
+            ),
+            SettingsCategorySummary(
                 SettingsCategoryId.ADVANCED_CONFIG,
                 "Advanced Config",
                 "Raw TOML view and expert configuration editing.",
@@ -2541,7 +2555,10 @@ class SettingsScreen(BaseAppScreen):
                     SettingsCategoryId.PRIVACY_SECURITY,
                 ),
             ),
-            ("Troubleshooting", (SettingsCategoryId.DIAGNOSTICS,)),
+            (
+                "Troubleshooting",
+                (SettingsCategoryId.DIAGNOSTICS, SettingsCategoryId.ABOUT),
+            ),
             (
                 "Expert",
                 (
@@ -2863,6 +2880,16 @@ class SettingsScreen(BaseAppScreen):
                 boundary_copy="Diagnostics validates and reloads without mutating raw TOML.",
                 recovery_copy="Validate before reload; use Advanced Config only for expert repairs.",
                 read_only_reason="Diagnostic checks are non-destructive by design.",
+            ),
+            SettingsOwnershipRecord(
+                category=SettingsCategoryId.ABOUT,
+                owns_config_sections=("nothing",),
+                reads_runtime_state_from=("installed package metadata",),
+                writes_allowed=False,
+                runtime_owner="About",
+                boundary_copy="About shows version, license, and project links only.",
+                recovery_copy="Nothing to recover; links open in the system browser.",
+                read_only_reason="About is informational only.",
             ),
             SettingsOwnershipRecord(
                 category=SettingsCategoryId.ADVANCED_CONFIG,
@@ -4137,6 +4164,7 @@ class SettingsScreen(BaseAppScreen):
             SettingsCategoryId.OVERVIEW: "Guided edits: choose Providers or Console.",
             SettingsCategoryId.PRIVACY_SECURITY: "Guided edits: use Check Privacy.",
             SettingsCategoryId.DIAGNOSTICS: "Guided edits: use Validate/Reload.",
+            SettingsCategoryId.ABOUT: "Guided edits: read-only; links open in browser.",
             SettingsCategoryId.ADVANCED_CONFIG: "Guided edits: use Raw TOML controls.",
         }
         if category in DOMAIN_SETTINGS_CATEGORY_IDS:
@@ -11744,6 +11772,27 @@ class SettingsScreen(BaseAppScreen):
             return
         panel.apply_profile_choices(choices, unavailable=failed)
 
+    @on(Markdown.LinkClicked, "#settings-about-markdown")
+    def _handle_about_link(self, event: Markdown.LinkClicked) -> None:
+        """About links: http(s) opens the system browser with a notify (TASK-2775).
+
+        Any other scheme gets a visible warning and nothing opens — the same
+        explicit policy as the Console transcript and HF README links.
+        """
+        event.stop()
+        href = (event.href or "").strip()
+        if href.startswith(("http://", "https://")):
+            import webbrowser
+
+            webbrowser.open(href)
+            self.notify(f"Opened in browser: {href}", timeout=4)
+        else:
+            self.notify(
+                f"Link not opened (unsupported scheme): {href}",
+                severity="warning",
+                timeout=6,
+            )
+
     def _render_detail_pane(self) -> ComposeResult:
         category = SettingsCategoryId(self.active_category)
         if category is SettingsCategoryId.OVERVIEW:
@@ -12178,6 +12227,20 @@ class SettingsScreen(BaseAppScreen):
                     self._diagnostics_reload_result,
                     id="settings-diagnostics-reload-result",
                     classes="settings-status-row",
+                )
+        elif category is SettingsCategoryId.ABOUT:
+            # TASK-2775: the About surface lost its home when TASK-1346
+            # retired ToolsSettingsWindow; this is its canonical place now.
+            yield Static("About", classes="destination-section settings-column-title")
+            with Vertical(id="settings-about-card", classes="settings-focus-card"):
+                yield self._detail_row("Version", get_app_version())
+                yield self._detail_row("License", "AGPLv3+")
+                # open_links=False: clicks go through _handle_about_link so
+                # the policy (browser + notify) is explicit and testable.
+                yield Markdown(
+                    ABOUT_MARKDOWN,
+                    id="settings-about-markdown",
+                    open_links=False,
                 )
         elif category in DOMAIN_SETTINGS_CATEGORY_IDS:
             yield from self._render_domain_category_detail(category)

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -124,35 +124,9 @@ SETTINGS_DATABASES = (
     ("subscriptions", "Subscriptions", "tldw_cli_subscriptions"),
 )
 
-#: TASK-1995: real markdown, rendered by the About pane's Markdown widget.
-#: This text was previously Rich console markup ([bold]/[italic]/[link=…]),
-#: which Textual's Markdown does not interpret — the tags rendered literally.
-ABOUT_MARKDOWN = """\
-**tldw-chatbook** is a sophisticated Terminal User Interface (TUI) application for interacting with various Large Language Model APIs.
-
-*Features:*
-
-- Multi-provider LLM support (OpenAI, Anthropic, Google, and many more)
-- Advanced conversation management with branching
-- Character-based conversations with personality cards
-- Comprehensive note-taking with bidirectional file sync
-- Media ingestion and analysis (video, audio, documents, PDFs, e-books)
-- RAG (Retrieval-Augmented Generation) for intelligent search
-- Local LLM server management
-- Extensive customization options
-
-*License:* AGPLv3+
-
-*Links:*
-
-- GitHub: <https://github.com/rmusser01/tldw>
-- Documentation: <https://github.com/rmusser01/tldw/wiki>
-- Issues: <https://github.com/rmusser01/tldw/issues>
-
-*Created by:* rmusser01 and contributors
-
-Thank you for using tldw-chatbook! 🎉
-"""
+#: TASK-2775: the About text's canonical home is Utils/about_text (rendered by
+#: the F9 Settings screen's About category); re-exported here for back-compat.
+from tldw_chatbook.Utils.about_text import ABOUT_MARKDOWN  # noqa: E402,F401
 
 
 class ToolsSettingsWindow(Container):

--- a/tldw_chatbook/Utils/about_text.py
+++ b/tldw_chatbook/Utils/about_text.py
@@ -1,0 +1,52 @@
+"""Application About text and version lookup (TASK-2775).
+
+The About content lived only in the deprecated ToolsSettingsWindow, which has
+been unrouted dead UI since TASK-1346 — no reachable surface showed the
+project description, license, or links. The canonical home is now the F9
+Settings screen's About category; the legacy window re-imports from here.
+"""
+
+from importlib import metadata
+
+#: Real markdown (TASK-1995 converted it from Rich console markup, which the
+#: Markdown widget rendered literally).
+ABOUT_MARKDOWN = """\
+**tldw-chatbook** is a sophisticated Terminal User Interface (TUI) application for interacting with various Large Language Model APIs.
+
+*Features:*
+
+- Multi-provider LLM support (OpenAI, Anthropic, Google, and many more)
+- Advanced conversation management with branching
+- Character-based conversations with personality cards
+- Comprehensive note-taking with bidirectional file sync
+- Media ingestion and analysis (video, audio, documents, PDFs, e-books)
+- RAG (Retrieval-Augmented Generation) for intelligent search
+- Local LLM server management
+- Extensive customization options
+
+*License:* AGPLv3+
+
+*Links:*
+
+- GitHub: <https://github.com/rmusser01/tldw>
+- Documentation: <https://github.com/rmusser01/tldw/wiki>
+- Issues: <https://github.com/rmusser01/tldw/issues>
+
+*Created by:* rmusser01 and contributors
+
+Thank you for using tldw-chatbook! 🎉
+"""
+
+
+def get_app_version() -> str:
+    """Return the installed tldw_chatbook version, or a source-checkout marker.
+
+    Returns:
+        The distribution version string, or ``"unknown (source checkout)"``
+        when the package metadata is unavailable (e.g. running from a
+        checkout that was never pip-installed).
+    """
+    try:
+        return metadata.version("tldw_chatbook")
+    except metadata.PackageNotFoundError:
+        return "unknown (source checkout)"


### PR DESCRIPTION
Closes TASK-2775 (filed from the task-1995 reachability finding: About has been dead UI since TASK-1346 — no place in the app showed the version, license, or issue link).

**About** is a read-only **(view)** category under Troubleshooting on the F9 Settings screen:
- Version from installed package metadata (`Utils/about_text.get_app_version()`, source-checkout fallback), license row, and the real-markdown About text (TASK-1995's conversion — canonical home now `Utils/about_text.py`; the deprecated window re-imports it).
- Explicit link policy (`open_links=False`): http(s) → system browser + notify; anything else → visible warning. Same policy as the Console transcript and HF README links.
- Taught to **every** per-category surface — summaries, rail group, `_INSPECTOR_GUIDANCE` (compose-critical), ownership matrix (`writes_allowed=False` → automatic `(view)` badge), guided-edit hints, detail pane. The pinned category-count guard moves 23→24 deliberately, per its own docstring.

**Verification**: new `test_settings_about_2775.py` (registration/read-only, version+markdown render, link policy); **full settings hub suite green (315 passed)** including the exhaustiveness guards. Live tmux at 235x52: `> About (view)` in the rail, `Version: 0.1.8.0`, AGPLv3+, rendered links, About-specific inspector guidance. User Guide `settings.md` updated (category table + section) and re-stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only About category to the F9 Settings (Troubleshooting) showing version, license, and project links, making this info reachable again. Addresses TASK-2775 with an explicit link policy and updated docs/tests.

- **New Features**
  - New `SettingsCategoryId.ABOUT` pane with Version (via `get_app_version()`), License (AGPLv3+), and Markdown `ABOUT_MARKDOWN`.
  - Explicit link policy: http(s) → system browser + notification; other schemes warn (`open_links=false` + `Markdown.LinkClicked` handler).
  - Integrated across settings surfaces: summaries, group, inspector guidance, ownership (read-only), guided-edit hint, detail pane.
  - Moved About text to `tldw_chatbook/Utils/about_text.py`; legacy window re-imports for back-compat.
  - Tests: added `Tests/UI/test_settings_about_2775.py`; updated category count guard to 24; docs updated (`Docs/User_Guide/settings.md`).

<sup>Written for commit 4b15608092b28637bf7ac325e617304a3984fbd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

