### PR TITLE
fix(watchlists): keep sources search focus across typing recomposes (TASK-3071)

### DIFF
--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -29,6 +29,7 @@ from tldw_chatbook.UI.Watchlists_Modules.sources_pane import (
     ExportOpmlRequested,
     ImportOpmlRequested,
     SourceSelected,
+    SourcesPane,
 )
 from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import TreeScope, TreeScopeChanged
 
@@ -717,6 +718,40 @@ async def test_space_in_items_search_input_still_types():
         assert search.value == "f o"
         assert search.has_focus, "typing must not lose the search box"
         assert screen._selected_content_item is None
+
+
+@pytest.mark.asyncio
+async def test_typing_in_sources_search_survives_the_recompose():
+    """task-3071: the SourcesPane sibling of the items-search bug pinned
+    above. `SourcesPane.search_query` is likewise `reactive(...,
+    recompose=True)`, so every keystroke rebuilt the pane and destroyed
+    the focused input -- and its `recompose()` only re-homed CREATE-FORM
+    focus, so the box was lost (and with Textual's default
+    `select_on_focus=True`, any programmatic refocus would have
+    selected-all, replacing the half-typed query on the next keystroke).
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        db = app.watchlist_bundle_service._db
+        db.add_subscription(name="ArXiv", type="rss", source="https://a.example/f")
+        db.add_subscription(name="Krebs", type="rss", source="https://b.example/f")
+
+        screen.active_section = "sources"
+        await pilot.pause(0.3)
+        pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+        pane.query_one("#sources-search-input", Input).focus()
+        await pilot.press("k", "r", "e", "b", "s")
+        await pilot.pause(0.2)
+
+        # Re-query: each keystroke recomposes the pane, so the input that
+        # was focused at the start was destroyed; this is the live
+        # replacement.
+        search = pane.query_one("#sources-search-input", Input)
+        assert search.value == "krebs"
+        assert search.has_focus, "typing must not lose the sources search box"
 
 
 @pytest.mark.asyncio

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -722,13 +722,15 @@ async def test_space_in_items_search_input_still_types():
 
 @pytest.mark.asyncio
 async def test_typing_in_sources_search_survives_the_recompose():
-    """task-3071: the SourcesPane sibling of the items-search bug pinned
-    above. `SourcesPane.search_query` is likewise `reactive(...,
-    recompose=True)`, so every keystroke rebuilt the pane and destroyed
-    the focused input -- and its `recompose()` only re-homed CREATE-FORM
-    focus, so the box was lost (and with Textual's default
-    `select_on_focus=True`, any programmatic refocus would have
-    selected-all, replacing the half-typed query on the next keystroke).
+    """Typing in the sources search box keeps focus and value across recomposes.
+
+    task-3071: the SourcesPane sibling of the items-search bug pinned above.
+    `SourcesPane.search_query` is likewise `reactive(..., recompose=True)`,
+    so every keystroke rebuilt the pane and destroyed the focused input --
+    and its `recompose()` only re-homed CREATE-FORM focus, so the box was
+    lost (and with Textual's default `select_on_focus=True`, any
+    programmatic refocus would have selected-all, replacing the half-typed
+    query on the next keystroke).
     """
     app = _build_test_app()
     host = DestinationHarness(app, "watchlists_collections")
@@ -752,6 +754,39 @@ async def test_typing_in_sources_search_survives_the_recompose():
         search = pane.query_one("#sources-search-input", Input)
         assert search.value == "krebs"
         assert search.has_focus, "typing must not lose the sources search box"
