### PR TITLE
perf(db): AgentRunsDB holds one connection per thread (task 3012)

### DIFF
--- a/Tests/Agents/test_agent_runs_db_connection_reuse.py
+++ b/Tests/Agents/test_agent_runs_db_connection_reuse.py
@@ -1,0 +1,96 @@
+"""task-3012: AgentRunsDB holds one connection per thread.
+
+Its module docstring said it "follows the Workspace_DB pattern: per-call
+connections" — the anti-pattern task-3011 removed from WorkspaceDB after it
+measured ~60% of the Console push. AgentRuns pays it per agent step.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+@pytest.fixture()
+def connection_spy(monkeypatch):
+    """Count real private-sqlite connection opens through the base-db seam."""
+    import tldw_chatbook.DB.base_db as base_db
+
+    real_connect = base_db.connect_private_sqlite
+    opened: list[object] = []
+
+    def counting_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(base_db, "connect_private_sqlite", counting_connect)
+    return opened
+
+
+def test_repeated_reads_open_no_new_connections(tmp_path: Path, connection_spy):
+    db = AgentRunsDB(tmp_path / "agent_runs.sqlite", client_id="client-1")
+    db.create_run(conversation_id="conv-1", agent_kind="primary")  # warm-up
+
+    baseline = len(connection_spy)
+    for _ in range(10):
+        db.list_runs(conversation_id="conv-1")
+    assert len(connection_spy) == baseline, (
+        f"{len(connection_spy) - baseline} new connections opened for 10 "
+        "reads — the per-query connect is back"
+    )
+
+
+def test_failed_transaction_rolls_back_and_connection_stays_usable(
+    tmp_path: Path,
+):
+    db = AgentRunsDB(tmp_path / "agent_runs.sqlite", client_id="client-1")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with db.transaction() as conn:
+            conn.execute(
+                "UPDATE agent_runs SET status = ? WHERE id = ?",
+                ("failed", run_id),
+            )
+            raise RuntimeError("boom")
+
+    # Rolled back (BEGIN IMMEDIATE path)...
+    runs = {r["id"]: r for r in db.list_runs(conversation_id="conv-1")}
+    assert runs[run_id]["status"] == "running"
+    # ...and the held connection keeps working for writes afterwards.
+    second = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    assert second in {
+        r["id"] for r in db.list_runs(conversation_id="conv-1")
+    }
+
+
+def test_each_thread_gets_its_own_connection(tmp_path: Path):
+    db = AgentRunsDB(tmp_path / "agent_runs.sqlite", client_id="client-1")
+    db.create_run(conversation_id="conv-1", agent_kind="primary")
+
+    seen: dict[str, object] = {}
+    errors: list[BaseException] = []
+
+    def read(tag: str) -> None:
+        try:
+            with db.connection() as conn:
+                conn.execute("SELECT COUNT(*) FROM agent_runs").fetchone()
+                seen[tag] = conn
+        except BaseException as exc:  # noqa: BLE001 - surface to the test
+            errors.append(exc)
+
+    threads = [threading.Thread(target=read, args=(f"t{i}",)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"cross-thread use failed: {errors}"
+    assert seen["t0"] is not seen["t1"], (
+        "two threads shared one sqlite connection"
+    )

--- a/backlog/tasks/task-3012 - AgentRuns_DB-per-call-connections-same-fix-as-3011.md
+++ b/backlog/tasks/task-3012 - AgentRuns_DB-per-call-connections-same-fix-as-3011.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-3012
 title: AgentRuns_DB opens per-call connections — apply the task-3011 held-connection fix
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-07 06:00'
 labels:
@@ -18,10 +18,26 @@ priority: low
 Found while gating task-3011: `AgentRuns_DB`'s module docstring says it "follows the Workspace_DB pattern: BaseDB, per-call connections" — the exact anti-pattern task-3011 just removed from WorkspaceDB (which measured ~60% of the Console push). AgentRuns is hot during agent runs (per-step persistence), so each step currently pays full private-SQLite connection setup. Apply the same thread-local held-connection idiom (idle-gated liveness ping, per-thread isolation, close() teardown) with the same three-test shape (reuse pin watched RED, rollback+usable guard, per-thread guard). Note the agent service runs on a worker thread — the thread-local design covers it, but the audit should confirm no connection is shared across the service/main boundary.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Differences from 3011 that must survive: `BEGIN IMMEDIATE` transactions (concurrent primary + sub-agent writers), WAL + busy_timeout pragmas (documented cross-process contention), and the reconcile-on-init sweep. All are per-connection properties — a thread-local held connection keeps every one.
+2. Thread audit: agent service worker thread + sub-agent threads + main-loop UI reads — thread-local gives each its own connection; short-lived run threads leak-close at GC exactly as ChaChaNotes' pattern does.
+3. RED: the 3011 three-test shape against AgentRunsDB (reuse pin via the base-db spy watched RED; failed-BEGIN-IMMEDIATE rollback + connection-stays-usable; two-thread isolation).
+4. GREEN: same thread-local + idle-gated liveness idiom; `close()` teardown.
+5. Gate: Agents test files using AgentRunsDB + collect-only.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
-- [ ] Repeated AgentRuns reads/writes on one thread open no new connections after warm-up (spy-pinned, watched RED first).
-- [ ] Transaction rollback semantics and post-failure usability preserved; per-thread isolation pinned.
-- [ ] Existing AgentRuns/Agents test files green.
+- [x] Repeated AgentRuns reads/writes on one thread open no new connections after warm-up (spy-pinned, watched RED first).
+- [x] Transaction rollback semantics and post-failure usability preserved; per-thread isolation pinned.
+- [x] Existing AgentRuns/Agents test files green.
 <!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Applied the 3011 idiom (thread-local held connection, idle-gated liveness ping, `close()` teardown) with AgentRuns' specifics preserved: `BEGIN IMMEDIATE` transactions, WAL + busy_timeout pragmas, and reconcile-on-init — all per-connection properties re-applied on every (re)open. One real discovery beyond the mechanical port: **the held connection required `isolation_level = None`** — Python's default mode auto-BEGINs on any DML, and the accumulated implicit transaction made the explicit `BEGIN IMMEDIATE` raise "cannot start a transaction within a transaction". The per-call shape had masked this — and worse, it silently ROLLED BACK any bare DML issued through `connection()` (close-without-commit). Audited every `connection()` site before switching: all read-only except `_initialize_schema`, whose `executescript` self-commits under either mode, so autocommit changes no existing behavior. Tests: the 3011 three-test shape (reuse pin watched RED at one-connection-per-read; BEGIN-IMMEDIATE rollback + connection-stays-usable; two-thread isolation). Gate: full `Tests/Agents/` + change-review screen + agent rail + agent bridge — 938 passed. Files: tldw_chatbook/DB/AgentRuns_DB.py, Tests/Agents/test_agent_runs_db_connection_reuse.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -1,15 +1,19 @@
 """SQLite persistence for agent run records (primary + sub-agent).
 
