### PR TITLE
MCP inspector honesty residue: Test Tool crash, stale badge in three views, dishonest gate_error cells (tasks 2740/2270/2870)

### DIFF
--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -152,4 +152,10 @@ boolean fields — live check pending Task 9). Fix round I, 2026-08-06:
 "do anything else to cancel" on the Test Tool confirm now genuinely
 covers editing the argument form (it previously did not), and a
 background section load can no longer cancel an Advanced confirm you
-armed while it loaded — only your own actions cancel, as written.*
+armed while it loaded — only your own actions cancel, as written.
+2026-08-07 (tasks 2740/2270/2870): opening Test Tool on a tool with
+only-checkbox or no arguments no longer crashes the app; the "Pick a
+server, tool, or entry…" placeholder now clears for Permissions-row,
+Audit-entry, and Finding detail exactly as it does for tool detail; and
+a permission the app could not read shows as "Unknown" (never a false
+"Off") in the matrix, the State column, and the inspector alike.*

--- a/Tests/MCP/test_permission_resolution.py
+++ b/Tests/MCP/test_permission_resolution.py
@@ -114,6 +114,24 @@ def test_ui_label_is_defensive_against_unknown_state():
     assert EffectiveToolState(state="", origin="global_default").ui_label == "Ask"
 
 
+def test_ui_label_reads_unknown_not_off_for_a_gate_error_origin():
+    """task-2870: `origin="gate_error"` is the synthesized fail-closed
+    verdict -- the permission RESOLVER raised, not a configured Off
+    (`MCPWorkbench._resolve_test_gate()`/`_effective_for_display()` pair it
+    unconditionally with `state="deny"`). Mapping it to "Off" made every
+    `ui_label` renderer (Permissions matrix State cells, Tools-mode State
+    column) print a confident configuration claim about a state that could
+    not be read -- the same lie PR #1385's round J removed from the
+    inspector's permission block one surface at a time. Owning it HERE
+    fixes every renderer at once; a genuine deny keeps "Off"."""
+    assert (
+        EffectiveToolState(state="deny", origin="gate_error").ui_label == "Unknown"
+    )
+    # Genuine denies -- any non-gate_error origin -- keep the honest "Off".
+    assert EffectiveToolState(state="deny", origin="tool_override").ui_label == "Off"
+    assert EffectiveToolState(state="deny", origin="global_default").ui_label == "Off"
+
+
 # -- HIGH_RISK_TAGS ------------------------------------------------------------
 
 

--- a/Tests/UI/test_mcp_inspector.py
+++ b/Tests/UI/test_mcp_inspector.py
@@ -3898,6 +3898,128 @@ async def test_update_readiness_does_not_resurrect_badge_over_displayed_tool():
         assert badge.display is True
 
 