+
+
+@pytest.mark.asyncio
+async def test_create_form_open_focuses_first_field_over_search():
+    """Opening the create form focuses its first field even when search had focus.
+
+    Qodo, PR #1418: task-3071 made `SourcesPane.recompose()` restore search
+    focus whenever the search input was focused pre-teardown. When the SAME
+    recompose is the one mounting the create form (e.g. the screen's
+    deferred open timer fires while the user sits in the search box), the
+    form's focus-first-field-on-open behavior must still win -- the pane
+    captures whether the form was already mounted pre-teardown and only
+    lets the search branch keep the caret when the form is not opening.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = host.screen_stack[-1]
+        screen.active_section = "sources"
+        await pilot.pause(0.3)
+        pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+        pane.query_one("#sources-search-input", Input).focus()
+        await pilot.pause(0.1)
+
+        pane.show_create_form = True
+        await pilot.pause(0.5)
+
+        first_field = pane.query_one("#sources-create-name", Input)
+        assert first_field.has_focus, (
+            "opening the create form must focus its first field even when "
+            "the sources search box was focused"
+        )
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-3071 - SourcesPane-search-loses-focus-and-query-on-recompose.md
+++ b/backlog/tasks/task-3071 - SourcesPane-search-loses-focus-and-query-on-recompose.md
@@ -1,0 +1,48 @@
+---
+id: TASK-3071
+title: SourcesPane search loses focus and query on recompose
+status: Done
+assignee: []
+created_date: '2026-08-07 16:17'
+updated_date: '2026-08-07 17:01'
+labels:
+  - watchlists
+  - ux
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Sibling of the ItemsPane focus bug fixed in task-2513 Task 10: SourcesPane's recompose() override only preserves create-form fields, so a recompose while typing in the sources search box steals focus (and with select_on_focus=True, the refocus selects-all so the next keystroke replaces the half-typed query). Apply the same treatment: capture focused widget pre-teardown, restore caret-at-end via call_after_refresh, select_on_focus=False on the search input.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Typing in sources search survives a pane recompose with focus and caret intact
+- [x] #2 Half-typed query is not replaced on refocus
+- [x] #3 Regression tests mirror the ItemsPane focus tests
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Mirror ItemsPane's task-2513 Task-10 fix: capture screen.focused pre-teardown in recompose(), restore caret-at-end via call_after_refresh
+2. select_on_focus=False on the sources search input
+3. Regression tests mirroring the ItemsPane focus tests
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Applied the ItemsPane task-2513 Task-10 treatment to SourcesPane, integrated with its existing create-form focus logic (TASK-1035/TASK-1345):
+
+- `recompose()` now captures `self.screen.focused` pre-teardown (not `app.focused` -- ScreenStackError on transient empty stack, same reason as ItemsPane); when `#sources-search-input` held focus, it schedules `_restore_search_focus` via `call_after_refresh` and returns BEFORE the create-form path, so a still-armed `_pending_create_focus` can never yank the caret mid-keystroke (the TASK-1345 "current focus beats stale intent" ordering, extended to the search box).
+- New `_restore_search_focus()` focuses the live replacement input, caret at end -- mirroring `ItemsPane._restore_search_focus`.
+- `select_on_focus=False` on the search input (load-bearing: Textual's default True made the programmatic refocus select-all, so the next keystroke replaced the query).
+- Docstring updated: two create-form cases become three focus cases.
+
+Red-green verified: the new screen-level test (type "krebs" into the box, assert full value + has_focus on the live replacement input) FAILS on pre-fix dev and PASSES with the fix. Suites: Tests/Watchlists sources_pane + collections_screen 77/77, ruff clean.
+
+Modified: tldw_chatbook/UI/Watchlists_Modules/sources_pane.py, Tests/Watchlists/test_watchlists_collections_screen.py
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -992,6 +992,13 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         search_had_focus = (
             focused is not None and focused.id == "sources-search-input"
         )
+        # Capture whether the create form is mounted NOW, while the old DOM
+        # still exists: after the rebuild, `show_create_form` alone cannot
+        # distinguish "the form is OPENING with this recompose" (its
+        # focus-on-open must win over the search box) from "the form was
+        # already open" (an in-flight keystroke's focus must win).
+        # Qodo, PR #1418.
+        form_was_open = bool(self.query("#sources-create-form"))
         restore = self._focused_create_field_id() or self._pending_create_focus
         await super().recompose()
         # Guard explicitly after the await: the pane can be torn down while
@@ -1000,20 +1007,29 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         # post-recompose work.
         if not self.is_mounted or not self.is_running:
             return
-        if search_had_focus:
-            # Typing mid-search must keep the box: refocus the fresh input
-            # and never let a still-armed create-form intent yank the caret
-            # away mid-keystroke -- the same "the user's CURRENT focus wins
-            # over a stale intent" ordering the TASK-1345 follow-up pinned
-            # for in-form fields.
-            self.call_after_refresh(self._restore_search_focus)
-            return
         if not self.show_create_form:
             # The form closed (Cancel/Create) while this recompose was in
             # flight. Any focus intent still armed is for a form that no
             # longer exists -- drop it so it cannot resurface later and
-            # steal focus for an unrelated rebuild (TASK-1345).
+            # steal focus for an unrelated rebuild (TASK-1345). This runs
+            # BEFORE the search branch so a closed form's stale intent is
+            # cleared even when the search box keeps focus (Qodo, PR #1418).
             self._pending_create_focus = None
+            if search_had_focus:
+                self.call_after_refresh(self._restore_search_focus)
+            return
+        if search_had_focus and form_was_open:
+            # Typing mid-search must keep the box: refocus the fresh input
+            # and never let a still-armed create-form intent yank the caret
+            # away mid-keystroke -- the same "the user's CURRENT focus wins
+            # over a stale intent" ordering the TASK-1345 follow-up pinned
+            # for in-form fields. Gated on `form_was_open`: when THIS
+            # recompose is the one mounting the form, focus-on-open wins
+            # instead (falls through to the restore path below), so the
+            # form's auto-focus-first-field behavior survives the screen's
+            # deferred open firing while the search box happens to be
+            # focused (Qodo, PR #1418).
+            self.call_after_refresh(self._restore_search_focus)
             return
         if not restore:
             return

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -324,6 +324,13 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
                     placeholder="Search sources...",
                     id="sources-search-input",
                     value=self.search_query,
+                    # `select_on_focus=False` is load-bearing (same as
+                    # `#items-search-input`, task-2513): Textual's default
+                    # `select_on_focus=True` makes the programmatic refocus
+                    # after a recompose select ALL text, so the user's next
+                    # keystroke REPLACES the half-typed query instead of
+                    # appending to it.
+                    select_on_focus=False,
                     compact=True,
                 )
                 # TASK-2310: UAT read this row as "All / All statuses /
@@ -923,8 +930,19 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         re-applies `.focus()` against whatever is currently mounted, and the
         intent survives until one of them is actually confirmed.
 
-        Two cases are handled, and only these two — focus is never taken
-        from anywhere outside this pane's own create form:
+        task-3071 adds a third case ahead of these, checked first: the
+        search box (`#sources-search-input`) held focus when the teardown
+        started. `search_query` is `reactive(..., recompose=True)`, so
+        every keystroke in it rebuilds this pane, which used to destroy
+        the focused input mid-word -- only the first character of a search
+        ever landed (the exact bug `ItemsPane.recompose` fixed in
+        task-2513). Search focus is restored to the fresh input and the
+        create-form path below is skipped for that rebuild, so a still-
+        armed `_pending_create_focus` cannot yank the caret out of the box.
+
+        Two create-form cases are handled, and only these two — focus is
+        never taken from anywhere outside this pane's own create form or
+        the search box:
 
         1. The form just opened: `watch_show_create_form` armed
            `_pending_create_focus` with the first field, matching
@@ -961,6 +979,19 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         #     `_focused_create_field_id()` is `None` and
         #     `_pending_create_focus` (armed to field 0 by
         #     `watch_show_create_form`) still supplies the target.
+        # task-3071: the search box is this pane's OTHER focusable the
+        # recompose destroys (`search_query` is `reactive(...,
+        # recompose=True)`, so every keystroke rebuilds the pane) --
+        # capture it alongside the create-form cases. `self.screen.focused`,
+        # NOT `self.app.focused`, for the same ScreenStackError reason
+        # `ItemsPane.recompose` documents.
+        try:
+            focused = self.screen.focused if self.is_mounted else None
+        except Exception:
+            focused = None
+        search_had_focus = (
+            focused is not None and focused.id == "sources-search-input"
+        )
         restore = self._focused_create_field_id() or self._pending_create_focus
         await super().recompose()
         # Guard explicitly after the await: the pane can be torn down while
@@ -968,6 +999,14 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         # collapse), matching how `lab_frame.py` bails out of its own
         # post-recompose work.
         if not self.is_mounted or not self.is_running:
+            return
+        if search_had_focus:
+            # Typing mid-search must keep the box: refocus the fresh input
+            # and never let a still-armed create-form intent yank the caret
+            # away mid-keystroke -- the same "the user's CURRENT focus wins
+            # over a stale intent" ordering the TASK-1345 follow-up pinned
+            # for in-form fields.
+            self.call_after_refresh(self._restore_search_focus)
             return
         if not self.show_create_form:
             # The form closed (Cancel/Create) while this recompose was in
@@ -1006,6 +1045,22 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         # landed -- see `_confirm_create_focus` and the docstring above.
         self._pending_create_focus = restore
         self.call_after_refresh(self._confirm_create_focus, restore)
+
+    def _restore_search_focus(self) -> None:
+        """Focus the freshly recomposed search input, caret at end of query.
+
+        The search half of `recompose()`'s focus preservation (task-3071),
+        mirroring `ItemsPane._restore_search_focus`: the input this runs
+        against is always the LIVE replacement mounted by
+        `super().recompose()`, so a missing match just means the pane was
+        torn down in between -- bail quietly.
+        """
+        try:
+            search = self.query_one("#sources-search-input", Input)
+        except NoMatches:
+            return
+        search.focus()
+        search.cursor_position = len(search.value)
 
     def _confirm_create_focus(self, target: str, attempts: int = 0) -> None:
         """Clear the sticky create-focus intent once landed -- or once the


