### PR TITLE
feat(roleplay): the Default Assistant becomes a worked example — and editing it no longer corrupts the database (TASK-2451)

### DIFF
--- a/Tests/ChaChaNotesDB/test_message_generation_metadata.py
+++ b/Tests/ChaChaNotesDB/test_message_generation_metadata.py
@@ -28,7 +28,7 @@ def test_fresh_database_reaches_current_schema(db):
         v = cur.execute(
             "SELECT version FROM db_schema_version WHERE schema_name=?",
             ("rag_char_chat_schema",)).fetchone()[0]
-    assert v == 31
+    assert v == 32
 
 def test_set_and_batch_get_roundtrip(db):
     _, mid = _mk_message(db)

--- a/Tests/DB/test_chachanotes_active_leaf_migration.py
+++ b/Tests/DB/test_chachanotes_active_leaf_migration.py
@@ -15,7 +15,7 @@ def test_fresh_db_is_v28_with_active_leaf_column(tmp_path):
     # A fresh DB always migrates to the CURRENT schema version, not the
     # version this column was introduced at -- this assertion moves with
     # each newer migration.
-    assert version == 31
+    assert version == 32
     assert "active_leaf_message_id" in cols
 
 

--- a/Tests/DB/test_chachanotes_context_summary_migration.py
+++ b/Tests/DB/test_chachanotes_context_summary_migration.py
@@ -14,7 +14,7 @@ def test_fresh_db_is_v28_with_context_summary_columns(tmp_path):
         cols = {row[1] for row in conn.execute("PRAGMA table_info(conversations)").fetchall()}
     # Fresh databases always reach the current schema, not merely the version
     # where these columns were introduced.
-    assert version == 31
+    assert version == 32
     assert "context_summary" in cols
     assert "summary_boundary_message_id" in cols
 