+# -- task-2270: the RAG-50 badge fix covered Tools mode ONLY. The other -----
+# three detail views (Permissions matrix row, Audit entry, Finding) each
+# toggled only their own container and never touched `#mcp-inspector-state`,
+# so selecting any of them with no server selected left "Pick a server,
+# tool, or entry…" sitting above fully populated detail. Confirmed by
+# direct code read in the PR-5 task-6 review; fixed here by a single badge
+# owner (`_sync_state_badge_display()`): the badge shows exactly when NO
+# detail view is displayed, every view's show/clear path funnels through
+# it, and `update_readiness()` stays content-only in every mode.
+
+
+def _audit_entry() -> dict[str, Any]:
+    return {"server_key": "local:docs", "tool_name": "search"}
+
+
+@pytest.mark.asyncio
+async def test_empty_state_badge_hidden_when_permission_row_shown():
+    """Permissions-matrix row selection (`show_permission()`) must hide
+    the badge like Tools mode does, and the shared clear path
+    (`show_tool(None)`, which also blanks the permission container via
+    `_render_permission_container(None, None)`) must restore it."""
+    app = InspectorApp()
+    async with app.run_test(size=(100, 60)) as pilot:
+        inspector = app.query_one(MCPInspector)
+        await inspector.show_permission(
+            _tool(), EffectiveToolState(state="ask", origin="global_default")
+        )
+        await pilot.pause()
+        badge = app.query_one("#mcp-inspector-state", Static)
+        assert badge.display is False
+
+        await inspector.show_tool(None)
+        await pilot.pause()
+        assert badge.display is True
+
+
+@pytest.mark.asyncio
+async def test_empty_state_badge_hidden_when_audit_entry_shown():
+    app = InspectorApp()
+    async with app.run_test(size=(100, 60)) as pilot:
+        inspector = app.query_one(MCPInspector)
+        await inspector.show_audit_entry(_audit_entry())
+        await pilot.pause()
+        badge = app.query_one("#mcp-inspector-state", Static)
+        assert badge.display is False
+
+        await inspector.show_audit_entry(None)
+        await pilot.pause()
+        assert badge.display is True
+
+
+@pytest.mark.asyncio
+async def test_empty_state_badge_hidden_when_finding_shown():
+    app = InspectorApp()
+    async with app.run_test(size=(100, 60)) as pilot:
+        inspector = app.query_one(MCPInspector)
+        await inspector.show_finding(_finding(), server_key="local:docs")
+        await pilot.pause()
+        badge = app.query_one("#mcp-inspector-state", Static)
+        assert badge.display is False
+
+        await inspector.show_finding(None)
+        await pilot.pause()
+        assert badge.display is True
+
+
+@pytest.mark.asyncio
+async def test_empty_state_badge_stays_hidden_while_any_detail_remains():
+    """Audit mode can display an execution entry and a finding at once --
+    clearing ONE must not resurrect the badge while the other still shows
+    populated detail; only clearing the last one restores it."""
+    app = InspectorApp()
+    async with app.run_test(size=(100, 60)) as pilot:
+        inspector = app.query_one(MCPInspector)
+        await inspector.show_audit_entry(_audit_entry())
+        await inspector.show_finding(_finding(), server_key="local:docs")
+        await pilot.pause()
+        badge = app.query_one("#mcp-inspector-state", Static)
+        assert badge.display is False
+
+        await inspector.show_finding(None)
+        await pilot.pause()
+        assert badge.display is False, (
+            "finding cleared but the audit entry still shows detail -- "
+            "the badge must stay hidden"
+        )
+
+        await inspector.show_audit_entry(None)
+        await pilot.pause()
+        assert badge.display is True
+
+
+@pytest.mark.asyncio
+async def test_update_readiness_does_not_resurrect_badge_over_other_detail_views():
+    """AC3, beyond Tools mode: a background readiness sync while a
+    permission row / audit entry shows detail must not force the badge
+    back over it -- `update_readiness()` stays content-only."""
+    app = InspectorApp()
+    async with app.run_test(size=(100, 60)) as pilot:
+        inspector = app.query_one(MCPInspector)
+        badge = app.query_one("#mcp-inspector-state", Static)
+
+        await inspector.show_permission(
+            _tool(), EffectiveToolState(state="ask", origin="global_default")
+        )
+        await pilot.pause()
+        await inspector.update_readiness(_ready_snap())
+        await pilot.pause()
+        assert badge.display is False
+
+        await inspector.show_tool(None)
+        await inspector.show_audit_entry(_audit_entry())
+        await pilot.pause()
+        await inspector.update_readiness(_stale_snap())
+        await pilot.pause()
+        assert badge.display is False
+
+        await inspector.show_audit_entry(None)
+        await pilot.pause()
+        assert badge.display is True
+
+
 # -- Task 6 (PR-T3), Route B: the Advanced runner's `tool.execute` hatch -----
 # Every OTHER Advanced action reads or mutates control-plane config; this one
 # EXECUTES a tool. It ran on a single press, ungated and unlogged. The service

--- a/Tests/UI/test_mcp_inspector.py
+++ b/Tests/UI/test_mcp_inspector.py
@@ -2459,6 +2459,65 @@ async def test_test_panel_open_moves_focus_inside_and_escape_closes():
         assert app.query_one("#mcp-inspector-test-tool", Button).disabled is False
 
 