### PR DESCRIPTION
Sibling of the ItemsPane focus bug fixed in #1383 (task-2513 Task 10): `SourcesPane.search_query` is `reactive(recompose=True)`, so every keystroke in `#sources-search-input` tore the pane down and destroyed the focused input — only the first character of a search ever landed, and Textual's default `select_on_focus=True` would have replaced the half-typed query on any programmatic refocus.

## Fix
- `recompose()` captures `screen.focused` pre-teardown; when the search box held it, focus is restored to the fresh input (caret at end, `call_after_refresh`) and the create-form path is skipped for that rebuild, so a stale `_pending_create_focus` can never yank the caret mid-keystroke (the TASK-1345 "current focus beats stale intent" ordering, extended to search)
- `select_on_focus=False` on the search input (load-bearing)
- Docstring: two create-form focus cases become three

## Tests
- New screen-level regression test types `krebs` into the box and asserts the full value + `has_focus` on the live replacement input — **red on pre-fix dev, green with the fix**
- `Tests/Watchlists` sources_pane + collections_screen: **77/77**
- ruff clean

Backlog: TASK-3071 (marked Done with implementation notes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps focus and text in the Sources pane search while typing, and ensures the create form still grabs focus on open when it mounts during the same recompose. Addresses TASK-3071 and mirrors the Items pane behavior.

- **Bug Fixes**
  - Capture `screen.focused` before teardown and restore focus to `#sources-search-input` (caret at end) after rebuild, unless the create form is opening (then its first field wins).
  - Clear stale `_pending_create_focus` before the search branch; set `select_on_focus=False` on the search input to avoid select-all replacing partial queries.
  - Tests: search typing survives recomposes (`"krebs"` case) and create-form open focuses its first field even if search had focus; suites pass 78/78.

<sup>Written for commit 24787e1b676f4cef8c0c5d9888a85cf2678e80cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

