### PR TITLE
perf(roleplay): defer the four heavy hidden center views past first paint (task 2725)

### DIFF
--- a/Docs/User_Guide/roleplay-chat-dictionaries.md
+++ b/Docs/User_Guide/roleplay-chat-dictionaries.md
@@ -253,4 +253,4 @@ Screen-level keys only — global keys live in the [guide index](index.md).
   are live. Prompts moved out to Library and is no longer a mode here.
 
 —
-*Verified against dev @ 8b7fa5eb6 — 2026-07-31*
+*Verified against dev @ acaae68e9 + task-2725 deferred center views — 2026-08-07 (modes, selection, editor open/cancel exercised live)*

--- a/Tests/UI/test_personas_deferred_center_views.py
+++ b/Tests/UI/test_personas_deferred_center_views.py
@@ -1,0 +1,105 @@
+"""task-2725: the four heavy hidden center views mount after first paint.
+
+Profiling (task file) showed the Roleplay switch cost is widget-mount CSS
+application, with 290 of the detail stack's 358 widgets in four views that
+arrive hidden: the character editor (132), dictionary detail (67), lore
+detail (60), and persona profile editor (31). They now mount as the first
+step of `_load_after_mount` — off the click→paint critical path — instead
+of inside compose.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
+    PersonaProfileEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_dictionary_detail import (
+    PersonasDictionaryDetailWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_lore_detail import (
+    PersonasLoreDetailWidget,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_DEFERRED_TYPES = (
+    PersonasCharacterEditorWidget,
+    PersonasDictionaryDetailWidget,
+    PersonasLoreDetailWidget,
+    PersonaProfileEditorWidget,
+)
+
+#: The stack's document order — scroll flow depends on it, so the deferred
+#: mounts must land exactly where compose used to put them.
+_EXPECTED_STACK_ORDER = [
+    "ccp-character-card-view",
+    "ccp-character-editor-view",
+    "personas-character-attachments",
+    "ccp-persona-card-view",
+    "ccp-persona-editor-view",
+    "personas-conversation-actions",
+    "personas-dictionary-detail",
+    "personas-lore-detail",
+    "personas-conversation-transcript-view",
+    "personas-mode-placeholder",
+    "personas-characters-empty",
+]
+
+
+async def test_first_paint_excludes_the_four_heavy_center_views(monkeypatch):
+    """Compose alone must not mount the deferred views (the perf mechanism)."""
+    from Tests.UI.app_factory import _build_test_app
+
+    monkeypatch.setattr(
+        PersonasScreen, "_load_after_mount", AsyncMock(), raising=True
+    )
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        for deferred_type in _DEFERRED_TYPES:
+            assert not list(screen.query(deferred_type)), (
+                f"{deferred_type.__name__} mounted during compose — "
+                "back on the click→paint critical path"
+            )
+        total = len(list(screen.query("*")))
+        assert total < 300, (
+            f"first-paint widget count regressed to {total} (pre-fix: 494)"
+        )
+
+
+async def test_load_mounts_all_four_hidden_in_document_order():
+    """After the real load, the full DOM exists exactly as compose built it
+    pre-change: every deferred view present, hidden, in historical order."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        for _ in range(6):
+            await pilot.pause()
+
+        for deferred_type in _DEFERRED_TYPES:
+            found = list(screen.query(deferred_type))
+            assert len(found) == 1, f"{deferred_type.__name__} missing after load"
+            assert found[0].display is False, (
+                f"{deferred_type.__name__} arrived visible — it must stay "
+                "hidden until _show_center reveals it"
+            )
+
+        stack = screen.query_one("#personas-detail-stack")
+        assert [child.id for child in stack.children] == _EXPECTED_STACK_ORDER

--- a/backlog/tasks/task-2725 - Roleplay screen switch takes 2s where every other screen takes under 1s.md
+++ b/backlog/tasks/task-2725 - Roleplay screen switch takes 2s where every other screen takes under 1s.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2725
 title: Roleplay screen switch takes ~2s where every other screen takes under 1s
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-06 17:00'
 labels:
@@ -35,9 +35,9 @@ Profile before optimizing (per project rules) — the fix is likely deferring pe
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] Roleplay tab switch (click → screen interactive) is within 2× the median of the other screens on the same profile, measured before/after with the same method.
+- [x] Roleplay tab switch (click → screen interactive) is within 2× the median of the other screens on the same profile, measured before/after with the same method.
 - [x] The cause is identified by profiling and recorded in the task notes (not guessed).
-- [ ] No functional regression in the four Roleplay modes (Characters, Personas, Dictionaries, Lore all render their data).
+- [x] No functional regression in the four Roleplay modes (Characters, Personas, Dictionaries, Lore all render their data).
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
 
 ## Investigation Notes (2026-08-06, profiling done — fix deferred)