+@pytest.mark.asyncio
+async def test_test_panel_mounts_for_an_all_boolean_schema_and_focuses_the_checkbox():
+    """task-2740: `_mount_test_tool_panel()`'s F-056 focus query omitted
+    `Checkbox`, and `DOMQuery.first()` RAISES `NoMatches` on an empty
+    result (the `is None` fallback was dead code) -- so a tool whose
+    schema renders ONLY boolean fields killed the mount worker, taking
+    the app down (default `exit_on_error`). Found live during PR #1385's
+    round-I test writing. The panel must mount, and focus must land on
+    the first form control -- the Checkbox -- per F-056's own contract
+    ("the schema form's first control when there is one")."""
+    app = InspectorApp()
+    async with app.run_test(size=(100, 60)) as pilot:
+        inspector = app.query_one(MCPInspector)
+        await inspector.show_tool(_tool(input_schema={
+            "type": "object",
+            "properties": {"verbose": {"type": "boolean", "default": False}},
+        }))
+        await pilot.pause()
+        await pilot.click("#mcp-inspector-test-tool")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert list(app.query("#mcp-inspector-test-panel"))
+        focused = app.focused
+        assert focused is not None
+        assert focused.id == "mcp-schema-field-0", (
+            f"focus must land on the boolean form's Checkbox: {focused!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_test_panel_mounts_for_a_zero_control_schema_and_focuses_close():
+    """task-2740, the shape that made this a LIVE crasher: a schema with
+    empty `properties` renders a form with ZERO controls -- and the real
+    built-in `list_characters` ships exactly that schema, so opening Test
+    Tool on it crashed the app before this fix. With nothing to focus,
+    the panel must mount and the F-056 fallback to the Close button must
+    actually happen (it was unreachable dead code behind the raising
+    `.first()`)."""
+    app = InspectorApp()
+    async with app.run_test(size=(100, 60)) as pilot:
+        inspector = app.query_one(MCPInspector)
+        await inspector.show_tool(_tool(input_schema={
+            "type": "object",
+            "properties": {},
+        }))
+        await pilot.pause()
+        await pilot.click("#mcp-inspector-test-tool")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert list(app.query("#mcp-inspector-test-panel"))
+        focused = app.focused
+        assert focused is not None
+        assert focused.id == "mcp-inspector-test-close", (
+            f"with zero form controls, focus must land on Close: {focused!r}"
+        )
+
+
 # -- Task 5: gate-aware Test Tool -- arm-then-confirm mechanics --------------
 #
 # `require_confirm()`/`disarm_test_run()`/`test_run_armed` are the inspector-

--- a/Tests/UI/test_mcp_permissions_mode.py
+++ b/Tests/UI/test_mcp_permissions_mode.py
@@ -710,6 +710,26 @@ def test_format_tool_state_label_marker_precedence():
     )
 
 
+def test_format_tool_state_label_gate_error_reads_unknown_not_off():
+    """task-2870: a gate_error row (resolver raised; fail-closed deny) must
+    render "Unknown" in the matrix/State column, never "Off" -- and bare,
+    with no origin marker (gate_error is synthesized, never an explicit
+    override). The severity treatment is unchanged on purpose:
+    `tool_state_kind()` still buckets the fail-closed deny as "error",
+    because the EFFECT (blocked, don't trust it) is true -- only the
+    causal label lied."""
+    from tldw_chatbook.MCP.permission_store import EffectiveToolState
+
+    gate_error = EffectiveToolState(state="deny", origin="gate_error")
+    assert format_tool_state_label(gate_error) == "Unknown"
+    assert tool_state_kind(gate_error) == "error"
+    # A genuine deny keeps its honest "Off" on the same surface.
+    assert (
+        format_tool_state_label(EffectiveToolState(state="deny", origin="tool_override"))
+        == "Off •"
+    )
+
+
 # -- T8: server-source governance listing (read-only) ---------------------
 
 

--- a/backlog/tasks/task-2270 - Fix-inspector-empty-state-badge-staleness-in-Permissions-Audit-Findings-detail-views.md
+++ b/backlog/tasks/task-2270 - Fix-inspector-empty-state-badge-staleness-in-Permissions-Audit-Findings-detail-views.md
@@ -1,9 +1,13 @@
 ---
 id: TASK-2270
-title: Fix inspector empty-state badge staleness in Permissions/Audit/Findings detail views
-status: To Do
-assignee: []
+title: >-
+  Fix inspector empty-state badge staleness in Permissions/Audit/Findings detail
+  views
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-04 21:30'
+updated_date: '2026-08-07 01:27'
 labels:
   - mcp
   - ui
@@ -23,15 +27,23 @@ Rider from the PR-5 final review (same seam, honest-copy fix): when the test-gat
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selecting a permission row, audit entry, or finding with no server selected does not leave the empty-state badge above the populated detail.
+- [x] #2 All four detail views (Tools/Permissions/Audit/Findings) behave consistently: badge hidden while detail is displayed, restored on that view's clear path with the empty-state copy.
+- [x] #3 `update_readiness()` cannot resurrect the badge over displayed detail in any mode.
+- [x] #4 A `gate_error`-origin gate produces the honest "Permission state could not be resolved." note, never "This tool is set to Off." *(the rider — see Implementation Notes)*
+- [x] #5 Existing badge-content and Tools-mode pins keep passing; new behavior covered by additive tests per view.
+<!-- AC:END -->
 
