### PR TITLE
perf(mcp): defer hidden mode canvases past first paint (task 2901)

### DIFF
--- a/Tests/UI/test_mcp_deferred_canvases.py
+++ b/Tests/UI/test_mcp_deferred_canvases.py
@@ -1,0 +1,87 @@
+"""task-2901: MCP defers its three hidden mode canvases past first paint.
+
+Third application of the defer-past-first-paint pattern (2725 Roleplay,
+2900 Lab ▸ Models): Tools/Permissions/Audit arrive hidden inside the
+ContentSwitcher (Servers is initial). They now mount as the first step of
+the workbench's load worker, before `reload()` pushes data into them, so
+every push in the load pipeline still sees the full canvas set.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from textual.widgets import ContentSwitcher
+
+from tldw_chatbook.UI.MCP_Modules.mcp_audit_mode import MCPAuditMode
+from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import MCPPermissionsMode
+from tldw_chatbook.UI.MCP_Modules.mcp_servers_mode import MCPServersMode
+from tldw_chatbook.UI.MCP_Modules.mcp_tools_mode import MCPToolsMode
+from tldw_chatbook.UI.MCP_Modules.mcp_workbench import MCPWorkbench
+from Tests.UI.test_mcp_workbench import WorkbenchApp
+
+pytestmark = pytest.mark.asyncio
+
+_DEFERRED_TYPES = (MCPToolsMode, MCPPermissionsMode, MCPAuditMode)
+
+
+async def test_first_paint_excludes_the_hidden_mode_canvases(monkeypatch):
+    """Compose alone must not mount the deferred canvases."""
+    monkeypatch.setattr(
+        MCPWorkbench, "_mount_deferred_canvases", AsyncMock(), raising=False
+    )
+
+    app = WorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert list(app.query(MCPServersMode)), "initial Servers canvas missing"
+        for deferred_type in _DEFERRED_TYPES:
+            assert not list(app.query(deferred_type)), (
+                f"{deferred_type.__name__} mounted during compose — back on "
+                "the click→paint critical path"
+            )
+
+
+async def test_load_mounts_all_canvases_with_servers_current():
+    """After the real load, every mode canvas exists and Servers is current."""
+    app = WorkbenchApp()
+    async with app.run_test() as pilot:
+        for _ in range(6):
+            await pilot.pause()
+
+        for canvas_type in (MCPServersMode, *_DEFERRED_TYPES):
+            assert len(list(app.query(canvas_type))) == 1, (
+                f"{canvas_type.__name__} missing after load"
+            )
+        workbench = app.query_one(MCPWorkbench)
+        assert workbench.active_mode == "servers"
+        switcher = app.query_one(ContentSwitcher)
+        assert switcher.current == "mcp-mode-canvas-servers"
+
+
+async def test_mode_request_before_canvases_mount_is_stashed_not_crashed(
+    monkeypatch,
+):
+    """`ContentSwitcher.current` raises for an unmounted id — a fast mode-chip
+    click in the pre-mount window must stash the request and apply it once
+    the canvases exist, mirroring the `_reloading` restore stash."""
+    real_mount = MCPWorkbench._mount_deferred_canvases
+    monkeypatch.setattr(MCPWorkbench, "_mount_deferred_canvases", AsyncMock())
+
+    app = WorkbenchApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+
+        # The fast click: the audit canvas does not exist yet.
+        workbench.set_mode("audit")
+        await pilot.pause()
+
+        # Now the deferred mount lands (the real one).
+        await real_mount(workbench)
+        await pilot.pause()
+
+        assert workbench.active_mode == "audit"
+        switcher = app.query_one(ContentSwitcher)
+        assert switcher.current == "mcp-mode-canvas-audit"

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -917,6 +917,10 @@ def test_set_mode_defers_async_workers_as_callables():
     workbench = SimpleNamespace(
         _active_mode="servers",
         ModeChanged=lambda mode: SimpleNamespace(mode=mode),
+        # task-2901: set_mode probes for the target canvas before touching
+        # the switcher (deferred canvases stash instead); a non-empty result
+        # models "canvas mounted".
+        query=lambda _selector: [object()],
         query_one=lambda _widget_type: switcher,
         post_message=lambda message: posted.append(message),
         run_worker=lambda work, **kwargs: queued.append((work, kwargs)),

--- a/backlog/tasks/task-2901 - MCP-defer-mode-canvases-past-first-paint.md
+++ b/backlog/tasks/task-2901 - MCP-defer-mode-canvases-past-first-paint.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-2901
 title: MCP — defer the Audit and Tools mode canvases past first paint
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-07 02:00'
 labels:
@@ -21,7 +21,13 @@ Screen survey (task-2725 follow-up): MCP mounts 135 widgets; `MCPAuditMode#mcp-m
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] MCP first paint excludes the hidden mode canvases; every mode is reachable after load.
-- [ ] Mode switching, permissions, and audit flows keep their existing tests green.
-- [ ] The compose→load window is covered by verified tolerance (no unguarded queries of the deferred canvases).
+- [x] MCP first paint excludes the hidden mode canvases; every mode is reachable after load.
+- [x] Mode switching, permissions, and audit flows keep their existing tests green.
+- [x] The compose→load window is covered by verified tolerance (no unguarded queries of the deferred canvases).
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fourth defer-past-first-paint application (2725/2900 pattern). Compose keeps only the initial Servers canvas inside the ContentSwitcher; Tools/Permissions/Audit mount as `_reload_guarded`'s FIRST step — before `reload()` pushes data through the pipeline's unguarded `query_one(MCP*Mode)` sites, so their validity holds by ordering. Two screen-specific traps, both caught by tests: (1) **ContentSwitcher hides children from its `current` WATCHER** — late-mounted children arrive visible; all three canvases briefly stacked and pushed the current one's content off-screen (19 mounted-flow tests red with OutOfBounds) — deferred canvases are hidden explicitly at mount; (2) `ContentSwitcher.current` raises for an unmounted id, so `set_mode` stashes a request landing in the pre-mount window (`_pending_deferred_mode`) and `_mount_deferred_canvases` replays it through the normal path (ModeChanged included) — pinned by test. Results: MCP tab switch 1.11s → **0.25–0.26s** live; all four modes cycled live with real content, zero errors; **MCP 9-file surface: 692 passed, 0 failed**. Files: tldw_chatbook/UI/MCP_Modules/mcp_workbench.py, Tests/UI/test_mcp_deferred_canvases.py, Tests/UI/test_mcp_workbench.py (fake gains the new probe).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -678,6 +678,9 @@ class MCPWorkbench(Container):
         super().__init__(**kwargs)
         self._app_instance = app_instance
         self._active_mode = "servers"
+        #: Mode requested before the deferred canvases mounted (task-2901);
+        #: replayed by `_mount_deferred_canvases`.
+        self._pending_deferred_mode: str | None = None
         self._source = "local"
         self._selected_server_key: str | None = None
         # F-054: one-shot gate for `_preselect_single_problem_on_load()` --
@@ -909,15 +912,13 @@ class MCPWorkbench(Container):
                 classes="destination-workbench-pane",
             ):
                 yield MCPServersMode(id="mcp-mode-canvas-servers")
-                yield MCPToolsMode(id="mcp-mode-canvas-tools")
-                yield MCPPermissionsMode(id="mcp-mode-canvas-permissions")
-                # T7 (MCP Hub Phase 5): Audit mode now hosts the real
-                # `MCPAuditMode` canvas too -- every `MCP_HUB_MODES` entry is
-                # now a real canvas, so the generic phase-placeholder loop
-                # this used to fall through to (T12's `.ds-info-callout`
-                # Static) is gone; it would never have executed its body
-                # again anyway.
-                yield MCPAuditMode(id="mcp-mode-canvas-audit")
+                # task-2901: Tools/Permissions/Audit (T5/T6/T7 canvases —
+                # every `MCP_HUB_MODES` entry is a real canvas) arrive
+                # hidden behind the ContentSwitcher and are NOT composed
+                # here. They mount as `_reload_guarded`'s first step
+                # (`_mount_deferred_canvases`), before `reload()` pushes
+                # data into them — off the click→paint critical path with
+                # the load pipeline's ordering intact.
             yield MCPInspector(id="mcp-hub-inspector", classes="destination-workbench-pane")
 
     def on_mount(self) -> None:
@@ -1001,9 +1002,41 @@ class MCPWorkbench(Container):
             exclusive=True,
         )
 
+    async def _mount_deferred_canvases(self) -> None:
+        """Mount the three hidden mode canvases after first paint (task-2901).
+
+        Runs as `_reload_guarded`'s first step, so every data push inside
+        `reload()` (and everything after it) sees the full canvas set —
+        the pipeline's unguarded `query_one(MCP*Mode)` sites stay valid by
+        ordering, not by luck. A mode request that lands in the narrow
+        pre-mount window is stashed by `set_mode` and replayed here.
+        Idempotent for re-entered loads.
+        """
+        try:
+            switcher = self.query_one(ContentSwitcher)
+        except QueryError:
+            return
+        if not self.query(MCPToolsMode):
+            tools = MCPToolsMode(id="mcp-mode-canvas-tools")
+            permissions = MCPPermissionsMode(id="mcp-mode-canvas-permissions")
+            audit = MCPAuditMode(id="mcp-mode-canvas-audit")
+            # ContentSwitcher hides children from its `current` WATCHER, which
+            # only fires on change — late-mounted children arrive visible, and
+            # all three canvases briefly stacking pushed the current one's
+            # content off-screen. Hide explicitly; `current = <mode>` shows
+            # the right one when a mode change lands.
+            for canvas in (tools, permissions, audit):
+                canvas.display = False
+            await switcher.mount(tools, permissions, audit)
+        pending = self._pending_deferred_mode
+        if pending is not None:
+            self._pending_deferred_mode = None
+            self.set_mode(pending)
+
     async def _reload_guarded(self) -> None:
         """Run the mount-time reload without letting a failure strand the UI."""
         try:
+            await self._mount_deferred_canvases()
             await self.reload()
         except Exception as exc:
             # `reload()` clears `is_loading` in its own `finally`, but only for
@@ -2435,6 +2468,14 @@ class MCPWorkbench(Container):
     def set_mode(self, mode: str) -> None:
         if mode not in MCP_HUB_MODES:
             mode = "servers"
+        # task-2901: `ContentSwitcher.current` raises for an id with no
+        # child. A mode request landing before the deferred canvases mount
+        # (a fast chip click in the first paint-to-load window) is stashed
+        # and replayed by `_mount_deferred_canvases` — the same stash idea
+        # `_reloading` uses for restores.
+        if not self.query(f"#mcp-mode-canvas-{mode}"):
+            self._pending_deferred_mode = mode
+            return
         mode_changed = mode != self._active_mode
         self._active_mode = mode
         self.query_one(ContentSwitcher).current = f"mcp-mode-canvas-{mode}"


### PR DESCRIPTION
## Summary

Third shipped application of the defer-past-first-paint pattern (#1392 Roleplay, #1395 Lab ▸ Models). MCP's Tools/Permissions/Audit canvases arrive hidden inside the ContentSwitcher; they now mount as the load worker's **first** step — before `reload()` pushes data through the pipeline's unguarded `query_one(MCP*Mode)` sites, so their validity holds by ordering rather than luck.

## Two traps the test surface caught

1. **ContentSwitcher hides children from its `current` watcher only** — late-mounted children arrive *visible*; all three canvases briefly stacked and pushed the current one's content off-screen (19 mounted-flow tests red with `OutOfBounds`). Deferred canvases are hidden explicitly at mount; `current = <mode>` reveals the right one on change.
2. **`ContentSwitcher.current` raises for an unmounted id** — a fast mode-chip click in the pre-mount window now stashes the request (`_pending_deferred_mode`) and the mount replays it through the normal `set_mode` path, `ModeChanged` included. Pinned by test.

## Measured (live tmux, same method as the series)

| | before | after |
|---|---|---|
| MCP switch | 1.11s (walkthrough baseline) | **0.25s / 0.26s** |

## Verification
- Mechanism test watched RED (mount stubbed → only Servers present); integrity guard green before AND after (all four canvases post-load, Servers current); stash-replay pinned.
- **MCP 9-file surface: 692 passed, 0 failed.**
- Live: switch measured twice; all four modes cycled with real content (kill-switch toggle, Findings subview, tool search); zero errors in both logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers mounting of hidden MCP mode canvases (Tools, Permissions, Audit) until after first paint by mounting them at the start of the load worker. Implements TASK-2901, keeps all modes reachable after load, and cuts MCP switch time from 1.11s to ~0.25s.

- **Bug Fixes**
  - Late-mounted canvases arrived visible because the switcher only hides via its current watcher. Canvases now mount hidden; switching reveals the right one.
  - Fast mode clicks before canvases exist raised on an unmounted id. `set_mode` now stashes the request and `_mount_deferred_canvases` replays it (includes `ModeChanged`).

<sup>Written for commit 6219f2391353df999259b54c11ab64aa32fed59d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

