### PR TITLE
perf(lab): defer heavy Models views past first paint (task 2900)

### DIFF
--- a/Tests/UI/test_llm_deferred_views.py
+++ b/Tests/UI/test_llm_deferred_views.py
@@ -1,0 +1,124 @@
+"""task-2900: Lab ▸ Models defers its five heavy hidden views past first paint.
+
+Same pattern as task-2725 (Roleplay): the ollama view (58 widgets) and the
+four library views (download-models 76, curated, installed, remote) arrive
+`display: none` behind the CSS `-active` mechanism anyway; mounting them
+after first paint takes their CSS-application cost off the click→paint
+critical path. `watch_active_view` already tolerates absent views.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tldw_chatbook.config import get_cli_setting as _real_get_cli_setting
+from tldw_chatbook.UI.LLM_Management_Window import LLMManagementWindow
+from tldw_chatbook.UI.Screens.llm_screen import LLMScreen
+from Tests.UI.app_factory import _build_test_app
+
+pytestmark = pytest.mark.asyncio
+
+_DEFERRED_VIEW_IDS = (
+    "llm-view-ollama",
+    "llm-view-curated",
+    "llm-view-installed",
+    "llm-view-remote",
+    "llm-view-download-models",
+)
+
+_ALL_VIEW_IDS = _DEFERRED_VIEW_IDS + (
+    "llm-view-llama-cpp",
+    "llm-view-llamafile",
+    "llm-view-vllm",
+    "llm-view-onnx",
+    "llm-view-transformers",
+    "llm-view-mlx-lm",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_splash(monkeypatch):
+    def fake_get_cli_setting(section, key=None, default=None):
+        if section == "splash_screen" and key == "enabled":
+            return False
+        return _real_get_cli_setting(section, key, default)
+
+    monkeypatch.setattr("tldw_chatbook.app.get_cli_setting", fake_get_cli_setting)
+
+
+async def test_first_paint_excludes_the_deferred_views(monkeypatch):
+    """Compose alone must not mount the deferred views (the perf mechanism)."""
+    monkeypatch.setattr(
+        LLMManagementWindow,
+        "_mount_deferred_views",
+        AsyncMock(),
+        raising=False,
+    )
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = LLMScreen(app)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        for view_id in _DEFERRED_VIEW_IDS:
+            assert not list(screen.query(f"#{view_id}")), (
+                f"#{view_id} mounted during compose — back on the "
+                "click→paint critical path"
+            )
+
+
+async def test_load_mounts_every_view_with_llamacpp_active():
+    """After the real deferred mount, all eleven views exist, exactly one is
+    active (the initial llama-cpp), and the deferred ones stay CSS-hidden."""
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = LLMScreen(app)
+        await app.push_screen(screen)
+        for _ in range(6):
+            await pilot.pause()
+
+        for view_id in _ALL_VIEW_IDS:
+            found = list(screen.query(f"#{view_id}"))
+            assert len(found) == 1, f"#{view_id} missing after load"
+
+        active = [
+            view_id
+            for view_id in _ALL_VIEW_IDS
+            if screen.query_one(f"#{view_id}").has_class("-active")
+        ]
+        assert active == ["llm-view-llama-cpp"]
+
+
+async def test_ollama_view_activates_and_renders_after_deferral():
+    """The extracted ollama view must render its real content when shown —
+    the one view whose body moved out of `compose` (single-substitution
+    extraction: the prereq line)."""
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = LLMScreen(app)
+        await app.push_screen(screen)
+        for _ in range(6):
+            await pilot.pause()
+
+        window = screen.query_one(LLMManagementWindow)
+        window.active_view = "ollama"
+        await pilot.pause()
+
+        view = screen.query_one("#llm-view-ollama")
+        assert view.has_class("-active")
+        assert list(view.query("#ollama-exec-path")), (
+            "extracted ollama view lost its executable-path input"
+        )
+        prereq = [
+            str(w.renderable)
+            for w in view.query(".prereq-hint").results()
+        ]
+        assert any("Requires: Ollama" in text for text in prereq), (
+            f"prereq line missing from extracted view: {prereq}"
+        )

--- a/Tests/UI/test_ux_batch4.py
+++ b/Tests/UI/test_ux_batch4.py
@@ -121,11 +121,16 @@ async def test_dirty_form_escape_asks_before_discarding() -> None:
 
 
 # UX-070 -----------------------------------------------------------------
-def test_lab_default_view_is_ollama() -> None:
+def test_lab_default_view_starts_unset_until_children_exist() -> None:
+    """`active_view` deliberately starts at "" with init=False (see the
+    reactive's own comment: a real default fired the watcher before the
+    deferred body mount — ten QueryErrors per arrival). The real initial
+    view (llama-cpp since 9dd2374b5) is assigned by `_initialize_view`
+    after the children exist — pinned in test_llm_deferred_views.py."""
     from tldw_chatbook.UI.LLM_Management_Window import LLMManagementWindow
 
     window = LLMManagementWindow(None)
-    assert window.active_view == "ollama"
+    assert window.active_view == ""
 
 
 def test_ollama_prereq_reports_detection() -> None:

--- a/Tests/UI/test_ux_batch6.py
+++ b/Tests/UI/test_ux_batch6.py
@@ -39,42 +39,6 @@ async def test_queue_filter_narrows_rows_and_detail_follows_visible() -> None:
 
 # Lab position indicator + autofill (UX-077/078) --------------------------
 @pytest.mark.asyncio
-async def test_lab_sidebar_hint_shows_position_and_cycles() -> None:
-    import tldw_chatbook.Widgets.HuggingFace as hf
-    from tldw_chatbook.UI.LLM_Management_Window import LLMManagementWindow
-
-    class _StubWidget(_Container):
-        def __init__(self, *args, **kwargs):
-            super().__init__(**{k: v for k, v in kwargs.items() if k == "id"})
-
-    class Harness(App[None]):
-        def compose(self) -> ComposeResult:
-            yield LLMManagementWindow(None)
-
-    monkey = pytest.MonkeyPatch()
-    monkey.setattr(hf, "LocalModelsWidget", _StubWidget)
-    monkey.setattr(hf, "HuggingFaceModelBrowser", _StubWidget)
-    try:
-        app = Harness()
-        async with app.run_test(size=(140, 42)) as pilot:
-            await pilot.pause()
-            window = app.query_one(LLMManagementWindow)
-            hint = app.query_one("#llm-sidebar-hint", Static)
-            total = len(window.view_mapping)
-            assert f"of {total}" in str(hint.render())
-            assert "1 of" in str(hint.render())  # Ollama is the default view
-
-            window._cycle_view(1)
-            await pilot.pause()
-            assert "2 of" in str(hint.render())
-            window._cycle_view(-1)
-            await pilot.pause()
-            assert "1 of" in str(hint.render())
-    finally:
-        monkey.undo()
-
-
-@pytest.mark.asyncio
 async def test_ollama_path_autofills_when_found() -> None:
     from unittest.mock import patch
 

--- a/backlog/tasks/task-2900 - Lab-Models-defer-heavy-provider-views-past-first-paint.md
+++ b/backlog/tasks/task-2900 - Lab-Models-defer-heavy-provider-views-past-first-paint.md
@@ -1,0 +1,51 @@
+---
+id: TASK-2900
+title: Lab ▸ Models — defer heavy provider views past first paint
+status: Done
+assignee: []
+created_date: '2026-08-07 02:00'
+labels:
+  - lab
+  - performance
+  - defer-past-first-paint
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Screen survey (follow-up to task-2725): Lab ▸ Models mounts 388 widgets per visit, with the heavy weight in views that arrive hidden — `#llm-view-download-models` (76), `#llm-view-ollama` (58), plus the curated/installed/remote library views. All eleven views compose eagerly; visibility is CSS `-active` classes and switching funnels through `watch_active_view`, which already tolerates absent views (`QueryError` → warning). Per-view work is already deferred until shown (task-887), so the screen's own architecture supports the 2725 pattern.
+
+Apply defer-past-first-paint: compose only the shell + initial view eagerly; mount the five heavy deferred views (ollama + the four library views, which are thin wrappers over existing widget classes) right after first paint, then run the one-shot initializers that touch them (`_autofill_ollama_path` — UX-078 — would otherwise silently never fire).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: with the deferred-mount seam stubbed, pushing the LLM screen mounts none of the five deferred views and the widget total drops; guard test (green before+after): after settle, all eleven views exist and llama-cpp is active.
+2. GREEN: extract the ollama block into a small `VerticalScroll` subclass (single `self` reference: the prereq text, passed in); move the four library-view constructions into `_mount_deferred_views()`; `on_mount` chains mount → `_initialize_view` → re-run `_autofill_ollama_path`/`_update_ollama_api_state`.
+3. Full LLM/Lab test files + live latency + live view-switch exercise.
+<!-- SECTION:PLAN:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [x] Lab ▸ Models first paint excludes the five deferred views; all eleven are reachable after load, llama-cpp active by default.
+- [x] Tab-switch latency improves measurably live (same tmux method); no view renders broken when activated.
+- [x] One-shot initializers that touch deferred views still take effect (Ollama path autofill, API-state gating).
+- [x] Existing LLM/Lab tests green.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped the 2725 pattern with two screen-specific discoveries, both caught by the existing test surface during RED/GREEN:
+
+1. **Failure coupling**: sequencing the previously-independent `call_after_refresh` callbacks (initialize / autofill / API-gate) into one coroutine meant a failure in one killed the rest — `_finish_deferred_mount` now guards each step individually (this incidentally FIXED the dev-baseline `test_ollama_path_autofills_when_found` failure).
+2. **Recompose hydration race**: `LLMScreen`'s install-progress hydration fires from `on_lab_body_ready` via one `call_after_refresh`, which was only sufficient because compose built every view synchronously; with deferral it raced the mount and lost (three recompose-survival tests went red). Fix: the window posts `DeferredViewsMounted` when the views are queryable and the screen re-hydrates on it — hydration is internally guarded and idempotent, so both invocations are safe.
+
+Mechanics: the four library views (curated/installed/remote/download-models) were already thin wrappers over widget classes — moved verbatim into `_mount_deferred_views`; the ollama view (58 widgets, ONE self-reference) extracted into `OllamaServiceView` with the prereq text passed in. No order anchoring needed (CSS `-active` shows exactly one view). Also repaired the two remaining stale Lab tests in this surface (batch4's construction-default pin predating the ""-with-init=False race fix AND the llama-cpp default from 9dd2374b5; batch6's retired-sidebar hint test — cycling now lives in the Lab rail, covered by the adoption tests).
+
+Results: Lab switch 0.68s → **0.47–0.49s** live; ollama/curated/download views render with full content when activated, zero errors. Lab/LLM 12-file surface: **149 passed, 0 failed** (pristine dev baseline: 4 failed). Files: tldw_chatbook/UI/LLM_Management_Window.py, tldw_chatbook/UI/Screens/llm_screen.py, Tests/UI/test_llm_deferred_views.py, Tests/UI/test_ux_batch4.py, Tests/UI/test_ux_batch6.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2901 - MCP-defer-mode-canvases-past-first-paint.md
+++ b/backlog/tasks/task-2901 - MCP-defer-mode-canvases-past-first-paint.md
@@ -1,0 +1,27 @@
+---
+id: TASK-2901
+title: MCP — defer the Audit and Tools mode canvases past first paint
+status: To Do
+assignee: []
+created_date: '2026-08-07 02:00'
+labels:
+  - mcp
+  - performance
+  - defer-past-first-paint
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Screen survey (task-2725 follow-up): MCP mounts 135 widgets; `MCPAuditMode#mcp-mode-canvas-audit` (28) and `MCPToolsMode#mcp-mode-canvas-tools` (14) arrive hidden — ~31% of the screen deferrable. Both are existing widget classes, so the 2725/2900 pattern applies without extraction. Modest but cheap win; audit the mode-switch path's tolerance for absent canvases first (same discipline as 2725).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] MCP first paint excludes the hidden mode canvases; every mode is reachable after load.
+- [ ] Mode switching, permissions, and audit flows keep their existing tests green.
+- [ ] The compose→load window is covered by verified tolerance (no unguarded queries of the deferred canvases).
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/backlog/tasks/task-2902 - Console-defer-hidden-inspector-rail-and-task-surface-past-first-paint.md
+++ b/backlog/tasks/task-2902 - Console-defer-hidden-inspector-rail-and-task-surface-past-first-paint.md
@@ -1,0 +1,30 @@
+---
+id: TASK-2902
+title: Console — defer the hidden inspector rail and task surface past first paint
+status: To Do
+assignee: []
+created_date: '2026-08-07 02:00'
+labels:
+  - console
+  - performance
+  - defer-past-first-paint
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Screen survey (task-2725 follow-up): the Console screen mounts 357 widgets and is the app's default tab, so its cost is also perceived cold-start cost. 124 widgets arrive hidden in three roots: `ConsoleInspectorRail#console-right-rail` (76), `ChatTaskCards#console-task-surface` (32), `CompactModelBar#console-compact-model-bar` (16) — ~35% deferrable.
+
+This is deliberately LAST in the defer-past-first-paint series: `chat_screen.py` is the app's most complex screen and its sync pipeline (`_sync_native_console_chat_ui` and delegates) touches the rail, so the compose→load window audit is substantially harder than 2725/2900/2901. Do not start until both prior tasks have shipped and soaked. The audit must cover: every query of the three roots reachable from the sync path, `restore_state`, the control-bar build, and the session controllers introduced by console-decomposition wave 2.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] Console first paint excludes the three hidden roots; rail/task-surface/model-bar all function once revealed.
+- [ ] Console switch latency improves measurably live; cold-start-to-interactive improves.
+- [ ] The full Console test surface stays green (including the worker-lifecycle and generation-actions suites).
+- [ ] The compose→load window audit is recorded in the task notes (which query sites can run early, and why each is safe).
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -12,6 +12,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, VerticalScroll, Horizontal, Vertical
 from textual.css.query import QueryError
+from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Static, Button, Input, RichLog, Label, TextArea, Collapsible
 from loguru import logger
@@ -50,11 +51,218 @@ if TYPE_CHECKING:
 # Functions:
 
 
+
+
+class OllamaServiceView(VerticalScroll):
+    """The Ollama view body, extracted verbatim from `compose` (task-2900).
+
+    Deferred past first paint by `_mount_deferred_views`; the one dynamic
+    piece of the original inline block — the prereq line — is computed by
+    the window at build time and passed in.
+    """
+
+    def __init__(self, prereq_text: str, **kwargs) -> None:
+        kwargs.setdefault("id", "llm-view-ollama")
+        kwargs.setdefault("classes", "llm-view")
+        super().__init__(**kwargs)
+        self._prereq_text = prereq_text
+
+    def compose(self) -> ComposeResult:
+        yield Label("Ollama Service Management", classes="section-title")
+        yield Static(self._prereq_text, classes="prereq-hint")
+
+        with Container(classes="input_container"):
+            yield Label("Ollama Executable Path:", classes="inline-label")
+            yield Input(
+                id="ollama-exec-path",
+                placeholder="Path to ollama executable (e.g., /usr/local/bin/ollama)",
+            )
+            yield Button(
+                "Browse",
+                id="ollama-browse-exec-button",
+                classes="browse_button",
+                tooltip="Choose the Ollama executable.",
+            )
+
+        with Horizontal(classes="ollama-button-bar"):
+            yield Button(
+                "Start Ollama Service", id="ollama-start-service-button"
+            )
+            yield Button(
+                "Stop Ollama Service",
+                id="ollama-stop-service-button",
+                disabled=True,
+            )
+
+        yield Label(
+            "Ollama API Management (requires running service)",
+            classes="section_label",
+        )
+        yield Label("Ollama Server URL:", classes="label")
+        yield Input(
+            id="ollama-server-url",
+            value="http://localhost:11434",
+            classes="input_field_long",
+        )
+
+        with Horizontal(classes="ollama-button-bar"):
+            yield Button("List Local Models", id="ollama-list-models-button")
+            yield Button("List Running Models", id="ollama-ps-button")
+
+        with Horizontal(classes="ollama-actions-grid"):
+            # Left Column
+            with Vertical(classes="ollama-actions-column"):
+                yield Static("Model Management", classes="column-title")
+
+                yield Label("Show Info:", classes="label")
+                with Container(classes="input_action_container"):
+                    yield Input(
+                        id="ollama-show-model-name",
+                        placeholder="Model name",
+                        classes="input_field_short",
+                    )
+                    yield Button(
+                        "Show",
+                        id="ollama-show-model-button",
+                        classes="action_button_short",
+                    )
+
+                yield Label("Delete:", classes="label")
+                with Container(classes="input_action_container"):
+                    yield Input(
+                        id="ollama-delete-model-name",
+                        placeholder="Model to delete",
+                        classes="input_field_short",
+                    )
+                    yield Button(
+                        "Delete",
+                        id="ollama-delete-model-button",
+                        classes="action_button_short delete_button",
+                    )
+
+                yield Label("Copy Model:", classes="label")
+                with Horizontal(classes="input_action_container"):
+                    yield Input(
+                        id="ollama-copy-source-model",
+                        placeholder="Source",
+                        classes="input_field_short",
+                    )
+                    yield Input(
+                        id="ollama-copy-destination-model",
+                        placeholder="Destination",
+                        classes="input_field_short",
+                    )
+                yield Button(
+                    "Copy Model",
+                    id="ollama-copy-model-button",
+                    classes="full_width_button",
+                )
+
+            # Right Column
+            with Vertical(classes="ollama-actions-column"):
+                yield Static("Registry & Custom Models", classes="column-title")
+
+                yield Label("Pull Model from Registry:", classes="label")
+                with Container(classes="input_action_container"):
+                    yield Input(
+                        id="ollama-pull-model-name",
+                        placeholder="e.g. llama3",
+                        classes="input_field_short",
+                    )
+                    yield Button(
+                        "Pull",
+                        id="ollama-pull-model-button",
+                        classes="action_button_short",
+                    )
+
+                yield Label("Push Model to Registry:", classes="label")
+                with Container(classes="input_action_container"):
+                    yield Input(
+                        id="ollama-push-model-name",
+                        placeholder="e.g. my-registry/my-model",
+                        classes="input_field_short",
+                    )
+                    yield Button(
+                        "Push",
+                        id="ollama-push-model-button",
+                        classes="action_button_short",
+                    )
+
+                yield Label("Create Model from Modelfile:", classes="label")
+                yield Input(
+                    id="ollama-create-model-name",
+                    placeholder="New model name",
+                    classes="input_field_long",
+                )
+                with Horizontal(classes="input_action_container"):
+                    yield Input(
+                        id="ollama-create-modelfile-path",
+                        placeholder="Path to Modelfile...",
+                        disabled=True,
+                        classes="input_field_short",
+                    )
+                    yield Button(
+                        "Browse",
+                        id="ollama-browse-modelfile-button",
+                        classes="browse_button_short",
+                        tooltip="Choose the Modelfile used to create an Ollama model.",
+                    )
+                yield Button(
+                    "Create Model",
+                    id="ollama-create-model-button",
+                    classes="full_width_button",
+                )
+
+        yield Label("Generate Embeddings:", classes="section_label")
+        with Horizontal(classes="embeddings_container"):
+            with Vertical(classes="embeddings_inputs"):
+                yield Input(
+                    id="ollama-embeddings-model-name",
+                    placeholder="Model name for embeddings",
+                    classes="input_field_long",
+                )
+                yield Input(
+                    id="ollama-embeddings-prompt",
+                    placeholder="Text to generate embeddings for",
+                    classes="input_field_long",
+                )
+            yield Button(
+                "Generate Embeddings",
+                id="ollama-embeddings-button",
+                classes="action_button_tall",
+            )
+
+        yield Label("Result / Status:", classes="section_label")
+        yield RichLog(
+            id="ollama-combined-output",
+            wrap=True,
+            highlight=False,
+            classes="output_textarea_medium",
+        )
+
+        yield Label("Streaming Log:", classes="section_label")
+        yield RichLog(
+            id="ollama-log-output",
+            wrap=True,
+            highlight=True,
+            classes="log_output_large",
+        )
+
 class LLMManagementWindow(Container):
     """
     Container for the LLM Management Tab's UI.
     Follows Textual best practices with proper navigation and view management.
     """
+
+    class DeferredViewsMounted(Message):
+        """The five deferred views now exist (task-2900).
+
+        Posted at the end of `_finish_deferred_mount` so ancestors that
+        hydrate state into those views on (re)mount — `LLMScreen`'s
+        install-progress hydration fires from `on_lab_body_ready` via one
+        `call_after_refresh`, which raced (and lost to) the deferred mount —
+        get a second, correctly-ordered chance.
+        """
 
     DEFAULT_CSS = """
     LLMManagementWindow {
@@ -308,15 +516,99 @@ class LLMManagementWindow(Container):
     def on_mount(self) -> None:
         """Called when the widget is mounted."""
         logger.debug("LLMManagementWindow.on_mount called")
-        # The child views don't exist until after this refresh (the window
-        # itself may be mounted lazily by its parent screen), so defer the
-        # initial activation until they do.
-        self.call_after_refresh(self._initialize_view)
-        # Autofill the Ollama executable when it's discoverable (UX-078).
-        self.call_after_refresh(self._autofill_ollama_path)
-        # Keep the Ollama API controls gated on a live service (UX-091).
-        self.call_after_refresh(self._update_ollama_api_state)
+        # task-2900: the five heavy hidden views mount here, after the first
+        # refresh, then the initial activation and the one-shot Ollama
+        # initializers run — in that order, because both touch views that no
+        # longer exist at compose time (the autofill would otherwise
+        # silently never fire, UX-078).
+        self.call_after_refresh(self._finish_deferred_mount)
         self.set_interval(3.0, self._update_ollama_api_state)
+
+    async def _finish_deferred_mount(self) -> None:
+        """Mount deferred views, then run everything that assumes them.
+
+        Each step is guarded individually: before task-2900 these were
+        independent `call_after_refresh` callbacks, and one failing never
+        stopped the others (a harness without a real app instance breaks
+        `_initialize_view`'s process-control sync but must not kill the
+        Ollama autofill, UX-078). Sequencing adds the ordering guarantee;
+        it must not add failure coupling.
+        """
+        try:
+            await self._mount_deferred_views()
+        except Exception:
+            logger.exception("Deferred LLM view mount failed")
+        for step in (
+            self._initialize_view,
+            # Autofill the Ollama executable when it's discoverable (UX-078).
+            self._autofill_ollama_path,
+            # Keep the Ollama API controls gated on a live service (UX-091).
+            self._update_ollama_api_state,
+        ):
+            try:
+                step()
+            except Exception:
+                logger.exception(f"Post-mount step failed: {step.__name__}")
+        self.post_message(self.DeferredViewsMounted())
+
+    async def _mount_deferred_views(self) -> None:
+        """Mount the five heavy views that arrive CSS-hidden (task-2900).
+
+        Screen survey: `#llm-view-download-models` (76 widgets),
+        `#llm-view-ollama` (58) and the curated/installed/remote library
+        views dominated this screen's 388-widget mount cost while arriving
+        `display: none` behind the `-active` CSS mechanism. Mounting them
+        here — off the click→paint critical path — leaves every activation
+        path working: `watch_active_view` tolerates absent views, and view
+        order inside `#llm-main-content` is irrelevant (exactly one view is
+        ever shown). Idempotent for re-entered mounts.
+        """
+        try:
+            content = self.query_one("#llm-main-content", Container)
+        except QueryError:
+            return
+        if self.query("#llm-view-ollama"):
+            return
+
+        from .Screens.model_curated_view import CuratedView
+        from .Screens.model_installed_view import InstalledView
+        from .Screens.model_remote_view import RemoteView
+        from ..Widgets.HuggingFace import HuggingFaceModelBrowser
+
+        curated = Container(id="llm-view-curated", classes="llm-view")
+        installed = Container(id="llm-view-installed", classes="llm-view")
+        remote = Container(id="llm-view-remote", classes="llm-view")
+        download = Container(id="llm-view-download-models", classes="llm-view")
+        await content.mount(
+            OllamaServiceView(self._ollama_prereq_text()),
+            curated,
+            installed,
+            remote,
+            download,
+        )
+
+        legacy_dir = None
+        app_config = getattr(self.app_instance, "app_config", {})
+        if isinstance(app_config, dict):
+            configured = app_config.get("llm_management", {}).get(
+                "model_download_dir"
+            )
+            if configured:
+                from pathlib import Path
+
+                legacy_dir = Path(str(configured)).expanduser()
+
+        await curated.mount(CuratedView(id="curated-models-view"))
+        await installed.mount(
+            InstalledView(legacy_dir=legacy_dir, id="installed-models-view")
+        )
+        # Remote is explicitly idle until Search is submitted.
+        await remote.mount(RemoteView(id="remote-models-view"))
+        await download.mount(
+            HuggingFaceModelBrowser(
+                self.app_instance, id="huggingface-model-browser"
+            )
+        )
 
     def _ollama_api_available(self) -> bool:
         """True when an Ollama service answers (app-launched or external)."""
@@ -931,225 +1223,6 @@ class LLMManagementWindow(Container):
                     id="mlx-log-output", classes="log_output", wrap=True, highlight=True
                 )
 