-Follows the Workspace_DB pattern: BaseDB, per-call connections (reads get
-their own connection automatically), transaction() for writes.
+Follows the Workspace_DB pattern (task-3011 form): BaseDB with a
+thread-local held connection — the earlier per-call shape paid full
+private-SQLite connection setup on every read/write, per agent step —
+and ``transaction()`` (BEGIN IMMEDIATE) for writes.
 """
 
 from __future__ import annotations
 
 import json
 import sqlite3
+import threading
+import time
 import uuid
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Sequence, Iterator, Union
@@ -29,7 +33,13 @@ class AgentRunsDB(BaseDB):
     _CURRENT_SCHEMA_VERSION = 3
     _swept_paths: set[str] = set()  # DB files already reconciled this process
 
+    #: Liveness-ping gate (mirrors ChaChaNotes/WorkspaceDB, task-261/3011):
+    #: a per-call ``SELECT 1`` would double statement count on the per-step
+    #: persistence path; a recently-used held connection is known-good.
+    _LIVENESS_PING_IDLE_SECONDS = 30.0
+
     def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
+        self._thread_local = threading.local()
         super().__init__(db_path, client_id)
         # After super().__init__: the agent_runs table exists (base_db ran
         # _initialize_schema) and self.is_memory_db is set. Reconcile once per
@@ -59,18 +69,68 @@ class AgentRunsDB(BaseDB):
         if not self.is_memory_db:
             conn.execute("PRAGMA journal_mode = WAL")
         conn.row_factory = sqlite3.Row
+        # task-3012: the held (long-lived) connection needs true autocommit.
+        # Python's default isolation mode auto-BEGINs on any DML, and an
+        # implicit transaction accumulated outside `transaction()` makes the
+        # explicit `BEGIN IMMEDIATE` there fail with "cannot start a
+        # transaction within a transaction" (per-call connections masked
+        # this — and silently ROLLED BACK any bare DML on close). Audited:
+        # every `connection()` site is read-only except `_initialize_schema`,
+        # whose `executescript` self-commits under either mode.
+        conn.isolation_level = None
+        return conn
+
+    def _held_connection(self) -> sqlite3.Connection:
+        """Return this thread's held connection, opening or reviving it.
+
+        task-3012: mirrors ``WorkspaceDB._held_connection`` (itself the
+        ChaChaNotes idiom). Every per-connection property this DB relies on
+        — WAL, busy_timeout, foreign keys, row factory — is applied by
+        ``_get_connection`` when the held connection is (re)opened.
+        """
+        conn = getattr(self._thread_local, "conn", None)
+        if conn is not None:
+            last_used = getattr(self._thread_local, "conn_last_used", None)
+            if (
+                last_used is None
+                or (time.monotonic() - last_used)
+                >= self._LIVENESS_PING_IDLE_SECONDS
+            ):
+                try:
+                    conn.execute("SELECT 1")
+                except (sqlite3.ProgrammingError, sqlite3.OperationalError):
+                    try:
+                        conn.close()
+                    except Exception:  # noqa: BLE001 - already unusable
+                        pass
+                    conn = None
+        if conn is None:
+            conn = self._get_connection()
+            self._thread_local.conn = conn
+        self._thread_local.conn_last_used = time.monotonic()
         return conn
 
     @contextmanager
     def connection(self) -> Iterator[sqlite3.Connection]:
-        """Yield a fresh read connection, closed on exit.
+        """Yield the calling thread's held read connection.
 
         Yields:
-            A ``sqlite3.Connection`` scoped to this ``with`` block; every
-            caller gets its own connection (no shared/cached state).
+            The thread's held ``sqlite3.Connection`` (per-thread isolation
+            replaces the old per-call isolation; WAL keeps concurrent
+            reader/writer threads and processes non-blocking).
         """