-- [ ] Selecting a permission row, audit entry, or finding with no server selected does not leave the empty-state badge above the populated detail.
-- [ ] All four detail views (Tools/Permissions/Audit/Findings) behave consistently: badge hidden while detail is displayed, restored on that view's clear path with the empty-state copy.
-- [ ] `update_readiness()` cannot resurrect the badge over displayed detail in any mode.
-- [x] A `gate_error`-origin gate produces the honest "Permission state could not be resolved." note, never "This tool is set to Off." *(the rider — see Implementation Notes)*
-- [ ] Existing badge-content and Tools-mode pins keep passing; new behavior covered by additive tests per view.
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Single badge owner: _sync_state_badge_display() — badge displays only when NO detail view shows (tool/permission/audit/finding); every view's show/clear path funnels through it. 2. RED per view: permission row, audit entry, finding each currently leave the badge above populated detail. 3. AC3: update_readiness stays content-only; additive tests prove a readiness sync cannot resurrect the badge over any displayed detail. 4. Rider (gate_error decision note): verify satisfied-by-PR-1385 — the gate_error branch of _decision_note was proven dead and removed; the run path renders the derived unresolved copy — record evidence, no new code. 5. Mutation per new guard.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 **2026-08-06 (PR-T3 Task 3, commit `b1c103ff3`):** The rider (the fourth AC item
 above) shipped. `_decision_note()`'s synthetic `gate_error` origin now degrades to
 the honest `_UNKNOWN_ORIGIN_SENTENCE` ("Permission state could not be resolved.")
