### PR TITLE
perf(db): WorkspaceDB holds one connection per thread (task 3011)

### DIFF
--- a/Tests/Workspaces/test_workspace_db_connection_reuse.py
+++ b/Tests/Workspaces/test_workspace_db_connection_reuse.py
@@ -1,0 +1,104 @@
+"""task-3011: WorkspaceDB holds one connection per thread.
+
+cProfile of a single Console push (task-2902 round 2) showed
+`connect_private_sqlite` invoked 1,352 times through WorkspaceDB — a brand
+new SQLite connection per query, 0.64s of the ~2.5s first paint. Every
+other heavy DB in the repo already holds a thread-local connection
+(ChaChaNotes' `_get_thread_connection` idiom).
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+
+@pytest.fixture()
+def connection_spy(monkeypatch):
+    """Count real private-sqlite connection opens through the base-db seam."""
+    import tldw_chatbook.DB.base_db as base_db
+
+    real_connect = base_db.connect_private_sqlite
+    opened: list[object] = []
+
+    def counting_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(base_db, "connect_private_sqlite", counting_connect)
+    return opened
+
+
+def test_repeated_reads_open_no_new_connections(tmp_path: Path, connection_spy):
+    service = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1")
+    )
+    service.ensure_default_workspace()  # warm-up: schema + first held conn
+
+    baseline = len(connection_spy)
+    for _ in range(10):
+        service.get_active_workspace()
+        service.list_workspaces()
+    assert len(connection_spy) == baseline, (
+        f"{len(connection_spy) - baseline} new connections opened for 20 "
+        "reads — the per-query connect is back"
+    )
+
+
+def test_failed_transaction_rolls_back_and_connection_stays_usable(
+    tmp_path: Path,
+):
+    db = WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="ws-a", name="Alpha")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with db.transaction() as conn:
+            conn.execute(
+                "UPDATE workspace_records SET name = ? WHERE workspace_id = ?",
+                ("Broken", "ws-a"),
+            )
+            raise RuntimeError("boom")
+
+    # Rolled back...
+    rows = [w for w in service.list_workspaces() if w.workspace_id == "ws-a"]
+    assert rows and rows[0].name == "Alpha"
+    # ...and the held connection keeps working for writes afterwards.
+    service.create_workspace(workspace_id="ws-b", name="Beta")
+    assert any(
+        w.workspace_id == "ws-b" for w in service.list_workspaces()
+    )
+
+
+def test_each_thread_gets_its_own_connection(tmp_path: Path):
+    db = WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1")
+    service = LocalWorkspaceRegistryService(db)
+    service.ensure_default_workspace()
+
+    seen: dict[str, object] = {}
+    errors: list[BaseException] = []
+
+    def read(tag: str) -> None:
+        try:
+            with db.connection() as conn:
+                conn.execute("SELECT COUNT(*) FROM workspace_records").fetchone()
+                seen[tag] = conn
+        except BaseException as exc:  # noqa: BLE001 - surface to the test
+            errors.append(exc)
+
+    threads = [threading.Thread(target=read, args=(f"t{i}",)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"cross-thread use failed: {errors}"
+    assert seen["t0"] is not seen["t1"], (
+        "two threads shared one sqlite connection"
+    )

--- a/backlog/tasks/task-3011 - Workspace_DB-opens-a-fresh-SQLite-connection-per-query.md
+++ b/backlog/tasks/task-3011 - Workspace_DB-opens-a-fresh-SQLite-connection-per-query.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-3011
 title: Workspace_DB opens a fresh private-SQLite connection per query (1,352 in one Console push)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-07 23:30'
 labels:
@@ -20,10 +20,27 @@ cProfile of a single ChatScreen push (task-2902 round 2): `Workspace_DB.connecti
 Fix shape: hold one connection per Workspace_DB instance (thread-affine like the other `base_db` users), or at minimum a connection cache keyed by thread. Audit callers for cross-thread use before switching (the scheduler and screen both read workspace state).
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Thread audit: consumers are the main asyncio loop (screen/controller/registry service; Textual workers default to same-thread) plus potentially the agent worker thread — thread-local storage is correct for both by construction.
+2. RED: spy `connect_private_sqlite` at the base-db seam — after warm-up, 10 registry reads must open 0 new connections (today: 1 per call); a failing transaction must roll back AND leave the held connection usable; two threads must get two distinct connections.
+3. GREEN: follow the established ChaChaNotes idiom (thread-local held connection, liveness check with transparent reopen, PRAGMA foreign_keys at open) — WorkspaceDB's `connection()`/`transaction()` stop `closing()` per use; `close()` closes the current thread's connection.
+4. Gate: Workspaces test dir + the A/B push probe from task-2902's notes for the measured win.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] A Console push opens a bounded, small number of Workspace_DB connections (target: 1 per thread), verified by the same profiling method.
-- [ ] Thread-safety of the reused connection is explicitly verified for every current caller.
-- [ ] Existing Workspace_DB tests green.
+- [x] A Console push opens a bounded, small number of Workspace_DB connections (target: 1 per thread), verified by the same profiling method.
+- [x] Thread-safety of the reused connection is explicitly verified for every current caller.
+- [x] Existing Workspace_DB tests green.
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+WorkspaceDB now holds one connection per thread, following ChaChaNotes' `_get_thread_connection` idiom including the task-261 idle-gated liveness ping (a per-call `SELECT 1` would have doubled statement count on exactly this hot path); `connection()`/`transaction()` reuse the held connection, `close()` tears down the current thread's. Thread audit: consumers are the main asyncio loop plus the agent worker thread — thread-local is correct for both by construction, pinned by the two-threads test.
+
+**Measured (interleaved A/B push probes, dev vs branch, same machine): settled push 2.93–3.29s → 1.18–1.29s (~60%)** — far beyond the 0.64s the profile attributed to `connect_private_sqlite` alone, because every post-mount sync pass re-reads workspace state and each read previously paid full connection setup. Tests: reuse pin (spy on the base-db seam: 20 reads, 0 new connections — watched RED at 1-per-read), failed-transaction rollback + connection-stays-usable guard, per-thread isolation guard; full Workspaces dir + Tools workspace-roots + console consumer gate: 244 + 364 passed. Probe-time widget count differs by one between dev (359) and branch (358) — a loading indicator still mounted at dev's slower settle moment, not a DOM change (diff is DB-only). Follow-up task-3012: `AgentRuns_DB` documents itself as following "the Workspace_DB pattern: per-call connections" — same fix applies. Files: tldw_chatbook/DB/Workspace_DB.py, Tests/Workspaces/test_workspace_db_connection_reuse.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3012 - AgentRuns_DB-per-call-connections-same-fix-as-3011.md
+++ b/backlog/tasks/task-3012 - AgentRuns_DB-per-call-connections-same-fix-as-3011.md
@@ -1,0 +1,27 @@
+---
+id: TASK-3012
+title: AgentRuns_DB opens per-call connections — apply the task-3011 held-connection fix
+status: To Do
+assignee: []
+created_date: '2026-08-07 06:00'
+labels:
+  - db
+  - agents
+  - performance
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while gating task-3011: `AgentRuns_DB`'s module docstring says it "follows the Workspace_DB pattern: BaseDB, per-call connections" — the exact anti-pattern task-3011 just removed from WorkspaceDB (which measured ~60% of the Console push). AgentRuns is hot during agent runs (per-step persistence), so each step currently pays full private-SQLite connection setup. Apply the same thread-local held-connection idiom (idle-gated liveness ping, per-thread isolation, close() teardown) with the same three-test shape (reuse pin watched RED, rollback+usable guard, per-thread guard). Note the agent service runs on a worker thread — the thread-local design covers it, but the audit should confirm no connection is shared across the service/main boundary.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] Repeated AgentRuns reads/writes on one thread open no new connections after warm-up (spy-pinned, watched RED first).
+- [ ] Transaction rollback semantics and post-failure usability preserved; per-thread isolation pinned.
+- [ ] Existing AgentRuns/Agents test files green.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -2,20 +2,36 @@
 
 from __future__ import annotations
 
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 from pathlib import Path
 import sqlite3
+import threading
+import time
 from typing import Iterator, Union
 
 from .base_db import BaseDB
 
 
 class WorkspaceDB(BaseDB):
-    """Database wrapper for local workspace registry state."""
+    """Database wrapper for local workspace registry state.
+
+    task-3011: connections are held per thread (the ChaChaNotes
+    `_get_thread_connection` idiom, simplified). The old `closing()`-per-use
+    shape opened a brand-new private-SQLite connection for every query —
+    1,352 of them during a single Console screen push (0.64s of first
+    paint, cProfile in task-2902's notes).
+    """
 
     _CURRENT_SCHEMA_VERSION = 2
 
+    #: Liveness-ping gate (mirrors `ChaChaNotes_DB`, task-261): pinging on
+    #: every call roughly doubles the raw statement count on query-heavy
+    #: paths, and this DB is exactly such a path (~1,350 calls per Console
+    #: push). A recently-used held connection is known-good without a ping.
+    _LIVENESS_PING_IDLE_SECONDS = 30.0
+
     def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
+        self._thread_local = threading.local()
         super().__init__(db_path, client_id)
 
     def _get_connection(self) -> sqlite3.Connection:
@@ -23,26 +39,65 @@ class WorkspaceDB(BaseDB):
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
+    def _held_connection(self) -> sqlite3.Connection:
+        """Return this thread's held connection, opening or reviving it.
+
+        The liveness probe is a plain no-op statement; a connection another
+        component closed (or that SQLite invalidated) is transparently
+        replaced, mirroring `ChaChaNotes_DB._get_thread_connection`.
+        """
+        conn = getattr(self._thread_local, "conn", None)
+        if conn is not None:
+            last_used = getattr(self._thread_local, "conn_last_used", None)
+            if (
+                last_used is None
+                or (time.monotonic() - last_used)
+                >= self._LIVENESS_PING_IDLE_SECONDS
+            ):
+                try:
+                    conn.execute("SELECT 1")
+                except (sqlite3.ProgrammingError, sqlite3.OperationalError):
+                    try:
+                        conn.close()
+                    except Exception:  # noqa: BLE001 - already unusable
+                        pass
+                    conn = None
+        if conn is None:
+            conn = self._get_connection()
+            self._thread_local.conn = conn
+        self._thread_local.conn_last_used = time.monotonic()
+        return conn
+
     @contextmanager
     def connection(self) -> Iterator[sqlite3.Connection]:
-        """Open a connection with row factory and foreign keys enabled."""
+        """Yield the thread's held connection (row factory, foreign keys on)."""
 
-        with closing(self._get_connection()) as conn:
-            yield conn
+        yield self._held_connection()
 
     @contextmanager
     def transaction(self) -> Iterator[sqlite3.Connection]:
-        """Open a write transaction that rolls back on failure."""
+        """Run a write transaction on the held connection; roll back on failure."""
 
-        with closing(self._get_connection()) as conn:
-            conn.execute("BEGIN")
+        conn = self._held_connection()
+        conn.execute("BEGIN")
+        try:
+            yield conn
+        except Exception:
+            conn.rollback()
+            raise
+        else:
+            conn.commit()
+
+    def close(self) -> None:
+        """Close the current thread's held connection, if any."""
+
+        conn = getattr(self._thread_local, "conn", None)
+        self._thread_local.conn = None
+        if conn is not None:
             try:
-                yield conn
-            except Exception:
-                conn.rollback()
-                raise
-            else:
-                conn.commit()
+                conn.close()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
 
     def _initialize_schema(self) -> None:
         """Initialize the local workspace registry schema."""


### PR DESCRIPTION
## Summary

First of the two real Console levers task-2902's profiling named (the widget-deferral experiment measured 4–8% and was rejected; this one measured **~60%**).

`WorkspaceDB.connection()`/`transaction()` wrapped every use in `closing(fresh connection)` — **1,352 private-SQLite connections opened during a single Console screen push**. Every post-mount sync pass re-reads workspace state, so each read paid full connection setup (open, pragmas, private-mode). Now it holds one connection per thread, following ChaChaNotes' established `_get_thread_connection` idiom including the task-261 idle-gated liveness ping (a per-call `SELECT 1` would double statement count on exactly this hot path). `close()` tears down the current thread's connection.

## Measured (interleaved A/B push probes, dev vs branch, same machine)

| | dev | branch |
|---|---|---|
| push first paint | 1.36–2.51s | **0.99–1.10s** |
| push settled | 2.93–3.29s | **1.18–1.29s** |

Far beyond the 0.64s the profile attributed to `connect_private_sqlite` alone — the connection storm's real cost rode inside every sync pass.

## Verification
- Thread audit in-task: consumers are the main asyncio loop + the agent worker thread; thread-local is correct for both, pinned by a two-threads isolation test.
- TDD: connection-reuse pin (spy at the base-db seam; 20 reads → 0 new connections) watched RED at one-per-read; failed-transaction rollback + connection-stays-usable guard; per-thread guard.
- Full `Tests/Workspaces/` + Tools workspace-roots: 244 passed. Console consumer gate (chat controller + internals + workspace rail): 364 passed. `--collect-only`: 31,876.
- Probe-time widget counts differ by one (dev 359 / branch 358): a loading indicator still mounted at dev's slower settle moment — the diff is DB-only.

Also files **task-3012**: `AgentRuns_DB` documents itself as following 'the Workspace_DB pattern: per-call connections' — the same fix applies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hold one SQLite connection per thread in `WorkspaceDB` instead of opening a new one per query. Implements task-3011 and cuts Console push time by ~60% (settled 2.93–3.29s → 1.18–1.29s).

- **Refactors**
  - `connection()`/`transaction()` reuse a thread-local connection; `close()` tears down the current thread’s connection.
  - Idle-gated liveness ping (30s) revives stale connections without per-call queries.
  - Tests added: zero new connections after warm-up, rollback keeps connection usable, per-thread isolation. Follow-up noted in task-3012 for `AgentRuns_DB`.

<sup>Written for commit f328b5344d9a640cad78a8b64be44d82847fb8bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

