### PR TITLE
test(speech): trace exonerates preview-blocked refresh copy; honesty pinned (TASK-2952)

### DIFF
--- a/Tests/UI/test_speech_playground_pane.py
+++ b/Tests/UI/test_speech_playground_pane.py
@@ -22,6 +22,7 @@ from Tests.UI.speech_playground_fixtures import (
 from tldw_chatbook.TTS.adapter_types import (
     TTSProviderCatalog,
     TTSProviderReconfiguringError,
+    TTSRegistryClosedError,
 )
 from tldw_chatbook.TTS.audio_player import PlaybackState
 from tldw_chatbook.TTS.playground_types import STTSGeneratedAudio
@@ -1688,3 +1689,173 @@ async def test_generic_voice_failure_status_distinguishes_no_catalog_legacy(
             assert "unverified" not in status
         assert "private upstream detail" not in status
         assert "without fallback" in status
+
+
+# --- TASK-2952: `_profile_preview_blocked_presentation` branch trace -----
+#
+# The three "unverified"-styled returns there promise refresh/retry with no
+# check on provider class. Each was traced against the registry/catalog/
+# preset lifecycle (see the docstring on `_profile_preview_blocked_
+# presentation` for the full trace) and confirmed live below.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_id", "model_id", "voice_id"),
+    _ADOPTED_PRESET_PROVIDER_CASES,
+    ids=("audio_cpp", "openai"),
+)
+async def test_adopted_preset_preview_never_shows_a_null_revision_refresh(
+    faked_service: FakeTTSService,
+    provider_id: str,
+    model_id: str,
+    voice_id: str,
+) -> None:
+    """Branch trace, `expected_revision is None`: the catalog worker sets
+    `_profile_configuration_revision` synchronously, before any `await`, the
+    moment it targets the preset's own provider -- and production always
+    targets it on the very first load, for both provider classes
+    (`_profile_preset` is fixed at construction and never swapped). So this
+    cached revision must never still be None once the preview has settled
+    out of "loading", for either class -- otherwise the "refresh or retry"
+    copy would fire off a revision this pane never actually captured.
+    """
+    preset = _profile_preset(
+        provider_id=provider_id,
+        model_id=model_id,
+        voice_id=voice_id,
+        availability="unverified",
+    )
+    app = _AxisHarness(profile_preset=preset)
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        pane = app.query_one(SpeechPlaygroundPane)
+        assert not pane._profile_preview_loading
+        assert pane._profile_configuration_revision is not None, (
+            "cached configuration revision is still None after the preview "
+            "settled -- 'refresh or retry' would fire on a revision this "
+            "pane never captured"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_id", "model_id", "voice_id"),
+    _ADOPTED_PRESET_PROVIDER_CASES,
+    ids=("audio_cpp", "openai"),
+)
+async def test_adopted_preset_preview_revision_mismatch_refresh_recovers_for_both_classes(
+    faked_service: FakeTTSService,
+    provider_id: str,
+    model_id: str,
+    voice_id: str,
+) -> None:
+    """Branch trace, `current_revision != expected_revision`: pure registry
+    bookkeeping, not catalog content -- refresh re-reads the revision and
+    resolves the mismatch for ANY provider class, legacy included. Honest
+    for both; this pins that Refresh actually works for a legacy preset too.
+    """
+    preset = _profile_preset(
+        provider_id=provider_id,
+        model_id=model_id,
+        voice_id=voice_id,
+        availability="unverified",
+    )
+    app = _AxisHarness(profile_preset=preset)
+
+    async with app.run_test(size=(160, 60)) as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        pane = app.query_one(SpeechPlaygroundPane)
+        assert pane._profile_configuration_revision == 1
+
+        # Simulate a settings edit reconfiguring this exact provider while
+        # the pane sits on the adopted preset -- the registry's revision
+        # bumps; the pane does not hear about it until it next syncs.
+        faked_service.revisions[provider_id] = 2
+        pane._sync_profile_preview_status()
+        await pilot.pause()
+
+        banner = str(
+            app.query_one("#tts-profile-preview-status", Static).renderable
+        ).lower()
+        assert "tts settings changed" in banner
+        assert "refresh models" in banner
+
+        # The real recovery path a user would take.
+        pane.query_one("#tts-refresh-catalog-btn", Button).press()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert pane._profile_configuration_revision == 2, (
+            "Refresh did not re-sync the cached configuration revision"
+        )
+        banner_after = str(
+            app.query_one("#tts-profile-preview-status", Static).renderable
+        ).lower()
+        assert "tts settings changed" not in banner_after, (
+            f"Refresh did not resolve the revision mismatch: {banner_after!r}"
+        )
+        if provider_id == "audio_cpp":
+            assert "unverified" in banner_after
+        else:
+            assert "no catalog check" in banner_after
+
+
+@pytest.mark.asyncio
+async def test_adopted_preset_preview_registry_closed_during_voice_fetch_is_symmetric(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Branch trace, `not self._catalog_generation_allowed`: the one live
+    path found is `_load_provider_voices_worker`'s `TTSRegistryClosedError`
+    (non-reconfiguring) branch, which forces this flag False without an
+    `_apply_controls` recompute. `TTSRegistryClosedError` comes from
+    `TTSAdapterRegistry._closed` -- a registry-wide, one-way seal -- so it is
+    identical machinery for audio.cpp and every legacy provider, with no
+    legacy-specific false promise to fix. Pinned as symmetry: both classes
+    must show the exact same banner from the exact same failure.
+    """
+    banners: dict[str, str] = {}
+    for provider_id, model_id, voice_id in _ADOPTED_PRESET_PROVIDER_CASES:
+        service = FakeTTSService()
+        monkeypatch.setattr(
+            SpeechPlaygroundPane,
+            "_tts_service_factory",
+            lambda self, service=service: _resolved(service),
+        )
+        monkeypatch.setattr(
+            SpeechPlaygroundPane, "_check_higgs_installation", lambda self: None
+        )
+        preset = _profile_preset(
+            provider_id=provider_id,
+            model_id=model_id,
+            voice_id=voice_id,
+            availability="available",
+        )
+        app = _AxisHarness(profile_preset=preset)
+        async with app.run_test(size=(160, 60)) as pilot:
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            pane = app.query_one(SpeechPlaygroundPane)
+            catalog = pane._catalogs[provider_id]
+
+            service.voice_error = TTSRegistryClosedError("registry shutting down")
+            pane._load_provider_voices(
+                provider_id, model_id, catalog.revision, refresh=True
+            )
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            banners[provider_id] = str(
+                app.query_one("#tts-profile-preview-status", Static).renderable
+            ).lower()
+
+    assert "refresh or retry" in banners["audio_cpp"]
+    assert banners["audio_cpp"] == banners["openai"], (
+        f"registry-closed banner diverged by provider class: {banners}"
+    )

--- a/backlog/tasks/task-2952 - Trace-legacy-reachability-of-_profile_preview_blocked_presentations-refresh-or-retry-copy-in-the-Playground-preview.md
+++ b/backlog/tasks/task-2952 - Trace-legacy-reachability-of-_profile_preview_blocked_presentations-refresh-or-retry-copy-in-the-Playground-preview.md
@@ -3,9 +3,11 @@ id: TASK-2952
 title: >-
   Trace legacy reachability of _profile_preview_blocked_presentation's
   refresh-or-retry copy in the Playground preview
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 02:09'
+updated_date: '2026-08-07 06:06'
 labels:
   - ui
   - speech
@@ -22,8 +24,36 @@ SpeechProfileMixin._profile_preview_blocked_presentation (tldw_chatbook/UI/Speec
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every one of the three 'unverified'-returning branches in _profile_preview_blocked_presentation is traced to determine whether it is reachable when preset.provider_id is a legacy (non-audio_cpp) provider
-- [ ] #2 If a branch is legacy-reachable, its copy is made honest for legacy providers (no refresh/retry promise), consistent with the vocabulary this slice established (preset_has_no_catalog_check helper or equivalent), with a regression test pinning the legacy-vs-audio_cpp divergence
-- [ ] #3 If a branch is proven legacy-unreachable, that is documented in a code comment with the trace evidence, matching the pattern task 1 used for _PROFILE_UNVERIFIED_COPY
-- [ ] #4 The finding and its resolution (fixed or documented-unreachable, per branch) are recorded in the task's Implementation Notes
+- [x] #1 Every one of the three 'unverified'-returning branches in _profile_preview_blocked_presentation is traced to determine whether it is reachable when preset.provider_id is a legacy (non-audio_cpp) provider
+- [x] #2 If a branch is legacy-reachable, its copy is made honest for legacy providers (no refresh/retry promise), consistent with the vocabulary this slice established (preset_has_no_catalog_check helper or equivalent), with a regression test pinning the legacy-vs-audio_cpp divergence
+- [x] #3 If a branch is proven legacy-unreachable, that is documented in a code comment with the trace evidence, matching the pattern task 1 used for _PROFILE_UNVERIFIED_COPY
+- [x] #4 The finding and its resolution (fixed or documented-unreachable, per branch) are recorded in the task's Implementation Notes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Static trace of the three branches in _profile_preview_blocked_presentation against the registry/catalog/preset lifecycle to determine which app-level events reach each with a legacy preset adopted.
+2. Empirical probes (Tests/UI/test_task2952_probe.py, throwaway) driving the real SpeechPlaygroundPane via FakeTTSService to confirm/refute each branch's reachability and whether refresh genuinely resolves it, for both audio_cpp and legacy (openai) presets.
+3. Per branch: if honest for both classes, add a code comment citing the trace; if legacy gets a false promise, fix the copy using preset_has_no_catalog_check and add a TDD regression test in the permanent suite (test_speech_playground_pane.py, matching slice-2 task 3 conventions).
+4. Delete or fold the throwaway probe file once conclusions are captured as permanent pins.
+5. Run gates: speech pane/profile test files, ruff, repo-wide --collect-only.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Traced all three "unverified"-styled returns in _profile_preview_blocked_presentation against the registry/catalog/preset lifecycle, confirmed live via Tests/UI/test_speech_playground_pane.py (mutation-checked). Result: none needed a copy fix -- no legacy-specific false promise was found in any of the three branches (AC #2's fix condition never triggered), but each conclusion is pinned as a regression test per AC #2's spirit and AC #3.
+
+Branch 1, `expected_revision is None`: LEGACY-UNREACHABLE (and audio.cpp-unreachable -- not a class distinction). `_load_provider_catalog_worker` sets `_profile_configuration_revision` synchronously, before any `await`, the moment it targets the preset's own provider; production always targets it on the very first load since both provider classes are registered unconditionally (`adapter_bootstrap.build_default_tts_service`, `legacy_bridge.legacy_provider_specs`) and `_profile_preset` is fixed at construction, never reassigned. Pinned: test_adopted_preset_preview_never_shows_a_null_revision_refresh.
+
+Branch 2, `current_revision != expected_revision`: HONEST FOR BOTH CLASSES. Fires on genuine config drift (the provider's registry configuration_revision bumping after the preview loaded) -- pure registry bookkeeping, not catalog content, so refresh re-syncs it for legacy exactly as it does for audio.cpp. Confirmed live: bumping a legacy provider's revision produces the "TTS settings changed; refresh models" banner, and pressing Refresh resolves it into the honest per-class copy. Pinned: test_adopted_preset_preview_revision_mismatch_refresh_recovers_for_both_classes.
+
+Branch 3, `not self._catalog_generation_allowed`: HONEST FOR BOTH CLASSES (no legacy-specific divergence). The one live path found is `_load_provider_voices_worker`'s TTSRegistryClosedError (non-reconfiguring) branch, which forces the flag False without an _apply_controls recompute; the generic-exception and reconfiguring branches both self-heal. TTSRegistryClosedError comes from TTSAdapterRegistry._closed, a registry-wide one-way seal -- identical machinery for every provider class. Pinned as a cross-class symmetry check: test_adopted_preset_preview_registry_closed_during_voice_fetch_is_symmetric asserts audio_cpp and legacy produce the byte-identical banner from the same failure.
+
+Method: empirical probes (throwaway Tests/UI/test_task2952_probe.py, deleted) drove the real SpeechPlaygroundPane through FakeTTSService across full mount lifecycles and targeted fault injection, instrumented with a spy on _profile_preview_blocked_presentation recording state at every call. Conclusions were converted into permanent pins in test_speech_playground_pane.py and a trace docstring on _profile_preview_blocked_presentation itself (matching the _PROFILE_UNVERIFIED_COPY comment pattern). Mutation-tested both directions: disabling the revision assignment failed 4/5 new tests (branches 1+2); injecting an artificial legacy-only copy into branch 3 failed the symmetry pin -- both reverted after confirming.
+
+Files: tldw_chatbook/UI/Speech/speech_profile_mixin.py (trace docstring only, no behavior change), Tests/UI/test_speech_playground_pane.py (+3 pins, +TTSRegistryClosedError import).
+
+Gates: targeted speech pane/profile suites (170 passed, 2 pre-existing xfail unrelated to this change) + Tests/UI/test_stts_profile_library.py + test_studio_tts_preferences.py (90 passed); ruff clean on touched files; repo-wide --collect-only (31734 tests collected, 0 errors).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Speech/speech_profile_mixin.py
+++ b/tldw_chatbook/UI/Speech/speech_profile_mixin.py
@@ -180,7 +180,60 @@ class SpeechProfileMixin:
         self,
         preset: TTSPlaygroundSelectionPreset,
     ) -> tuple[str, ProfileAvailabilityState] | None:
-        """Return bounded recovery copy when the exact preset cannot generate."""
+        """Return bounded recovery copy when the exact preset cannot generate.
+
+        TASK-2952 branch trace -- the three "unverified"-styled returns below
+        promise a refresh/retry recovery with no check on `preset`'s provider
+        class. Each was traced (and confirmed live, `test_speech_playground_
+        pane.py`) for whether that promise is a false one on the six
+        legacy-bridge providers, the way slice 2 task 3 already fixed the two
+        adjacent adoption sites in `speech_catalog_mixin.py`:
+
+        `expected_revision is None` -- requires `_profile_preview_loading`
+        False while `_profile_configuration_revision` was never set for the
+        preset's own provider. `_load_provider_catalog_worker` sets that
+        field synchronously, before any `await`, the moment it targets
+        `preset.provider_id` -- and production always targets it on the
+        pane's very first load: `initialize`'s provider selection prefers
+        `preset_provider` whenever it is registered, and both provider
+        classes are registered unconditionally
+        (`adapter_bootstrap.build_default_tts_service`,
+        `legacy_bridge.legacy_provider_specs` register all six regardless of
+        config/deps). `_profile_preset` is also set once at construction and
+        never reassigned (`init_profile_state`/`_end_profile_preset` are the
+        only writers), so there is no "preset swapped after mount" path
+        either. LEGACY-UNREACHABLE -- and audio.cpp-unreachable too, so this
+        is not a class distinction to fix. `test_adopted_preset_preview_
+        never_shows_a_null_revision_refresh` pins the invariant this relies
+        on for both classes.
+
+        `current_revision != expected_revision` -- fires when the
+        provider's registry configuration revision changes after the
+        preview loaded (a genuine settings edit on that exact provider, or
+        `mark_provider_configuration_changed`/`_mark_stale_catalog_result`
+        noticing the same drift). This is pure registry bookkeeping
+        (`TTSAdapterRegistry.configuration_revision`), not catalog content --
+        refresh re-reads the revision and re-syncs it for any provider,
+        legacy included. HONEST FOR BOTH CLASSES: confirmed live that
+        bumping a legacy provider's revision produces this exact banner, and
+        pressing Refresh resolves it into the "no catalog check" copy just
+        as it resolves audio.cpp's into its "unverified" copy
+        (`test_adopted_preset_preview_revision_mismatch_refresh_recovers_
+        for_both_classes`).
+
+        `not self._catalog_generation_allowed` -- the one live path found is
+        `_load_provider_voices_worker`'s `TTSRegistryClosedError`
+        (non-reconfiguring) branch, which forces this flag False without an
+        `_apply_controls` recompute; the generic-exception and reconfiguring
+        branches both self-heal through `_apply_catalog`/`_apply_controls`
+        before this state could be observed. `TTSRegistryClosedError` comes
+        from `TTSAdapterRegistry._closed` -- a registry-wide, one-way seal
+        (`adapter_registry.py: close()`) -- identical machinery for
+        audio.cpp and every legacy provider. No legacy-specific divergence
+        found, so no fix belongs here; pinned as a cross-class symmetry
+        check (`test_adopted_preset_preview_registry_closed_during_voice_
+        fetch_is_symmetric`).
+        """
         service = self._tts_service
         if service is None:
             return (


### PR DESCRIPTION
Closes TASK-2952 — the last carry-forward from voice-profiles slice 2.

## Outcome: no defect — and now that's enforced, not assumed

The suspicion: `_profile_preview_blocked_presentation` returns "refresh…" copy for adopted presets without checking provider class, potentially promising legacy (no-catalog) providers a recovery that can't help (ADR-031).

The trace, branch by branch, with empirical probes against the real pane:
- **Null-revision branch: unreachable** for both classes — the catalog worker sets the revision synchronously before any await.
- **Revision-mismatch branch: honest for both** — it's registry-revision bookkeeping, not catalog content; a live probe drove a legacy preset through the mismatch and confirmed Refresh genuinely recovers it.
- **Registry-closed branch: honest for both** — a registry-wide seal, byte-identical banners for audio.cpp and legacy.

Production change is a 54-line trace docstring only (zero behavior). Three permanent pins enforce the conclusions — unreachability, both-class recovery, and banner symmetry — each mutation-tested (disabling the synchronous assignment fails four tests; an artificial legacy-only copy fails the symmetry pin).

138 speech-surface tests green post-rebase; collection clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Traced and documented the preview-blocked “refresh or retry” copy in `SpeechProfileMixin._profile_preview_blocked_presentation`, adding regression tests that prove no legacy-specific false promises; no runtime behavior changes. Addresses TASK-2952.

- **Tests**
  - Pin that the “null revision” branch is unreachable after preview load for both classes.
  - Verify a revision mismatch banner appears and “Refresh” resolves it for both audio.cpp and legacy providers.
  - Assert registry-closed failures show the exact same banner across provider classes.

<sup>Written for commit 8eda47b6ed757ef941b967c21fa06b7c7f1e53ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