--- a/Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py
+++ b/Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py
@@ -1,0 +1,449 @@
+"""v31 -> v32: enrich the seeded 'Default Assistant' character card (id=1)
+with documentation-grade content (task-2451), plus the pre-existing FTS5
+shadow-index defect this task's own enrichment write surfaced.
+
+Two things are under test:
+
+1. Enrichment itself: a fresh database seeds the rich content directly; an
+   existing database is promoted from bare to rich ONLY when every
+   user-editable content field on row 1 is still byte-identical to the
+   original bare-seed literals -- any single edited field (anywhere on the
+   row, not just the fields this migration writes) leaves it untouched.
+
+2. A regression fix discovered while building (1): row 1's INSERT in
+   ``_FULL_SCHEMA_SQL_V4`` used to run BEFORE ``character_cards_fts`` and its
+   ``character_cards_ai`` trigger existed, so row 1 was never indexed into
+   the FTS5 shadow tables on ANY database ever created by this schema. The
+   first UPDATE to that row (this migration's own enrichment write, or an
+   ordinary user edit via ``update_character_card``) made the
+   ``character_cards_au`` trigger ask FTS5 to remove index entries that were
+   never inserted, which raises ``sqlite3.DatabaseError: database disk image
+   is malformed`` (SQLITE_CORRUPT_VTAB). Fixed by reordering the schema SQL
+   (fresh databases) and rebuilding the FTS5 index inside the shared
+   enrichment routine (existing databases).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+# Matches CharactersRAGDB._SCHEMA_NAME, per the sibling migration tests
+# (Tests/DB/test_chachanotes_message_metadata_migration.py and friends).
+SCHEMA_NAME = "rag_char_chat_schema"
+
+BARE_NAME = "Default Assistant"
+BARE_DESCRIPTION = "A general-purpose assistant."
+BARE_FIRST_MESSAGE = "Hello! How can I help you today?"
+BARE_ALTERNATE_GREETINGS = "[]"
+BARE_TAGS = "[]"
+BARE_CREATOR = "System"
+BARE_CHARACTER_VERSION = "1.0"
+BARE_EXTENSIONS = "{}"
+
+
+def _version(connection) -> int:
+    row = connection.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (SCHEMA_NAME,),
+    ).fetchone()
+    return int(row[0])
+
+
+def _force_row1_bare(connection) -> None:
+    """Rewrite row 1 back to the ORIGINAL bare-seed literals via a raw
+    connection, simulating a database created before task-2451's fresh-seed
+    enrichment existed. Necessary because, post-fix, even a database
+    monkeypatched to schema version 31 gets the rich content directly at
+    creation time (``_apply_schema_v4`` always enriches a fresh bare row,
+    independent of ``_CURRENT_SCHEMA_VERSION``) -- so the constructor alone
+    can no longer produce the legacy "existing bare v31 database" state this
+    migration exists to handle.
+    """
+    connection.execute(
+        """
+        UPDATE character_cards
+           SET name = ?,
+               description = ?,
+               personality = NULL,
+               scenario = NULL,
+               system_prompt = NULL,
+               image = NULL,
+               post_history_instructions = NULL,
+               first_message = ?,
+               message_example = NULL,
+               creator_notes = NULL,
+               alternate_greetings = ?,
+               tags = ?,
+               creator = ?,
+               character_version = ?,
+               extensions = ?,
+               version = 1
+         WHERE id = 1
+        """,
+        (
+            BARE_NAME,
+            BARE_DESCRIPTION,
+            BARE_FIRST_MESSAGE,
+            BARE_ALTERNATE_GREETINGS,
+            BARE_TAGS,
+            BARE_CREATOR,
+            BARE_CHARACTER_VERSION,
+            BARE_EXTENSIONS,
+        ),
+    )
+    connection.commit()
+
+
+def _seed_v31_database_with_bare_row(path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    with monkeypatch.context() as v31_patch:
+        v31_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 31)
+        db = CharactersRAGDB(path, client_id="migration-seed")
+        connection = db.get_connection()
+        assert _version(connection) == 31
+        _force_row1_bare(connection)
+        row = db.get_character_card_by_id(1)
+        assert row["description"] == BARE_DESCRIPTION
+        assert row["version"] == 1
+        db.close_connection()
+
+
+# --------------------------------------------------------------------------
+# Fresh database: seeds rich content directly
+# --------------------------------------------------------------------------
+
+
+def test_fresh_database_seeds_rich_content(tmp_path):
+    db = CharactersRAGDB(tmp_path / "fresh.db", client_id="fresh-test")
+    row = db.get_character_card_by_id(1)
+
+    assert row["name"] == BARE_NAME  # FK anchor stays stable
+    assert row["creator"] == BARE_CREATOR  # provenance stays stable
+    assert row["description"] != BARE_DESCRIPTION
+    assert row["description"].startswith("The built-in Default Assistant character")
+    assert row["personality"]
+    assert row["system_prompt"]
+    assert "{{char}}" in row["system_prompt"]
+    assert row["first_message"] != BARE_FIRST_MESSAGE
+    assert "Roleplay" in row["first_message"]
+    assert "Voice & Speech" in row["first_message"]
+    assert row["creator_notes"]
+    assert row["alternate_greetings"] != BARE_ALTERNATE_GREETINGS
+
+    connection = db.get_connection()
+    assert _version(connection) == 32
+    db.close_connection()
+
+
+def test_fresh_database_alternate_greetings_is_a_two_item_json_list(tmp_path):
+    # get_character_card_by_id deserializes JSON columns (_CHARACTER_CARD_JSON_FIELDS)
+    # into native Python objects, so `alternate_greetings` comes back as a list already.
+    db = CharactersRAGDB(tmp_path / "fresh.db", client_id="fresh-test")
+    row = db.get_character_card_by_id(1)
+    greetings = row["alternate_greetings"]
+    assert isinstance(greetings, list)
+    assert len(greetings) == 2
+    assert all(isinstance(g, str) and g.strip() for g in greetings)
+    db.close_connection()
+
+
+# --------------------------------------------------------------------------
+# Migration: enriches an untouched bare row
+# --------------------------------------------------------------------------
+
+
+def test_migration_enriches_untouched_bare_row_and_bumps_version(tmp_path, monkeypatch):
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    db = CharactersRAGDB(db_path, client_id="migration-test")
+    connection = db.get_connection()
+    assert _version(connection) == 32
+
+    row = db.get_character_card_by_id(1)
+    assert row["name"] == BARE_NAME
+    assert row["creator"] == BARE_CREATOR
+    assert row["description"] != BARE_DESCRIPTION
+    assert row["first_message"] != BARE_FIRST_MESSAGE
+    assert row["personality"]
+    assert row["system_prompt"]
+    assert row["creator_notes"]
+    # The enrichment write itself bumps version (1 -> 2), matching how a
+    # real update_character_card() call represents a content change.
+    assert row["version"] == 2
+    db.close_connection()
+
+
+def test_migration_untouched_fields_not_written_stay_bare(tmp_path, monkeypatch):
+    """scenario, message_example, tags, character_version, extensions, image,
+    and post_history_instructions are not part of the authored rich content
+    (task-2451 step 2) and must stay exactly as the bare seed left them."""
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    db = CharactersRAGDB(db_path, client_id="migration-test")
+    row = db.get_character_card_by_id(1)
+    assert row["scenario"] is None
+    assert row["message_example"] is None
+    assert row["image"] is None
+    assert row["post_history_instructions"] is None
+    # tags/extensions are JSON columns; get_character_card_by_id deserializes them.
+    assert row["tags"] == []
+    assert row["character_version"] == BARE_CHARACTER_VERSION
+    assert row["extensions"] == {}
+    db.close_connection()
+
+
+# --------------------------------------------------------------------------
+# Migration: preserves a row with any single field edited
+# --------------------------------------------------------------------------
+
+
+_EDIT_CASES = [
+    ("name", "My Assistant"),
+    ("description", "Something I wrote myself."),
+    ("personality", "Grumpy but helpful."),
+    ("scenario", "A cozy cabin in the woods."),
+    ("system_prompt", "Always answer in haiku."),
+    ("first_message", "Yo, what's up?"),
+    ("message_example", "<START>\n{{user}}: Hi\n{{char}}: Hi!"),
+    ("creator_notes", "I made this the way I like it."),
+    ("alternate_greetings", '["Hey there!"]'),
+    ("tags", '["custom"]'),
+    ("creator", "SomeUser"),
+    ("character_version", "2.0"),
+    ("extensions", '{"custom_key": true}'),
+]
+
+
+# get_character_card_by_id deserializes these three JSON columns into native
+# Python objects (_CHARACTER_CARD_JSON_FIELDS), so the value read back through
+# the API differs in representation from the raw TEXT written via SQL.
+_JSON_FIELDS = {"alternate_greetings", "tags", "extensions"}
+
+
+@pytest.mark.parametrize("field, edited_value", _EDIT_CASES, ids=[c[0] for c in _EDIT_CASES])
+def test_migration_preserves_row_with_single_field_edited(
+    tmp_path, monkeypatch, field, edited_value
+):
+    import json
+
+    expected_value = json.loads(edited_value) if field in _JSON_FIELDS else edited_value
+
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    with monkeypatch.context() as v31_patch:
+        v31_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 31)
+        db = CharactersRAGDB(db_path, client_id="edit-seed")
+        connection = db.get_connection()
+        connection.execute(
+            f"UPDATE character_cards SET {field} = ? WHERE id = 1", (edited_value,)
+        )
+        connection.commit()
+        pre_migration_row = db.get_character_card_by_id(1)
+        assert pre_migration_row[field] == expected_value
+        pre_migration_version = pre_migration_row["version"]
+        db.close_connection()
+
+    db2 = CharactersRAGDB(db_path, client_id="migration-test")
+    connection2 = db2.get_connection()
+    assert _version(connection2) == 32  # migration still runs (DDL/version bump)
+
+    post_migration_row = db2.get_character_card_by_id(1)
+    # The edited field survives untouched.
+    assert post_migration_row[field] == expected_value
+    # Every OTHER field is exactly what it was before the migration ran --
+    # the whole row is left alone, not just the edited field.
+    for key in pre_migration_row.keys():
+        if key in ("last_modified",):
+            continue
+        assert post_migration_row[key] == pre_migration_row[key], (
+            f"field {key!r} changed even though the row had an edit to "
+            f"{field!r} and should have been left completely untouched"
+        )
+    assert post_migration_row["version"] == pre_migration_version
+    db2.close_connection()
+
+
+def test_migration_preserves_deleted_row(tmp_path, monkeypatch):
+    """A soft-deleted row 1 (deleted=1) must never be silently un-deleted or
+    enriched by the migration."""
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    with monkeypatch.context() as v31_patch:
+        v31_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 31)
+        db = CharactersRAGDB(db_path, client_id="delete-seed")
+        connection = db.get_connection()
+        connection.execute("UPDATE character_cards SET deleted = 1 WHERE id = 1")
+        connection.commit()
+        db.close_connection()
+
+    db2 = CharactersRAGDB(db_path, client_id="migration-test")
+    connection2 = db2.get_connection()
+    assert _version(connection2) == 32
+    row = connection2.execute(
+        "SELECT description, deleted FROM character_cards WHERE id = 1"
+    ).fetchone()
+    assert row["deleted"] == 1
+    assert row["description"] == BARE_DESCRIPTION  # untouched, still bare
+    db2.close_connection()
+
+
+# --------------------------------------------------------------------------
+# Idempotence
+# --------------------------------------------------------------------------
+
+
+def test_migration_is_idempotent_on_already_rich_row(tmp_path):
+    """A fresh database is already rich by the time it reaches v32 (the
+    enrichment happens at seed time, not via the migration). Re-running the
+    same conditional UPDATE (as a second migration attempt would) must be a
+    no-op: the WHERE clause no longer matches an enriched row."""
+    db = CharactersRAGDB(tmp_path / "fresh.db", client_id="idempotence-test")
+    row_before = db.get_character_card_by_id(1)
+
+    conn = db.get_connection()
+    db._enrich_default_assistant_card_if_bare(conn)
+    conn.commit()
+
+    row_after = db.get_character_card_by_id(1)
+    assert row_after == row_before
+    db.close_connection()
+
+
+def test_reopening_a_migrated_database_does_not_touch_row_again(tmp_path, monkeypatch):
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    db = CharactersRAGDB(db_path, client_id="migration-test")
+    row_after_migration = db.get_character_card_by_id(1)
+    db.close_connection()
+
+    db2 = CharactersRAGDB(db_path, client_id="reopen-test")
+    row_after_reopen = db2.get_character_card_by_id(1)
+    assert row_after_reopen == row_after_migration
+    db2.close_connection()
+
+
+# --------------------------------------------------------------------------
+# Regression: the FTS5 shadow-index defect this migration's write surfaced
+# --------------------------------------------------------------------------
+
+
+def test_first_edit_of_row_1_succeeds_on_a_fresh_database(tmp_path):
+    """Before the fix, ANY update to row 1 raised SQLITE_CORRUPT_VTAB
+    ("database disk image is malformed") because row 1's INSERT ran before
+    character_cards_fts/its triggers existed, so it was never indexed."""
+    db = CharactersRAGDB(tmp_path / "fresh.db", client_id="edit-test")
+    row = db.get_character_card_by_id(1)
+
+    result = db.update_character_card(
+        1, {"description": "my own description"}, expected_version=row["version"]
+    )
+    assert result is True
+
+    updated = db.get_character_card_by_id(1)
+    assert updated["description"] == "my own description"
+    db.close_connection()
+
+
+def test_first_edit_of_row_1_succeeds_on_a_migrated_pre_existing_database(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    db = CharactersRAGDB(db_path, client_id="migration-test")
+    row = db.get_character_card_by_id(1)
+
+    result = db.update_character_card(
+        1, {"description": "second edit after migration"}, expected_version=row["version"]
+    )
+    assert result is True
+    db.close_connection()
+
+
+def test_fts_search_finds_row_1_after_enrichment(tmp_path):
+    """Row 1 must be genuinely indexed (not just readable via a plain
+    SELECT, which FTS5 can satisfy from the content table alone even when
+    the index itself has no entry for that docid)."""
+    db = CharactersRAGDB(tmp_path / "fresh.db", client_id="search-test")
+    hits = db.search_character_cards("worked example")
+    assert hits, "expected the enriched Default Assistant card to be findable via FTS"
+    assert any(hit["id"] == 1 for hit in hits)
+    db.close_connection()
+
+
+def test_fts_search_finds_row_1_after_migration_from_bare(tmp_path, monkeypatch):
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    db = CharactersRAGDB(db_path, client_id="migration-test")
+    hits = db.search_character_cards("worked example")
+    assert hits
+    assert any(hit["id"] == 1 for hit in hits)
+    db.close_connection()
+
+
+def test_fts_rebuild_does_not_disturb_other_character_cards(tmp_path, monkeypatch):
+    """The enrichment routine's defensive `rebuild` reconstructs the WHOLE
+    FTS5 index, not just row 1's entry -- verify a second, independently
+    inserted character card is still searchable afterward."""
+    db_path = tmp_path / "chachanotes.db"
+    _seed_v31_database_with_bare_row(db_path, monkeypatch)
+
+    with monkeypatch.context() as v31_patch:
+        v31_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 31)
+        db = CharactersRAGDB(db_path, client_id="second-card-seed")
+        new_id = db.add_character_card(
+            {"name": "Zorblax", "description": "A xenophobic space pirate."}
+        )
+        assert new_id is not None
+        db.close_connection()
+
+    db2 = CharactersRAGDB(db_path, client_id="migration-test")
+    hits = db2.search_character_cards("space pirate")
+    assert any(hit["id"] == new_id for hit in hits)
+    db2.close_connection()
+
+
+# --------------------------------------------------------------------------
+# Regular chat / FK behavior unchanged
+# --------------------------------------------------------------------------
+
+
+def test_conversation_and_message_against_character_id_1_still_works(tmp_path):
+    db = CharactersRAGDB(tmp_path / "fresh.db", client_id="fk-test")
+    conv_id = db.add_conversation({"title": "chat with default", "character_id": 1})
+    assert conv_id
+    msg_id = db.add_message(
+        {"conversation_id": conv_id, "sender": "user", "content": "hi there"}
+    )
+    assert msg_id
+
+    conv = db.get_conversation_by_id(conv_id)
+    assert conv["character_id"] == 1
+    db.close_connection()
+
+
+# --------------------------------------------------------------------------
+# Schema version arithmetic
+# --------------------------------------------------------------------------
+
+
+def test_current_schema_version_is_32():
+    assert CharactersRAGDB._CURRENT_SCHEMA_VERSION == 32
+
+
+def test_migrate_from_v31_to_v32_requires_version_31(tmp_path):
+    db = CharactersRAGDB(tmp_path / "fresh.db", client_id="version-test")
+    conn = db.get_connection()
+    from tldw_chatbook.DB.ChaChaNotes_DB import SchemaError
+
+    with pytest.raises(SchemaError):
+        db._migrate_from_v31_to_v32(conn)
+    db.close_connection()

--- a/Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py
+++ b/Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py
@@ -23,6 +23,7 @@ Two things are under test:
    enrichment routine (existing databases).
 """
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -207,6 +208,8 @@ _EDIT_CASES = [
     ("personality", "Grumpy but helpful."),
     ("scenario", "A cozy cabin in the woods."),
     ("system_prompt", "Always answer in haiku."),
+    ("image", b"\x89PNG\r\n\x1a\n" + b"fake-avatar-bytes"),
+    ("post_history_instructions", "Always end with a one-line summary."),
     ("first_message", "Yo, what's up?"),
     ("message_example", "<START>\n{{user}}: Hi\n{{char}}: Hi!"),
     ("creator_notes", "I made this the way I like it."),
@@ -239,9 +242,20 @@ def test_migration_preserves_row_with_single_field_edited(
         v31_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 31)
         db = CharactersRAGDB(db_path, client_id="edit-seed")
         connection = db.get_connection()
-        connection.execute(
-            f"UPDATE character_cards SET {field} = ? WHERE id = 1", (edited_value,)
-        )
+        # `image` is the one BLOB column here (everything else is TEXT).
+        # sqlite3 binds a Python `bytes` object as BLOB, but that's an
+        # implementation detail worth making explicit rather than relying
+        # on -- the two branches deliberately mirror the two SQLite storage
+        # classes this fixture actually exercises.
+        if isinstance(edited_value, bytes):
+            connection.execute(
+                f"UPDATE character_cards SET {field} = ? WHERE id = 1",
+                (sqlite3.Binary(edited_value),),
+            )
+        else:
+            connection.execute(
+                f"UPDATE character_cards SET {field} = ? WHERE id = 1", (edited_value,)
+            )
         connection.commit()
         pre_migration_row = db.get_character_card_by_id(1)
         assert pre_migration_row[field] == expected_value

--- a/Tests/DB/test_chachanotes_message_metadata_migration.py
+++ b/Tests/DB/test_chachanotes_message_metadata_migration.py
@@ -47,7 +47,7 @@ def test_migration_adds_metadata_json_and_bumps_version(tmp_path, monkeypatch):
 
     db = CharactersRAGDB(db_path, client_id="migration-test")
     connection = db.get_connection()
-    assert _version(connection) == 31
+    assert _version(connection) == 32
     assert "metadata_json" in _message_columns(connection)
     db.close_connection()
 
@@ -154,7 +154,7 @@ def test_migration_is_idempotent_when_column_already_present(tmp_path, monkeypat
 
     db = CharactersRAGDB(db_path, client_id="migration-test")  # must not raise
     connection = db.get_connection()
-    assert _version(connection) == 31
+    assert _version(connection) == 32
     assert "metadata_json" in _message_columns(connection)
     # And the column is still usable, not left in some half-migrated state.
     conv_id = db.add_conversation({"title": "t"})

--- a/Tests/DB/test_chachanotes_message_usage_migration.py
+++ b/Tests/DB/test_chachanotes_message_usage_migration.py
@@ -46,7 +46,7 @@ def test_migration_adds_usage_json_and_bumps_version(tmp_path, monkeypatch):
 
     db = CharactersRAGDB(db_path, client_id="migration-test")
     connection = db.get_connection()
-    assert _version(connection) == 31
+    assert _version(connection) == 32
     assert "usage_json" in _message_columns(connection)
     db.close_connection()
 
@@ -111,7 +111,7 @@ def test_migration_is_idempotent_when_column_already_present(tmp_path, monkeypat
 
     db = CharactersRAGDB(db_path, client_id="migration-test")  # must not raise
     connection = db.get_connection()
-    assert _version(connection) == 31
+    assert _version(connection) == 32
     assert "usage_json" in _message_columns(connection)
     # And the column is still usable, not left in some half-migrated state.
     conv_id = db.add_conversation({"title": "t"})

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -803,3 +803,47 @@ mitigation has to be mechanical, not a mental note.
    it is the same shape as a guard that cannot fail (see "Mutation-test every guard
    you add," above), and here the false-positive mechanism was in the test harness's
    plumbing, not the guard's logic.
+
+---
+
+## 900+ green tests never exercised the first edit of a seeded row
+
+**TASK-2451, 2026-08-06.** Enriching the seeded 'Default Assistant' character card
+(`character_cards` id=1) meant writing a conditional `UPDATE` to that row. A quick
+manual prototype — construct a real `CharactersRAGDB` against a temp file, then run
+that `UPDATE` — crashed immediately with `sqlite3.DatabaseError: database disk image
+is malformed` (`SQLITE_CORRUPT_VTAB`). Nothing about the prototype's content mattered:
+even `UPDATE character_cards SET description = 'x' WHERE id = 1` crashed the same way,
+on a completely fresh database, through the real constructor. Root cause: row 1's
+`INSERT` in `_FULL_SCHEMA_SQL_V4` ran *before* `character_cards_fts` and its
+`character_cards_ai` trigger were created later in the same script, so row 1 was never
+indexed into the FTS5 shadow tables — on every database this schema had ever produced.
+The first `UPDATE` to that row makes `character_cards_au` ask FTS5 to remove index
+entries that were never inserted, and FTS5 reports that as disk corruption. This means
+`update_character_card(1, ...)` — an ordinary user editing the built-in Default
+Assistant via the normal Roleplay editor — already crashed the app, on every existing
+install, before this task touched anything. The full `Tests/ChaChaNotesDB/` +
+`Tests/DB/` suites (900+ tests, routinely green) never caught it, because no existing
+test performs a write against character id=1 as the first write after database
+creation — every test that touches character cards either inserts a fresh row first or
+edits a different id.
+
+**What to do.**
+1. Before trusting a migration's `UPDATE`/`INSERT` against a long-lived seeded row,
+   prototype it against a database built the SAME way production builds one (the real
+   constructor, not a hand-rolled minimal fixture) and actually run the write — do not
+   reason about FTS5/trigger ordering from reading the schema SQL alone.
+2. "900+ passing tests" is not evidence a specific write path has ever been exercised.
+   Ask what the very FIRST write to a specific row would look like, and whether any
+   test performs exactly that — a seeded/default row (id=1, "the default X") is
+   disproportionately likely to be read constantly and written to never, in the whole
+   existing suite.
+3. A `content=`/`content_rowid=` FTS5 table's row must be created strictly after the
+   external-content table's own `INSERT` trigger exists, or the row is invisible to the
+   index forever while still being readable via plain `SELECT` (FTS5 can satisfy an
+   unfiltered `SELECT` straight from the content table, so `SELECT rowid FROM fts_tbl`
+   looks fine and gives no warning). `PRAGMA integrity_check` also reports "ok" in this
+   state — it does not catch this class of defect. The tell is `SQLITE_CORRUPT_VTAB`
+   (not generic `SQLITE_CORRUPT`) the first time a row in that state is deleted or
+   updated. Fix forward with `INSERT INTO fts_tbl(fts_tbl) VALUES ('rebuild')`, which is
+   safe and idempotent for exactly this "shadow tables drifted from content" situation.

--- a/backlog/tasks/task-2451 - Make-the-default-assistant-an-editable-sample-persona.md
+++ b/backlog/tasks/task-2451 - Make-the-default-assistant-an-editable-sample-persona.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-05 04:48'
-updated_date: '2026-08-07 06:45'
+updated_date: '2026-08-07 07:08'
 labels: []
 dependencies:
   - TASK-2450
@@ -60,4 +60,6 @@ Gates: Tests/ChaChaNotesDB/ + Tests/DB/ = 903 passed, 1 skipped (Windows-only). 
 Files: tldw_chatbook/DB/ChaChaNotes_DB.py (schema version bump, FTS5 ordering fix, _enrich_default_assistant_card_if_bare + rich/bare content constants, _migrate_from_v31_to_v32, migration_steps registration); tldw_chatbook/DB/migrations/chachanotes_v31_to_v32_default_assistant_enrichment.sql (documentation mirror, not loaded at runtime); Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py (new); 5 existing test files with the version-number ripple fix.
 
 Lesson worth banking: prototype a migration's actual write path against a schema built the same way production builds it (constructor, not a hand-rolled minimal fixture) before trusting it -- a trivial single-column UPDATE with no relation to this task's content surfaced a years-old, always-crashing defect that 900+ existing green tests never exercised because nothing had ever tried to edit character id=1 as the first write after its creation.
+
+Post-Done review fix: _EDIT_CASES was missing 2 of the 15 byte-identity-gated fields (image BLOB, post_history_instructions) -- both genuinely user-editable (personas_character_editor_widget.py:796,:1265). Reviewer mutation-proved the gap by dropping each WHERE-clause comparison from production and confirming all tests stayed green. Added both cases (Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py, now 30 cases), re-confirmed each mutation now fails exactly its new case, restored production unchanged. Re-ran: enrichment file + Tests/ChaChaNotesDB/ = 205 passed; Tests/DB/ = 730 passed/1 skipped; ruff clean.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2451 - Make-the-default-assistant-an-editable-sample-persona.md
+++ b/backlog/tasks/task-2451 - Make-the-default-assistant-an-editable-sample-persona.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-2451
 title: Make the default assistant an editable sample persona
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-05 04:48'
-updated_date: '2026-08-05 04:49'
+updated_date: '2026-08-07 06:45'
 labels: []
 dependencies:
   - TASK-2450
@@ -15,19 +16,48 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The voice-profiles expansion design (2026-08-04) deferred an idea raised while scoping per-character voice settings: today's seeded 'Default Assistant' is a fixed character with no persona-side identity of its own. Owner ruling 1 on that spec explicitly separated this from the voice work ('a separate follow-up task, not this feature') and asked for it to be filed noting ADR-037's constraint. This task is that filing: give the default assistant an editable Persona presence so a new user has something to customize on day one, without letting that Persona acquire the character's own live identity or its TTS assignment.
+The seeded 'Default Assistant' character card (DB row 1, Character_Chat_Lib.DEFAULT_CHARACTER_ID) currently ships with placeholder, non-illustrative content, so a new user has nothing worth customizing on day one and no worked example of what a character card can hold. Owner rulings on the original persona-shaped design (recorded 2026-08-06) redirected this task: personas cannot carry voices until TASK-617/ADR-037, so the sample is the existing character card itself, enriched in place -- not a new Persona entity and not a second character card. Enrichment must never overwrite a user's own customization of that row, and the card cannot claim a pre-assigned voice (voice profiles live in a separate store that is empty at seed time), so the card teaches voice assignment instructionally instead.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A new user has an editable Persona (name, description, and the other Persona-domain fields) available out of the box, seeded from or alongside the default assistant character, without any manual setup
-- [ ] #2 Editing that Persona never mutates the seeded character card, and the Persona is never treated as the character's live identity (ADR-037: a Persona's origin-character provenance is not a live character identity)
-- [ ] #3 The sample Persona does not inherit, read, or expose the default assistant character's TTS assignment; Persona-side voice identity remains out of scope here per ADR-037's characters-remain-the-voice-bearing-entity boundary
-- [ ] #4 Existing installs that already have Persona records are unaffected; the sample Persona is additive, not a migration that alters or removes anything a user already created
+- [x] #1 A freshly created database seeds the 'Default Assistant' character card (id=1) with rich, documentation-grade content (description, personality, system_prompt, first_message, alternate_greetings, creator_notes) instead of the historical one-line placeholder text
+- [x] #2 On an existing database, row 1 is promoted to the rich content ONLY when every user-editable content field on it is still byte-identical to the original bare-seed literals; a row with any single field ever edited by a user is left completely unmodified
+- [x] #3 name stays 'Default Assistant' and creator stays 'System' in both the bare and enriched versions of the card, so the FK anchor (Character_Chat_Lib.DEFAULT_CHARACTER_ID) and provenance are unaffected
+- [x] #4 The card's own content never claims a pre-assigned voice; instead it walks the user through assigning one via the character editor's Voice & Speech section and mentions Settings > Speech & TTS's Default voice profile for the app-wide default, and every UI label the content cites is verified against the real running screens
+- [x] #5 Editing the seeded Default Assistant card (id=1) for the first time succeeds without error on both a fresh database and an existing pre-task-2451 database -- fixes a pre-existing FTS5 shadow-index defect (row 1's INSERT ran before its FTS5 table/triggers existed) that this task's own enrichment write would otherwise hit
+- [x] #6 Schema version is bumped with an accompanying, tested migration following the existing DB/migrations pattern; ordinary character_id=1 conversation/FK behavior is unchanged
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Capture the exact bare-seed literals in tldw_chatbook/DB/ChaChaNotes_DB.py's character_cards row-1 INSERT as the byte-identity baseline.
+2. Author rich content for description/personality/system_prompt/first_message/alternate_greetings/creator_notes; verify every UI label it cites (Roleplay nav label, Characters mode, Voice & Speech section title, Settings > Speech & TTS, Default voice profile field) against the real source.
+3. Diagnose and fix the pre-existing FTS5 ordering defect discovered while prototyping the migration (row-1 INSERT precedes character_cards_fts/its triggers in _FULL_SCHEMA_SQL_V4, so any UPDATE to row 1 -- including this task's own enrichment -- raises SQLITE_CORRUPT_VTAB "database disk image is malformed"): reorder the fresh-schema SQL and rebuild the FTS index for existing databases before the migration's content UPDATE runs.
+4. Add a shared conditional-enrichment routine comparing every character_cards content column (not just the ones being written) against the bare-seed literals; wire it into both the fresh-DB seed path and a new v31->v32 migration; bump _CURRENT_SCHEMA_VERSION and add the DB/migrations mirror file.
+5. TDD: fresh DB seeds rich; migration enriches an untouched bare row; migration preserves a row with any single field edited (parametrized); migration/enrichment is idempotent; first edit to row 1 no longer crashes (fresh AND pre-existing DB); regular character_id=1 FK/chat behavior unchanged; schema version arithmetic correct.
+6. Run the ChaChaNotes DB test files + character-lib tests, a repo-wide --collect-only sweep, and ruff; update the task's ACs (done up front per repo convention) and Implementation Notes.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Filed per owner ruling 1 in Docs/superpowers/specs/2026-08-04-voice-profiles-expansion-design.md section 4.4: 'the default assistant becomes an editable sample persona' idea, explicitly scoped OUT of the voice-profiles slice work and left as its own follow-up. ADR-037 (backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md) governs the boundary this task must respect: a Persona may retain an origin-character snapshot but that provenance is not a live character identity and a Persona does not inherit a character TTS assignment. Full Persona runtime parity (assignment UI, speech runtime, authority/provenance work) is tracked separately as TASK-617 and its five subtasks -- this task is scoped to the sample-persona UX only, not to closing 617.
+Redirected by owner rulings recorded 2026-08-06 (see conversation, not a spec file): the sample is the EXISTING seeded 'Default Assistant' character card (row 1, Character_Chat_Lib.DEFAULT_CHARACTER_ID), enriched in place -- not a new Persona entity (personas can't carry voices until TASK-617/ADR-037) and not a second character card. ACs were rewritten up front to match before implementation, per repo convention. Filing history (ADR-037 boundary, TASK-617 scope) preserved above; superseded by this note as the authoritative summary.
+
+Approach: authored rich description/personality/system_prompt/first_message/alternate_greetings(2)/creator_notes for row 1, keeping name='Default Assistant' and creator='System' stable (FK anchor + provenance). A shared routine, `_enrich_default_assistant_card_if_bare`, runs a single conditional UPDATE gated on ALL character_cards content columns (not just the ones it writes) matching the original bare-seed literals byte-for-byte -- any single field ever edited by a user, anywhere on the row, leaves it completely untouched. This routine is called from both `_apply_schema_v4` (fresh databases enrich immediately after the bare row is inserted) and the new `_migrate_from_v31_to_v32` migration (existing databases), so both paths share one definition of "still bare" and "rich". Schema bumped 31->32; DB/migrations mirror file added (generated from the Python constants so it can't drift).
+
+Blocking defect found and fixed: prototyping the migration's UPDATE crashed with `sqlite3.DatabaseError: database disk image is malformed` (SQLITE_CORRUPT_VTAB) on EVERY database, fresh or old -- a pre-existing bug independent of this task. Row 1's INSERT in `_FULL_SCHEMA_SQL_V4` ran BEFORE `character_cards_fts`/its `character_cards_ai` trigger existed, so row 1 was never indexed; the first-ever UPDATE to that row (character_cards_au's FTS5 'delete' special command, asking FTS5 to remove entries that were never inserted) corrupted the shadow index. This meant a real user's first edit of the Default Assistant character, via the ordinary Roleplay editor, already crashed the app before this task touched anything. Fixed two ways: (1) reordered `_FULL_SCHEMA_SQL_V4` so the row-1 INSERT runs after the FTS5 table/triggers exist (fresh installs never hit it again), and (2) the shared enrichment routine runs `INSERT INTO character_cards_fts(character_cards_fts) VALUES ('rebuild')` before its content UPDATE, which safely reconstructs the whole index from the content table for any pre-existing (already-created) database, guarded by a `character_cards` table-existence check so synthetic/legacy test fixtures without that table are a no-op.
+
+Verified against source (not memory): "Roleplay" nav label (Constants.py TAB_PERSONAS), "Characters" mode chip (personas_screen.py), "Voice & Speech" section title (personas_character_tts_widget.py:180, mounted in the character editor), "Speech & TTS" Settings category and "Default voice profile" field label (settings_screen.py / speech_tts_settings_panel.py). Content claims about which fields feed the model (system_prompt verbatim first; personality/description/scenario/message_example labelled; creator/version/tags never sent) verified against `compose_character_card_text` in Character_Chat_Lib.py.
+
+Tests (Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py, 28 cases, TDD): fresh DB seeds rich content + version 32; migration enriches an untouched bare row and bumps its version; fields the migration doesn't write stay exactly bare; migration preserves a row with any ONE of 13 fields edited (parametrized, asserts every OTHER field is byte-identical to pre-migration, not just the edited one); a soft-deleted row 1 is left alone; enrichment/migration is idempotent (re-running is a no-op; reopening doesn't re-touch); the crash regression is fixed on both a fresh DB and a migrated pre-existing DB; FTS search actually finds row 1 post-enrichment (a plain SELECT alone can't distinguish "indexed" from "readable via content table"); the FTS rebuild doesn't disturb a second, independently-inserted character card; ordinary character_id=1 conversation/message FK behavior is unchanged; schema-version arithmetic (32, and the v31->v32 migration rejects a non-31 starting version).
+
+Ripple: 5 pre-existing tests hard-coded "fresh DB reaches v31" (or similar) and were updated to 32, following this repo's established pattern for every prior schema bump (Tests/ChaChaNotesDB/test_message_generation_metadata.py, Tests/DB/test_chachanotes_active_leaf_migration.py, test_chachanotes_context_summary_migration.py, test_chachanotes_message_metadata_migration.py, test_chachanotes_message_usage_migration.py).
+
+Gates: Tests/ChaChaNotesDB/ + Tests/DB/ = 903 passed, 1 skipped (Windows-only). Tests/Character_Chat/ + Tests/Chat/test_chat_functions.py + Tests/Chatbooks/ = 799 passed, 1 skipped (--run-slow gated). Repo-wide `pytest --collect-only` = 31789 collected, 0 errors. `ruff check` on all touched files = clean.
+
+Files: tldw_chatbook/DB/ChaChaNotes_DB.py (schema version bump, FTS5 ordering fix, _enrich_default_assistant_card_if_bare + rich/bare content constants, _migrate_from_v31_to_v32, migration_steps registration); tldw_chatbook/DB/migrations/chachanotes_v31_to_v32_default_assistant_enrichment.sql (documentation mirror, not loaded at runtime); Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py (new); 5 existing test files with the version-number ripple fix.
+
+Lesson worth banking: prototype a migration's actual write path against a schema built the same way production builds it (constructor, not a hand-rolled minimal fixture) before trusting it -- a trivial single-column UPDATE with no relation to this task's content surfaced a years-old, always-crashing defect that 900+ existing green tests never exercised because nothing had ever tried to edit character id=1 as the first write after its creation.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -162,7 +162,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 31  # Adds local-only messages.metadata_json (task-2364).
+    _CURRENT_SCHEMA_VERSION = 32  # Enriches the seeded Default Assistant card with documentation-grade content, if still bare (task-2451).
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -219,18 +219,6 @@ CREATE TABLE IF NOT EXISTS character_cards(
   version       INTEGER  NOT NULL DEFAULT 1
 );
 
-/* Ensure default character card (ID 1) exists */
-INSERT OR IGNORE INTO character_cards
-    (id, name, description, personality, scenario, system_prompt, image,
-     post_history_instructions, first_message, message_example,
-     creator_notes, alternate_greetings, tags, creator, character_version, extensions,
-     created_at, last_modified, client_id, version, deleted)
-VALUES
-    (1, 'Default Assistant', 'A general-purpose assistant.', NULL, NULL, NULL, NULL, NULL,
-     'Hello! How can I help you today?', NULL, NULL, '[]', '[]', 'System', '1.0', '{}',
-     CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'system_init', 1, 0);
-/* End of insertion of default character card */
-
 CREATE VIRTUAL TABLE IF NOT EXISTS character_cards_fts
 USING fts5(
   name, description, personality, scenario, system_prompt,
@@ -267,6 +255,28 @@ AFTER DELETE ON character_cards BEGIN
                                   name,description,personality,scenario,system_prompt)
   VALUES('delete',old.id,old.name,old.description,old.personality,old.scenario,old.system_prompt);
 END;
+
+/* Ensure default character card (ID 1) exists. task-2451: this INSERT must
+   come AFTER character_cards_fts and its ai/au/ad triggers exist -- for
+   years it ran BEFORE them, so character_cards_ai never fired for this row
+   and row 1 was never indexed into the FTS5 shadow tables. The first-ever
+   UPDATE to row 1 (character_cards_au's 'delete' special command asking
+   FTS5 to remove index entries that were never inserted) then raised
+   SQLITE_CORRUPT_VTAB ("database disk image is malformed") -- discovered
+   via this task's own enrichment write, but it hit ANY edit of the seeded
+   Default Assistant card, on every existing database. See
+   _enrich_default_assistant_card_if_bare's 'rebuild' call for the
+   companion fix that repairs already-created databases. */
+INSERT OR IGNORE INTO character_cards
+    (id, name, description, personality, scenario, system_prompt, image,
+     post_history_instructions, first_message, message_example,
+     creator_notes, alternate_greetings, tags, creator, character_version, extensions,
+     created_at, last_modified, client_id, version, deleted)
+VALUES
+    (1, 'Default Assistant', 'A general-purpose assistant.', NULL, NULL, NULL, NULL, NULL,
+     'Hello! How can I help you today?', NULL, NULL, '[]', '[]', 'System', '1.0', '{}',
+     CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'system_init', 1, 0);
+/* End of insertion of default character card */
 
 /*----------------------------------------------------------------
   2. Conversations
@@ -3226,6 +3236,15 @@ UPDATE db_schema_version
             logger.info(
                 f"[{self._SCHEMA_NAME} V4] Schema 4 applied and version confirmed for DB: {self.db_path_str}."
             )
+            # task-2451: a brand-new database seeds the enriched Default
+            # Assistant card directly rather than passing through the bare
+            # seed state the v31->v32 migration exists to fix for EXISTING
+            # databases. Calling the same conditional-UPDATE routine here
+            # keeps "what counts as still bare" and "what rich content looks
+            # like" defined in exactly one place for both paths -- the WHERE
+            # clause matches the row this INSERT just created (still bare),
+            # so this always enriches a fresh install.
+            self._enrich_default_assistant_card_if_bare(conn)
         except sqlite3.Error as e:
             logger.opt(exception=True).error(
                 f"[{self._SCHEMA_NAME} V4] Schema application failed: {e}"
@@ -3242,6 +3261,244 @@ UPDATE db_schema_version
             raise SchemaError(
                 f"Unexpected error applying schema V4 for '{self._SCHEMA_NAME}': {e}"
             ) from e
+
+    # task-2451: bare vs. rich literals for the seeded 'Default Assistant'
+    # card (id=1). A row is "still bare" only when EVERY content field below
+    # matches, byte-for-byte -- not just the fields this migration writes.
+    # Any single edited field (even one this migration never touches, like
+    # `tags`) means a user has customized the card, and owner ruling 2 is
+    # explicit: it is left exactly as-is. The compared set is every
+    # user-editable content column on `character_cards`; `id`, `created_at`,
+    # `last_modified`, `deleted`, `client_id`, and `version` are bookkeeping,
+    # not content, and are deliberately excluded from the comparison.
+    #
+    # Keep this runner content aligned with tldw_chatbook/DB/migrations/
+    # chachanotes_v31_to_v32_default_assistant_enrichment.sql (a hand-apply
+    # reference generated FROM these constants; it is not read at runtime).
+    _DEFAULT_ASSISTANT_BARE_NAME = "Default Assistant"
+    _DEFAULT_ASSISTANT_BARE_DESCRIPTION = "A general-purpose assistant."
+    _DEFAULT_ASSISTANT_BARE_FIRST_MESSAGE = "Hello! How can I help you today?"
+    _DEFAULT_ASSISTANT_BARE_ALTERNATE_GREETINGS = "[]"
+    _DEFAULT_ASSISTANT_BARE_TAGS = "[]"
+    _DEFAULT_ASSISTANT_BARE_CREATOR = "System"
+    _DEFAULT_ASSISTANT_BARE_CHARACTER_VERSION = "1.0"
+    _DEFAULT_ASSISTANT_BARE_EXTENSIONS = "{}"
+    # personality, scenario, system_prompt, image, post_history_instructions,
+    # and message_example are all bare-seeded NULL (compared via `IS NULL`).
+
+    # Rich content only. `name` stays 'Default Assistant' and `creator` stays
+    # 'System' -- both are the FK anchor / provenance and must not move.
+    _DEFAULT_ASSISTANT_RICH_DESCRIPTION = (
+        "The built-in Default Assistant character -- used for any new "
+        "conversation until you choose a different character. It also "
+        "serves as a worked example: every field on this card (personality, "
+        "system prompt, greeting, alternate greetings, creator notes) is "
+        "filled in on purpose, so editing one and starting a fresh chat "
+        "shows exactly what that field does."
+    )
+    _DEFAULT_ASSISTANT_RICH_PERSONALITY = (
+        "Concise by default: gives the direct answer first, then reasoning "
+        "only if it adds something. Says which parts of an answer are "
+        "uncertain instead of guessing at them. Asks one clarifying "
+        "question before assuming something that would change the answer, "
+        "rather than assuming and hoping."
+    )
+    _DEFAULT_ASSISTANT_RICH_SYSTEM_PROMPT = (
+        "You are {{char}}: a measured, general-purpose assistant.\n"
+        "\n"
+        "1. Lead with the answer. Give the direct answer first, then "
+        "explain your reasoning if it adds something.\n"
+        "2. Name what you're relying on. When an answer depends on a "
+        "specific fact, document, or source, say which one. When it "
+        "depends on your own judgment instead, say that.\n"
+        "3. Ask before assuming. If a request is ambiguous in a way that "
+        "would change the answer, ask one clarifying question rather than "
+        "guessing.\n"
+        "4. Match {{user}}'s register. Mirror their level of formality and "
+        "technical depth instead of defaulting to one style.\n"
+        "5. Say what you don't know. A confident wrong answer is worse "
+        "than an honest \"I'm not sure.\"\n"
+        "\n"
+        "Stay consistent with these rules as the conversation continues."
+    )
+    _DEFAULT_ASSISTANT_RICH_FIRST_MESSAGE = (
+        "Hello! I'm the Default Assistant -- the character every new chat "
+        "starts with until you pick another one.\n"
+        "\n"
+        "This card is also a working example: everything about me is "
+        "editable from **Roleplay ▸ Characters ▸ Default "
+        "Assistant** -- personality, system prompt, this greeting, all of "
+        "it. I don't come with a voice assigned (voice profiles are set up "
+        "separately) -- give me one from the card's **Voice & Speech** "
+        "section, or set an app-wide default under **Settings ▸ "
+        "Speech & TTS ▸ Default voice profile**.\n"
+        "\n"
+        "Prefer to keep this card as-is? Duplicate it from the Characters "
+        "list and customize the copy instead.\n"
+        "\n"
+        "What can I help you with?"
+    )
+    _DEFAULT_ASSISTANT_RICH_CREATOR_NOTES = (
+        "This is the Default Assistant: tldw_chatbook's built-in character "
+        "and a worked example of what a character card can hold. Everything "
+        "on it is safe to edit or delete -- nothing else in the app depends "
+        "on these specific values.\n"
+        "\n"
+        "Where each field surfaces (Roleplay ▸ Characters ▸ "
+        "Default Assistant):\n"
+        "- Description -- shown in the character list, and folded into the "
+        "system prompt as \"Description: ...\".\n"
+        "- Personality -- folded into the system prompt as "
+        "\"Personality: ...\"; the quickest field to change to see a "
+        "difference in tone.\n"
+        "- System prompt -- sent to the model verbatim, first.\n"
+        "- First message -- what a new conversation opens with.\n"
+        "- Alternate greetings -- extra opening lines to pick between when "
+        "starting a chat.\n"
+        "- Creator / Version / Tags -- bookkeeping only; never sent to the "
+        "model.\n"
+        "\n"
+        "Voice: a character card ships with no voice assigned -- voice "
+        "profiles live in a separate store and can't be pre-assigned at "
+        "install time. To give this character a voice, open its editor's "
+        "Voice & Speech section and choose a profile; leaving it on \"Use "
+        "global default\" follows whatever is set under Settings ▸ "
+        "Speech & TTS ▸ Default voice profile.\n"
+        "\n"
+        "To make this yours: edit any field above, or duplicate the card "
+        "from the Characters list and edit the copy instead."
+    )
+    _DEFAULT_ASSISTANT_RICH_ALTERNATE_GREETINGS = json.dumps(
+        [
+            (
+                "Hi -- quick orientation, since this is an alternate "
+                "greeting: this character card lives at Roleplay ▸ "
+                "Characters ▸ Default Assistant, and everything on it "
+                "(including which greeting opens a chat) is editable. What "
+                "are you working on?"
+            ),
+            (
+                "Hey. You picked this card's second greeting -- a "
+                "demonstration that a character can offer more than one "
+                "opening line. Add, edit, or reorder them from the card's "
+                "editor. What's on your mind?"
+            ),
+        ]
+    )
+
+    def _enrich_default_assistant_card_if_bare(self, conn: sqlite3.Connection) -> None:
+        """Promote the seeded 'Default Assistant' card (id=1) to
+        documentation-grade rich content (task-2451), but ONLY when it is
+        still byte-identical to the original bare-seed literals across
+        every content field -- not just the ones this promotes. Any user
+        edit, anywhere on the row, leaves it untouched (owner ruling 2:
+        nobody's customization is ever overwritten). `name` and `creator`
+        are part of the bare-identity comparison (a renamed or
+        re-attributed card is a real edit) even though the rich content
+        keeps their values unchanged -- they are the FK anchor and
+        provenance fields and must not move.
+
+        Shared by two callers so both agree on what "still bare" and "rich"
+        mean: `_apply_schema_v4` (a fresh database, immediately after the
+        bare row is inserted) and `_migrate_from_v31_to_v32` (an existing
+        database walking forward through the migration chain). Affects 0 or
+        1 rows; the caller does not treat a 0-row result as an error --
+        that's the expected outcome for an already-rich or user-edited row.
+
+        Every database created before this task's schema-SQL reordering fix
+        has row 1's `character_cards_fts` shadow index permanently missing
+        (its INSERT ran before the `character_cards_ai` trigger existed to
+        index it), which raises SQLITE_CORRUPT_VTAB the first time ANYTHING
+        updates that row -- including this very UPDATE. The FTS5 `rebuild`
+        special command discards and reconstructs the whole index from the
+        current `character_cards` content table, which is always safe and
+        idempotent (SQLite docs: for exactly this "shadow tables drifted
+        from content" situation) and fixes every row, not just id=1.
+
+        Guarded by an existence check: some tests (and, in principle, a
+        pre-v4 fixture) build a synthetic database that never went through
+        `_apply_schema_v4` and so has neither `character_cards` nor
+        `character_cards_fts` at all. A real production database always has
+        both from v4 onward, but this routine has no business assuming that
+        -- if the table doesn't exist there is nothing to rebuild and
+        nothing to enrich, so it is simply a no-op.
+        """
+        table_exists = (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?",
+                ("character_cards",),
+            ).fetchone()
+            is not None
+        )
+        if not table_exists:
+            logger.debug(
+                "[task-2451] character_cards table absent; skipping Default "
+                f"Assistant enrichment for DB: {self.db_path_str}."
+            )
+            return
+        conn.execute("INSERT INTO character_cards_fts(character_cards_fts) VALUES ('rebuild')")
+        cursor = conn.execute(
+            """
+            UPDATE character_cards
+               SET description = ?,
+                   personality = ?,
+                   system_prompt = ?,
+                   first_message = ?,
+                   creator_notes = ?,
+                   alternate_greetings = ?,
+                   last_modified = ?,
+                   version = version + 1,
+                   client_id = ?
+             WHERE id = 1
+               AND deleted = 0
+               AND name IS ?
+               AND description IS ?
+               AND personality IS ?
+               AND scenario IS ?
+               AND system_prompt IS ?
+               AND image IS ?
+               AND post_history_instructions IS ?
+               AND first_message IS ?
+               AND message_example IS ?
+               AND creator_notes IS ?
+               AND alternate_greetings IS ?
+               AND tags IS ?
+               AND creator IS ?
+               AND character_version IS ?
+               AND extensions IS ?
+            """,
+            (
+                # SET values (rich content)
+                self._DEFAULT_ASSISTANT_RICH_DESCRIPTION,
+                self._DEFAULT_ASSISTANT_RICH_PERSONALITY,
+                self._DEFAULT_ASSISTANT_RICH_SYSTEM_PROMPT,
+                self._DEFAULT_ASSISTANT_RICH_FIRST_MESSAGE,
+                self._DEFAULT_ASSISTANT_RICH_CREATOR_NOTES,
+                self._DEFAULT_ASSISTANT_RICH_ALTERNATE_GREETINGS,
+                self._get_current_utc_timestamp_iso(),
+                self.client_id,
+                # WHERE bare-identity comparison values (original seed literals)
+                self._DEFAULT_ASSISTANT_BARE_NAME,
+                self._DEFAULT_ASSISTANT_BARE_DESCRIPTION,
+                None,  # personality
+                None,  # scenario
+                None,  # system_prompt
+                None,  # image
+                None,  # post_history_instructions
+                self._DEFAULT_ASSISTANT_BARE_FIRST_MESSAGE,
+                None,  # message_example
+                None,  # creator_notes
+                self._DEFAULT_ASSISTANT_BARE_ALTERNATE_GREETINGS,
+                self._DEFAULT_ASSISTANT_BARE_TAGS,
+                self._DEFAULT_ASSISTANT_BARE_CREATOR,
+                self._DEFAULT_ASSISTANT_BARE_CHARACTER_VERSION,
+                self._DEFAULT_ASSISTANT_BARE_EXTENSIONS,
+            ),
+        )
+        logger.debug(
+            f"[task-2451] Default Assistant enrichment UPDATE affected "
+            f"{cursor.rowcount} row(s) in DB: {self.db_path_str}."
+        )
 
     def _migrate_from_v4_to_v5(self, conn: sqlite3.Connection):
         """
@@ -4424,6 +4681,67 @@ UPDATE db_schema_version
                 f"Unexpected error migrating from V30 to V31 for '{self._SCHEMA_NAME}': {e}"
             ) from e
 
+    def _migrate_from_v31_to_v32(self, conn: sqlite3.Connection) -> None:
+        """Migrate schema V31->V32: enrich the seeded 'Default Assistant'
+        character card (id=1) with documentation-grade content (task-2451),
+        but ONLY when the row is still byte-identical to the original
+        bare-seed literals -- see `_enrich_default_assistant_card_if_bare`
+        for the shared conditional-UPDATE routine and the exact field set
+        compared. A row with any single field edited by a user is left
+        completely untouched; this is data enrichment, not a DDL change,
+        so there is no ALTER/CREATE to guard for idempotence -- the WHERE
+        clause itself is the idempotence guard (an already-rich row no
+        longer matches it)."""
+        if self._get_db_version(conn) != 31:
+            raise SchemaError(
+                f"[{self._SCHEMA_NAME} V31→V32] Migration requires schema version 31"
+            )
+        logger.info(
+            f"Migrating schema from V31 to V32 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
+        )
+        try:
+            self._enrich_default_assistant_card_if_bare(conn)
+
+            version_cursor = conn.execute(
+                """
+                UPDATE db_schema_version
+                   SET version = 32
+                 WHERE schema_name = ?
+                   AND version = 31
+                """,
+                (self._SCHEMA_NAME,),
+            )
+            if version_cursor.rowcount != 1:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V31→V32] Migration version update was not applied"
+                )
+
+            final_version = self._get_db_version(conn)
+            if final_version != 32:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V31→V32] Migration version check failed. Expected 32, got: {final_version}"
+                )
+
+            logger.info(
+                f"[{self._SCHEMA_NAME} V31→V32] Migration completed successfully for DB: {self.db_path_str}."
+            )
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error(
+                f"[{self._SCHEMA_NAME} V31→V32] Migration failed: {e}"
+            )
+            raise SchemaError(
+                f"Migration from V31 to V32 failed for '{self._SCHEMA_NAME}': {e}"
+            ) from e
+        except SchemaError:
+            raise
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"[{self._SCHEMA_NAME} V31→V32] Unexpected error during migration: {e}"
+            )
+            raise SchemaError(
+                f"Unexpected error migrating from V31 to V32 for '{self._SCHEMA_NAME}': {e}"
+            ) from e
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -4585,6 +4903,7 @@ UPDATE db_schema_version
                     28: self._migrate_from_v28_to_v29,
                     29: self._migrate_from_v29_to_v30,
                     30: self._migrate_from_v30_to_v31,
+                    31: self._migrate_from_v31_to_v32,
                 }
 
                 if current_db_version == 0:

--- a/tldw_chatbook/DB/migrations/chachanotes_v31_to_v32_default_assistant_enrichment.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v31_to_v32_default_assistant_enrichment.sql
@@ -1,0 +1,73 @@
+-- ChaChaNotes v31 -> v32: enrich the seeded 'Default Assistant' character
+-- card (id=1) with documentation-grade content (task-2451), but ONLY when
+-- the row is still byte-identical to the original bare-seed literals across
+-- EVERY content field (not just the ones this UPDATE writes). Any single
+-- user edit -- to any field -- leaves the row untouched (owner ruling 2:
+-- nobody's customization is ever overwritten).
+--
+-- This mirrors CharactersRAGDB._enrich_default_assistant_card_if_bare, the
+-- Python routine both the fresh-DB seed path (_apply_schema_v4) and this
+-- migration (_migrate_from_v31_to_v32) call, generated here from the exact
+-- same class-level content constants so the two never drift apart. Keep
+-- the two in step if either side changes. This file is documentation only
+-- (a hand-apply reference for a raw sqlite3 shell); the application never
+-- reads it -- the Python constants are the runtime source of truth.
+
+UPDATE character_cards
+   SET description = 'The built-in Default Assistant character -- used for any new conversation until you choose a different character. It also serves as a worked example: every field on this card (personality, system prompt, greeting, alternate greetings, creator notes) is filled in on purpose, so editing one and starting a fresh chat shows exactly what that field does.',
+       personality = 'Concise by default: gives the direct answer first, then reasoning only if it adds something. Says which parts of an answer are uncertain instead of guessing at them. Asks one clarifying question before assuming something that would change the answer, rather than assuming and hoping.',
+       system_prompt = 'You are {{char}}: a measured, general-purpose assistant.
+
+1. Lead with the answer. Give the direct answer first, then explain your reasoning if it adds something.
+2. Name what you''re relying on. When an answer depends on a specific fact, document, or source, say which one. When it depends on your own judgment instead, say that.
+3. Ask before assuming. If a request is ambiguous in a way that would change the answer, ask one clarifying question rather than guessing.
+4. Match {{user}}''s register. Mirror their level of formality and technical depth instead of defaulting to one style.
+5. Say what you don''t know. A confident wrong answer is worse than an honest "I''m not sure."
+
+Stay consistent with these rules as the conversation continues.',
+       first_message = 'Hello! I''m the Default Assistant -- the character every new chat starts with until you pick another one.
+
+This card is also a working example: everything about me is editable from **Roleplay ▸ Characters ▸ Default Assistant** -- personality, system prompt, this greeting, all of it. I don''t come with a voice assigned (voice profiles are set up separately) -- give me one from the card''s **Voice & Speech** section, or set an app-wide default under **Settings ▸ Speech & TTS ▸ Default voice profile**.
+
+Prefer to keep this card as-is? Duplicate it from the Characters list and customize the copy instead.
+
+What can I help you with?',
+       creator_notes = 'This is the Default Assistant: tldw_chatbook''s built-in character and a worked example of what a character card can hold. Everything on it is safe to edit or delete -- nothing else in the app depends on these specific values.
+
+Where each field surfaces (Roleplay ▸ Characters ▸ Default Assistant):
+- Description -- shown in the character list, and folded into the system prompt as "Description: ...".
+- Personality -- folded into the system prompt as "Personality: ..."; the quickest field to change to see a difference in tone.
+- System prompt -- sent to the model verbatim, first.
+- First message -- what a new conversation opens with.
+- Alternate greetings -- extra opening lines to pick between when starting a chat.
+- Creator / Version / Tags -- bookkeeping only; never sent to the model.
+
+Voice: a character card ships with no voice assigned -- voice profiles live in a separate store and can''t be pre-assigned at install time. To give this character a voice, open its editor''s Voice & Speech section and choose a profile; leaving it on "Use global default" follows whatever is set under Settings ▸ Speech & TTS ▸ Default voice profile.
+
+To make this yours: edit any field above, or duplicate the card from the Characters list and edit the copy instead.',
+       alternate_greetings = '["Hi -- quick orientation, since this is an alternate greeting: this character card lives at Roleplay \u25b8 Characters \u25b8 Default Assistant, and everything on it (including which greeting opens a chat) is editable. What are you working on?", "Hey. You picked this card''s second greeting -- a demonstration that a character can offer more than one opening line. Add, edit, or reorder them from the card''s editor. What''s on your mind?"]',
+       last_modified = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+       version = version + 1,
+       client_id = client_id -- the runner binds the real client_id; this mirror leaves it a no-op
+ WHERE id = 1
+   AND deleted = 0
+   AND name IS 'Default Assistant'
+   AND description IS 'A general-purpose assistant.'
+   AND personality IS NULL
+   AND scenario IS NULL
+   AND system_prompt IS NULL
+   AND image IS NULL
+   AND post_history_instructions IS NULL
+   AND first_message IS 'Hello! How can I help you today?'
+   AND message_example IS NULL
+   AND creator_notes IS NULL
+   AND alternate_greetings IS '[]'
+   AND tags IS '[]'
+   AND creator IS 'System'
+   AND character_version IS '1.0'
+   AND extensions IS '{}';
+
+UPDATE db_schema_version
+   SET version = 32
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 31;


### PR DESCRIPTION
Closes TASK-2451, the final follow-up from the voice-profiles program.

## What

The seeded **Default Assistant** character card (DB row 1) becomes a self-documenting worked example of what a character card can hold: a real description, a deliberately-visible personality, a system prompt worth copying, an orienting first message, alternate greetings, and creator notes that walk through customizing every field — including how to give it a voice (Roleplay ▸ Voice & Speech; Settings ▸ Speech & TTS ▸ Default voice profile). Every UI label the card cites was verified against source; the voice guidance is instructional by necessity (no profile can exist at seed time).

**Owner rulings honored:** it's the character card (not a Persona-entity, per ADR-037's constraint), and existing databases are enriched **only if row 1 is byte-identical to the bare seed across all 15 content fields** — any user edit, including an avatar-only upload, leaves the card exactly as-is. Preservation is parametrized over all 15 fields (30 cases), each mutation-proven load-bearing; the migration is idempotent; regular-chat FK behavior is pinned unchanged. Schema v31 → v32.

## The bug this task tripped over

**Editing the seeded Default Assistant crashed with `SQLITE_CORRUPT_VTAB` ("database disk image is malformed") on every existing database.** Row 1's INSERT ran before its FTS5 table and triggers existed, so the first edit through the normal Roleplay editor detonated the index — while `PRAGMA integrity_check` reported `ok` and 900+ tests stayed green, because nothing ever edited that row. Independently reproduced at the base commit with a one-field edit.

Fixed both ways: fresh installs reorder the schema so the FTS table precedes the seed; existing installs get an unconditional FTS `rebuild` in the migration — verified to cure even databases whose user-edited row skips enrichment entirely. Regression tests cover both paths, and a lessons entry records the incident.

## Verification

205 DB tests green post-rebase (28 new); Character_Chat/chat-functions/Chatbooks suites green; repo-wide collection clean; ruff clean. Review independently reproduced the corruption at base, verified the fix on user-edited databases, mutation-tested the byte-identity gate field-by-field, and fact-checked the card's copy claim-by-claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the seeded Default Assistant into a real, editable example with helpful content, and fixes a long-standing crash when editing it on existing databases. Addresses TASK-2451 with a guarded v31→v32 migration and an FTS ordering fix.

- New Features
  - Enriches the built-in character (id=1) with description, personality, system prompt, first message, alternate greetings, and creator notes.
  - Migration updates row 1 only if all editable fields match the original bare seed; any prior edit preserves the row untouched.
  - Fresh installs seed the rich content immediately; `name` and `creator` stay stable; schema bumped to 32.
  - Voice guidance is instructional and points to Roleplay ▸ Voice & Speech and Settings ▸ Speech & TTS ▸ Default voice profile.

- Bug Fixes
  - Prevents `SQLITE_CORRUPT_VTAB` by creating `character_cards_fts` and triggers before seeding, and rebuilding the FTS index during migration for existing DBs.
  - First edit to the Default Assistant now succeeds on fresh and existing databases; FTS search includes row 1.

<sup>Written for commit e6964143a4bc1135e5fe546fdcb6025b0926ff54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

