### PR TITLE
fix(speech): honest first-load staleness + stuck-Generate token detach (TASK-2970, TASK-3000)

### DIFF
--- a/Tests/UI/test_speech_playground_pane_lifecycle.py
+++ b/Tests/UI/test_speech_playground_pane_lifecycle.py
@@ -1983,6 +1983,70 @@ async def test_exact_profile_cannot_generate_while_voice_validation_is_pending(
         assert app.query_one("#tts-generate-btn", Button).disabled is True
 
 
+# TASK-3000 (fixed): a config change arriving while an exact profile's
+# voice validation is in flight, on a request that ignores cancellation
+# and keeps running, never cleared `_profile_voice_validation_token` --
+# not in `mark_provider_configuration_changed`, not in the failed-reload
+# exception path, not in `_catalog_failure`. `_generation_readiness_
+# error`'s preset branch blocks unconditionally on that token being
+# non-None, so Generate stayed disabled forever with no way to recover
+# short of leaving and re-entering the Playground. Confirmed pre-existing
+# by task-2951's own re-review, identical against pre- and post-fix
+# task-2951 code -- a fail-*closed* gap, the opposite direction from the
+# two fail-open CRITICALs that task fixed. The retired widget's own
+# `mark_provider_configuration_changed` (`git show
+# f560217fb~1:tldw_chatbook/UI/STTS_Window.py`) detached the token
+# immediately, as soon as the change targeted the token's own provider,
+# before any reload even ran -- ported verbatim rather than inventing a
+# parallel settling path; the existing `_catalog_failure` preset branch
+# (task-2951 CRITICAL-2) already settles availability to "unverified" and
+# re-enables Generate for one warned exact attempt once the token is out
+# of the way.
+@pytest.mark.asyncio
+async def test_configuration_change_detaches_cancellation_resistant_profile_voice_gate(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    request_key = ("audio_cpp", "<opaque:model>")
+    service.voice_started_by_request[request_key] = asyncio.Event()
+    service.voice_finished_by_request[request_key] = asyncio.Event()
+    service.voice_gates[request_key] = asyncio.Event()
+    service.voice_ignore_cancellation.add(request_key)
+    preset = _profile_preset(model_id=request_key[1], voice_id="[voice]")
+    app = _PaneHost(preset=preset)
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await service.voice_started_by_request[request_key].wait()
+        pane = app.query_one(SpeechPlaygroundPane)
+
+        service.revisions["audio_cpp"] = 2
+        pane.mark_provider_configuration_changed("audio_cpp", 2)
+        service.catalog_error = RuntimeError("private catalog failure")
+        pane._load_provider_catalog("audio_cpp", refresh=True)
+        await _wait_until(
+            pilot,
+            lambda: (
+                pane._profile_effective_availability == "unverified"
+                and pane._catalog_generation_allowed
+            ),
+        )
+
+        assert pane._profile_voice_validation_token is None
+        assert app.query_one("#tts-generate-btn", Button).disabled is False
+
+        pane.action_generate_tts()
+        await pilot.pause()
+
+        assert len(app.generation_events) == 1
+        assert any(
+            "unverified" in message.lower() and severity == "warning"
+            for message, severity in app.notices
+        )
+
+        service.voice_gates[request_key].set()
+        await service.voice_finished_by_request[request_key].wait()
+
+
 @pytest.mark.asyncio
 async def test_stale_catalog_downgrades_available_profile_to_warned_unverified_attempt(
     audio_cpp_playground: FakeTTSService,

--- a/Tests/UI/test_speech_playground_pane_lifecycle.py
+++ b/Tests/UI/test_speech_playground_pane_lifecycle.py
@@ -1278,9 +1278,9 @@ async def test_higgs_saved_profile_is_prefixed_exactly_once_in_request(
         assert app.generation_events[0].request.voice_id == "profile:saved-voice"
 
 
-#: PANE DEFECT (see the `xfail`s below): `_load_provider_catalog_worker`
-#: adds a provider to `_stale_providers` whenever the *freshly-fetched*
-#: catalog itself reports `health.fresh is False` --
+#: TASK-2970 (fixed): `_load_provider_catalog_worker` used to add a
+#: provider to `_stale_providers` whenever the *freshly-fetched* catalog
+#: itself reported `health.fresh is False`, unconditionally --
 #:
 #:     if catalog.health.fresh:
 #:         self._stale_providers.discard(provider_id)
@@ -1288,28 +1288,22 @@ async def test_higgs_saved_profile_is_prefixed_exactly_once_in_request(
 #:         self._stale_providers.add(provider_id)
 #:
 #: -- and `_catalog_health_copy` checks `_stale_providers` FIRST, ahead of
-#: `health.state`, so any fresh (first-ever) load whose health happens to
+#: `health.state`, so any fresh (first-ever) load whose health happened to
 #: report `fresh=False` (a "reconfiguring" provider, or a naturally stale
-#: "available" catalog) is shown the generic "settings changed; refresh
+#: "available" catalog) was shown the generic "settings changed; refresh
 #: models" instead of the accurate, state-specific recovery copy -- even
-#: though nothing has changed; this is simply how the very first read came
-#: back. Confirmed NOT present in the retired widget: its equivalent
+#: though nothing had changed; this was simply how the very first read
+#: came back. Confirmed NOT present in the retired widget: its equivalent
 #: success path was an unconditional `self._stale_providers.discard(
 #: provider_id)` with no `health.fresh` branch at all (verified by diffing
 #: `git show HEAD:tldw_chatbook/UI/STTS_Window.py` against the pane before
-#: this branch's own sibling task deleted the widget). `_catalog_health_
-#: copy` itself is byte-for-byte identical between the two -- the
-#: divergence is entirely in what populates `_stale_providers`.
-_STALE_ON_FIRST_LOAD_DEFECT = (
-    "PANE DEFECT (TASK-2951 finding): a fresh (first-ever) catalog load "
-    "whose reported health.fresh is False is shown the generic 'settings "
-    "changed; refresh models' instead of the accurate state-specific "
-    "copy, because _load_provider_catalog_worker marks the provider "
-    "'stale' purely from health.fresh on ANY load, not only a load that "
-    "followed a real configuration change. The retired widget's "
-    "equivalent success path never did this (unconditional discard, no "
-    "health.fresh branch)."
-)
+#: TASK-2951 deleted the widget). Fixed by only adding to `_stale_
+#: providers` when this load's own configuration revision genuinely
+#: supersedes a previously recorded one for the same provider -- a real
+#: configuration change this particular fetch has not caught up to yet --
+#: not merely because this load's health happens to read non-fresh with no
+#: revision history behind it. The two health2/health3 parametrizations
+#: below were `xfail(strict=True)` against the pre-fix code; both now pass.
 
 
 @pytest.mark.asyncio
@@ -1324,21 +1318,13 @@ _STALE_ON_FIRST_LOAD_DEFECT = (
             ProviderHealth(state="not_configured", fresh=True),
             "not configured",
         ),
-        pytest.param(
+        (
             ProviderHealth(state="reconfiguring", fresh=False),
             "settings are being applied",
-            marks=pytest.mark.xfail(
-                reason=_STALE_ON_FIRST_LOAD_DEFECT,
-                strict=True,
-            ),
         ),
-        pytest.param(
+        (
             ProviderHealth(state="available", fresh=False),
             "catalog is stale",
-            marks=pytest.mark.xfail(
-                reason=_STALE_ON_FIRST_LOAD_DEFECT,
-                strict=True,
-            ),
         ),
     ),
 )

--- a/Tests/UI/test_speech_playground_pane_lifecycle.py
+++ b/Tests/UI/test_speech_playground_pane_lifecycle.py
@@ -1354,6 +1354,49 @@ async def test_audio_cpp_health_states_use_fixed_safe_recovery_copy(
         assert service.catalog_calls == [("audio_cpp", False)]
 
 
+# TASK-2970 positive branch: health2/health3 above pin the negative case (a
+# first-ever non-fresh load must NOT be marked stale). This test pins the
+# other half of AC#3 -- a SECOND load whose own configuration revision has
+# genuinely moved past the one recorded from the first is a real
+# supersession, and must still be marked stale with the settings-changed
+# copy. Mutation-checked by disabling the `elif` branch in
+# `_load_provider_catalog_worker` (`speech_catalog_mixin.py`, the genuine-
+# supersession check) so it always falls through to `discard` -- this test
+# alone goes red; health2/health3 and the TASK-3000 tests stay green.
+@pytest.mark.asyncio
+async def test_second_load_after_genuine_config_change_marks_provider_stale(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    app = _PaneHost()
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        pane = app.query_one(SpeechPlaygroundPane)
+
+        assert "audio_cpp" not in pane._stale_providers
+        assert pane._catalog_configuration_revisions["audio_cpp"] == 1
+
+        # A genuine configuration-revision bump, then a second, successful
+        # (token-current) reload whose catalog still reports non-fresh
+        # health -- unlike the first-ever load above, this one really did
+        # follow a real config change.
+        service.revisions["audio_cpp"] = 2
+        service.catalogs["audio_cpp"] = _audio_catalog(
+            health=ProviderHealth(state="available", fresh=False)
+        )
+        pane._load_provider_catalog("audio_cpp", refresh=True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert pane._catalog_configuration_revisions["audio_cpp"] == 2
+        assert "audio_cpp" in pane._stale_providers
+        status = str(app.query_one("#tts-provider-status", Static).render()).lower()
+        assert "settings changed" in status
+
+
 # =====================================================================
 # Section B -- playback, export, unmount cleanup, mount rehydration
 # =====================================================================
@@ -2042,6 +2085,82 @@ async def test_configuration_change_detaches_cancellation_resistant_profile_voic
             "unverified" in message.lower() and severity == "warning"
             for message, severity in app.notices
         )
+
+        service.voice_gates[request_key].set()
+        await service.voice_finished_by_request[request_key].wait()
+
+
+# TASK-3000 regression guard (a): the token must detach ONLY on a genuine,
+# provider-matched `mark_provider_configuration_changed` call -- not on any
+# catalog-load failure whatsoever. A plain, unrelated catalog reload failure
+# while a voice validation is in flight (no config change anywhere in this
+# sequence) must leave the token, and Generate's disabled state, untouched.
+# Mutation-checked: widening `_load_provider_catalog_worker`'s `except
+# Exception` handler (speech_catalog_mixin.py ~:424-426) to clear
+# `self._profile_voice_validation_token` unconditionally, instead of only
+# its own locally-reserved `profile_voice_token`, turns this test red.
+@pytest.mark.asyncio
+async def test_unrelated_catalog_failure_does_not_detach_in_flight_profile_voice_token(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    request_key = ("audio_cpp", "<opaque:model>")
+    service.voice_started_by_request[request_key] = asyncio.Event()
+    service.voice_finished_by_request[request_key] = asyncio.Event()
+    service.voice_gates[request_key] = asyncio.Event()
+    preset = _profile_preset(model_id=request_key[1], voice_id="[voice]")
+    app = _PaneHost(preset=preset)
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await service.voice_started_by_request[request_key].wait()
+        pane = app.query_one(SpeechPlaygroundPane)
+        pending_token = pane._profile_voice_validation_token
+        assert pending_token is not None
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+
+        # No configuration change anywhere in this sequence -- just an
+        # unrelated catalog reload that fails for its own reasons.
+        service.catalog_error = RuntimeError("unrelated catalog failure")
+        pane._load_provider_catalog("audio_cpp", refresh=True)
+        await _wait_until(pilot, lambda: "audio_cpp" in pane._stale_providers)
+
+        assert pane._profile_voice_validation_token is pending_token
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
+
+        service.voice_gates[request_key].set()
+        await service.voice_finished_by_request[request_key].wait()
+
+
+# TASK-3000 regression guard (b): `mark_provider_configuration_changed`'s
+# token-detach only fires when the changed provider matches the token's OWN
+# provider. A config change for a completely different provider must leave
+# an audio_cpp exact profile's in-flight voice-validation token (and
+# Generate's disabled state) untouched. Mutation-checked: removing the
+# `pending_voice_token.provider_id == provider_id` guard
+# (speech_catalog_mixin.py ~:1527-1532) turns this test red.
+@pytest.mark.asyncio
+async def test_configuration_change_for_unrelated_provider_does_not_detach_profile_voice_token(
+    audio_cpp_playground: FakeTTSService,
+) -> None:
+    service = audio_cpp_playground
+    request_key = ("audio_cpp", "<opaque:model>")
+    service.voice_started_by_request[request_key] = asyncio.Event()
+    service.voice_finished_by_request[request_key] = asyncio.Event()
+    service.voice_gates[request_key] = asyncio.Event()
+    preset = _profile_preset(model_id=request_key[1], voice_id="[voice]")
+    app = _PaneHost(preset=preset)
+
+    async with app.run_test(size=(180, 70)) as pilot:
+        await service.voice_started_by_request[request_key].wait()
+        pane = app.query_one(SpeechPlaygroundPane)
+        pending_token = pane._profile_voice_validation_token
+        assert pending_token is not None
+
+        pane.mark_provider_configuration_changed("openai", 2)
+        await pilot.pause()
+
+        assert pane._profile_voice_validation_token is pending_token
+        assert app.query_one("#tts-generate-btn", Button).disabled is True
 
         service.voice_gates[request_key].set()
         await service.voice_finished_by_request[request_key].wait()

--- a/backlog/tasks/task-2970 - SpeechPlaygroundPane-marks-a-provider-stale-on-any-non-fresh-first-catalog-load-not-only-after-a-real-config-change.md
+++ b/backlog/tasks/task-2970 - SpeechPlaygroundPane-marks-a-provider-stale-on-any-non-fresh-first-catalog-load-not-only-after-a-real-config-change.md
@@ -91,4 +91,20 @@ there). Repo-wide --collect-only: 31874 collected, 0 errors. ruff check + format
 
 Files: tldw_chatbook/UI/Speech/speech_catalog_mixin.py,
 Tests/UI/test_speech_playground_pane_lifecycle.py (un-xfail + comment rewrite).
+
+### Review round: positive-branch coverage added
+
+Coordinator review approved the fix but flagged that health2/health3 only pin the
+negative case (a first-ever non-fresh load must NOT be marked stale) -- AC#3's
+positive branch (a genuine second-load supersession MUST still be marked stale) had
+no dedicated test of its own. Added
+test_second_load_after_genuine_config_change_marks_provider_stale to
+Tests/UI/test_speech_playground_pane_lifecycle.py: mounts normally (records
+configuration revision 1), bumps service.revisions["audio_cpp"] to 2, drives a
+second, successful (token-current) reload whose catalog still reports fresh=False,
+and asserts _stale_providers gains the provider with the "settings changed" status
+copy. Mutation-checked by disabling the elif genuine-supersession branch in
+_load_provider_catalog_worker (falls through to unconditional discard); RED under
+that mutation (only this test), GREEN restored -- health2/health3 and both TASK-3000
+tests unaffected in either direction. No production-code change in this round.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2970 - SpeechPlaygroundPane-marks-a-provider-stale-on-any-non-fresh-first-catalog-load-not-only-after-a-real-config-change.md
+++ b/backlog/tasks/task-2970 - SpeechPlaygroundPane-marks-a-provider-stale-on-any-non-fresh-first-catalog-load-not-only-after-a-real-config-change.md
@@ -3,9 +3,11 @@ id: TASK-2970
 title: >-
   SpeechPlaygroundPane marks a provider stale on any non-fresh first catalog
   load, not only after a real config change
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 04:19'
+updated_date: '2026-08-07 13:05'
 labels:
   - ui
   - speech
@@ -22,13 +24,71 @@ A first-ever (not-yet-configuration-changed) audio.cpp/OpenAI/etc. catalog load 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A first (or otherwise non-configuration-change) catalog load whose health.fresh is False shows the accurate state-specific recovery copy (reconfiguring -> settings are being applied; a naturally-stale available catalog -> catalog is stale), not the generic settings-changed copy
-- [ ] #2 The two xfail(strict=True) parametrizations in Tests/UI/test_speech_playground_pane_lifecycle.py::test_audio_cpp_health_states_use_fixed_safe_recovery_copy (health2, health3) are un-xfailed and pass
-- [ ] #3 SpeechCatalogMixin._load_provider_catalog_worker only adds a provider to _stale_providers when a catalog is genuinely superseding a previously-fresher one (e.g. a real configuration-revision change), not on every catalog application regardless of history
+- [x] #1 A first (or otherwise non-configuration-change) catalog load whose health.fresh is False shows the accurate state-specific recovery copy (reconfiguring -> settings are being applied; a naturally-stale available catalog -> catalog is stale), not the generic settings-changed copy
+- [x] #2 The two xfail(strict=True) parametrizations in Tests/UI/test_speech_playground_pane_lifecycle.py::test_audio_cpp_health_states_use_fixed_safe_recovery_copy (health2, health3) are un-xfailed and pass
+- [x] #3 SpeechCatalogMixin._load_provider_catalog_worker only adds a provider to _stale_providers when a catalog is genuinely superseding a previously-fresher one (e.g. a real configuration-revision change), not on every catalog application regardless of history
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Un-xfail the health2/health3 parametrizations in test_audio_cpp_health_states_use_fixed_safe_recovery_copy; run to confirm genuine RED against current code.
+2. In SpeechCatalogMixin._load_provider_catalog_worker's success path, capture the provider's previously-stored configuration revision (from _catalog_configuration_revisions) before it is overwritten by this load's own revision.
+3. Replace the unconditional `if catalog.health.fresh: discard else: add` with: discard when fresh; add only when NOT fresh AND a previous revision was recorded AND it differs from this load's revision (a genuine, real configuration-revision change this load hasn't caught up to yet); otherwise discard. This preserves _mark_stale_catalog_result and mark_provider_configuration_changed's own unconditional adds (untouched, out of scope) while fixing only this success-path branch.
+4. Re-run the two un-xfailed tests to confirm GREEN; blast-radius grep every _stale_providers reader/writer and run the full Speech/TTS gate list to confirm mark_provider_configuration_changed's own genuine-config-change copy is unaffected.
+5. Update the task file (AC boxes, Implementation Notes) and mark Done.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Filed from TASK-2951 (second TTSPlaygroundWidget deletion pass); full evidence trail (both code paths diffed, git show HEAD comparison) lives in the xfail reasons in Tests/UI/test_speech_playground_pane_lifecycle.py.
+Un-xfailed health2/health3 in test_audio_cpp_health_states_use_fixed_safe_recovery_copy;
+confirmed genuine RED (both asserted "settings changed; refresh models" instead of the
+state-specific copy) against pre-fix code before touching production code.
+
+Root cause confirmed via git show f560217fb~1:tldw_chatbook/UI/STTS_Window.py: the
+retired widget's equivalent success path did an unconditional
+self._stale_providers.discard(provider_id) with NO health.fresh branch at all -- the
+mixin-based rebuild independently reimplemented this path and added an
+if/else on catalog.health.fresh that marks ANY non-fresh load "stale", including the
+very first one, before any configuration could possibly have changed.
+
+Fix (SpeechCatalogMixin._load_provider_catalog_worker, success path): capture the
+provider's previously-stored configuration revision (_catalog_configuration_revisions,
+before this load overwrites it) and only add to _stale_providers when health.fresh is
+False AND a previous revision was recorded AND it differs from this load's own
+revision -- a genuine, real configuration-revision change this fetch has not caught up
+to yet. Otherwise (first load ever, or a non-fresh repeat load with no revision
+change) discard, matching the retired widget for the reachable case AC#1/#2 cover.
+This is a narrower rule than the retired widget's own (unconditional discard, no
+add path at all on this branch), chosen because AC#3's own wording specifically
+calls out "genuinely superseding a previously-fresher one (e.g. a real
+configuration-revision change)" as still warranting the add -- the configuration-
+revision transition is the literal, most precise signal for that, and it cannot
+misfire on the "flaky fresh flag with no real change" case a catalog-freshness-only
+comparison would.
+
+_mark_stale_catalog_result and mark_provider_configuration_changed (the two other,
+explicit _stale_providers.add() call sites) are untouched -- out of this task's scope,
+confirmed still producing the settings-changed copy via the existing
+test_configuration_change_marks_catalog_stale_without_connecting and
+test_catalog_result_is_discarded_when_configuration_revision_changes (both still
+green).
+
+Mutation-checked: temporarily reverted the fix back to the unconditional
+if/else -- confirmed ONLY health2/health3 failed, the sibling TASK-3000 test and
+health0/health1 stayed green; restored.
+
+Gates: targeted Speech/TTS suite (Tests/UI/test_speech_playground_pane_lifecycle.py,
+test_speech_playground_pane.py, test_stts_playground_catalog.py,
+Tests/TTS/test_stts_audio_cpp_generation.py) 205 passed; full Tests/UI/test_speech_*.py
++ test_stts_*.py + Tests/TTS/ + Tests/TTS_Events/ sweep: 2860 passed, 16 skipped
+(optional deps), 1 pre-existing failure unrelated to this change
+(test_first_time_audio_cpp_setup_lab_generation_and_console_handoff, already documented
+pre-existing in task-2951's own notes, confirmed against the unmodified base commit
+there). Repo-wide --collect-only: 31874 collected, 0 errors. ruff check + format
+--check clean on touched files.
+
+Files: tldw_chatbook/UI/Speech/speech_catalog_mixin.py,
+Tests/UI/test_speech_playground_pane_lifecycle.py (un-xfail + comment rewrite).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3000 - SpeechPlaygroundPane-a-cancellation-resistant-profile-voice-check-never-detaches-on-config-change-leaving-Generate-stuck-disabled.md
+++ b/backlog/tasks/task-3000 - SpeechPlaygroundPane-a-cancellation-resistant-profile-voice-check-never-detaches-on-config-change-leaving-Generate-stuck-disabled.md
@@ -3,9 +3,11 @@ id: TASK-3000
 title: >-
   SpeechPlaygroundPane: a cancellation-resistant profile voice check never
   detaches on config change, leaving Generate stuck disabled
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 05:40'
+updated_date: '2026-08-07 13:09'
 labels:
   - ui
   - speech
@@ -23,14 +25,66 @@ Fail-closed availability gap in the exact-profile generate-readiness path, disti
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 _profile_voice_validation_token detaches (returns to None) when a provider-configuration change is followed by a failed catalog reload while an exact profile's voice validation is in flight
-- [ ] #2 Profile availability settles to an honest state (unverified, matching the retired widget's behavior for this sequence) instead of staying stuck mid-validation
-- [ ] #3 Generate becomes enabled again and one warned exact attempt is allowed, matching the one-warned-attempt contract already restored for the naturally-stale-catalog case (task-2951 CRITICAL 2)
-- [ ] #4 test_configuration_change_detaches_cancellation_resistant_profile_voice_gate is ported from the retired widget's test suite as a real (non-xfail) assertion against SpeechPlaygroundPane and passes
+- [x] #1 _profile_voice_validation_token detaches (returns to None) when a provider-configuration change is followed by a failed catalog reload while an exact profile's voice validation is in flight
+- [x] #2 Profile availability settles to an honest state (unverified, matching the retired widget's behavior for this sequence) instead of staying stuck mid-validation
+- [x] #3 Generate becomes enabled again and one warned exact attempt is allowed, matching the one-warned-attempt contract already restored for the naturally-stale-catalog case (task-2951 CRITICAL 2)
+- [x] #4 test_configuration_change_detaches_cancellation_resistant_profile_voice_gate is ported from the retired widget's test suite as a real (non-xfail) assertion against SpeechPlaygroundPane and passes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Port test_configuration_change_detaches_cancellation_resistant_profile_voice_gate from the retired widget's pre-deletion test file (git show <sha>~1:Tests/UI/test_stts_playground_audio_cpp.py) into test_speech_playground_pane_lifecycle.py, targeting SpeechPlaygroundPane/_PaneHost with the FakeTTSService's existing voice_started_by_request/voice_gates/voice_ignore_cancellation machinery. Run it to confirm genuine RED against current code (button stuck disabled, token never clears).
+2. In SpeechCatalogMixin.mark_provider_configuration_changed, port the retired widget's token-detach block: when the currently in-flight _profile_voice_validation_token belongs to the provider whose configuration just changed, clear it (set to None) immediately, mirroring the retired widget's own mark_provider_configuration_changed verbatim (git show <sha>~1:tldw_chatbook/UI/STTS_Window.py).
+3. Re-run the ported test to confirm GREEN -- reuse the existing _catalog_failure preset branch (already settles availability to "unverified" and computes generation_allowed via _project_profile_preset_controls, per task-2951's CRITICAL-2 fix) rather than adding a parallel settling path.
+4. Interaction/mutation check against TASK-2970: re-run 2970's tests after 3000's change and vice versa; revert each fix independently and confirm only its own test(s) fail.
+5. Run the full gate list, ruff + format --check on touched files, repo-wide --collect-only; update the task file (AC boxes, notes) and mark Done.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Filed from task-2951's re-review (second TTSPlaygroundWidget deletion pass). Confirmed via an independent probe against both pre-fix and post-fix task-2951 code with identical results, so this is pre-existing and outside that task's own scope, not a regression it introduced. Retired widget reference: STTS_Window.py (pre-deletion) mark_provider_configuration_changed / the TTSProviderReconfiguringError-and-preset branch inside the voice-discovery exception handler, and the widget's own test_configuration_change_detaches_cancellation_resistant_profile_voice_gate.
+Ported test_configuration_change_detaches_cancellation_resistant_profile_voice_gate
+from the retired widget's pre-deletion test file (git show
+f560217fb~1:Tests/UI/test_stts_playground_audio_cpp.py) into
+Tests/UI/test_speech_playground_pane_lifecycle.py, targeting SpeechPlaygroundPane/
+_PaneHost via the existing FakeTTSService voice_started_by_request/voice_gates/
+voice_ignore_cancellation machinery (Tests/UI/speech_playground_fixtures.py already
+supported cancellation-resistant per-request-key gating, no fixture changes needed).
+Confirmed genuine RED against current code first: _profile_voice_validation_token
+stayed set (a real CatalogRequestToken, not None) and the assertion failed exactly as
+predicted by tracing _generation_readiness_error's preset branch, which blocks
+unconditionally on that token being non-None.
+
+Fix: ported the retired widget's own mark_provider_configuration_changed token-detach
+block verbatim (git show f560217fb~1:tldw_chatbook/UI/STTS_Window.py) -- when the
+currently in-flight _profile_voice_validation_token belongs to the provider whose
+configuration just changed, clear it to None immediately, before any reload even
+starts. This alone was sufficient: the existing _catalog_failure preset branch
+(task-2951's CRITICAL-2 fix) already settles _profile_effective_availability to
+"unverified" and computes _catalog_generation_allowed via
+_project_profile_preset_controls on the subsequent failed reload, so once the token
+stops blocking _generation_readiness_error, that already-correct settling path takes
+over on its own -- no parallel settling path was added, per the task's own framing
+("reuse that path, don't invent a parallel one").
+
+Interaction/mutation checks against TASK-2970 (both touch mark_provider_configuration_
+changed / the same success-path region of _load_provider_catalog_worker):
+- Mutation: temporarily removed the token-detach block -- confirmed ONLY this ported
+  test failed; TASK-2970's health2/health3 stayed green. Restored.
+- Interaction: re-ran TASK-2970's tests after this fix (green) and this test after
+  TASK-2970's fix (green); both fixes coexist in the full targeted suite with no
+  cross-contamination.
+
+Gates: targeted Speech/TTS suite (Tests/UI/test_speech_playground_pane_lifecycle.py,
+test_speech_playground_pane.py, test_stts_playground_catalog.py,
+Tests/TTS/test_stts_audio_cpp_generation.py) 205 passed (both fixes applied); full
+Tests/UI/test_speech_*.py + test_stts_*.py + Tests/TTS/ + Tests/TTS_Events/ sweep:
+2860 passed, 16 skipped (optional deps), 1 pre-existing failure unrelated to this
+change (test_first_time_audio_cpp_setup_lab_generation_and_console_handoff, already
+documented pre-existing in task-2951's own notes). Repo-wide --collect-only: 31874
+collected, 0 errors. ruff check + format --check clean on touched files.
+
+Files: tldw_chatbook/UI/Speech/speech_catalog_mixin.py (mark_provider_configuration_
+changed), Tests/UI/test_speech_playground_pane_lifecycle.py (new ported test).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3000 - SpeechPlaygroundPane-a-cancellation-resistant-profile-voice-check-never-detaches-on-config-change-leaving-Generate-stuck-disabled.md
+++ b/backlog/tasks/task-3000 - SpeechPlaygroundPane-a-cancellation-resistant-profile-voice-check-never-detaches-on-config-change-leaving-Generate-stuck-disabled.md
@@ -87,4 +87,45 @@ collected, 0 errors. ruff check + format --check clean on touched files.
 
 Files: tldw_chatbook/UI/Speech/speech_catalog_mixin.py (mark_provider_configuration_
 changed), Tests/UI/test_speech_playground_pane_lifecycle.py (new ported test).
+
+### Review round: trigger-wording correction + two regression-guard tests
+
+Coordinator review approved the fix as correct but flagged two things.
+
+First, a wording correction (no code change): this task's own description and my
+Implementation Notes above frame the trigger as "config change, followed by a failed
+catalog reload" -- narrower than what the fix actually depends on. The token detaches
+the moment mark_provider_configuration_changed runs for its own provider, full stop;
+no reload -- successful, failed, or never attempted at all -- has to follow. The
+failed reload in the ported test exists only to demonstrate that Generate *recovers*
+afterward (via the pre-existing _catalog_failure settling path), which is a separate
+guarantee from the detach itself. This isn't an ad-hoc relaxation: the event stream
+feeding mark_provider_configuration_changed is already scoped upstream to genuinely
+*applied* changes -- on_stts_provider_configuration_changed (stts_events.py
+:2092-2100) forwards every STTSProviderConfigurationChanged event verbatim, and that
+event is only ever posted by _post_applied_settings_changes (stts_events.py
+:1584-1598) for providers whose settings-save status == "applied".
+
+Second, two coverage-pinning tests were added to Tests/UI/test_speech_playground_pane_
+lifecycle.py to pin the fix's actual scope (only these two conditions -- no others --
+detach the token), rather than relying only on the reviewer's own throwaway probes:
+- test_unrelated_catalog_failure_does_not_detach_in_flight_profile_voice_token: voice
+  validation in flight, NO config-change event anywhere, an unrelated catalog reload
+  failure -- token and disabled button both untouched. Mutation-checked by widening
+  _load_provider_catalog_worker's except Exception handler to clear
+  self._profile_voice_validation_token unconditionally instead of only its own
+  locally-reserved profile_voice_token; RED under that mutation (only this test),
+  GREEN restored.
+- test_configuration_change_for_unrelated_provider_does_not_detach_profile_voice_token:
+  mark_provider_configuration_changed for a DIFFERENT provider while the token belongs
+  to audio_cpp -- token and disabled button both untouched. Mutation-checked by
+  removing the pending_voice_token.provider_id == provider_id guard; RED under that
+  mutation (only this test), GREEN restored.
+
+Both mutation checks were run together with health0-3 (TASK-2970) and the originally
+ported TASK-3000 test in one pytest invocation each, confirming no cross-
+contamination. Full 4-file targeted gate after adding both tests: 208 passed (205 +
+3, including TASK-2970's own new positive-branch test from the same review round).
+ruff check + format --check clean. No production-code changes in this round --
+mark_provider_configuration_changed's fix from the original pass is unchanged.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Speech/speech_catalog_mixin.py
+++ b/tldw_chatbook/UI/Speech/speech_catalog_mixin.py
@@ -1511,6 +1511,25 @@ class SpeechCatalogMixin:
             for key, value in self._voice_runtime_observed_at.items()
             if key[0] != provider_id
         }
+        # TASK-3000: an exact profile's voice validation can be in flight
+        # on a request that ignores cancellation and keeps running past
+        # the `cancel_group` calls below -- ported verbatim from the
+        # retired widget's own `mark_provider_configuration_changed`
+        # (`git show f560217fb~1:tldw_chatbook/UI/STTS_Window.py`), which
+        # detached the token right here, unconditionally, the moment a
+        # config change targeted its own provider. Without this, nothing
+        # downstream (this method's own worker cancellation, a failed
+        # catalog reload's exception path, `_catalog_failure`) ever clears
+        # it, `_generation_readiness_error`'s preset branch blocks
+        # unconditionally on it being non-None, and Generate stays
+        # disabled with no way to recover short of leaving and
+        # re-entering the Playground.
+        pending_voice_token = self._profile_voice_validation_token
+        if (
+            pending_voice_token is not None
+            and pending_voice_token.provider_id == provider_id
+        ):
+            self._profile_voice_validation_token = None
         if provider_id != self._selected_provider_id:
             return
         self.app.workers.cancel_group(self, "stts-catalog-discovery")

--- a/tldw_chatbook/UI/Speech/speech_catalog_mixin.py
+++ b/tldw_chatbook/UI/Speech/speech_catalog_mixin.py
@@ -316,6 +316,9 @@ class SpeechCatalogMixin:
                     for key, value in self._voice_runtime_observed_at.items()
                     if key[0] != provider_id
                 }
+            previous_configuration_revision = self._catalog_configuration_revisions.get(
+                provider_id
+            )
             self._catalogs[provider_id] = catalog
             self._catalog_configuration_revisions[provider_id] = configuration_revision
             self._catalog_observed_at[provider_id] = datetime.now(timezone.utc)
@@ -329,8 +332,29 @@ class SpeechCatalogMixin:
                 self._catalog_unavailable_providers.add(provider_id)
             if catalog.health.fresh:
                 self._stale_providers.discard(provider_id)
-            else:
+            elif (
+                previous_configuration_revision is not None
+                and previous_configuration_revision != configuration_revision
+            ):
+                # TASK-2970: a genuine supersession -- this provider's
+                # configuration actually changed since our last successful
+                # catalog load (tracked via `_catalog_configuration_
+                # revisions`), and this fresh fetch itself hasn't caught up
+                # to that change yet (`health.fresh` is False). Mirror that
+                # as "stale" so the status line's settings-changed copy
+                # stays accurate. A load that merely reports non-fresh
+                # health with no revision history behind it -- most
+                # notably the very first load ever for this provider,
+                # where `previous_configuration_revision` is None -- is
+                # NOT a genuine supersession: nothing has changed, this is
+                # simply how the first read came back. The retired
+                # widget's equivalent success path never marked stale here
+                # at all (unconditional discard, no `health.fresh` branch);
+                # this narrower condition is the one case task-2970's own
+                # AC#3 calls out as still warranting it.
                 self._stale_providers.add(provider_id)
+            else:
+                self._stale_providers.discard(provider_id)
             preset = self._profile_preset
             if preset is not None and preset.provider_id == provider_id:
                 self._profile_effective_availability = (


### PR DESCRIPTION
Closes TASK-2970 and TASK-3000 — the two behavioral residues from the TTSPlaygroundWidget second-deletion pass (#1405).

## TASK-2970 — staleness copy told users about a change that never happened

A first-ever catalog load whose health wasn't fresh got the generic "settings changed; refresh models" recovery copy — implying a configuration change that never occurred — because the rebuilt mixin added every non-fresh catalog application to `_stale_providers` unconditionally (the retired widget never did). Now a provider is only marked stale on a **genuine supersession**: the newly-applied catalog's configuration revision differing from the previously recorded one. Chosen over a freshness-transition rule because it can't misfire on a flaky fresh-flag with no real change; the review verified the registry's per-provider revision is strictly monotonic and only applied loads record it, so no real supersession can slip through. The two `xfail(strict=True)` pins from #1405 are un-xfailed and green; the genuine-config-change path's copy is unchanged (existing tests named and passing).

## TASK-3000 — a stuck-disabled Generate with no way out

An exact profile's voice validation in flight + a cancellation-resistant provider request + an applied configuration change left `_profile_voice_validation_token` set forever: availability never settled, Generate stayed disabled until the user left the Playground. The retired widget detached the token on exactly this sequence. The fix ports that behavior verbatim (review diffed it against the pre-deletion source): the token detaches on the provider-matched applied-config-change event, availability settles at "unverified", and exactly one warned exact attempt is allowed — through the same shared path as #1405's stale-catalog fix, not a parallel reimplementation.

**The direction that mattered most in review**: over-eager detaching would convert this fail-closed guard into the fail-open bypass #1405 closed. The review adversarially probed both non-detach directions (unrelated catalog failure; config change for a different provider) — the token correctly holds — and both directions are now pinned by mutation-checked tests, alongside 2970's positive supersession branch.

## Verification

208 tests green across the 4-file Speech/TTS gate post-rebase; per-fix mutation matrix verified in both directions (each revert breaks only its own tests); repo-wide collection clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Speech Playground bugs: honest staleness messaging on first catalog load and a stuck “Generate” state after a config change. We now only mark a provider stale on a real config revision change, and we detach an in‑flight profile voice check when its provider’s config changes.

- **Bug Fixes**
  - TASK-2970: Only add a provider to `_stale_providers` when the new catalog’s `configuration_revision` differs from the previously recorded one. First non‑fresh loads now show accurate, state‑specific copy. Still mark stale after a genuine supersession. Tests un‑xfail health2/health3 and add a positive supersession test.
  - TASK-3000: Detach `_profile_voice_validation_token` on a provider‑matched `mark_provider_configuration_changed`. Availability settles to “unverified” and “Generate” re‑enables for one warned exact attempt via the existing failure path. Guard tests ensure no detach on unrelated catalog failures or config changes for other providers.

<sup>Written for commit 8f470d9143e0eccb35ba18996feeca58a4970f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