-        with closing(self._get_connection()) as conn:
-            yield conn
+        yield self._held_connection()
+
+    def close(self) -> None:
+        """Close the current thread's held connection, if any."""
+
+        conn = getattr(self._thread_local, "conn", None)
+        self._thread_local.conn = None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
 
     @contextmanager
     def transaction(self) -> Iterator[sqlite3.Connection]:
@@ -91,15 +151,15 @@ class AgentRunsDB(BaseDB):
             Exception: Re-raised after rolling back, on any error inside
                 the ``with`` block. On clean exit the transaction commits.
         """
-        with closing(self._get_connection()) as conn:
-            conn.execute("BEGIN IMMEDIATE")
-            try:
-                yield conn
-            except Exception:
-                conn.rollback()
-                raise
-            else:
-                conn.commit()
+        conn = self._held_connection()
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+        except Exception:
+            conn.rollback()
+            raise
+        else:
+            conn.commit()
 
     def _initialize_schema(self) -> None:
         with self.connection() as conn:


### PR DESCRIPTION
## Summary

Follow-up filed from task-3011: `AgentRunsDB`'s module docstring described itself as following 'the Workspace_DB pattern: per-call connections' — the anti-pattern that measured ~60% of the Console push when removed from WorkspaceDB. AgentRuns paid it per agent step (run creation, step persistence, snapshots). Same thread-local held-connection idiom now applied, with AgentRuns' specifics preserved: `BEGIN IMMEDIATE` transactions (concurrent primary + sub-agent writers), WAL + busy_timeout (documented cross-process contention), reconcile-on-init.

## The one non-mechanical finding

The held connection required `isolation_level = None`: Python's default mode auto-BEGINs a transaction on any DML, and the accumulated implicit transaction made the explicit `BEGIN IMMEDIATE` raise *'cannot start a transaction within a transaction'*. The per-call shape had masked this — and worse, it was **silently rolling back any bare DML issued through `connection()`** (close-without-commit). Audited before switching: every `connection()` site is read-only except `_initialize_schema`, whose `executescript` self-commits under either mode — so autocommit changes no existing behavior, it just stops the silent-rollback trap being possible.

## Verification
- 3011's three-test shape: connection-reuse pin (spy at the base-db seam) watched RED at one-per-read; BEGIN-IMMEDIATE rollback + connection-stays-usable guard; two-thread isolation guard.
- Consumer gate: full `Tests/Agents/` + change-review screen + console agent rail + agent bridge — **938 passed, 0 failed**.
- `--collect-only`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`AgentRunsDB` now holds one SQLite connection per thread to remove per-call connection overhead and speed up agent-step performance. Implements task-3012 while preserving existing concurrency and transaction semantics.

- **Refactors**
  - Use a thread-local held connection with an idle liveness ping; `connection()` returns it and `close()` tears it down.
  - Preserve `BEGIN IMMEDIATE`, `WAL`, `busy_timeout`, and reconcile-on-init per connection.
  - Set `isolation_level=None` to avoid auto-BEGIN so explicit `BEGIN IMMEDIATE` works and to prevent silent rollbacks.
  - Update `transaction()` to use the held connection; add tests for reuse, rollback-then-usable, and per-thread isolation.

<sup>Written for commit 5c678632c51fe5d00402d8d7486a9244785d0db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