-            # Ollama View
-            with VerticalScroll(id="llm-view-ollama", classes="llm-view"):
-                yield Label("Ollama Service Management", classes="section-title")
-                yield Static(self._ollama_prereq_text(), classes="prereq-hint")
-
-                with Container(classes="input_container"):
-                    yield Label("Ollama Executable Path:", classes="inline-label")
-                    yield Input(
-                        id="ollama-exec-path",
-                        placeholder="Path to ollama executable (e.g., /usr/local/bin/ollama)",
-                    )
-                    yield Button(
-                        "Browse",
-                        id="ollama-browse-exec-button",
-                        classes="browse_button",
-                        tooltip="Choose the Ollama executable.",
-                    )
-
-                with Horizontal(classes="ollama-button-bar"):
-                    yield Button(
-                        "Start Ollama Service", id="ollama-start-service-button"
-                    )
-                    yield Button(
-                        "Stop Ollama Service",
-                        id="ollama-stop-service-button",
-                        disabled=True,
-                    )
-
-                yield Label(
-                    "Ollama API Management (requires running service)",
-                    classes="section_label",
-                )
-                yield Label("Ollama Server URL:", classes="label")
-                yield Input(
-                    id="ollama-server-url",
-                    value="http://localhost:11434",
-                    classes="input_field_long",
-                )
-
-                with Horizontal(classes="ollama-button-bar"):
-                    yield Button("List Local Models", id="ollama-list-models-button")
-                    yield Button("List Running Models", id="ollama-ps-button")
-
-                with Horizontal(classes="ollama-actions-grid"):
-                    # Left Column
-                    with Vertical(classes="ollama-actions-column"):
-                        yield Static("Model Management", classes="column-title")
-
-                        yield Label("Show Info:", classes="label")
-                        with Container(classes="input_action_container"):
-                            yield Input(
-                                id="ollama-show-model-name",
-                                placeholder="Model name",
-                                classes="input_field_short",
-                            )
-                            yield Button(
-                                "Show",
-                                id="ollama-show-model-button",
-                                classes="action_button_short",
-                            )
-
-                        yield Label("Delete:", classes="label")
-                        with Container(classes="input_action_container"):
-                            yield Input(
-                                id="ollama-delete-model-name",
-                                placeholder="Model to delete",
-                                classes="input_field_short",
-                            )
-                            yield Button(
-                                "Delete",
-                                id="ollama-delete-model-button",
-                                classes="action_button_short delete_button",
-                            )
-
-                        yield Label("Copy Model:", classes="label")
-                        with Horizontal(classes="input_action_container"):
-                            yield Input(
-                                id="ollama-copy-source-model",
-                                placeholder="Source",
-                                classes="input_field_short",
-                            )
-                            yield Input(
-                                id="ollama-copy-destination-model",
-                                placeholder="Destination",
-                                classes="input_field_short",
-                            )
-                        yield Button(
-                            "Copy Model",
-                            id="ollama-copy-model-button",
-                            classes="full_width_button",
-                        )
-
-                    # Right Column
-                    with Vertical(classes="ollama-actions-column"):
-                        yield Static("Registry & Custom Models", classes="column-title")
-
-                        yield Label("Pull Model from Registry:", classes="label")
-                        with Container(classes="input_action_container"):
-                            yield Input(
-                                id="ollama-pull-model-name",
-                                placeholder="e.g. llama3",
-                                classes="input_field_short",
-                            )
-                            yield Button(
-                                "Pull",
-                                id="ollama-pull-model-button",
-                                classes="action_button_short",
-                            )
-
-                        yield Label("Push Model to Registry:", classes="label")
-                        with Container(classes="input_action_container"):
-                            yield Input(
-                                id="ollama-push-model-name",
-                                placeholder="e.g. my-registry/my-model",
-                                classes="input_field_short",
-                            )
-                            yield Button(
-                                "Push",
-                                id="ollama-push-model-button",
-                                classes="action_button_short",
-                            )
-
-                        yield Label("Create Model from Modelfile:", classes="label")
-                        yield Input(
-                            id="ollama-create-model-name",
-                            placeholder="New model name",
-                            classes="input_field_long",
-                        )
-                        with Horizontal(classes="input_action_container"):
-                            yield Input(
-                                id="ollama-create-modelfile-path",
-                                placeholder="Path to Modelfile...",
-                                disabled=True,
-                                classes="input_field_short",
-                            )
-                            yield Button(
-                                "Browse",
-                                id="ollama-browse-modelfile-button",
-                                classes="browse_button_short",
-                                tooltip="Choose the Modelfile used to create an Ollama model.",
-                            )
-                        yield Button(
-                            "Create Model",
-                            id="ollama-create-model-button",
-                            classes="full_width_button",
-                        )
-
-                yield Label("Generate Embeddings:", classes="section_label")
-                with Horizontal(classes="embeddings_container"):
-                    with Vertical(classes="embeddings_inputs"):
-                        yield Input(
-                            id="ollama-embeddings-model-name",
-                            placeholder="Model name for embeddings",
-                            classes="input_field_long",
-                        )
-                        yield Input(
-                            id="ollama-embeddings-prompt",
-                            placeholder="Text to generate embeddings for",
-                            classes="input_field_long",
-                        )
-                    yield Button(
-                        "Generate Embeddings",
-                        id="ollama-embeddings-button",
-                        classes="action_button_tall",
-                    )
-
-                yield Label("Result / Status:", classes="section_label")
-                yield RichLog(
-                    id="ollama-combined-output",
-                    wrap=True,
-                    highlight=False,
-                    classes="output_textarea_medium",
-                )
-
-                yield Label("Streaming Log:", classes="section_label")
-                yield RichLog(
-                    id="ollama-log-output",
-                    wrap=True,
-                    highlight=True,
-                    classes="log_output_large",
-                )
-
-            # Curated and Installed stay idle until their rail row is selected.
-            with Container(id="llm-view-curated", classes="llm-view"):
-                from .Screens.model_curated_view import CuratedView
-
-                yield CuratedView(id="curated-models-view")
-
-            with Container(id="llm-view-installed", classes="llm-view"):
-                from .Screens.model_installed_view import InstalledView
-
-                legacy_dir = None
-                app_config = getattr(self.app_instance, "app_config", {})
-                if isinstance(app_config, dict):
-                    configured = app_config.get("llm_management", {}).get(
-                        "model_download_dir"
-                    )
-                    if configured:
-                        from pathlib import Path
-
-                        legacy_dir = Path(str(configured)).expanduser()
-                yield InstalledView(
-                    legacy_dir=legacy_dir,
-                    id="installed-models-view",
-                )
-
-            # Remote is explicitly idle until Search is submitted.
-            with Container(id="llm-view-remote", classes="llm-view"):
-                from .Screens.model_remote_view import RemoteView
-
-                yield RemoteView(id="remote-models-view")
-
-            # Download Models View (preserved unchanged)
-            with Container(id="llm-view-download-models", classes="llm-view"):
-                from ..Widgets.HuggingFace import HuggingFaceModelBrowser
-
-                yield HuggingFaceModelBrowser(
-                    self.app_instance, id="huggingface-model-browser"
-                )
 
     @on(InstallProgressed)
     def _managed_install_progressed(self, event: InstallProgressed) -> None:

--- a/tldw_chatbook/UI/Screens/llm_screen.py
+++ b/tldw_chatbook/UI/Screens/llm_screen.py
@@ -1175,6 +1175,21 @@ class LLMScreen(LabScreen):
         if self._model_install_active:
             self.call_after_refresh(self._hydrate_model_install_progress)
 
+    @on(LLMManagementWindow.DeferredViewsMounted)
+    def _on_deferred_views_mounted(self) -> None:
+        """Re-run install-progress hydration once the deferred views exist.
+
+        task-2900: `on_lab_body_ready`'s single `call_after_refresh` used to
+        suffice because compose built every view synchronously; with the
+        heavy views mounted after first paint, that hydration races the
+        deferred mount and loses (its view lookups no-op). The window posts
+        this message when the views are actually queryable — the correctly
+        ordered second chance. `_hydrate_model_install_progress` is
+        idempotent and internally guarded, so running both is safe.
+        """
+        if self._model_install_active:
+            self._hydrate_model_install_progress()
+
     def _hydrate_model_install_progress(self) -> None:
         """Re-apply the last known install progress after a recompose.
 


### PR DESCRIPTION
## Summary

Second application of the defer-past-first-paint pattern (task-2725 → Roleplay, merged in #1392), per the screen survey: Lab ▸ Models composed 388 widgets per visit with 160+ in views arriving `display: none` behind the `-active` CSS mechanism. The ollama view (58 widgets, extracted with a single substitution — its one `self` reference) and the four library views (curated/installed/remote/download-models — already thin wrappers over widget classes) now mount as `on_mount`'s deferred step. No order anchoring needed: exactly one view is ever shown. Also files tasks 2901 (MCP) and 2902 (Console) for the remaining survey candidates.

## Two holes the existing tests caught (and their fixes)

1. **Failure coupling**: sequencing the three previously-independent `call_after_refresh` callbacks into one coroutine let a failure in `_initialize_view` kill the Ollama autofill behind it — each post-mount step is now guarded individually. This incidentally **fixes the dev-baseline `test_ollama_path_autofills_when_found` failure**.
2. **Recompose hydration race**: `LLMScreen`'s install-progress hydration (one `call_after_refresh` from `on_lab_body_ready`) was only sufficient because compose built every view synchronously; deferred mounting made it lose the race (three recompose-survival tests went red). The window now posts `DeferredViewsMounted` when the views are queryable; the screen re-hydrates on it (internally guarded + idempotent, so double invocation is safe).

Also repairs the two remaining stale Lab tests: batch4 pinned a construction-time default view that predates both the `""`/init=False race fix and the llama-cpp default (9dd2374b5); batch6's sidebar-hint test exercises a sidebar the Lab adoption retired (cycling lives in the Lab rail, covered by the adoption tests).

## Measured (live tmux, same method as #1378/#1392)

| | before | after |
|---|---|---|
| Lab switch | 0.68s | **0.47s / 0.49s** |

## Verification
- Mechanism test watched RED (deferred-mount stubbed → none of the five mount); guards green before AND after (all eleven views exist post-load, llama-cpp active; extracted ollama view renders its real content).
- **Lab/LLM 12-file surface: 149 passed, 0 failed — pristine dev baseline for the same set: 4 failed.**
- Live: Lab switch measured twice; Ollama/Curated/Download Models activated and rendering full content; zero errors in both logs.
- `--collect-only`: 31,682 collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers the five heavy, hidden views in Lab ▸ Models until after first paint to reduce tab switch time from 0.68s to ~0.47–0.49s. Addresses task-2900 and keeps Ollama autofill and install-progress behavior intact.

- **Refactors**
  - Mounts the deferred views after the first refresh via a new `_finish_deferred_mount` flow.
  - Extracts the Ollama UI into `OllamaServiceView`; mounts curated/installed/remote/download views lazily.
  - Emits `LLMManagementWindow.DeferredViewsMounted`; the screen re-hydrates install progress on this signal.
  - Adds focused tests for the deferral mechanism; logs follow-ups for task-2901 and task-2902.

- **Bug Fixes**
  - Guards each post-mount step to prevent failure coupling; fixes the Ollama path autofill test.
  - Fixes a hydration race by re-running install-progress hydration when deferred views are ready.
  - Updates/removes stale Lab tests aligned with current defaults and UI.

<sup>Written for commit edef7424bcdf0ad876087ea3a248611885db19ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

