### PR TITLE
refactor(console): decomposition wave 3 — message, transcript, prompts + a size ratchet

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -424,3 +424,15 @@ wiring time. Second, if a proxy property is write-only, its getter must raise
 `getattr(obj, name, default)` swallow `AttributeError` specifically, so a
 defensive read would silently take the default forever with nothing raised
 anywhere.
+
+**New Console code goes in `UI/Console_Modules/`, and a ratchet enforces it.**
+The decomposition's first two waves extracted ~4,900 lines out of
+`chat_screen.py` and the file still ended up *larger* than when the work
+started, because ~5,500 lines of concurrent feature work landed in it over the
+same window. Extraction cannot outrun growth, so the screen's size is now a
+ceiling: `Tests/Architecture/test_screen_size_ratchet.py` holds a line and
+method budget that may only ever be lowered. A wave lowers it in the same PR
+that earns the reduction; a feature that would raise it belongs in a module
+instead. The test's failure message names the module directory and this
+section, because the moment it fires is the moment someone needs to know where
+else to put the code — not a link to chase later.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -425,6 +425,24 @@ wiring time. Second, if a proxy property is write-only, its getter must raise
 defensive read would silently take the default forever with nothing raised
 anywhere.
 
+**A proxy property standing in for a plain attribute must be read-WRITE.**
+The rule above governs the write-only case; wave 3 found its mirror image and
+paid for it. Moving state into a controller turns what was
+`self._console_original_attempt_previews = {}` in `__init__` into a `@property`
+on the screen that forwards to the controller — and a `@property` with only a
+getter makes the name **assignment-hostile**, where the plain attribute it
+replaced accepted writes from anywhere. Wave 3 shipped one getter-only proxy
+and turned **41 tests red in a file the branch never touched**, all of them
+`AttributeError: property '…' of 'ChatScreen' object has no setter`. Two
+things follow. First, check the *baseline* shape before writing a proxy: if it
+was a plain assignable attribute, the proxy needs a setter, and "nothing writes
+it today" is a coverage claim rather than a contract — write the setter anyway.
+Second, the setter must write THROUGH to the controller (`self._message.x = v`),
+never to a shadow attribute the controller never reads; that variant is worse
+than the crash, because the tests go green over a dead write. An `ast` audit
+comparing every new property against the baseline attribute's shape catches
+both, and is cheap enough to run every wave.
+
 **New Console code goes in `UI/Console_Modules/`, and a ratchet enforces it.**
 The decomposition's first two waves extracted ~4,900 lines out of
 `chat_screen.py` and the file still ended up *larger* than when the work

--- a/Docs/superpowers/plans/2026-08-06-console-decomposition-wave3.md
+++ b/Docs/superpowers/plans/2026-08-06-console-decomposition-wave3.md
@@ -1,0 +1,149 @@
+# Console Decomposition — Wave 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the message cluster together with the visual surfaces that reflect its state, plus the prompt cluster — then lower the size ratchet so the gain is locked in rather than re-consumed.
+
+**Architecture:** Per `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md` and the four controllers + two region widgets already in `UI/Console_Modules/`. Message and its surfaces go together because the control bar and transcript reflect message/generation state; splitting them across waves would force a cross-wave seam.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest.
+
+**Measured on dev at `22c08f958` (post-wave-2) — re-locate by anchor, never by line number:**
+- `chat_screen.py` 20,964 lines, `ChatScreen` 612 methods.
+- **message: 1,577 lines / 35 methods** — the largest remaining cluster. `handle_console_message_action` is 294 lines.
+- **prompt: 853 / 18** — contains `_open_console_prompts_modal` (397), the biggest non-`__init__` method on the class.
+- **transcript: 607 / 14** — the visual surface coupled to message.
+- The monsters now: `__init__` (603), `_open_console_prompts_modal` (397), `on_button_pressed` (381), `on_key` (309), `compose_content` (309).
+- **`__init__` has grown to 603 lines, largely from wiring four controllers.** That is a real cost of this pattern and is wave 4's problem, not this wave's — do not attack it here, but do not make it worse: keep new wiring blocks tight and grouped.
+
+## Global Constraints
+
+The spec's six migration rules bind every task (see its "Migration safety" section). Plus, hard-won across waves 1–2:
+
+**THE CONTROLLER BINDING RULE** — canonical example is `ConsoleDictationController.__init__`'s docstring:
+- Framework services (`run_worker`, `set_timer`, `post_message`, `push_screen`, `call_after_refresh`, `is_mounted`) — live-read from the screen via `@property`.
+- App-level dependencies — **named keyword-only callable parameters**, wired at the construction site as late-binding lambdas (`x_accessor=lambda: self._x()`), never bound methods, never constructor snapshots.
+- `app_instance` — snapshot only, justified in the docstring.
+- Workers — preserve pre-move group names; never invent a flat cluster group.
+- **Controller-to-controller traffic goes through named callables the screen wires**, resolved at CALL time (a construction-time capture leaves whichever controller is built second as `None`). Never a back-door through screen attributes.
+- **A write-only proxy getter raises `RuntimeError`, not `AttributeError`** — `hasattr()`/`getattr(_, _, default)` swallow exactly that exception, so a defensive read would silently take the default forever.
+- **Zero `query_one`/DOM access in a controller.** All four existing controllers have zero. Match them.
+- **A region widget never stores a child-widget instance the screen may replace** — pass a zero-arg builder (DESIGN.md §7).
+
+**Process rules, each paid for:**
+- **`git push` after EVERY commit.** An entire unpushed wave was destroyed by the `/private/tmp` cleaner. Work lives in `.worktrees/`, never `/private/tmp`; the interpreter is `<repo>/.venv/bin/python`.
+- **Characterise BEFORE extracting**, always. Two wave-2 tasks did it retroactively and a reviewer ruled that count-level evidence only — it cannot detect an assertion-weakening retarget when the test files change in the same commit.
+- **Commit the extraction the moment it exists**, before any sweep.
+- Tests FOREGROUND with Bash `timeout: 600000`; the dispatch names the verification files AND requires running every file the task edits.
+- Gate before each task: **open PRs touching `chat_screen.py`** (`gh pr list` + per-PR file check), never branch last-commit age. Branch age is what let #1350's 2,285 lines blindside wave 2 mid-flight.
+- Rebase onto `origin/dev` before each task; CSS-bundle conflicts resolve by `git checkout --theirs` then regenerating via `.venv/bin/python tldw_chatbook/css/build_css.py`.
+- **A scripted rename across this boundary needs an ambiguity check first.** Several methods exist in BOTH the screen (real implementation) and a controller (same-named accessor property); a blind rename turns correct prose wrong. Check for exactly one definition site before rewriting any reference.
+
+**Three defect classes that have already bitten this programme:**
+1. **Dead bodies** — a moved method left behind with zero callers (cost a fix round in wave 1, another in wave 2). Audit every moved method: gone, or an intentional ≤14-line delegation WITH real callers.
+2. **Silent drops outside diff markers** — an orphaned `import threading` (runtime NameError) and a config symbol needing a dual import, neither visible in any hunk. Run pyflakes on `chat_screen.py` and the new module; compare to the pre-move baseline.
+3. **Single-module test helpers** — a helper pinning a config symbol on `chat_screen_module` stops governing the moved path once a controller reads its own copy. Three instances found so far. Grep helpers for every symbol you move.
+
+## File Structure
+
+- `tldw_chatbook/UI/Console_Modules/message.py` (new) — `ConsoleMessageController`
+- `tldw_chatbook/UI/Console_Modules/transcript.py` (new) — the transcript region widget
+- `tldw_chatbook/UI/Console_Modules/prompts.py` (new) — `ConsolePromptsController`
+- `tldw_chatbook/UI/Screens/chat_screen.py` — delegations shrink
+- `Tests/Architecture/test_screen_size_ratchet.py` — budget lowered in Task 4
+- Tests mirror each under `Tests/UI/`
+
+---
+
+### Task 1: The message controller
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/message.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_message_controller.py` (new)
+
+**Interfaces:**
+- Consumes: the binding rule; seams to the session and workspace controllers (messages belong to a session, which lives in workspace context) — named callables in both directions, wired by the screen.
+- Produces: `ConsoleMessageController` owning message state and lifecycle.
+
+- [ ] **Step 1: Map the cluster.** Every `*message*` method (35, ~1,577 lines) plus everything reading message state; per-method verdict (moves / ≤14-line delegation / stays with reason). `handle_console_message_action` (294 lines) is the risk centre — it dispatches user actions across regenerate/branch/delete/copy and will have the largest stays-list. Map message↔session and message↔transcript traffic in both directions. If the boundary has no clean answer, **report BLOCKED with the map**.
+- [ ] **Step 2: Characterise first.** Grep `Tests/` for message coverage; run what exists against unmodified code and record counts. Send/receive and at least one `handle_console_message_action` branch need tests driving REAL interactions before the move, asserting the persisted result (message rows in the store), not widget state. Commit separately, push, green pre-move.
+- [ ] **Step 3: Extract** per the binding rule.
+- [ ] **Step 4: Commit, push, then verify** in one foreground call (timeout 600000): the new test file + `Tests/UI/test_console_native_chat_flow.py` + `Tests/UI/test_console_shell_regions.py` + `Tests/Architecture/test_screen_size_ratchet.py`; then a second call for every other file edited.
+- [ ] **Step 5: Report** the map, the `handle_console_message_action` decision, the seams, the dead-body audit, pyflakes before/after, the test-helper grep.
+
+Commit: `refactor(console): message controller (wave 3)`
+
+---
+
+### Task 2: The transcript region widget
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/transcript.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`, `tldw_chatbook/css/features/_console.tcss` if any CSS moves
+- Test: `Tests/UI/test_console_transcript_region.py` (new)
+
+**Interfaces:**
+- Consumes: `frame_console_region` from `Console_Modules/frame.py`; `ConsoleMessageController` (Task 1) via named callables.
+- Produces: the transcript region widget, composing the block `compose_content` currently builds inline around `#console-main-column`'s transcript area — **ids verbatim, same nesting**.
+
+This is a region, not a controller: it owns pixels. Follow `left_rail.py`/`right_rail.py`, not the controllers.
+
+- [ ] **Step 1: Map the block** in `compose_content` (309 lines) — every id, widget class, and `self.*` reference. The transcript cluster is 607 lines / 14 methods; decide per method whether it is region-owned (composition, its own event handlers) or controller-owned (state that survives a recompose).
+- [ ] **Step 2: Characterise first** — a real `pilot` interaction against the mounted transcript, asserting persisted state; committed, pushed, green pre-move. The geometry baseline (`Tests/UI/test_console_shell_regions.py`) must stay byte-identical throughout.
+- [ ] **Step 3: Extract**, ids verbatim, `@on` handlers for what stays inside, messages upward for cross-region effects, zero-arg builders for any child the screen replaces at runtime.
+- [ ] **Step 4: Commit, push, verify** (same two-call shape as Task 1).
+- [ ] **Step 5: Report** including whether any CSS moved and the bundle regeneration.
+
+Commit: `refactor(console): transcript region widget (wave 3)`
+
+---
+
+### Task 3: The prompts controller
+
+**Files:**
+- Create: `tldw_chatbook/UI/Console_Modules/prompts.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_prompts_controller.py` (new)
+
+**Interfaces:**
+- Produces: `ConsolePromptsController` owning the prompt cluster (853 lines / 18 methods), including `_open_console_prompts_modal` (397 lines — the largest non-`__init__` method on the class).
+
+`push_screen` for the modal is a framework service, not a reason to stay. The modal's own widget is not in scope; only the screen-side orchestration moves.
+
+- [ ] **Step 1: Map the cluster**, per-method verdicts, and the prompt↔composer/message traffic.
+- [ ] **Step 2: Characterise first** — driving the real modal-open path and asserting the persisted selection; committed, pushed, green pre-move.
+- [ ] **Step 3: Extract** per the binding rule.
+- [ ] **Step 4: Commit, push, verify** (two calls).
+- [ ] **Step 5: Report** as above.
+
+Commit: `refactor(console): prompts controller (wave 3)`
+
+---
+
+### Task 4: Close the wave and lower the ratchet
+
+**Files:**
+- Modify: `Tests/Architecture/test_screen_size_ratchet.py`, `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md`, `DESIGN.md` if the wave established a new rule
+
+- [ ] **Step 1: Measure** the new `chat_screen.py` line count and `ChatScreen` method count with `ast`.
+- [ ] **Step 2: Lower the ratchet** in `_BUDGETS` to exactly those numbers. This is the step the whole wave exists to earn — the second ratchet test fails if you skip it, by design.
+- [ ] **Step 3: Annotate the spec** — mark message/transcript/prompt done, and update the Progress section's numbers honestly (both the raw figures and the fact that concurrent growth continues).
+- [ ] **Step 4: `DESIGN.md`** — add any rule this wave established that waves 1–2 did not already cover; if none, say so in the report rather than inventing one.
+- [ ] **Step 5: Serial gate**, at most two foreground calls (timeout 600000), then commit and push.
+
+Commit: `refactor(console): wave 3 closed — ratchet lowered, honest numbers`
+
+---
+
+## Wave 3 exit criteria
+
+- Message, transcript, and prompt clusters live in `UI/Console_Modules/`; the screen holds delegations.
+- Every controller follows the binding rule; the transcript region follows the region rules; zero DOM access in controllers.
+- The geometry baseline is byte-identical and green.
+- No behaviour change; every pre-existing DOM-driven test passes unchanged.
+- **The ratchet is lowered to the new measurement** — the wave's gain is locked in.
+
+## Not in wave 3 (deliberate)
+
+`__init__` (603 lines, much of it controller wiring — a real cost of this pattern and wave 4's problem), `on_button_pressed` (381), `on_key` (309), and the agent/character/image/skill/citation clusters. Settings and Library screens remain their own future efforts under the same spec.

--- a/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
+++ b/Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md
@@ -226,7 +226,7 @@ become a controller.
 shared frame helper, `ConsoleLeftRail`, `ConsoleInspectorRail`,
 `ConsoleDictationController`.
 
-**Wave 2 (this branch)** — `ConsoleWorkspaceController`,
+**Wave 2 (merged, PR #1381)** — `ConsoleWorkspaceController`,
 `ConsoleHandsFreeController`, `ConsoleSessionController`.
 
 Measured against dev at the wave-2 close: `chat_screen.py` **24,195 → 20,964
@@ -242,6 +242,47 @@ Controller discipline at the close, verified per module rather than asserted:
 **zero** `query_one`/DOM access in any of the four controllers, and `self._screen`
 uses held to 3–6 each, every one either a framework service or a documented
 sibling-state proxy.
+
+**Wave 3 (this branch)** — `ConsoleMessageController`, `ConsoleTranscriptRegion`,
+`ConsolePromptsController`, plus the size ratchet.
+
+`chat_screen.py` **20,964 → 18,904 lines**, `ChatScreen` **612 → 598 methods**
+(−2,060 / −14). `UI/Console_Modules/` now holds 11,363 lines across six
+controllers, three region widgets, and the frame helper.
+
+**The finding that reframed the programme, recorded here because it changes what
+the next wave should optimise for.** Waves 1 and 2 extracted ~4,900 lines, and
+`chat_screen.py` finished those waves *larger* than it started — roughly 5,500
+lines of concurrent feature work landed in it over the same window. Extraction
+cannot outrun growth. Every one of those lines went into the screen because the
+screen was the path of least resistance: `UI/Console_Modules/` either did not
+exist yet or was not yet the obvious destination. So wave 3 adds
+`Tests/Architecture/test_screen_size_ratchet.py`, a one-way ratchet that makes
+the current size a **ceiling** rather than a waypoint, with a second test that
+fails if a wave lands without lowering the budget. Budgets may only go down.
+This, not the extraction, is what makes a wave's gain stick.
+
+Two honest notes on wave 3's own numbers, since a spec that only records wins
+teaches the wrong lesson:
+
+- **`ConsoleTranscriptRegion` netted +1 line and +1 method.** The composed block
+  was 13 lines and the moved bodies 54; the delegations cost the same. It landed
+  anyway, on the ground that all three `#console-workspace-grid` children are now
+  region widgets built identically, and leaving one of three inline is the
+  asymmetry that costs when `compose_content` is attacked. It is a structural
+  change, not a size one — and the transcript's DOM now has **two** access
+  idioms (3 paths route through the region, 9 still `query_one` directly), a
+  transitional state a later wave should finish or deliberately stop, not read
+  as settled design.
+- **The wave's gain is tasks 1 (−1,328) and 3 (−759).** `_open_console_prompts_modal`
+  moved verbatim at 397 lines and took 15 of the prompts controller's 18 named
+  dependencies. Review judged the fan-out inherent rather than a wrong boundary —
+  but noted the method is a class in disguise (a modal callback-bundle factory
+  with 17 nested closures). Decomposing it is follow-up work, not a passenger on
+  a byte-fidelity wave.
+
+`__init__` remains the largest method on the class and grows with each wave's
+controller wiring — a real cost of this pattern, and the next wave's problem.
 
 ## Migration safety
 
@@ -265,8 +306,14 @@ Rules, all non-negotiable:
    **and** 235x52. Where such a test already exists for the region, it must pass
    unchanged; where none exists, it is written *before* the move, against the current
    code, so it is proven to pass before it is relied upon.
-4. **CSS moves with its region**, into `tldw_chatbook/css/features/`, and the bundle is regenerated via
-   `/private/tmp/tldw-venv/bin/python tldw_chatbook/css/build_css.py`. The bundle is never hand-edited.
+4. **CSS moves with its region**, and the bundle is regenerated via
+   `<repo>/.venv/bin/python tldw_chatbook/css/build_css.py`. The bundle is never hand-edited.
+   Two corrections from wave 3: the Console's CSS is not in `css/features/` —
+   `features/_console.tcss` does not exist, and the rules live in
+   `css/components/_agentic_terminal.tcss`; and no interpreter under
+   `/private/tmp` is usable (a cleaner destroyed one mid-programme, along with
+   an entire unpushed wave). Wave 3 moved no CSS at all: every Console rule is
+   id-scoped, so ids-verbatim extraction leaves the selectors matching.
 5. **Behaviour changes are forbidden in an extraction.** An extraction that also fixes a
    bug is two changes; do the fix separately, before or after, so a regression has one
    candidate cause.

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -1,0 +1,133 @@
+"""A one-way ratchet on the screens being decomposed.
+
+**Why this test exists.** Between 2026-08-02 and 2026-08-06 the Console
+decomposition extracted ~4,900 lines out of `chat_screen.py` across two
+reviewed waves — and the file ended up *larger* than when the work started,
+because ~5,500 lines of concurrent feature work landed in it over the same
+window. Every one of those lines went into the screen because the screen was
+the path of least resistance: `UI/Console_Modules/` did not exist yet, or was
+not yet the obvious place to put things.
+
+Extraction alone therefore cannot win. This test makes the screen's current
+size a *ceiling* rather than a waypoint, so a wave's gain cannot be silently
+re-consumed by the next feature.
+
+**This is a ratchet, not a limit.** The budgets below may only ever go DOWN.
+When a wave lands, lower them to the new measurement in the same PR. If you
+are here because CI failed, do NOT raise a number to make it pass — that
+defeats the entire mechanism and re-opens the hole this test was written to
+close.
+
+**What to do when this test fails.** Your new Console code belongs in
+`tldw_chatbook/UI/Console_Modules/`, next to `workspace.py`, `session.py`,
+`hands_free.py` and `dictation.py`. `DESIGN.md` §7 states the rule and the
+binding contract those controllers follow. A region that owns pixels becomes
+a widget; behaviour and state with no region become a controller. Both take
+their dependencies as named constructor callables rather than reaching back
+through the screen.
+
+Method count is tracked alongside line count deliberately: a screen can be
+made shorter without being made simpler (by compressing bodies), and it is
+the number of responsibilities the class holds — not its character count —
+that made it hard to change.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: path -> (class name, max lines, max methods in that class).
+#: LOWER these when a decomposition wave lands. Never raise them.
+#: Baselines recorded 2026-08-06, immediately after wave 2 merged (PR #1381).
+_BUDGETS: dict[str, tuple[str, int, int]] = {
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 20964, 612),
+}
+
+
+def _measure(rel_path: str, class_name: str) -> tuple[int, int]:
+    """Line count of a module and method count of one class inside it.
+
+    Args:
+        rel_path: Repo-relative path to the module.
+        class_name: The dominant class whose methods are counted.
+
+    Returns:
+        tuple[int, int]: ``(module line count, class method count)``.
+
+    Raises:
+        AssertionError: If the module or the named class is missing — either
+            means the budget entry is stale and must be updated deliberately
+            rather than silently skipped.
+    """
+    path = _REPO_ROOT / rel_path
+    assert path.exists(), f"{rel_path} not found; the budget entry is stale."
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    classes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    ]
+    assert classes, f"class {class_name} not found in {rel_path}; budget stale."
+    methods = [
+        node
+        for node in classes[0].body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    return len(source.splitlines()), len(methods)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("rel_path", sorted(_BUDGETS))
+def test_screen_does_not_grow_past_its_budget(rel_path: str) -> None:
+    class_name, max_lines, max_methods = _BUDGETS[rel_path]
+    lines, methods = _measure(rel_path, class_name)
+
+    guidance = (
+        f"\n\n{rel_path} is under a one-way size ratchet "
+        f"(Tests/Architecture/test_screen_size_ratchet.py).\n"
+        f"New Console code belongs in tldw_chatbook/UI/Console_Modules/ — see "
+        f"DESIGN.md section 7 for the region-vs-controller rule and the "
+        f"dependency-binding contract.\n"
+        f"Do NOT raise the budget to make this pass. Lower it when a "
+        f"decomposition wave lands."
+    )
+
+    assert lines <= max_lines, (
+        f"{rel_path} grew to {lines} lines (budget {max_lines}, "
+        f"+{lines - max_lines}).{guidance}"
+    )
+    assert methods <= max_methods, (
+        f"{class_name} grew to {methods} methods (budget {max_methods}, "
+        f"+{methods - max_methods}).{guidance}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("rel_path", sorted(_BUDGETS))
+def test_budget_is_not_left_slack_after_a_wave(rel_path: str) -> None:
+    """The recorded budget should track reality, not drift above it.
+
+    A ratchet with slack silently permits regrowth up to the stale number, so
+    a wave that forgets to lower its budget quietly buys the next feature
+    headroom it was never meant to have. The tolerance is deliberately loose
+    (200 lines / 10 methods) so ordinary in-file edits do not fail CI — it
+    only fires when a decomposition landed and its budget was not updated.
+    """
+    class_name, max_lines, max_methods = _BUDGETS[rel_path]
+    lines, methods = _measure(rel_path, class_name)
+
+    assert max_lines - lines <= 200, (
+        f"{rel_path} is {max_lines - lines} lines under its budget "
+        f"({lines} vs {max_lines}). A wave landed without lowering the "
+        f"ratchet — set it to {lines} so the gain is locked in."
+    )
+    assert max_methods - methods <= 10, (
+        f"{class_name} is {max_methods - methods} methods under its budget "
+        f"({methods} vs {max_methods}). Set it to {methods}."
+    )

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -44,9 +44,13 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: path -> (class name, max lines, max methods in that class).
 #: LOWER these when a decomposition wave lands. Never raise them.
 #: Lowered 2026-08-06 at the wave-3 close (message + transcript + prompts):
-#: 20,964/612 -> 18,904/598. First recorded immediately after wave 2 (PR #1381).
+#: 20,964/612 -> 18,905/598. First recorded immediately after wave 2 (PR #1381).
+#: The odd trailing 5 is real and worth leaving: the wave earned 18,904, and
+#: `c1c9146b7` on dev added a net line during the merge-day rebase. Measured
+#: after the rebase, not before -- a budget set against a stale base is a
+#: budget that fails the moment it lands.
 _BUDGETS: dict[str, tuple[str, int, int]] = {
-    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 18904, 598),
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 18905, 598),
 }
 
 

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -43,9 +43,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 #: path -> (class name, max lines, max methods in that class).
 #: LOWER these when a decomposition wave lands. Never raise them.
-#: Baselines recorded 2026-08-06, immediately after wave 2 merged (PR #1381).
+#: Lowered 2026-08-06 at the wave-3 close (message + transcript + prompts):
+#: 20,964/612 -> 18,904/598. First recorded immediately after wave 2 (PR #1381).
 _BUDGETS: dict[str, tuple[str, int, int]] = {
-    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 20964, 612),
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 18904, 598),
 }
 
 

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -35,6 +35,7 @@ that made it hard to change.
 from __future__ import annotations
 
 import ast
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -54,8 +55,15 @@ _BUDGETS: dict[str, tuple[str, int, int]] = {
 }
 
 
+@lru_cache(maxsize=None)
 def _measure(rel_path: str, class_name: str) -> tuple[int, int]:
     """Line count of a module and method count of one class inside it.
+
+    Cached: both tests below run over the same parametrization, so an
+    uncached version reads and `ast.parse`s every budgeted file twice
+    per session for no extra coverage. The cache is per-process, so
+    mutation-testing this ratchet (edit the file, re-run) still works --
+    just not by editing a file from inside a running test.
 
     Args:
         rel_path: Repo-relative path to the module.
@@ -90,6 +98,19 @@ def _measure(rel_path: str, class_name: str) -> tuple[int, int]:
 @pytest.mark.unit
 @pytest.mark.parametrize("rel_path", sorted(_BUDGETS))
 def test_screen_does_not_grow_past_its_budget(rel_path: str) -> None:
+    """The ceiling itself: a budgeted screen may not exceed its numbers.
+
+    Args:
+        rel_path: Repo-relative path of the budgeted module, supplied by
+            the parametrization over `_BUDGETS`.
+
+    Raises:
+        AssertionError: If the module grew past its line budget or the
+            class grew past its method budget. The message names
+            `UI/Console_Modules/` and `DESIGN.md` section 7, because the
+            fix is to put the new code somewhere else -- never to raise
+            the number.
+    """
     class_name, max_lines, max_methods = _BUDGETS[rel_path]
     lines, methods = _measure(rel_path, class_name)
 

--- a/Tests/Architecture/test_screen_size_ratchet.py
+++ b/Tests/Architecture/test_screen_size_ratchet.py
@@ -45,13 +45,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 #: path -> (class name, max lines, max methods in that class).
 #: LOWER these when a decomposition wave lands. Never raise them.
 #: Lowered 2026-08-06 at the wave-3 close (message + transcript + prompts):
-#: 20,964/612 -> 18,905/598. First recorded immediately after wave 2 (PR #1381).
-#: The odd trailing 5 is real and worth leaving: the wave earned 18,904, and
-#: `c1c9146b7` on dev added a net line during the merge-day rebase. Measured
-#: after the rebase, not before -- a budget set against a stale base is a
-#: budget that fails the moment it lands.
+#: 20,964/612 -> 18,909/598. First recorded immediately after wave 2 (PR #1381).
+#: The odd trailing 9 is real and worth leaving. The wave itself earned
+#: 18,904; `c1c9146b7` and `86ea8fcd5` on dev added a net 5 lines to the
+#: screen while wave 3 was in review -- in a single week, which is the whole
+#: reason this file exists. Always MEASURE after the final rebase: a budget
+#: set against a stale base is a budget that fails the moment it lands.
 _BUDGETS: dict[str, tuple[str, int, int]] = {
-    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 18905, 598),
+    "tldw_chatbook/UI/Screens/chat_screen.py": ("ChatScreen", 18909, 598),
 }
 
 

--- a/Tests/Chat/test_console_attachment_riders.py
+++ b/Tests/Chat/test_console_attachment_riders.py
@@ -165,13 +165,17 @@ class TestSaveImageToastEscaping:
 
     @staticmethod
     def _screen_with_message(tmp_path, monkeypatch, attachment_count=1):
-        from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+        from tldw_chatbook.UI.Console_Modules import message as message_module
+        from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
         from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
         markup_dir = tmp_path / "sav[e]dir"
         markup_dir.mkdir()
+        # `_save_console_message_image` moved to `ConsoleMessageController`
+        # (wave-3 console decomposition, task 1) -- it reads `get_cli_
+        # setting` from ITS OWN module namespace now, not `chat_screen`'s.
         monkeypatch.setattr(
-            chat_screen_module,
+            message_module,
             "get_cli_setting",
             lambda section, key=None, default=None: str(markup_dir),
         )
@@ -199,6 +203,37 @@ class TestSaveImageToastEscaping:
         screen.app_instance = SimpleNamespace(
             notify=lambda text, **kwargs: notices.append(str(text)),
             chachanotes_db=None,
+        )
+
+        def _unreached(*_args, **_kwargs):
+            raise AssertionError(
+                "_screen_with_message: this constructor callable is not "
+                "wired for real -- only _save_console_message_image is "
+                "exercised here."
+            )
+
+        screen._message = ConsoleMessageController(
+            screen,
+            app_instance=screen.app_instance,
+            chat_store_accessor=lambda: store,
+            current_chat_store_accessor=lambda: store,
+            ensure_console_chat_controller=_unreached,
+            current_chat_controller_accessor=lambda: None,
+            sync_native_console_chat_ui=_unreached,
+            active_session_is_ephemeral=_unreached,
+            active_native_console_session=_unreached,
+            current_console_conversation_id=_unreached,
+            active_console_provider_model_display=_unreached,
+            console_initial_session_title_for_workspace=_unreached,
+            console_change_review_run_id=_unreached,
+            open_change_review=_unreached,
+            start_console_transcript_sync_timer=_unreached,
+            clear_native_console_message_selection=_unreached,
+            regenerate_console_generation_variant=_unreached,
+            select_console_generation_variant=_unreached,
+            keep_console_generation_variant=_unreached,
+            handle_console_toggle_image_view=_unreached,
+            invalidate_console_persisted_rows_cache=_unreached,
         )
         return screen, message, notices
 

--- a/Tests/Chat/test_console_generation_actions.py
+++ b/Tests/Chat/test_console_generation_actions.py
@@ -44,6 +44,7 @@ from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSPlaybackEvent,
 )
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
@@ -106,25 +107,77 @@ def _bare_generation_screen(store: ConsoleChatStore) -> ChatScreen:
     """Build a ``ChatScreen`` shell wired for direct action-handler calls.
 
     Bypasses ``ChatScreen.__init__`` (no mounted Textual app needed) and
-    stubs the two seams the new handlers touch that WOULD need one:
+    stubs the seams the new handlers touch that WOULD need one:
     ``app_instance.notify`` (recorded, never raises) and
     ``_sync_native_console_chat_ui`` (an ``AsyncMock`` no-op -- the real
     method walks the live render/inspector pipeline, irrelevant to the pure
     store-mutation logic under test here).
+
+    ``handle_console_message_action`` moved to ``ConsoleMessageController``
+    (wave-3 console decomposition, task 1); ``screen._message`` is built the
+    same way ``screen._session`` already was here -- bypassing ITS
+    ``__init__`` too, with only the constructor callables this file's
+    generation-branch scenarios (regenerate/keep/variant/speak/speak-stop)
+    can actually reach wired for real. The four callables reaching
+    clusters these tests never touch (change-review, the transcript-sync
+    timer, native message selection, the conversation-browser cache) are
+    stubbed to raise -- a fail-loud guard if a future test in this file
+    starts exercising a branch that needs one for real, instead of a
+    silently-wrong no-op.
     """
     screen = ChatScreen.__new__(ChatScreen)
     screen._console_chat_store = store
     screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._session._chat_store_accessor = lambda: screen._console_chat_store
     screen._session._current_chat_store_accessor = lambda: screen._console_chat_store
-    screen._console_message_action_service = ConsoleMessageActionService()
-    screen._pending_console_delete_message_id = None
     screen.app_instance = SimpleNamespace(notify=lambda *a, **k: None)
     screen._sync_native_console_chat_ui = AsyncMock()
     # `_clear_console_composer_draft` now also syncs the slash-command popup;
     # on a detached screen (no `_nodes`) that query dies with AttributeError,
     # not the guarded QueryError — same class of seam as the sync stub above.
     screen._sync_console_command_popup = lambda: None
+
+    def _unreached(*_args, **_kwargs):
+        raise AssertionError(
+            "_bare_generation_screen: this constructor callable is not "
+            "wired for real -- the scenario reaching it needs its own stub."
+        )
+
+    screen._message = ConsoleMessageController(
+        screen,
+        app_instance=screen.app_instance,
+        chat_store_accessor=lambda: screen._console_chat_store,
+        current_chat_store_accessor=lambda: screen._console_chat_store,
+        ensure_console_chat_controller=_unreached,
+        current_chat_controller_accessor=lambda: None,
+        sync_native_console_chat_ui=screen._sync_native_console_chat_ui,
+        active_session_is_ephemeral=(
+            lambda: screen._session._console_active_session_is_ephemeral()
+        ),
+        active_native_console_session=_unreached,
+        current_console_conversation_id=_unreached,
+        active_console_provider_model_display=_unreached,
+        console_initial_session_title_for_workspace=lambda workspace_id: "",
+        console_change_review_run_id=_unreached,
+        open_change_review=_unreached,
+        start_console_transcript_sync_timer=_unreached,
+        clear_native_console_message_selection=_unreached,
+        regenerate_console_generation_variant=(
+            lambda message_id: screen._regenerate_console_generation_variant(
+                message_id
+            )
+        ),
+        select_console_generation_variant=(
+            lambda message, direction: screen._select_console_generation_variant(
+                message, direction=direction
+            )
+        ),
+        keep_console_generation_variant=(
+            lambda message: screen._keep_console_generation_variant(message)
+        ),
+        handle_console_toggle_image_view=_unreached,
+        invalidate_console_persisted_rows_cache=_unreached,
+    )
     return screen
 
 

--- a/Tests/Chat/test_console_generation_card.py
+++ b/Tests/Chat/test_console_generation_card.py
@@ -30,8 +30,8 @@ from tldw_chatbook.Chat.console_chat_models import (
     GenerationVariantMeta,
     MessageAttachment,
 )
+from Tests.UI.console_controller_stubs import stub_message_controller
 from tldw_chatbook.Chat.console_image_view import ConsoleImageRowSpec
-from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console.console_generation_card import (
     ConsoleGenerationCard,
@@ -60,36 +60,7 @@ def _bare_screen() -> ChatScreen:
     branch that needs one for real, rather than a silently-wrong no-op.
     """
     screen = ChatScreen.__new__(ChatScreen)
-
-    def _unreached(*_args, **_kwargs):
-        raise AssertionError(
-            "_bare_screen: this constructor callable is not wired for real "
-            "-- only _recent_console_image_messages is exercised here."
-        )
-
-    screen._message = ConsoleMessageController(
-        screen,
-        app_instance=None,
-        chat_store_accessor=_unreached,
-        current_chat_store_accessor=_unreached,
-        ensure_console_chat_controller=_unreached,
-        current_chat_controller_accessor=_unreached,
-        sync_native_console_chat_ui=_unreached,
-        active_session_is_ephemeral=_unreached,
-        active_native_console_session=_unreached,
-        current_console_conversation_id=_unreached,
-        active_console_provider_model_display=_unreached,
-        console_initial_session_title_for_workspace=_unreached,
-        console_change_review_run_id=_unreached,
-        open_change_review=_unreached,
-        start_console_transcript_sync_timer=_unreached,
-        clear_native_console_message_selection=_unreached,
-        regenerate_console_generation_variant=_unreached,
-        select_console_generation_variant=_unreached,
-        keep_console_generation_variant=_unreached,
-        handle_console_toggle_image_view=_unreached,
-        invalidate_console_persisted_rows_cache=_unreached,
-    )
+    stub_message_controller(screen, context="test_console_generation_card._bare_screen")
     return screen
 
 

--- a/Tests/Chat/test_console_generation_card.py
+++ b/Tests/Chat/test_console_generation_card.py
@@ -30,7 +30,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     GenerationVariantMeta,
     MessageAttachment,
 )
-from Tests.UI.console_controller_stubs import stub_message_controller
+from Tests.UI.console_controller_stubs import NO_APP, stub_message_controller
 from tldw_chatbook.Chat.console_image_view import ConsoleImageRowSpec
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console.console_generation_card import (
@@ -60,7 +60,13 @@ def _bare_screen() -> ChatScreen:
     branch that needs one for real, rather than a silently-wrong no-op.
     """
     screen = ChatScreen.__new__(ChatScreen)
-    stub_message_controller(screen, context="test_console_generation_card._bare_screen")
+    stub_message_controller(
+        screen,
+        context="test_console_generation_card._bare_screen",
+        # No harness app -- see the sibling note in
+        # test_console_rag_settings_modal; declared, not inferred.
+        app_instance=NO_APP,
+    )
     return screen
 
 

--- a/Tests/Chat/test_console_generation_card.py
+++ b/Tests/Chat/test_console_generation_card.py
@@ -31,6 +31,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     MessageAttachment,
 )
 from tldw_chatbook.Chat.console_image_view import ConsoleImageRowSpec
+from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console.console_generation_card import (
     ConsoleGenerationCard,
@@ -48,8 +49,48 @@ def _bare_screen() -> ChatScreen:
     ``_bare_console_screen`` pattern -- ``_ensure_console_image_view`` reads
     ``app_instance``/``app_config`` defensively via ``getattr`` specifically
     so tests can call it on an unmounted screen shell like this one.
+
+    ``_recent_console_image_messages`` moved to ``ConsoleMessageController``
+    (wave-3 console decomposition, task 1) and is reached here through
+    ``ChatScreen``'s delegation, so this shell needs a ``_message`` that
+    ``__init__`` would otherwise have built. That one method is pure (it
+    filters a list against ``IMAGE_CACHE_MAX_ENTRIES`` and touches no
+    injected seam), so every constructor callable is stubbed to raise --
+    a fail-loud guard if a future test in this file starts exercising a
+    branch that needs one for real, rather than a silently-wrong no-op.
     """
-    return ChatScreen.__new__(ChatScreen)
+    screen = ChatScreen.__new__(ChatScreen)
+
+    def _unreached(*_args, **_kwargs):
+        raise AssertionError(
+            "_bare_screen: this constructor callable is not wired for real "
+            "-- only _recent_console_image_messages is exercised here."
+        )
+
+    screen._message = ConsoleMessageController(
+        screen,
+        app_instance=None,
+        chat_store_accessor=_unreached,
+        current_chat_store_accessor=_unreached,
+        ensure_console_chat_controller=_unreached,
+        current_chat_controller_accessor=_unreached,
+        sync_native_console_chat_ui=_unreached,
+        active_session_is_ephemeral=_unreached,
+        active_native_console_session=_unreached,
+        current_console_conversation_id=_unreached,
+        active_console_provider_model_display=_unreached,
+        console_initial_session_title_for_workspace=_unreached,
+        console_change_review_run_id=_unreached,
+        open_change_review=_unreached,
+        start_console_transcript_sync_timer=_unreached,
+        clear_native_console_message_selection=_unreached,
+        regenerate_console_generation_variant=_unreached,
+        select_console_generation_variant=_unreached,
+        keep_console_generation_variant=_unreached,
+        handle_console_toggle_image_view=_unreached,
+        invalidate_console_persisted_rows_cache=_unreached,
+    )
+    return screen
 
 
 def _meta(

--- a/Tests/Chat/test_console_remote_images.py
+++ b/Tests/Chat/test_console_remote_images.py
@@ -77,12 +77,19 @@ from tldw_chatbook.Chat.console_chat_models import (
 
 
 def _bare_screen(*, enabled: bool):
+    from Tests.UI.console_controller_stubs import stub_message_controller
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = ChatScreen.__new__(ChatScreen)
     screen.app_instance = SimpleNamespace(
         app_config={"chat": {"images": {"render_remote_images": enabled}}}
     )
+    # `_build_console_image_specs` calls `_recent_console_image_messages`,
+    # which moved to `ConsoleMessageController` (wave-3 console
+    # decomposition, task 1) and is reached through `ChatScreen`'s
+    # delegation. `ChatScreen.__new__` skips the construction `__init__`
+    # would do. That method touches no injected seam, so nothing is wired.
+    stub_message_controller(screen, context="test_console_remote_images._bare_screen")
     return screen
 
 

--- a/Tests/UI/console_controller_stubs.py
+++ b/Tests/UI/console_controller_stubs.py
@@ -59,6 +59,11 @@ def _raiser(name: str, context: str):
     return _unreached
 
 
+#: Sentinel for "this fixture deliberately has no app". Distinct from the
+#: `None` a not-yet-wired shell yields, which is the bug this separates out.
+NO_APP: Any = object()
+
+
 def stub_message_controller(
     screen: Any,
     *,
@@ -74,7 +79,8 @@ def stub_message_controller(
         context: Label used in the failure message of unwired callables, so
             a fail-loud trip names the fixture it came from.
         app_instance: Value for the controller's ``app_instance`` snapshot.
-            Defaults to the shell's own ``app_instance`` when it has one.
+            Defaults to the shell's own ``app_instance``. Pass the sentinel
+            ``NO_APP`` to assert deliberately that this fixture has no app.
         **wired: Any subset of ``MESSAGE_CONTROLLER_CALLABLES``, wired for
             real. Everything omitted raises ``AssertionError`` when called.
 
@@ -85,6 +91,15 @@ def stub_message_controller(
         TypeError: If ``wired`` names something that is not a constructor
             callable -- a typo would otherwise silently leave that seam
             raising.
+        AssertionError: If no ``app_instance`` can be resolved and ``NO_APP``
+            was not passed. The controller SNAPSHOTS this value, so a fixture
+            that attaches before its harness app exists captures ``None``
+            forever -- and every moved body reads it through
+            ``getattr(self.app_instance, ..., None)``, so the test then takes
+            a silent default branch instead of failing. That already happened
+            once (a fixture attaching the controller a line too early), and
+            it is the one silent-default hole in an otherwise fail-loud
+            factory. Making it explicit costs one argument and closes it.
     """
     unknown = set(wired) - set(MESSAGE_CONTROLLER_CALLABLES)
     if unknown:
@@ -97,13 +112,19 @@ def stub_message_controller(
         name: wired.get(name, _raiser(name, context))
         for name in MESSAGE_CONTROLLER_CALLABLES
     }
+    resolved_app = (
+        app_instance
+        if app_instance is not None
+        else getattr(screen, "app_instance", None)
+    )
+    assert resolved_app is not None, (
+        f"{context}: no app_instance to snapshot. Attach the controller AFTER "
+        "the harness app sets screen.app_instance, or pass app_instance=NO_APP "
+        "to state that this fixture deliberately has none."
+    )
     controller = ConsoleMessageController(
         screen,
-        app_instance=(
-            app_instance
-            if app_instance is not None
-            else getattr(screen, "app_instance", None)
-        ),
+        app_instance=None if resolved_app is NO_APP else resolved_app,
         **kwargs,
     )
     screen._message = controller

--- a/Tests/UI/console_controller_stubs.py
+++ b/Tests/UI/console_controller_stubs.py
@@ -1,0 +1,110 @@
+"""Controller stubs for bypassed-``__init__`` ``ChatScreen`` test shells.
+
+Many Console tests build their screen with ``ChatScreen.__new__(ChatScreen)``
+and hand-set the handful of attributes the code under test reads, instead of
+mounting a real app. That shell never runs ``ChatScreen.__init__``, so it
+never gets the sub-controllers the Console decomposition introduced -- and
+any call into a method that was moved to one (reached through the screen's
+delegation under its original name) fails with
+``AttributeError: 'ChatScreen' object has no attribute '_message'``.
+
+``stub_message_controller`` closes that gap. Every constructor callable
+defaults to a raiser, so a shell only gets working behaviour for the seams
+the caller explicitly wires -- a test that wanders into an unwired branch
+fails loudly at the seam instead of silently taking a no-op path.
+
+Wave-3 console decomposition, task 1. Waves 2 and 3 keep expanding the set
+of moved methods, so prefer extending this module over hand-rolling another
+copy of the constructor call inside a test file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
+
+#: Every keyword-only dependency of ``ConsoleMessageController.__init__``
+#: except ``app_instance`` (a plain value, not a callable).
+MESSAGE_CONTROLLER_CALLABLES = (
+    "chat_store_accessor",
+    "current_chat_store_accessor",
+    "ensure_console_chat_controller",
+    "current_chat_controller_accessor",
+    "sync_native_console_chat_ui",
+    "active_session_is_ephemeral",
+    "active_native_console_session",
+    "current_console_conversation_id",
+    "active_console_provider_model_display",
+    "console_initial_session_title_for_workspace",
+    "console_change_review_run_id",
+    "open_change_review",
+    "start_console_transcript_sync_timer",
+    "clear_native_console_message_selection",
+    "regenerate_console_generation_variant",
+    "select_console_generation_variant",
+    "keep_console_generation_variant",
+    "handle_console_toggle_image_view",
+    "invalidate_console_persisted_rows_cache",
+)
+
+
+def _raiser(name: str, context: str):
+    def _unreached(*_args, **_kwargs):
+        raise AssertionError(
+            f"{context}: constructor callable {name!r} is not wired for real "
+            "-- the scenario reaching it needs its own stub."
+        )
+
+    return _unreached
+
+
+def stub_message_controller(
+    screen: Any,
+    *,
+    context: str = "stub_message_controller",
+    app_instance: Any = None,
+    **wired: Any,
+) -> ConsoleMessageController:
+    """Attach a ``ConsoleMessageController`` to a bare ``ChatScreen`` shell.
+
+    Args:
+        screen: The ``ChatScreen.__new__(ChatScreen)`` shell. Gets its
+            ``_message`` attribute set as a side effect.
+        context: Label used in the failure message of unwired callables, so
+            a fail-loud trip names the fixture it came from.
+        app_instance: Value for the controller's ``app_instance`` snapshot.
+            Defaults to the shell's own ``app_instance`` when it has one.
+        **wired: Any subset of ``MESSAGE_CONTROLLER_CALLABLES``, wired for
+            real. Everything omitted raises ``AssertionError`` when called.
+
+    Returns:
+        The controller, already assigned to ``screen._message``.
+
+    Raises:
+        TypeError: If ``wired`` names something that is not a constructor
+            callable -- a typo would otherwise silently leave that seam
+            raising.
+    """
+    unknown = set(wired) - set(MESSAGE_CONTROLLER_CALLABLES)
+    if unknown:
+        raise TypeError(
+            f"stub_message_controller got unknown callable(s) {sorted(unknown)}; "
+            f"expected a subset of {list(MESSAGE_CONTROLLER_CALLABLES)}"
+        )
+
+    kwargs = {
+        name: wired.get(name, _raiser(name, context))
+        for name in MESSAGE_CONTROLLER_CALLABLES
+    }
+    controller = ConsoleMessageController(
+        screen,
+        app_instance=(
+            app_instance
+            if app_instance is not None
+            else getattr(screen, "app_instance", None)
+        ),
+        **kwargs,
+    )
+    screen._message = controller
+    return controller

--- a/Tests/UI/test_chat_screen_worker_groups.py
+++ b/Tests/UI/test_chat_screen_worker_groups.py
@@ -15,13 +15,45 @@ from pathlib import Path
 
 import pytest
 
-CHAT_SCREEN_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "tldw_chatbook"
-    / "UI"
-    / "Screens"
-    / "chat_screen.py"
-)
+_UI_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook" / "UI"
+CHAT_SCREEN_PATH = _UI_ROOT / "Screens" / "chat_screen.py"
+_CONSOLE_MODULES_DIR = _UI_ROOT / "Console_Modules"
+
+
+def _guarded_paths() -> list[Path]:
+    """Every file that may dispatch a Console worker.
+
+    The screen alone is no longer the answer, and assuming it was let this
+    guard erode silently. The decomposition moved Console clusters into
+    ``UI/Console_Modules/``, taking their ``run_worker`` sites with them: by
+    the wave-3 close only 2 of the 6 run-coroutine dispatch sites were still
+    in ``chat_screen.py``, and 7 exclusive-worker sites had left the scanned
+    scope entirely — while both tests below stayed green, because what
+    remained still satisfied them. A guard that shrinks with its subject
+    certifies an invariant nobody is checking.
+
+    Returns:
+        list[Path]: `chat_screen.py` plus every `Console_Modules` module.
+
+    Raises:
+        AssertionError: If either half is missing — a rename that emptied
+            this list would otherwise silently restore the blind spot.
+    """
+    assert CHAT_SCREEN_PATH.exists(), f"{CHAT_SCREEN_PATH} not found."
+    modules = sorted(
+        path
+        for path in _CONSOLE_MODULES_DIR.glob("*.py")
+        if path.name != "__init__.py"
+    )
+    assert modules, (
+        f"no modules found in {_CONSOLE_MODULES_DIR}; this guard's scope "
+        "collapsed back to the screen alone."
+    )
+    return [CHAT_SCREEN_PATH, *modules]
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(_UI_ROOT.parents[1]))
 
 
 def _call_name(node: ast.Call) -> str:
@@ -65,14 +97,18 @@ def test_every_exclusive_worker_on_chat_screen_names_a_group():
     """An exclusive worker without group= joins the default group and cancels
     (or is cancelled by) every other ungrouped exclusive worker on the screen
     — including the Console send worker mid-stream. Never ship one."""
-    tree = ast.parse(CHAT_SCREEN_PATH.read_text(encoding="utf-8"))
-    ungrouped = [
-        lineno for lineno, has_group in _exclusive_worker_sites(tree) if not has_group
-    ]
+    ungrouped: list[str] = []
+    for path in _guarded_paths():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        ungrouped.extend(
+            f"{_rel(path)}:{lineno}"
+            for lineno, has_group in _exclusive_worker_sites(tree)
+            if not has_group
+        )
     assert ungrouped == [], (
         "exclusive worker (run_worker or @work) without an explicit group= at "
-        f"chat_screen.py lines {ungrouped} — these share Textual's default "
-        "worker group and silently cancel each other (see TASK-228)."
+        f"{ungrouped} — these share Textual's default worker group and "
+        "silently cancel each other (see TASK-228)."
     )
 
 
@@ -109,7 +145,6 @@ def test_console_run_and_sync_workers_use_disjoint_groups():
     a group with the run workers. The names-a-group guard alone would pass if
     someone put a sync kick into group="console-run" — and the collision this
     branch fixed would silently return."""
-    tree = ast.parse(CHAT_SCREEN_PATH.read_text(encoding="utf-8"))
     RUN_COROUTINES = {
         "_submit_console_native_draft",
         "_retry_console_message",
@@ -125,20 +160,34 @@ def test_console_run_and_sync_workers_use_disjoint_groups():
     SYNC_COROUTINE = "_sync_native_console_chat_ui"
     run_groups: set[str] = set()
     sync_groups: set[str] = set()
-    for node in ast.walk(tree):
-        if not (isinstance(node, ast.Call) and _call_name(node) == "run_worker"):
-            continue
-        if not node.args:
-            continue
-        first = node.args[0]
-        target = _call_name(first) if isinstance(first, ast.Call) else ""
-        keywords = {kw.arg: kw.value for kw in node.keywords if kw.arg}
-        group = keywords.get("group")
-        group_name = _group_family(group)
-        if target in RUN_COROUTINES:
-            run_groups.add(group_name)
-        elif target == SYNC_COROUTINE:
-            sync_groups.add(group_name)
+    seen_run_targets: set[str] = set()
+    for path in _guarded_paths():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and _call_name(node) == "run_worker"):
+                continue
+            if not node.args:
+                continue
+            first = node.args[0]
+            target = _call_name(first) if isinstance(first, ast.Call) else ""
+            keywords = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+            group = keywords.get("group")
+            group_name = _group_family(group)
+            if target in RUN_COROUTINES:
+                run_groups.add(group_name)
+                seen_run_targets.add(target)
+            elif target == SYNC_COROUTINE:
+                sync_groups.add(group_name)
+    # Every named run coroutine must actually be FOUND somewhere in scope.
+    # Without this the set above degrades gracefully as sites move out of
+    # the scanned files -- which is exactly how this guard lost 4 of its 6
+    # dispatch sites while staying green.
+    assert seen_run_targets == RUN_COROUTINES, (
+        "run-coroutine dispatch sites not found in the guarded files: "
+        f"{sorted(RUN_COROUTINES - seen_run_targets)}. Either the dispatch "
+        "moved outside chat_screen.py + UI/Console_Modules/, or it was "
+        "renamed; widen _guarded_paths() rather than trimming this set."
+    )
     assert run_groups == {"console-run"}, run_groups
     assert sync_groups == {"console-sync"}, sync_groups
     # Explicit disjointness, independent of the exact-set assertions above:

--- a/Tests/UI/test_console_citation_sources.py
+++ b/Tests/UI/test_console_citation_sources.py
@@ -64,9 +64,9 @@ from tldw_chatbook.Constants import (
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
 )
+from Tests.UI.console_controller_stubs import stub_message_controller
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
-from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console.console_citation_sources_modal import (
     ConsoleCitationSourceRow,
@@ -439,53 +439,26 @@ async def _async_noop() -> None:
 def _attach_message_controller(screen: ChatScreen) -> None:
     """Give a bypassed-``__init__`` screen shell its ``_message`` controller.
 
-    The citation cluster stays screen-owned, but three of the members it
-    reaches moved to ``ConsoleMessageController`` (wave-3 console
-    decomposition, task 1) and are reached here through ``ChatScreen``'s
-    delegations/proxy properties: ``_native_console_messages``,
+    The citation cluster stays screen-owned, but several members it reaches
+    moved to ``ConsoleMessageController`` (wave-3 console decomposition,
+    task 1) and are reached here through ``ChatScreen``'s delegations/proxy
+    properties: ``_native_console_messages``,
     ``_console_citation_message_body``, and the
     ``_console_original_attempt_previews``/``_pending_console_swipe_
     selection`` state these tests assign directly. ``ChatScreen.__new__``
-    skips the construction ``__init__`` would do, so it is done here --
-    mirroring the same fixture pattern in ``Tests/Chat/test_console_
-    generation_actions.py`` and ``Tests/UI/test_console_native_chat_flow.py``.
+    skips the construction ``__init__`` would do, so it is done here.
 
-    Only the store accessors are wired for real (that is all
-    ``_native_console_messages`` reads). Every other constructor callable
-    raises -- a fail-loud guard if a future test here starts exercising a
-    branch that needs one, rather than a silently-wrong no-op.
+    Only the store accessors are wired for real -- that is all
+    ``_native_console_messages`` reads.
     """
-
-    def _unreached(*_args, **_kwargs):
-        raise AssertionError(
-            "_attach_message_controller: this constructor callable is not "
-            "wired for real -- the scenario reaching it needs its own stub."
-        )
-
-    screen._message = ConsoleMessageController(
+    stub_message_controller(
         screen,
-        app_instance=getattr(screen, "app_instance", None),
+        context="test_console_citation_sources._bare_screen",
         chat_store_accessor=lambda: screen._console_chat_store,
         current_chat_store_accessor=lambda: screen._console_chat_store,
-        ensure_console_chat_controller=_unreached,
         current_chat_controller_accessor=lambda: getattr(
             screen, "_console_chat_controller", None
         ),
-        sync_native_console_chat_ui=_unreached,
-        active_session_is_ephemeral=_unreached,
-        active_native_console_session=_unreached,
-        current_console_conversation_id=_unreached,
-        active_console_provider_model_display=_unreached,
-        console_initial_session_title_for_workspace=_unreached,
-        console_change_review_run_id=_unreached,
-        open_change_review=_unreached,
-        start_console_transcript_sync_timer=_unreached,
-        clear_native_console_message_selection=_unreached,
-        regenerate_console_generation_variant=_unreached,
-        select_console_generation_variant=_unreached,
-        keep_console_generation_variant=_unreached,
-        handle_console_toggle_image_view=_unreached,
-        invalidate_console_persisted_rows_cache=_unreached,
     )
 
 

--- a/Tests/UI/test_console_citation_sources.py
+++ b/Tests/UI/test_console_citation_sources.py
@@ -1285,7 +1285,6 @@ def _citation_harness(
     screen._console_chat_store = _FakeStore([message])
     screen._console_citation_counts = {"assistant-1": 2}
     screen._console_citation_request_generation = 1
-    _attach_message_controller(screen)
     app = _CitationHarnessApp(
         screen,
         repository,
@@ -1293,6 +1292,12 @@ def _citation_harness(
         [message],
         {"assistant-1": 2},
     )
+    # After the harness app, not before: the controller snapshots
+    # ``app_instance``, which ``_CitationHarnessApp.__init__`` is what sets on
+    # the screen. Attaching first snapshots ``None``, and every moved method
+    # that reads it via ``getattr(..., default)`` would then silently take the
+    # default branch instead of failing loudly.
+    _attach_message_controller(screen)
     return app, screen, repository, message
 
 

--- a/Tests/UI/test_console_citation_sources.py
+++ b/Tests/UI/test_console_citation_sources.py
@@ -66,6 +66,7 @@ from tldw_chatbook.Constants import (
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
+from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console.console_citation_sources_modal import (
     ConsoleCitationSourceRow,
@@ -435,6 +436,59 @@ async def _async_noop() -> None:
     return None
 
 
+def _attach_message_controller(screen: ChatScreen) -> None:
+    """Give a bypassed-``__init__`` screen shell its ``_message`` controller.
+
+    The citation cluster stays screen-owned, but three of the members it
+    reaches moved to ``ConsoleMessageController`` (wave-3 console
+    decomposition, task 1) and are reached here through ``ChatScreen``'s
+    delegations/proxy properties: ``_native_console_messages``,
+    ``_console_citation_message_body``, and the
+    ``_console_original_attempt_previews``/``_pending_console_swipe_
+    selection`` state these tests assign directly. ``ChatScreen.__new__``
+    skips the construction ``__init__`` would do, so it is done here --
+    mirroring the same fixture pattern in ``Tests/Chat/test_console_
+    generation_actions.py`` and ``Tests/UI/test_console_native_chat_flow.py``.
+
+    Only the store accessors are wired for real (that is all
+    ``_native_console_messages`` reads). Every other constructor callable
+    raises -- a fail-loud guard if a future test here starts exercising a
+    branch that needs one, rather than a silently-wrong no-op.
+    """
+
+    def _unreached(*_args, **_kwargs):
+        raise AssertionError(
+            "_attach_message_controller: this constructor callable is not "
+            "wired for real -- the scenario reaching it needs its own stub."
+        )
+
+    screen._message = ConsoleMessageController(
+        screen,
+        app_instance=getattr(screen, "app_instance", None),
+        chat_store_accessor=lambda: screen._console_chat_store,
+        current_chat_store_accessor=lambda: screen._console_chat_store,
+        ensure_console_chat_controller=_unreached,
+        current_chat_controller_accessor=lambda: getattr(
+            screen, "_console_chat_controller", None
+        ),
+        sync_native_console_chat_ui=_unreached,
+        active_session_is_ephemeral=_unreached,
+        active_native_console_session=_unreached,
+        current_console_conversation_id=_unreached,
+        active_console_provider_model_display=_unreached,
+        console_initial_session_title_for_workspace=_unreached,
+        console_change_review_run_id=_unreached,
+        open_change_review=_unreached,
+        start_console_transcript_sync_timer=_unreached,
+        clear_native_console_message_selection=_unreached,
+        regenerate_console_generation_variant=_unreached,
+        select_console_generation_variant=_unreached,
+        keep_console_generation_variant=_unreached,
+        handle_console_toggle_image_view=_unreached,
+        invalidate_console_persisted_rows_cache=_unreached,
+    )
+
+
 def _bare_screen(
     messages: list[ConsoleChatMessage],
     repository: object | None,
@@ -455,6 +509,7 @@ def _bare_screen(
     )
     screen._sync_native_console_transcript_to_legacy_surface = _async_noop
     screen._sync_native_console_chat_ui = _async_noop
+    _attach_message_controller(screen)
     return screen
 
 
@@ -1257,6 +1312,7 @@ def _citation_harness(
     screen._console_chat_store = _FakeStore([message])
     screen._console_citation_counts = {"assistant-1": 2}
     screen._console_citation_request_generation = 1
+    _attach_message_controller(screen)
     app = _CitationHarnessApp(
         screen,
         repository,

--- a/Tests/UI/test_console_command_composer.py
+++ b/Tests/UI/test_console_command_composer.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Prompt_Management.prompt_scope_service import (
     PromptScopeService,
 )
 from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
+from tldw_chatbook.UI.Console_Modules.prompts import ConsolePromptsController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
 from tldw_chatbook.Widgets.Console.console_prompt_picker_modal import (
@@ -98,64 +99,77 @@ async def _spy_submit_draft(console) -> AsyncMock:
 
 @pytest.mark.asyncio
 async def test_console_prompt_name_resolution_refuses_recipe_candidates() -> None:
-    screen = SimpleNamespace(
+    # `_resolve_console_prompt_by_name` moved to `ConsolePromptsController`
+    # (wave-3 console decomposition, task 3); still exercised unbound against
+    # a hand-built `self`, now the controller's rather than the screen's.
+    controller = SimpleNamespace(
         _console_prompt_search=AsyncMock(return_value=[_recipe_record()]),
-        _is_recipe_prompt_record=ChatScreen._is_recipe_prompt_record,
+        _is_recipe_prompt_record=ConsolePromptsController._is_recipe_prompt_record,
     )
 
-    resolved = await ChatScreen._resolve_console_prompt_by_name(screen, "Outcome first")
+    resolved = await ConsolePromptsController._resolve_console_prompt_by_name(
+        controller, "Outcome first"
+    )
 
     assert resolved is None
 
 
 @pytest.mark.asyncio
 async def test_prompt_command_rejects_recipe_before_composer_mutation() -> None:
-    screen = SimpleNamespace(
+    controller = SimpleNamespace(
         _resolve_console_prompt_by_name=AsyncMock(return_value=_recipe_record()),
         _insert_prompt_text_into_composer=Mock(),
         _open_console_prompt_picker_for_insert=AsyncMock(),
         _append_native_console_system_message=AsyncMock(),
-        _is_recipe_prompt_record=ChatScreen._is_recipe_prompt_record,
-        _RECIPE_EXECUTION_BLOCKED_COPY=ChatScreen._RECIPE_EXECUTION_BLOCKED_COPY,
+        _is_recipe_prompt_record=ConsolePromptsController._is_recipe_prompt_record,
+        _RECIPE_EXECUTION_BLOCKED_COPY=(
+            ConsolePromptsController._RECIPE_EXECUTION_BLOCKED_COPY
+        ),
     )
 
-    await ChatScreen._console_command_insert_prompt(
-        screen, SimpleNamespace(args="Outcome first")
+    await ConsolePromptsController._console_command_insert_prompt(
+        controller, SimpleNamespace(args="Outcome first")
     )
 
-    screen._insert_prompt_text_into_composer.assert_not_called()
-    screen._open_console_prompt_picker_for_insert.assert_not_awaited()
-    screen._append_native_console_system_message.assert_awaited_once()
+    controller._insert_prompt_text_into_composer.assert_not_called()
+    controller._open_console_prompt_picker_for_insert.assert_not_awaited()
+    controller._append_native_console_system_message.assert_awaited_once()
     assert (
         "recipe"
-        in screen._append_native_console_system_message.await_args.args[0].lower()
+        in controller._append_native_console_system_message.await_args.args[0].lower()
     )
 
 
 @pytest.mark.asyncio
 async def test_system_command_rejects_recipe_before_session_or_draft_mutation() -> None:
-    screen = SimpleNamespace(
+    # The `self._session._apply_console_session_system_prompt(...)` reach in
+    # the pre-move body is now the controller's own same-named session-seam
+    # property (wave-3 console decomposition, task 3), so the fake `self`
+    # carries it directly instead of behind a `_session` namespace.
+    controller = SimpleNamespace(
         _resolve_console_prompt_by_name=AsyncMock(return_value=_recipe_record()),
         _open_console_system_prompt_editor=AsyncMock(),
         _open_console_prompt_picker_for_apply_system=AsyncMock(),
         _append_native_console_system_message=AsyncMock(),
-        _session=SimpleNamespace(_apply_console_session_system_prompt=Mock()),
+        _apply_console_session_system_prompt=Mock(),
         _clear_console_composer_draft=Mock(),
-        _is_recipe_prompt_record=ChatScreen._is_recipe_prompt_record,
-        _RECIPE_EXECUTION_BLOCKED_COPY=ChatScreen._RECIPE_EXECUTION_BLOCKED_COPY,
+        _is_recipe_prompt_record=ConsolePromptsController._is_recipe_prompt_record,
+        _RECIPE_EXECUTION_BLOCKED_COPY=(
+            ConsolePromptsController._RECIPE_EXECUTION_BLOCKED_COPY
+        ),
     )
 
-    await ChatScreen._console_command_apply_system(
-        screen, SimpleNamespace(args="Outcome first")
+    await ConsolePromptsController._console_command_apply_system(
+        controller, SimpleNamespace(args="Outcome first")
     )
 
-    screen._session._apply_console_session_system_prompt.assert_not_called()
-    screen._clear_console_composer_draft.assert_not_called()
-    screen._open_console_prompt_picker_for_apply_system.assert_not_awaited()
-    screen._append_native_console_system_message.assert_awaited_once()
+    controller._apply_console_session_system_prompt.assert_not_called()
+    controller._clear_console_composer_draft.assert_not_called()
+    controller._open_console_prompt_picker_for_apply_system.assert_not_awaited()
+    controller._append_native_console_system_message.assert_awaited_once()
     assert (
         "recipe"
-        in screen._append_native_console_system_message.await_args.args[0].lower()
+        in controller._append_native_console_system_message.await_args.args[0].lower()
     )
 
 

--- a/Tests/UI/test_console_composer_history.py
+++ b/Tests/UI/test_console_composer_history.py
@@ -326,7 +326,7 @@ async def test_console_ghost_text_renders_and_right_arrow_accepts(
     history_path = tmp_path / "prompt_history.jsonl"
     _seed_history_file(history_path, "explain quantum computing")
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.chat_screen.default_prompt_history_path",
+        "tldw_chatbook.UI.Console_Modules.prompts.default_prompt_history_path",
         lambda: history_path,
     )
     app = _build_test_app()
@@ -373,7 +373,7 @@ async def test_console_up_down_recall_gated_to_boundary_rows(tmp_path, monkeypat
     history_path = tmp_path / "prompt_history.jsonl"
     _seed_history_file(history_path, "first prompt", "second prompt")
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.chat_screen.default_prompt_history_path",
+        "tldw_chatbook.UI.Console_Modules.prompts.default_prompt_history_path",
         lambda: history_path,
     )
     app = _build_test_app()
@@ -429,7 +429,7 @@ async def test_console_send_records_to_shared_prompt_history(tmp_path, monkeypat
 
     history_path = tmp_path / "prompt_history.jsonl"
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.chat_screen.default_prompt_history_path",
+        "tldw_chatbook.UI.Console_Modules.prompts.default_prompt_history_path",
         lambda: history_path,
     )
     gateway = CapturingGateway()

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1859,6 +1859,8 @@ def _bare_console_screen_for_restore(app_instance=None) -> ChatScreen:
         ChatScreen: A bare ChatScreen instance suitable for unit-level
             restore-path testing.
     """
+    from Tests.UI.console_controller_stubs import stub_message_controller
+
     screen = ChatScreen.__new__(ChatScreen)
     screen.app_instance = app_instance
     screen._console_chat_store = ConsoleChatStore()
@@ -1866,6 +1868,15 @@ def _bare_console_screen_for_restore(app_instance=None) -> ChatScreen:
     screen._console_visible_draft_session_id = None
     screen._console_composer_or_none = lambda: None
     screen._task_resume_state = TaskResumeState()
+    # `_restore_native_console_state` calls the three
+    # `_rehydrate_console_message_*` helpers, which moved to
+    # `ConsoleMessageController` (wave-3 console decomposition, task 1) and
+    # are reached through `ChatScreen`'s delegations. `ChatScreen.__new__`
+    # skips the construction `__init__` would do. Those three read only
+    # `app_instance`, so nothing else is wired.
+    stub_message_controller(
+        screen, context="test_console_live_work_handoffs._bare_console_screen"
+    )
     return screen
 
 

--- a/Tests/UI/test_console_message_controller.py
+++ b/Tests/UI/test_console_message_controller.py
@@ -1,0 +1,202 @@
+"""Characterisation tests for the Console message cluster (wave-3 task 1).
+
+Run GREEN against unmodified `ChatScreen` before `ConsoleMessageController`
+exists (`tldw_chatbook/UI/Console_Modules/message.py`) -- see
+`.superpowers/sdd/2026-08-06-console-decomposition-wave3/progress.md` for the
+mandatory characterise-before-extract sequence this file satisfies. Every
+assertion below reads the ACTUAL persisted result (`ConsoleChatStore` rows),
+never widget/DOM state, and drives the real screen methods end-to-end --
+nothing here is monkeypatched.
+
+Covers, at minimum, the two surfaces the wave-3 brief calls out explicitly:
+the send/receive path (`test_console_message_send_persists_user_and_
+assistant_rows`) and at least one `handle_console_message_action` branch
+(delete + feedback-up below). Also pins the pure serialize/restore round
+trip and the sibling-variant navigation helper, since both move as part of
+the same cluster and have no other direct coverage of their post-move
+public surface (`ChatScreen._serialize_console_message` /
+`ChatScreen._restore_console_message` / `ChatScreen._select_console_message_
+variant`, all still reachable under their pre-move names after the move --
+see the extraction report's delegation table).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_destination_shells import _build_test_app
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from Tests.UI.test_console_native_chat_flow import (
+    CapturingGateway,
+    _configure_native_ready_console,
+    _select_llamacpp_console,
+    _wait_for_selector,
+    _wait_for_text,
+)
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar, ConsoleTranscript
+
+
+@pytest.mark.asyncio
+async def test_console_message_send_persists_user_and_assistant_rows():
+    """Send/receive path: a real send queues a user turn and persists the
+    streamed assistant reply as store rows, not just visible text."""
+    gateway = CapturingGateway(chunks=("hello ", "there"))
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("characterisation probe")
+
+        console.query_one("#console-send-message", Button).press()
+        await _wait_for_text(console, pilot, "hello there")
+
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
+        messages = store.messages_for_session(session_id)
+
+    user_rows = [m for m in messages if m.role == ConsoleMessageRole.USER]
+    assistant_rows = [m for m in messages if m.role == ConsoleMessageRole.ASSISTANT]
+    assert any(row.content == "characterisation probe" for row in user_rows)
+    assert any(
+        row.content == "hello there" and row.status == "complete"
+        for row in assistant_rows
+    )
+
+
+@pytest.mark.asyncio
+async def test_console_message_action_delete_removes_persisted_row():
+    """`handle_console_message_action`'s delete branch: two presses actually
+    remove the row from the store (persisted result), not just the widget."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+        )
+        await console._sync_native_console_chat_ui()
+        # `_sync_console_pending_delete_confirmation` resets the armed id the
+        # moment it disagrees with the transcript's own selection -- an
+        # unselected row would silently disarm between the two presses below.
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.select_message(message.id)
+        await console._sync_native_console_chat_ui()
+
+        event = SimpleNamespace(
+            button=SimpleNamespace(
+                id=f"console-message-action-delete-{message.id}"
+            ),
+            stop=Mock(),
+        )
+        # First press only arms the confirmation -- nothing removed yet.
+        handled = await console.handle_console_message_action(event)
+        assert handled is True
+        assert message in store.messages_for_session(session.id)
+
+        # Second press on the same id actually deletes.
+        handled_again = await console.handle_console_message_action(event)
+        assert handled_again is True
+
+    assert message not in store.messages_for_session(session.id)
+
+
+@pytest.mark.asyncio
+async def test_console_message_action_feedback_persists_to_store():
+    """`handle_console_message_action`'s feedback branch writes through to
+    the store's own `feedback` field, not just `_last_console_action`."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id, role=ConsoleMessageRole.ASSISTANT, content="answer"
+        )
+        await console._sync_native_console_chat_ui()
+
+        event = SimpleNamespace(
+            button=SimpleNamespace(
+                id=f"console-message-action-feedback-up-{message.id}"
+            ),
+            stop=Mock(),
+        )
+        handled = await console.handle_console_message_action(event)
+        assert handled is True
+
+    assert store.get_message(message.id).feedback == "up"
+
+
+def test_console_message_serialize_restore_round_trip():
+    """Pure (de)serialization: a round trip through the screen-state payload
+    shape preserves role/content/status/persisted id."""
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="round trip me",
+    )
+
+    payload = ChatScreen._serialize_console_message(message)
+    assert payload["role"] == "user"
+    assert payload["content"] == "round trip me"
+
+    restored = ChatScreen._restore_console_message(payload)
+    assert restored is not None
+    assert restored.role is ConsoleMessageRole.USER
+    assert restored.content == "round trip me"
+    assert restored.status == "complete"
+
+
+def test_console_message_select_variant_moves_active_leaf():
+    """`_select_console_message_variant` moves the store's active leaf to
+    the target sibling -- persisted store state, not a transcript selection.
+
+    Mirrors `Tests/Chat/test_console_sibling_nav.py`'s established
+    unmounted-`ChatScreen(app)` pattern: the method under test only touches
+    `self._ensure_console_chat_store()`, so no Textual mount is required.
+    """
+    app = _build_test_app()
+    screen = ChatScreen(app)
+    store = screen._ensure_console_chat_store()
+    session = store.ensure_session(title="t")
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    first = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="first"
+    )
+    second = store.create_sibling(
+        first.id, role=ConsoleMessageRole.ASSISTANT, content="second"
+    )
+    assert store.active_leaf(session.id) == second.id
+
+    target = screen._select_console_message_variant(
+        second.id, direction="variant-previous"
+    )
+
+    assert target == first.id
+    assert store.active_leaf(session.id) == first.id

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -59,7 +59,9 @@ from tldw_chatbook.UI.Screens.chat_screen import (
     ChatScreen,
 )
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
+import tldw_chatbook.UI.Console_Modules.message as message_module
 import tldw_chatbook.UI.Console_Modules.session as session_module
+from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
 from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
@@ -5572,7 +5574,7 @@ def test_console_save_as_destinations_never_show_a_literal_none_reason():
     assistant = SimpleNamespace(role=ConsoleMessageRole.ASSISTANT, content="answer")
     screen._console_active_session_is_ephemeral = lambda: True
 
-    with patch.object(chat_screen_module, "blocked_reason", lambda *a, **k: None):
+    with patch.object(message_module, "blocked_reason", lambda *a, **k: None):
         destinations = screen._console_save_as_destinations(assistant)
 
     reasons = {d.label: d.reason for d in destinations}
@@ -5618,7 +5620,7 @@ def test_console_save_as_labels_are_all_registered_in_the_ephemeral_gate():
         requested_action_ids.append(action_id)
         return real_blocked_reason(action_id, ephemeral=ephemeral)
 
-    with patch.object(chat_screen_module, "blocked_reason", spy):
+    with patch.object(message_module, "blocked_reason", spy):
         destinations = screen._console_save_as_destinations(assistant)
 
     assert requested_action_ids, (
@@ -5791,7 +5793,7 @@ async def test_console_selected_message_save_as_chatbook_registers_console_artif
     host = ConsoleHarness(app)
 
     with patch(
-        "tldw_chatbook.UI.Screens.chat_screen.resolve_console_artifact_owner_request",
+        "tldw_chatbook.UI.Console_Modules.message.resolve_console_artifact_owner_request",
         return_value=owner_request,
     ):
         async with host.run_test(size=(160, 48)) as pilot:
@@ -9604,6 +9606,69 @@ def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
     screen._console_visible_draft_session_id = None
     screen._console_composer_or_none = lambda: None
     screen._task_resume_state = TaskResumeState()
+    # `_rehydrate_console_message_image`/`_attachments` read `self.
+    # app_instance.chachanotes_db` (best-effort; both tolerate `None`).
+    screen.app_instance = SimpleNamespace(
+        notify=lambda *a, **k: None, chachanotes_db=None
+    )
+
+    # `_restore_native_console_state`'s message-rehydration calls
+    # (`_rehydrate_console_message_image`/`_attachments`/`_generation_
+    # metadata`) and several tests using this helper directly
+    # (`_save_console_message_image`, `_console_save_as_destinations`,
+    # `_save_console_message_as_chatbook`) moved to `ConsoleMessageController`
+    # (wave-3 console decomposition, task 1). `screen._message` is built
+    # the same bare-`__new__` way `screen._session` already is above, with
+    # every constructor callable wired for real -- unlike `_bare_generation_
+    # screen` in `Tests/Chat/test_console_generation_actions.py`, this
+    # helper's callers span enough of the cluster (serialize/restore,
+    # save-as, save-image) that stubbing the "unreached" ones would just
+    # move the maintenance burden, not reduce it.
+    screen._message = ConsoleMessageController(
+        screen,
+        app_instance=screen.app_instance,
+        chat_store_accessor=lambda: screen._console_chat_store,
+        current_chat_store_accessor=lambda: screen._console_chat_store,
+        ensure_console_chat_controller=lambda: screen._ensure_console_chat_controller(),
+        current_chat_controller_accessor=lambda: getattr(
+            screen, "_console_chat_controller", None
+        ),
+        sync_native_console_chat_ui=lambda: screen._sync_native_console_chat_ui(),
+        active_session_is_ephemeral=(
+            lambda: screen._session._console_active_session_is_ephemeral()
+        ),
+        active_native_console_session=(
+            lambda: screen._session._active_native_console_session()
+        ),
+        current_console_conversation_id=(
+            lambda: screen._session._current_console_conversation_id()
+        ),
+        active_console_provider_model_display=(
+            lambda: screen._active_console_provider_model_display()
+        ),
+        console_initial_session_title_for_workspace=lambda workspace_id: "",
+        console_change_review_run_id=lambda store, message_id: None,
+        open_change_review=lambda run_id: None,
+        start_console_transcript_sync_timer=lambda: None,
+        clear_native_console_message_selection=lambda: None,
+        regenerate_console_generation_variant=(
+            lambda message_id: screen._regenerate_console_generation_variant(
+                message_id
+            )
+        ),
+        select_console_generation_variant=(
+            lambda message, direction: screen._select_console_generation_variant(
+                message, direction=direction
+            )
+        ),
+        keep_console_generation_variant=(
+            lambda message: screen._keep_console_generation_variant(message)
+        ),
+        handle_console_toggle_image_view=(
+            lambda message_id: screen._handle_console_toggle_image_view(message_id)
+        ),
+        invalidate_console_persisted_rows_cache=lambda: None,
+    )
     return screen
 
 
@@ -10575,7 +10640,7 @@ async def test_save_console_message_image_writes_file(tmp_path, monkeypatch):
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
         monkeypatch.setattr(
-            "tldw_chatbook.UI.Screens.chat_screen.get_cli_setting",
+            "tldw_chatbook.UI.Console_Modules.message.get_cli_setting",
             lambda section, key, default=None: (
                 str(tmp_path)
                 if (section, key) == ("chat.images", "save_location")
@@ -10618,7 +10683,7 @@ async def test_save_console_message_image_disambiguates_filename_collision(
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
         monkeypatch.setattr(
-            "tldw_chatbook.UI.Screens.chat_screen.get_cli_setting",
+            "tldw_chatbook.UI.Console_Modules.message.get_cli_setting",
             lambda section, key, default=None: (
                 str(tmp_path)
                 if (section, key) == ("chat.images", "save_location")
@@ -11472,7 +11537,7 @@ async def test_save_image_saves_all_attachments(tmp_path, monkeypatch):
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
         monkeypatch.setattr(
-            "tldw_chatbook.UI.Screens.chat_screen.get_cli_setting",
+            "tldw_chatbook.UI.Console_Modules.message.get_cli_setting",
             lambda section, key, default=None: (
                 str(tmp_path)
                 if (section, key) == ("chat.images", "save_location")

--- a/Tests/UI/test_console_prompts_controller.py
+++ b/Tests/UI/test_console_prompts_controller.py
@@ -14,10 +14,17 @@ behaviour that must survive the move unchanged:
 * the `/system` editor's save-to-Library outcome copy;
 * the Library "Use in Console" staged-insert handoff;
 * the lazily-created shared prompt-history store.
+
+The final section pins the extraction's own contract: the controller is
+wired in `ChatScreen.__init__`, owns zero DOM, and every screen-level name
+a staying caller or a pre-existing test reaches by is still a real
+delegation onto it.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -26,6 +33,7 @@ from textual.app import App
 
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 
+from tldw_chatbook.UI.Console_Modules.prompts import ConsolePromptsController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar, ConsolePromptsModal
 from tldw_chatbook.Widgets.Console.console_prompts_modal import ConsolePromptsResult
@@ -280,21 +288,25 @@ async def test_prompt_search_filters_recipes_and_uses_a_prefix_fts_query() -> No
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-shell")
 
-        records = await console._console_prompt_search("Summ")
+        records = await console._prompts._console_prompt_search("Summ")
 
         assert records == []
         assert service.search_calls[-1]["fts_match_query"] == '"Summ"*'
-        assert await console._resolve_console_prompt_by_name("Summ") is None
+        assert (
+            await console._prompts._resolve_console_prompt_by_name("Summ") is None
+        )
 
 
 def test_recipe_records_are_never_executable() -> None:
-    assert ChatScreen._is_recipe_prompt_record({"artifact_type": "Recipe"}) is True
-    assert ChatScreen._is_recipe_prompt_record({"artifact_type": "prompt"}) is False
-    assert ChatScreen._is_recipe_prompt_record({}) is False
+    is_recipe = ConsolePromptsController._is_recipe_prompt_record
+    assert is_recipe({"artifact_type": "Recipe"}) is True
+    assert is_recipe({"artifact_type": "prompt"}) is False
+    assert is_recipe({}) is False
 
 
 def test_prompt_prefix_fts_query_escapes_embedded_quotes() -> None:
-    assert ChatScreen._console_prompt_prefix_fts_query('a"b') == '"a""b"*'
+    prefix_query = ConsolePromptsController._console_prompt_prefix_fts_query
+    assert prefix_query('a"b') == '"a""b"*'
 
 
 # ---------------------------------------------------------------------------
@@ -315,22 +327,26 @@ async def test_system_prompt_save_to_library_reports_create_and_collision() -> N
         await _wait_for_selector(console, pilot, "#console-shell")
 
         assert (
-            await console._save_console_system_prompt_to_library("", "body")
+            await console._prompts._save_console_system_prompt_to_library("", "body")
             == "Enter a name to save this system prompt to Library."
         )
         assert (
-            await console._save_console_system_prompt_to_library("Name", "  ")
+            await console._prompts._save_console_system_prompt_to_library(
+                "Name", "  "
+            )
             == "Enter a system prompt to save."
         )
         assert (
-            await console._save_console_system_prompt_to_library("Fresh", "Be terse.")
+            await console._prompts._save_console_system_prompt_to_library(
+                "Fresh", "Be terse."
+            )
             == "Saved."
         )
         assert service.saved[-1]["name"] == "Fresh"
         assert service.saved[-1]["system_prompt"] == "Be terse."
 
         service.existing = {"name": "Fresh", "id": 1}
-        outcome = await console._save_console_system_prompt_to_library(
+        outcome = await console._prompts._save_console_system_prompt_to_library(
             "Fresh", "Be terse."
         )
         assert "already in use" in outcome
@@ -407,3 +423,78 @@ async def test_library_prompt_insert_handoff_is_blocked_before_setup_completes()
             HandoffChannel.CONSOLE_PROMPT_INSERT
         )
         assert notify.called
+
+
+# ---------------------------------------------------------------------------
+# The extraction's own contract (wave-3 console decomposition, task 3)
+# ---------------------------------------------------------------------------
+
+
+def test_prompts_controller_is_wired_in_chat_screen_init() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+
+    screen = ChatScreen(app)
+
+    assert isinstance(screen._prompts, ConsolePromptsController)
+    assert screen._prompts._screen is screen
+    assert screen._prompts.app_instance is app
+
+
+def test_prompts_controller_owns_no_dom() -> None:
+    """A controller owns behaviour and state, and zero pixels: no `query_one`
+    /`query` anywhere in the module, matching every existing controller."""
+    source = inspect.getsource(
+        __import__(
+            "tldw_chatbook.UI.Console_Modules.prompts", fromlist=["prompts"]
+        )
+    )
+    tree = ast.parse(source)
+    dom_calls = [
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"query", "query_one", "query_exactly_one"}
+    ]
+
+    assert dom_calls == []
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "_open_console_prompts_modal",
+        "_ensure_console_prompt_history",
+        "_console_command_insert_prompt",
+        "_console_command_apply_system",
+        "_open_console_system_prompt_editor",
+        "_consume_pending_console_prompt_insert",
+    ],
+)
+def test_screen_keeps_a_real_delegation_for_every_outside_caller(name: str) -> None:
+    """These six are reached from outside the cluster -- by a staying screen
+    method, by Textual's `action_*` resolution, by the command-registry dict,
+    or by a pre-existing test that replaces the exact screen attribute. Each
+    must stay a thin forwarder onto the controller, never a re-implementation
+    and never absent."""
+    method = getattr(ChatScreen, name)
+    body = inspect.getsource(method)
+
+    assert "self._prompts." + name in body
+    assert len(body.splitlines()) <= 4
+
+
+def test_moved_methods_are_gone_from_the_screen() -> None:
+    """The seven with no outside caller left no residue at all."""
+    for name in (
+        "_is_recipe_prompt_record",
+        "_console_prompt_prefix_fts_query",
+        "_console_prompt_search",
+        "_resolve_console_prompt_by_name",
+        "_open_console_prompt_picker_for_insert",
+        "_open_console_prompt_picker_for_apply_system",
+        "_save_console_system_prompt_to_library",
+    ):
+        assert not hasattr(ChatScreen, name), name
+        assert hasattr(ConsolePromptsController, name), name

--- a/Tests/UI/test_console_prompts_controller.py
+++ b/Tests/UI/test_console_prompts_controller.py
@@ -1,0 +1,409 @@
+"""Characterisation + contract tests for the Console prompt cluster.
+
+Written BEFORE the wave-3 task-3 extraction of `ConsolePromptsController`
+out of `ChatScreen`, so every assertion below is a statement about
+behaviour that must survive the move unchanged:
+
+* the real `_open_console_prompts_modal` path (a live screen, a live chat
+  store, a real `ConsolePromptsModal` on the stack) and the SELECTION it
+  persists -- `apply_improvement_result` writing the reviewed System
+  prompt through `ConsoleChatStore.set_session_system_prompt`, plus its
+  stale-guard refusing when the live System prompt moved underneath it;
+* `/prompt <name>` and `/system <name>` name resolution, including their
+  shared refuse-a-Recipe guard;
+* the `/system` editor's save-to-Library outcome copy;
+* the Library "Use in Console" staged-insert handoff;
+* the lazily-created shared prompt-history store.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from textual.app import App
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar, ConsolePromptsModal
+from tldw_chatbook.Widgets.Console.console_prompts_modal import ConsolePromptsResult
+
+
+class ConsoleHarness(App):
+    def __init__(self, app_instance):
+        super().__init__()
+        self.app_instance = app_instance
+
+    async def on_mount(self) -> None:
+        await self.push_screen(ChatScreen(self.app_instance))
+
+
+def _configure_native_ready_console(app, model: str = "local-model") -> None:
+    """A send-ready Console so the blocking first-run setup modal stays hidden."""
+    app.app_config["chat_defaults"] = {"provider": "llama_cpp", "model": model}
+    app.app_config["api_settings"] = {
+        "llama_cpp": {"api_url": "http://127.0.0.1:9099", "model": model}
+    }
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = model
+
+
+def _prompt_record(
+    *,
+    name: str = "Summarize",
+    artifact_type: str = "prompt",
+    system_prompt: str = "You are terse.",
+    user_prompt: str = "Summarize the following.",
+) -> dict[str, object]:
+    return {
+        "id": "local:prompt:11",
+        "local_id": 11,
+        "source_id": "11",
+        "name": name,
+        "artifact_type": artifact_type,
+        "system_prompt": system_prompt,
+        "user_prompt": user_prompt,
+        "version": 1,
+    }
+
+
+class _PromptScopeService:
+    """The `app_instance.prompt_scope_service` seam the cluster reads."""
+
+    def __init__(self, record: dict[str, object] | None = None) -> None:
+        self.record = record if record is not None else _prompt_record()
+        self.search_calls: list[dict[str, object]] = []
+        self.saved: list[dict[str, object]] = []
+        self.existing: dict[str, object] | None = None
+        self.save_result: object = {"local_id": 42}
+
+    async def get_capabilities(self, *, mode: str):
+        return SimpleNamespace(
+            structured_kinds=frozenset(),
+            artifact_types=frozenset({"prompt", "recipe"}),
+            conditional_update=True,
+        )
+
+    async def list_prompts(self, *, mode: str, page: int, per_page: int):
+        return {
+            "items": [dict(self.record)],
+            "page": page,
+            "per_page": per_page,
+            "total_items": 1,
+            "total_pages": 1,
+        }
+
+    async def search_prompts(self, *, mode: str, query: str, limit: int, **kwargs):
+        self.search_calls.append({"mode": mode, "query": query, "limit": limit, **kwargs})
+        return [dict(self.record)]
+
+    async def get_prompt(self, *, mode: str, prompt_identifier: str, **kwargs):
+        return self.existing
+
+    async def save_prompt(self, *, mode: str, **payload):
+        self.saved.append({"mode": mode, **payload})
+        return self.save_result
+
+
+# ---------------------------------------------------------------------------
+# The real modal-open path, and the selection it persists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prompts_modal_open_persists_the_reviewed_system_selection() -> None:
+    """Drive `_open_console_prompts_modal` for real, then apply through the
+    modal's own host coordinator and assert the store PERSISTED it."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.insert_text("draft body")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
+
+        console._open_console_prompts_modal()
+        await pilot.pause()
+        modal = host.screen_stack[-1]
+        assert isinstance(modal, ConsolePromptsModal)
+
+        result = ConsolePromptsResult(
+            kind="apply",
+            composer_snapshot=composer.capture_draft_snapshot(),
+            user_text=None,
+            system_text="You answer in one sentence.",
+            apply_user=False,
+            apply_system=True,
+            captured_system_fingerprint=None,
+        )
+        outcome = await modal._apply_improvement_result(result, None)
+
+        assert outcome.kind == "applied"
+        settings = console._session._ensure_active_console_session_settings()
+        assert settings.system_prompt == "You answer in one sentence."
+        assert (
+            store.session_settings(session_id).system_prompt
+            == "You answer in one sentence."
+        )
+
+
+@pytest.mark.asyncio
+async def test_prompts_modal_apply_refuses_when_the_system_prompt_moved() -> None:
+    """The opening fingerprint is the guard: a System prompt changed behind
+    the modal must make the apply stale rather than clobber it."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+
+        console._open_console_prompts_modal()
+        await pilot.pause()
+        modal = host.screen_stack[-1]
+
+        # Somebody else moved the live System prompt after the modal opened.
+        store.set_session_system_prompt(session_id, "Changed elsewhere.")
+
+        result = ConsolePromptsResult(
+            kind="apply",
+            composer_snapshot=composer.capture_draft_snapshot(),
+            user_text=None,
+            system_text="Never lands.",
+            apply_user=False,
+            apply_system=True,
+            captured_system_fingerprint=None,
+        )
+        outcome = await modal._apply_improvement_result(result, None)
+
+        assert outcome.kind == "stale"
+        assert (
+            store.session_settings(session_id).system_prompt == "Changed elsewhere."
+        )
+
+
+@pytest.mark.asyncio
+async def test_prompts_modal_reads_provider_recovery_off_the_screen_at_open() -> None:
+    """The Configure-provider seam is resolved when the modal is BUILT, so a
+    screen-level replacement made beforehand must reach the modal."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-shell")
+        recovery = AsyncMock()
+        console._open_console_provider_recovery = recovery
+        console._console_provider_blocker_copy = lambda: "No provider configured."
+
+        console._open_console_prompts_modal()
+        await pilot.pause()
+        modal = host.screen_stack[-1]
+
+        assert modal._configure_provider is recovery
+        assert modal._improve_unavailable_reason == "No provider configured."
+
+
+# ---------------------------------------------------------------------------
+# `/prompt` and `/system` name resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prompt_command_replaces_the_draft_with_the_resolved_body() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.insert_text("/prompt Summarize")
+
+        await console._console_command_insert_prompt(
+            SimpleNamespace(args="Summarize")
+        )
+        await pilot.pause()
+
+        assert composer.draft_text() == "Summarize the following."
+
+
+@pytest.mark.asyncio
+async def test_system_command_applies_and_persists_the_resolved_system_part() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.insert_text("/system Summarize")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+
+        await console._console_command_apply_system(SimpleNamespace(args="Summarize"))
+        await pilot.pause()
+
+        assert store.session_settings(session_id).system_prompt == "You are terse."
+        # A handled command never leaves its own invocation text behind.
+        assert composer.draft_text() == ""
+
+
+@pytest.mark.asyncio
+async def test_prompt_search_filters_recipes_and_uses_a_prefix_fts_query() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    service = _PromptScopeService(_prompt_record(artifact_type="recipe"))
+    app.prompt_scope_service = service
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-shell")
+
+        records = await console._console_prompt_search("Summ")
+
+        assert records == []
+        assert service.search_calls[-1]["fts_match_query"] == '"Summ"*'
+        assert await console._resolve_console_prompt_by_name("Summ") is None
+
+
+def test_recipe_records_are_never_executable() -> None:
+    assert ChatScreen._is_recipe_prompt_record({"artifact_type": "Recipe"}) is True
+    assert ChatScreen._is_recipe_prompt_record({"artifact_type": "prompt"}) is False
+    assert ChatScreen._is_recipe_prompt_record({}) is False
+
+
+def test_prompt_prefix_fts_query_escapes_embedded_quotes() -> None:
+    assert ChatScreen._console_prompt_prefix_fts_query('a"b') == '"a""b"*'
+
+
+# ---------------------------------------------------------------------------
+# Save-to-Library, handoff insert, prompt history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_save_to_library_reports_create_and_collision() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    service = _PromptScopeService()
+    app.prompt_scope_service = service
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-shell")
+
+        assert (
+            await console._save_console_system_prompt_to_library("", "body")
+            == "Enter a name to save this system prompt to Library."
+        )
+        assert (
+            await console._save_console_system_prompt_to_library("Name", "  ")
+            == "Enter a system prompt to save."
+        )
+        assert (
+            await console._save_console_system_prompt_to_library("Fresh", "Be terse.")
+            == "Saved."
+        )
+        assert service.saved[-1]["name"] == "Fresh"
+        assert service.saved[-1]["system_prompt"] == "Be terse."
+
+        service.existing = {"name": "Fresh", "id": 1}
+        outcome = await console._save_console_system_prompt_to_library(
+            "Fresh", "Be terse."
+        )
+        assert "already in use" in outcome
+
+
+@pytest.mark.asyncio
+async def test_prompt_history_store_is_lazy_shared_and_factory_seamed() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    sentinel = object()
+    app.console_prompt_history_factory = lambda: sentinel
+    screen = ChatScreen(app)
+
+    first = screen._ensure_console_prompt_history()
+
+    assert first is sentinel
+    assert screen._ensure_console_prompt_history() is sentinel
+
+
+@pytest.mark.asyncio
+async def test_library_prompt_insert_handoff_appends_onto_the_live_draft() -> None:
+    from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
+
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.clear_draft()
+        composer.insert_text("existing")
+        app.pending_handoffs.stage(
+            HandoffChannel.CONSOLE_PROMPT_INSERT, "staged body"
+        )
+
+        await console._consume_pending_console_prompt_insert()
+        await pilot.pause()
+
+        assert composer.draft_text() == "existing\nstaged body"
+        assert not app.pending_handoffs.has_pending(
+            HandoffChannel.CONSOLE_PROMPT_INSERT
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_prompt_insert_handoff_is_blocked_before_setup_completes() -> None:
+    from tldw_chatbook.UI.Navigation.pending_handoff_store import HandoffChannel
+
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.clear_draft()
+        console._console_setup_blocked_reason = lambda: "blocked"
+        notify = Mock()
+        app.notify = notify
+        app.pending_handoffs.stage(
+            HandoffChannel.CONSOLE_PROMPT_INSERT, "staged body"
+        )
+
+        await console._consume_pending_console_prompt_insert()
+        await pilot.pause()
+
+        assert composer.draft_text() == ""
+        assert not app.pending_handoffs.has_pending(
+            HandoffChannel.CONSOLE_PROMPT_INSERT
+        )
+        assert notify.called

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -465,6 +465,8 @@ def test_source_scope_survives_a_screen_state_round_trip():
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
     from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 
+    from Tests.UI.console_controller_stubs import stub_message_controller
+
     def _bare_screen(store: ConsoleChatStore) -> ChatScreen:
         screen = ChatScreen.__new__(ChatScreen)
         screen._console_chat_store = store
@@ -472,6 +474,16 @@ def test_source_scope_survives_a_screen_state_round_trip():
         screen._console_visible_draft_session_id = None
         screen._console_composer_or_none = lambda: None
         screen._task_resume_state = TaskResumeState()
+        # `_restore_native_console_state` calls the three
+        # `_rehydrate_console_message_*` helpers, which moved to
+        # `ConsoleMessageController` (wave-3 console decomposition, task 1)
+        # and are reached through `ChatScreen`'s delegations.
+        # `ChatScreen.__new__` skips the construction `__init__` would do.
+        # Those three read only `app_instance`, so nothing else is wired.
+        stub_message_controller(
+            screen,
+            context="test_console_rag_settings_modal._bare_screen",
+        )
         return screen
 
     store = ConsoleChatStore()

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -465,7 +465,7 @@ def test_source_scope_survives_a_screen_state_round_trip():
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
     from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 
-    from Tests.UI.console_controller_stubs import stub_message_controller
+    from Tests.UI.console_controller_stubs import NO_APP, stub_message_controller
 
     def _bare_screen(store: ConsoleChatStore) -> ChatScreen:
         screen = ChatScreen.__new__(ChatScreen)
@@ -483,6 +483,11 @@ def test_source_scope_survives_a_screen_state_round_trip():
         stub_message_controller(
             screen,
             context="test_console_rag_settings_modal._bare_screen",
+            # No harness app: this shell exercises the three rehydrate
+            # helpers, which read `app_instance` only through
+            # `getattr(..., None)`. Declared rather than inferred, so a
+            # future helper needing a real app fails loudly here.
+            app_instance=NO_APP,
         )
         return screen
 

--- a/Tests/UI/test_console_transcript_region.py
+++ b/Tests/UI/test_console_transcript_region.py
@@ -1,0 +1,276 @@
+"""Characterisation of the Console transcript region, written BEFORE its extraction.
+
+Wave-3 console decomposition, task 2. Every assertion here was run green
+against ``ChatScreen`` as it stood at ``4348d5b1c`` -- i.e. with the
+transcript block still composed inline inside ``compose_content`` and the
+four transcript-DOM methods still defined on the screen -- and committed
+separately, before a single production line moved. That ordering is the
+point: a characterisation written after the move can only prove the tests
+still pass, never that the behaviour they describe is the behaviour that
+existed beforehand.
+
+Two things are pinned, matching the two ways this extraction could go
+wrong:
+
+1. **The composed block** -- the ``#console-main-column`` >
+   ``#console-transcript-region`` > ``#console-session-surface`` >
+   ``#console-native-transcript`` chain, the inline sizing the workspace
+   grid depends on, and the deliberately top-less frame on
+   ``#console-transcript-region`` (``_frame_console_region(..., top=False)``,
+   which is what makes the transcript read as continuous with the control
+   bar above it). Ids and nesting are the extraction's stated contract, so
+   they are asserted as a parent/child chain rather than by bare presence:
+   a region widget that mounted the right ids in the wrong place would pass
+   a presence check.
+
+2. **The four transcript-DOM methods** that move into the region --
+   ``_capture_console_transcript_reading_state``,
+   ``_restore_console_transcript_reading_state``,
+   ``_clear_native_console_message_selection`` and
+   ``_note_console_follow_intent`` -- each driven against a REAL mounted
+   transcript rendering REAL store-persisted rows (``store.append_message``
+   -> ``_sync_native_console_chat_ui`` -> the widget), never a stub. They
+   are called here through their SCREEN-level names on purpose: post-move
+   those names are delegations, so this file is the direct evidence that
+   the delegation table works.
+"""
+
+import pytest
+
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Widgets.Console import ConsoleTranscript
+
+
+def _ready_console_host() -> ConsoleHarness:
+    """Build a Console harness whose provider readiness is already satisfied."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    return ConsoleHarness(app)
+
+
+def _tail_is_anchored(transcript: ConsoleTranscript) -> bool:
+    """Return Textual's semantic tail-follow state, including manual release.
+
+    ``ScrollView.is_anchored`` stays True after ``release_anchor()`` -- the
+    release is recorded separately on ``_anchor_released``. This is the same
+    pair ``_capture_console_transcript_reading_state`` itself reads, so the
+    assertions below check exactly the state the captured snapshot means
+    (and ``test_console_composer_collapse`` carries an identical helper for
+    the same reason).
+    """
+    return bool(
+        transcript.is_anchored and not getattr(transcript, "_anchor_released", False)
+    )
+
+
+async def _mounted_console(host: ConsoleHarness, pilot):
+    """Return the mounted Console screen once its composer exists."""
+    console = host.screen_stack[-1]
+    await _wait_for_selector(console, pilot, "#console-native-composer")
+    return console
+
+
+async def _seed_transcript(console, pilot):
+    """Persist enough rows to make the mounted transcript scrollable.
+
+    Mirrors ``test_console_composer_collapse._seed_overflowing_transcript``:
+    rows go into the real ``ConsoleChatStore`` and reach the widget through
+    the production sync path, so what the assertions below read back is the
+    transcript's response to persisted state, not a hand-set attribute.
+
+    The ``pilot.pause()`` is load-bearing, not defensive: ``max_scroll_y``
+    is derived from the laid-out virtual size, so without letting Textual
+    run a layout pass the freshly pushed rows can still measure as
+    zero-height and every anchor assertion below degenerates (``scroll_y ==
+    max_scroll_y == 0`` reads as "anchored"). Observed as an order-dependent
+    flake while writing this file.
+
+    Args:
+        console: The mounted ``ChatScreen``.
+        pilot: The Textual pilot driving that screen.
+
+    Returns:
+        A ``(transcript, selected_message_id)`` pair: the mounted
+        ``ConsoleTranscript`` and the id of the last row appended, already
+        selected on it.
+    """
+    store = console._ensure_console_chat_store()
+    selected_message_id = ""
+    for index in range(24):
+        message = store.append_message(
+            store.active_session_id,
+            role=(
+                ConsoleMessageRole.USER
+                if index % 2 == 0
+                else ConsoleMessageRole.ASSISTANT
+            ),
+            content="\n".join(f"message {index} line {line}" for line in range(3)),
+        )
+        selected_message_id = message.id
+    await console._sync_native_console_chat_ui()
+    await pilot.pause()
+    transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+    assert transcript.max_scroll_y > 0
+    transcript.select_message(selected_message_id)
+    return transcript, selected_message_id
+
+
+@pytest.mark.asyncio
+async def test_transcript_region_composes_its_ids_in_the_documented_nesting():
+    host = _ready_console_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+
+        main_column = console.query_one("#console-main-column")
+        transcript_region = console.query_one("#console-transcript-region")
+        session_surface = console.query_one("#console-session-surface")
+        transcript = console.query_one("#console-native-transcript")
+
+        # The chain, link by link -- presence alone would not catch a
+        # region mounted as a sibling instead of a parent.
+        assert main_column.parent is console.query_one("#console-workspace-grid")
+        assert transcript_region.parent is main_column
+        assert session_surface.parent is transcript_region
+        assert transcript_region in main_column.children
+        assert session_surface in transcript_region.children
+        assert transcript in session_surface.query(ConsoleTranscript).nodes
+
+        # `console-region` is what the shell's own styling keys off.
+        assert transcript_region.has_class("console-region")
+
+
+@pytest.mark.asyncio
+async def test_transcript_region_keeps_its_inline_sizing_and_topless_frame():
+    host = _ready_console_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+
+        main_column = console.query_one("#console-main-column")
+        transcript_region = console.query_one("#console-transcript-region")
+        left_rail = console.query_one("#console-left-rail")
+
+        # Inline sizing set at compose time (the stylesheet carries
+        # different values, so these prove the inline assignments survived).
+        assert main_column.styles.width is not None
+        assert main_column.styles.width.value == 13
+        assert main_column.styles.min_width is not None
+        assert main_column.styles.min_width.value == 56
+        assert main_column.styles.min_height is not None
+        assert main_column.styles.min_height.value == 0
+
+        # The main column really is the dominant pane at this width.
+        assert main_column.region.width > left_rail.region.width
+
+        # `_frame_console_region(..., top=False)`: three solid edges, no top.
+        border = transcript_region.styles.border
+        assert border.top[0] in {"", "none"}
+        assert border.right[0] == "solid"
+        assert border.bottom[0] == "solid"
+        assert border.left[0] == "solid"
+        assert transcript_region.has_class("console-frame-solid")
+
+
+@pytest.mark.asyncio
+async def test_manual_reading_state_captures_and_restores_scroll_and_selection():
+    host = _ready_console_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        transcript, selected = await _seed_transcript(console, pilot)
+        transcript.release_anchor()
+        transcript.scroll_to(y=2, animate=False)
+        await pilot.pause()
+
+        captured = console._capture_console_transcript_reading_state()
+        assert captured is not None
+        assert captured.anchored is False
+        assert captured.scroll_y == pytest.approx(2.0)
+        assert captured.selected_message_id == selected
+
+        # Move away from the captured position in both dimensions.
+        transcript.scroll_to(y=0, animate=False)
+        transcript.selected_message_id = None
+        await pilot.pause()
+
+        console._restore_console_transcript_reading_state(captured)
+        await pilot.pause()
+
+        assert transcript.selected_message_id == selected
+        assert transcript.scroll_y == pytest.approx(2.0)
+        assert _tail_is_anchored(transcript) is False
+
+
+@pytest.mark.asyncio
+async def test_anchored_reading_state_restores_tail_follow():
+    host = _ready_console_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        transcript, selected = await _seed_transcript(console, pilot)
+        transcript.anchor()
+        await pilot.pause()
+
+        captured = console._capture_console_transcript_reading_state()
+        assert captured is not None
+        assert captured.anchored is True
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        assert _tail_is_anchored(transcript) is False
+
+        console._restore_console_transcript_reading_state(captured)
+        await pilot.pause()
+
+        assert _tail_is_anchored(transcript) is True
+        assert transcript.selected_message_id == selected
+
+
+@pytest.mark.asyncio
+async def test_restoring_a_missing_reading_state_is_inert():
+    host = _ready_console_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        transcript, selected = await _seed_transcript(console, pilot)
+        await pilot.pause()
+
+        console._restore_console_transcript_reading_state(None)
+        await pilot.pause()
+
+        assert transcript.selected_message_id == selected
+
+
+@pytest.mark.asyncio
+async def test_clear_message_selection_clears_the_mounted_transcript():
+    host = _ready_console_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        transcript, selected = await _seed_transcript(console, pilot)
+        await pilot.pause()
+        assert transcript.selected_message_id == selected
+
+        console._clear_native_console_message_selection()
+        await pilot.pause()
+
+        assert transcript.selected_message_id is None
+
+
+@pytest.mark.asyncio
+async def test_note_follow_intent_stamps_the_mounted_transcript():
+    host = _ready_console_host()
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = await _mounted_console(host, pilot)
+        transcript, _selected = await _seed_transcript(console, pilot)
+        transcript.release_anchor()
+        await pilot.pause()
+        before = transcript._follow_intent_time
+
+        console._note_console_follow_intent()
+
+        # TASK-336's whole mechanism is "the most recent of (follow intent,
+        # user scroll) wins", so the stamp must land AFTER the release above.
+        assert transcript._follow_intent_time > before
+        assert transcript._follow_intent_time >= transcript._user_scroll_time

--- a/Tests/UI/test_ui_responsiveness.py
+++ b/Tests/UI/test_ui_responsiveness.py
@@ -290,6 +290,53 @@ def test_console_transcript_sync_timer_updates_responsiveness_monitor():
     assert stopped == [True]
 
 
+def _console_controller_slots() -> set[str]:
+    """The controller attributes `MagicMock(spec=ChatScreen)` cannot see.
+
+    The decomposition wires each controller in `__init__`, so they are
+    *instance* attributes; `spec=` reads the CLASS and therefore never stubs
+    them. `_sync_native_console_chat_ui` reaches some of them directly rather
+    than through a screen-level delegation, so an unstubbed slot fails with
+    `Mock object has no attribute '_session'` — which is how wave 2 shipped
+    this test red to dev.
+
+    Read back out of `__init__` rather than re-listed here, so the next wave's
+    controller does not re-open the treadmill `_make_sync_probe_screen`'s
+    docstring warns about.
+
+    Returns:
+        set[str]: Attribute names assigned a `Console*Controller(...)`.
+
+    Raises:
+        AssertionError: If the pattern matches nothing — that means the wiring
+            shape changed and this helper is silently stubbing nothing.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(ChatScreen.__init__)))
+    slots = {
+        target.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id.startswith("Console")
+        and node.value.func.id.endswith("Controller")
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "self"
+    }
+    assert slots, (
+        "no Console*Controller assignments found in ChatScreen.__init__; the "
+        "wiring shape changed and this helper now stubs nothing."
+    )
+    return slots
+
+
 def _make_sync_probe_screen(monitor):
     """A ChatScreen stand-in for exercising the console-sync recording bracket.
 
@@ -307,6 +354,8 @@ def _make_sync_probe_screen(monitor):
     from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     screen = MagicMock(spec=ChatScreen)
+    for slot in _console_controller_slots():
+        setattr(screen, slot, MagicMock())
     screen._console_sync_in_progress = False
     screen._console_sync_requested = False
     # Console decomposition wave 2 (PR #1381) moved stages onto instance-held

--- a/Tests/test_application_state_ownership.py
+++ b/Tests/test_application_state_ownership.py
@@ -37,6 +37,12 @@ SCREEN_STATE_STORE_PATH = (
 )
 HANDOFF_STORE_PATH = PRODUCTION_ROOT / "UI" / "Navigation" / "pending_handoff_store.py"
 CHAT_SCREEN_PATH = PRODUCTION_ROOT / "UI" / "Screens" / "chat_screen.py"
+#: The Console prompt cluster moved off `ChatScreen` in the wave-3
+#: decomposition (task 3); the screen keeps only a thin delegation, so the
+#: real `_consume_pending_console_prompt_insert` body lives here now.
+CONSOLE_PROMPTS_PATH = (
+    PRODUCTION_ROOT / "UI" / "Console_Modules" / "prompts.py"
+)
 CHAT_SCREEN_STATE_PATH = PRODUCTION_ROOT / "UI" / "Screens" / "chat_screen_state.py"
 MEDIA_WINDOW_PATH = PRODUCTION_ROOT / "UI" / "MediaWindow_v2.py"
 MEDIA_SCREEN_PATH = PRODUCTION_ROOT / "UI" / "Screens" / "media_screen.py"
@@ -2161,6 +2167,9 @@ def test_handoff_exception_logs_are_metadata_only() -> None:
     study_class = _class_definition(STUDY_SCREEN_PATH, "StudyScreen")
     artifacts_class = _class_definition(ARTIFACTS_SCREEN_PATH, "ArtifactsScreen")
     acp_class = _class_definition(ACP_SCREEN_PATH, "ACPScreen")
+    prompts_class = _class_definition(
+        CONSOLE_PROMPTS_PATH, "ConsolePromptsController"
+    )
     methods = (
         (APP_PATH, _method_definition(app_class, "_stage_handoff")),
         (
@@ -2168,8 +2177,10 @@ def test_handoff_exception_logs_are_metadata_only() -> None:
             _method_definition(chat_class, "_consume_pending_console_launch"),
         ),
         (
-            CHAT_SCREEN_PATH,
-            _method_definition(chat_class, "_consume_pending_console_prompt_insert"),
+            CONSOLE_PROMPTS_PATH,
+            _method_definition(
+                prompts_class, "_consume_pending_console_prompt_insert"
+            ),
         ),
         (
             CHAT_SCREEN_PATH,

--- a/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
+++ b/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
@@ -1,0 +1,24 @@
+---
+id: TASK-2766
+title: 'Decompose _open_console_prompts_modal (397 lines, 17 nested closures)'
+status: To Do
+assignee: []
+created_date: '2026-08-07 06:41'
+labels:
+  - refactor
+  - console
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wave 3 moved this method verbatim into ConsolePromptsController. Review judged its 15-of-18 dependency fan-out inherent rather than a wrong controller boundary, but identified the method itself as a class in disguise: a modal callback-bundle factory whose 17 nested closures each own one dependency. Decomposing it was deliberately kept out of a byte-fidelity wave.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The modal's callbacks are objects or methods with named dependencies rather than closures over a 397-line scope
+- [ ] #2 ConsolePromptsController's constructor dependency count falls below 18
+- [ ] #3 No behaviour change: the modal-open path's characterisation tests pass unchanged
+<!-- AC:END -->

--- a/backlog/tasks/task-2767 - Finish-or-stop-the-transcript-regions-two-access-idioms.md
+++ b/backlog/tasks/task-2767 - Finish-or-stop-the-transcript-regions-two-access-idioms.md
@@ -1,0 +1,23 @@
+---
+id: TASK-2767
+title: Finish or stop the transcript region's two access idioms
+status: To Do
+assignee: []
+created_date: '2026-08-07 06:41'
+labels:
+  - refactor
+  - console
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wave 3's ConsoleTranscriptRegion left the transcript's DOM with two access idioms: 3 screen methods route through _console_transcript_region_or_none, while 9 still query_one the transcript widgets directly. Both resolve to the same widget today, so this is not a defect -- it is a transitional state a later reader could mistake for settled design. Decide deliberately: migrate the remaining 9, or document the split as intentional.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Either all screen access to the transcript's widgets routes through the region, or the mixed state is documented in DESIGN.md as deliberate with its reason
+- [ ] #2 No behaviour change; the geometry baseline stays byte-identical
+<!-- AC:END -->

--- a/backlog/tasks/task-2768 - Persistent-diagnostic-inventory-is-stale-on-dev.md
+++ b/backlog/tasks/task-2768 - Persistent-diagnostic-inventory-is-stale-on-dev.md
@@ -1,0 +1,22 @@
+---
+id: TASK-2768
+title: Persistent-diagnostic inventory is stale on dev
+status: To Do
+assignee: []
+created_date: '2026-08-07 06:42'
+labels:
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+scripts/check_persistent_diagnostic_inventory.py fails on clean dev (verified at 22c08f958), so Tests/Architecture/test_persistent_diagnostic_inventory.py is red there. The regeneration diff is ~199 insertions spanning new diagnostic owners in Agents/local_tool_provider.py and Chat/prompt_history.py plus six UI/Console_Modules entries that the decomposition waves moved. Wave 3 deliberately did NOT run --write: the checker prints 'review the diff before running --write' because this is a security artifact, and signing off on two unrelated modules' new diagnostic owners is exactly the rubber-stamp that gate exists to prevent. Someone who owns those diagnostics should review and regenerate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each new diagnostic owner in the regeneration diff has been reviewed by someone who can vouch for it
+- [ ] #2 The inventory is regenerated and Tests/Architecture/test_persistent_diagnostic_inventory.py passes on dev
+<!-- AC:END -->

--- a/backlog/tasks/task-2769 - Two-pre-existing-Console-test-failures-on-dev.md
+++ b/backlog/tasks/task-2769 - Two-pre-existing-Console-test-failures-on-dev.md
@@ -1,0 +1,23 @@
+---
+id: TASK-2769
+title: Two pre-existing Console test failures on dev
+status: To Do
+assignee: []
+created_date: '2026-08-07 06:42'
+labels:
+  - tech-debt
+  - tests
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while verifying wave 3, both reproduced on clean dev at 22c08f958 in disposable worktrees and therefore NOT wave-3 regressions. (1) Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_restores_draft_when_batch_raises fails deterministically in isolation -- a bare-screen fixture reaching query_one via _sync_console_command_popup. (2) Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_retries_console_follow_after_initial_adapter_failure is a load-dependent pilot.click/pause flake: green in a 10-file slice at both commits, red only in a 30-file run.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The generation-actions failure passes in isolation
+- [ ] #2 The live-work-handoffs flake is either fixed or its load dependency is documented
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -128,6 +128,7 @@ from ...Chat.console_chat_models import (
 from ...Chat.console_chat_store import ConsoleChatStore
 from ...Chat.console_command_grammar import GENERATE_IMAGE_COMMAND_HANDLER_ID
 from ...Chat.console_ephemeral import blocked_reason
+from ...Chat.console_image_view import IMAGE_CACHE_MAX_ENTRIES
 from ...Chat.console_message_actions import ConsoleActionResult, ConsoleMessageActionService
 from ...Chat.console_save_targets import (
     console_chatbook_artifact_payload,
@@ -472,8 +473,6 @@ class ConsoleMessageController:
         them here would double-render and burn a plain-image LRU slot under
         their bare message id for no row that ever reads it (TASK P2a-7).
         """
-        from ...Chat.console_image_view import IMAGE_CACHE_MAX_ENTRIES
-
         # Bound the working set to the cache capacity so prep can never evict
         # what the transcript still shows (churn guard).
         image_messages = [

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -1017,7 +1017,22 @@ class ConsoleMessageController:
         await self._sync_native_console_chat_ui()
 
     async def handle_console_message_action(self, event: Button.Pressed) -> bool:
-        """Route selected transcript message actions through the native action service."""
+        """Route a transcript message action through the native action service.
+
+        The dispatcher for the transcript's per-message buttons: it decodes
+        the button id, then routes to the cluster that owns that action. It
+        stays one method because the routing table IS the unit -- splitting
+        it would relocate the switch, not remove it.
+
+        Args:
+            event: The `Button.Pressed` from a transcript message action
+                button, whose id encodes `<action>-<message id>`.
+
+        Returns:
+            bool: True when the id parsed and the action was dispatched
+                (the event is then stopped); False when the button is not a
+                message action, leaving the event to propagate.
+        """
         button_id = event.button.id or ""
         action_id, message_id = self._parse_console_message_action_button_id(button_id)
         if action_id is None or message_id is None:

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -1,0 +1,2043 @@
+"""Console message controller.
+
+Extracted out of `ChatScreen` (wave-3 console decomposition, task 1): the
+native Console transcript MESSAGE cluster -- serialize/restore, resume-tree
+flattening, screen-state rehydration, the per-message save-as/edit/retry/
+continue/regenerate/variant-navigation helpers, and `handle_console_message_
+action`, the 294-line dispatcher that routes every transcript row action
+button (copy/edit/save-as/retry/regenerate/variant/keep/feedback/toggle-
+image/save-image/delete/continue/speak/speak-stop/review-changes).
+
+This module follows the SAME binding rule waves 1-2 established (see
+`dictation.py`'s `ConsoleDictationController.__init__` docstring for the
+canonical statement; restated briefly here):
+
+1. **Framework services** (`run_worker`, `push_screen`) live-read from the
+   screen via `@property` on every access -- never snapshotted.
+2. **Everything else this cluster depends on that is not its own state** is a
+   NAMED keyword-only constructor callable, matching the design spec's rule
+   that "a controller's dependencies are its signature". Each is a
+   zero-arg (or narrowly-typed) callable the CALLER (`ChatScreen.__init__`)
+   constructs as a late-binding lambda closing over `self` -- never a bound
+   method passed directly (the same instance-patch staleness reason
+   `ConsoleDictationController.__init__`'s docstring gives in full). The
+   controller's own property of the SAME NAME as the original private
+   method/attribute is a thin wrapper around the stored callable.
+3. `app_instance` is a plain snapshot, for the same reason `dictation.py`
+   snapshots it: every read here is a bare-attribute/`notify()`/
+   `post_message()` call in the pre-move source, never through a call that
+   could go stale.
+
+**Controller-to-controller seams this cluster needed** (session and
+workspace; messages belong to a session, which lives in workspace context):
+`active_native_console_session`/`current_console_conversation_id` reach
+`ConsoleSessionController` directly (two moved bodies called
+`self._session.X(...)` in the pre-move source -- each drops that prefix in
+favour of a same-named property here, wrapping a constructor-injected
+callable `ChatScreen.__init__` points at `self._session.X`, matching
+`session.py`'s own documented seam to `ConsoleWorkspaceController`).
+`active_session_is_ephemeral` is the one exception: it routes through the
+SCREEN's own `_console_active_session_is_ephemeral` delegation instead
+(session.py's disclosed exception for `console_transcript.py`'s bare-name
+reach) because the pre-existing test suite ALSO monkeypatches that screen-
+level name directly (see `__init__`'s own docstring for this parameter).
+`console_initial_session_title_for_workspace` reaches
+`ConsoleWorkspaceController` the same direct way (one moved body called
+`self._workspace.X(...)`). The REVERSE seam -- `ConsoleWorkspaceController`
+resuming a persisted conversation needs this cluster's own conversation-tree
+flattener -- already existed as a named callable BEFORE this task
+(`messages_from_conversation_tree_accessor`, wave-2 task 2); this task only
+re-points that existing lambda at `self._message` instead of the screen.
+Python resolves every one of these lambdas at CALL time, so construction
+order between controllers never matters.
+
+**`handle_console_message_action` is the wave's risk centre** (294 lines,
+the largest constructor in this cluster as a direct consequence): it has NO
+DOM access of its own, so nothing blocks the move, but it dispatches across
+several clusters that stay screen-owned this wave (change-review, image-
+generation, citation) -- each of those reaches becomes exactly one more
+named callable here, never a back-door through `self.screen`.
+
+**Dead bodies / delegation table**: this cluster's pre-move test suite
+reaches an unusually large number of these methods directly by their
+ORIGINAL private name -- `screen.handle_console_message_action(...)`,
+`ChatScreen._serialize_console_message(...)`, `screen._select_console_
+message_variant(...)`, etc, built up across many prior test-writing rounds
+that predate this decomposition. Every one of those (17 of the 29 moved
+`*message*`-named methods, plus none of the 7 non-matching helper functions
+this cluster also owns exclusively) keeps a thin (<=3-line) delegation on
+`ChatScreen` under its original name, forwarding to `self._message.X(...)`
+(or, for the two state-free classmethods `_serialize_console_message`/
+`_restore_console_message` and the staticmethod `_parse_console_message_
+action_button_id`, to `ConsoleMessageController.X(...)` directly on the
+class, since tests call those UNBOUND via `ChatScreen.X(...)` with no
+instance). Three more moved methods keep their single in-repo staying
+caller pointed at `self._message.X(...)` directly instead of a delegation
+(`_active_console_transcript_has_messages`, `_console_message_excerpt`,
+`_console_message_role_label` -- one staying caller each, no test
+coupling, so a direct call-site edit was simpler than a delegation). The
+full per-method table (moves clean / moves + delegation / moves + direct
+call-site edit / stays, with reasons) is in the task-1 extraction report.
+
+**Stays on `ChatScreen`, despite matching the `*message*` name pattern**:
+- `_console_realtime_exit_message` -- the V4 realtime engine's own toast
+  text, not `ConsoleChatMessage` state; `hands_free.py`/`session.py` already
+  document the whole realtime engine as staying screen-owned this
+  programme.
+- `_console_imagegen_inflight_message_ids` -- image-generation in-flight
+  bookkeeping keyed by message id, the message-id-keyed sibling of
+  `_console_imagegen_inflight_sessions`, which `session.py`'s own docstring
+  already calls out as a name-pattern false positive staying screen-owned
+  for the identical reason.
+- `_selected_console_message_inspector_rows` / `_clear_native_console_
+  message_selection` -- real `query_one` DOM access.
+- `handle_console_send_message` / `_send_console_message_from_visible_
+  action` -- the latter does raw `query_one` DOM access (not through the
+  established `_console_composer_or_none` accessor) and is composer/
+  command-dispatch orchestration (command registry parsing, skill-blocked
+  hints, the keyboard-capture draft stash shared with `on_key`, itself out
+  of scope this wave) that only ever REACHES message creation by calling
+  `_dispatch_console_draft_send` -> `_submit_console_native_draft` ->
+  `ConsoleChatController.submit_draft` (business logic already outside
+  `ChatScreen`), none of which are `*message*`-named or move this task.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, TYPE_CHECKING
+import asyncio
+import inspect
+import os
+import uuid
+
+from loguru import logger
+from rich.markup import escape as escape_markup
+from textual.widgets import Button
+
+from ...Chat.console_chat_controller import ConsoleChatController
+from ...Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+    ConsoleVariant,
+    ConsoleVariantSet,
+    MessageAttachment,
+)
+from ...Chat.console_chat_store import ConsoleChatStore
+from ...Chat.console_command_grammar import GENERATE_IMAGE_COMMAND_HANDLER_ID
+from ...Chat.console_ephemeral import blocked_reason
+from ...Chat.console_message_actions import ConsoleActionResult, ConsoleMessageActionService
+from ...Chat.console_save_targets import (
+    console_chatbook_artifact_payload,
+    derive_console_save_title,
+    resolve_console_artifact_owner_request,
+)
+from ...Chat.message_metadata import MessageMetadata
+from ...Chat.provider_usage import ProviderUsage
+from ...config import get_cli_setting
+from ...Notes.notes_scope_service import ScopeType
+from ...Widgets.Console import ConsoleEditMessageModal, ConsoleEditResult, ConsoleSaveAsModal
+
+if TYPE_CHECKING:
+    from ..Screens.chat_screen import ChatScreen
+
+logger = logger.bind(module="ChatScreen")
+
+
+# -- Module-level pure helpers this cluster owns exclusively (see module
+# docstring) -- moved verbatim from `chat_screen.py`, which no longer
+# references either name for itself.
+
+
+def _apply_console_message_attachments(
+    message: ConsoleChatMessage,
+    attachments: "Iterable[MessageAttachment]",
+) -> None:
+    """Set a message's attachments tuple and mirror position 0 into scalars.
+
+    Mirrors ``ConsoleChatStore._set_message_attachments``'s invariant --
+    every attachments mutation sets the tuple AND the scalar image fields
+    (``image_data``, ``image_mime_type``, ``attachment_label``) together --
+    for call sites that build or rehydrate ``ConsoleChatMessage`` objects
+    directly (screen-state restore, saved-conversation resume), outside the
+    store, where that helper isn't reachable.
+    """
+    rebased = tuple(
+        replace(attachment, position=index)
+        for index, attachment in enumerate(attachments)
+    )
+    message.attachments = rebased
+    first = rebased[0] if rebased else None
+    message.image_data = first.data if first else None
+    message.image_mime_type = first.mime_type if first else None
+    message.attachment_label = (
+        first.display_name if first and first.display_name else None
+    )
+
+
+class ConsoleMessageController:
+    """Owns the Console shell's native message-transcript cluster:
+    serialize/restore, resume-tree flattening, screen-state rehydration,
+    per-message save-as/edit/retry/continue/regenerate/variant navigation,
+    and `handle_console_message_action`'s full action dispatch.
+
+    `ChatScreen` constructs exactly one of these, in `__init__`, and keeps a
+    `self._message` reference plus the delegation/call-site-edit table
+    described in the module docstring.
+    """
+
+    def __init__(
+        self,
+        screen: "ChatScreen",
+        *,
+        app_instance: Any,
+        chat_store_accessor: Callable[[], ConsoleChatStore],
+        current_chat_store_accessor: Callable[[], ConsoleChatStore | None],
+        ensure_console_chat_controller: Callable[[], Any],
+        current_chat_controller_accessor: Callable[[], Any | None],
+        sync_native_console_chat_ui: Callable[[], Any],
+        active_session_is_ephemeral: Callable[[], bool],
+        active_native_console_session: Callable[[], Any],
+        current_console_conversation_id: Callable[[], Any],
+        active_console_provider_model_display: Callable[[], tuple],
+        console_initial_session_title_for_workspace: Callable[[str | None], str],
+        console_change_review_run_id: Callable[[ConsoleChatStore, str], str | None],
+        open_change_review: Callable[[str | None], None],
+        start_console_transcript_sync_timer: Callable[[], None],
+        clear_native_console_message_selection: Callable[[], None],
+        regenerate_console_generation_variant: Callable[[str], Any],
+        select_console_generation_variant: Callable[[Any, str], None],
+        keep_console_generation_variant: Callable[[Any], None],
+        handle_console_toggle_image_view: Callable[[str], None],
+        invalidate_console_persisted_rows_cache: Callable[[], None],
+    ) -> None:
+        """Build the controller and bind everything its moved bodies need.
+
+        Every one of the 36 method bodies below (29 of the pre-move
+        `*message*`-named cluster, plus 7 exclusively-owned helpers whose
+        names don't match that pattern -- `_apply_console_message_
+        attachments`, `_batch_fetch_console_resume_attachments`,
+        `_serialize_console_variants`, `_restore_console_variants`,
+        `_console_save_as_destinations`, `_console_save_source_title`,
+        `_clear_console_original_attempt_preview`) is a byte-for-byte copy
+        of the pre-extraction `ChatScreen` method, EXCEPT: the four
+        documented `self._session.X(...)`/`self._workspace.X(...)` seam
+        call sites (dropping that prefix for a same-named property here,
+        per the module docstring's "Controller-to-controller seams"
+        section) and every `self.app.push_screen(...)` call site (dropping
+        the `.app.` for the `push_screen` framework property below, the
+        same transformation `session.py`'s own moved bodies already made).
+
+        Args:
+            screen: The Console screen. Used ONLY for the framework
+                services (`run_worker`, `push_screen`) below. Zero
+                `query_one`/`query` traffic reaches through `screen` here --
+                every DOM-touching sibling of this cluster (`_selected_
+                console_message_inspector_rows`, `_clear_native_console_
+                message_selection`, `_send_console_message_from_visible_
+                action`) stayed on `ChatScreen`; see the module docstring.
+            app_instance: Snapshotted once, not re-read through `screen` --
+                every reference in the moved bodies is a bare-attribute or
+                `notify()`/`post_message()` call, never one that could
+                observe a later `screen.app_instance` reassignment.
+            chat_store_accessor: `ChatScreen._ensure_console_chat_store`,
+                the general store accessor already shared by every other
+                controller (see `session.py`'s identical parameter).
+            current_chat_store_accessor: `ChatScreen._console_chat_store`'s
+                bare-attribute-read shape (may be `None` pre-mount);
+                distinct from `chat_store_accessor` for the same reason
+                `session.py` keeps the two separate.
+            ensure_console_chat_controller: `ChatScreen._ensure_console_
+                chat_controller`.
+            current_chat_controller_accessor: `ChatScreen._console_chat_
+                controller`'s bare-attribute-read shape (may be `None`
+                pre-mount, never lazily creates) -- used only by
+                `_clear_console_original_attempt_preview`, distinct from
+                `ensure_console_chat_controller` for the same reason
+                `chat_store_accessor`/`current_chat_store_accessor` are
+                kept separate.
+            sync_native_console_chat_ui: `ChatScreen._sync_native_console_
+                chat_ui`, the big render/inspector re-sync bridge -- stays
+                screen-owned (DOM), reached here as an async callable.
+            active_session_is_ephemeral: `ChatScreen._console_active_session_
+                is_ephemeral`, the screen's OWN disclosed delegation to
+                `ConsoleSessionController` (see `session.py`'s docstring for
+                why that delegation exists: `console_transcript.py`'s
+                bare-name reach) -- routed through the screen rather than
+                straight to `self._session` because the pre-existing test
+                suite also monkeypatches it at that name (4 sites in
+                `test_console_native_chat_flow.py`).
+            active_native_console_session: `ConsoleSessionController._active_
+                native_console_session`, same seam, used only by
+                `_console_save_source_title`.
+            current_console_conversation_id: `ConsoleSessionController.
+                _current_console_conversation_id`, same seam, used only by
+                `_save_console_message_as_chatbook`.
+            active_console_provider_model_display: `ChatScreen._active_
+                console_provider_model_display`, a general screen helper
+                (10 call sites across clusters) used only by
+                `_save_console_message_as_chatbook` here.
+            console_initial_session_title_for_workspace: `ConsoleWorkspace
+                Controller._console_initial_session_title_for_workspace`
+                (workspace <-> message seam), used only by `_append_native_
+                console_system_message`.
+            console_change_review_run_id: `ChatScreen._console_change_
+                review_run_id` (DOM: reads the transcript's display model
+                first) -- the change-review cluster stays screen-owned this
+                wave.
+            open_change_review: `ChatScreen._open_change_review` (`push_
+                screen`) -- same cluster, same reason.
+            start_console_transcript_sync_timer: `ChatScreen._start_console_
+                transcript_sync_timer`, used by the four retry/continue/
+                regenerate/edit-resend run launchers.
+            clear_native_console_message_selection: `ChatScreen._clear_
+                native_console_message_selection` (DOM), used only by
+                `_continue_console_message`.
+            regenerate_console_generation_variant: `ChatScreen._regenerate_
+                console_generation_variant`, the image-generation cluster's
+                own regenerate-append -- stays screen-owned this wave
+                (image cluster explicitly out of scope), reached only from
+                `handle_console_message_action`'s regenerate branch.
+            select_console_generation_variant: `ChatScreen._select_console_
+                generation_variant`, same cluster, same reason.
+            keep_console_generation_variant: `ChatScreen._keep_console_
+                generation_variant`, same cluster, same reason.
+            handle_console_toggle_image_view: `ChatScreen._handle_console_
+                toggle_image_view`, the image-VIEW cluster's own toggle --
+                also out of scope this wave.
+            invalidate_console_persisted_rows_cache: `ChatScreen._invalidate_
+                console_persisted_rows_cache`, the conversation-browser
+                cluster's cache invalidator (already a named callable on
+                `session.py`), used only by `handle_console_message_
+                action`'s delete branch.
+        """
+        self._screen = screen
+        self.app_instance = app_instance
+        self._chat_store_accessor = chat_store_accessor
+        self._current_chat_store_accessor = current_chat_store_accessor
+        self._ensure_console_chat_controller_fn = ensure_console_chat_controller
+        self._current_chat_controller_accessor = current_chat_controller_accessor
+        self._sync_native_console_chat_ui_fn = sync_native_console_chat_ui
+        self._active_session_is_ephemeral_fn = active_session_is_ephemeral
+        self._active_native_console_session_fn = active_native_console_session
+        self._current_console_conversation_id_fn = current_console_conversation_id
+        self._active_console_provider_model_display_fn = (
+            active_console_provider_model_display
+        )
+        self._console_initial_session_title_for_workspace_fn = (
+            console_initial_session_title_for_workspace
+        )
+        self._console_change_review_run_id_fn = console_change_review_run_id
+        self._open_change_review_fn = open_change_review
+        self._start_console_transcript_sync_timer_fn = (
+            start_console_transcript_sync_timer
+        )
+        self._clear_native_console_message_selection_fn = (
+            clear_native_console_message_selection
+        )
+        self._regenerate_console_generation_variant_fn = (
+            regenerate_console_generation_variant
+        )
+        self._select_console_generation_variant_fn = select_console_generation_variant
+        self._keep_console_generation_variant_fn = keep_console_generation_variant
+        self._handle_console_toggle_image_view_fn = handle_console_toggle_image_view
+        self._invalidate_console_persisted_rows_cache_fn = (
+            invalidate_console_persisted_rows_cache
+        )
+
+        # This cluster's own state, moved verbatim from `ChatScreen.__init__`.
+        # `ChatScreen` keeps proxy properties under the original attribute
+        # names for the members an external widget (`console_transcript.py`,
+        # `_console_speaking_message_id`) or a staying screen method still
+        # reads/writes -- see `chat_screen.py`'s own "Message cluster state"
+        # comment block for the exact list.
+        self._console_message_action_service = ConsoleMessageActionService()
+        self._last_console_action: ConsoleActionResult | None = None
+        self._pending_console_delete_message_id: str | None = None
+        self._console_original_attempt_previews: Dict[str, str] = {}
+        self._console_speaking_message_id: str | None = None
+        self._pending_console_swipe_selection: str | None = None
+
+    # -- Framework services (live-read via `@property`) --------------------
+
+    @property
+    def run_worker(self) -> Any:
+        """`Screen.run_worker`, bound. See `__init__`'s docstring for why
+        this is a property rather than a value snapshotted once."""
+        return self._screen.run_worker
+
+    @property
+    def push_screen(self) -> Any:
+        """`Screen.app.push_screen`, bound. See `__init__`'s docstring."""
+        return self._screen.app.push_screen
+
+    # -- Named constructor dependencies -------------------------------------
+    #
+    # Each property below is a thin wrapper around a stored callable, kept
+    # under the SAME name the original `ChatScreen` method/attribute used --
+    # see `__init__`'s docstring. `_console_chat_store` is the one
+    # bare-attribute-read shape (calls the accessor immediately and returns
+    # the value); every other property returns the callable itself, matching
+    # every other controller in this package.
+
+    @property
+    def _ensure_console_chat_store(self) -> Any:
+        return self._chat_store_accessor
+
+    @property
+    def _console_chat_store(self) -> ConsoleChatStore | None:
+        return self._current_chat_store_accessor()
+
+    @property
+    def _ensure_console_chat_controller(self) -> Any:
+        return self._ensure_console_chat_controller_fn
+
+    @property
+    def _console_chat_controller(self) -> Any | None:
+        return self._current_chat_controller_accessor()
+
+    @property
+    def _sync_native_console_chat_ui(self) -> Any:
+        return self._sync_native_console_chat_ui_fn
+
+    @property
+    def _console_active_session_is_ephemeral(self) -> Any:
+        return self._active_session_is_ephemeral_fn
+
+    @property
+    def _active_native_console_session(self) -> Any:
+        return self._active_native_console_session_fn
+
+    @property
+    def _current_console_conversation_id(self) -> Any:
+        return self._current_console_conversation_id_fn
+
+    @property
+    def _active_console_provider_model_display(self) -> Any:
+        return self._active_console_provider_model_display_fn
+
+    @property
+    def _console_initial_session_title_for_workspace(self) -> Any:
+        return self._console_initial_session_title_for_workspace_fn
+
+    @property
+    def _console_change_review_run_id(self) -> Any:
+        return self._console_change_review_run_id_fn
+
+    @property
+    def _open_change_review(self) -> Any:
+        return self._open_change_review_fn
+
+    @property
+    def _start_console_transcript_sync_timer(self) -> Any:
+        return self._start_console_transcript_sync_timer_fn
+
+    @property
+    def _clear_native_console_message_selection(self) -> Any:
+        return self._clear_native_console_message_selection_fn
+
+    @property
+    def _regenerate_console_generation_variant(self) -> Any:
+        return self._regenerate_console_generation_variant_fn
+
+    @property
+    def _select_console_generation_variant(self) -> Any:
+        return self._select_console_generation_variant_fn
+
+    @property
+    def _keep_console_generation_variant(self) -> Any:
+        return self._keep_console_generation_variant_fn
+
+    @property
+    def _handle_console_toggle_image_view(self) -> Any:
+        return self._handle_console_toggle_image_view_fn
+
+    @property
+    def _invalidate_console_persisted_rows_cache(self) -> Any:
+        return self._invalidate_console_persisted_rows_cache_fn
+
+    # -- Moved cluster methods (byte-for-byte except as documented above) --
+
+    def _recent_console_image_messages(self, messages) -> list[Any]:
+        """Return the most recent image-bearing messages, bounded to cache capacity.
+
+        Mirrors the provider payload's most-recent-N image policy
+        (``_provider_message_payloads``'s ``image_ids[-image_budget:]``).
+
+        Excludes image-generation messages (non-empty ``generation_metadata``)
+        -- those render as a ``"generation-card"`` row instead of the plain
+        ``"image"`` row (see ``_build_generation_card_specs``), so including
+        them here would double-render and burn a plain-image LRU slot under
+        their bare message id for no row that ever reads it (TASK P2a-7).
+        """
+        from ...Chat.console_image_view import IMAGE_CACHE_MAX_ENTRIES
+
+        # Bound the working set to the cache capacity so prep can never evict
+        # what the transcript still shows (churn guard).
+        image_messages = [
+            message
+            for message in messages
+            if getattr(message, "image_data", None) is not None
+            and not getattr(message, "generation_metadata", ())
+        ]
+        return image_messages[-IMAGE_CACHE_MAX_ENTRIES:]
+
+    @staticmethod
+    def _console_message_role_from_persisted(
+        message: dict[str, Any],
+    ) -> ConsoleMessageRole:
+        """Return a native Console role for a persisted Chat message row."""
+        raw_role = str(message.get("role") or "").strip().lower()
+        if raw_role:
+            try:
+                return ConsoleMessageRole(raw_role)
+            except ValueError:
+                pass
+        sender = str(message.get("sender") or "").strip().lower()
+        if sender in {"user", "system", "tool"}:
+            return ConsoleMessageRole(sender)
+        return ConsoleMessageRole.ASSISTANT
+
+    def _console_messages_from_conversation_tree(
+        self,
+        tree: dict[str, Any],
+    ) -> list[ConsoleChatMessage]:
+        """Build native Console messages from a persisted conversation tree.
+
+        Task 8: flattens the ENTIRE tree (every node, all branches -- not just
+        the ``children[-1]`` latest branch), each message carrying its
+        ``persisted_message_id`` and persisted ``parent_message_id`` so the
+        store can reconnect the full tree and pick the active branch from the
+        stored active-leaf pointer.
+
+        Parenthood is taken from the tree's own NESTING (the id of the node we
+        recursed from), not the row's ``parent_message_id`` field: the real DB
+        tree sets both consistently, but a node's structural position is the
+        authoritative source and stays correct even for trees whose rows omit
+        the field. A truly-empty node (no content and no image) is dropped but
+        transparent to parenthood -- its children re-parent to the nearest kept
+        ancestor -- so a skipped row never orphans a branch.
+        """
+        messages: list[ConsoleChatMessage] = []
+
+        def _walk(node: Any, parent_persisted_id: str | None) -> None:
+            if not isinstance(node, dict):
+                return
+            content = str(node.get("content") or "")
+            raw_image = node.get("image_data")
+            image_data = (
+                bytes(raw_image) if isinstance(raw_image, (bytes, bytearray)) else None
+            )
+            raw_mime = node.get("image_mime_type")
+            image_mime_type = str(raw_mime) if raw_mime else None
+            usage = ProviderUsage.from_json(node.get("usage_json"))
+            metadata = MessageMetadata.from_json(node.get("metadata_json"))
+            raw_id = node.get("id")
+            node_persisted_id = str(raw_id) if raw_id is not None else None
+            kept = bool(content) or image_data is not None
+            if kept:
+                # The tree only carries the legacy position-0 columns; positions
+                # >= 1 (multi-attachment table rows) are batch-fetched below,
+                # once for the whole resumed list.
+                attachments: tuple[MessageAttachment, ...] = (
+                    (
+                        MessageAttachment(
+                            data=image_data,
+                            mime_type=image_mime_type or "",
+                            display_name="",
+                            position=0,
+                        ),
+                    )
+                    if image_data is not None
+                    else ()
+                )
+                messages.append(
+                    ConsoleChatMessage(
+                        role=self._console_message_role_from_persisted(node),
+                        content=content,
+                        status="complete",
+                        persisted_message_id=node_persisted_id,
+                        parent_message_id=parent_persisted_id,
+                        image_data=image_data,
+                        image_mime_type=image_mime_type,
+                        attachments=attachments,
+                        usage=usage,
+                        metadata=metadata,
+                    )
+                )
+            # Children re-parent to this node when kept, else pass the nearest
+            # kept ancestor straight through (a dropped empty row is invisible
+            # to the tree linkage).
+            child_parent_id = node_persisted_id if kept else parent_persisted_id
+            children = node.get("children")
+            if isinstance(children, list):
+                for child in children:
+                    _walk(child, child_parent_id)
+
+        root_threads = tree.get("root_threads")
+        if isinstance(root_threads, list):
+            for root in root_threads:
+                _walk(root, None)
+        self._batch_fetch_console_resume_attachments(messages)
+        return messages
+
+    def _batch_fetch_console_resume_attachments(
+        self, messages: list[ConsoleChatMessage]
+    ) -> None:
+        """Fill positions >= 1 for resumed multi-attachment messages, once.
+
+        ``get_conversation_tree`` only returns the legacy image columns
+        (position 0); the ``message_attachments`` table (positions >= 1) is
+        fetched here in a SINGLE batched call covering every message this
+        resume produced, then folded into each message's attachments tuple
+        via ``_apply_console_message_attachments`` (see that helper for the
+        store mirror invariant it replicates by hand).
+        """
+        ids = [m.persisted_message_id for m in messages if m.persisted_message_id]
+        if not ids:
+            return
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        getter = getattr(db, "get_attachments_for_messages", None)
+        if not callable(getter):
+            return
+        try:
+            rows_by_id = getter(ids)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Console resume attachment batch fetch failed."
+            )
+            return
+        if not isinstance(rows_by_id, dict):
+            return
+        for message in messages:
+            extra_rows = (
+                rows_by_id.get(message.persisted_message_id)
+                if message.persisted_message_id
+                else None
+            )
+            if not extra_rows:
+                continue
+            extras = [
+                MessageAttachment(
+                    data=row.get("data"),
+                    mime_type=row.get("mime_type") or "",
+                    display_name=row.get("display_name") or "",
+                    position=int(row.get("position", 0)),
+                )
+                for row in extra_rows
+            ]
+            _apply_console_message_attachments(
+                message, list(message.attachments) + extras
+            )
+
+    @staticmethod
+    def _serialize_console_variants(
+        variants: ConsoleVariantSet | None,
+    ) -> dict[str, Any] | None:
+        """Return a JSON-safe snapshot of regenerated message variants."""
+        if variants is None:
+            return None
+        return {
+            "turn_id": variants.turn_id,
+            "selected_index": variants.selected_index,
+            "variants": [
+                {"id": variant.id, "content": variant.content}
+                for variant in variants.variants
+            ],
+        }
+
+    @staticmethod
+    def _restore_console_variants(payload: Any) -> ConsoleVariantSet | None:
+        """Return regenerated message variants from a saved state payload."""
+        if not isinstance(payload, dict):
+            return None
+        raw_variants = payload.get("variants")
+        if not isinstance(raw_variants, list) or not raw_variants:
+            return None
+        variants: list[ConsoleVariant] = []
+        for raw_variant in raw_variants:
+            if not isinstance(raw_variant, dict):
+                continue
+            content = str(raw_variant.get("content") or "")
+            variant_id = str(raw_variant.get("id") or uuid.uuid4())
+            variants.append(ConsoleVariant(content=content, id=variant_id))
+        if not variants:
+            return None
+        selected_index = payload.get("selected_index", 0)
+        if not isinstance(selected_index, int):
+            selected_index = 0
+        selected_index = min(max(selected_index, 0), len(variants) - 1)
+        return ConsoleVariantSet(
+            turn_id=str(payload.get("turn_id") or uuid.uuid4()),
+            variants=variants,
+            selected_index=selected_index,
+        )
+
+    @classmethod
+    def _serialize_console_message(
+        cls,
+        message: ConsoleChatMessage,
+    ) -> dict[str, Any]:
+        """Return a JSON-safe snapshot of a native Console transcript message."""
+        role = message.role.value if hasattr(message.role, "value") else message.role
+        return {
+            "id": message.id,
+            "role": role,
+            "content": message.content,
+            "turn_id": message.turn_id,
+            "status": message.status,
+            "persisted_message_id": message.persisted_message_id,
+            "feedback": message.feedback,
+            "variants": cls._serialize_console_variants(message.variants),
+            "image_mime_type": getattr(message, "image_mime_type", None),
+            "attachment_label": getattr(message, "attachment_label", None),
+            # Labels only -- bytes are dropped from screen-state snapshots
+            # the same way the legacy `image_data` scalar always has been.
+            # `getattr` (not `message.attachments`) tolerates plain-object
+            # stand-ins (e.g. a bare SimpleNamespace) that predate the
+            # `attachments` field, matching this method's existing
+            # tolerance for `image_mime_type`/`attachment_label` above.
+            "attachment_labels": [
+                attachment.display_name
+                for attachment in getattr(message, "attachments", ())
+            ],
+            # Normalized provider usage (Console cost ticker): carried as the
+            # same JSON string persistence uses, so a screen-state round trip
+            # (navigate away and back) keeps a turn's real cost instead of
+            # silently zeroing it. `getattr` tolerates plain-object stand-ins
+            # that predate the field, like the neighbours above.
+            "usage_json": (
+                usage.to_json()
+                if (usage := getattr(message, "usage", None)) is not None
+                else None
+            ),
+            # Structured message metadata (task-2364): same reasoning as
+            # `usage_json` above -- a screen-state round trip that dropped
+            # it would lose the interrupted flag and a voice row's
+            # transcript status, silently re-stranding what this field
+            # exists to record.
+            "metadata_json": (
+                metadata.to_json()
+                if (metadata := getattr(message, "metadata", None)) is not None
+                else None
+            ),
+        }
+
+    @classmethod
+    def _restore_console_message(cls, payload: Any) -> ConsoleChatMessage | None:
+        """Return a native Console transcript message from a saved state payload."""
+        if not isinstance(payload, dict):
+            return None
+        try:
+            role = ConsoleMessageRole(str(payload.get("role") or "system"))
+        except ValueError:
+            role = ConsoleMessageRole.SYSTEM
+        status = str(payload.get("status") or "complete")
+        if status not in {"complete", "pending", "streaming", "stopped", "failed"}:
+            status = "complete"
+        feedback = payload.get("feedback")
+        if feedback not in {None, "up", "down"}:
+            feedback = None
+        image_mime_type = (
+            str(payload["image_mime_type"]) if payload.get("image_mime_type") else None
+        )
+        attachment_label = (
+            str(payload["attachment_label"])
+            if payload.get("attachment_label")
+            else None
+        )
+        raw_labels = payload.get("attachment_labels")
+        if isinstance(raw_labels, list):
+            attachment_labels = [str(label) for label in raw_labels]
+        else:
+            # Legacy payloads (saved before `attachment_labels` existed)
+            # carried at most one label -- the singular `attachment_label`.
+            attachment_labels = [attachment_label] if attachment_label else []
+        # Metadata-only: bytes were never serialized, so every reconstructed
+        # attachment starts with `data=None` (refilled by
+        # `_rehydrate_console_message_image`/`_rehydrate_console_message_attachments`
+        # after restore). `image_mime_type` is the only mime carried across
+        # a screen-state snapshot, so it stands in for every position until
+        # per-attachment mime types come back from the DB.
+        attachments = tuple(
+            MessageAttachment(
+                data=None,
+                mime_type=image_mime_type or "",
+                display_name=label,
+                position=index,
+            )
+            for index, label in enumerate(attachment_labels)
+        )
+        return ConsoleChatMessage(
+            role=role,
+            content=str(payload.get("content") or ""),
+            id=str(payload.get("id") or uuid.uuid4()),
+            turn_id=(
+                str(payload["turn_id"]) if payload.get("turn_id") is not None else None
+            ),
+            status=status,  # type: ignore[arg-type]
+            persisted_message_id=(
+                str(payload["persisted_message_id"])
+                if payload.get("persisted_message_id") is not None
+                else None
+            ),
+            variants=cls._restore_console_variants(payload.get("variants")),
+            feedback=feedback,  # type: ignore[arg-type]
+            image_mime_type=image_mime_type,
+            attachment_label=attachment_label,
+            attachments=attachments,
+            # `from_json` returns None for missing/legacy/corrupt payloads,
+            # which is exactly the "no usage known" state.
+            usage=ProviderUsage.from_json(payload.get("usage_json")),
+            # Same degrade-never-raise contract for structured metadata.
+            metadata=MessageMetadata.from_json(payload.get("metadata_json")),
+        )
+
+    def _rehydrate_console_message_image(self, message: ConsoleChatMessage) -> None:
+        """Refill image bytes dropped by screen-state restore (metadata-only).
+
+        Screen-state restore only carries image metadata (mime type + label),
+        never raw bytes, so a restored message that still points at an image
+        has no bytes for the provider payload builder to attach even though
+        its chip renders from metadata alone. Refetch the bytes from the
+        ChaChaNotes DB using the message's persisted id; on any failure leave
+        the message metadata-only so the chip still renders (graceful
+        degradation) instead of raising.
+        """
+        if message.image_data is not None:
+            return
+        if not message.image_mime_type or not message.persisted_message_id:
+            return
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        try:
+            row = (
+                db.get_message_by_id(message.persisted_message_id)
+                if db is not None
+                else None
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Console restore image rehydration DB lookup failed."
+            )
+            return
+        if not row:
+            return
+        image_data = row.get("image_data")
+        if image_data is None:
+            return
+        message.image_data = image_data
+        message.image_mime_type = row.get("image_mime_type") or message.image_mime_type
+
+    def _rehydrate_console_message_attachments(
+        self, messages: list[ConsoleChatMessage]
+    ) -> None:
+        """Batch-refill ``message_attachments`` table rows for restored messages.
+
+        ``_rehydrate_console_message_image`` (still called per message, see
+        its own docstring/tests) already refilled the legacy position-0
+        bytes into each message's scalar mirror; this pass runs ONE batched
+        ``get_attachments_for_messages`` call covering every message in this
+        restore, then folds the now-current scalar mirror plus any table
+        rows (positions >= 1) back into each message's attachments tuple.
+        Any failure (missing DB, unreachable batch call) leaves messages
+        metadata-only -- graceful degradation, matching
+        ``_rehydrate_console_message_image``'s own contract.
+        """
+        ids = [m.persisted_message_id for m in messages if m.persisted_message_id]
+        rows_by_id: Dict[str, list[dict[str, Any]]] = {}
+        if ids:
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            getter = getattr(db, "get_attachments_for_messages", None)
+            if callable(getter):
+                try:
+                    fetched = getter(ids)
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Console restore attachment batch fetch failed."
+                    )
+                    fetched = None
+                if isinstance(fetched, dict):
+                    rows_by_id = fetched
+
+        for message in messages:
+            if not message.attachments:
+                continue
+            entries = list(message.attachments)
+            # Position 0 mirrors whatever `_rehydrate_console_message_image`
+            # just refilled into the scalar fields (bytes included, when it
+            # found a row).
+            entries[0] = replace(
+                entries[0],
+                data=message.image_data,
+                mime_type=message.image_mime_type or entries[0].mime_type,
+            )
+            extra_rows = (
+                rows_by_id.get(message.persisted_message_id, [])
+                if message.persisted_message_id
+                else []
+            )
+            rows_by_position = {int(row.get("position", 0)): row for row in extra_rows}
+            for index in range(1, len(entries)):
+                row = rows_by_position.get(index)
+                if row is None:
+                    continue
+                entries[index] = replace(
+                    entries[index],
+                    data=row.get("data"),
+                    mime_type=row.get("mime_type") or entries[index].mime_type,
+                    display_name=row.get("display_name") or entries[index].display_name,
+                )
+            _apply_console_message_attachments(message, entries)
+
+    def _rehydrate_console_message_generation_metadata(
+        self,
+        store: "ConsoleChatStore",
+        restored_messages_by_session: Dict[str, list[ConsoleChatMessage]],
+    ) -> None:
+        """Batch-refill ``generation_metadata`` for messages restored from screen state.
+
+        Counterpart of ``_rehydrate_console_message_attachments`` for the
+        generation-metadata sidecar: `restore_state` -- the tab-switch
+        (in-memory) restore path -- does not itself hydrate
+        `generation_metadata`, unlike `restore_persisted_session` (the
+        DB-resume path), which drives this same
+        `get_generation_metadata_for_messages` +
+        `ConsoleChatStore.hydrate_generation_metadata` seam internally. One
+        batched call covers every restored message across every restored
+        session in this pass, then `hydrate_generation_metadata` is invoked
+        once per session (it filters by that session's own tree-node
+        persisted ids, so handing it the whole merged mapping is safe and
+        avoids a second per-session round trip). Must run AFTER
+        `store.restore_state(...)`, which is what populates the store's
+        tree nodes (and therefore `persisted_message_id` lookups)
+        `hydrate_generation_metadata` needs. Any failure (missing DB,
+        unreachable batch call) leaves messages metadata-only -- graceful
+        degradation, matching `_rehydrate_console_message_attachments`'s
+        own contract.
+
+        Args:
+            store: The Console chat store just populated by `restore_state`.
+            restored_messages_by_session: The same per-session message lists
+                passed to `store.restore_state(...)`.
+        """
+        persistence = getattr(store, "persistence", None)
+        getter = getattr(persistence, "get_generation_metadata_for_messages", None)
+        if not callable(getter):
+            return
+        ids = [
+            message.persisted_message_id
+            for messages in restored_messages_by_session.values()
+            for message in messages
+            if message.persisted_message_id
+        ]
+        if not ids:
+            return
+        try:
+            rows_by_message = getter(ids)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Console restore generation-metadata batch fetch failed."
+            )
+            return
+        if not isinstance(rows_by_message, dict):
+            return
+        for session_id in restored_messages_by_session:
+            store.hydrate_generation_metadata(session_id, rows_by_message)
+
+    def _native_console_messages(self) -> list[Any]:
+        """Return messages for the active native Console session."""
+        store = self._ensure_console_chat_store()
+        if store.active_session_id is None:
+            return []
+        return store.messages_for_session(store.active_session_id)
+
+    @staticmethod
+    def _console_citation_message_body(message: Any) -> str:
+        """Return the exact currently selected body for one Console message."""
+        variants = getattr(message, "variants", None)
+        if variants is not None:
+            try:
+                body = variants.current.content
+            except (AttributeError, IndexError):
+                body = getattr(message, "content", "")
+        else:
+            body = getattr(message, "content", "")
+        return body if isinstance(body, str) else ""
+
+    async def _append_native_console_system_message(
+        self, message: str, *, session_id: str | None = None
+    ) -> None:
+        """Append a system message to native Console state and refresh the bridge.
+
+        Task 4 (background-write audit): most callers are synchronous
+        command handlers with no ``await`` between "the user's intended
+        session" and this call, so the default (``session_id=None``,
+        resolving whichever session is active RIGHT NOW via
+        ``store.ensure_session``) is safe -- there is no gap in which the
+        active session could have changed underneath them.
+
+        A handler that spans a real await gap while already anchored to a
+        specific session (e.g. `/generate-image`'s in-flight batch, tracked
+        per session in ``_console_imagegen_inflight_sessions``) must pass
+        that session's id explicitly instead -- re-resolving "active" at
+        append time would let a session switch during the awaited work
+        misattribute the row to whatever the user is looking at NOW rather
+        than the session that actually produced it. The resync below is
+        unconditional either way and stays harmless: it only ever renders
+        the store's CURRENTLY active session, so a background session's
+        just-appended row simply doesn't show until the user visits it
+        (store-first discipline; no view write needs gating here beyond
+        that existing pull-based rebuild).
+        """
+        store = self._ensure_console_chat_store()
+        if session_id is not None:
+            try:
+                store.append_message(
+                    session_id,
+                    role=ConsoleMessageRole.SYSTEM,
+                    content=message,
+                )
+            except KeyError:
+                # Session vanished (closed) before its background operation's
+                # outcome could be attributed to it -- nothing to append to.
+                pass
+        else:
+            session = store.ensure_session(
+                title=self._console_initial_session_title_for_workspace(
+                    store.workspace_context.active_workspace_id
+                ),
+                workspace_id=store.workspace_context.active_workspace_id,
+            )
+            store.append_message(
+                session.id,
+                role=ConsoleMessageRole.SYSTEM,
+                content=message,
+            )
+        await self._sync_native_console_chat_ui()
+
+    async def handle_console_message_action(self, event: Button.Pressed) -> bool:
+        """Route selected transcript message actions through the native action service."""
+        button_id = event.button.id or ""
+        action_id, message_id = self._parse_console_message_action_button_id(button_id)
+        if action_id is None or message_id is None:
+            return False
+
+        event.stop()
+        store = self._ensure_console_chat_store()
+
+        if action_id == "review-changes":
+            # TASK-2030 (live-UAT headline defect): the ✎ summary row is a
+            # display-only TOOL marker -- deliberately NOT a tree node -- so
+            # `store.get_message` can NEVER resolve it, and the pre-dispatch
+            # lookup below killed the row's own advertised affordance
+            # ("review with `v`") with the not-found toast on every press.
+            # The run id is display data already ON the rendered row:
+            # resolve it from the transcript's display model, falling back
+            # to the store for tree-node rows. Every other action keeps the
+            # store resolution (and its failure toast) untouched.
+            self._pending_console_delete_message_id = None
+            run_id = self._console_change_review_run_id(store, message_id)
+            if run_id is None:
+                self.app_instance.notify(
+                    "Console message action target no longer exists.",
+                    severity="warning",
+                )
+                return True
+            self._open_change_review(run_id)
+            return True
+
+        try:
+            message = store.get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message action target no longer exists.", severity="warning"
+            )
+            return True
+
+        if action_id != "delete":
+            self._pending_console_delete_message_id = None
+
+        if action_id == "save-as":
+            destinations = self._console_save_as_destinations(message)
+
+            def _apply_save_as(destination: str | None) -> None:
+                savers = {
+                    "Note": self._save_console_message_as_note,
+                    "Media": self._save_console_message_as_media,
+                    "Prompt": self._save_console_message_as_prompt,
+                    "Chatbook": self._save_console_message_as_chatbook,
+                }
+                saver = savers.get(destination or "")
+                if saver is not None:
+                    self.run_worker(
+                        saver(message_id), exclusive=True, group="console-save-as"
+                    )
+
+            await self.push_screen(
+                ConsoleSaveAsModal(
+                    destinations=destinations,
+                    message_role=self._console_message_role_label(message),
+                    message_excerpt=self._console_message_excerpt(message),
+                    ephemeral=self._console_active_session_is_ephemeral(),
+                ),
+                callback=_apply_save_as,
+            )
+            self._last_console_action = ConsoleActionResult(
+                action_id=action_id,
+                status="completed",
+                visible_copy="Opened Save as destinations.",
+            )
+            return True
+
+        result = self._console_message_action_service.dispatch(action_id, message)
+        self._last_console_action = result
+        if action_id == "view-original-attempt" and result.status == "completed":
+            controller = self._ensure_console_chat_controller()
+            original_attempt = controller.original_attempt_for_message(message_id)
+            if original_attempt is None:
+                self._console_original_attempt_previews.pop(message_id, None)
+            elif message_id in self._console_original_attempt_previews:
+                self._console_original_attempt_previews.pop(message_id, None)
+            else:
+                self._console_original_attempt_previews[message_id] = original_attempt
+            await self._sync_native_console_chat_ui()
+            return True
+        if result.clipboard_text is not None:
+            copy_to_clipboard = getattr(self.app_instance, "copy_to_clipboard", None)
+            if callable(copy_to_clipboard):
+                copy_to_clipboard(result.clipboard_text)
+        if action_id == "speak" and result.status == "completed":
+            from tldw_chatbook.Chat.console_speech import (
+                ConsoleSpeechSnapshotRejected,
+            )
+            from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+                TTSMessageSpeechRequestEvent,
+            )
+
+            try:
+                speech_snapshot = store.issue_tts_message_speech_snapshot(message.id)
+            except ConsoleSpeechSnapshotRejected as error:
+                self.app_instance.notify(str(error), severity="warning")
+                return True
+            self.app_instance.post_message(
+                TTSMessageSpeechRequestEvent(
+                    speech_snapshot,
+                    store.validate_tts_message_speech_snapshot,
+                )
+            )
+            # task-559 unit 2: track this message as "speaking" so the
+            # action row swaps 🔊 -> ⏹ (a fresh speak always supersedes
+            # whatever was previously tracked -- the underlying player is a
+            # single-slot global singleton that stops any prior clip before
+            # starting a new one, so the tracked id and reality agree).
+            self._console_speaking_message_id = message.id
+            await self._sync_native_console_chat_ui()
+        if action_id == "speak-stop" and result.status == "completed":
+            # Reuses the legacy stop-button's exact plumbing (spec: "do not
+            # invent a parallel audio-control path") -- safe to post
+            # unconditionally, the app-level handler no-ops when nothing is
+            # cached/playing for this message id.
+            from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+                TTSPlaybackEvent,
+            )
+
+            was_speaking = (
+                getattr(self, "_console_speaking_message_id", None) == message.id
+            )
+            self.app_instance.post_message(
+                TTSPlaybackEvent(action="stop", message_id=message.id)
+            )
+            if was_speaking:
+                # Only when the screen itself believed this message was
+                # driving TTS do we clear state / re-sync / give feedback
+                # (fix round 1). A speak-stop dispatched for a message the
+                # screen never tracked as speaking -- e.g. a directly
+                # crafted button id, or a stale press racing an already-
+                # cleared state -- is a genuinely idle no-op: the stop
+                # event above is still posted for safety, but claiming
+                # "Stopped speaking." or forcing a re-sync for nothing
+                # would be misleading UI feedback.
+                self._console_speaking_message_id = None
+                await self._sync_native_console_chat_ui()
+                self.app_instance.notify(result.visible_copy, severity="information")
+            return True
+        if action_id == "edit" and result.status == "edit_requested":
+            await self._open_console_message_edit_modal(
+                message_id=message_id,
+                content=result.target_content or "",
+            )
+            return True
+        if action_id == "retry" and result.status == "completed":
+            controller = self._ensure_console_chat_controller()
+            # Gate BEFORE spawning: an exclusive console-run worker cancels the
+            # in-flight run at creation time, before the controller's own
+            # rejection can run -- the screen must refuse, like the submit path.
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
+                return True
+            self.run_worker(
+                self._retry_console_message(controller, message_id),
+                exclusive=True,
+                group=f"console-run-{target_session_id}",
+            )
+            return True
+        if action_id == "regenerate" and result.status == "wip":
+            if message.generation_metadata:
+                # A generation message's regenerate ALWAYS appends one new
+                # image variant -- never an LLM text sibling -- so it skips
+                # the controller/run-state gate entirely (that gate exists
+                # for chat runs; image generation has its own in-flight
+                # guard, checked inside this call).
+                #
+                # F5 follow-up (task-9 review): this is a fourth door onto
+                # the same disk-writing sink /generate-image's dispatch
+                # gate covers -- it calls `run_generation_batch` directly
+                # and never passes through `_dispatch_console_command`, so
+                # it needs its own check against the same registry entry.
+                image_blocked = blocked_reason(
+                    GENERATE_IMAGE_COMMAND_HANDLER_ID,
+                    ephemeral=self._console_active_session_is_ephemeral(),
+                )
+                if image_blocked is not None:
+                    self.app_instance.notify(image_blocked, severity="warning")
+                    return True
+                await self._regenerate_console_generation_variant(message_id)
+                return True
+            controller = self._ensure_console_chat_controller()
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
+                return True
+            self.run_worker(
+                self._regenerate_console_message(controller, message_id),
+                exclusive=True,
+                group=f"console-run-{target_session_id}",
+            )
+            return True
+        if (
+            action_id in {"variant-previous", "variant-next"}
+            and result.status == "completed"
+        ):
+            landed_sibling_id: str | None = None
+            if message.generation_metadata:
+                self._select_console_generation_variant(message, direction=action_id)
+            else:
+                landed_sibling_id = self._select_console_message_variant(
+                    message_id, direction=action_id
+                )
+            # task-501: keep the selection (and its action row) on the swapped
+            # sibling so repeated `<`/`>` presses work without re-clicking the
+            # row. The post-swipe view reaches the transcript asynchronously
+            # (possibly coalesced), so hand the target off as a PENDING
+            # selection the transcript applies at ingest time -- selecting
+            # eagerly here would either miss its membership guard or be
+            # cleared by reconciliation against the stale set. Other
+            # selection-clearing actions ("continue" etc.) are untouched.
+            if landed_sibling_id is not None:
+                # Held on the screen (remount-proof); the sync below transfers
+                # it onto whichever transcript instance receives the push.
+                self._pending_console_swipe_selection = landed_sibling_id
+            await self._sync_native_console_chat_ui()
+            return True
+        if action_id == "keep" and result.status == "completed":
+            self._keep_console_generation_variant(message)
+            await self._sync_native_console_chat_ui()
+            self.app_instance.notify(result.visible_copy, severity="information")
+            return True
+        if (
+            action_id in {"feedback-up", "feedback-down"}
+            and result.status == "completed"
+        ):
+            feedback = "up" if action_id == "feedback-up" else "down"
+            store.set_message_feedback(message_id, feedback)
+            await self._sync_native_console_chat_ui()
+            self.app_instance.notify(result.visible_copy, severity="information")
+            return True
+        if action_id == "toggle-image-view" and result.status == "completed":
+            self._handle_console_toggle_image_view(message_id)
+            await self._sync_native_console_chat_ui()
+            return True
+        if action_id == "save-image" and result.status == "completed":
+            self.run_worker(
+                self._save_console_message_image(message_id),
+                exclusive=True,
+                group="console-save-image",
+            )
+            return True
+        if action_id == "delete" and result.status == "completed":
+            if self._pending_console_delete_message_id != message_id:
+                self._pending_console_delete_message_id = message_id
+                self._last_console_action = ConsoleActionResult(
+                    action_id=action_id,
+                    status="blocked",
+                    visible_copy="Press Delete again to remove this message.",
+                    target_message_id=message_id,
+                )
+                await self._sync_native_console_chat_ui()
+                return True
+            self._pending_console_delete_message_id = None
+            session_id = store.session_id_for_message(message_id)
+            controller = self._ensure_console_chat_controller()
+            # Deletion is subtree-wide, so clear the owning session while
+            # descendant-to-session identity is still available.
+            controller.clear_original_attempts_for_session(session_id)
+            self._console_original_attempt_previews.clear()
+            store.delete_message(message_id)
+            # TASK-251: a deleted message can change what the browser row
+            # shows for this conversation (title/updated_at) -- invalidate
+            # so the next sync reflects it immediately.
+            self._invalidate_console_persisted_rows_cache()
+            await self._sync_native_console_chat_ui()
+            self.app_instance.notify(result.visible_copy, severity="information")
+            return True
+        if action_id == "continue" and result.status == "continue_requested":
+            controller = self._ensure_console_chat_controller()
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
+                return True
+            self.run_worker(
+                self._continue_console_message(controller, message_id),
+                exclusive=True,
+                group=f"console-run-{target_session_id}",
+            )
+            return True
+        severity = "information" if result.status in {"completed", "wip"} else "warning"
+        self.app_instance.notify(result.visible_copy, severity=severity)
+        return True
+
+    @staticmethod
+    def _console_message_role_label(message: ConsoleChatMessage) -> str:
+        """Return a user-facing role label for a Console transcript message."""
+        role = (
+            message.role.value if hasattr(message.role, "value") else str(message.role)
+        )
+        return role.title()
+
+    @staticmethod
+    def _console_message_content(message: ConsoleChatMessage) -> str:
+        """Return the currently visible content for a Console transcript message."""
+        if message.variants is not None:
+            return message.variants.current.content
+        return message.content
+
+    @classmethod
+    def _console_message_excerpt(
+        cls,
+        message: ConsoleChatMessage,
+        *,
+        max_length: int = 120,
+    ) -> str:
+        """Return a single-line excerpt for selected-message context surfaces."""
+        normalized = " ".join(cls._console_message_content(message).split())
+        if len(normalized) <= max_length:
+            return normalized
+        return f"{normalized[: max(0, max_length - 1)].rstrip()}…"
+
+    def _console_save_as_destinations(self, message: Any) -> list[Any]:
+        """Return Save-as destinations available in the current app runtime.
+
+        A temporary session blocks every destination outright: the write
+        itself is the problem, so service readiness is moot and is never
+        even checked in that case.
+        """
+        available_destinations: set[str] = set()
+        unavailable_reasons: dict[str, str] = {}
+
+        if self._console_active_session_is_ephemeral():
+            # F4 (task-9 review): `blocked_reason` returns `str | None`;
+            # every label above has a registry entry today, so this is
+            # never None in practice, but `unavailable_reasons` is typed
+            # `dict[str, str]` -- fall back to a generic sentence instead
+            # of silently letting a future registry-key drift surface the
+            # literal string "None" on the modal.
+            for label in ("Chatbook", "Note", "Media", "Prompt"):
+                unavailable_reasons[label] = (
+                    blocked_reason(f"save-as-{label.lower()}", ephemeral=True)
+                    or "Not available in a temporary chat."
+                )
+            return ConsoleMessageActionService(
+                available_save_destinations=set(),
+                unavailable_save_reasons=unavailable_reasons,
+            ).save_as_destinations(message)
+
+        notes_scope_service = getattr(self.app_instance, "notes_scope_service", None)
+        if callable(getattr(notes_scope_service, "save_note", None)):
+            available_destinations.add("Note")
+        else:
+            unavailable_reasons["Note"] = "Notes service is not ready in this session."
+
+        media_db = getattr(self.app_instance, "media_db", None)
+        if callable(getattr(media_db, "add_media_with_keywords", None)):
+            available_destinations.add("Media")
+        else:
+            unavailable_reasons["Media"] = "Media library is not ready in this session."
+
+        prompts_db = getattr(self.app_instance, "prompts_db", None)
+        if callable(getattr(prompts_db, "add_prompt", None)):
+            available_destinations.add("Prompt")
+        else:
+            unavailable_reasons["Prompt"] = (
+                "Prompts service is not ready in this session."
+            )
+
+        chatbook_service = getattr(self.app_instance, "local_chatbook_service", None)
+        if not callable(getattr(chatbook_service, "create_chatbook", None)):
+            unavailable_reasons["Chatbook"] = (
+                "Chatbook artifacts service is not ready in this session."
+            )
+        elif not ConsoleMessageActionService._is_assistant_message(message):
+            unavailable_reasons["Chatbook"] = (
+                "Only assistant responses can be saved as Chatbook artifacts."
+            )
+        else:
+            available_destinations.add("Chatbook")
+
+        return ConsoleMessageActionService(
+            available_save_destinations=available_destinations,
+            unavailable_save_reasons=unavailable_reasons,
+        ).save_as_destinations(message)
+
+    def _console_save_source_title(self) -> str:
+        """Return the active Console conversation title for save-as derivations."""
+        session = self._active_native_console_session()
+        return str(getattr(session, "title", "") or "").strip()
+
+    async def _save_console_message_image(self, message_id: str) -> None:
+        """Write ALL of a Console message's image attachments to disk.
+
+        In-memory bytes are used first; any attachment still dataless (e.g.
+        a metadata-only entry left by screen-state restore) falls back to
+        one batched DB fetch -- the legacy `messages.image_data` column for
+        position 0, `get_attachments_for_messages` for positions >= 1 --
+        per the HARD interface contract split addressing.
+        """
+        import mimetypes as _mimetypes
+        from datetime import datetime as _datetime
+
+        store = self._ensure_console_chat_store()
+        try:
+            message = store.get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message no longer exists.", severity="warning"
+            )
+            return
+
+        attachments = list(message.attachments)
+        if not attachments and (
+            message.image_data is not None or message.persisted_message_id is not None
+        ):
+            # Legacy/raw-constructed messages may carry the scalar image
+            # fields without a populated attachments tuple; synthesize a
+            # position-0 entry so the fallback below still covers them.
+            attachments = [
+                MessageAttachment(
+                    data=message.image_data,
+                    mime_type=message.image_mime_type or "image/png",
+                    display_name=message.attachment_label or "",
+                    position=0,
+                )
+            ]
+
+        missing_positions = any(a.data is None for a in attachments)
+        if missing_positions and message.persisted_message_id is not None:
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            persisted_message_id = message.persisted_message_id
+
+            def _fetch_persisted_attachment_data() -> dict[
+                int, tuple[Any, Optional[str]]
+            ]:
+                fetched: dict[int, tuple[Any, Optional[str]]] = {}
+                try:
+                    row = (
+                        db.get_message_by_id(persisted_message_id)
+                        if db is not None
+                        else None
+                    )
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Console save-image DB fallback lookup failed."
+                    )
+                    row = None
+                if row and row.get("image_data") is not None:
+                    fetched[0] = (row.get("image_data"), row.get("image_mime_type"))
+                getter = getattr(db, "get_attachments_for_messages", None)
+                if callable(getter):
+                    try:
+                        batch = getter([persisted_message_id])
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Console save-image attachment batch fetch failed."
+                        )
+                        batch = None
+                    if isinstance(batch, dict):
+                        for row_dict in batch.get(persisted_message_id, []) or []:
+                            position = int(row_dict.get("position", 0))
+                            fetched[position] = (
+                                row_dict.get("data"),
+                                row_dict.get("mime_type"),
+                            )
+                return fetched
+
+            fetched = await asyncio.to_thread(_fetch_persisted_attachment_data)
+            if fetched:
+                attachments = [
+                    replace(
+                        attachment,
+                        data=fetched[attachment.position][0],
+                        mime_type=fetched[attachment.position][1]
+                        or attachment.mime_type,
+                    )
+                    if attachment.data is None and attachment.position in fetched
+                    else attachment
+                    for attachment in attachments
+                ]
+
+        saveable = [a for a in attachments if a.data]
+        if not saveable:
+            self.app_instance.notify(
+                "No image data available for this message.", severity="warning"
+            )
+            return
+
+        def _write_images_to_disk() -> tuple[list[Path], Path]:
+            from tldw_chatbook.Utils.path_validation import validate_path_simple
+
+            save_location = validate_path_simple(
+                os.path.expanduser(
+                    get_cli_setting("chat.images", "save_location", "~/Downloads")
+                )
+            )
+            save_location.mkdir(parents=True, exist_ok=True)
+            base_name = f"console_image_{_datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            written: list[Path] = []
+            for attachment in saveable:
+                extension = (
+                    _mimetypes.guess_extension(attachment.mime_type or "image/png")
+                    or ".png"
+                )
+                target = save_location / f"{base_name}{extension}"
+                counter = 1
+                while target.exists() or target in written:
+                    target = save_location / f"{base_name}_{counter}{extension}"
+                    counter += 1
+                target.write_bytes(bytes(attachment.data))
+                written.append(target)
+            return written, save_location
+
+        try:
+            written, save_location = await asyncio.to_thread(_write_images_to_disk)
+        except Exception as exc:
+            logger.opt(exception=True).warning("Console save-image write failed.")
+            self.app_instance.notify(
+                f"Could not save image: {escape_markup(str(exc))}", severity="error"
+            )
+            return
+        if len(written) == 1:
+            self.app_instance.notify(f"Image saved to {escape_markup(str(written[0]))}")
+        else:
+            self.app_instance.notify(
+                f"Saved {len(written)} images to {escape_markup(str(save_location))}"
+            )
+
+    async def _save_console_message_as_note(self, message_id: str) -> None:
+        """Persist one selected Console message as a local Note."""
+        notes_scope_service = getattr(self.app_instance, "notes_scope_service", None)
+        save_note = getattr(notes_scope_service, "save_note", None)
+        if not callable(save_note):
+            self.app_instance.notify(
+                "Save as Note is unavailable: Notes service is not ready.",
+                severity="warning",
+            )
+            return
+
+        try:
+            message = self._ensure_console_chat_store().get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message action target no longer exists.",
+                severity="warning",
+            )
+            return
+
+        content = self._console_message_content(message)
+        title = derive_console_save_title(self._console_save_source_title())
+        try:
+            result = save_note(
+                scope=ScopeType.LOCAL_NOTE.value,
+                title=title,
+                content=content,
+                note_id=None,
+                version=None,
+                user_id=getattr(self.app_instance, "current_user", None)
+                or "default_user",
+                workspace_id=None,
+                keywords=["console"],
+            )
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as exc:
+            logger.opt(exception=True).warning("Console save-as Note failed.")
+            self.app_instance.notify(f"Save as Note failed: {exc}", severity="error")
+            return
+        if not result:
+            self.app_instance.notify("Save as Note failed.", severity="error")
+            return
+        self._last_console_action = ConsoleActionResult(
+            action_id="save-as-note",
+            status="completed",
+            visible_copy="Saved message as Note.",
+            target_message_id=message_id,
+            target_content=content,
+        )
+        self.app_instance.notify("Saved message as Note.", severity="information")
+
+    async def _save_console_message_as_media(self, message_id: str) -> None:
+        """Persist one selected Console message as a Library media item."""
+        media_db = getattr(self.app_instance, "media_db", None)
+        add_media = getattr(media_db, "add_media_with_keywords", None)
+        if not callable(add_media):
+            self.app_instance.notify(
+                "Save as Media is unavailable: Media library is not ready.",
+                severity="warning",
+            )
+            return
+
+        try:
+            message = self._ensure_console_chat_store().get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message action target no longer exists.",
+                severity="warning",
+            )
+            return
+
+        content = self._console_message_content(message)
+        title = derive_console_save_title(
+            self._console_save_source_title(),
+            role_label=self._console_message_role_label(message),
+        )
+        try:
+            media_id, _media_uuid, save_message = add_media(
+                title=title,
+                media_type="plaintext",
+                content=content,
+                keywords=["console"],
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Console save-as Media failed.")
+            self.app_instance.notify(f"Save as Media failed: {exc}", severity="error")
+            return
+        if media_id is None:
+            self.app_instance.notify(
+                f"Save as Media failed: {save_message or 'no media record was created.'}",
+                severity="error",
+            )
+            return
+        self._last_console_action = ConsoleActionResult(
+            action_id="save-as-media",
+            status="completed",
+            visible_copy="Saved message as Media.",
+            target_message_id=message_id,
+            target_content=content,
+        )
+        self.app_instance.notify(
+            "Saved message as Media. It appears under Library ▸ Media.",
+            severity="information",
+        )
+
+    async def _save_console_message_as_prompt(self, message_id: str) -> None:
+        """Persist one selected Console message as a prompt in the Prompts library."""
+        prompts_db = getattr(self.app_instance, "prompts_db", None)
+        add_prompt = getattr(prompts_db, "add_prompt", None)
+        if not callable(add_prompt):
+            self.app_instance.notify(
+                "Save as Prompt is unavailable: Prompts service is not ready.",
+                severity="warning",
+            )
+            return
+
+        try:
+            message = self._ensure_console_chat_store().get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message action target no longer exists.",
+                severity="warning",
+            )
+            return
+
+        from tldw_chatbook.DB.Prompts_DB import ConflictError
+
+        content = self._console_message_content(message)
+        conversation_title = self._console_save_source_title()
+        base_name = derive_console_save_title(conversation_title)
+        details = (
+            f"Saved from Console conversation: {conversation_title}."
+            if conversation_title
+            else "Saved from a Console conversation."
+        )
+        prompt_id = None
+        saved_name = base_name
+        try:
+            for attempt in range(1, 10):
+                saved_name = base_name if attempt == 1 else f"{base_name} ({attempt})"
+                try:
+                    prompt_id, _prompt_uuid, save_message = add_prompt(
+                        name=saved_name,
+                        author="Console",
+                        details=details,
+                        system_prompt=content,
+                        keywords=["console"],
+                        overwrite=False,
+                    )
+                except ConflictError:
+                    continue
+                if prompt_id is not None and "soft-deleted" in str(save_message or ""):
+                    # Name collides with a soft-deleted prompt: nothing was
+                    # saved, so keep probing suffixed names.
+                    prompt_id = None
+                    continue
+                break
+        except Exception as exc:
+            logger.opt(exception=True).warning("Console save-as Prompt failed.")
+            self.app_instance.notify(f"Save as Prompt failed: {exc}", severity="error")
+            return
+        if prompt_id is None:
+            self.app_instance.notify(
+                "Save as Prompt failed: a prompt with this name already exists.",
+                severity="error",
+            )
+            return
+        self._last_console_action = ConsoleActionResult(
+            action_id="save-as-prompt",
+            status="completed",
+            visible_copy="Saved message as Prompt.",
+            target_message_id=message_id,
+            target_content=content,
+        )
+        self.app_instance.notify(
+            f"Saved message as Prompt '{saved_name}' in the local Prompts library.",
+            severity="information",
+        )
+
+    async def _save_console_message_as_chatbook(self, message_id: str) -> None:
+        """Register one selected assistant message as a Chatbook artifact."""
+        chatbook_service = getattr(self.app_instance, "local_chatbook_service", None)
+        create_chatbook = getattr(chatbook_service, "create_chatbook", None)
+        if not callable(create_chatbook):
+            self.app_instance.notify(
+                "Save as Chatbook is unavailable: Chatbook artifacts service is not ready.",
+                severity="warning",
+            )
+            return
+
+        try:
+            message = self._ensure_console_chat_store().get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message action target no longer exists.",
+                severity="warning",
+            )
+            return
+
+        if not ConsoleMessageActionService._is_assistant_message(message):
+            self.app_instance.notify(
+                "Only assistant responses can be saved as Chatbook artifacts.",
+                severity="warning",
+            )
+            return
+
+        content = self._console_message_content(message)
+        provider: str | None = None
+        model: str | None = None
+        try:
+            provider, model, _settings = self._active_console_provider_model_display()
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Console save-as Chatbook could not resolve provider/model context."
+            )
+        payload = console_chatbook_artifact_payload(
+            title=derive_console_save_title(self._console_save_source_title()),
+            message_text=content,
+            message_role=self._console_message_role_label(message),
+            conversation_id=self._current_console_conversation_id(),
+            message_id=message_id,
+            provider=provider,
+            model=model,
+        )
+        coordinator = getattr(
+            self.app_instance,
+            "citation_artifact_ownership_coordinator",
+            None,
+        )
+        owner_request = resolve_console_artifact_owner_request(
+            coordinator=coordinator,
+            persisted_message_id=message.persisted_message_id,
+            message_text=content,
+        )
+        if owner_request is not None:
+            payload["provenance_owner_request"] = owner_request
+        try:
+            result = create_chatbook(**payload)
+            if inspect.isawaitable(result):
+                await result
+            if owner_request is not None and coordinator is not None:
+                try:
+                    await asyncio.to_thread(coordinator.reconcile_pending, limit=1)
+                except Exception:
+                    logger.warning(
+                        "Citation artifact reconciliation deferred: "
+                        "artifact_reconciliation_failed"
+                    )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Console save-as Chatbook failed.")
+            self.app_instance.notify(
+                f"Save as Chatbook failed: {exc}", severity="error"
+            )
+            return
+        self._last_console_action = ConsoleActionResult(
+            action_id="save-as-chatbook",
+            status="completed",
+            visible_copy="Saved message as Chatbook artifact.",
+            target_message_id=message_id,
+            target_content=content,
+        )
+        self.app_instance.notify(
+            "Saved message as a Chatbook artifact. It appears under Artifacts.",
+            severity="information",
+        )
+
+    def _clear_console_original_attempt_preview(self, message_id: str) -> None:
+        """Clear one screen preview and its controller-owned cached body."""
+        self._console_original_attempt_previews.pop(message_id, None)
+        controller = self._console_chat_controller
+        if controller is not None:
+            controller.clear_original_attempt(message_id)
+
+    async def _open_console_message_edit_modal(
+        self, *, message_id: str, content: str
+    ) -> None:
+        """Open the dedicated transcript edit modal for one Console message."""
+        store = self._ensure_console_chat_store()
+        try:
+            message = store.get_message(message_id)
+        except KeyError:
+            self.app_instance.notify(
+                "Console message action target no longer exists.",
+                severity="error",
+            )
+            return
+        can_resend = message.role is ConsoleMessageRole.USER
+
+        def _apply_edit(result: ConsoleEditResult | None) -> None:
+            if result is None:
+                return
+            self._clear_console_original_attempt_preview(message_id)
+            if not result.resend:
+                try:
+                    store.update_message_content(message_id, result.text)
+                except ValueError as exc:
+                    self.app_instance.notify(str(exc), severity="warning")
+                    return
+                except KeyError:
+                    self.app_instance.notify(
+                        "Console message action target no longer exists.",
+                        severity="error",
+                    )
+                    return
+                self._last_console_action = ConsoleActionResult(
+                    action_id="edit",
+                    status="completed",
+                    visible_copy="Edited message.",
+                    target_message_id=message_id,
+                    target_content=result.text,
+                )
+                self.run_worker(
+                    self._sync_native_console_chat_ui(),
+                    exclusive=True,
+                    group="console-sync",
+                )
+                self.app_instance.notify("Edited message.", severity="information")
+                return
+            controller = self._ensure_console_chat_controller()
+            # Gate BEFORE spawning: an exclusive console-run worker cancels the
+            # in-flight run at creation time, before the controller's own
+            # rejection can run -- the screen must refuse, like the submit path.
+            target_session_id = controller.store.active_session_id
+            refusal = controller.send_refusal_copy(target_session_id)
+            if refusal:
+                self.app_instance.notify(refusal, severity="warning")
+                return
+            self.run_worker(
+                self._edit_resend_console_message(controller, message_id, result.text),
+                exclusive=True,
+                group=f"console-run-{target_session_id}",
+            )
+
+        await self.push_screen(
+            ConsoleEditMessageModal(content=content, can_resend=can_resend),
+            callback=_apply_edit,
+        )
+
+    @staticmethod
+    def _parse_console_message_action_button_id(
+        button_id: str,
+    ) -> tuple[str | None, str | None]:
+        prefixes = (
+            (
+                "console-message-action-view-original-attempt-",
+                "view-original-attempt",
+            ),
+            ("console-message-action-feedback-up-", "feedback-up"),
+            ("console-message-action-feedback-down-", "feedback-down"),
+            ("console-message-action-variant-previous-", "variant-previous"),
+            ("console-message-action-variant-next-", "variant-next"),
+            ("console-message-action-keep-", "keep"),
+            ("console-message-action-review-changes-", "review-changes"),
+            ("console-message-action-save-as-", "save-as"),
+            ("console-message-action-save-image-", "save-image"),
+            ("console-message-action-toggle-image-view-", "toggle-image-view"),
+            ("console-message-action-regenerate-", "regenerate"),
+            ("console-message-action-continue-", "continue"),
+            ("console-message-action-delete-", "delete"),
+            ("console-message-action-retry-", "retry"),
+            # speak-stop MUST be checked before speak -- "speak-" is itself
+            # a prefix of "speak-stop-", so the more specific entry has to
+            # win the ordered startswith() scan below (else a speak-stop
+            # button id would mis-parse as action "speak" with message id
+            # "stop-<real id>").
+            ("console-message-action-speak-stop-", "speak-stop"),
+            ("console-message-action-speak-", "speak"),
+            ("console-message-action-copy-", "copy"),
+            ("console-message-action-edit-", "edit"),
+        )
+        for prefix, action_id in prefixes:
+            if button_id.startswith(prefix):
+                return action_id, button_id.removeprefix(prefix)
+        return None, None
+
+    async def _retry_console_message(
+        self,
+        controller: ConsoleChatController,
+        message_id: str,
+    ) -> None:
+        # TASK-343: without the sync timer these awaits run the whole
+        # generation with zero on-screen feedback (the timer self-stops
+        # when the run leaves an active status).
+        self._start_console_transcript_sync_timer()
+        result = await controller.retry_message(message_id)
+        if result.visible_copy:
+            severity = "warning" if not result.accepted else "information"
+            self.app_instance.notify(result.visible_copy, severity=severity)
+        await self._sync_native_console_chat_ui()
+
+    async def _continue_console_message(
+        self,
+        controller: ConsoleChatController,
+        message_id: str,
+    ) -> None:
+        self._start_console_transcript_sync_timer()
+        result = await controller.continue_from_message(message_id)
+        if result.visible_copy and not result.accepted:
+            self.app_instance.notify(result.visible_copy, severity="warning")
+        if result.accepted:
+            self._clear_native_console_message_selection()
+        await self._sync_native_console_chat_ui()
+
+    async def _regenerate_console_message(
+        self,
+        controller: ConsoleChatController,
+        message_id: str,
+    ) -> None:
+        self._start_console_transcript_sync_timer()
+        result = await controller.regenerate_message(message_id)
+        if result.visible_copy and not result.accepted:
+            self.app_instance.notify(result.visible_copy, severity="warning")
+        await self._sync_native_console_chat_ui()
+
+    async def _edit_resend_console_message(
+        self,
+        controller: ConsoleChatController,
+        message_id: str,
+        new_content: str,
+    ) -> None:
+        # TASK-343: without the sync timer these awaits run the whole
+        # generation with zero on-screen feedback (the timer self-stops
+        # when the run leaves an active status).
+        self._start_console_transcript_sync_timer()
+        result = await controller.edit_and_resend_message(message_id, new_content)
+        if result.visible_copy and not result.accepted:
+            self.app_instance.notify(result.visible_copy, severity="warning")
+        await self._sync_native_console_chat_ui()
+
+    def _select_console_message_variant(
+        self, message_id: str, *, direction: str
+    ) -> str | None:
+        """Move the active leaf across ``message_id``'s persisted siblings.
+
+        Returns the target sibling's native id when the swipe moved (so the
+        caller can re-select that row after the UI sync -- task-501: repeated
+        ``<``/``>`` presses must not require re-clicking the row), or ``None``
+        on a no-op at either end of the sibling list.
+
+        ``message_id`` identifies the transcript ROW the swipe control was
+        clicked on -- this may be off the CURRENT active leaf's own subtree
+        (e.g. after a previous swipe landed deep inside a sibling's branch),
+        so sibling lookup always resolves from ``message_id`` itself via
+        ``store.siblings_at`` (works for off-path nodes too), never from
+        ``store.active_leaf``. The target sibling's own most-recent
+        descendant (``store._leaf_under``) becomes the new active leaf, so
+        swiping back into a branch that was mid-conversation resumes at its
+        deepest turn rather than snapping back to the fork point. A no-op at
+        either end of the sibling list (nothing before the first / after the
+        last) leaves the active leaf untouched -- the caller re-syncs the UI
+        either way, which is harmless when nothing moved.
+        """
+        store = self._ensure_console_chat_store()
+        siblings, index, count = store.siblings_at(message_id)
+        if direction == "variant-previous":
+            target_index = index - 1
+        elif direction == "variant-next":
+            target_index = index + 1
+        else:
+            return None
+        if target_index < 0 or target_index >= count:
+            return None
+        target_sibling_id = siblings[target_index].id
+        session_id = store.session_id_for_message(message_id)
+        store.set_active_leaf(session_id, store._leaf_under(target_sibling_id))
+        return target_sibling_id
+
+    def _console_transcript_has_messages(self) -> bool:
+        """Return whether the active Console transcript has user/session content.
+
+        Dead code, pre-existing (task-1 extraction audit, wave-3): zero
+        callers anywhere in the repository. Moved verbatim rather than
+        fixed/removed -- behaviour changes are out of scope for this
+        extraction; see the task-1 report.
+        """
+        if self._console_chat_store is not None:
+            session_id = self._console_chat_store.active_session_id
+            if session_id is not None and self._console_chat_store.messages_for_session(
+                session_id
+            ):
+                return True
+
+        return False
+
+    def _active_console_transcript_has_messages(self) -> bool:
+        """Return whether the active Console session's store transcript has messages."""
+        store = self._console_chat_store
+        if store is None:
+            return False
+        session_id = store.active_session_id
+        if session_id is None:
+            return False
+        return bool(store.messages_for_session(session_id))

--- a/tldw_chatbook/UI/Console_Modules/prompts.py
+++ b/tldw_chatbook/UI/Console_Modules/prompts.py
@@ -336,7 +336,14 @@ class ConsolePromptsController:
 
     @property
     def push_screen(self) -> Any:
-        """`Screen.app.push_screen`, bound. See `__init__`'s docstring."""
+        """`Screen.app.push_screen`, live-read rather than snapshotted.
+
+        See `__init__`'s docstring for why a framework service is reached
+        through a property on every access instead of captured once.
+
+        Returns:
+            Any: The screen's app-level `push_screen`, bound.
+        """
         return self._screen.app.push_screen
 
     # -- Named constructor dependencies -------------------------------------

--- a/tldw_chatbook/UI/Console_Modules/prompts.py
+++ b/tldw_chatbook/UI/Console_Modules/prompts.py
@@ -13,7 +13,7 @@ This module follows the SAME binding rule waves 1-2 established (see
 canonical statement, and `message.py` for the closest analogue in size and
 fan-in; restated briefly here):
 
-1. **Framework services** (`run_worker`, `push_screen`) live-read from the
+1. **Framework services** (`push_screen`) live-read from the
    screen via `@property` on every access -- never snapshotted.
 2. **Everything else this cluster depends on that is not its own state** is
    a NAMED keyword-only constructor callable, matching the design spec's
@@ -220,7 +220,7 @@ class ConsolePromptsController:
 
         Args:
             screen: The Console screen. Used ONLY for the framework
-                services (`run_worker`, `push_screen`) below. Zero
+                services (`push_screen`) below. Zero
                 `query_one`/`query` traffic reaches through `screen` here --
                 see the module docstring's "Zero DOM" section.
             app_instance: Snapshotted once, not re-read through `screen` --
@@ -333,12 +333,6 @@ class ConsolePromptsController:
         self._console_prompt_history: Any | None = None
 
     # -- Framework services (live-read via `@property`) --------------------
-
-    @property
-    def run_worker(self) -> Any:
-        """`Screen.run_worker`, bound. See `__init__`'s docstring for why
-        this is a property rather than a value snapshotted once."""
-        return self._screen.run_worker
 
     @property
     def push_screen(self) -> Any:

--- a/tldw_chatbook/UI/Console_Modules/prompts.py
+++ b/tldw_chatbook/UI/Console_Modules/prompts.py
@@ -1,0 +1,1250 @@
+"""Console prompts controller.
+
+Extracted out of `ChatScreen` (wave-3 console decomposition, task 3): the
+Console shell's PROMPT cluster -- the source-aware Prompt Library modal
+(`_open_console_prompts_modal`, 397 lines, the largest non-`__init__`
+method the pre-move class had), `/prompt` and `/system` name resolution
+and their shared refuse-a-Recipe guard, both prompt-picker launches, the
+system-prompt editor and its save-to-Library flow, the Library "Use in
+Console" staged-insert handoff, and the shared prompt-history store.
+
+This module follows the SAME binding rule waves 1-2 established (see
+`dictation.py`'s `ConsoleDictationController.__init__` docstring for the
+canonical statement, and `message.py` for the closest analogue in size and
+fan-in; restated briefly here):
+
+1. **Framework services** (`run_worker`, `push_screen`) live-read from the
+   screen via `@property` on every access -- never snapshotted.
+2. **Everything else this cluster depends on that is not its own state** is
+   a NAMED keyword-only constructor callable, matching the design spec's
+   rule that "a controller's dependencies are its signature". Each is a
+   callable the CALLER (`ChatScreen.__init__`) constructs as a late-binding
+   lambda closing over `self` -- never a bound method passed directly. That
+   matters concretely here: `Tests/UI/test_console_workbench_contract.py`
+   replaces `_open_console_provider_recovery` and `_console_provider_
+   blocker_copy` on the SCREEN INSTANCE and then calls the modal opener,
+   and eleven of the eighteen dependencies below are monkeypatched by name
+   somewhere in the pre-existing suite. A constructor snapshot would
+   silently stop observing every one of those.
+3. `app_instance` is a plain snapshot, for the same reason `dictation.py`
+   and `message.py` snapshot it: every read in the moved bodies is a
+   bare-attribute or `notify()` call, never one that could observe a later
+   `screen.app_instance` reassignment.
+
+**Zero DOM.** No `query_one`/`query` traffic reaches through `screen` here.
+That is why `_insert_prompt_text_into_composer` -- which does a raw
+`self.query_one("#console-native-composer", ConsoleComposerBar)` -- did NOT
+move and is instead one of the eighteen injected callables, even though it
+is the single most prompt-shaped helper on the screen. (Six pre-existing
+test sites also replace it on the screen by name, so it has to keep
+resolving through the screen either way.)
+
+**Controller-to-controller seam** (session): three moved bodies called
+`self._session.X(...)` in the pre-move source -- `_ensure_active_console_
+session_settings`, `_apply_console_session_system_prompt`, `_sync_console_
+session_draft`. Each drops that prefix in favour of a same-named property
+here, wrapping a constructor-injected callable `ChatScreen.__init__` points
+at `self._session.X`, exactly as `message.py` documents for its own session
+seam. Python resolves those lambdas at CALL time, so construction order
+between controllers never matters. There is no reverse seam: nothing on
+`ConsoleSessionController` reaches back into this cluster.
+
+**Delegation table.** `ChatScreen` keeps a thin (<=4-line) delegation under
+the ORIGINAL private name for every moved method that is still reached from
+outside the cluster -- either by a staying screen method, by Textual's own
+`action_*` resolution, by the `/prompt`+`/system` command-registry dict, or
+by a pre-existing test that monkeypatches or calls that exact name:
+
+- `_open_console_prompts_modal` -- `_handle_console_composer_menu_choice`'s
+  `ACTION_PROMPTS` branch, and `test_console_composer_menu.py` replaces the
+  screen attribute wholesale.
+- `_ensure_console_prompt_history` -- `_ensure_console_chat_controller` and
+  the composer's `set_prompt_history` mount wiring, plus
+  `test_console_composer_history.py`.
+- `_console_command_insert_prompt` / `_console_command_apply_system` -- the
+  `/prompt` and `/system` rows of the command-handler dict, which
+  `test_console_command_composer.py` replaces per-instance.
+- `_open_console_system_prompt_editor` -- `action_open_console_system_
+  prompt_editor` (stays: Textual resolves `action_*` by name on the
+  Screen), the setup-modal recovery branch, and six sites in
+  `test_console_system_prompt.py`.
+- `_consume_pending_console_prompt_insert` -- two `set_timer` schedules
+  (`on_mount`, `on_screen_resume`) plus five test sites.
+
+The remaining moved methods (`_is_recipe_prompt_record`, `_console_prompt_
+prefix_fts_query`, `_console_prompt_search`, `_resolve_console_prompt_by_
+name`, `_open_console_prompt_picker_for_insert`, `_open_console_prompt_
+picker_for_apply_system`, `_save_console_system_prompt_to_library`) have no
+staying caller other than `action_open_console_prompt_insert`, which got a
+direct `self._prompts.X(...)` call-site edit instead of a delegation.
+
+**Stays on `ChatScreen`, despite matching the `*prompt*` name pattern**:
+- `action_open_console_prompt_insert` / `action_open_console_system_prompt_
+  editor` -- Textual resolves `action_*` by name on the Screen.
+- `_console_system_prompt_chip_activated` -- an `@on`-decorated message
+  handler; Textual's message dispatch requires the decorator on the class
+  that receives the message.
+- `_insert_prompt_text_into_composer` -- real `query_one` DOM access (see
+  "Zero DOM" above).
+- `_console_prompted_source_count` -- a name-pattern false positive: it
+  counts RAG evidence entries "put in front of the model", i.e. it belongs
+  to the live-work/citation cluster, and touches no prompt record at all.
+- `_insert_console_caption_prompt` -- appends one canned caption string to
+  the composer draft; composer cluster, not the Prompt Library.
+- `_console_rewind_prompt_rows` -- builds `RewindPromptRow`s from a
+  session's USER turns for the `/rewind` menu; rewind cluster.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import replace
+from typing import Any, Optional, TYPE_CHECKING
+import asyncio
+import uuid
+
+from loguru import logger
+
+from ..Navigation.pending_handoff_store import HandoffChannel
+from ...Chat.console_command_grammar import CommandParse
+from ...Chat.console_provider_endpoints import safe_endpoint_display
+from ...Chat.prompt_history import PromptHistory, default_prompt_history_path
+from ...Library.library_prompts_state import classify_prompt_save_error
+from ...Prompt_Management.prompt_artifact_codec import decode_prompt_artifact
+from ...Prompt_Management.prompt_improvement_models import (
+    PromptImprovementRequestSnapshot,
+    fingerprint_block_definition,
+    fingerprint_text,
+)
+from ...Prompt_Management.prompt_improvement_service import PromptImprovementService
+from ...Widgets.Console.console_prompt_improve_view import (
+    ConsolePromptImprovementContext,
+)
+from ...Widgets.Console.console_prompt_picker_modal import (
+    MODE_APPLY_SYSTEM as CONSOLE_PROMPT_PICKER_MODE_APPLY_SYSTEM,
+    ConsolePromptPickerModal,
+)
+from ...Widgets.Console.console_prompts_modal import (
+    ConsolePromptsApplyOutcome,
+    ConsolePromptsModal,
+    ConsolePromptsResult,
+    ConsoleRecipeApplyGuard,
+    ConsoleSavedPromptApplyGuard,
+)
+from ...Widgets.Console.console_system_prompt_modal import ConsoleSystemPromptModal
+
+if TYPE_CHECKING:
+    from ..Screens.chat_screen import ChatScreen
+
+logger = logger.bind(module="ChatScreen")
+
+
+# -- Module-level copy this cluster owns exclusively -- moved verbatim from
+# `chat_screen.py`, which no longer references either name for itself.
+
+#: Console's `/system` editor only ever performs a Library prompt CREATE
+#: (never an update to an existing one, unlike the Library prompt editor's
+#: own save flow), but the outcome copy the user sees must read identically
+#: either way -- duplicated here rather than imported across screens to
+#: avoid a Screen-to-Screen import.
+CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY = {
+    "ok": "Saved.",
+    "name-in-use": "Name already in use — pick another or open the existing prompt.",
+    "soft-deleted-name": "A deleted prompt holds this name — restore it or choose another.",
+    "error": "Couldn't save this prompt. Try again.",
+}
+CONSOLE_SYSTEM_PROMPT_NO_SYSTEM_PART_TEMPLATE = 'Prompt "{name}" has no system part.'
+
+
+class ConsolePromptsController:
+    """Owns the Console shell's prompt cluster: the Prompt Library modal,
+    `/prompt` + `/system` resolution and their pickers, the system-prompt
+    editor and its save-to-Library flow, the Library staged-insert handoff,
+    and the shared prompt-history store.
+
+    `ChatScreen` constructs exactly one of these, in `__init__`, and keeps a
+    `self._prompts` reference plus the delegation table described in the
+    module docstring.
+    """
+
+    # Bounded prompt-search page size for `/prompt` resolution and the
+    # picker's own search callable -- mirrors Task 11's picker contract
+    # (PromptScopeService.search_prompts, FTS-ranked, <= 25 rows).
+    _CONSOLE_PROMPT_SEARCH_LIMIT = 25
+
+    _LIBRARY_PROMPT_INSERT_BLOCKED_COPY = "Finish provider setup to insert prompts."
+    _RECIPE_EXECUTION_BLOCKED_COPY = (
+        "Recipes cannot be applied directly. Open Prompts and edit the Recipe "
+        "as an unsaved Prompt copy first."
+    )
+
+    def __init__(
+        self,
+        screen: "ChatScreen",
+        *,
+        app_instance: Any,
+        composer_accessor: Callable[[], Any],
+        chat_store_accessor: Callable[[], Any],
+        ensure_active_console_session_settings: Callable[[], Any],
+        apply_console_session_system_prompt: Callable[[str], None],
+        sync_console_session_draft: Callable[[], None],
+        active_console_provider_model_display: Callable[[], tuple],
+        build_console_provider_selection: Callable[[], Any],
+        ensure_console_provider_gateway: Callable[[], Any],
+        console_provider_blocker_copy: Callable[[], str],
+        open_console_provider_recovery_accessor: Callable[[], Any],
+        console_setup_blocked_reason: Callable[[], str],
+        focus_console_composer_if_needed: Callable[..., None],
+        insert_prompt_text_into_composer: Callable[..., bool],
+        clear_console_composer_draft: Callable[[], None],
+        append_native_console_system_message: Callable[[str], Any],
+        sync_console_chat_core_state: Callable[[], None],
+        sync_console_rail_system_line: Callable[[], None],
+        sync_console_settings_summary: Callable[[], None],
+    ) -> None:
+        """Build the controller and bind everything its moved bodies need.
+
+        Every one of the 13 method bodies below is a byte-for-byte copy of
+        the pre-extraction `ChatScreen` method, EXCEPT the three documented
+        `self._session.X(...)` seam call sites (dropping that prefix for a
+        same-named property here, per the module docstring's
+        "Controller-to-controller seam" section) and every
+        `self.app.push_screen(...)` call site (dropping the `.app.` for the
+        `push_screen` framework property below, the same transformation
+        `session.py` and `message.py`'s own moved bodies already made).
+
+        Eighteen named dependencies is squarely in the band waves 1-3 have
+        established (dictation: 12; message: 19). Fifteen of the eighteen
+        are needed by `_open_console_prompts_modal` alone -- it is the
+        cluster's whole fan-in, not a sprawl across many methods.
+
+        Args:
+            screen: The Console screen. Used ONLY for the framework
+                services (`run_worker`, `push_screen`) below. Zero
+                `query_one`/`query` traffic reaches through `screen` here --
+                see the module docstring's "Zero DOM" section.
+            app_instance: Snapshotted once, not re-read through `screen` --
+                every reference in the moved bodies is a bare-attribute
+                read (`prompt_scope_service`, `pending_handoffs`,
+                `console_prompt_history_factory`) or a `notify()` call,
+                never one that could observe a later reassignment.
+            composer_accessor: `ChatScreen._console_composer_or_none`, the
+                general screen helper (33 call sites screen-wide, not
+                prompt-specific), replaced by name at 9 test sites.
+            chat_store_accessor: `ChatScreen._ensure_console_chat_store`,
+                the general store accessor already shared by every other
+                controller (see `session.py`'s identical parameter).
+            ensure_active_console_session_settings: `ConsoleSession
+                Controller._ensure_active_console_session_settings` --
+                session seam, read by the modal opener (twice, inside
+                closures that must see LIVE settings) and the system-prompt
+                editor.
+            apply_console_session_system_prompt: `ConsoleSessionController.
+                _apply_console_session_system_prompt` -- session seam, the
+                one write path both `/system` and the apply-system picker
+                use.
+            sync_console_session_draft: `ConsoleSessionController._sync_
+                console_session_draft` -- session seam; the staged-insert
+                handoff calls it to settle `_console_visible_draft_session_
+                id` immediately before inserting, so a racing session
+                switch cannot clobber the insert.
+            active_console_provider_model_display: `ChatScreen._active_
+                console_provider_model_display`, a general screen helper
+                (10 call sites across clusters), used for the modal's
+                opening disclosure labels.
+            build_console_provider_selection: `ChatScreen._build_console_
+                provider_selection` -- rebuilt (not captured) at every
+                resolve so the modal's staleness guards compare against a
+                LIVE selection; replaced by name at 3 test sites.
+            ensure_console_provider_gateway: `ChatScreen._ensure_console_
+                provider_gateway`, the shared provider gateway the
+                improvement service runs against.
+            console_provider_blocker_copy: `ChatScreen._console_provider_
+                blocker_copy`, the "why Improve is unavailable" copy; a
+                CALL, evaluated at modal-build time.
+            open_console_provider_recovery_accessor: The one
+                bare-attribute-read shape here. `ChatScreen._open_console_
+                provider_recovery` is passed to the modal as a CALLABLE
+                (`configure_provider=...`), not called, so this accessor
+                returns the screen's current attribute rather than wrapping
+                it -- which is what keeps
+                `test_console_workbench_contract.py`'s
+                `console._open_console_provider_recovery = AsyncMock()`
+                landing on the modal, exactly as it did pre-move.
+            console_setup_blocked_reason: `ChatScreen._console_setup_
+                blocked_reason` -- the first-run readiness gate the staged
+                Library insert honours.
+            focus_console_composer_if_needed: `ChatScreen._focus_console_
+                composer_if_needed` (DOM: focuses a queried widget) --
+                stays screen-owned, called on every modal/picker dismissal.
+            insert_prompt_text_into_composer: `ChatScreen._insert_prompt_
+                text_into_composer` -- raw `query_one` DOM access, so it
+                stays on the screen (module docstring, "Zero DOM"); also
+                replaced by name at 6 pre-existing test sites.
+            clear_console_composer_draft: `ChatScreen._clear_console_
+                composer_draft` (DOM via the composer accessor) -- `/system`
+                clears its own invocation text after a successful apply.
+            append_native_console_system_message: `ChatScreen._append_
+                native_console_system_message` -- the inline transcript
+                error channel both command handlers use to refuse a Recipe.
+            sync_console_chat_core_state: `ChatScreen._sync_console_chat_
+                core_state`, one of the three post-apply re-sync bridges
+                (all DOM-adjacent, all staying screen-owned).
+            sync_console_rail_system_line: `ChatScreen._sync_console_rail_
+                system_line`, ditto.
+            sync_console_settings_summary: `ChatScreen._sync_console_
+                settings_summary`, ditto.
+        """
+        self._screen = screen
+        self.app_instance = app_instance
+        self._composer_accessor = composer_accessor
+        self._chat_store_accessor = chat_store_accessor
+        self._ensure_active_console_session_settings_fn = (
+            ensure_active_console_session_settings
+        )
+        self._apply_console_session_system_prompt_fn = (
+            apply_console_session_system_prompt
+        )
+        self._sync_console_session_draft_fn = sync_console_session_draft
+        self._active_console_provider_model_display_fn = (
+            active_console_provider_model_display
+        )
+        self._build_console_provider_selection_fn = build_console_provider_selection
+        self._ensure_console_provider_gateway_fn = ensure_console_provider_gateway
+        self._console_provider_blocker_copy_fn = console_provider_blocker_copy
+        self._open_console_provider_recovery_accessor = (
+            open_console_provider_recovery_accessor
+        )
+        self._console_setup_blocked_reason_fn = console_setup_blocked_reason
+        self._focus_console_composer_if_needed_fn = focus_console_composer_if_needed
+        self._insert_prompt_text_into_composer_fn = insert_prompt_text_into_composer
+        self._clear_console_composer_draft_fn = clear_console_composer_draft
+        self._append_native_console_system_message_fn = (
+            append_native_console_system_message
+        )
+        self._sync_console_chat_core_state_fn = sync_console_chat_core_state
+        self._sync_console_rail_system_line_fn = sync_console_rail_system_line
+        self._sync_console_settings_summary_fn = sync_console_settings_summary
+
+        # This cluster's own state, moved verbatim from `ChatScreen.__init__`.
+        # Nothing outside this cluster ever read the attribute directly (only
+        # `_ensure_console_prompt_history()`), so `ChatScreen` keeps no proxy
+        # property for it -- unlike the message/dictation clusters.
+        self._console_prompt_history: Any | None = None
+
+    # -- Framework services (live-read via `@property`) --------------------
+
+    @property
+    def run_worker(self) -> Any:
+        """`Screen.run_worker`, bound. See `__init__`'s docstring for why
+        this is a property rather than a value snapshotted once."""
+        return self._screen.run_worker
+
+    @property
+    def push_screen(self) -> Any:
+        """`Screen.app.push_screen`, bound. See `__init__`'s docstring."""
+        return self._screen.app.push_screen
+
+    # -- Named constructor dependencies -------------------------------------
+    #
+    # Each property below is a thin wrapper around a stored callable, kept
+    # under the SAME name the original `ChatScreen` method used -- see
+    # `__init__`'s docstring. `_open_console_provider_recovery` is the one
+    # bare-attribute-read shape (calls its accessor immediately and returns
+    # the value, because the moved body passes it on as a callable rather
+    # than calling it); every other property returns the callable itself.
+
+    @property
+    def _console_composer_or_none(self) -> Any:
+        return self._composer_accessor
+
+    @property
+    def _ensure_console_chat_store(self) -> Any:
+        return self._chat_store_accessor
+
+    @property
+    def _ensure_active_console_session_settings(self) -> Any:
+        return self._ensure_active_console_session_settings_fn
+
+    @property
+    def _apply_console_session_system_prompt(self) -> Any:
+        return self._apply_console_session_system_prompt_fn
+
+    @property
+    def _sync_console_session_draft(self) -> Any:
+        return self._sync_console_session_draft_fn
+
+    @property
+    def _active_console_provider_model_display(self) -> Any:
+        return self._active_console_provider_model_display_fn
+
+    @property
+    def _build_console_provider_selection(self) -> Any:
+        return self._build_console_provider_selection_fn
+
+    @property
+    def _ensure_console_provider_gateway(self) -> Any:
+        return self._ensure_console_provider_gateway_fn
+
+    @property
+    def _console_provider_blocker_copy(self) -> Any:
+        return self._console_provider_blocker_copy_fn
+
+    @property
+    def _open_console_provider_recovery(self) -> Any:
+        """The screen's CURRENT `_open_console_provider_recovery` attribute.
+
+        Calls the accessor and returns the value, not the callable wrapping
+        it: `_open_console_prompts_modal` hands this straight to the modal
+        as `configure_provider=`, so the modal must receive the same object
+        identity the pre-move code gave it. See `__init__`'s docstring.
+        """
+        return self._open_console_provider_recovery_accessor()
+
+    @property
+    def _console_setup_blocked_reason(self) -> Any:
+        return self._console_setup_blocked_reason_fn
+
+    @property
+    def _focus_console_composer_if_needed(self) -> Any:
+        return self._focus_console_composer_if_needed_fn
+
+    @property
+    def _insert_prompt_text_into_composer(self) -> Any:
+        return self._insert_prompt_text_into_composer_fn
+
+    @property
+    def _clear_console_composer_draft(self) -> Any:
+        return self._clear_console_composer_draft_fn
+
+    @property
+    def _append_native_console_system_message(self) -> Any:
+        return self._append_native_console_system_message_fn
+
+    @property
+    def _sync_console_chat_core_state(self) -> Any:
+        return self._sync_console_chat_core_state_fn
+
+    @property
+    def _sync_console_rail_system_line(self) -> Any:
+        return self._sync_console_rail_system_line_fn
+
+    @property
+    def _sync_console_settings_summary(self) -> Any:
+        return self._sync_console_settings_summary_fn
+
+    # -- Moved bodies -------------------------------------------------------
+
+    def _ensure_console_prompt_history(self) -> PromptHistory:
+        """Return the shared JSONL prompt-history store (TASK-1364).
+
+        One instance feeds both the composer (ghost text, Up/Down recall)
+        and the controller (recording accepted sends). Creation is lazy and
+        IO-free -- the store self-loads on first awaited use, and the
+        composer kicks a background `load()` on mount so ghost text works on
+        the first keystroke. `console_prompt_history_factory` on the app is
+        the test seam, mirroring `console_provider_gateway_factory`.
+        """
+        history = getattr(self, "_console_prompt_history", None)
+        if history is None:
+            factory = getattr(self.app_instance, "console_prompt_history_factory", None)
+            history = (
+                factory()
+                if callable(factory)
+                else PromptHistory(default_prompt_history_path())
+            )
+            self._console_prompt_history = history
+        return history
+
+    def _open_console_prompts_modal(self) -> None:
+        """Open the source-aware Prompt Library without changing the draft."""
+        service = getattr(self.app_instance, "prompt_scope_service", None)
+        composer = self._console_composer_or_none()
+        if composer is None:
+            return
+        settings = self._ensure_active_console_session_settings()
+        store = self._ensure_console_chat_store()
+        session_id = store.active_session_id
+        if session_id is None:
+            return
+        composer_snapshot = composer.capture_draft_snapshot()
+        current_system = str(settings.system_prompt or "")
+        current_system_fingerprint = fingerprint_text(current_system)
+        provider_display, model_display, _settings = (
+            self._active_console_provider_model_display()
+        )
+        opening_selection = self._build_console_provider_selection()
+        gateway = self._ensure_console_provider_gateway()
+        improvement_service = PromptImprovementService(gateway=gateway)
+        pinned_improvement_resolution: Any | None = None
+        improvement_context = ConsolePromptImprovementContext(
+            session_id=session_id,
+            composer_snapshot=composer_snapshot,
+            current_user_projection=None,
+            current_system_prompt=current_system,
+            current_system_fingerprint=current_system_fingerprint,
+            provider_label=str(provider_display or "Not configured"),
+            model_label=str(model_display or "Not configured"),
+            endpoint_label=(
+                safe_endpoint_display(opening_selection.base_url)
+                or "Resolve on Improve"
+            ),
+            model_unavailable_reason=self._console_provider_blocker_copy(),
+        )
+
+        async def capabilities(source: str) -> Any:
+            method = getattr(service, "get_capabilities", None)
+            if not callable(method):
+                raise ValueError(f"{source.title()} Prompt source is unavailable.")
+            return await method(mode=source)
+
+        async def list_page(source: str, page: int) -> Any:
+            method = getattr(service, "list_prompts", None)
+            if not callable(method):
+                raise ValueError(f"{source.title()} Prompt source is unavailable.")
+            return await method(mode=source, page=page, per_page=10)
+
+        async def search(source: str, query: str) -> Any:
+            method = getattr(service, "search_prompts", None)
+            if not callable(method):
+                raise ValueError(f"{source.title()} Prompt search is unavailable.")
+            return await method(mode=source, query=query, limit=25)
+
+        async def detail(source: str, identifier: str) -> Any:
+            method = getattr(service, "get_prompt", None)
+            if not callable(method):
+                raise ValueError(f"{source.title()} Prompt source is unavailable.")
+            return await method(mode=source, prompt_identifier=identifier)
+
+        async def save(**payload: Any) -> Any:
+            method = getattr(service, "save_prompt", None)
+            if not callable(method):
+                raise ValueError("The selected Prompt source cannot save.")
+            source = str(payload.pop("source", "local"))
+            return await method(mode=source, **payload)
+
+        def _active_system_fingerprint() -> str:
+            live_settings = self._ensure_active_console_session_settings()
+            return fingerprint_text(str(live_settings.system_prompt or ""))
+
+        def _resolution_identity(resolution: Any) -> tuple[str, str, str, str, str]:
+            return (
+                str(getattr(resolution, "provider", "")),
+                str(getattr(resolution, "model", "")),
+                str(getattr(resolution, "base_url", "")),
+                str(getattr(resolution, "readiness_key", "")),
+                str(getattr(resolution, "execution_key", "")),
+            )
+
+        async def activate_improvement_context() -> Any:
+            """Pin and disclose the exact target before any model path can run."""
+
+            nonlocal pinned_improvement_resolution
+            if store.active_session_id != session_id:
+                raise ValueError("The active Console session changed.")
+            if _active_system_fingerprint() != current_system_fingerprint:
+                raise ValueError("The Console System prompt changed.")
+            projection = None
+            projection_blocker = ""
+            try:
+                projection = composer.project_snapshot_for_model(
+                    composer_snapshot,
+                    request_nonce=f"prompt-preview-{uuid.uuid4().hex}",
+                )
+            except ValueError:
+                projection_blocker = (
+                    "Model improvement is unavailable because the draft contains "
+                    "reserved protected-placeholder text. Remove or rename that "
+                    "literal token, then reopen Improve."
+                )
+            try:
+                resolution = await gateway.resolve_for_send(
+                    self._build_console_provider_selection()
+                )
+            except Exception:
+                pinned_improvement_resolution = None
+                return replace(
+                    improvement_context,
+                    current_user_projection=projection,
+                    endpoint_label="Unavailable",
+                    model_unavailable_reason=(
+                        projection_blocker
+                        or "Prompt improvement could not resolve the current provider "
+                        "target. Review Console provider settings and reopen Improve."
+                    ),
+                )
+            pinned_improvement_resolution = resolution
+            blocker = projection_blocker
+            if not blocker and (
+                not resolution.ready or not str(resolution.model or "").strip()
+            ):
+                blocker = str(
+                    resolution.visible_copy
+                    or "Choose a ready provider and model, then reopen Improve."
+                )
+            return replace(
+                improvement_context,
+                current_user_projection=projection,
+                provider_label=str(resolution.provider or "Not configured"),
+                model_label=str(resolution.model or "Not configured"),
+                endpoint_label=(
+                    safe_endpoint_display(resolution.base_url)
+                    or "Provider default"
+                ),
+                model_unavailable_reason=blocker,
+                pinned_resolution=resolution,
+            )
+
+        async def capture_manual_resolution() -> Any:
+            """Capture the effective target once for a later model-free Apply."""
+
+            nonlocal pinned_improvement_resolution
+            if pinned_improvement_resolution is None:
+                pinned_improvement_resolution = await gateway.resolve_for_send(
+                    self._build_console_provider_selection()
+                )
+            return pinned_improvement_resolution
+
+        async def build_improvement_snapshot(**values: Any) -> Any:
+            if store.active_session_id != session_id:
+                raise ValueError("The active Console session changed.")
+            if _active_system_fingerprint() != current_system_fingerprint:
+                raise ValueError("The Console System prompt changed.")
+            request_id = str(values["request_id"])
+            projection = composer.project_snapshot_for_model(
+                composer_snapshot,
+                request_nonce=request_id,
+            )
+            composer.validate_improvement(composer_snapshot, projection.text)
+            pinned_resolution = pinned_improvement_resolution
+            if pinned_resolution is None:
+                raise ValueError(
+                    "The provider target is no longer pinned. Reopen Improve to refresh disclosure."
+                )
+            live_resolution = await gateway.resolve_for_send(
+                self._build_console_provider_selection()
+            )
+            if _resolution_identity(live_resolution) != _resolution_identity(
+                pinned_resolution
+            ):
+                raise ValueError(
+                    "The provider, model, or endpoint changed. Reopen Improve to refresh disclosure."
+                )
+            if not pinned_resolution.ready or not str(
+                pinned_resolution.model or ""
+            ).strip():
+                raise ValueError(
+                    pinned_resolution.visible_copy or "Provider is unavailable."
+                )
+            include_system = bool(values.get("include_system"))
+            recipe_definition = values.get("recipe_definition")
+            return PromptImprovementRequestSnapshot(
+                request_id=request_id,
+                mode=values["mode"],
+                session_id=session_id,
+                composer_snapshot=composer_snapshot,
+                projection=projection,
+                system_prompt=current_system if include_system else None,
+                system_fingerprint=(
+                    current_system_fingerprint if include_system else None
+                ),
+                resolution=pinned_resolution,
+                provider_label=pinned_resolution.provider,
+                model_label=str(pinned_resolution.model),
+                recipe_source=values.get("recipe_source"),
+                recipe_source_id=values.get("recipe_source_id"),
+                recipe_version=values.get("recipe_version"),
+                recipe_definition=recipe_definition,
+                recipe_fingerprint=(
+                    fingerprint_block_definition(recipe_definition)
+                    if recipe_definition is not None
+                    else None
+                ),
+            )
+
+        def validate_improvement(captured: Any, text: str) -> None:
+            snapshot = getattr(captured, "composer_snapshot", composer_snapshot)
+            composer.validate_improvement(snapshot, text)
+
+        async def validate_saved_recipe(captured: Any) -> None:
+            recipe_source_id = str(
+                getattr(captured, "recipe_source_id", "") or ""
+            )
+            if not recipe_source_id or recipe_source_id.startswith("builtin:"):
+                return
+            source = getattr(captured, "recipe_source", None)
+            if source not in {"local", "server"}:
+                raise ValueError("The selected Recipe source changed.")
+            latest = await detail(source, recipe_source_id)
+            if not isinstance(latest, Mapping):
+                raise ValueError("The selected Recipe is no longer available.")
+            latest_identity = (
+                latest.get("source_id") or latest.get("id") or latest.get("uuid")
+            )
+            if str(latest_identity or "") != recipe_source_id:
+                raise ValueError("The selected Recipe identity changed.")
+            latest_version = latest.get("version", latest.get("optimistic_version"))
+            if latest_version != getattr(captured, "recipe_version", None):
+                raise ValueError("The selected Recipe version changed.")
+            decoded = decode_prompt_artifact(latest)
+            if decoded.artifact_type != "recipe" or decoded.definition is None:
+                raise ValueError("The selected Recipe is no longer compatible.")
+            if fingerprint_block_definition(decoded.definition) != getattr(
+                captured, "recipe_fingerprint", None
+            ):
+                raise ValueError("The selected Recipe changed.")
+
+        async def validate_saved_prompt(captured: Any) -> None:
+            if not isinstance(captured, ConsoleSavedPromptApplyGuard):
+                return
+            latest = await detail(captured.source, captured.prompt_source_id)
+            if not isinstance(latest, Mapping):
+                raise ValueError("The selected Prompt is no longer available.")
+            latest_identity = (
+                latest.get("source_id") or latest.get("id") or latest.get("uuid")
+            )
+            if str(latest_identity or "") != captured.prompt_source_id:
+                raise ValueError("The selected Prompt identity changed.")
+            latest_version = latest.get("version", latest.get("optimistic_version"))
+            if latest_version != captured.prompt_version:
+                raise ValueError("The selected Prompt version changed.")
+            decoded = decode_prompt_artifact(latest)
+            if decoded.artifact_type != "prompt" or decoded.definition is None:
+                raise ValueError("The selected Prompt is no longer compatible.")
+            if fingerprint_block_definition(decoded.definition) != captured.prompt_fingerprint:
+                raise ValueError("The selected Prompt changed.")
+
+        async def record_applied_usage(captured: Any) -> None:
+            if not isinstance(
+                captured, ConsoleSavedPromptApplyGuard
+            ) or not captured.record_usage:
+                return
+            recorder = getattr(service, "record_prompt_usage", None)
+            if not callable(recorder):
+                return
+            try:
+                await recorder(
+                    mode=captured.source,
+                    prompt_identifier=captured.prompt_source_id,
+                )
+            except Exception:
+                self.app_instance.notify(
+                    "The prompt was applied, but Library usage could not be recorded.",
+                    severity="warning",
+                )
+
+        async def apply_improvement_result(
+            result: ConsolePromptsResult, captured: Any
+        ) -> ConsolePromptsApplyOutcome:
+            if store.active_session_id != session_id:
+                return ConsolePromptsApplyOutcome(
+                    "stale", "The active Console session changed."
+                )
+            if _active_system_fingerprint() != current_system_fingerprint:
+                return ConsolePromptsApplyOutcome(
+                    "stale", "The Console System prompt changed."
+                )
+            if isinstance(captured, PromptImprovementRequestSnapshot):
+                live_resolution = await gateway.resolve_for_send(
+                    self._build_console_provider_selection()
+                )
+                if _resolution_identity(live_resolution) != _resolution_identity(
+                    captured.resolution
+                ):
+                    return ConsolePromptsApplyOutcome(
+                        "stale", "The provider, model, or endpoint changed."
+                    )
+            elif isinstance(
+                captured, (ConsoleRecipeApplyGuard, ConsoleSavedPromptApplyGuard)
+            ):
+                captured_resolution = captured.provider_resolution
+                if captured_resolution is None:
+                    return ConsolePromptsApplyOutcome(
+                        "stale",
+                        "The provider target was not captured. Reopen the Prompt and retry.",
+                    )
+                live_resolution = await gateway.resolve_for_send(
+                    self._build_console_provider_selection()
+                )
+                if _resolution_identity(live_resolution) != _resolution_identity(
+                    captured_resolution
+                ):
+                    return ConsolePromptsApplyOutcome(
+                        "stale", "The provider, model, or endpoint changed."
+                    )
+            try:
+                await validate_saved_recipe(captured)
+                await validate_saved_prompt(captured)
+                if result.apply_user:
+                    if result.user_text is None:
+                        raise ValueError("The reviewed User prompt is missing.")
+                    composer.validate_improvement(
+                        result.composer_snapshot, result.user_text
+                    )
+                elif composer.capture_draft_snapshot() != result.composer_snapshot:
+                    raise ValueError("The Console draft changed.")
+            except Exception:
+                return ConsolePromptsApplyOutcome(
+                    "stale",
+                    "The draft or Recipe changed. Review the working copy and retry.",
+                )
+
+            if result.apply_user and result.user_text is not None:
+                composer.apply_improvement(
+                    result.composer_snapshot,
+                    result.user_text,
+                )
+                store.set_session_draft(session_id, composer.draft_text())
+            persisted = True
+            if result.apply_system:
+                _session, persisted = store.set_session_system_prompt(
+                    session_id, result.system_text
+                )
+                self._sync_console_chat_core_state()
+                self._sync_console_rail_system_line()
+                self._sync_console_settings_summary()
+            await record_applied_usage(captured)
+            if not persisted:
+                return ConsolePromptsApplyOutcome("persistence_failed")
+            return ConsolePromptsApplyOutcome("applied")
+
+        async def retry_improvement_persistence(
+            result: ConsolePromptsResult,
+        ) -> ConsolePromptsApplyOutcome:
+            if store.active_session_id != session_id or not result.apply_system:
+                return ConsolePromptsApplyOutcome(
+                    "stale", "The active Console session changed."
+                )
+            live_settings = self._ensure_active_console_session_settings()
+            if str(live_settings.system_prompt or "") != str(result.system_text or ""):
+                return ConsolePromptsApplyOutcome(
+                    "stale", "The live System prompt changed."
+                )
+            _session, persisted = store.set_session_system_prompt(
+                session_id, result.system_text
+            )
+            self._sync_console_chat_core_state()
+            self._sync_console_rail_system_line()
+            self._sync_console_settings_summary()
+            return ConsolePromptsApplyOutcome(
+                "applied" if persisted else "persistence_failed"
+            )
+
+        def restore_focus(_result: ConsolePromptsResult | None) -> None:
+            self._focus_console_composer_if_needed(force=True)
+
+        self.push_screen(
+            ConsolePromptsModal(
+                capabilities=capabilities,
+                list_page=list_page,
+                search=search,
+                detail=detail,
+                save=save,
+                improve_unavailable_reason=self._console_provider_blocker_copy(),
+                configure_provider=self._open_console_provider_recovery,
+                improvement_context=improvement_context,
+                activate_improvement_context=activate_improvement_context,
+                capture_manual_resolution=capture_manual_resolution,
+                build_improvement_snapshot=build_improvement_snapshot,
+                improve=improvement_service.improve,
+                validate_improvement=validate_improvement,
+                apply_improvement_result=apply_improvement_result,
+                retry_improvement_persistence=retry_improvement_persistence,
+            ),
+            callback=restore_focus,
+        )
+
+    @staticmethod
+    def _is_recipe_prompt_record(record: Mapping[str, Any]) -> bool:
+        """Return whether a normalized or raw record is a non-executable Recipe."""
+        return str(record.get("artifact_type") or "prompt").casefold() == "recipe"
+
+    @staticmethod
+    def _console_prompt_prefix_fts_query(text: str) -> str:
+        """Build an FTS5 phrase-prefix MATCH expression for ``text``.
+
+        Plain FTS5 MATCH requires a full token, which would defeat both the
+        `/prompt` prefix-match resolution stage (a query like "Summ" would
+        never match a stored name "Summarize") and a picker that is supposed
+        to filter results as the user is still mid-word. Quoting the whole
+        query as a phrase with a trailing ``*`` makes FTS5 match names whose
+        tokens *start with* the typed text instead -- a prefix match trivially
+        covers an exact match too, so one query shape serves both. Embedded
+        quotes are doubled per FTS5 string-literal escaping (mirrors
+        ``library_fts_query._quote_fts_term``), so user text can never break
+        out of the quoted phrase to inject MATCH operators.
+        """
+        escaped = text.replace('"', '""')
+        return f'"{escaped}"*'
+
+    async def _console_prompt_search(self, query: str) -> list:
+        """Bounded FTS prompt search bound to the active scope service.
+
+        Shared by `/prompt` resolution and the picker's ``prompt_search``
+        callable so both always read a fresh page rather than any cached
+        boot-time snapshot.
+        """
+        service = getattr(self.app_instance, "prompt_scope_service", None)
+        search_prompts = getattr(service, "search_prompts", None)
+        if not callable(search_prompts):
+            return []
+        stripped_query = query.strip()
+        fts_kwargs = (
+            {"fts_match_query": self._console_prompt_prefix_fts_query(stripped_query)}
+            if stripped_query
+            else {}
+        )
+        try:
+            records = await search_prompts(
+                mode="local",
+                query=query,
+                limit=self._CONSOLE_PROMPT_SEARCH_LIMIT,
+                **fts_kwargs,
+            )
+            return [
+                record
+                for record in records
+                if isinstance(record, Mapping)
+                and not self._is_recipe_prompt_record(record)
+            ]
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Console prompt search failed for query {query!r}."
+            )
+            return []
+
+    async def _resolve_console_prompt_by_name(
+        self, query: str
+    ) -> Optional[Mapping[str, Any]]:
+        """Resolve `/prompt <name>` to a single prompt record, or ``None``.
+
+        ``None`` means the caller should fall back to the picker: no
+        candidates, an ambiguous (2+) exact case-insensitive name match, or
+        no/ambiguous unique prefix match either.
+        """
+        candidates = [
+            record
+            for record in await self._console_prompt_search(query)
+            if isinstance(record, Mapping) and not self._is_recipe_prompt_record(record)
+        ]
+        normalized_query = query.strip().casefold()
+        exact_matches = [
+            record
+            for record in candidates
+            if str(record.get("name") or "").strip().casefold() == normalized_query
+        ]
+        if len(exact_matches) == 1:
+            return exact_matches[0]
+        if len(exact_matches) > 1:
+            return None
+        prefix_matches = [
+            record
+            for record in candidates
+            if str(record.get("name") or "")
+            .strip()
+            .casefold()
+            .startswith(normalized_query)
+        ]
+        if len(prefix_matches) == 1:
+            return prefix_matches[0]
+        return None
+
+    async def _console_command_insert_prompt(self, parse: CommandParse) -> None:
+        """Resolve and insert a saved prompt's ``user_prompt`` for `/prompt`.
+
+        Resolution order (brief): exact case-insensitive name match over a
+        bounded search page; else a unique case-insensitive name-prefix
+        match over that same page; else (no args, 0 matches, or an
+        ambiguous 2+ match at either stage) open the picker prefilled with
+        the typed args. A resolved match REPLACES the composer draft
+        wholesale (the draft IS the `/prompt ...` command being replaced by
+        its result) via paste semantics, so an oversized body still
+        collapses to a token exactly like a real paste would.
+        """
+        query = parse.args.strip()
+        resolved = await self._resolve_console_prompt_by_name(query) if query else None
+        if resolved is not None:
+            if self._is_recipe_prompt_record(resolved):
+                await self._append_native_console_system_message(
+                    self._RECIPE_EXECUTION_BLOCKED_COPY
+                )
+                return
+            self._insert_prompt_text_into_composer(
+                str(resolved.get("user_prompt") or ""), replace=True
+            )
+            return
+        await self._open_console_prompt_picker_for_insert(query)
+
+    async def _open_console_prompt_picker_for_insert(self, initial_query: str) -> None:
+        """Open the prompt picker for `/prompt`, inserting whatever is chosen."""
+
+        def _apply_picker_choice(record: Optional[Mapping[str, Any]]) -> None:
+            self._focus_console_composer_if_needed(force=True)
+            if record is None:
+                return
+            if self._is_recipe_prompt_record(record):
+                self.app_instance.notify(
+                    self._RECIPE_EXECUTION_BLOCKED_COPY,
+                    severity="warning",
+                )
+                return
+            self._insert_prompt_text_into_composer(
+                str(record.get("user_prompt") or ""), replace=True
+            )
+
+        self.push_screen(
+            ConsolePromptPickerModal(
+                mode="insert",
+                initial_query=initial_query,
+                prompt_search=self._console_prompt_search,
+            ),
+            callback=_apply_picker_choice,
+        )
+
+    async def _consume_pending_console_prompt_insert(self) -> None:
+        """Consume a Library "Use in Console" staged prompt body, if any.
+
+        Mirrors ``_consume_pending_chat_handoff``'s stage-then-consume
+        shape, but the staged payload is a bare string appended into the
+        composer -- never a ``ChatHandoffPayload``. Gated on the same
+        first-run provider/model setup readiness the composer's own Send
+        button uses: unlike the in-composer `/prompt` command (which Task
+        10 deliberately lets run even while Send is blocked, since
+        composing is not sending), this cross-screen hop is an unattended
+        action the user did not consciously type into this composer, so a
+        blocked first-run state gets an honest toast instead of a silent
+        insert -- the draft is left untouched and nothing about the source
+        Library prompt is touched either.
+        """
+        store = self.app_instance.pending_handoffs
+        claim = store.claim(HandoffChannel.CONSOLE_PROMPT_INSERT)
+        if claim is None:
+            return
+        text = claim.value
+        if not text.strip():
+            store.acknowledge(claim)
+            return
+        if self._console_setup_blocked_reason():
+            # A persistent state, not a mount-timing race -- always safe to
+            # consume+notify here regardless of whether the composer widget
+            # itself has finished mounting yet.
+            store.acknowledge(claim)
+            self.app_instance.notify(
+                self._LIBRARY_PROMPT_INSERT_BLOCKED_COPY,
+                severity="warning",
+            )
+            return
+        # Settle the active-session draft tracking BEFORE inserting so this
+        # consumption is self-guarding no matter which lifecycle hook
+        # (`on_mount`, `on_screen_resume`, or any other resume-adjacent path)
+        # scheduled it. If a session switch races ahead of us,
+        # `_console_visible_draft_session_id` can be stale relative to the
+        # store's active session; a *later* `_sync_native_console_chat_ui`
+        # pass would then unconditionally reload the composer from that
+        # newly-active session's stored draft, silently discarding the
+        # insert below (the pending field is already cleared once the
+        # insert lands, so there is no retry). Calling this here -- and
+        # nowhere between here and the insert, so the two run atomically
+        # within this event-loop turn -- settles the tracker onto the
+        # current active session first, so any subsequent sync pass takes
+        # the no-op fast path instead of clobbering what we're about to
+        # insert.
+        try:
+            self._sync_console_session_draft()
+            inserted = self._insert_prompt_text_into_composer(text, replace=False)
+        except asyncio.CancelledError:
+            store.release(claim)
+            raise
+        except Exception as exc:
+            store.release(claim)
+            logger.warning(
+                "Console prompt handoff transfer failed "
+                "(channel={}, revision={}, exception_category={})",
+                claim.channel.value,
+                claim.revision,
+                type(exc).__name__,
+            )
+            return
+        # A missing composer is transient. Release the exact claim so a later
+        # mount/resume can retry without disturbing any newer replacement.
+        if not inserted:
+            store.release(claim)
+            return
+        store.acknowledge(claim)
+        self._focus_console_composer_if_needed(force=True)
+
+    async def _console_command_apply_system(self, parse: CommandParse) -> None:
+        """Resolve and apply a saved prompt's ``system_prompt`` for `/system`.
+
+        Bare `/system` (no args) opens the system prompt editor modal seeded
+        with the active session's current system prompt. With args,
+        resolution mirrors `/prompt` (Task 12): exact case-insensitive name
+        match over a bounded search page, else a unique case-insensitive
+        name-prefix match; a resolved match with a blank ``system_prompt``
+        shows an inline transcript error (the session is left unchanged,
+        and the draft is deliberately left in place so the user can correct
+        it) rather than silently clearing it, since that is very likely not
+        what the user meant by naming that specific prompt. A resolved match
+        WITH a system part applies it and clears the `/system <name>`
+        command text from the composer -- mirrors `/prompt`'s successful
+        insert always replacing its own draft (Task 12) -- so a handled
+        command never leaves its own invocation text behind. 0 or 2+
+        matches at either stage fall back to the apply-system picker mode
+        (Task 11), prefilled with the typed args.
+        """
+        args = parse.args.strip()
+        if not args:
+            await self._open_console_system_prompt_editor()
+            return
+        resolved = await self._resolve_console_prompt_by_name(args)
+        if resolved is not None:
+            if self._is_recipe_prompt_record(resolved):
+                await self._append_native_console_system_message(
+                    self._RECIPE_EXECUTION_BLOCKED_COPY
+                )
+                return
+            # Blank check only via strip(); the applied value below is the
+            # raw prompt text so leading/trailing whitespace and internal
+            # formatting survive verbatim.
+            raw_system_prompt = resolved.get("system_prompt")
+            system_prompt = (
+                raw_system_prompt if isinstance(raw_system_prompt, str) else ""
+            )
+            if not system_prompt.strip():
+                name = str(resolved.get("name") or args)
+                await self._append_native_console_system_message(
+                    CONSOLE_SYSTEM_PROMPT_NO_SYSTEM_PART_TEMPLATE.format(name=name)
+                )
+                return
+            self._apply_console_session_system_prompt(system_prompt)
+            self._clear_console_composer_draft()
+            return
+        await self._open_console_prompt_picker_for_apply_system(args)
+
+    async def _open_console_prompt_picker_for_apply_system(
+        self, initial_query: str
+    ) -> None:
+        """Open the prompt picker in apply-system mode for `/system`.
+
+        Rows without a ``system_prompt`` render dimmed and refuse selection
+        (``ConsolePromptPickerModal``'s own ``MODE_APPLY_SYSTEM`` behavior,
+        Task 11) -- this caller only needs to apply whatever record the
+        picker actually dismisses with.
+        """
+
+        def _apply_picker_choice(record: Optional[Mapping[str, Any]]) -> None:
+            self._focus_console_composer_if_needed(force=True)
+            if record is None:
+                return
+            if self._is_recipe_prompt_record(record):
+                self.app_instance.notify(
+                    self._RECIPE_EXECUTION_BLOCKED_COPY,
+                    severity="warning",
+                )
+                return
+            # Blank check only via strip(); the applied value is the raw
+            # prompt text so formatting survives verbatim.
+            raw_system_prompt = record.get("system_prompt")
+            system_prompt = (
+                raw_system_prompt if isinstance(raw_system_prompt, str) else ""
+            )
+            if not system_prompt.strip():
+                return
+            self._apply_console_session_system_prompt(system_prompt)
+
+        self.push_screen(
+            ConsolePromptPickerModal(
+                mode=CONSOLE_PROMPT_PICKER_MODE_APPLY_SYSTEM,
+                initial_query=initial_query,
+                prompt_search=self._console_prompt_search,
+            ),
+            callback=_apply_picker_choice,
+        )
+
+    async def _open_console_system_prompt_editor(self) -> None:
+        """Open the system prompt editor modal for the active Console session."""
+        settings = self._ensure_active_console_session_settings()
+
+        def _apply_modal_result(result: Optional[str]) -> None:
+            self._focus_console_composer_if_needed(force=True)
+            if result is None:
+                return
+            self._apply_console_session_system_prompt(result)
+
+        self.push_screen(
+            ConsoleSystemPromptModal(
+                system_prompt=settings.system_prompt,
+                save_to_library=self._save_console_system_prompt_to_library,
+            ),
+            callback=_apply_modal_result,
+        )
+
+    async def _save_console_system_prompt_to_library(self, name: str, text: str) -> str:
+        """Save the system-prompt editor's text as a brand-new Library prompt.
+
+        Always a CREATE (the Console `/system` editor never edits an
+        existing Library prompt): pre-checks the name for a collision the
+        same way ``library_screen._save_library_prompt``'s own create path
+        does, so a genuine duplicate is classified via
+        ``classify_prompt_save_error`` -- with ``exc=None`` and a manually
+        built message -- rather than racing the DB's raw ``ConflictError``,
+        and reports the SAME outcome copy that screen's own save flow shows.
+
+        Args:
+            name: Name for the new Library prompt.
+            text: The prompt's ``system_prompt`` body (the modal's current
+                editor text).
+
+        Returns:
+            User-facing outcome copy to display inline in the modal.
+        """
+        name = name.strip()
+        if not name:
+            return "Enter a name to save this system prompt to Library."
+        text = text.strip()
+        if not text:
+            return "Enter a system prompt to save."
+        service = getattr(self.app_instance, "prompt_scope_service", None)
+        get_prompt = getattr(service, "get_prompt", None)
+        save_prompt = getattr(service, "save_prompt", None)
+        if not callable(get_prompt) or not callable(save_prompt):
+            return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
+        try:
+            candidate = await get_prompt(
+                mode="local", prompt_identifier=name, include_deleted=True
+            )
+        except Exception:
+            candidate = None
+        if isinstance(candidate, Mapping) and candidate:
+            if candidate.get("deleted"):
+                outcome = classify_prompt_save_error(
+                    None, f"Prompt '{name}' exists but is soft-deleted.", None
+                )
+            else:
+                outcome = classify_prompt_save_error(
+                    None, f"Prompt '{name}' already exists.", None
+                )
+            return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY.get(
+                outcome, CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
+            )
+        try:
+            result = await save_prompt(
+                mode="local", name=name, system_prompt=text, user_prompt=""
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning(
+                f"Console system-prompt save-to-library failed for name {name!r}."
+            )
+            outcome = classify_prompt_save_error(None, str(exc), exc)
+            return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY.get(
+                outcome, CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
+            )
+        result_id = (
+            result.get("local_id")
+            if isinstance(result, Mapping)
+            else (1 if result else None)
+        )
+        outcome = classify_prompt_save_error(result_id, "", None)
+        return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY.get(
+            outcome, CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
+        )

--- a/tldw_chatbook/UI/Console_Modules/transcript.py
+++ b/tldw_chatbook/UI/Console_Modules/transcript.py
@@ -1,0 +1,257 @@
+"""Console shell transcript region — the main column and its transcript surface.
+
+Extracted verbatim out of ``ChatScreen.compose_content`` (wave-3 console
+decomposition, task 2): the subtree that used to be built inline as
+
+    main_column = Vertical(id="console-main-column")
+    with main_column:
+        transcript_region = self._frame_console_region(
+            Vertical(id="console-transcript-region", classes="console-region"),
+            top=False,
+        )
+        with transcript_region:
+            yield self._ensure_console_session_surface()
+
+Ids and nesting inside this subtree are preserved exactly, and this class
+reuses ``id="console-main-column"`` as its own root, so it sits in the DOM
+exactly where the old plain ``Vertical`` sat — the same "reuse the outer id
+as the region root" shape ``ConsoleLeftRail``/``ConsoleInspectorRail`` used
+in wave 1. ``#console-main-column`` is pinned by the painted-geometry
+baseline (``Tests/UI/test_console_shell_regions.py``) at all three sizes, so
+that placement is not a stylistic preference.
+
+**Naming**: the DOM here spells two things, an outer column and an inner
+framed region, and the whole column exists to hold the transcript — there is
+no other content in it. So the class is named for what the column is FOR
+(``ConsoleTranscriptRegion``) while the ids stay exactly as they are, the
+same judgement call ``ConsoleInspectorRail`` made when the plan's placeholder
+name disagreed with the DOM.
+
+**The sizing stays on the screen.** ``width``/``min_width``/``min_height``
+are still assigned by ``compose_content`` on the constructed instance, not in
+here — they are facts about this widget's place among its ``#console-
+workspace-grid`` siblings (``3fr`` left rail, ``13fr`` main column, ``4fr``
+inspector), not about the transcript. Both rails are wired the same way.
+
+**What did NOT move, and why.** By the rule wave 1 settled (a body that
+reaches beyond the region's own DOM stays on the screen; screen-side
+``query_one`` into a region's ids crosses the compound-widget boundary
+transparently), these all stay on ``ChatScreen`` and keep working unmodified:
+
+- ``_sync_native_console_transcript`` (124 lines) — the transcript's render
+  pump. Every DOM write it makes is region-local, but its body also reads
+  and MUTATES three other clusters' state (``_console_original_attempt_
+  previews`` — owned by ``ConsoleMessageController`` since task 1;
+  ``_console_image_preparing`` — the image-generation cluster;
+  ``_console_citation_counts`` — the citation cluster), dispatches the
+  ``console-image-prep`` worker, and calls ``_sync_console_transcript_
+  guidance`` (which reaches ``#console-setup-modal``, outside this region).
+  A region that mutated three sibling clusters' mutable state through
+  accessor callables would be a controller wearing a region's clothes.
+- ``_native_console_transcript_fingerprint`` — pure, no DOM, sole caller is
+  the method above.
+- ``_start_console_transcript_sync_timer`` / ``_stop_...`` — named for the
+  transcript, but the 0.2 s tick pumps ``_sync_native_console_chat_ui`` (tab
+  glyphs, rails, chips), and the timer handle is screen-lifecycle state
+  (``on_unmount`` stops it).
+- ``_sync_console_transcript_guidance`` and ``_sync_console_native_session_
+  tabs`` — both query ``#console-session-surface`` (inside this region) but
+  also reach the setup modal / the store / the session+workspace
+  controllers.
+- ``_ensure_console_session_surface`` — owns ``ChatScreen.console_session_
+  surface``, a public attribute other screen code reads (the fleet
+  coach-mark path). This region takes a zero-arg builder instead; see
+  ``__init__``.
+- ``_selected_console_message_inspector_rows``, ``_console_change_review_
+  run_id``, ``_sync_console_pending_delete_confirmation``, ``on_key``,
+  ``handle_console_citation_sources`` — each reads this region's transcript
+  but exists to serve another surface (Inspector rows, the change-review
+  screen, the message controller's pending-delete state, screen-wide key
+  routing, the citation modal).
+- ``_clear_native_console_message_selection`` — the near-miss worth
+  recording. Its first four lines are pure region-local DOM, and it reads
+  like the third sibling of the two reading-state methods below; its
+  remaining three clear ``_pending_console_delete_message_id`` (a
+  ``ConsoleMessageController`` proxy since task 1), reset the screen's
+  ``_last_native_transcript_refresh_key`` render gate, and call the
+  guidance sync. Verdict flipped from "moves" to "stays" only once the
+  whole body was read, which is the argument for reading whole bodies.
+
+**No ``@on`` handlers moved.** Every event that originates inside this
+region and is handled today (``.console-transcript-citation-sources``,
+``#console-fleet-coachmark-dismiss``, the session tab buttons in
+``on_button_pressed``) has a body that reaches beyond it. This region stops
+nothing, so all of them keep bubbling to the screen exactly as before —
+matching ``ConsoleInspectorRail``, which likewise owns pixels and zero
+handlers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.css.query import QueryError
+from textual.widget import Widget
+
+from ...Widgets.Console import ConsoleTranscript
+from .frame import frame_console_region
+
+
+@dataclass(frozen=True)
+class _ConsoleTranscriptReadingState:
+    """The transcript's semantic reading position across a layout change.
+
+    Moved verbatim from ``chat_screen.py`` (which imports it back from here
+    for ``_finish_console_composer_layout_change``'s signature — that
+    annotation is evaluated at class-creation time, so the name is a real
+    runtime dependency there, not a typing-only one).
+    """
+
+    anchored: bool
+    scroll_y: float
+    selected_message_id: str | None
+
+
+class ConsoleTranscriptRegion(Vertical):
+    """The Console shell's main column: the framed transcript surface.
+
+    Composes nothing of its own beyond the two containers the screen used to
+    build inline; the transcript itself lives inside ``ConsoleSessionSurface``
+    (``Widgets/Console/console_session_surface.py``), an existing leaf widget
+    this region places rather than absorbs — a region is a one-place
+    composition of leaf widgets, not a relocation of them (DESIGN.md §7,
+    "The One Home Rule"). Nothing here reaches ``app_instance``.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_surface_builder: Callable[[], Widget],
+        **kwargs,
+    ) -> None:
+        """Create the main column around a session-surface builder.
+
+        Args:
+            session_surface_builder: Zero-arg callable that returns the
+                Console session surface to mount inside
+                ``#console-transcript-region``. A builder, not a pre-built
+                instance, is the point — and here the reason is sharper than
+                it was for ``ConsoleLeftRail``'s avatar: the screen CACHES
+                this widget on ``ChatScreen.console_session_surface`` and
+                hands the SAME instance back on every call, so storing it
+                here would look harmless right up until something recomposes
+                this region and ``compose()`` re-yielded a widget Textual had
+                already removed from the DOM. Calling
+                ``_ensure_console_session_surface`` fresh from ``compose()``
+                also re-applies the current background-effect settings, which
+                a stored instance would silently skip. Late-binding at CALL
+                time, matching ``ConsoleDictationController``'s constructor
+                rule (see ``dictation.py``'s module docstring).
+            kwargs: Forwarded to ``Vertical``.
+        """
+        super().__init__(id="console-main-column", **kwargs)
+        self._session_surface_builder = session_surface_builder
+
+    def compose(self) -> ComposeResult:
+        """Compose the framed transcript region and the session surface.
+
+        Returns:
+            The framed ``#console-transcript-region`` container holding the
+            Console session surface. ``top=False`` is deliberate: the control
+            bar directly above already paints that edge, so the transcript
+            reads as continuous with it instead of drawing a doubled rule.
+        """
+        transcript_region = frame_console_region(
+            Vertical(id="console-transcript-region", classes="console-region"),
+            top=False,
+        )
+        with transcript_region:
+            yield self._session_surface_builder()
+
+    def _transcript_or_none(self) -> ConsoleTranscript | None:
+        """Return the mounted transcript widget, or ``None`` when absent.
+
+        Every method below opened with this same try/query/except before the
+        move; it is factored out here rather than repeated four times.
+
+        Returns:
+            The ``#console-native-transcript`` widget inside this region, or
+            ``None`` before it is mounted (or after it is torn down).
+        """
+        try:
+            return self.query_one("#console-native-transcript", ConsoleTranscript)
+        except QueryError:
+            return None
+
+    def capture_reading_state(self) -> _ConsoleTranscriptReadingState | None:
+        """Capture the semantic reading position before composer layout changes.
+
+        Moved verbatim from ``ChatScreen._capture_console_transcript_reading_
+        state``.
+
+        Returns:
+            The transcript's tail-follow state, scroll offset and selected
+            message id, or ``None`` when no transcript is mounted.
+        """
+        transcript = self._transcript_or_none()
+        if transcript is None:
+            return None
+        return _ConsoleTranscriptReadingState(
+            anchored=bool(
+                transcript.is_anchored
+                and not getattr(transcript, "_anchor_released", False)
+            ),
+            scroll_y=float(transcript.scroll_y),
+            selected_message_id=transcript.selected_message_id,
+        )
+
+    def restore_reading_state(
+        self,
+        state: _ConsoleTranscriptReadingState | None,
+    ) -> None:
+        """Restore the transcript anchor, offset, and selected message.
+
+        Moved verbatim from ``ChatScreen._restore_console_transcript_reading_
+        state``.
+
+        Args:
+            state: A previously captured reading state; ``None`` is a no-op,
+                which is what callers pass when the capture found no
+                transcript.
+        """
+        if state is None:
+            return
+        transcript = self._transcript_or_none()
+        if transcript is None:
+            return
+        transcript.selected_message_id = state.selected_message_id
+        if state.anchored:
+            transcript.anchor()
+            return
+        transcript.release_anchor()
+        transcript.scroll_to(
+            y=min(state.scroll_y, float(transcript.max_scroll_y)),
+            animate=False,
+        )
+
+    def note_follow_intent(self) -> None:
+        """Stamp a programmatic jump-to-tail intent on the transcript (TASK-336).
+
+        Moved verbatim from ``ChatScreen._note_console_follow_intent``,
+        including its finding: this stays singular/view-only on purpose.
+        Unlike the screen's per-session stash maps, it never carries
+        session-owned DATA across a send's lifetime — it is a one-shot
+        directive consumed by whichever session's transcript happens to be
+        ``#console-native-transcript`` (a single widget instance reflecting
+        the ACTIVE session) at the next render. A background session's send
+        stamping this while a different session is viewed just requests an
+        extra, harmless tail-follow on whatever the transcript renders next;
+        there is no cross-session data to leak or clobber.
+        """
+        transcript = self._transcript_or_none()
+        if transcript is None:
+            return
+        transcript.note_follow_intent()

--- a/tldw_chatbook/UI/Console_Modules/transcript.py
+++ b/tldw_chatbook/UI/Console_Modules/transcript.py
@@ -138,16 +138,16 @@ class ConsoleTranscriptRegion(Vertical):
             session_surface_builder: Zero-arg callable that returns the
                 Console session surface to mount inside
                 ``#console-transcript-region``. A builder, not a pre-built
-                instance, is the point — and here the reason is sharper than
-                it was for ``ConsoleLeftRail``'s avatar: the screen CACHES
-                this widget on ``ChatScreen.console_session_surface`` and
-                hands the SAME instance back on every call, so storing it
-                here would look harmless right up until something recomposes
-                this region and ``compose()`` re-yielded a widget Textual had
-                already removed from the DOM. Calling
-                ``_ensure_console_session_surface`` fresh from ``compose()``
-                also re-applies the current background-effect settings, which
-                a stored instance would silently skip. Late-binding at CALL
+                instance, is the point — though for a reason narrower than
+                ``ConsoleLeftRail``'s avatar, and worth stating precisely so
+                nobody over-trusts it: the screen MEMOISES this widget on
+                ``ChatScreen.console_session_surface``, so a builder and a
+                stored instance would re-yield the very same object, and the
+                builder buys no protection against re-yielding a widget
+                Textual has already removed. What it does buy is the
+                re-sync: ``_ensure_console_session_surface`` re-applies the
+                current background-effect settings on every call, which a
+                stored instance would silently skip. Late-binding at CALL
                 time, matching ``ConsoleDictationController``'s constructor
                 rule (see ``dictation.py``'s module docstring).
             kwargs: Forwarded to ``Vertical``.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -8088,13 +8088,20 @@ class ChatScreen(BaseAppScreen):
         stored on the screen (the same way ``_sync_console_rail_visibility``
         reaches ``ConsoleLeftRail``).
 
+        Note that ``NoMatches`` is a ``QueryError``, and so is ``WrongType``:
+        an id collision that put some other widget class at
+        ``#console-main-column`` degrades to ``None`` here rather than
+        raising. That is deliberate — every caller already handles the
+        not-yet-composed case — but it means this must never become the
+        place a shape error is expected to surface.
+
         Returns:
             The ``#console-main-column`` region widget, or ``None`` when the
             shell is not (yet) mounted.
         """
         try:
             return self.query_one("#console-main-column", ConsoleTranscriptRegion)
-        except (NoMatches, QueryError):
+        except QueryError:
             return None
 
     def _capture_console_transcript_reading_state(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -72,6 +72,10 @@ from ..Console_Modules.hands_free import (
 from ..Console_Modules.left_rail import ConsoleLeftRail
 from ..Console_Modules.message import ConsoleMessageController
 from ..Console_Modules.right_rail import ConsoleInspectorRail
+from ..Console_Modules.transcript import (
+    ConsoleTranscriptRegion,
+    _ConsoleTranscriptReadingState,
+)
 from ..Console_Modules.workspace import ConsoleWorkspaceController
 from ..Console_Modules.session import (
     ConsoleSessionController,
@@ -1000,13 +1004,6 @@ class ConsoleRealtimeSession:
     adopt_capture: bool = False
     failure_text: str = ""
     transcript_dirty: bool = False
-
-
-@dataclass(frozen=True)
-class _ConsoleTranscriptReadingState:
-    anchored: bool
-    scroll_y: float
-    selected_message_id: str | None
 
 
 CONSOLE_WORKBENCH_SHORTCUTS = (
@@ -8083,43 +8080,54 @@ class ChatScreen(BaseAppScreen):
         self._dictation._request_console_dictation_start()
 
 
+    def _console_transcript_region_or_none(self) -> ConsoleTranscriptRegion | None:
+        """Return the mounted transcript region, or ``None`` before compose.
+
+        A region widget only exists once the screen has composed, and a
+        recompose replaces the instance -- so it is reached by id, never
+        stored on the screen (the same way ``_sync_console_rail_visibility``
+        reaches ``ConsoleLeftRail``).
+
+        Returns:
+            The ``#console-main-column`` region widget, or ``None`` when the
+            shell is not (yet) mounted.
+        """
+        try:
+            return self.query_one("#console-main-column", ConsoleTranscriptRegion)
+        except (NoMatches, QueryError):
+            return None
+
     def _capture_console_transcript_reading_state(
         self,
     ) -> _ConsoleTranscriptReadingState | None:
-        """Capture the semantic reading position before composer layout changes."""
-        try:
-            transcript = self.query_one("#console-native-transcript", ConsoleTranscript)
-        except QueryError:
-            return None
-        return _ConsoleTranscriptReadingState(
-            anchored=bool(
-                transcript.is_anchored
-                and not getattr(transcript, "_anchor_released", False)
-            ),
-            scroll_y=float(transcript.scroll_y),
-            selected_message_id=transcript.selected_message_id,
-        )
+        """Capture the semantic reading position before composer layout changes.
+
+        Delegates to ``ConsoleTranscriptRegion.capture_reading_state`` (wave-3
+        task 2); kept as a screen method because
+        ``_set_console_composer_collapsed`` and a mounted composer-collapse
+        regression both call it by this name.
+
+        Returns:
+            The transcript's reading state, or ``None`` when no transcript
+            region is mounted.
+        """
+        region = self._console_transcript_region_or_none()
+        return None if region is None else region.capture_reading_state()
 
     def _restore_console_transcript_reading_state(
         self,
         state: _ConsoleTranscriptReadingState | None,
     ) -> None:
-        """Restore the transcript anchor, offset, and selected message."""
-        if state is None:
-            return
-        try:
-            transcript = self.query_one("#console-native-transcript", ConsoleTranscript)
-        except QueryError:
-            return
-        transcript.selected_message_id = state.selected_message_id
-        if state.anchored:
-            transcript.anchor()
-            return
-        transcript.release_anchor()
-        transcript.scroll_to(
-            y=min(state.scroll_y, float(transcript.max_scroll_y)),
-            animate=False,
-        )
+        """Restore the transcript anchor, offset, and selected message.
+
+        Delegates to ``ConsoleTranscriptRegion.restore_reading_state``.
+
+        Args:
+            state: The reading state captured before the layout change.
+        """
+        region = self._console_transcript_region_or_none()
+        if region is not None:
+            region.restore_reading_state(state)
 
     def _set_console_composer_collapsed(self, collapsed: bool) -> None:
         """Synchronize screen-owned collapse state with the mounted composer."""
@@ -13536,19 +13544,30 @@ class ChatScreen(BaseAppScreen):
                     left_rail.styles.display = "none"
                 yield self._frame_console_region(left_rail)
 
-                main_column = Vertical(id="console-main-column")
+                # `session_surface_builder` hands `ConsoleTranscriptRegion` a
+                # zero-arg callable, not a pre-built widget, for the same
+                # reason `character_avatar_widget_builder` does above -- and
+                # with a sharper edge here: `_ensure_console_session_surface`
+                # CACHES its result on `self.console_session_surface` and
+                # returns the same instance every time, so a stored instance
+                # would re-yield a widget Textual may already have removed on
+                # the next recompose, and would skip the background-effect
+                # re-sync that call performs. The lambda closes over `self`
+                # and resolves at CALL time (matching
+                # `ConsoleDictationController`'s late-binding constructor rule
+                # -- see `dictation.py`'s module docstring).
+                main_column = ConsoleTranscriptRegion(
+                    session_surface_builder=(
+                        lambda: self._ensure_console_session_surface()
+                    ),
+                )
+                # Sizing stays here, not in the region: these are facts about
+                # this pane's place among its `#console-workspace-grid`
+                # siblings (3fr / 13fr / 4fr), exactly as both rails are wired.
                 main_column.styles.width = "13fr"
                 main_column.styles.min_width = 56
                 main_column.styles.min_height = 0
-                with main_column:
-                    transcript_region = self._frame_console_region(
-                        Vertical(
-                            id="console-transcript-region", classes="console-region"
-                        ),
-                        top=False,
-                    )
-                    with transcript_region:
-                        yield self._ensure_console_session_surface()
+                yield main_column
 
                 # The live-work card is the one piece of this rail's content
                 # that reaches beyond rail-local state (self.app_instance,
@@ -15547,21 +15566,15 @@ class ChatScreen(BaseAppScreen):
     def _note_console_follow_intent(self) -> None:
         """Stamp a programmatic jump-to-tail intent on the transcript (TASK-336).
 
-        Task 3b audit: stays singular/view-only on purpose. Unlike the
-        stash maps above, this never carries session-owned DATA across a
-        send's lifetime -- it is a one-shot directive consumed by whichever
-        session's transcript happens to be `#console-native-transcript`
-        (a single widget instance reflecting the ACTIVE session) at the
-        next render. A background session's send stamping this while a
-        different session is viewed just requests an extra, harmless
-        tail-follow on whatever the transcript renders next; there is no
-        cross-session data to leak or clobber.
+        Delegates to ``ConsoleTranscriptRegion.note_follow_intent`` (wave-3
+        task 2), which carries the task-3b audit note about why this stays
+        singular/view-only. Kept as a screen method because the session and
+        workspace controllers are both wired to it by this name
+        (``note_follow_intent=lambda: self._note_console_follow_intent()``).
         """
-        try:
-            transcript = self.query_one("#console-native-transcript", ConsoleTranscript)
-        except QueryError:
-            return
-        transcript.note_follow_intent()
+        region = self._console_transcript_region_or_none()
+        if region is not None:
+            region.note_follow_intent()
 
     def _restore_console_send_stash(self, stash: "ConsoleDraftStash | None") -> None:
         """Hand a keypress-captured draft back to the composer (TASK-340)."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -70,6 +70,7 @@ from ..Console_Modules.hands_free import (
     ConsoleHandsFreeSession,
 )
 from ..Console_Modules.left_rail import ConsoleLeftRail
+from ..Console_Modules.message import ConsoleMessageController
 from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ..Console_Modules.workspace import ConsoleWorkspaceController
 from ..Console_Modules.session import (
@@ -180,8 +181,6 @@ from ...Chat.console_chat_models import (
     ConsoleMessageRole,
     ConsoleProviderSelection,
     ConsoleRunStatus,
-    ConsoleVariant,
-    ConsoleVariantSet,
     MessageAttachment,
     derive_console_session_title,
 )
@@ -307,15 +306,6 @@ from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Chat.provider_catalog import provider_display_name
 from ...Chat.provider_readiness import get_provider_readiness, provider_config_key
 from ...Chat.console_ephemeral import ACTION_SAVE_CHAT, blocked_reason
-from ...Chat.console_message_actions import (
-    ConsoleActionResult,
-    ConsoleMessageActionService,
-)
-from ...Chat.console_save_targets import (
-    console_chatbook_artifact_payload,
-    derive_console_save_title,
-    resolve_console_artifact_owner_request,
-)
 from ...Chat.console_live_work import (
     PENDING_LAUNCH_CARD_ID,
     SOURCE_READINESS_CARD_ID,
@@ -330,7 +320,6 @@ from ...Chat.console_expression_state import (
 )
 from ...Chat.console_command_suggestions import suggestions_for_draft
 from ...Chat.console_image_view import (
-    IMAGE_CACHE_MAX_ENTRIES,
     ConsoleImageRenderCache,
     ConsoleImageRowSpec,
     ConsoleImageViewState,
@@ -380,7 +369,6 @@ from ...Library.library_rag_service import (
     scope_empty_recovery_state,
 )
 from ...Library.library_rag_state import library_rag_source_scope_summary
-from ...Notes.notes_scope_service import ScopeType
 from ...Constants import (
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
@@ -414,12 +402,9 @@ from ...Widgets.Console import (
     ConsoleComposerUndoHistory,
     ConsoleDraftStash,
     ConsoleControlBar,
-    ConsoleEditMessageModal,
-    ConsoleEditResult,
     ConsoleRailHandle,
     ConsoleRetrievalScopeRow,
     ConsoleRunInspector,
-    ConsoleSaveAsModal,
     ConsoleSessionSurface,
     ConsoleSettingsModal,
     ConsoleSettingsSummary,
@@ -1338,32 +1323,6 @@ def _console_draft_looks_like_rag_query(draft: Any) -> bool:
         if parsed.scheme in ("http", "https") and parsed.netloc:
             return False
     return True
-
-
-def _apply_console_message_attachments(
-    message: ConsoleChatMessage,
-    attachments: "Iterable[MessageAttachment]",
-) -> None:
-    """Set a message's attachments tuple and mirror position 0 into scalars.
-
-    Mirrors ``ConsoleChatStore._set_message_attachments``'s invariant --
-    every attachments mutation sets the tuple AND the scalar image fields
-    (``image_data``, ``image_mime_type``, ``attachment_label``) together --
-    for call sites that build or rehydrate ``ConsoleChatMessage`` objects
-    directly (screen-state restore, saved-conversation resume), outside the
-    store, where that helper isn't reachable.
-    """
-    rebased = tuple(
-        replace(attachment, position=index)
-        for index, attachment in enumerate(attachments)
-    )
-    message.attachments = rebased
-    first = rebased[0] if rebased else None
-    message.image_data = first.data if first else None
-    message.image_mime_type = first.mime_type if first else None
-    message.attachment_label = (
-        first.display_name if first and first.display_name else None
-    )
 
 
 def _run_dictionary_summary_off_thread(
@@ -2507,8 +2466,19 @@ class ChatScreen(BaseAppScreen):
                     session
                 )
             ),
+            # Message <-> workspace seam (the reverse direction of the
+            # session/message seams the message controller's own
+            # constructor takes): the resume flow's tree flattener now
+            # lives on `ConsoleMessageController` (wave-3 task 1). This
+            # accessor already existed as a named callable before that
+            # move (wave-2 task 2); only its target changed, from the
+            # screen's own delegation to the controller directly. Python
+            # resolves `self._message` at CALL time, so construction order
+            # (workspace built before message) does not matter.
             messages_from_conversation_tree_accessor=(
-                lambda tree: self._console_messages_from_conversation_tree(tree)
+                lambda tree: self._message._console_messages_from_conversation_tree(
+                    tree
+                )
             ),
             session_settings_for_resume_accessor=(
                 lambda conversation: self._session._console_session_settings_for_resume(
@@ -2751,6 +2721,105 @@ class ChatScreen(BaseAppScreen):
                 )
             ),
         )
+        #: The native message-transcript cluster -- serialize/restore,
+        #: resume-tree flattening, screen-state rehydration, per-message
+        #: save-as/edit/retry/continue/regenerate/variant navigation, and
+        #: `handle_console_message_action`'s full dispatch -- moved to
+        #: `ConsoleMessageController` (wave-3 console decomposition, task
+        #: 1), the largest cluster in wave 3. `self._console_message_action_
+        #: service`/`_last_console_action`/`_pending_console_delete_message_
+        #: id`/`_console_original_attempt_previews`/`_console_speaking_
+        #: message_id`/`_pending_console_swipe_selection` stay readable/
+        #: writable via the proxy properties defined near
+        #: `_console_composer_or_none`, so nothing outside this cluster (a
+        #: few DOM-touching siblings, `console_transcript.py`'s bare-name
+        #: reach for `_console_speaking_message_id`, tests) had to change.
+        #: See `message.py`'s module docstring for the full map of what
+        #: moved, the delegation table its own pre-move test coupling
+        #: required, and why.
+        self._message = ConsoleMessageController(
+            self,
+            app_instance=self.app_instance,
+            chat_store_accessor=lambda: self._ensure_console_chat_store(),
+            current_chat_store_accessor=lambda: self._console_chat_store,
+            ensure_console_chat_controller=(
+                lambda: self._ensure_console_chat_controller()
+            ),
+            current_chat_controller_accessor=(
+                lambda: self._console_chat_controller
+            ),
+            sync_native_console_chat_ui=lambda: self._sync_native_console_chat_ui(),
+            # Session <-> message seam (design spec: "a named callable
+            # between them; design it deliberately, never a back-door
+            # through the screen"). `self._session` was constructed above;
+            # Python resolves it at CALL time inside these lambdas, so
+            # construction order does not matter.
+            #
+            # `active_session_is_ephemeral` is the one exception, routed
+            # through the screen's OWN `_console_active_session_is_
+            # ephemeral` delegation (session.py's disclosed exception for
+            # `console_transcript.py`'s bare-name reach) rather than
+            # straight to `self._session`: the pre-existing test suite
+            # monkeypatches `screen._console_active_session_is_ephemeral`
+            # directly (4 sites, `test_console_native_chat_flow.py`) to
+            # stub ephemeral state for `_console_save_as_destinations`
+            # scenarios -- reaching `self._session` directly here would
+            # silently stop observing that patch.
+            active_session_is_ephemeral=(
+                lambda: self._console_active_session_is_ephemeral()
+            ),
+            active_native_console_session=(
+                lambda: self._session._active_native_console_session()
+            ),
+            current_console_conversation_id=(
+                lambda: self._session._current_console_conversation_id()
+            ),
+            active_console_provider_model_display=(
+                lambda: self._active_console_provider_model_display()
+            ),
+            # Workspace <-> message seam, same shape.
+            console_initial_session_title_for_workspace=(
+                lambda workspace_id: (
+                    self._workspace._console_initial_session_title_for_workspace(
+                        workspace_id
+                    )
+                )
+            ),
+            # The change-review, image-generation, and image-view clusters
+            # stay screen-owned this wave (out of scope) -- each reach is a
+            # named callable, never a back-door through screen attributes.
+            console_change_review_run_id=(
+                lambda store, message_id: self._console_change_review_run_id(
+                    store, message_id
+                )
+            ),
+            open_change_review=lambda run_id: self._open_change_review(run_id),
+            start_console_transcript_sync_timer=(
+                lambda: self._start_console_transcript_sync_timer()
+            ),
+            clear_native_console_message_selection=(
+                lambda: self._clear_native_console_message_selection()
+            ),
+            regenerate_console_generation_variant=(
+                lambda message_id: self._regenerate_console_generation_variant(
+                    message_id
+                )
+            ),
+            select_console_generation_variant=(
+                lambda message, direction: self._select_console_generation_variant(
+                    message, direction=direction
+                )
+            ),
+            keep_console_generation_variant=(
+                lambda message: self._keep_console_generation_variant(message)
+            ),
+            handle_console_toggle_image_view=(
+                lambda message_id: self._handle_console_toggle_image_view(message_id)
+            ),
+            invalidate_console_persisted_rows_cache=(
+                lambda: self._invalidate_console_persisted_rows_cache()
+            ),
+        )
         #: The realtime (V4) hands-free loop's live session, or None when
         #: that loop is not running. Mutually exclusive with
         #: `_console_hands_free` by construction: the engine fork in
@@ -2780,28 +2849,15 @@ class ChatScreen(BaseAppScreen):
         self._console_image_cache: ConsoleImageRenderCache | None = None
         self._console_image_default_mode: Literal["pixels", "graphics"] | None = None
         self._console_image_preparing: set[str] = set()
-        self._console_message_action_service = ConsoleMessageActionService()
         self._console_model_option_warnings: dict[tuple[str, str], str] = {}
-        self._last_console_action: ConsoleActionResult | None = None
-        self._pending_console_delete_message_id: str | None = None
-        self._console_original_attempt_previews: dict[str, str] = {}
-        #: task-559 unit 2: id of the Console message currently driving TTS
-        #: (from speak dispatch until an explicit speak-stop, or until a
-        #: DIFFERENT message's speak overwrites it -- see
-        #: ``ConsoleTranscript._console_tts_speaking_message_id`` for the
-        #: read side and ``handle_console_message_action``'s speak/
-        #: speak-stop branches for the write side). No event bridges actual
-        #: audio-playback completion back into the app, so this does NOT
-        #: clear itself when playback ends naturally -- a documented
-        #: limitation shared with the legacy chat widgets' own "playing"
-        #: state, not a new gap introduced here.
-        self._console_speaking_message_id: str | None = None
-        #: task-501: sibling-swipe selection handoff. Held on the SCREEN (not
-        #: the transcript widget) because the transcript can be remounted by a
-        #: recompose between the swipe and the next message push — the sync
-        #: transfers this onto whichever transcript instance is current when
-        #: it pushes the post-swipe messages.
-        self._pending_console_swipe_selection: str | None = None
+        #: `_console_message_action_service`/`_last_console_action`/
+        #: `_pending_console_delete_message_id`/`_console_original_attempt_
+        #: previews`/`_console_speaking_message_id`/`_pending_console_swipe_
+        #: selection` now live on `self._message` (`ConsoleMessageController`,
+        #: constructed above) -- see the proxy properties defined near
+        #: `_console_composer_or_none` and `message.py`'s own docstring for
+        #: why `_console_speaking_message_id` in particular still needs one
+        #: (`console_transcript.py` reaches it by bare name off `self.screen`).
         self._console_transcript_sync_timer: Any | None = None
         # Cost-ticker PR3 (task-5): the 10s WARM->EXPIRED repaint timer --
         # mirrors `_console_transcript_sync_timer` (started/stopped via the
@@ -4198,26 +4254,10 @@ class ChatScreen(BaseAppScreen):
         return self._console_image_view_state, self._console_image_cache
 
     def _recent_console_image_messages(self, messages) -> list[Any]:
-        """Return the most recent image-bearing messages, bounded to cache capacity.
-
-        Mirrors the provider payload's most-recent-N image policy
-        (``_provider_message_payloads``'s ``image_ids[-image_budget:]``).
-
-        Excludes image-generation messages (non-empty ``generation_metadata``)
-        -- those render as a ``"generation-card"`` row instead of the plain
-        ``"image"`` row (see ``_build_generation_card_specs``), so including
-        them here would double-render and burn a plain-image LRU slot under
-        their bare message id for no row that ever reads it (TASK P2a-7).
-        """
-        # Bound the working set to the cache capacity so prep can never evict
-        # what the transcript still shows (churn guard).
-        image_messages = [
-            message
-            for message in messages
-            if getattr(message, "image_data", None) is not None
-            and not getattr(message, "generation_metadata", ())
-        ]
-        return image_messages[-IMAGE_CACHE_MAX_ENTRIES:]
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the image-view cluster's own staying callers and the
+        pre-existing test suite's direct-call/monkeypatch convention."""
+        return self._message._recent_console_image_messages(messages)
 
     def _build_console_image_specs(self, messages) -> dict[str, ConsoleImageRowSpec]:
         """Build image-row payloads for prepared, non-hidden image messages."""
@@ -4837,6 +4877,55 @@ class ChatScreen(BaseAppScreen):
     @_console_dictation_late_discard_ack.setter
     def _console_dictation_late_discard_ack(self, value: bool) -> None:
         self._dictation._console_dictation_late_discard_ack = value
+
+    # Message-cluster state moved to `ConsoleMessageController` (wave-3
+    # console decomposition, task 1). These properties keep `self._console_
+    # message_action_service`/`_last_console_action`/`_pending_console_
+    # delete_message_id`/`_console_original_attempt_previews`/`_console_
+    # speaking_message_id`/`_pending_console_swipe_selection` readable (and,
+    # where the pre-move source ever wrote them from outside the cluster,
+    # writable) exactly as before -- for the DOM-touching siblings that
+    # stayed on `ChatScreen` (`_selected_console_message_inspector_rows`,
+    # `_clear_native_console_message_selection`, `_sync_console_pending_
+    # delete_confirmation`, `_sync_native_console_transcript`, `on_unmount`),
+    # for `console_transcript.py`'s bare-name `getattr(self.screen,
+    # "_console_speaking_message_id", None)` reach, and for tests that poke
+    # this state directly -- each proxies straight through to
+    # `self._message`, so none of those call sites needed to change.
+    # `_console_message_action_service` has no proxy: nothing outside the
+    # moved cluster ever read or wrote it (a pre-existing bare-screen test
+    # fixture assigns it defensively; see the task-1 extraction report).
+    @property
+    def _last_console_action(self) -> Any:
+        return self._message._last_console_action
+
+    @property
+    def _pending_console_delete_message_id(self) -> str | None:
+        return self._message._pending_console_delete_message_id
+
+    @_pending_console_delete_message_id.setter
+    def _pending_console_delete_message_id(self, value: str | None) -> None:
+        self._message._pending_console_delete_message_id = value
+
+    @property
+    def _console_original_attempt_previews(self) -> dict[str, str]:
+        return self._message._console_original_attempt_previews
+
+    @property
+    def _console_speaking_message_id(self) -> str | None:
+        return self._message._console_speaking_message_id
+
+    @_console_speaking_message_id.setter
+    def _console_speaking_message_id(self, value: str | None) -> None:
+        self._message._console_speaking_message_id = value
+
+    @property
+    def _pending_console_swipe_selection(self) -> str | None:
+        return self._message._pending_console_swipe_selection
+
+    @_pending_console_swipe_selection.setter
+    def _pending_console_swipe_selection(self, value: str | None) -> None:
+        self._message._pending_console_swipe_selection = value
 
     def _sync_console_dictation_availability(self) -> None:
         """Refresh the mic button's dictation-availability tooltip.
@@ -9372,104 +9461,15 @@ class ChatScreen(BaseAppScreen):
             logger.opt(exception=True).debug("avatar: pixels build failed")
             return Static("no avatar", id="console-character-avatar-empty")
 
-    @staticmethod
-    def _console_message_role_from_persisted(
-        message: dict[str, Any],
-    ) -> ConsoleMessageRole:
-        """Return a native Console role for a persisted Chat message row."""
-        raw_role = str(message.get("role") or "").strip().lower()
-        if raw_role:
-            try:
-                return ConsoleMessageRole(raw_role)
-            except ValueError:
-                pass
-        sender = str(message.get("sender") or "").strip().lower()
-        if sender in {"user", "system", "tool"}:
-            return ConsoleMessageRole(sender)
-        return ConsoleMessageRole.ASSISTANT
-
     def _console_messages_from_conversation_tree(
-        self,
-        tree: dict[str, Any],
+        self, tree: dict[str, Any]
     ) -> list[ConsoleChatMessage]:
-        """Build native Console messages from a persisted conversation tree.
-
-        Task 8: flattens the ENTIRE tree (every node, all branches -- not just
-        the ``children[-1]`` latest branch), each message carrying its
-        ``persisted_message_id`` and persisted ``parent_message_id`` so the
-        store can reconnect the full tree and pick the active branch from the
-        stored active-leaf pointer.
-
-        Parenthood is taken from the tree's own NESTING (the id of the node we
-        recursed from), not the row's ``parent_message_id`` field: the real DB
-        tree sets both consistently, but a node's structural position is the
-        authoritative source and stays correct even for trees whose rows omit
-        the field. A truly-empty node (no content and no image) is dropped but
-        transparent to parenthood -- its children re-parent to the nearest kept
-        ancestor -- so a skipped row never orphans a branch.
-        """
-        messages: list[ConsoleChatMessage] = []
-
-        def _walk(node: Any, parent_persisted_id: str | None) -> None:
-            if not isinstance(node, dict):
-                return
-            content = str(node.get("content") or "")
-            raw_image = node.get("image_data")
-            image_data = (
-                bytes(raw_image) if isinstance(raw_image, (bytes, bytearray)) else None
-            )
-            raw_mime = node.get("image_mime_type")
-            image_mime_type = str(raw_mime) if raw_mime else None
-            usage = ProviderUsage.from_json(node.get("usage_json"))
-            metadata = MessageMetadata.from_json(node.get("metadata_json"))
-            raw_id = node.get("id")
-            node_persisted_id = str(raw_id) if raw_id is not None else None
-            kept = bool(content) or image_data is not None
-            if kept:
-                # The tree only carries the legacy position-0 columns; positions
-                # >= 1 (multi-attachment table rows) are batch-fetched below,
-                # once for the whole resumed list.
-                attachments: tuple[MessageAttachment, ...] = (
-                    (
-                        MessageAttachment(
-                            data=image_data,
-                            mime_type=image_mime_type or "",
-                            display_name="",
-                            position=0,
-                        ),
-                    )
-                    if image_data is not None
-                    else ()
-                )
-                messages.append(
-                    ConsoleChatMessage(
-                        role=self._console_message_role_from_persisted(node),
-                        content=content,
-                        status="complete",
-                        persisted_message_id=node_persisted_id,
-                        parent_message_id=parent_persisted_id,
-                        image_data=image_data,
-                        image_mime_type=image_mime_type,
-                        attachments=attachments,
-                        usage=usage,
-                        metadata=metadata,
-                    )
-                )
-            # Children re-parent to this node when kept, else pass the nearest
-            # kept ancestor straight through (a dropped empty row is invisible
-            # to the tree linkage).
-            child_parent_id = node_persisted_id if kept else parent_persisted_id
-            children = node.get("children")
-            if isinstance(children, list):
-                for child in children:
-                    _walk(child, child_parent_id)
-
-        root_threads = tree.get("root_threads")
-        if isinstance(root_threads, list):
-            for root in root_threads:
-                _walk(root, None)
-        self._batch_fetch_console_resume_attachments(messages)
-        return messages
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the pre-existing test suite's direct-call convention (7 sites
+        across 6 files); real production wiring (`ConsoleWorkspace
+        Controller`'s `messages_from_conversation_tree_accessor`) now
+        points at `self._message` directly, bypassing this delegation."""
+        return self._message._console_messages_from_conversation_tree(tree)
 
     def _inject_resume_agent_markers(
         self,
@@ -9519,54 +9519,6 @@ class ChatScreen(BaseAppScreen):
             messages, bridge.resume_marker_messages(conversation_id)
         )
 
-    def _batch_fetch_console_resume_attachments(
-        self, messages: list[ConsoleChatMessage]
-    ) -> None:
-        """Fill positions >= 1 for resumed multi-attachment messages, once.
-
-        ``get_conversation_tree`` only returns the legacy image columns
-        (position 0); the ``message_attachments`` table (positions >= 1) is
-        fetched here in a SINGLE batched call covering every message this
-        resume produced, then folded into each message's attachments tuple
-        via ``_apply_console_message_attachments`` (see that helper for the
-        store mirror invariant it replicates by hand).
-        """
-        ids = [m.persisted_message_id for m in messages if m.persisted_message_id]
-        if not ids:
-            return
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        getter = getattr(db, "get_attachments_for_messages", None)
-        if not callable(getter):
-            return
-        try:
-            rows_by_id = getter(ids)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Console resume attachment batch fetch failed."
-            )
-            return
-        if not isinstance(rows_by_id, dict):
-            return
-        for message in messages:
-            extra_rows = (
-                rows_by_id.get(message.persisted_message_id)
-                if message.persisted_message_id
-                else None
-            )
-            if not extra_rows:
-                continue
-            extras = [
-                MessageAttachment(
-                    data=row.get("data"),
-                    mime_type=row.get("mime_type") or "",
-                    display_name=row.get("display_name") or "",
-                    position=int(row.get("position", 0)),
-                )
-                for row in extra_rows
-            ]
-            _apply_console_message_attachments(
-                message, list(message.attachments) + extras
-            )
 
 
     async def _resolve_resumed_character_name(self, character_id: int) -> str:
@@ -12315,7 +12267,7 @@ class ChatScreen(BaseAppScreen):
         rows = [
             ConsoleDisplayRow(
                 "Selected message",
-                f"{self._console_message_role_label(message)} message",
+                f"{self._message._console_message_role_label(message)} message",
             ),
             ConsoleDisplayRow(
                 "Message actions",
@@ -12347,7 +12299,7 @@ class ChatScreen(BaseAppScreen):
         excerpt = (
             "Streaming…"
             if message.status == "streaming"
-            else self._console_message_excerpt(message, max_length=90)
+            else self._message._console_message_excerpt(message, max_length=90)
         )
         if excerpt:
             rows.append(ConsoleDisplayRow("Excerpt", excerpt))
@@ -12661,26 +12613,7 @@ class ChatScreen(BaseAppScreen):
             )
         return ("Review settings", "console", "Review this Console session's settings")
 
-    def _console_transcript_has_messages(self) -> bool:
-        """Return whether the active Console transcript has user/session content."""
-        if self._console_chat_store is not None:
-            session_id = self._console_chat_store.active_session_id
-            if session_id is not None and self._console_chat_store.messages_for_session(
-                session_id
-            ):
-                return True
 
-        return False
-
-    def _active_console_transcript_has_messages(self) -> bool:
-        """Return whether the active Console session's store transcript has messages."""
-        store = self._console_chat_store
-        if store is None:
-            return False
-        session_id = store.active_session_id
-        if session_id is None:
-            return False
-        return bool(store.messages_for_session(session_id))
 
     def _build_console_setup_card_state(self) -> ConsoleSetupCardState:
         """Build the empty-transcript onboarding state from current readiness."""
@@ -12691,7 +12624,7 @@ class ChatScreen(BaseAppScreen):
             provider_label=str(getattr(settings, "provider", "") or "Provider"),
             has_model=has_model,
             first_send_completed=self._console_first_send_completed(),
-            has_messages=self._active_console_transcript_has_messages(),
+            has_messages=self._message._active_console_transcript_has_messages(),
             guidance_dismissed=self._console_guidance_dismissed,
         )
 
@@ -13924,168 +13857,23 @@ class ChatScreen(BaseAppScreen):
         super().on_unmount()
 
 
-    @staticmethod
-    def _serialize_console_variants(
-        variants: ConsoleVariantSet | None,
-    ) -> dict[str, Any] | None:
-        """Return a JSON-safe snapshot of regenerated message variants."""
-        if variants is None:
-            return None
-        return {
-            "turn_id": variants.turn_id,
-            "selected_index": variants.selected_index,
-            "variants": [
-                {"id": variant.id, "content": variant.content}
-                for variant in variants.variants
-            ],
-        }
-
-    @staticmethod
-    def _restore_console_variants(payload: Any) -> ConsoleVariantSet | None:
-        """Return regenerated message variants from a saved state payload."""
-        if not isinstance(payload, dict):
-            return None
-        raw_variants = payload.get("variants")
-        if not isinstance(raw_variants, list) or not raw_variants:
-            return None
-        variants: list[ConsoleVariant] = []
-        for raw_variant in raw_variants:
-            if not isinstance(raw_variant, dict):
-                continue
-            content = str(raw_variant.get("content") or "")
-            variant_id = str(raw_variant.get("id") or uuid.uuid4())
-            variants.append(ConsoleVariant(content=content, id=variant_id))
-        if not variants:
-            return None
-        selected_index = payload.get("selected_index", 0)
-        if not isinstance(selected_index, int):
-            selected_index = 0
-        selected_index = min(max(selected_index, 0), len(variants) - 1)
-        return ConsoleVariantSet(
-            turn_id=str(payload.get("turn_id") or uuid.uuid4()),
-            variants=variants,
-            selected_index=selected_index,
-        )
-
     @classmethod
     def _serialize_console_message(
-        cls,
-        message: ConsoleChatMessage,
+        cls, message: ConsoleChatMessage
     ) -> dict[str, Any]:
-        """Return a JSON-safe snapshot of a native Console transcript message."""
-        role = message.role.value if hasattr(message.role, "value") else message.role
-        return {
-            "id": message.id,
-            "role": role,
-            "content": message.content,
-            "turn_id": message.turn_id,
-            "status": message.status,
-            "persisted_message_id": message.persisted_message_id,
-            "feedback": message.feedback,
-            "variants": cls._serialize_console_variants(message.variants),
-            "image_mime_type": getattr(message, "image_mime_type", None),
-            "attachment_label": getattr(message, "attachment_label", None),
-            # Labels only -- bytes are dropped from screen-state snapshots
-            # the same way the legacy `image_data` scalar always has been.
-            # `getattr` (not `message.attachments`) tolerates plain-object
-            # stand-ins (e.g. a bare SimpleNamespace) that predate the
-            # `attachments` field, matching this method's existing
-            # tolerance for `image_mime_type`/`attachment_label` above.
-            "attachment_labels": [
-                attachment.display_name
-                for attachment in getattr(message, "attachments", ())
-            ],
-            # Normalized provider usage (Console cost ticker): carried as the
-            # same JSON string persistence uses, so a screen-state round trip
-            # (navigate away and back) keeps a turn's real cost instead of
-            # silently zeroing it. `getattr` tolerates plain-object stand-ins
-            # that predate the field, like the neighbours above.
-            "usage_json": (
-                usage.to_json()
-                if (usage := getattr(message, "usage", None)) is not None
-                else None
-            ),
-            # Structured message metadata (task-2364): same reasoning as
-            # `usage_json` above -- a screen-state round trip that dropped
-            # it would lose the interrupted flag and a voice row's
-            # transcript status, silently re-stranding what this field
-            # exists to record.
-            "metadata_json": (
-                metadata.to_json()
-                if (metadata := getattr(message, "metadata", None)) is not None
-                else None
-            ),
-        }
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        (unbound, `ChatScreen.X(...)`) for `_serialize_native_console_
+        state`'s staying call and the pre-existing test suite's
+        direct-call convention (8 sites)."""
+        return ConsoleMessageController._serialize_console_message(message)
 
     @classmethod
     def _restore_console_message(cls, payload: Any) -> ConsoleChatMessage | None:
-        """Return a native Console transcript message from a saved state payload."""
-        if not isinstance(payload, dict):
-            return None
-        try:
-            role = ConsoleMessageRole(str(payload.get("role") or "system"))
-        except ValueError:
-            role = ConsoleMessageRole.SYSTEM
-        status = str(payload.get("status") or "complete")
-        if status not in {"complete", "pending", "streaming", "stopped", "failed"}:
-            status = "complete"
-        feedback = payload.get("feedback")
-        if feedback not in {None, "up", "down"}:
-            feedback = None
-        image_mime_type = (
-            str(payload["image_mime_type"]) if payload.get("image_mime_type") else None
-        )
-        attachment_label = (
-            str(payload["attachment_label"])
-            if payload.get("attachment_label")
-            else None
-        )
-        raw_labels = payload.get("attachment_labels")
-        if isinstance(raw_labels, list):
-            attachment_labels = [str(label) for label in raw_labels]
-        else:
-            # Legacy payloads (saved before `attachment_labels` existed)
-            # carried at most one label -- the singular `attachment_label`.
-            attachment_labels = [attachment_label] if attachment_label else []
-        # Metadata-only: bytes were never serialized, so every reconstructed
-        # attachment starts with `data=None` (refilled by
-        # `_rehydrate_console_message_image`/`_rehydrate_console_message_attachments`
-        # after restore). `image_mime_type` is the only mime carried across
-        # a screen-state snapshot, so it stands in for every position until
-        # per-attachment mime types come back from the DB.
-        attachments = tuple(
-            MessageAttachment(
-                data=None,
-                mime_type=image_mime_type or "",
-                display_name=label,
-                position=index,
-            )
-            for index, label in enumerate(attachment_labels)
-        )
-        return ConsoleChatMessage(
-            role=role,
-            content=str(payload.get("content") or ""),
-            id=str(payload.get("id") or uuid.uuid4()),
-            turn_id=(
-                str(payload["turn_id"]) if payload.get("turn_id") is not None else None
-            ),
-            status=status,  # type: ignore[arg-type]
-            persisted_message_id=(
-                str(payload["persisted_message_id"])
-                if payload.get("persisted_message_id") is not None
-                else None
-            ),
-            variants=cls._restore_console_variants(payload.get("variants")),
-            feedback=feedback,  # type: ignore[arg-type]
-            image_mime_type=image_mime_type,
-            attachment_label=attachment_label,
-            attachments=attachments,
-            # `from_json` returns None for missing/legacy/corrupt payloads,
-            # which is exactly the "no usage known" state.
-            usage=ProviderUsage.from_json(payload.get("usage_json")),
-            # Same degrade-never-raise contract for structured metadata.
-            metadata=MessageMetadata.from_json(payload.get("metadata_json")),
-        )
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        (unbound, `ChatScreen.X(...)`) for `_restore_native_console_
+        state`'s staying call and the pre-existing test suite's
+        direct-call convention (7 sites)."""
+        return ConsoleMessageController._restore_console_message(payload)
 
     # App-object attribute holding staged-but-unsent attachments across screen
     # recreation. Full PendingAttachment objects (bytes included, so clipboard
@@ -14321,155 +14109,28 @@ class ChatScreen(BaseAppScreen):
         )
 
     def _rehydrate_console_message_image(self, message: ConsoleChatMessage) -> None:
-        """Refill image bytes dropped by screen-state restore (metadata-only).
-
-        Screen-state restore only carries image metadata (mime type + label),
-        never raw bytes, so a restored message that still points at an image
-        has no bytes for the provider payload builder to attach even though
-        its chip renders from metadata alone. Refetch the bytes from the
-        ChaChaNotes DB using the message's persisted id; on any failure leave
-        the message metadata-only so the chip still renders (graceful
-        degradation) instead of raising.
-        """
-        if message.image_data is not None:
-            return
-        if not message.image_mime_type or not message.persisted_message_id:
-            return
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        try:
-            row = (
-                db.get_message_by_id(message.persisted_message_id)
-                if db is not None
-                else None
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Console restore image rehydration DB lookup failed."
-            )
-            return
-        if not row:
-            return
-        image_data = row.get("image_data")
-        if image_data is None:
-            return
-        message.image_data = image_data
-        message.image_mime_type = row.get("image_mime_type") or message.image_mime_type
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for `_restore_native_console_state`'s staying call and the
+        pre-existing test suite's direct-call convention."""
+        self._message._rehydrate_console_message_image(message)
 
     def _rehydrate_console_message_attachments(
         self, messages: list[ConsoleChatMessage]
     ) -> None:
-        """Batch-refill ``message_attachments`` table rows for restored messages.
-
-        ``_rehydrate_console_message_image`` (still called per message, see
-        its own docstring/tests) already refilled the legacy position-0
-        bytes into each message's scalar mirror; this pass runs ONE batched
-        ``get_attachments_for_messages`` call covering every message in this
-        restore, then folds the now-current scalar mirror plus any table
-        rows (positions >= 1) back into each message's attachments tuple.
-        Any failure (missing DB, unreachable batch call) leaves messages
-        metadata-only -- graceful degradation, matching
-        ``_rehydrate_console_message_image``'s own contract.
-        """
-        ids = [m.persisted_message_id for m in messages if m.persisted_message_id]
-        rows_by_id: Dict[str, list[dict[str, Any]]] = {}
-        if ids:
-            db = getattr(self.app_instance, "chachanotes_db", None)
-            getter = getattr(db, "get_attachments_for_messages", None)
-            if callable(getter):
-                try:
-                    fetched = getter(ids)
-                except Exception:
-                    logger.opt(exception=True).warning(
-                        "Console restore attachment batch fetch failed."
-                    )
-                    fetched = None
-                if isinstance(fetched, dict):
-                    rows_by_id = fetched
-
-        for message in messages:
-            if not message.attachments:
-                continue
-            entries = list(message.attachments)
-            # Position 0 mirrors whatever `_rehydrate_console_message_image`
-            # just refilled into the scalar fields (bytes included, when it
-            # found a row).
-            entries[0] = replace(
-                entries[0],
-                data=message.image_data,
-                mime_type=message.image_mime_type or entries[0].mime_type,
-            )
-            extra_rows = (
-                rows_by_id.get(message.persisted_message_id, [])
-                if message.persisted_message_id
-                else []
-            )
-            rows_by_position = {int(row.get("position", 0)): row for row in extra_rows}
-            for index in range(1, len(entries)):
-                row = rows_by_position.get(index)
-                if row is None:
-                    continue
-                entries[index] = replace(
-                    entries[index],
-                    data=row.get("data"),
-                    mime_type=row.get("mime_type") or entries[index].mime_type,
-                    display_name=row.get("display_name") or entries[index].display_name,
-                )
-            _apply_console_message_attachments(message, entries)
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for `_restore_native_console_state`'s staying call."""
+        self._message._rehydrate_console_message_attachments(messages)
 
     def _rehydrate_console_message_generation_metadata(
         self,
         store: "ConsoleChatStore",
         restored_messages_by_session: Dict[str, list[ConsoleChatMessage]],
     ) -> None:
-        """Batch-refill ``generation_metadata`` for messages restored from screen state.
-
-        Counterpart of ``_rehydrate_console_message_attachments`` for the
-        generation-metadata sidecar: `restore_state` -- the tab-switch
-        (in-memory) restore path -- does not itself hydrate
-        `generation_metadata`, unlike `restore_persisted_session` (the
-        DB-resume path), which drives this same
-        `get_generation_metadata_for_messages` +
-        `ConsoleChatStore.hydrate_generation_metadata` seam internally. One
-        batched call covers every restored message across every restored
-        session in this pass, then `hydrate_generation_metadata` is invoked
-        once per session (it filters by that session's own tree-node
-        persisted ids, so handing it the whole merged mapping is safe and
-        avoids a second per-session round trip). Must run AFTER
-        `store.restore_state(...)`, which is what populates the store's
-        tree nodes (and therefore `persisted_message_id` lookups)
-        `hydrate_generation_metadata` needs. Any failure (missing DB,
-        unreachable batch call) leaves messages metadata-only -- graceful
-        degradation, matching `_rehydrate_console_message_attachments`'s
-        own contract.
-
-        Args:
-            store: The Console chat store just populated by `restore_state`.
-            restored_messages_by_session: The same per-session message lists
-                passed to `store.restore_state(...)`.
-        """
-        persistence = getattr(store, "persistence", None)
-        getter = getattr(persistence, "get_generation_metadata_for_messages", None)
-        if not callable(getter):
-            return
-        ids = [
-            message.persisted_message_id
-            for messages in restored_messages_by_session.values()
-            for message in messages
-            if message.persisted_message_id
-        ]
-        if not ids:
-            return
-        try:
-            rows_by_message = getter(ids)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Console restore generation-metadata batch fetch failed."
-            )
-            return
-        if not isinstance(rows_by_message, dict):
-            return
-        for session_id in restored_messages_by_session:
-            store.hydrate_generation_metadata(session_id, rows_by_message)
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for `_restore_native_console_state`'s staying call."""
+        self._message._rehydrate_console_message_generation_metadata(
+            store, restored_messages_by_session
+        )
 
     def save_state(self) -> Dict[str, Any]:
         """Save only state owned by the native Console."""
@@ -14677,11 +14338,9 @@ class ChatScreen(BaseAppScreen):
         )
 
     def _native_console_messages(self) -> list[Any]:
-        """Return messages for the active native Console session."""
-        store = self._ensure_console_chat_store()
-        if store.active_session_id is None:
-            return []
-        return store.messages_for_session(store.active_session_id)
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the citation cluster's own staying callers."""
+        return self._message._native_console_messages()
 
     def _console_citation_modal_request_is_current(
         self,
@@ -14775,18 +14434,10 @@ class ChatScreen(BaseAppScreen):
 
         self.app.push_screen(modal, callback=_open_source_in_library)
 
-    @staticmethod
-    def _console_citation_message_body(message: Any) -> str:
-        """Return the exact currently selected body for one Console message."""
-        variants = getattr(message, "variants", None)
-        if variants is not None:
-            try:
-                body = variants.current.content
-            except (AttributeError, IndexError):
-                body = getattr(message, "content", "")
-        else:
-            body = getattr(message, "content", "")
-        return body if isinstance(body, str) else ""
+    def _console_citation_message_body(self, message: Any) -> str:
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the citation cluster's own staying callers."""
+        return self._message._console_citation_message_body(message)
 
     def _console_citation_signature(
         self,
@@ -15209,12 +14860,6 @@ class ChatScreen(BaseAppScreen):
         self._last_native_transcript_refresh_key = None
         self._sync_console_transcript_guidance()
 
-    def _clear_console_original_attempt_preview(self, message_id: str) -> None:
-        """Clear one screen preview and its controller-owned cached body."""
-        self._console_original_attempt_previews.pop(message_id, None)
-        controller = self._console_chat_controller
-        if controller is not None:
-            controller.clear_original_attempt(message_id)
 
     def _native_run_status_copy(self) -> str:
         controller = self._console_chat_controller
@@ -15346,53 +14991,12 @@ class ChatScreen(BaseAppScreen):
     async def _append_native_console_system_message(
         self, message: str, *, session_id: str | None = None
     ) -> None:
-        """Append a system message to native Console state and refresh the bridge.
-
-        Task 4 (background-write audit): most callers are synchronous
-        command handlers with no ``await`` between "the user's intended
-        session" and this call, so the default (``session_id=None``,
-        resolving whichever session is active RIGHT NOW via
-        ``store.ensure_session``) is safe -- there is no gap in which the
-        active session could have changed underneath them.
-
-        A handler that spans a real await gap while already anchored to a
-        specific session (e.g. `/generate-image`'s in-flight batch, tracked
-        per session in ``_console_imagegen_inflight_sessions``) must pass
-        that session's id explicitly instead -- re-resolving "active" at
-        append time would let a session switch during the awaited work
-        misattribute the row to whatever the user is looking at NOW rather
-        than the session that actually produced it. The resync below is
-        unconditional either way and stays harmless: it only ever renders
-        the store's CURRENTLY active session, so a background session's
-        just-appended row simply doesn't show until the user visits it
-        (store-first discipline; no view write needs gating here beyond
-        that existing pull-based rebuild).
-        """
-        store = self._ensure_console_chat_store()
-        if session_id is not None:
-            try:
-                store.append_message(
-                    session_id,
-                    role=ConsoleMessageRole.SYSTEM,
-                    content=message,
-                )
-            except KeyError:
-                # Session vanished (closed) before its background operation's
-                # outcome could be attributed to it -- nothing to append to.
-                pass
-        else:
-            session = store.ensure_session(
-                title=self._workspace._console_initial_session_title_for_workspace(
-                    store.workspace_context.active_workspace_id
-                ),
-                workspace_id=store.workspace_context.active_workspace_id,
-            )
-            store.append_message(
-                session.id,
-                role=ConsoleMessageRole.SYSTEM,
-                content=message,
-            )
-        await self._sync_native_console_chat_ui()
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        under the original name for its ~10 staying callers across other
+        clusters and for tests that monkeypatch/call it directly."""
+        await self._message._append_native_console_system_message(
+            message, session_id=session_id
+        )
 
     def _start_console_transcript_sync_timer(self) -> None:
         if self._console_transcript_sync_timer is not None:
@@ -17956,942 +17560,52 @@ class ChatScreen(BaseAppScreen):
         self.handle_console_save_chatbook(event)
 
     async def handle_console_message_action(self, event: Button.Pressed) -> bool:
-        """Route selected transcript message actions through the native action service."""
-        button_id = event.button.id or ""
-        action_id, message_id = self._parse_console_message_action_button_id(button_id)
-        if action_id is None or message_id is None:
-            return False
-
-        event.stop()
-        store = self._ensure_console_chat_store()
-
-        if action_id == "review-changes":
-            # TASK-2030 (live-UAT headline defect): the ✎ summary row is a
-            # display-only TOOL marker — deliberately NOT a tree node — so
-            # `store.get_message` can NEVER resolve it, and the pre-dispatch
-            # lookup below killed the row's own advertised affordance
-            # ("review with `v`") with the not-found toast on every press.
-            # The run id is display data already ON the rendered row:
-            # resolve it from the transcript's display model, falling back
-            # to the store for tree-node rows. Every other action keeps the
-            # store resolution (and its failure toast) untouched.
-            self._pending_console_delete_message_id = None
-            run_id = self._console_change_review_run_id(store, message_id)
-            if run_id is None:
-                self.app_instance.notify(
-                    "Console message action target no longer exists.",
-                    severity="warning",
-                )
-                return True
-            self._open_change_review(run_id)
-            return True
-
-        try:
-            message = store.get_message(message_id)
-        except KeyError:
-            self.app_instance.notify(
-                "Console message action target no longer exists.", severity="warning"
-            )
-            return True
-
-        if action_id != "delete":
-            self._pending_console_delete_message_id = None
-
-        if action_id == "save-as":
-            destinations = self._console_save_as_destinations(message)
-
-            def _apply_save_as(destination: str | None) -> None:
-                savers = {
-                    "Note": self._save_console_message_as_note,
-                    "Media": self._save_console_message_as_media,
-                    "Prompt": self._save_console_message_as_prompt,
-                    "Chatbook": self._save_console_message_as_chatbook,
-                }
-                saver = savers.get(destination or "")
-                if saver is not None:
-                    self.run_worker(
-                        saver(message_id), exclusive=True, group="console-save-as"
-                    )
-
-            await self.app.push_screen(
-                ConsoleSaveAsModal(
-                    destinations=destinations,
-                    message_role=self._console_message_role_label(message),
-                    message_excerpt=self._console_message_excerpt(message),
-                    ephemeral=self._console_active_session_is_ephemeral(),
-                ),
-                callback=_apply_save_as,
-            )
-            self._last_console_action = ConsoleActionResult(
-                action_id=action_id,
-                status="completed",
-                visible_copy="Opened Save as destinations.",
-            )
-            return True
-
-        result = self._console_message_action_service.dispatch(action_id, message)
-        self._last_console_action = result
-        if action_id == "view-original-attempt" and result.status == "completed":
-            controller = self._ensure_console_chat_controller()
-            original_attempt = controller.original_attempt_for_message(message_id)
-            if original_attempt is None:
-                self._console_original_attempt_previews.pop(message_id, None)
-            elif message_id in self._console_original_attempt_previews:
-                self._console_original_attempt_previews.pop(message_id, None)
-            else:
-                self._console_original_attempt_previews[message_id] = original_attempt
-            await self._sync_native_console_chat_ui()
-            return True
-        if result.clipboard_text is not None:
-            copy_to_clipboard = getattr(self.app_instance, "copy_to_clipboard", None)
-            if callable(copy_to_clipboard):
-                copy_to_clipboard(result.clipboard_text)
-        if action_id == "speak" and result.status == "completed":
-            from tldw_chatbook.Chat.console_speech import (
-                ConsoleSpeechSnapshotRejected,
-            )
-            from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
-                TTSMessageSpeechRequestEvent,
-            )
-
-            try:
-                speech_snapshot = store.issue_tts_message_speech_snapshot(message.id)
-            except ConsoleSpeechSnapshotRejected as error:
-                self.app_instance.notify(str(error), severity="warning")
-                return True
-            self.app_instance.post_message(
-                TTSMessageSpeechRequestEvent(
-                    speech_snapshot,
-                    store.validate_tts_message_speech_snapshot,
-                )
-            )
-            # task-559 unit 2: track this message as "speaking" so the
-            # action row swaps 🔊 -> ⏹ (a fresh speak always supersedes
-            # whatever was previously tracked -- the underlying player is a
-            # single-slot global singleton that stops any prior clip before
-            # starting a new one, so the tracked id and reality agree).
-            self._console_speaking_message_id = message.id
-            await self._sync_native_console_chat_ui()
-        if action_id == "speak-stop" and result.status == "completed":
-            # Reuses the legacy stop-button's exact plumbing (spec: "do not
-            # invent a parallel audio-control path") -- safe to post
-            # unconditionally, the app-level handler no-ops when nothing is
-            # cached/playing for this message id.
-            from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
-                TTSPlaybackEvent,
-            )
-
-            was_speaking = (
-                getattr(self, "_console_speaking_message_id", None) == message.id
-            )
-            self.app_instance.post_message(
-                TTSPlaybackEvent(action="stop", message_id=message.id)
-            )
-            if was_speaking:
-                # Only when the screen itself believed this message was
-                # driving TTS do we clear state / re-sync / give feedback
-                # (fix round 1). A speak-stop dispatched for a message the
-                # screen never tracked as speaking -- e.g. a directly
-                # crafted button id, or a stale press racing an already-
-                # cleared state -- is a genuinely idle no-op: the stop
-                # event above is still posted for safety, but claiming
-                # "Stopped speaking." or forcing a re-sync for nothing
-                # would be misleading UI feedback.
-                self._console_speaking_message_id = None
-                await self._sync_native_console_chat_ui()
-                self.app_instance.notify(result.visible_copy, severity="information")
-            return True
-        if action_id == "edit" and result.status == "edit_requested":
-            await self._open_console_message_edit_modal(
-                message_id=message_id,
-                content=result.target_content or "",
-            )
-            return True
-        if action_id == "retry" and result.status == "completed":
-            controller = self._ensure_console_chat_controller()
-            # Gate BEFORE spawning: an exclusive console-run worker cancels the
-            # in-flight run at creation time, before the controller's own
-            # rejection can run — the screen must refuse, like the submit path.
-            target_session_id = controller.store.active_session_id
-            refusal = controller.send_refusal_copy(target_session_id)
-            if refusal:
-                self.app_instance.notify(refusal, severity="warning")
-                return True
-            self.run_worker(
-                self._retry_console_message(controller, message_id),
-                exclusive=True,
-                group=f"console-run-{target_session_id}",
-            )
-            return True
-        if action_id == "regenerate" and result.status == "wip":
-            if message.generation_metadata:
-                # A generation message's regenerate ALWAYS appends one new
-                # image variant -- never an LLM text sibling -- so it skips
-                # the controller/run-state gate entirely (that gate exists
-                # for chat runs; image generation has its own in-flight
-                # guard, checked inside this call).
-                #
-                # F5 follow-up (task-9 review): this is a fourth door onto
-                # the same disk-writing sink /generate-image's dispatch
-                # gate covers -- it calls `run_generation_batch` directly
-                # and never passes through `_dispatch_console_command`, so
-                # it needs its own check against the same registry entry.
-                image_blocked = blocked_reason(
-                    GENERATE_IMAGE_COMMAND_HANDLER_ID,
-                    ephemeral=self._console_active_session_is_ephemeral(),
-                )
-                if image_blocked is not None:
-                    self.app_instance.notify(image_blocked, severity="warning")
-                    return True
-                await self._regenerate_console_generation_variant(message_id)
-                return True
-            controller = self._ensure_console_chat_controller()
-            target_session_id = controller.store.active_session_id
-            refusal = controller.send_refusal_copy(target_session_id)
-            if refusal:
-                self.app_instance.notify(refusal, severity="warning")
-                return True
-            self.run_worker(
-                self._regenerate_console_message(controller, message_id),
-                exclusive=True,
-                group=f"console-run-{target_session_id}",
-            )
-            return True
-        if (
-            action_id in {"variant-previous", "variant-next"}
-            and result.status == "completed"
-        ):
-            landed_sibling_id: str | None = None
-            if message.generation_metadata:
-                self._select_console_generation_variant(message, direction=action_id)
-            else:
-                landed_sibling_id = self._select_console_message_variant(
-                    message_id, direction=action_id
-                )
-            # task-501: keep the selection (and its action row) on the swapped
-            # sibling so repeated `<`/`>` presses work without re-clicking the
-            # row. The post-swipe view reaches the transcript asynchronously
-            # (possibly coalesced), so hand the target off as a PENDING
-            # selection the transcript applies at ingest time — selecting
-            # eagerly here would either miss its membership guard or be
-            # cleared by reconciliation against the stale set. Other
-            # selection-clearing actions ("continue" etc.) are untouched.
-            if landed_sibling_id is not None:
-                # Held on the screen (remount-proof); the sync below transfers
-                # it onto whichever transcript instance receives the push.
-                self._pending_console_swipe_selection = landed_sibling_id
-            await self._sync_native_console_chat_ui()
-            return True
-        if action_id == "keep" and result.status == "completed":
-            self._keep_console_generation_variant(message)
-            await self._sync_native_console_chat_ui()
-            self.app_instance.notify(result.visible_copy, severity="information")
-            return True
-        if (
-            action_id in {"feedback-up", "feedback-down"}
-            and result.status == "completed"
-        ):
-            feedback = "up" if action_id == "feedback-up" else "down"
-            store.set_message_feedback(message_id, feedback)
-            await self._sync_native_console_chat_ui()
-            self.app_instance.notify(result.visible_copy, severity="information")
-            return True
-        if action_id == "toggle-image-view" and result.status == "completed":
-            self._handle_console_toggle_image_view(message_id)
-            await self._sync_native_console_chat_ui()
-            return True
-        if action_id == "save-image" and result.status == "completed":
-            self.run_worker(
-                self._save_console_message_image(message_id),
-                exclusive=True,
-                group="console-save-image",
-            )
-            return True
-        if action_id == "delete" and result.status == "completed":
-            if self._pending_console_delete_message_id != message_id:
-                self._pending_console_delete_message_id = message_id
-                self._last_console_action = ConsoleActionResult(
-                    action_id=action_id,
-                    status="blocked",
-                    visible_copy="Press Delete again to remove this message.",
-                    target_message_id=message_id,
-                )
-                await self._sync_native_console_chat_ui()
-                return True
-            self._pending_console_delete_message_id = None
-            session_id = store.session_id_for_message(message_id)
-            controller = self._ensure_console_chat_controller()
-            # Deletion is subtree-wide, so clear the owning session while
-            # descendant-to-session identity is still available.
-            controller.clear_original_attempts_for_session(session_id)
-            self._console_original_attempt_previews.clear()
-            store.delete_message(message_id)
-            # TASK-251: a deleted message can change what the browser row
-            # shows for this conversation (title/updated_at) -- invalidate
-            # so the next sync reflects it immediately.
-            self._invalidate_console_persisted_rows_cache()
-            await self._sync_native_console_chat_ui()
-            self.app_instance.notify(result.visible_copy, severity="information")
-            return True
-        if action_id == "continue" and result.status == "continue_requested":
-            controller = self._ensure_console_chat_controller()
-            target_session_id = controller.store.active_session_id
-            refusal = controller.send_refusal_copy(target_session_id)
-            if refusal:
-                self.app_instance.notify(refusal, severity="warning")
-                return True
-            self.run_worker(
-                self._continue_console_message(controller, message_id),
-                exclusive=True,
-                group=f"console-run-{target_session_id}",
-            )
-            return True
-        severity = "information" if result.status in {"completed", "wip"} else "warning"
-        self.app_instance.notify(result.visible_copy, severity=severity)
-        return True
-
-    @staticmethod
-    def _console_message_role_label(message: ConsoleChatMessage) -> str:
-        """Return a user-facing role label for a Console transcript message."""
-        role = (
-            message.role.value if hasattr(message.role, "value") else str(message.role)
-        )
-        return role.title()
-
-    @staticmethod
-    def _console_message_content(message: ConsoleChatMessage) -> str:
-        """Return the currently visible content for a Console transcript message."""
-        if message.variants is not None:
-            return message.variants.current.content
-        return message.content
-
-    @classmethod
-    def _console_message_excerpt(
-        cls,
-        message: ConsoleChatMessage,
-        *,
-        max_length: int = 120,
-    ) -> str:
-        """Return a single-line excerpt for selected-message context surfaces."""
-        normalized = " ".join(cls._console_message_content(message).split())
-        if len(normalized) <= max_length:
-            return normalized
-        return f"{normalized[: max(0, max_length - 1)].rstrip()}…"
+        """Delegate to `ConsoleMessageController` (wave-3 task 1). Kept
+        under the original name for `on_button_pressed` and the
+        pre-existing test suite's direct-call convention -- see
+        `message.py`'s module docstring."""
+        return await self._message.handle_console_message_action(event)
 
     def _console_save_as_destinations(self, message: Any) -> list[Any]:
-        """Return Save-as destinations available in the current app runtime.
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the pre-existing test suite's direct-call convention."""
+        return self._message._console_save_as_destinations(message)
 
-        A temporary session blocks every destination outright: the write
-        itself is the problem, so service readiness is moot and is never
-        even checked in that case.
-        """
-        available_destinations: set[str] = set()
-        unavailable_reasons: dict[str, str] = {}
-
-        if self._console_active_session_is_ephemeral():
-            # F4 (task-9 review): `blocked_reason` returns `str | None`;
-            # every label above has a registry entry today, so this is
-            # never None in practice, but `unavailable_reasons` is typed
-            # `dict[str, str]` -- fall back to a generic sentence instead
-            # of silently letting a future registry-key drift surface the
-            # literal string "None" on the modal.
-            for label in ("Chatbook", "Note", "Media", "Prompt"):
-                unavailable_reasons[label] = (
-                    blocked_reason(f"save-as-{label.lower()}", ephemeral=True)
-                    or "Not available in a temporary chat."
-                )
-            return ConsoleMessageActionService(
-                available_save_destinations=set(),
-                unavailable_save_reasons=unavailable_reasons,
-            ).save_as_destinations(message)
-
-        notes_scope_service = getattr(self.app_instance, "notes_scope_service", None)
-        if callable(getattr(notes_scope_service, "save_note", None)):
-            available_destinations.add("Note")
-        else:
-            unavailable_reasons["Note"] = "Notes service is not ready in this session."
-
-        media_db = getattr(self.app_instance, "media_db", None)
-        if callable(getattr(media_db, "add_media_with_keywords", None)):
-            available_destinations.add("Media")
-        else:
-            unavailable_reasons["Media"] = "Media library is not ready in this session."
-
-        prompts_db = getattr(self.app_instance, "prompts_db", None)
-        if callable(getattr(prompts_db, "add_prompt", None)):
-            available_destinations.add("Prompt")
-        else:
-            unavailable_reasons["Prompt"] = (
-                "Prompts service is not ready in this session."
-            )
-
-        chatbook_service = getattr(self.app_instance, "local_chatbook_service", None)
-        if not callable(getattr(chatbook_service, "create_chatbook", None)):
-            unavailable_reasons["Chatbook"] = (
-                "Chatbook artifacts service is not ready in this session."
-            )
-        elif not ConsoleMessageActionService._is_assistant_message(message):
-            unavailable_reasons["Chatbook"] = (
-                "Only assistant responses can be saved as Chatbook artifacts."
-            )
-        else:
-            available_destinations.add("Chatbook")
-
-        return ConsoleMessageActionService(
-            available_save_destinations=available_destinations,
-            unavailable_save_reasons=unavailable_reasons,
-        ).save_as_destinations(message)
-
-    def _console_save_source_title(self) -> str:
-        """Return the active Console conversation title for save-as derivations."""
-        session = self._session._active_native_console_session()
-        return str(getattr(session, "title", "") or "").strip()
 
     async def _save_console_message_image(self, message_id: str) -> None:
-        """Write ALL of a Console message's image attachments to disk.
-
-        In-memory bytes are used first; any attachment still dataless (e.g.
-        a metadata-only entry left by screen-state restore) falls back to
-        one batched DB fetch -- the legacy `messages.image_data` column for
-        position 0, `get_attachments_for_messages` for positions >= 1 --
-        per the HARD interface contract split addressing.
-        """
-        import mimetypes as _mimetypes
-        from datetime import datetime as _datetime
-
-        store = self._ensure_console_chat_store()
-        try:
-            message = store.get_message(message_id)
-        except KeyError:
-            self.app_instance.notify(
-                "Console message no longer exists.", severity="warning"
-            )
-            return
-
-        attachments = list(message.attachments)
-        if not attachments and (
-            message.image_data is not None or message.persisted_message_id is not None
-        ):
-            # Legacy/raw-constructed messages may carry the scalar image
-            # fields without a populated attachments tuple; synthesize a
-            # position-0 entry so the fallback below still covers them.
-            attachments = [
-                MessageAttachment(
-                    data=message.image_data,
-                    mime_type=message.image_mime_type or "image/png",
-                    display_name=message.attachment_label or "",
-                    position=0,
-                )
-            ]
-
-        missing_positions = any(a.data is None for a in attachments)
-        if missing_positions and message.persisted_message_id is not None:
-            db = getattr(self.app_instance, "chachanotes_db", None)
-            persisted_message_id = message.persisted_message_id
-
-            def _fetch_persisted_attachment_data() -> dict[
-                int, tuple[Any, Optional[str]]
-            ]:
-                fetched: dict[int, tuple[Any, Optional[str]]] = {}
-                try:
-                    row = (
-                        db.get_message_by_id(persisted_message_id)
-                        if db is not None
-                        else None
-                    )
-                except Exception:
-                    logger.opt(exception=True).warning(
-                        "Console save-image DB fallback lookup failed."
-                    )
-                    row = None
-                if row and row.get("image_data") is not None:
-                    fetched[0] = (row.get("image_data"), row.get("image_mime_type"))
-                getter = getattr(db, "get_attachments_for_messages", None)
-                if callable(getter):
-                    try:
-                        batch = getter([persisted_message_id])
-                    except Exception:
-                        logger.opt(exception=True).warning(
-                            "Console save-image attachment batch fetch failed."
-                        )
-                        batch = None
-                    if isinstance(batch, dict):
-                        for row_dict in batch.get(persisted_message_id, []) or []:
-                            position = int(row_dict.get("position", 0))
-                            fetched[position] = (
-                                row_dict.get("data"),
-                                row_dict.get("mime_type"),
-                            )
-                return fetched
-
-            fetched = await asyncio.to_thread(_fetch_persisted_attachment_data)
-            if fetched:
-                attachments = [
-                    replace(
-                        attachment,
-                        data=fetched[attachment.position][0],
-                        mime_type=fetched[attachment.position][1]
-                        or attachment.mime_type,
-                    )
-                    if attachment.data is None and attachment.position in fetched
-                    else attachment
-                    for attachment in attachments
-                ]
-
-        saveable = [a for a in attachments if a.data]
-        if not saveable:
-            self.app_instance.notify(
-                "No image data available for this message.", severity="warning"
-            )
-            return
-
-        def _write_images_to_disk() -> tuple[list[Path], Path]:
-            from tldw_chatbook.Utils.path_validation import validate_path_simple
-
-            save_location = validate_path_simple(
-                os.path.expanduser(
-                    get_cli_setting("chat.images", "save_location", "~/Downloads")
-                )
-            )
-            save_location.mkdir(parents=True, exist_ok=True)
-            base_name = f"console_image_{_datetime.now().strftime('%Y%m%d_%H%M%S')}"
-            written: list[Path] = []
-            for attachment in saveable:
-                extension = (
-                    _mimetypes.guess_extension(attachment.mime_type or "image/png")
-                    or ".png"
-                )
-                target = save_location / f"{base_name}{extension}"
-                counter = 1
-                while target.exists() or target in written:
-                    target = save_location / f"{base_name}_{counter}{extension}"
-                    counter += 1
-                target.write_bytes(bytes(attachment.data))
-                written.append(target)
-            return written, save_location
-
-        try:
-            written, save_location = await asyncio.to_thread(_write_images_to_disk)
-        except Exception as exc:
-            logger.opt(exception=True).warning("Console save-image write failed.")
-            self.app_instance.notify(
-                f"Could not save image: {escape_markup(str(exc))}", severity="error"
-            )
-            return
-        if len(written) == 1:
-            self.app_instance.notify(f"Image saved to {escape_markup(str(written[0]))}")
-        else:
-            self.app_instance.notify(
-                f"Saved {len(written)} images to {escape_markup(str(save_location))}"
-            )
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the pre-existing test suite's direct-call convention."""
+        await self._message._save_console_message_image(message_id)
 
     async def _save_console_message_as_note(self, message_id: str) -> None:
-        """Persist one selected Console message as a local Note."""
-        notes_scope_service = getattr(self.app_instance, "notes_scope_service", None)
-        save_note = getattr(notes_scope_service, "save_note", None)
-        if not callable(save_note):
-            self.app_instance.notify(
-                "Save as Note is unavailable: Notes service is not ready.",
-                severity="warning",
-            )
-            return
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the pre-existing test suite's direct-call convention."""
+        await self._message._save_console_message_as_note(message_id)
 
-        try:
-            message = self._ensure_console_chat_store().get_message(message_id)
-        except KeyError:
-            self.app_instance.notify(
-                "Console message action target no longer exists.",
-                severity="warning",
-            )
-            return
 
-        content = self._console_message_content(message)
-        title = derive_console_save_title(self._console_save_source_title())
-        try:
-            result = save_note(
-                scope=ScopeType.LOCAL_NOTE.value,
-                title=title,
-                content=content,
-                note_id=None,
-                version=None,
-                user_id=getattr(self.app_instance, "current_user", None)
-                or "default_user",
-                workspace_id=None,
-                keywords=["console"],
-            )
-            if inspect.isawaitable(result):
-                result = await result
-        except Exception as exc:
-            logger.opt(exception=True).warning("Console save-as Note failed.")
-            self.app_instance.notify(f"Save as Note failed: {exc}", severity="error")
-            return
-        if not result:
-            self.app_instance.notify("Save as Note failed.", severity="error")
-            return
-        self._last_console_action = ConsoleActionResult(
-            action_id="save-as-note",
-            status="completed",
-            visible_copy="Saved message as Note.",
-            target_message_id=message_id,
-            target_content=content,
-        )
-        self.app_instance.notify("Saved message as Note.", severity="information")
 
-    async def _save_console_message_as_media(self, message_id: str) -> None:
-        """Persist one selected Console message as a Library media item."""
-        media_db = getattr(self.app_instance, "media_db", None)
-        add_media = getattr(media_db, "add_media_with_keywords", None)
-        if not callable(add_media):
-            self.app_instance.notify(
-                "Save as Media is unavailable: Media library is not ready.",
-                severity="warning",
-            )
-            return
-
-        try:
-            message = self._ensure_console_chat_store().get_message(message_id)
-        except KeyError:
-            self.app_instance.notify(
-                "Console message action target no longer exists.",
-                severity="warning",
-            )
-            return
-
-        content = self._console_message_content(message)
-        title = derive_console_save_title(
-            self._console_save_source_title(),
-            role_label=self._console_message_role_label(message),
-        )
-        try:
-            media_id, _media_uuid, save_message = add_media(
-                title=title,
-                media_type="plaintext",
-                content=content,
-                keywords=["console"],
-            )
-        except Exception as exc:
-            logger.opt(exception=True).warning("Console save-as Media failed.")
-            self.app_instance.notify(f"Save as Media failed: {exc}", severity="error")
-            return
-        if media_id is None:
-            self.app_instance.notify(
-                f"Save as Media failed: {save_message or 'no media record was created.'}",
-                severity="error",
-            )
-            return
-        self._last_console_action = ConsoleActionResult(
-            action_id="save-as-media",
-            status="completed",
-            visible_copy="Saved message as Media.",
-            target_message_id=message_id,
-            target_content=content,
-        )
-        self.app_instance.notify(
-            "Saved message as Media. It appears under Library ▸ Media.",
-            severity="information",
-        )
-
-    async def _save_console_message_as_prompt(self, message_id: str) -> None:
-        """Persist one selected Console message as a prompt in the Prompts library."""
-        prompts_db = getattr(self.app_instance, "prompts_db", None)
-        add_prompt = getattr(prompts_db, "add_prompt", None)
-        if not callable(add_prompt):
-            self.app_instance.notify(
-                "Save as Prompt is unavailable: Prompts service is not ready.",
-                severity="warning",
-            )
-            return
-
-        try:
-            message = self._ensure_console_chat_store().get_message(message_id)
-        except KeyError:
-            self.app_instance.notify(
-                "Console message action target no longer exists.",
-                severity="warning",
-            )
-            return
-
-        from tldw_chatbook.DB.Prompts_DB import ConflictError
-
-        content = self._console_message_content(message)
-        conversation_title = self._console_save_source_title()
-        base_name = derive_console_save_title(conversation_title)
-        details = (
-            f"Saved from Console conversation: {conversation_title}."
-            if conversation_title
-            else "Saved from a Console conversation."
-        )
-        prompt_id = None
-        saved_name = base_name
-        try:
-            for attempt in range(1, 10):
-                saved_name = base_name if attempt == 1 else f"{base_name} ({attempt})"
-                try:
-                    prompt_id, _prompt_uuid, save_message = add_prompt(
-                        name=saved_name,
-                        author="Console",
-                        details=details,
-                        system_prompt=content,
-                        keywords=["console"],
-                        overwrite=False,
-                    )
-                except ConflictError:
-                    continue
-                if prompt_id is not None and "soft-deleted" in str(save_message or ""):
-                    # Name collides with a soft-deleted prompt: nothing was
-                    # saved, so keep probing suffixed names.
-                    prompt_id = None
-                    continue
-                break
-        except Exception as exc:
-            logger.opt(exception=True).warning("Console save-as Prompt failed.")
-            self.app_instance.notify(f"Save as Prompt failed: {exc}", severity="error")
-            return
-        if prompt_id is None:
-            self.app_instance.notify(
-                "Save as Prompt failed: a prompt with this name already exists.",
-                severity="error",
-            )
-            return
-        self._last_console_action = ConsoleActionResult(
-            action_id="save-as-prompt",
-            status="completed",
-            visible_copy="Saved message as Prompt.",
-            target_message_id=message_id,
-            target_content=content,
-        )
-        self.app_instance.notify(
-            f"Saved message as Prompt '{saved_name}' in the local Prompts library.",
-            severity="information",
-        )
-
-    async def _save_console_message_as_chatbook(self, message_id: str) -> None:
-        """Register one selected assistant message as a Chatbook artifact."""
-        chatbook_service = getattr(self.app_instance, "local_chatbook_service", None)
-        create_chatbook = getattr(chatbook_service, "create_chatbook", None)
-        if not callable(create_chatbook):
-            self.app_instance.notify(
-                "Save as Chatbook is unavailable: Chatbook artifacts service is not ready.",
-                severity="warning",
-            )
-            return
-
-        try:
-            message = self._ensure_console_chat_store().get_message(message_id)
-        except KeyError:
-            self.app_instance.notify(
-                "Console message action target no longer exists.",
-                severity="warning",
-            )
-            return
-
-        if not ConsoleMessageActionService._is_assistant_message(message):
-            self.app_instance.notify(
-                "Only assistant responses can be saved as Chatbook artifacts.",
-                severity="warning",
-            )
-            return
-
-        content = self._console_message_content(message)
-        provider: str | None = None
-        model: str | None = None
-        try:
-            provider, model, _settings = self._active_console_provider_model_display()
-        except Exception:
-            logger.opt(exception=True).debug(
-                "Console save-as Chatbook could not resolve provider/model context."
-            )
-        payload = console_chatbook_artifact_payload(
-            title=derive_console_save_title(self._console_save_source_title()),
-            message_text=content,
-            message_role=self._console_message_role_label(message),
-            conversation_id=self._session._current_console_conversation_id(),
-            message_id=message_id,
-            provider=provider,
-            model=model,
-        )
-        coordinator = getattr(
-            self.app_instance,
-            "citation_artifact_ownership_coordinator",
-            None,
-        )
-        owner_request = resolve_console_artifact_owner_request(
-            coordinator=coordinator,
-            persisted_message_id=message.persisted_message_id,
-            message_text=content,
-        )
-        if owner_request is not None:
-            payload["provenance_owner_request"] = owner_request
-        try:
-            result = create_chatbook(**payload)
-            if inspect.isawaitable(result):
-                await result
-            if owner_request is not None and coordinator is not None:
-                try:
-                    await asyncio.to_thread(coordinator.reconcile_pending, limit=1)
-                except Exception:
-                    logger.warning(
-                        "Citation artifact reconciliation deferred: "
-                        "artifact_reconciliation_failed"
-                    )
-        except Exception as exc:
-            logger.opt(exception=True).warning("Console save-as Chatbook failed.")
-            self.app_instance.notify(
-                f"Save as Chatbook failed: {exc}", severity="error"
-            )
-            return
-        self._last_console_action = ConsoleActionResult(
-            action_id="save-as-chatbook",
-            status="completed",
-            visible_copy="Saved message as Chatbook artifact.",
-            target_message_id=message_id,
-            target_content=content,
-        )
-        self.app_instance.notify(
-            "Saved message as a Chatbook artifact. It appears under Artifacts.",
-            severity="information",
-        )
 
     async def _open_console_message_edit_modal(
         self, *, message_id: str, content: str
     ) -> None:
-        """Open the dedicated transcript edit modal for one Console message."""
-        store = self._ensure_console_chat_store()
-        try:
-            message = store.get_message(message_id)
-        except KeyError:
-            self.app_instance.notify(
-                "Console message action target no longer exists.",
-                severity="error",
-            )
-            return
-        can_resend = message.role is ConsoleMessageRole.USER
-
-        def _apply_edit(result: ConsoleEditResult | None) -> None:
-            if result is None:
-                return
-            self._clear_console_original_attempt_preview(message_id)
-            if not result.resend:
-                try:
-                    store.update_message_content(message_id, result.text)
-                except ValueError as exc:
-                    self.app_instance.notify(str(exc), severity="warning")
-                    return
-                except KeyError:
-                    self.app_instance.notify(
-                        "Console message action target no longer exists.",
-                        severity="error",
-                    )
-                    return
-                self._last_console_action = ConsoleActionResult(
-                    action_id="edit",
-                    status="completed",
-                    visible_copy="Edited message.",
-                    target_message_id=message_id,
-                    target_content=result.text,
-                )
-                self.run_worker(
-                    self._sync_native_console_chat_ui(),
-                    exclusive=True,
-                    group="console-sync",
-                )
-                self.app_instance.notify("Edited message.", severity="information")
-                return
-            controller = self._ensure_console_chat_controller()
-            # Gate BEFORE spawning: an exclusive console-run worker cancels the
-            # in-flight run at creation time, before the controller's own
-            # rejection can run -- the screen must refuse, like the submit path.
-            target_session_id = controller.store.active_session_id
-            refusal = controller.send_refusal_copy(target_session_id)
-            if refusal:
-                self.app_instance.notify(refusal, severity="warning")
-                return
-            self.run_worker(
-                self._edit_resend_console_message(controller, message_id, result.text),
-                exclusive=True,
-                group=f"console-run-{target_session_id}",
-            )
-
-        await self.app.push_screen(
-            ConsoleEditMessageModal(content=content, can_resend=can_resend),
-            callback=_apply_edit,
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the pre-existing test suite's direct-call convention."""
+        await self._message._open_console_message_edit_modal(
+            message_id=message_id, content=content
         )
 
     @staticmethod
     def _parse_console_message_action_button_id(
         button_id: str,
     ) -> tuple[str | None, str | None]:
-        prefixes = (
-            (
-                "console-message-action-view-original-attempt-",
-                "view-original-attempt",
-            ),
-            ("console-message-action-feedback-up-", "feedback-up"),
-            ("console-message-action-feedback-down-", "feedback-down"),
-            ("console-message-action-variant-previous-", "variant-previous"),
-            ("console-message-action-variant-next-", "variant-next"),
-            ("console-message-action-keep-", "keep"),
-            ("console-message-action-review-changes-", "review-changes"),
-            ("console-message-action-save-as-", "save-as"),
-            ("console-message-action-save-image-", "save-image"),
-            ("console-message-action-toggle-image-view-", "toggle-image-view"),
-            ("console-message-action-regenerate-", "regenerate"),
-            ("console-message-action-continue-", "continue"),
-            ("console-message-action-delete-", "delete"),
-            ("console-message-action-retry-", "retry"),
-            # speak-stop MUST be checked before speak -- "speak-" is itself
-            # a prefix of "speak-stop-", so the more specific entry has to
-            # win the ordered startswith() scan below (else a speak-stop
-            # button id would mis-parse as action "speak" with message id
-            # "stop-<real id>").
-            ("console-message-action-speak-stop-", "speak-stop"),
-            ("console-message-action-speak-", "speak"),
-            ("console-message-action-copy-", "copy"),
-            ("console-message-action-edit-", "edit"),
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        (unbound, `ChatScreen.X(...)`) for the pre-existing test suite."""
+        return ConsoleMessageController._parse_console_message_action_button_id(
+            button_id
         )
-        for prefix, action_id in prefixes:
-            if button_id.startswith(prefix):
-                return action_id, button_id.removeprefix(prefix)
-        return None, None
 
-    async def _retry_console_message(
-        self,
-        controller: ConsoleChatController,
-        message_id: str,
-    ) -> None:
-        # TASK-343: without the sync timer these awaits run the whole
-        # generation with zero on-screen feedback (the timer self-stops
-        # when the run leaves an active status).
-        self._start_console_transcript_sync_timer()
-        result = await controller.retry_message(message_id)
-        if result.visible_copy:
-            severity = "warning" if not result.accepted else "information"
-            self.app_instance.notify(result.visible_copy, severity=severity)
-        await self._sync_native_console_chat_ui()
 
-    async def _continue_console_message(
-        self,
-        controller: ConsoleChatController,
-        message_id: str,
-    ) -> None:
-        self._start_console_transcript_sync_timer()
-        result = await controller.continue_from_message(message_id)
-        if result.visible_copy and not result.accepted:
-            self.app_instance.notify(result.visible_copy, severity="warning")
-        if result.accepted:
-            self._clear_native_console_message_selection()
-        await self._sync_native_console_chat_ui()
 
-    async def _regenerate_console_message(
-        self,
-        controller: ConsoleChatController,
-        message_id: str,
-    ) -> None:
-        self._start_console_transcript_sync_timer()
-        result = await controller.regenerate_message(message_id)
-        if result.visible_copy and not result.accepted:
-            self.app_instance.notify(result.visible_copy, severity="warning")
-        await self._sync_native_console_chat_ui()
 
     async def _summarize_console_up_to(
         self,
@@ -18913,58 +17627,16 @@ class ChatScreen(BaseAppScreen):
             self.app_instance.notify(result.visible_copy, severity=severity)
         await self._sync_native_console_chat_ui()
 
-    async def _edit_resend_console_message(
-        self,
-        controller: ConsoleChatController,
-        message_id: str,
-        new_content: str,
-    ) -> None:
-        # TASK-343: without the sync timer these awaits run the whole
-        # generation with zero on-screen feedback (the timer self-stops
-        # when the run leaves an active status).
-        self._start_console_transcript_sync_timer()
-        result = await controller.edit_and_resend_message(message_id, new_content)
-        if result.visible_copy and not result.accepted:
-            self.app_instance.notify(result.visible_copy, severity="warning")
-        await self._sync_native_console_chat_ui()
 
     def _select_console_message_variant(
         self, message_id: str, *, direction: str
     ) -> str | None:
-        """Move the active leaf across ``message_id``'s persisted siblings.
-
-        Returns the target sibling's native id when the swipe moved (so the
-        caller can re-select that row after the UI sync — task-501: repeated
-        ``<``/``>`` presses must not require re-clicking the row), or ``None``
-        on a no-op at either end of the sibling list.
-
-        ``message_id`` identifies the transcript ROW the swipe control was
-        clicked on -- this may be off the CURRENT active leaf's own subtree
-        (e.g. after a previous swipe landed deep inside a sibling's branch),
-        so sibling lookup always resolves from ``message_id`` itself via
-        ``store.siblings_at`` (works for off-path nodes too), never from
-        ``store.active_leaf``. The target sibling's own most-recent
-        descendant (``store._leaf_under``) becomes the new active leaf, so
-        swiping back into a branch that was mid-conversation resumes at its
-        deepest turn rather than snapping back to the fork point. A no-op at
-        either end of the sibling list (nothing before the first / after the
-        last) leaves the active leaf untouched -- the caller re-syncs the UI
-        either way, which is harmless when nothing moved.
-        """
-        store = self._ensure_console_chat_store()
-        siblings, index, count = store.siblings_at(message_id)
-        if direction == "variant-previous":
-            target_index = index - 1
-        elif direction == "variant-next":
-            target_index = index + 1
-        else:
-            return None
-        if target_index < 0 or target_index >= count:
-            return None
-        target_sibling_id = siblings[target_index].id
-        session_id = store.session_id_for_message(message_id)
-        store.set_active_leaf(session_id, store._leaf_under(target_sibling_id))
-        return target_sibling_id
+        """Delegate to `ConsoleMessageController` (wave-3 task 1) -- kept
+        for the pre-existing test suite's direct-call convention (12
+        sites across 2 files)."""
+        return self._message._select_console_message_variant(
+            message_id, direction=direction
+        )
 
     def _select_console_generation_variant(
         self, message: ConsoleChatMessage, *, direction: str

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -550,6 +550,7 @@ CONSOLE_FOCUS_FRAME_COLOR = "#0178D4"
 CONSOLE_FOCUS_FRAME_BORDER = ("solid", CONSOLE_FOCUS_FRAME_COLOR)
 CONSOLE_START_HERE_COPY = ""
 CONSOLE_ACTION_HINTS_COPY = ""
+# "Absent" bucket of the untrusted-refuse copy (Task 7's SKILL_UNTRUSTED_REFUSE):
 # a typed skill name that matches nothing at all -- not a trusted candidate,
 # not even a needs-review one.
 CONSOLE_SKILL_RUN_REFUSE_REASON_ABSENT = "no matching skill"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -15,7 +15,6 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, Iterable, Literal, Optional, TYPE_CHECKING
 from urllib.parse import urlparse
-import uuid
 
 import toml
 from loguru import logger
@@ -71,6 +70,7 @@ from ..Console_Modules.hands_free import (
 )
 from ..Console_Modules.left_rail import ConsoleLeftRail
 from ..Console_Modules.message import ConsoleMessageController
+from ..Console_Modules.prompts import ConsolePromptsController
 from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ..Console_Modules.transcript import (
     ConsoleTranscriptRegion,
@@ -87,7 +87,7 @@ from ..Console_Modules.session import (
 from ...Chat.chat_persistence_service import ChatPersistenceService
 from ...Chat.citation_trace_repository import ActiveCitationTraceState
 from ...Chat.console_chat_controller import ConsoleChatController
-from ...Chat.prompt_history import PromptHistory, default_prompt_history_path
+from ...Chat.prompt_history import PromptHistory
 from ...Chat.console_cost_tracker import (
     ConsoleCacheState,
     ConsoleCostRowTotals,
@@ -211,10 +211,7 @@ from ...Chat.console_provider_gateway import (
     ConsoleProviderGateway,
     normalize_llamacpp_base_url,
 )
-from ...Chat.console_provider_endpoints import (
-    first_configured_endpoint,
-    safe_endpoint_display,
-)
+from ...Chat.console_provider_endpoints import first_configured_endpoint
 
 from ...Chat.console_voice_input import (
     NO_CAPTURE_MESSAGE,
@@ -365,7 +362,6 @@ from ...config import (
     save_setting_to_cli_config,
     save_settings_to_cli_config,
 )
-from ...Library.library_prompts_state import classify_prompt_save_error
 from ...Library.library_rag_service import (
     LibraryRagSearchOutcome,
     LibraryRagSearchRequest,
@@ -469,23 +465,6 @@ from ...Widgets.Console.console_composer_menu_modal import (
     ACTION_UNDO_PROMPT_IMPROVEMENT,
     ConsoleComposerMenuModal,
 )
-from ...Widgets.Console.console_prompt_improve_view import (
-    ConsolePromptImprovementContext,
-)
-from ...Widgets.Console.console_prompts_modal import (
-    ConsolePromptsApplyOutcome,
-    ConsolePromptsModal,
-    ConsolePromptsResult,
-    ConsoleRecipeApplyGuard,
-    ConsoleSavedPromptApplyGuard,
-)
-from ...Prompt_Management.prompt_artifact_codec import decode_prompt_artifact
-from ...Prompt_Management.prompt_improvement_models import (
-    PromptImprovementRequestSnapshot,
-    fingerprint_block_definition,
-    fingerprint_text,
-)
-from ...Prompt_Management.prompt_improvement_service import PromptImprovementService
 from ...Widgets.Console.console_generate_image_modal import (
     ConsoleGenerateImageModal,
 )
@@ -494,14 +473,9 @@ from ...Widgets.Console.console_model_popover import (
     CONSOLE_POPOVER_OPEN_FULL_SETTINGS,
     ConsoleModelPopover,
 )
-from ...Widgets.Console.console_prompt_picker_modal import (
-    MODE_APPLY_SYSTEM as CONSOLE_PROMPT_PICKER_MODE_APPLY_SYSTEM,
-    ConsolePromptPickerModal,
-)
 from ...Widgets.Console.console_run_log_modal import ConsoleRunLogModal
 from ...Widgets.Console.console_skill_picker_modal import ConsoleSkillPickerModal
 from ...Widgets.Console.console_style_picker_modal import ConsoleStylePickerModal
-from ...Widgets.Console.console_system_prompt_modal import ConsoleSystemPromptModal
 from ...Widgets.Console.console_setup_modal import (
     CONSOLE_SETUP_MODAL_DETECTED_WORKBENCH_ACTION,
 )
@@ -576,20 +550,6 @@ CONSOLE_FOCUS_FRAME_COLOR = "#0178D4"
 CONSOLE_FOCUS_FRAME_BORDER = ("solid", CONSOLE_FOCUS_FRAME_COLOR)
 CONSOLE_START_HERE_COPY = ""
 CONSOLE_ACTION_HINTS_COPY = ""
-# Mirrors `library_screen.LIBRARY_PROMPT_SAVE_STATUS_COPY` verbatim: the
-# Console `/system` editor's "Save to Library" action is always a brand-new
-# prompt CREATE (never an update to an existing one, unlike the Library
-# prompt editor's own save flow), but the outcome copy the user sees must
-# read identically either way -- duplicated here rather than imported across
-# screens to avoid a Screen-to-Screen import.
-CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY = {
-    "ok": "Saved.",
-    "name-in-use": "Name already in use — pick another or open the existing prompt.",
-    "soft-deleted-name": "A deleted prompt holds this name — restore it or choose another.",
-    "error": "Couldn't save this prompt. Try again.",
-}
-CONSOLE_SYSTEM_PROMPT_NO_SYSTEM_PART_TEMPLATE = 'Prompt "{name}" has no system part.'
-# "Absent" bucket of the untrusted-refuse copy (Task 7's SKILL_UNTRUSTED_REFUSE):
 # a typed skill name that matches nothing at all -- not a trusted candidate,
 # not even a needs-review one.
 CONSOLE_SKILL_RUN_REFUSE_REASON_ABSENT = "no matching skill"
@@ -2095,7 +2055,7 @@ class ChatScreen(BaseAppScreen):
         if self._console_setup_modal_blocking():
             return
         self.run_worker(
-            self._open_console_prompt_picker_for_insert(""),
+            self._prompts._open_console_prompt_picker_for_insert(""),
             exclusive=False,
         )
 
@@ -2817,6 +2777,89 @@ class ChatScreen(BaseAppScreen):
                 lambda: self._invalidate_console_persisted_rows_cache()
             ),
         )
+        #: The prompt cluster -- Prompt Library modal, `/prompt` + `/system`
+        #: resolution and their pickers, the system-prompt editor and its
+        #: save-to-Library flow, the Library staged-insert handoff, and the
+        #: shared prompt-history store (wave-3 console decomposition, task
+        #: 3). Every dependency below is a LATE-BINDING lambda, never a
+        #: bound method: eleven of the eighteen are replaced by name on the
+        #: screen instance somewhere in the pre-existing suite, and a
+        #: constructor snapshot would silently stop observing every one of
+        #: those. See `Console_Modules/prompts.py`'s `__init__` docstring
+        #: for the per-parameter rationale.
+        self._prompts = ConsolePromptsController(
+            self,
+            app_instance=self.app_instance,
+            composer_accessor=lambda: self._console_composer_or_none(),
+            chat_store_accessor=lambda: self._ensure_console_chat_store(),
+            # Session <-> prompts seam (design spec: "a named callable
+            # between them; design it deliberately, never a back-door
+            # through the screen"). `self._session` was constructed above;
+            # Python resolves it at CALL time inside these lambdas, so
+            # construction order does not matter.
+            ensure_active_console_session_settings=(
+                lambda: self._session._ensure_active_console_session_settings()
+            ),
+            apply_console_session_system_prompt=(
+                lambda system_prompt: (
+                    self._session._apply_console_session_system_prompt(system_prompt)
+                )
+            ),
+            sync_console_session_draft=(
+                lambda: self._session._sync_console_session_draft()
+            ),
+            active_console_provider_model_display=(
+                lambda: self._active_console_provider_model_display()
+            ),
+            build_console_provider_selection=(
+                lambda: self._build_console_provider_selection()
+            ),
+            ensure_console_provider_gateway=(
+                lambda: self._ensure_console_provider_gateway()
+            ),
+            console_provider_blocker_copy=(
+                lambda: self._console_provider_blocker_copy()
+            ),
+            # A bare-attribute READ, not a call: the modal opener hands
+            # this straight to `ConsolePromptsModal(configure_provider=...)`
+            # without calling it, so the accessor must return the screen's
+            # current attribute rather than a wrapper around it -- that is
+            # what keeps `test_console_workbench_contract.py`'s
+            # `console._open_console_provider_recovery = AsyncMock()`
+            # reaching the modal exactly as it did pre-move.
+            open_console_provider_recovery_accessor=(
+                lambda: self._open_console_provider_recovery
+            ),
+            console_setup_blocked_reason=(
+                lambda: self._console_setup_blocked_reason()
+            ),
+            focus_console_composer_if_needed=(
+                lambda **kwargs: self._focus_console_composer_if_needed(**kwargs)
+            ),
+            # DOM-touching, so it stays on the screen (`query_one` on the
+            # native composer) -- and six pre-existing test sites replace it
+            # there by name.
+            insert_prompt_text_into_composer=(
+                lambda text, *, replace: self._insert_prompt_text_into_composer(
+                    text, replace=replace
+                )
+            ),
+            clear_console_composer_draft=(
+                lambda: self._clear_console_composer_draft()
+            ),
+            append_native_console_system_message=(
+                lambda text: self._append_native_console_system_message(text)
+            ),
+            sync_console_chat_core_state=(
+                lambda: self._sync_console_chat_core_state()
+            ),
+            sync_console_rail_system_line=(
+                lambda: self._sync_console_rail_system_line()
+            ),
+            sync_console_settings_summary=(
+                lambda: self._sync_console_settings_summary()
+            ),
+        )
         #: The realtime (V4) hands-free loop's live session, or None when
         #: that loop is not running. Mutually exclusive with
         #: `_console_hands_free` by construction: the engine fork in
@@ -2830,7 +2873,6 @@ class ChatScreen(BaseAppScreen):
         #: see `_teardown_console_realtime_loop`.
         self._console_realtime_close_worker: Any | None = None
         self._console_provider_gateway: Any | None = None
-        self._console_prompt_history: Any | None = None
         self._console_chat_controller: ConsoleChatController | None = None
         self._console_command_registry: ConsoleCommandRegistry = (
             default_console_registry()
@@ -4508,25 +4550,8 @@ class ChatScreen(BaseAppScreen):
         return self._console_provider_gateway
 
     def _ensure_console_prompt_history(self) -> PromptHistory:
-        """Return the shared JSONL prompt-history store (TASK-1364).
-
-        One instance feeds both the composer (ghost text, Up/Down recall)
-        and the controller (recording accepted sends). Creation is lazy and
-        IO-free -- the store self-loads on first awaited use, and the
-        composer kicks a background `load()` on mount so ghost text works on
-        the first keystroke. `console_prompt_history_factory` on the app is
-        the test seam, mirroring `console_provider_gateway_factory`.
-        """
-        history = getattr(self, "_console_prompt_history", None)
-        if history is None:
-            factory = getattr(self.app_instance, "console_prompt_history_factory", None)
-            history = (
-                factory()
-                if callable(factory)
-                else PromptHistory(default_prompt_history_path())
-            )
-            self._console_prompt_history = history
-        return history
+        """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
+        return self._prompts._ensure_console_prompt_history()
 
     def _ensure_console_chat_controller(self) -> ConsoleChatController:
         """Return the native Console chat controller with fresh selection state."""
@@ -5245,402 +5270,8 @@ class ChatScreen(BaseAppScreen):
             )
 
     def _open_console_prompts_modal(self) -> None:
-        """Open the source-aware Prompt Library without changing the draft."""
-        service = getattr(self.app_instance, "prompt_scope_service", None)
-        composer = self._console_composer_or_none()
-        if composer is None:
-            return
-        settings = self._session._ensure_active_console_session_settings()
-        store = self._ensure_console_chat_store()
-        session_id = store.active_session_id
-        if session_id is None:
-            return
-        composer_snapshot = composer.capture_draft_snapshot()
-        current_system = str(settings.system_prompt or "")
-        current_system_fingerprint = fingerprint_text(current_system)
-        provider_display, model_display, _settings = (
-            self._active_console_provider_model_display()
-        )
-        opening_selection = self._build_console_provider_selection()
-        gateway = self._ensure_console_provider_gateway()
-        improvement_service = PromptImprovementService(gateway=gateway)
-        pinned_improvement_resolution: Any | None = None
-        improvement_context = ConsolePromptImprovementContext(
-            session_id=session_id,
-            composer_snapshot=composer_snapshot,
-            current_user_projection=None,
-            current_system_prompt=current_system,
-            current_system_fingerprint=current_system_fingerprint,
-            provider_label=str(provider_display or "Not configured"),
-            model_label=str(model_display or "Not configured"),
-            endpoint_label=(
-                safe_endpoint_display(opening_selection.base_url)
-                or "Resolve on Improve"
-            ),
-            model_unavailable_reason=self._console_provider_blocker_copy(),
-        )
-
-        async def capabilities(source: str) -> Any:
-            method = getattr(service, "get_capabilities", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt source is unavailable.")
-            return await method(mode=source)
-
-        async def list_page(source: str, page: int) -> Any:
-            method = getattr(service, "list_prompts", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt source is unavailable.")
-            return await method(mode=source, page=page, per_page=10)
-
-        async def search(source: str, query: str) -> Any:
-            method = getattr(service, "search_prompts", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt search is unavailable.")
-            return await method(mode=source, query=query, limit=25)
-
-        async def detail(source: str, identifier: str) -> Any:
-            method = getattr(service, "get_prompt", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt source is unavailable.")
-            return await method(mode=source, prompt_identifier=identifier)
-
-        async def save(**payload: Any) -> Any:
-            method = getattr(service, "save_prompt", None)
-            if not callable(method):
-                raise ValueError("The selected Prompt source cannot save.")
-            source = str(payload.pop("source", "local"))
-            return await method(mode=source, **payload)
-
-        def _active_system_fingerprint() -> str:
-            live_settings = self._session._ensure_active_console_session_settings()
-            return fingerprint_text(str(live_settings.system_prompt or ""))
-
-        def _resolution_identity(resolution: Any) -> tuple[str, str, str, str, str]:
-            return (
-                str(getattr(resolution, "provider", "")),
-                str(getattr(resolution, "model", "")),
-                str(getattr(resolution, "base_url", "")),
-                str(getattr(resolution, "readiness_key", "")),
-                str(getattr(resolution, "execution_key", "")),
-            )
-
-        async def activate_improvement_context() -> Any:
-            """Pin and disclose the exact target before any model path can run."""
-
-            nonlocal pinned_improvement_resolution
-            if store.active_session_id != session_id:
-                raise ValueError("The active Console session changed.")
-            if _active_system_fingerprint() != current_system_fingerprint:
-                raise ValueError("The Console System prompt changed.")
-            projection = None
-            projection_blocker = ""
-            try:
-                projection = composer.project_snapshot_for_model(
-                    composer_snapshot,
-                    request_nonce=f"prompt-preview-{uuid.uuid4().hex}",
-                )
-            except ValueError:
-                projection_blocker = (
-                    "Model improvement is unavailable because the draft contains "
-                    "reserved protected-placeholder text. Remove or rename that "
-                    "literal token, then reopen Improve."
-                )
-            try:
-                resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-            except Exception:
-                pinned_improvement_resolution = None
-                return replace(
-                    improvement_context,
-                    current_user_projection=projection,
-                    endpoint_label="Unavailable",
-                    model_unavailable_reason=(
-                        projection_blocker
-                        or "Prompt improvement could not resolve the current provider "
-                        "target. Review Console provider settings and reopen Improve."
-                    ),
-                )
-            pinned_improvement_resolution = resolution
-            blocker = projection_blocker
-            if not blocker and (
-                not resolution.ready or not str(resolution.model or "").strip()
-            ):
-                blocker = str(
-                    resolution.visible_copy
-                    or "Choose a ready provider and model, then reopen Improve."
-                )
-            return replace(
-                improvement_context,
-                current_user_projection=projection,
-                provider_label=str(resolution.provider or "Not configured"),
-                model_label=str(resolution.model or "Not configured"),
-                endpoint_label=(
-                    safe_endpoint_display(resolution.base_url)
-                    or "Provider default"
-                ),
-                model_unavailable_reason=blocker,
-                pinned_resolution=resolution,
-            )
-
-        async def capture_manual_resolution() -> Any:
-            """Capture the effective target once for a later model-free Apply."""
-
-            nonlocal pinned_improvement_resolution
-            if pinned_improvement_resolution is None:
-                pinned_improvement_resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-            return pinned_improvement_resolution
-
-        async def build_improvement_snapshot(**values: Any) -> Any:
-            if store.active_session_id != session_id:
-                raise ValueError("The active Console session changed.")
-            if _active_system_fingerprint() != current_system_fingerprint:
-                raise ValueError("The Console System prompt changed.")
-            request_id = str(values["request_id"])
-            projection = composer.project_snapshot_for_model(
-                composer_snapshot,
-                request_nonce=request_id,
-            )
-            composer.validate_improvement(composer_snapshot, projection.text)
-            pinned_resolution = pinned_improvement_resolution
-            if pinned_resolution is None:
-                raise ValueError(
-                    "The provider target is no longer pinned. Reopen Improve to refresh disclosure."
-                )
-            live_resolution = await gateway.resolve_for_send(
-                self._build_console_provider_selection()
-            )
-            if _resolution_identity(live_resolution) != _resolution_identity(
-                pinned_resolution
-            ):
-                raise ValueError(
-                    "The provider, model, or endpoint changed. Reopen Improve to refresh disclosure."
-                )
-            if not pinned_resolution.ready or not str(
-                pinned_resolution.model or ""
-            ).strip():
-                raise ValueError(
-                    pinned_resolution.visible_copy or "Provider is unavailable."
-                )
-            include_system = bool(values.get("include_system"))
-            recipe_definition = values.get("recipe_definition")
-            return PromptImprovementRequestSnapshot(
-                request_id=request_id,
-                mode=values["mode"],
-                session_id=session_id,
-                composer_snapshot=composer_snapshot,
-                projection=projection,
-                system_prompt=current_system if include_system else None,
-                system_fingerprint=(
-                    current_system_fingerprint if include_system else None
-                ),
-                resolution=pinned_resolution,
-                provider_label=pinned_resolution.provider,
-                model_label=str(pinned_resolution.model),
-                recipe_source=values.get("recipe_source"),
-                recipe_source_id=values.get("recipe_source_id"),
-                recipe_version=values.get("recipe_version"),
-                recipe_definition=recipe_definition,
-                recipe_fingerprint=(
-                    fingerprint_block_definition(recipe_definition)
-                    if recipe_definition is not None
-                    else None
-                ),
-            )
-
-        def validate_improvement(captured: Any, text: str) -> None:
-            snapshot = getattr(captured, "composer_snapshot", composer_snapshot)
-            composer.validate_improvement(snapshot, text)
-
-        async def validate_saved_recipe(captured: Any) -> None:
-            recipe_source_id = str(
-                getattr(captured, "recipe_source_id", "") or ""
-            )
-            if not recipe_source_id or recipe_source_id.startswith("builtin:"):
-                return
-            source = getattr(captured, "recipe_source", None)
-            if source not in {"local", "server"}:
-                raise ValueError("The selected Recipe source changed.")
-            latest = await detail(source, recipe_source_id)
-            if not isinstance(latest, Mapping):
-                raise ValueError("The selected Recipe is no longer available.")
-            latest_identity = (
-                latest.get("source_id") or latest.get("id") or latest.get("uuid")
-            )
-            if str(latest_identity or "") != recipe_source_id:
-                raise ValueError("The selected Recipe identity changed.")
-            latest_version = latest.get("version", latest.get("optimistic_version"))
-            if latest_version != getattr(captured, "recipe_version", None):
-                raise ValueError("The selected Recipe version changed.")
-            decoded = decode_prompt_artifact(latest)
-            if decoded.artifact_type != "recipe" or decoded.definition is None:
-                raise ValueError("The selected Recipe is no longer compatible.")
-            if fingerprint_block_definition(decoded.definition) != getattr(
-                captured, "recipe_fingerprint", None
-            ):
-                raise ValueError("The selected Recipe changed.")
-
-        async def validate_saved_prompt(captured: Any) -> None:
-            if not isinstance(captured, ConsoleSavedPromptApplyGuard):
-                return
-            latest = await detail(captured.source, captured.prompt_source_id)
-            if not isinstance(latest, Mapping):
-                raise ValueError("The selected Prompt is no longer available.")
-            latest_identity = (
-                latest.get("source_id") or latest.get("id") or latest.get("uuid")
-            )
-            if str(latest_identity or "") != captured.prompt_source_id:
-                raise ValueError("The selected Prompt identity changed.")
-            latest_version = latest.get("version", latest.get("optimistic_version"))
-            if latest_version != captured.prompt_version:
-                raise ValueError("The selected Prompt version changed.")
-            decoded = decode_prompt_artifact(latest)
-            if decoded.artifact_type != "prompt" or decoded.definition is None:
-                raise ValueError("The selected Prompt is no longer compatible.")
-            if fingerprint_block_definition(decoded.definition) != captured.prompt_fingerprint:
-                raise ValueError("The selected Prompt changed.")
-
-        async def record_applied_usage(captured: Any) -> None:
-            if not isinstance(
-                captured, ConsoleSavedPromptApplyGuard
-            ) or not captured.record_usage:
-                return
-            recorder = getattr(service, "record_prompt_usage", None)
-            if not callable(recorder):
-                return
-            try:
-                await recorder(
-                    mode=captured.source,
-                    prompt_identifier=captured.prompt_source_id,
-                )
-            except Exception:
-                self.app_instance.notify(
-                    "The prompt was applied, but Library usage could not be recorded.",
-                    severity="warning",
-                )
-
-        async def apply_improvement_result(
-            result: ConsolePromptsResult, captured: Any
-        ) -> ConsolePromptsApplyOutcome:
-            if store.active_session_id != session_id:
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The active Console session changed."
-                )
-            if _active_system_fingerprint() != current_system_fingerprint:
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The Console System prompt changed."
-                )
-            if isinstance(captured, PromptImprovementRequestSnapshot):
-                live_resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-                if _resolution_identity(live_resolution) != _resolution_identity(
-                    captured.resolution
-                ):
-                    return ConsolePromptsApplyOutcome(
-                        "stale", "The provider, model, or endpoint changed."
-                    )
-            elif isinstance(
-                captured, (ConsoleRecipeApplyGuard, ConsoleSavedPromptApplyGuard)
-            ):
-                captured_resolution = captured.provider_resolution
-                if captured_resolution is None:
-                    return ConsolePromptsApplyOutcome(
-                        "stale",
-                        "The provider target was not captured. Reopen the Prompt and retry.",
-                    )
-                live_resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-                if _resolution_identity(live_resolution) != _resolution_identity(
-                    captured_resolution
-                ):
-                    return ConsolePromptsApplyOutcome(
-                        "stale", "The provider, model, or endpoint changed."
-                    )
-            try:
-                await validate_saved_recipe(captured)
-                await validate_saved_prompt(captured)
-                if result.apply_user:
-                    if result.user_text is None:
-                        raise ValueError("The reviewed User prompt is missing.")
-                    composer.validate_improvement(
-                        result.composer_snapshot, result.user_text
-                    )
-                elif composer.capture_draft_snapshot() != result.composer_snapshot:
-                    raise ValueError("The Console draft changed.")
-            except Exception:
-                return ConsolePromptsApplyOutcome(
-                    "stale",
-                    "The draft or Recipe changed. Review the working copy and retry.",
-                )
-
-            if result.apply_user and result.user_text is not None:
-                composer.apply_improvement(
-                    result.composer_snapshot,
-                    result.user_text,
-                )
-                store.set_session_draft(session_id, composer.draft_text())
-            persisted = True
-            if result.apply_system:
-                _session, persisted = store.set_session_system_prompt(
-                    session_id, result.system_text
-                )
-                self._sync_console_chat_core_state()
-                self._sync_console_rail_system_line()
-                self._sync_console_settings_summary()
-            await record_applied_usage(captured)
-            if not persisted:
-                return ConsolePromptsApplyOutcome("persistence_failed")
-            return ConsolePromptsApplyOutcome("applied")
-
-        async def retry_improvement_persistence(
-            result: ConsolePromptsResult,
-        ) -> ConsolePromptsApplyOutcome:
-            if store.active_session_id != session_id or not result.apply_system:
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The active Console session changed."
-                )
-            live_settings = self._session._ensure_active_console_session_settings()
-            if str(live_settings.system_prompt or "") != str(result.system_text or ""):
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The live System prompt changed."
-                )
-            _session, persisted = store.set_session_system_prompt(
-                session_id, result.system_text
-            )
-            self._sync_console_chat_core_state()
-            self._sync_console_rail_system_line()
-            self._sync_console_settings_summary()
-            return ConsolePromptsApplyOutcome(
-                "applied" if persisted else "persistence_failed"
-            )
-
-        def restore_focus(_result: ConsolePromptsResult | None) -> None:
-            self._focus_console_composer_if_needed(force=True)
-
-        self.app.push_screen(
-            ConsolePromptsModal(
-                capabilities=capabilities,
-                list_page=list_page,
-                search=search,
-                detail=detail,
-                save=save,
-                improve_unavailable_reason=self._console_provider_blocker_copy(),
-                configure_provider=self._open_console_provider_recovery,
-                improvement_context=improvement_context,
-                activate_improvement_context=activate_improvement_context,
-                capture_manual_resolution=capture_manual_resolution,
-                build_improvement_snapshot=build_improvement_snapshot,
-                improve=improvement_service.improve,
-                validate_improvement=validate_improvement,
-                apply_improvement_result=apply_improvement_result,
-                retry_improvement_persistence=retry_improvement_persistence,
-            ),
-            callback=restore_focus,
-        )
+        """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
+        self._prompts._open_console_prompts_modal()
 
 
     @on(ConsoleTemporaryChip.SaveRequested)
@@ -15645,163 +15276,9 @@ class ChatScreen(BaseAppScreen):
             return
         await handler(parse)
 
-    # Bounded prompt-search page size for `/prompt` resolution and the
-    # picker's own search callable -- mirrors Task 11's picker contract
-    # (PromptScopeService.search_prompts, FTS-ranked, <= 25 rows).
-    _CONSOLE_PROMPT_SEARCH_LIMIT = 25
-
-    _LIBRARY_PROMPT_INSERT_BLOCKED_COPY = "Finish provider setup to insert prompts."
-    _RECIPE_EXECUTION_BLOCKED_COPY = (
-        "Recipes cannot be applied directly. Open Prompts and edit the Recipe "
-        "as an unsaved Prompt copy first."
-    )
-
-    @staticmethod
-    def _is_recipe_prompt_record(record: Mapping[str, Any]) -> bool:
-        """Return whether a normalized or raw record is a non-executable Recipe."""
-        return str(record.get("artifact_type") or "prompt").casefold() == "recipe"
-
     async def _console_command_insert_prompt(self, parse: CommandParse) -> None:
-        """Resolve and insert a saved prompt's ``user_prompt`` for `/prompt`.
-
-        Resolution order (brief): exact case-insensitive name match over a
-        bounded search page; else a unique case-insensitive name-prefix
-        match over that same page; else (no args, 0 matches, or an
-        ambiguous 2+ match at either stage) open the picker prefilled with
-        the typed args. A resolved match REPLACES the composer draft
-        wholesale (the draft IS the `/prompt ...` command being replaced by
-        its result) via paste semantics, so an oversized body still
-        collapses to a token exactly like a real paste would.
-        """
-        query = parse.args.strip()
-        resolved = await self._resolve_console_prompt_by_name(query) if query else None
-        if resolved is not None:
-            if self._is_recipe_prompt_record(resolved):
-                await self._append_native_console_system_message(
-                    self._RECIPE_EXECUTION_BLOCKED_COPY
-                )
-                return
-            self._insert_prompt_text_into_composer(
-                str(resolved.get("user_prompt") or ""), replace=True
-            )
-            return
-        await self._open_console_prompt_picker_for_insert(query)
-
-    @staticmethod
-    def _console_prompt_prefix_fts_query(text: str) -> str:
-        """Build an FTS5 phrase-prefix MATCH expression for ``text``.
-
-        Plain FTS5 MATCH requires a full token, which would defeat both the
-        `/prompt` prefix-match resolution stage (a query like "Summ" would
-        never match a stored name "Summarize") and a picker that is supposed
-        to filter results as the user is still mid-word. Quoting the whole
-        query as a phrase with a trailing ``*`` makes FTS5 match names whose
-        tokens *start with* the typed text instead -- a prefix match trivially
-        covers an exact match too, so one query shape serves both. Embedded
-        quotes are doubled per FTS5 string-literal escaping (mirrors
-        ``library_fts_query._quote_fts_term``), so user text can never break
-        out of the quoted phrase to inject MATCH operators.
-        """
-        escaped = text.replace('"', '""')
-        return f'"{escaped}"*'
-
-    async def _console_prompt_search(self, query: str) -> list:
-        """Bounded FTS prompt search bound to the active scope service.
-
-        Shared by `/prompt` resolution and the picker's ``prompt_search``
-        callable so both always read a fresh page rather than any cached
-        boot-time snapshot.
-        """
-        service = getattr(self.app_instance, "prompt_scope_service", None)
-        search_prompts = getattr(service, "search_prompts", None)
-        if not callable(search_prompts):
-            return []
-        stripped_query = query.strip()
-        fts_kwargs = (
-            {"fts_match_query": self._console_prompt_prefix_fts_query(stripped_query)}
-            if stripped_query
-            else {}
-        )
-        try:
-            records = await search_prompts(
-                mode="local",
-                query=query,
-                limit=self._CONSOLE_PROMPT_SEARCH_LIMIT,
-                **fts_kwargs,
-            )
-            return [
-                record
-                for record in records
-                if isinstance(record, Mapping)
-                and not self._is_recipe_prompt_record(record)
-            ]
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Console prompt search failed for query {query!r}."
-            )
-            return []
-
-    async def _resolve_console_prompt_by_name(
-        self, query: str
-    ) -> Optional[Mapping[str, Any]]:
-        """Resolve `/prompt <name>` to a single prompt record, or ``None``.
-
-        ``None`` means the caller should fall back to the picker: no
-        candidates, an ambiguous (2+) exact case-insensitive name match, or
-        no/ambiguous unique prefix match either.
-        """
-        candidates = [
-            record
-            for record in await self._console_prompt_search(query)
-            if isinstance(record, Mapping) and not self._is_recipe_prompt_record(record)
-        ]
-        normalized_query = query.strip().casefold()
-        exact_matches = [
-            record
-            for record in candidates
-            if str(record.get("name") or "").strip().casefold() == normalized_query
-        ]
-        if len(exact_matches) == 1:
-            return exact_matches[0]
-        if len(exact_matches) > 1:
-            return None
-        prefix_matches = [
-            record
-            for record in candidates
-            if str(record.get("name") or "")
-            .strip()
-            .casefold()
-            .startswith(normalized_query)
-        ]
-        if len(prefix_matches) == 1:
-            return prefix_matches[0]
-        return None
-
-    async def _open_console_prompt_picker_for_insert(self, initial_query: str) -> None:
-        """Open the prompt picker for `/prompt`, inserting whatever is chosen."""
-
-        def _apply_picker_choice(record: Optional[Mapping[str, Any]]) -> None:
-            self._focus_console_composer_if_needed(force=True)
-            if record is None:
-                return
-            if self._is_recipe_prompt_record(record):
-                self.app_instance.notify(
-                    self._RECIPE_EXECUTION_BLOCKED_COPY,
-                    severity="warning",
-                )
-                return
-            self._insert_prompt_text_into_composer(
-                str(record.get("user_prompt") or ""), replace=True
-            )
-
-        self.app.push_screen(
-            ConsolePromptPickerModal(
-                mode="insert",
-                initial_query=initial_query,
-                prompt_search=self._console_prompt_search,
-            ),
-            callback=_apply_picker_choice,
-        )
+        """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
+        await self._prompts._console_command_insert_prompt(parse)
 
     async def _open_console_style_picker_for_insert(self) -> None:
         """Open the image-style picker, inserting whatever style is chosen."""
@@ -15906,124 +15383,12 @@ class ChatScreen(BaseAppScreen):
         return True
 
     async def _consume_pending_console_prompt_insert(self) -> None:
-        """Consume a Library "Use in Console" staged prompt body, if any.
-
-        Mirrors ``_consume_pending_chat_handoff``'s stage-then-consume
-        shape, but the staged payload is a bare string appended into the
-        composer -- never a ``ChatHandoffPayload``. Gated on the same
-        first-run provider/model setup readiness the composer's own Send
-        button uses: unlike the in-composer `/prompt` command (which Task
-        10 deliberately lets run even while Send is blocked, since
-        composing is not sending), this cross-screen hop is an unattended
-        action the user did not consciously type into this composer, so a
-        blocked first-run state gets an honest toast instead of a silent
-        insert -- the draft is left untouched and nothing about the source
-        Library prompt is touched either.
-        """
-        store = self.app_instance.pending_handoffs
-        claim = store.claim(HandoffChannel.CONSOLE_PROMPT_INSERT)
-        if claim is None:
-            return
-        text = claim.value
-        if not text.strip():
-            store.acknowledge(claim)
-            return
-        if self._console_setup_blocked_reason():
-            # A persistent state, not a mount-timing race -- always safe to
-            # consume+notify here regardless of whether the composer widget
-            # itself has finished mounting yet.
-            store.acknowledge(claim)
-            self.app_instance.notify(
-                self._LIBRARY_PROMPT_INSERT_BLOCKED_COPY,
-                severity="warning",
-            )
-            return
-        # Settle the active-session draft tracking BEFORE inserting so this
-        # consumption is self-guarding no matter which lifecycle hook
-        # (`on_mount`, `on_screen_resume`, or any other resume-adjacent path)
-        # scheduled it. If a session switch races ahead of us,
-        # `_console_visible_draft_session_id` can be stale relative to the
-        # store's active session; a *later* `_sync_native_console_chat_ui`
-        # pass would then unconditionally reload the composer from that
-        # newly-active session's stored draft, silently discarding the
-        # insert below (the pending field is already cleared once the
-        # insert lands, so there is no retry). Calling this here -- and
-        # nowhere between here and the insert, so the two run atomically
-        # within this event-loop turn -- settles the tracker onto the
-        # current active session first, so any subsequent sync pass takes
-        # the no-op fast path instead of clobbering what we're about to
-        # insert.
-        try:
-            self._session._sync_console_session_draft()
-            inserted = self._insert_prompt_text_into_composer(text, replace=False)
-        except asyncio.CancelledError:
-            store.release(claim)
-            raise
-        except Exception as exc:
-            store.release(claim)
-            logger.warning(
-                "Console prompt handoff transfer failed "
-                "(channel={}, revision={}, exception_category={})",
-                claim.channel.value,
-                claim.revision,
-                type(exc).__name__,
-            )
-            return
-        # A missing composer is transient. Release the exact claim so a later
-        # mount/resume can retry without disturbing any newer replacement.
-        if not inserted:
-            store.release(claim)
-            return
-        store.acknowledge(claim)
-        self._focus_console_composer_if_needed(force=True)
+        """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
+        await self._prompts._consume_pending_console_prompt_insert()
 
     async def _console_command_apply_system(self, parse: CommandParse) -> None:
-        """Resolve and apply a saved prompt's ``system_prompt`` for `/system`.
-
-        Bare `/system` (no args) opens the system prompt editor modal seeded
-        with the active session's current system prompt. With args,
-        resolution mirrors `/prompt` (Task 12): exact case-insensitive name
-        match over a bounded search page, else a unique case-insensitive
-        name-prefix match; a resolved match with a blank ``system_prompt``
-        shows an inline transcript error (the session is left unchanged,
-        and the draft is deliberately left in place so the user can correct
-        it) rather than silently clearing it, since that is very likely not
-        what the user meant by naming that specific prompt. A resolved match
-        WITH a system part applies it and clears the `/system <name>`
-        command text from the composer -- mirrors `/prompt`'s successful
-        insert always replacing its own draft (Task 12) -- so a handled
-        command never leaves its own invocation text behind. 0 or 2+
-        matches at either stage fall back to the apply-system picker mode
-        (Task 11), prefilled with the typed args.
-        """
-        args = parse.args.strip()
-        if not args:
-            await self._open_console_system_prompt_editor()
-            return
-        resolved = await self._resolve_console_prompt_by_name(args)
-        if resolved is not None:
-            if self._is_recipe_prompt_record(resolved):
-                await self._append_native_console_system_message(
-                    self._RECIPE_EXECUTION_BLOCKED_COPY
-                )
-                return
-            # Blank check only via strip(); the applied value below is the
-            # raw prompt text so leading/trailing whitespace and internal
-            # formatting survive verbatim.
-            raw_system_prompt = resolved.get("system_prompt")
-            system_prompt = (
-                raw_system_prompt if isinstance(raw_system_prompt, str) else ""
-            )
-            if not system_prompt.strip():
-                name = str(resolved.get("name") or args)
-                await self._append_native_console_system_message(
-                    CONSOLE_SYSTEM_PROMPT_NO_SYSTEM_PART_TEMPLATE.format(name=name)
-                )
-                return
-            self._session._apply_console_session_system_prompt(system_prompt)
-            self._clear_console_composer_draft()
-            return
-        await self._open_console_prompt_picker_for_apply_system(args)
+        """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
+        await self._prompts._console_command_apply_system(parse)
 
     async def _console_command_prefill(self, parse: CommandParse) -> None:
         """Arm, pin, clear, or report the Console response prefill (`/prefill`).
@@ -16657,134 +16022,10 @@ class ChatScreen(BaseAppScreen):
             composer.clear_draft()
             self._sync_console_command_popup()
 
-    async def _open_console_prompt_picker_for_apply_system(
-        self, initial_query: str
-    ) -> None:
-        """Open the prompt picker in apply-system mode for `/system`.
-
-        Rows without a ``system_prompt`` render dimmed and refuse selection
-        (``ConsolePromptPickerModal``'s own ``MODE_APPLY_SYSTEM`` behavior,
-        Task 11) -- this caller only needs to apply whatever record the
-        picker actually dismisses with.
-        """
-
-        def _apply_picker_choice(record: Optional[Mapping[str, Any]]) -> None:
-            self._focus_console_composer_if_needed(force=True)
-            if record is None:
-                return
-            if self._is_recipe_prompt_record(record):
-                self.app_instance.notify(
-                    self._RECIPE_EXECUTION_BLOCKED_COPY,
-                    severity="warning",
-                )
-                return
-            # Blank check only via strip(); the applied value is the raw
-            # prompt text so formatting survives verbatim.
-            raw_system_prompt = record.get("system_prompt")
-            system_prompt = (
-                raw_system_prompt if isinstance(raw_system_prompt, str) else ""
-            )
-            if not system_prompt.strip():
-                return
-            self._session._apply_console_session_system_prompt(system_prompt)
-
-        self.app.push_screen(
-            ConsolePromptPickerModal(
-                mode=CONSOLE_PROMPT_PICKER_MODE_APPLY_SYSTEM,
-                initial_query=initial_query,
-                prompt_search=self._console_prompt_search,
-            ),
-            callback=_apply_picker_choice,
-        )
-
 
     async def _open_console_system_prompt_editor(self) -> None:
-        """Open the system prompt editor modal for the active Console session."""
-        settings = self._session._ensure_active_console_session_settings()
-
-        def _apply_modal_result(result: Optional[str]) -> None:
-            self._focus_console_composer_if_needed(force=True)
-            if result is None:
-                return
-            self._session._apply_console_session_system_prompt(result)
-
-        self.app.push_screen(
-            ConsoleSystemPromptModal(
-                system_prompt=settings.system_prompt,
-                save_to_library=self._save_console_system_prompt_to_library,
-            ),
-            callback=_apply_modal_result,
-        )
-
-    async def _save_console_system_prompt_to_library(self, name: str, text: str) -> str:
-        """Save the system-prompt editor's text as a brand-new Library prompt.
-
-        Always a CREATE (the Console `/system` editor never edits an
-        existing Library prompt): pre-checks the name for a collision the
-        same way ``library_screen._save_library_prompt``'s own create path
-        does, so a genuine duplicate is classified via
-        ``classify_prompt_save_error`` -- with ``exc=None`` and a manually
-        built message -- rather than racing the DB's raw ``ConflictError``,
-        and reports the SAME outcome copy that screen's own save flow shows.
-
-        Args:
-            name: Name for the new Library prompt.
-            text: The prompt's ``system_prompt`` body (the modal's current
-                editor text).
-
-        Returns:
-            User-facing outcome copy to display inline in the modal.
-        """
-        name = name.strip()
-        if not name:
-            return "Enter a name to save this system prompt to Library."
-        text = text.strip()
-        if not text:
-            return "Enter a system prompt to save."
-        service = getattr(self.app_instance, "prompt_scope_service", None)
-        get_prompt = getattr(service, "get_prompt", None)
-        save_prompt = getattr(service, "save_prompt", None)
-        if not callable(get_prompt) or not callable(save_prompt):
-            return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
-        try:
-            candidate = await get_prompt(
-                mode="local", prompt_identifier=name, include_deleted=True
-            )
-        except Exception:
-            candidate = None
-        if isinstance(candidate, Mapping) and candidate:
-            if candidate.get("deleted"):
-                outcome = classify_prompt_save_error(
-                    None, f"Prompt '{name}' exists but is soft-deleted.", None
-                )
-            else:
-                outcome = classify_prompt_save_error(
-                    None, f"Prompt '{name}' already exists.", None
-                )
-            return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY.get(
-                outcome, CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
-            )
-        try:
-            result = await save_prompt(
-                mode="local", name=name, system_prompt=text, user_prompt=""
-            )
-        except Exception as exc:
-            logger.opt(exception=True).warning(
-                f"Console system-prompt save-to-library failed for name {name!r}."
-            )
-            outcome = classify_prompt_save_error(None, str(exc), exc)
-            return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY.get(
-                outcome, CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
-            )
-        result_id = (
-            result.get("local_id")
-            if isinstance(result, Mapping)
-            else (1 if result else None)
-        )
-        outcome = classify_prompt_save_error(result_id, "", None)
-        return CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY.get(
-            outcome, CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY["error"]
-        )
+        """Delegate to `ConsolePromptsController` (wave-3 console decomposition, task 3)."""
+        await self._prompts._open_console_system_prompt_editor()
 
     # ------------------------------------------------------------------
     # Task 9 (Skills spec, Phase 2), reshaped by the `$`-mention migration

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4895,9 +4895,23 @@ class ChatScreen(BaseAppScreen):
     # `_console_message_action_service` has no proxy: nothing outside the
     # moved cluster ever read or wrote it (a pre-existing bare-screen test
     # fixture assigns it defensively; see the task-1 extraction report).
+    # Every proxy below is read-WRITE. At baseline each of these was a plain
+    # assignable instance attribute set in `ChatScreen.__init__`, so a
+    # getter-only property would turn a legal write into `AttributeError` --
+    # a behaviour change, which this decomposition's contract forbids
+    # regardless of whether an in-repo writer exists today. (`_last_console_
+    # action` has no writer outside the moved cluster right now; its setter
+    # is here for exactly that reason -- see the task-1 fix-round report.)
+    # Note this is the OPPOSITE case to the binding rule's write-only proxy,
+    # where the *getter* deliberately raises `RuntimeError`: that forbids a
+    # direction the pre-move source never had, this restores one it did.
     @property
     def _last_console_action(self) -> Any:
         return self._message._last_console_action
+
+    @_last_console_action.setter
+    def _last_console_action(self, value: Any) -> None:
+        self._message._last_console_action = value
 
     @property
     def _pending_console_delete_message_id(self) -> str | None:
@@ -4910,6 +4924,10 @@ class ChatScreen(BaseAppScreen):
     @property
     def _console_original_attempt_previews(self) -> dict[str, str]:
         return self._message._console_original_attempt_previews
+
+    @_console_original_attempt_previews.setter
+    def _console_original_attempt_previews(self, value: dict[str, str]) -> None:
+        self._message._console_original_attempt_previews = value
 
     @property
     def _console_speaking_message_id(self) -> str | None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -8102,14 +8102,10 @@ class ChatScreen(BaseAppScreen):
     ) -> _ConsoleTranscriptReadingState | None:
         """Capture the semantic reading position before composer layout changes.
 
-        Delegates to ``ConsoleTranscriptRegion.capture_reading_state`` (wave-3
-        task 2); kept as a screen method because
-        ``_set_console_composer_collapsed`` and a mounted composer-collapse
-        regression both call it by this name.
+        Delegates to ``ConsoleTranscriptRegion.capture_reading_state``.
 
         Returns:
-            The transcript's reading state, or ``None`` when no transcript
-            region is mounted.
+            The transcript's reading state, or ``None`` when unmounted.
         """
         region = self._console_transcript_region_or_none()
         return None if region is None else region.capture_reading_state()
@@ -13544,26 +13540,18 @@ class ChatScreen(BaseAppScreen):
                     left_rail.styles.display = "none"
                 yield self._frame_console_region(left_rail)
 
-                # `session_surface_builder` hands `ConsoleTranscriptRegion` a
-                # zero-arg callable, not a pre-built widget, for the same
-                # reason `character_avatar_widget_builder` does above -- and
-                # with a sharper edge here: `_ensure_console_session_surface`
-                # CACHES its result on `self.console_session_surface` and
-                # returns the same instance every time, so a stored instance
-                # would re-yield a widget Textual may already have removed on
-                # the next recompose, and would skip the background-effect
-                # re-sync that call performs. The lambda closes over `self`
-                # and resolves at CALL time (matching
-                # `ConsoleDictationController`'s late-binding constructor rule
-                # -- see `dictation.py`'s module docstring).
+                # A zero-arg builder, not a pre-built widget, for the same
+                # reason `character_avatar_widget_builder` above is one --
+                # with a sharper edge here, since the surface is CACHED on
+                # the screen; full reasoning in `ConsoleTranscriptRegion.
+                # __init__`'s docstring. Sizing stays on this side: it
+                # describes this pane's place among its grid siblings
+                # (3fr / 13fr / 4fr), exactly as both rails are wired.
                 main_column = ConsoleTranscriptRegion(
                     session_surface_builder=(
                         lambda: self._ensure_console_session_surface()
                     ),
                 )
-                # Sizing stays here, not in the region: these are facts about
-                # this pane's place among its `#console-workspace-grid`
-                # siblings (3fr / 13fr / 4fr), exactly as both rails are wired.
                 main_column.styles.width = "13fr"
                 main_column.styles.min_width = 56
                 main_column.styles.min_height = 0


### PR DESCRIPTION
Wave 3 of the Console decomposition, per `Docs/superpowers/specs/2026-08-02-screen-decomposition-design.md` and the wave-3 plan. Follows wave 1 (#1345) and wave 2 (#1381).

`chat_screen.py` **20,964 → 18,905 lines**, `ChatScreen` **612 → 598 methods**.

## What lands

| | |
|---|---|
| `Console_Modules/message.py` — `ConsoleMessageController` (2,042 lines) | −1,328 |
| `Console_Modules/transcript.py` — `ConsoleTranscriptRegion` (257 lines) | +1 |
| `Console_Modules/prompts.py` — `ConsolePromptsController` (1,244 lines) | −759 |
| `Tests/Architecture/test_screen_size_ratchet.py` | the wave's real deliverable |

**Zero behaviour change** is the contract. Every moved body is byte-identical to its pre-move form apart from mechanical receiver rewrites (`self._session.X` → `self.X`, `self.app.push_screen` → `self.push_screen`), verified by AST diff against the merge base — including the 397-line `_open_console_prompts_modal` and the 294-line `handle_console_message_action`.

## Why the ratchet exists

Waves 1 and 2 extracted ~4,900 lines from `chat_screen.py`, and the file finished those waves **larger** than it started: ~5,500 lines of concurrent feature work landed over the same window, every line going into the screen because the screen was the path of least resistance.

Extraction alone cannot win. `test_screen_size_ratchet.py` makes the current size a **ceiling** rather than a waypoint — budgets may only go DOWN, and a second test fires if a wave lands without lowering one. Both tests are mutation-verified rather than merely written.

## Honest accounting

Two things this wave did *not* achieve, recorded in the spec's Progress section rather than smoothed over:

- **The transcript region netted +1 line and +1 method.** The composed block was 13 lines and the moved bodies 54; the delegations cost the same. Kept because all three `#console-workspace-grid` children are now built identically, and leaving one of three inline is the asymmetry that costs when `compose_content` is attacked. It leaves the transcript's DOM with **two access idioms** (3 delegating, 9 still direct) — a transitional state, filed as task-2767, not a settled design.
- **`_open_console_prompts_modal` moved verbatim at 397 lines**, carrying 15 of the controller's 18 named dependencies. Review judged the fan-out inherent rather than a wrong boundary, but the method is a class in disguise (17 nested closures). Decomposition filed as task-2766.

## Defects the reviews caught

- **A getter-only proxy property** over a baseline plain attribute turned **41 tests red in a file this branch never touched**. The fix round found the review had itself under-counted: six affected fixtures, not one, and the setter alone didn't clear it (a proxy setter writes *through*, so the traceback merely moved). Now a `DESIGN.md` §7 rule with an AST audit behind it.
- **`test_chat_screen_worker_groups` had silently stopped guarding.** It AST-parses `chat_screen.py` only; as waves moved workers into `Console_Modules/`, 4 of 6 run-coroutine dispatch sites and 7 exclusive-worker sites left its scope while both tests stayed green. Widened to `chat_screen.py + Console_Modules/*.py`, plus an assertion that the named coroutines are actually found — so the erosion itself now fails, not only its consequences. Mutation-verified both directions.
- **Wave 2's dev debt fixed**: `test_console_sync_records_worker_lifecycle` has been red on `dev` since #1381 — `MagicMock(spec=ChatScreen)` reads the CLASS, so `__init__`-wired controllers are invisible to it. Slots are now derived from `__init__` via `ast`, so wave 4's controller is picked up automatically.

## Not fixed here, deliberately

`Docs/security/production-diagnostic-inventory.json` is stale and **red on clean dev** (verified at `22c08f958`). Regenerating means signing off on ~199 lines including new diagnostic owners in two unrelated modules — exactly the rubber-stamp its "review the diff before running --write" gate exists to prevent. Filed as **task-2768** for whoever owns those diagnostics.

## Verification

- Serial, `-p no:randomly`: 104 + 113 + 62 + 304 = **583 passed, 0 failed** across the three new test files, the geometry baseline, the architecture suite, and every file referencing a moved name.
- `pytest Tests/ --collect-only` → **31,796 collected, 0 errors**.
- The geometry baseline (`test_console_shell_regions.py`) is **byte-identical to dev** and green.
- pyflakes on `chat_screen.py` is byte-identical to the merge base (31 findings, same set).
- Whole-branch review on the most capable model: one Important (the worker-group guard, fixed above), two Minor (fixed). No Critical.

Follow-ups filed: **2766, 2767, 2768, 2769**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decomposed the Console screen: moved message logic, transcript region, and prompt workflows into dedicated modules, and added a one-way size ratchet to keep `chat_screen.py` small. No behavior change; `chat_screen.py` is reduced 20,964 → 18,909 lines and `ChatScreen` methods 612 → 598.

- **Refactors**
  - Extracted message cluster to `ConsoleMessageController` with thin delegations on `ChatScreen`.
  - Moved transcript DOM to `ConsoleTranscriptRegion`; ids/structure unchanged; added delegations for reading-state helpers.
  - Extracted prompt cluster to `ConsolePromptsController`; kept command/menu entry points via delegations.
  - Added one-way size/method ratchet in `Tests/Architecture/test_screen_size_ratchet.py` (budgets 18,909 / 598), cached the measurement, added docstrings, and documented the read-write proxy rule in `DESIGN.md`.

- **Bug Fixes**
  - Restored write access for `_console_original_attempt_previews` and `_last_console_action` via proxy setters.
  - Widened worker-group guard to scan `UI/Console_Modules/` in addition to `chat_screen.py`.
  - Hardened tests: attached `ConsoleMessageController` to `__new__` shells via a shared stub and correct app wiring order, and stubbed controller slots for `MagicMock(spec=ChatScreen)` to fix the sync test.

<sup>Written for commit 4981f9b1112af9d8327f43facc1757c07ae3878c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