@@ -45,3 +57,4 @@ populated detail in the Permissions, Audit, and Findings views (AC #1–#3, #5) 
 UNTOUCHED and remains open.** PR-T3 only reached the decision-note text in the same
 seam; the badge-staleness defect itself was out of that PR's scope. This task stays
 **To Do**.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2740 - Test-Tool-panel-mount-crashes-for-an-all-boolean-argument-schema.md
+++ b/backlog/tasks/task-2740 - Test-Tool-panel-mount-crashes-for-an-all-boolean-argument-schema.md
@@ -1,10 +1,15 @@
 ---
 id: TASK-2740
 title: Test Tool panel mount crashes for an all-boolean argument schema
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-06 23:45'
-labels: [mcp, ui, crash]
+updated_date: '2026-08-07 01:27'
+labels:
+  - mcp
+  - ui
+  - crash
 dependencies: []
 priority: high
 ---
@@ -54,8 +59,32 @@ reachable or be removed — it currently documents behavior that cannot occur.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening the Test Tool panel for a tool whose schema renders only Checkbox controls does not raise and does not kill the mount worker
-- [ ] #2 Focus lands on a deliberate target for the all-boolean case (first Checkbox or Close button — decided, not accidental) and a test pins it
-- [ ] #3 The dead `is None` fallback is either made reachable or removed; no comment promises a fallback that cannot fire
-- [ ] #4 A regression test mounts the panel with an all-boolean schema (the exact scenario that crashed) and passes
+- [x] #1 Opening the Test Tool panel for a tool whose schema renders only Checkbox controls does not raise and does not kill the mount worker
+- [x] #2 Focus lands on a deliberate target for the all-boolean case (first Checkbox or Close button — decided, not accidental) and a test pins it
+- [x] #3 The dead `is None` fallback is either made reachable or removed; no comment promises a fallback that cannot fire
+- [x] #4 A regression test mounts the panel with an all-boolean schema (the exact scenario that crashed) and passes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: regression tests — all-boolean schema and empty-properties schema (the live list_characters shape) both mount the Test Tool panel without crashing; focus pins: first Checkbox for the boolean form, Close button for the zero-control form. 2. GREEN: add Checkbox to the focus query; replace the dead .first()/is-None fallback with a truthiness-guarded real fallback. 3. Mutation: re-drop Checkbox from the query and re-break the fallback, confirm each test reds.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in `_mount_test_tool_panel()` (mcp_inspector.py): `Checkbox` joins
+the F-056 focus query, and the `.first()` call is guarded by DOMQuery
+truthiness — the old `is None` fallback was dead code because `.first()`
+raises `NoMatches` on an empty result, and the raise escaped a
+default-`exit_on_error` worker (app crash). Investigation upgraded the
+severity: the real built-in `list_characters` ships empty `properties`,
+so the crash needed no exotic schema. Focus decisions per AC #2: first
+Checkbox for a boolean form (F-056's "first form control" contract);
+Close button for a genuinely zero-control form (the fallback, now
+reachable and pinned). Tests: `test_test_panel_mounts_for_an_all_boolean_
+schema_and_focuses_the_checkbox`, `test_test_panel_mounts_for_a_zero_
+control_schema_and_focuses_close`; each mutation-verified independently.
+Commit bfd5d38d9 on fix/mcp-inspector-honesty-residue.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2870 - Permissions-matrix-and-Tools-State-column-claim-Off-for-a-resolver-failure.md
+++ b/backlog/tasks/task-2870 - Permissions-matrix-and-Tools-State-column-claim-Off-for-a-resolver-failure.md
@@ -1,0 +1,65 @@
+---
+id: TASK-2870
+title: Permissions matrix and Tools State column claim "Off" for a resolver failure
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-07 01:30'
+updated_date: '2026-08-07 01:27'
+labels:
+  - mcp
+  - ui
+  - honesty
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #1385's round J made the inspector's permission block stop rendering
+"Permission: Off" for a `gate_error` verdict (the synthesized fail-closed
+state when the permission RESOLVER raises — not a configured Off). Its
+commit deliberately left the other `ui_label` renderers alone and pointed
+at task-2270 — a mis-attribution: 2270 covers badge staleness and the
+decision-note copy, not these labels. This task is the actual filing.
+
+`EffectiveToolState.ui_label` maps `state="deny"` to "Off" with no origin
+awareness, so `format_tool_state_label()` renders "Off ·" for gate_error
+rows in the Permissions matrix and the Tools-mode State column — a
+confident configuration claim about a state the resolver could not read.
+Reachable live: `MCPWorkbench._effective_for_display()` synthesizes
+`EffectiveToolState(state="deny", origin="gate_error")` whenever per-tool
+resolution raises.
+
+The truthful vocabulary is already ruled: "Unknown" for the label (round
+J), error-severity color kept (the fail-closed EFFECT is real; only the
+causal label lied).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A gate_error-origin state renders "Unknown", never "Off", everywhere `ui_label` feeds copy (Permissions matrix State cells, Tools-mode State column, inspector permission block).
+- [x] #2 A genuine deny (any non-gate_error origin) still renders "Off" on every one of those surfaces.
+- [x] #3 The severity color/kind for gate_error rows is unchanged (still the blocked/error treatment).
+- [x] #4 Round J's inspector test keeps passing; new coverage pins the label at the `ui_label` seam and at least one view-level render.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`EffectiveToolState.ui_label` now owns the honesty rule: `origin ==
+"gate_error"` → "Unknown"; genuine denies from any other origin keep
+"Off". The inspector's round-J site-local branch collapsed back to a
+plain `ui_label` read (round J's test now pins through the property),
+`format_tool_state_label()` renders a bare "Unknown" (no origin marker)
+for matrix/State-column rows, and `tool_state_kind()` is deliberately
+unchanged (error bucket — the fail-closed effect is real). Consumer
+sweep before changing the shared property: `_decision_note()`'s string
+branches are proven unreachable for gate_error; `_cycled_ui_label()`
+and the default-rung renderers construct their own non-gate_error
+states. Mutation: dropping the branch reds both new tests and round J's
+inspector test. 539 passed across the five reachable suites; no
+existing test relied on the dishonest cell. Commit b94bb0910 on
+fix/mcp-inspector-honesty-residue.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/MCP/permission_store.py
+++ b/tldw_chatbook/MCP/permission_store.py
@@ -620,6 +620,22 @@ class EffectiveToolState:
 
     @property
     def ui_label(self) -> str:
+        # task-2870: `origin == "gate_error"` is the synthesized
+        # fail-closed verdict -- the permission RESOLVER raised, not a
+        # configured Off (`MCPWorkbench._resolve_test_gate()`/
+        # `_effective_for_display()` pair it unconditionally with
+        # `state="deny"`). Mapping it to "Off" made every renderer of this
+        # property (Permissions matrix State cells, Tools-mode State
+        # column, the inspector's permission block) print a confident
+        # configuration claim about a state that could not be read -- the
+        # contradiction PR #1385's round J removed from the inspector one
+        # surface at a time. Owned HERE so every renderer tells the same
+        # truth; severity/color is deliberately NOT this property's job
+        # (`tool_state_kind()` keeps the fail-closed deny in the "error"
+        # bucket -- the blocked EFFECT is real, only the causal label
+        # lied).
+        if self.origin == "gate_error":
+            return "Unknown"
         # I2: second layer of defense against a hand-edited/corrupted
         # `mcp_permissions.json` whose `global_default` is some non-store
         # value (e.g. "banana") -- `resolve_effective_state()` itself now

--- a/tldw_chatbook/MCP/permission_store.py
+++ b/tldw_chatbook/MCP/permission_store.py
@@ -606,6 +606,14 @@ class EffectiveToolState:
             ``global_default``, or (built-in tools only, via
             ``resolve_builtin_state``) ``builtin_default``, the allow
             floor applied when nothing more specific overrides it.
+            One SYNTHETIC value exists outside the precedence walk:
+            ``gate_error``, constructed by ``MCPWorkbench`` (paired
+            unconditionally with ``state="deny"``) when per-tool
+            resolution RAISES -- a fail-closed verdict, not a configured
+            state, which is why ``ui_label`` renders it "Unknown"
+            (task-2870) and every copy surface derives its explanation
+            from ``PERMISSION_STATE_UNRESOLVED_CLAUSE`` rather than
+            claiming "Off".
         config_changed: True when an explicit tool-level ``allow`` was
             downgraded to ``ask`` by the rug-pull guard (hash mismatch
             and/or a persisted ``config_changed`` marker).

--- a/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
@@ -1544,6 +1544,40 @@ class MCPInspector(Vertical):
 
     # -- T6: tool detail view + Test Tool runner ------------------------------
 
+    def _any_detail_displayed(self) -> bool:
+        """True while any of the four detail views has content on screen.
+
+        Returns:
+            True when a tool, permission row, audit entry, or finding is
+            currently displayed; False when every detail view is cleared.
+        """
+        return (
+            self._current_tool is not None
+            or self._current_permission_tool is not None
+            or self._current_audit_entry is not None
+            or self._current_finding is not None
+        )
+
+    def _sync_state_badge_display(self) -> None:
+        """task-2270: single owner of `#mcp-inspector-state`'s DISPLAY.
+
+        The badge (empty-state copy, or the selected server's readiness --
+        whatever `update_readiness()` last wrote) shows exactly when NO
+        detail view is displayed. RAG-50 fixed this for Tools mode only,
+        with `show_tool()` writing `state.display` directly; the other
+        three detail views (`show_permission()` via
+        `_render_permission_container()`, `show_audit_entry()`,
+        `show_finding()`) never touched it and left the "Pick a server,
+        tool, or entry…" badge stacked above fully populated detail.
+        Every view's show/clear path now funnels through this method, so
+        clearing ONE view cannot resurrect the badge while another still
+        shows detail, and `update_readiness()` stays content-only (it can
+        never force the badge back over displayed detail in any mode).
+        """
+        self.query_one("#mcp-inspector-state", Static).display = (
+            not self._any_detail_displayed()
+        )
+
     async def show_tool(
         self, tool: HubTool | None, *, effective: EffectiveToolState | None = None
     ) -> None:
@@ -1580,28 +1614,23 @@ class MCPInspector(Vertical):
             self._test_run_armed = False
             container = self.query_one("#mcp-inspector-tool", Vertical)
             await container.remove_children()
-            # RAG-50: `#mcp-inspector-state` is composed once with
-            # `_EMPTY_STATE_COPY` and its CONTENT is written only by
-            # `update_readiness()`, whose only caller is fed by the
-            # selected SERVER -- this populate path has no such dependency
-            # (Tools mode can show a tool with no server selected at all),
-            # so left untouched the empty-state badge sat above fully
-            # populated tool detail. This is the seam that owns its
-            # DISPLAY: hidden the instant any tool detail is shown, restored
-            # on the clear path (`show_tool(None)` -- the same method is
-            # the clear/blank entry point; see `MCPWorkbench.
-            # _clear_tool_view()`). Content is untouched here -- still
-            # `update_readiness()`'s job -- restoring visibility just
-            # reveals whatever it last wrote (or the compose()-time
-            # `_EMPTY_STATE_COPY` if it never ran).
-            state = self.query_one("#mcp-inspector-state", Static)
+            # RAG-50 / task-2270: the empty-state badge's DISPLAY is owned
+            # by `_sync_state_badge_display()` (badge shows exactly when NO
+            # detail view is displayed -- RAG-50 fixed Tools mode alone and
+            # left the other three views stacking the badge over populated
+            # detail). The sync here runs BEFORE any await so a paint
+            # between this method's awaits can never show badge + detail
+            # together; the branch-final `_render_permission_container()`
+            # call syncs again after `_current_permission_tool` settles.
+            # Content stays `update_readiness()`'s job -- restoring
+            # visibility just reveals whatever it last wrote (or the
+            # compose()-time `_EMPTY_STATE_COPY` if it never ran).
+            self._sync_state_badge_display()
             if tool is None:
                 container.display = False
-                state.display = True
                 await self._render_permission_container(None, None)
                 return
             container.display = True
-            state.display = False
             widgets: list[Any] = [
                 Static(
                     f"{tool.name} — {tool.server_label}",
@@ -1689,9 +1718,16 @@ class MCPInspector(Vertical):
         if tool is None or effective is None:
             container.display = False
             self._current_permission_tool = None
+            # task-2270: restore the badge -- unless another detail view
+            # (tool/audit/finding) still shows content.
+            self._sync_state_badge_display()
             return
         container.display = True
         self._current_permission_tool = tool
+        # task-2270: a Permissions-matrix row selection hides the badge
+        # exactly like Tools mode does; synced before the mounts below so
+        # no paint frame shows badge + populated detail together.
+        self._sync_state_badge_display()
         widgets: list[Any] = [
             # UX batch item 8: identity line first, mirroring
             # `show_tool()`'s own `#mcp-inspector-tool-name` -- this block
@@ -1834,9 +1870,13 @@ class MCPInspector(Vertical):
             if entry is None:
                 container.display = False
                 self._current_audit_entry = None
+                # task-2270: restore the badge unless another detail view
+                # still shows content (e.g. a finding alongside this entry).
+                self._sync_state_badge_display()
                 return
             container.display = True
             self._current_audit_entry = entry
+            self._sync_state_badge_display()  # task-2270: hide over detail
             server_key = str(entry.get("server_key") or "")
             tool_name = str(entry.get("tool_name") or "")
             detail_payload = audit_entry_detail_payload(entry)
@@ -1916,10 +1956,14 @@ class MCPInspector(Vertical):
                 container.display = False
                 self._current_finding = None
                 self._current_finding_server_key = None
+                # task-2270: restore the badge unless another detail view
+                # still shows content (e.g. the audit entry beside this).
+                self._sync_state_badge_display()
                 return
             container.display = True
             self._current_finding = finding
             self._current_finding_server_key = server_key
+            self._sync_state_badge_display()  # task-2270: hide over detail
             severity = _finding_text(finding, "severity")
             finding_type = _finding_text(finding, "finding_type", "type")
             message = _finding_text(finding, "message")

--- a/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
@@ -2035,12 +2035,27 @@ class MCPInspector(Vertical):
         await container.mount(panel)
         # F-056: opening the panel moves keyboard focus into it -- the
         # schema form's first control when there is one (a raw-JSON
-        # TextArea, an enum Select, or a scalar Input), the Close button
-        # otherwise. `call_after_refresh` so this lands after Textual's own
-        # mount-time focus settling instead of racing it.
-        first_control = panel.query("Input, Select, TextArea").first()
-        if first_control is None:
-            first_control = panel.query_one("#mcp-inspector-test-close", Button)
+        # TextArea, an enum Select, a Checkbox, or a scalar Input), the
+        # Close button otherwise. `call_after_refresh` so this lands after
+        # Textual's own mount-time focus settling instead of racing it.
+        #
+        # task-2740: two stacked defects made this a live CRASHER, not a
+        # focus nit -- the query omitted `Checkbox`, and `DOMQuery.first()`
+        # RAISES `NoMatches` on an empty result (it never returns None, so
+        # the old `is None` fallback to Close was dead code and the
+        # "otherwise" above never happened). Any tool whose schema renders
+        # no Input/Select/TextArea -- an all-boolean schema, or the empty
+        # `properties` the real built-in `list_characters` ships -- blew up
+        # this mount worker (default `exit_on_error`) and took the app
+        # down. The truthiness guard below is the check `DOMQuery`
+        # actually supports; the Close fallback is now reachable, and the
+        # zero-control regression test pins it.
+        controls = panel.query("Input, Select, TextArea, Checkbox")
+        first_control = (
+            controls.first()
+            if controls
+            else panel.query_one("#mcp-inspector-test-close", Button)
+        )
         self.call_after_refresh(first_control.focus)
 
     async def action_close_test_panel(self) -> None:

--- a/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
@@ -1750,29 +1750,21 @@ class MCPInspector(Vertical):
             # one of `allow|ask|deny`), so `mcp-status-{kind}` always
             # resolves to one of the three classes the bundle defines.
             #
-            # Fix Round J: `origin == "gate_error"` is the synthesized
-            # fail-closed verdict (the permission RESOLVER raised, not a
-            # configured Off) -- `ui_label` maps its `state="deny"` to
-            # "Off", which stacked "Permission: Off" (a confident
+            # Fix Round J (PR #1385) found the stacked contradiction here:
+            # a gate_error verdict rendered "Permission: Off" (a confident
             # configuration claim) one line above "Permission state could
-            # not be resolved." (an admission we don't know it) -- the
-            # exact contradiction shape rounds B/D/F removed from the Test
-            # Tool body and the Advanced hatch, reassembled here by two
-            # truthful-in-isolation widgets. The label now says what is
-            # actually known ("Unknown"); the `error` status class is KEPT
-            # on purpose -- the color encodes the EFFECT (fail-closed, the
-            # tool will not run; don't trust it), which is true, while the
-            # label no longer misstates the CAUSE. The other `ui_label`
-            # renderers (Permissions matrix rows, Tools-mode State column
-            # via `format_tool_state_label()`) still print "Off ·" for
-            # gate_error rows -- that is task-2270's scope (gate_error copy
-            # across the views), not silently expanded here.
+            # not be resolved." (an admission we don't know it), and this
+            # site grew its own origin-aware label branch. task-2870 moved
+            # that ownership INTO `EffectiveToolState.ui_label` (gate_error
+            # -> "Unknown") so the matrix/State-column renderers tell the
+            # same truth -- the branch here collapsed back to the plain
+            # read, and round J's test now pins the behavior through
+            # `ui_label` like every other surface. The `error` status
+            # class is KEPT on purpose: the color encodes the EFFECT
+            # (fail-closed, the tool will not run), which is true; only
+            # the causal label lied.
             Static(
-                (
-                    "Permission: Unknown"
-                    if effective.origin == "gate_error"
-                    else f"Permission: {effective.ui_label}"
-                ),
+                f"Permission: {effective.ui_label}",
                 id="mcp-inspector-permission-state",
                 classes=f"ds-field-row mcp-status-{tool_state_kind(effective)}",
                 markup=False,

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -257,7 +257,8 @@ class PermRow:
 
 # `PermRow.state_label` never carries the raw resolved state (`allow`/
 # `ask`/`deny`) itself -- only the already-formatted UI word
-# (`EffectiveToolState.ui_label`, always "Allow"/"Ask"/"Off") plus an
+# (`EffectiveToolState.ui_label`, "Allow"/"Ask"/"Off" -- or "Unknown" for
+# a gate_error-origin fail-closed verdict, task-2870) plus an
 # optional trailing marker glyph. The matrix's rows (global/server/tool, all
 # built by `mcp_workbench.py`'s `_build_permission_rows()`) don't carry an
 # `EffectiveToolState` object the way `mcp_tools_mode.py`'s `_apply_filter()`


### PR DESCRIPTION
## MCP inspector honesty residue: the crash, the stale badge, the dishonest cell

The three items PR #1385 deliberately excluded, each now fixed with RED-first tests and per-fix mutation proofs.

**task-2740 (HIGH) — Test Tool mount crash.** `_mount_test_tool_panel()`'s focus query omitted `Checkbox`, and `DOMQuery.first()` raises on an empty result — the `is None` fallback was dead code and the raise escaped a default-`exit_on_error` worker. Not exotic: the real built-in `list_characters` ships empty `properties`, so opening Test Tool on it took the app down. Fixed (Checkbox in the query; truthiness-guarded fallback, now reachable); focus targets pinned both ways (first Checkbox for boolean forms, Close for zero-control forms).

**task-2270 — the empty-state badge covered Tools mode only.** Selecting a Permissions-matrix row, Audit entry, or Finding with no server selected left "Pick a server, tool, or entry…" stacked above populated detail. One owner now (`_sync_state_badge_display()`): badge shows exactly when no detail view displays; clearing one view can't resurrect it while another still shows detail; `update_readiness()` stays content-only in every mode. The task's decision-note rider was already satisfied by #1385's arc (special case shipped → path rerouted honest → dead branch removed with a traced proof) — recorded, no new code.

**task-2870 (new filing; corrects a #1385 mis-attribution) — "Off ·" for a resolver failure.** `ui_label` mapped the synthesized fail-closed deny to "Off", so matrix State cells and the Tools-mode State column claimed a configuration that could not be read. The honesty rule now lives in `EffectiveToolState.ui_label` itself (gate_error → "Unknown"; genuine denies keep "Off"); round J's inspector branch collapsed into it; severity/color deliberately unchanged. Consumer sweep documented in the commit (the string-keyed branches are proven unreachable for gate_error).

**Verification:** 539 passed across resolution/permissions/inspector/workbench/tools-mode; full-tree collection 31683 = 31674 + exactly the 9 new tests; every fix mutation-verified (7 mutations total, each redding only its own test). Guide stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Test Tool crash and cleans up two UI honesty issues in the MCP inspector. Opening Test Tool no longer crashes on boolean-only/no-arg schemas, the empty-state badge behaves consistently, resolver failures show “Unknown” instead of a false “Off”, and the docs now document the synthetic `gate_error` origin.

- **Bug Fixes**
  - Test Tool: added `Checkbox` to the focus query and a safe Close-button fallback so panels mount for boolean-only and zero-control schemas without crashing.
  - Empty-state badge: centralized display with `_sync_state_badge_display()` so the badge hides whenever any detail view is shown (Tools/Permissions/Audit/Findings) and `update_readiness()` never resurrects it.
  - Permission labels: `EffectiveToolState.ui_label` returns “Unknown” for `origin="gate_error"` (fail-closed resolver errors); genuine denies still read “Off”. Severity/color unchanged across the matrix, Tools State column, and inspector.

<sup>Written for commit ee3ee09d3f285b75fd60fa42ca40691067ee5d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

