### PR TITLE
chore(backlog): file TASK-3070 — chat_screen ratchet red on dev

### DIFF
--- a/backlog/tasks/task-3070 - chat_screen size ratchet red on dev after console decomposition wave 3.md
+++ b/backlog/tasks/task-3070 - chat_screen size ratchet red on dev after console decomposition wave 3.md
@@ -1,0 +1,34 @@
+---
+id: TASK-3070
+title: chat_screen size ratchet red on dev after console decomposition wave 3
+status: To Do
+assignee: []
+created_date: '2026-08-07 18:20'
+labels:
+  - console
+  - architecture-gate
+  - tech-debt
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Architecture/test_screen_size_ratchet.py::test_screen_does_not_grow_past_its_budget[tldw_chatbook/UI/Screens/chat_screen.py]`
+fails on dev: 18,930 lines against a budget of 18,909. Introduced by PR #1408 (console
+decomposition wave 3) itself — confirmed byte-identical on a clean dev-tip worktree at
+`15407a641` during the TASK-3035/3045 architecture-gate refresh (PR #1416), so it is not
+an artifact of any other branch. The decomposition stream is actively shrinking this
+screen; the 21-line overage is presumably transitional. Filed so the red gate is owned
+rather than becoming the next "pre-existing noise" that hides something real (see
+lessons-testing-evidence.md's TASK-2610 entry for how that ends). Resolve by shrinking
+the screen below budget in the next wave — not by raising the budget, unless the
+decomposition stream's owner explicitly decides the budget is wrong.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The chat_screen size-ratchet test passes on dev
+- [ ] #2 The resolution shrinks the screen (or an explicit, documented owner decision adjusts the budget)
+<!-- AC:END -->


### PR DESCRIPTION
Files the routing task for the one remaining red architecture gate (introduced by #1408, confirmed on clean dev tip during #1416's refresh). Task-file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog task TASK-3070 to track the red architecture gate for chat_screen size ratchet on dev. Documents the overage (18,930 lines vs 18,909 budget) and sets acceptance criteria to resolve by shrinking the screen or making an explicit, documented budget change.

<sup>Written for commit c35b3d984a07c6940cd1ae779544870a5a64a3d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