@@ -48,4 +48,25 @@ Profiled via cProfile around `push_screen(PersonasScreen)` in the standard test-
 **Recommended fix (own PR):** defer composition of the non-active mode's detail widgets (mount on first mode activation). NOT landed in the 2720-2726 batch deliberately: 81 in-screen references + 4 external modules address these widgets, and `restore_state` runs before mount — deferral needs a centralized accessor plus an audit of every query site, which is its own reviewable change, not a rider. `textual.lazy.Lazy` alone is insufficient for the same reason (queries during `on_mount`/restore would hit unmounted children).
 
 AC1/AC3 remain unchecked pending that change; AC2 (profiled cause) is satisfied by this note.
+<!-- SECTION:NOTES:END -->
+
+## Implementation Plan (fix round, 2026-08-07)
+
+<!-- SECTION:PLAN:BEGIN -->
+Scoping probe: the four heavy hidden center views carry 290 of the stack's 358 widgets — `PersonasCharacterEditorWidget` 132, `PersonasDictionaryDetailWidget` 67, `PersonasLoreDetailWidget` 60, `PersonaProfileEditorWidget` 31. Architecture check: `_show_center` already tolerates missing nodes (skips absent selectors) and the editor funnels through `_editor_or_none`, so deferred mounting is supported by existing tolerance.
+
+Design: **defer-past-first-paint**, not mount-on-demand — compose the four heavy views nowhere; mount them (hidden, order-anchored) as the FIRST step of `_load_after_mount`, before `_apply_pending_restore`/auto-select. Every query site downstream of load sees the full DOM; only the compose→load window must tolerate absence, which `_show_center`/`_editor_or_none` already do. Total work unchanged; the click→paint critical path drops by ~59% of the screen's widgets.
+
+1. RED A: with `_load_after_mount` stubbed, pushing the screen mounts none of the four and the widget total drops below 300 (was 494).
+2. Guard B (passes before AND after): after a real load settles, all four are present, hidden, and the stack's child order is exactly the historical document order.
+3. GREEN: compose drops the four yields; `_mount_deferred_center_views()` mounts them with `after=` anchors and `display=False`; `_load_after_mount` awaits it first.
+4. Full personas suites + live tmux latency before/after with the walkthrough method.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes (fix round)
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped the defer-past-first-paint design: `compose_content` no longer yields the four heavy hidden center views (character editor 132 widgets, dictionary detail 67, lore detail 60, persona profile editor 31 — 290 of the screen's 494); `_mount_deferred_center_views()` mounts them hidden and order-anchored (`after=` the widgets compose used to place them behind) as `_load_after_mount`'s first step, before `_apply_pending_restore`/auto-select, so every downstream query site sees the full DOM. The compose→load window is covered by existing tolerance (`_show_center` skips absent selectors; `_editor_or_none` returns None) — chosen over mount-on-demand precisely to avoid auditing the 85+ query sites. Idempotent for re-entered loads.
+
+Results: tab-switch latency 2.19s/1.97s → **0.69–0.94s** live (same tmux click→highlight method, same seeded profile; other screens 0.26–0.47s, so within 2× median). Tests: mechanism pin (load stubbed → none of the four mount, widget total <300) watched RED first; integrity guard (all four present+hidden after load, stack document order exactly the historical sequence) green before AND after. Full personas suites 474 passed; live: all four modes cycled, character selected, deferred editor opened via Edit and cancelled back to the card, zero errors/warnings in both logs. Files: tldw_chatbook/UI/Screens/personas_screen.py, Tests/UI/test_personas_deferred_center_views.py, Docs/User_Guide/roleplay-chat-dictionaries.md (stamp).
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -842,14 +842,21 @@ class PersonasScreen(BaseAppScreen):
                     # the old bottom-docked wrapper, which let the two
                     # empty panels displace the card at 100x30 and left a
                     # dead void between them at 170x50.)
+                    # task-2725: the four heavy hidden center views (character
+                    # editor, persona editor, dictionary/lore detail — 290 of
+                    # this screen's ~494 widgets) are NOT composed here. They
+                    # mount hidden, order-anchored, as the first step of
+                    # `_load_after_mount` (`_mount_deferred_center_views`),
+                    # taking their CSS-application cost off the click→paint
+                    # critical path. `_show_center` skips absent selectors and
+                    # `_editor_or_none` returns None, so the compose→load
+                    # window is tolerated by design.
                     with VerticalScroll(id="personas-detail-stack"):
                         yield PersonasCharacterCardWidget()
-                        yield PersonasCharacterEditorWidget()
                         with Vertical(id="personas-character-attachments"):
                             yield PersonasCharacterDictionariesWidget()
                             yield PersonasCharacterWorldBooksWidget()
                         yield PersonaProfileCardWidget()
-                        yield PersonaProfileEditorWidget()
                         with Horizontal(id="personas-conversation-actions"):
                             yield Button(
                                 "Back to card", id="personas-conversation-back"
@@ -865,10 +872,6 @@ class PersonasScreen(BaseAppScreen):
                                 "Open in Library",
                                 id="personas-conversation-open-library",
                             )
-                        yield PersonasDictionaryDetailWidget(
-                            id="personas-dictionary-detail"
-                        )
-                        yield PersonasLoreDetailWidget(id="personas-lore-detail")
                         yield PersonasConversationTranscriptWidget()
                         yield Static(
                             self._mode_placeholder_text("prompts"),
@@ -1108,9 +1111,48 @@ class PersonasScreen(BaseAppScreen):
             exclusive=True,
         )
 
+    async def _mount_deferred_center_views(self) -> None:
+        """Mount the four heavy hidden center views after first paint.
+
+        task-2725: profiling showed the Roleplay switch cost is widget-mount
+        CSS application, and 290 of the detail stack's 358 widgets sit in
+        views that arrive hidden (`display: False`) anyway. Mounting them
+        here — as `_load_after_mount`'s first step, before
+        `_apply_pending_restore` and auto-select — keeps every downstream
+        query site valid while taking them off the click→paint critical
+        path. Each mounts hidden and order-anchored so the stack's document
+        (scroll) order is exactly what compose used to produce; `_show_
+        center` owns visibility from then on. Idempotent: a re-entered load
+        (e.g. runtime-source switch re-running `_load_after_mount`) skips
+        mounting.
+        """
+        try:
+            stack = self.query_one("#personas-detail-stack", VerticalScroll)
+        except QueryError:
+            return
+        if self.query(PersonasCharacterEditorWidget):
+            return
+
+        character_editor = PersonasCharacterEditorWidget()
+        persona_editor = PersonaProfileEditorWidget()
+        dictionary_detail = PersonasDictionaryDetailWidget(
+            id="personas-dictionary-detail"
+        )
+        lore_detail = PersonasLoreDetailWidget(id="personas-lore-detail")
+        for view in (character_editor, persona_editor, dictionary_detail, lore_detail):
+            view.display = False
+
+        await stack.mount(character_editor, after="#ccp-character-card-view")
+        await stack.mount(persona_editor, after="#ccp-persona-card-view")
+        await stack.mount(dictionary_detail, after="#personas-conversation-actions")
+        await stack.mount(lore_detail, after="#personas-dictionary-detail")
+
     async def _load_after_mount(self) -> None:
         """Load the character library once the screen is already on screen."""
         try:
+            # Must precede everything below: `_apply_pending_restore` and the
+            # selection sync assume the full center-view DOM (task-2725).
+            await self._mount_deferred_center_views()
             loading_manager = getattr(self, "loading_manager", None)
             setup_loading = getattr(loading_manager, "setup", None)
             if callable(setup_loading):


### PR DESCRIPTION
## Summary

Closes the deferred half of task-2725 (filed+profiled in #1378). The Roleplay tab switch cost 2.19s where every other screen takes 0.25–1.1s; profiling showed it is widget-mount CSS application — 290 of the screen's 494 widgets sit in four center views that arrive `display: False` anyway (character editor 132, dictionary detail 67, lore detail 60, persona profile editor 31).

**Design: defer past first paint, not mount-on-demand.** `compose_content` no longer yields the four; `_mount_deferred_center_views()` mounts them hidden and order-anchored as the first step of `_load_after_mount`, before `_apply_pending_restore`/auto-select — so every downstream query site sees the full DOM, and only the compose→load window must tolerate absence, which the architecture already does (`_show_center` skips absent selectors; `_editor_or_none` returns None). This deliberately avoids auditing the 85+ direct query sites an on-demand design would require. Idempotent for re-entered loads; stack document (scroll) order is pinned by test to the exact historical sequence.

## Measured (live tmux, same method + seeded profile as the #1378 walkthrough)

| | before | after |
|---|---|---|
| Roleplay switch | 2.19s / 1.97s (repeat) | **0.94s / 0.91s / 0.69s** |
| other screens | 0.25–1.1s | unchanged (Home 0.26s, Library 0.47s) |

Within 2× the ~0.5s median → AC1 met by the AC's own method.

## Verification
- Mechanism pin watched RED first: with load stubbed, none of the four mount and first-paint widget total < 300 (pre-fix 494).
- Integrity guard (green before AND after): all four present + hidden after load, stack child order exactly the historical document order.
- **Full personas suites: 474 passed.**
- Live: all four modes cycled, character selected, the deferred 132-widget editor opened via Edit and cancelled back to the card — zero errors, zero warnings in the persistent log and the in-app buffer.
- `--collect-only`: 31,558 collected.
- Roleplay User Guide 'Verified against' stamp refreshed per the UI-change rule (no visible UI change; DOM after load is identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers the four heavy, hidden center views on the Roleplay screen until after first paint to cut tab switch time from ~2.19s to 0.69–0.94s, bringing it within 2× the median of other screens. Addresses TASK-2725 without functional regressions and keeps the post-load DOM identical.

- **Refactors**
  - Stop composing `PersonasCharacterEditorWidget`, `PersonasDictionaryDetailWidget`, `PersonasLoreDetailWidget`, and `PersonaProfileEditorWidget`; mount them hidden and order-anchored via `_mount_deferred_center_views()` as the first step of `_load_after_mount`.
  - Preserve behavior: downstream queries see the full DOM after load; the compose→load window is tolerated by `_show_center` and `_editor_or_none`.
  - Tests: added coverage to pin first-paint exclusion, post-load presence/hidden state, and historical stack order.
  - Docs: refreshed Roleplay guide verification stamp.

<sup>Written for commit ab364c4df9e84787c29382deccf180932a8ba1aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

