### PR TITLE
refactor(console): decompose _open_console_prompts_modal into two collaborators (task-2766)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2022,7 +2022,7 @@
     },
     {
       "call_count": 3,
-      "diagnostic_digest": "542edfd662c59a16f67f",
+      "diagnostic_digest": "2fee300efb749f9af99f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/prompts.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/UI/test_console_prompts_controller.py
+++ b/Tests/UI/test_console_prompts_controller.py
@@ -33,6 +33,7 @@ from textual.app import App
 
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
 from tldw_chatbook.UI.Console_Modules.prompts import ConsolePromptsController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar, ConsolePromptsModal
@@ -225,6 +226,286 @@ async def test_prompts_modal_reads_provider_recovery_off_the_screen_at_open() ->
 
         assert modal._configure_provider is recovery
         assert modal._improve_unavailable_reason == "No provider configured."
+
+
+# ---------------------------------------------------------------------------
+# The callback bundle the modal opener hands to `ConsolePromptsModal`
+#
+# Written BEFORE task-2766 decomposed `_open_console_prompts_modal`'s 17
+# nested closures into named collaborators, so every assertion below is a
+# statement about behaviour that must survive that change byte-identically:
+# the exact prompt-source contract each data callable forwards, the copy each
+# raises when the source cannot serve, the pinned-target lifecycle the
+# improvement flow shares across callbacks, and the dismissal focus restore.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingPromptScopeService(_PromptScopeService):
+    """Records the exact keyword contract each source callable forwards."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def get_capabilities(self, *, mode: str):
+        self.calls.append(("get_capabilities", {"mode": mode}))
+        return await super().get_capabilities(mode=mode)
+
+    async def list_prompts(self, *, mode: str, page: int, per_page: int):
+        self.calls.append(
+            ("list_prompts", {"mode": mode, "page": page, "per_page": per_page})
+        )
+        return await super().list_prompts(mode=mode, page=page, per_page=per_page)
+
+    async def search_prompts(self, *, mode: str, query: str, limit: int, **kwargs):
+        self.calls.append(
+            ("search_prompts", {"mode": mode, "query": query, "limit": limit, **kwargs})
+        )
+        return await super().search_prompts(
+            mode=mode, query=query, limit=limit, **kwargs
+        )
+
+    async def get_prompt(self, *, mode: str, prompt_identifier: str, **kwargs):
+        self.calls.append(
+            (
+                "get_prompt",
+                {"mode": mode, "prompt_identifier": prompt_identifier, **kwargs},
+            )
+        )
+        return await super().get_prompt(
+            mode=mode, prompt_identifier=prompt_identifier, **kwargs
+        )
+
+    async def save_prompt(self, *, mode: str, **payload):
+        self.calls.append(("save_prompt", {"mode": mode, **payload}))
+        return await super().save_prompt(mode=mode, **payload)
+
+    def payloads(self, name: str) -> list[dict[str, object]]:
+        return [payload for called, payload in self.calls if called == name]
+
+
+class _CountingResolutionGateway:
+    """A ready provider whose `resolve_for_send` count is observable."""
+
+    def __init__(self) -> None:
+        self.resolve_calls = 0
+
+    async def resolve_for_send(self, selection):
+        self.resolve_calls += 1
+        return ConsoleProviderResolution(
+            provider="llama_cpp",
+            base_url=selection.base_url or "http://127.0.0.1:9099",
+            model=(
+                selection.explicit_model
+                or selection.configured_model
+                or "local-model"
+            ),
+            ready=True,
+            readiness_key="llama_cpp",
+            execution_key="llama_cpp",
+        )
+
+
+async def _open_prompts_modal(host, pilot, console) -> ConsolePromptsModal:
+    console._open_console_prompts_modal()
+    await pilot.pause()
+    modal = host.screen_stack[-1]
+    assert isinstance(modal, ConsolePromptsModal)
+    return modal
+
+
+@pytest.mark.asyncio
+async def test_prompt_source_callables_forward_the_exact_service_contract() -> None:
+    """Page size, search limit and the `source`-to-`mode` rename are the
+    contract the Prompt Library modal is built against."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    service = _RecordingPromptScopeService()
+    app.prompt_scope_service = service
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        modal = await _open_prompts_modal(host, pilot, console)
+        service.calls.clear()
+
+        await modal._capabilities("server")
+        await modal._list_page("server", 3)
+        await modal._search("local", "terse")
+        await modal._detail("local", "11")
+        await modal._save(source="server", name="Fresh", system_prompt="Be terse.")
+
+        assert service.payloads("get_capabilities") == [{"mode": "server"}]
+        assert service.payloads("list_prompts") == [
+            {"mode": "server", "page": 3, "per_page": 10}
+        ]
+        assert service.payloads("search_prompts") == [
+            {"mode": "local", "query": "terse", "limit": 25}
+        ]
+        assert service.payloads("get_prompt") == [
+            {"mode": "local", "prompt_identifier": "11"}
+        ]
+        # `save` routes the payload's own `source` into the service's `mode`.
+        assert service.payloads("save_prompt") == [
+            {"mode": "server", "name": "Fresh", "system_prompt": "Be terse."}
+        ]
+
+
+@pytest.mark.asyncio
+async def test_prompt_source_callables_name_the_source_they_cannot_reach() -> None:
+    """A scope service missing a method is a user-visible refusal, per
+    callable and per source -- never an AttributeError."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = SimpleNamespace()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        modal = await _open_prompts_modal(host, pilot, console)
+
+        with pytest.raises(ValueError, match="Local Prompt source is unavailable"):
+            await modal._capabilities("local")
+        with pytest.raises(ValueError, match="Server Prompt source is unavailable"):
+            await modal._list_page("server", 1)
+        with pytest.raises(ValueError, match="Local Prompt search is unavailable"):
+            await modal._search("local", "terse")
+        with pytest.raises(ValueError, match="Server Prompt source is unavailable"):
+            await modal._detail("server", "11")
+        with pytest.raises(ValueError, match="selected Prompt source cannot save"):
+            await modal._save(source="local", name="Fresh")
+
+
+@pytest.mark.asyncio
+async def test_prompts_modal_dismissal_restores_composer_focus() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        modal = await _open_prompts_modal(host, pilot, console)
+        focus_calls: list[dict[str, object]] = []
+        console._focus_console_composer_if_needed = (
+            lambda **kwargs: focus_calls.append(kwargs)
+        )
+
+        modal.dismiss(None)
+        await pilot.pause()
+
+        assert focus_calls == [{"force": True}]
+
+
+@pytest.mark.asyncio
+async def test_improvement_target_is_pinned_once_and_shared_across_callbacks() -> None:
+    """`activate` pins the disclosed target; the model-free manual path must
+    reuse that same pin rather than resolve a second, possibly different one."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    gateway = _CountingResolutionGateway()
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.insert_text("draft body")
+
+        modal = await _open_prompts_modal(host, pilot, console)
+
+        first = await modal._capture_manual_resolution()
+        resolved_once = gateway.resolve_calls
+        second = await modal._capture_manual_resolution()
+
+        assert first is second
+        assert gateway.resolve_calls == resolved_once
+
+        activated = await modal._activate_improvement_context()
+        assert activated.pinned_resolution is not None
+        assert await modal._capture_manual_resolution() is activated.pinned_resolution
+
+
+@pytest.mark.asyncio
+async def test_improvement_activation_refuses_a_moved_system_prompt() -> None:
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    app.console_provider_gateway_factory = lambda: _CountingResolutionGateway()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+
+        modal = await _open_prompts_modal(host, pilot, console)
+        store.set_session_system_prompt(session_id, "Changed elsewhere.")
+
+        with pytest.raises(ValueError, match="The Console System prompt changed"):
+            await modal._activate_improvement_context()
+
+
+@pytest.mark.asyncio
+async def test_improvement_snapshot_refuses_an_unpinned_provider_target() -> None:
+    """No disclosure, no request: the snapshot builder must not fall back to
+    resolving a target the user was never shown."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    app.console_provider_gateway_factory = lambda: _CountingResolutionGateway()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.insert_text("draft body")
+
+        modal = await _open_prompts_modal(host, pilot, console)
+
+        with pytest.raises(ValueError, match="no longer pinned"):
+            await modal._build_improvement_snapshot(request_id="req-1", mode="auto")
+
+
+@pytest.mark.asyncio
+async def test_improvement_validation_prefers_the_captured_snapshot() -> None:
+    """The reviewed working copy is validated against the snapshot the request
+    captured; a captured object without one falls back to the opening draft."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.prompt_scope_service = _PromptScopeService()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.insert_text("draft body")
+        opening_snapshot = composer.capture_draft_snapshot()
+
+        modal = await _open_prompts_modal(host, pilot, console)
+        seen: list[tuple[object, str]] = []
+        composer.validate_improvement = lambda snapshot, text: seen.append(
+            (snapshot, text)
+        )
+
+        modal._validate_improvement(
+            SimpleNamespace(composer_snapshot="captured"), "reviewed"
+        )
+        modal._validate_improvement(object(), "fallback")
+
+        assert seen[0] == ("captured", "reviewed")
+        assert seen[1] == (opening_snapshot, "fallback")
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_prompts_controller.py
+++ b/Tests/UI/test_console_prompts_controller.py
@@ -779,3 +779,46 @@ def test_moved_methods_are_gone_from_the_screen() -> None:
     ):
         assert not hasattr(ChatScreen, name), name
         assert hasattr(ConsolePromptsController, name), name
+
+
+def test_stale_reason_reports_the_session_change_before_the_system_change() -> None:
+    """Order matters here, and nothing else pins it.
+
+    `_stale_reason` checks two facts pinned when the modal opened: the session
+    it was opened over, and the System prompt it disclosed. When BOTH have
+    moved the user sees only the first message, so the order chooses the copy.
+    A task-2766 review mutated this ordering and all 28 controller tests plus
+    all 304 native-chat-flow tests still passed -- the branch that reports the
+    session change was reachable in no test where the fingerprint had also
+    moved.
+
+    Session-before-System is the right order because the session change is the
+    larger fact: the System prompt the modal disclosed belongs TO a session, so
+    naming the System prompt while the user has actually switched sessions
+    describes a consequence rather than the cause.
+    """
+    from tldw_chatbook.UI.Console_Modules.prompts import (
+        _ConsolePromptImprovementFlow,
+    )
+
+    flow = _ConsolePromptImprovementFlow.__new__(_ConsolePromptImprovementFlow)
+    flow._session_id = "session-a"
+    flow._current_system_fingerprint = "fingerprint-a"
+    flow._store = SimpleNamespace(active_session_id="session-a")
+    flow._active_system_fingerprint = lambda: "fingerprint-a"
+
+    assert flow._stale_reason() == ""
+
+    # Only the System prompt moved.
+    flow._active_system_fingerprint = lambda: "fingerprint-b"
+    assert flow._stale_reason() == "The Console System prompt changed."
+
+    # Only the session moved.
+    flow._active_system_fingerprint = lambda: "fingerprint-a"
+    flow._store = SimpleNamespace(active_session_id="session-b")
+    assert flow._stale_reason() == "The active Console session changed."
+
+    # BOTH moved -- the session is reported, not the System prompt. This is
+    # the assertion the mutation slipped past.
+    flow._active_system_fingerprint = lambda: "fingerprint-b"
+    assert flow._stale_reason() == "The active Console session changed."

--- a/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
+++ b/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-2766
 title: 'Decompose _open_console_prompts_modal (397 lines, 17 nested closures)'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-07 06:41'
+updated_date: '2026-08-07 19:08'
 labels:
   - refactor
   - console
@@ -18,7 +20,38 @@ Wave 3 moved this method verbatim into ConsolePromptsController. Review judged i
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The modal's callbacks are objects or methods with named dependencies rather than closures over a 397-line scope
-- [ ] #2 ConsolePromptsController's constructor dependency count falls below 18
-- [ ] #3 No behaviour change: the modal-open path's characterisation tests pass unchanged
+- [x] #1 The modal's callbacks are objects or methods with named dependencies rather than closures over a 397-line scope
+- [x] #2 ConsolePromptsController's constructor dependency count falls below 18
+- [x] #3 No behaviour change: the modal-open path's characterisation tests pass unchanged
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Characterise the modal-open path (5 source callables, pin lifecycle, focus restore) and mutation-check the new assertions.
+2. Extract the 5 data-source closures into a `_ConsolePromptSource` adapter over the app's prompt_scope_service (its only capture).
+3. Extract the 11 improvement-flow closures into a `_ConsolePromptImprovementFlow` collaborator whose shared per-open state (session id, composer, opening snapshot/fingerprint, gateway, pinned resolution) becomes fields and whose app-level needs stay named callables.
+4. Promote `restore_focus` to a controller method and `_resolution_identity` to a module-level pure function; leave nothing inline that only a closure could express.
+5. Collapse the three post-apply re-sync bridges (always called as an ordered trio, only here) into one named dependency, taking the constructor from 18 to 16.
+6. Re-run the characterisation + the 304-test native chat flow suite and the wiring/architecture gates.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`_open_console_prompts_modal` is 82 lines with zero nested closures (was 397 with 17). Its callbacks are now the bound methods of two collaborators built per modal open.
+
+**`_ConsolePromptSource`** (5 closures). Those five captured exactly one thing -- `app_instance.prompt_scope_service` -- and did one thing with it, so the cluster's whole source contract now lives in one 96-line class: pages of 10, searches capped at 25, `save`'s `source` routed into the service's `mode`, and a `_require` helper carrying the per-callable refusal copy a duck-typed source triggers. `record_prompt_usage` joined it, since the improvement flow read the same service.
+
+**`_ConsolePromptImprovementFlow`** (11 closures). The stateful half: `nonlocal pinned_improvement_resolution` becomes a field, and the eight values the closures each re-captured (store, session id, composer, opening snapshot, System prompt + fingerprint, gateway, disclosure context) become named constructor arguments. Its two staleness guards, duplicated across three call sites, collapse into `_stale_reason()`, which still raises or returns the exact copy each site always did.
+
+`restore_focus` (captured only `self`) became `ConsolePromptsController._restore_console_composer_focus`; `_resolution_identity` (a pure function of its argument) became module-level `_provider_resolution_identity`. Nothing was left inline.
+
+**Constructor 18 -> 16 named dependencies.** The three post-apply re-sync bridges were only ever called as an ordered trio, at the two moments the store accepted a new System prompt, never individually -- so `sync_console_system_prompt_surfaces` replaces them. `wiring.py` resolves each screen method by name at CALL time inside a nested function, so every instance-level replacement the suite makes is still observed. Nothing else could be shed without manufacturing an abstraction: the five provider dependencies are genuinely distinct services and the rest are single-use-but-irreducible.
+
+**Behaviour.** An AST equivalence check against HEAD~1 shows every moved body identical modulo the four documented transformations (`_stale_reason`, `_require`, the trio collapse, `self.` prefixes); `capture_manual_resolution`, `validate_improvement`, both saved-artifact guards and `restore_focus` are byte-identical. Call order, the two `_console_provider_blocker_copy()` reads and the modal's kwarg evaluation order are unchanged; the controller still owns zero DOM. One deliberate non-identity: `record_prompt_usage`'s availability lookup now sits inside the caller's `try`, so a scope service whose attribute ACCESS raised would warn instead of propagating into an already-applied apply -- strictly safer, and unreachable for any plain object.
+
+**Evidence.** 7 new characterisation tests written and pushed green BEFORE the refactor, mutation-checked (per_page 10->11 and dropping the capture-once guard each fail exactly one). After: 44 prompts controller + wiring, 304 native chat flow (identical to baseline), 268 across the prompt-cluster files, 195 responsiveness/agent-swap/internals, 89 architecture + ownership, 9073 collected clean over Tests/UI, ruff clean. Only failure is the pre-existing `test_persistent_diagnostic_inventory` (task-2768), which names neither changed file.
+
+**Files**: `tldw_chatbook/UI/Console_Modules/prompts.py`, `tldw_chatbook/UI/Console_Modules/wiring.py`, `Tests/UI/test_console_prompts_controller.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
+++ b/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
@@ -55,3 +55,25 @@ Wave 3 moved this method verbatim into ConsolePromptsController. Review judged i
 
 **Files**: `tldw_chatbook/UI/Console_Modules/prompts.py`, `tldw_chatbook/UI/Console_Modules/wiring.py`, `Tests/UI/test_console_prompts_controller.py`.
 <!-- SECTION:NOTES:END -->
+
+### Review addenda (task-2766 review)
+
+- Report numbers were stale by one commit: `prompts.py` is **1,484** lines, not
+  1,474; docstrings **+168**, code-only **804 -> 841 (+37)**.
+- "5 byte-identical bodies" is inexact -- the identical set is **6** different
+  bodies (`capture_manual_resolution` drops its `nonlocal` line).
+- The review confirmed the two disclosed risks are narrower than advertised:
+  the `record_prompt_usage` non-identity drops no usage record in EITHER arm
+  (the old path let the raise escape into a modal that showed "capture it
+  again" *after* the apply had landed), and the flow object's lifetime is
+  exactly one per modal open -- mutation-proved.
+- Two findings actioned here: the duplicate search-limit constant introduced
+  while addressing Qodo is collapsed to one number with two readers, and
+  `_stale_reason`'s ordering now has a test. The review mutated that ordering
+  and 28 controller + 304 native-chat-flow tests all still passed; the new
+  test fails on exactly that mutation.
+- One residual, unreachable and recorded rather than changed: the three deps
+  handed to the flow are property reads evaluated at flow construction, where
+  the old closures re-read per call. Screen-level late binding is preserved by
+  the `wiring.py` lambdas, and nothing rebinds the controller's `_..._fn`
+  attributes.

--- a/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
+++ b/backlog/tasks/task-2766 - Decompose-_open_console_prompts_modal-397-lines-17-nested-closures.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-2766
 title: 'Decompose _open_console_prompts_modal (397 lines, 17 nested closures)'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 06:41'
-updated_date: '2026-08-07 19:08'
+updated_date: '2026-08-07 19:09'
 labels:
   - refactor
   - console

--- a/task-2766-report.md
+++ b/task-2766-report.md
@@ -1,0 +1,208 @@
+# task-2766 — Decomposing `_open_console_prompts_modal`
+
+Branch `refactor/prompts-modal-2766`, based on `origin/dev` (`a453e7ded`).
+
+## The decomposition, and why
+
+The method was not one thing that had grown too long. It was **three** things
+sharing a scope, and the split follows what the closures actually captured —
+not what they were named.
+
+### 1. `_ConsolePromptSource` — the data adapter (5 closures)
+
+`capabilities`, `list_page`, `search`, `detail`, `save` captured **exactly one
+thing**: `app_instance.prompt_scope_service`. Each did the same three steps —
+look a method up, refuse in user-visible copy if the source cannot serve it,
+forward the call with this cluster's own contract. That is the textbook shape
+of an adapter, so it is one: a class with one field, whose bound methods the
+modal receives.
+
+It earns its keep beyond line count. The cluster's source contract — browse
+pages of 10, searches capped at 25, `save`'s `source` routed into the
+service's `mode` — is now stated in one place instead of being spread across
+five sibling closures where a drift between them would be invisible. The
+five duplicated `getattr`/`callable`/`raise` triples collapse into one
+`_require` helper that carries the per-callable refusal copy.
+
+`record_prompt_usage` moved here too, even though its closure lived in the
+improvement group: it reads the same service, through the same duck-typed
+lookup, and the improvement flow now reaches it the same way it reaches
+`detail` for its freshness probes.
+
+### 2. `_ConsolePromptImprovementFlow` — the stateful sub-flow (11 closures)
+
+These eleven were a single conversation with **shared mutable state**: pin and
+disclose a provider target, build a request snapshot against it, validate what
+comes back against the artifact it came from, apply it, retry a failed
+System-prompt persist. The `nonlocal pinned_improvement_resolution` is the
+tell — one closure wrote it, three read it, and nothing else in the 397-line
+scope touched it. That is an object; the `nonlocal` becomes
+`self._pinned_resolution` and the eight values the closures each re-captured
+become named constructor arguments.
+
+Its app-level needs stay **callables** (`active_session_settings`,
+`build_provider_selection`, `sync_system_prompt_surfaces`), and `app_instance`
+is held rather than snapshotted into a bound `notify` — the same binding rule
+the controller follows, for the same reason: the suite replaces those targets
+on the screen instance after the modal is already open.
+
+One dedupe inside it: the session-changed / System-prompt-changed guard pair
+appeared **three times verbatim**. It is now `_stale_reason()`, returning the
+copy or `""`; the two raising call sites raise it, the applying one returns a
+stale outcome with it. Short-circuit order is preserved, so the live
+fingerprint is still only computed when the session check passes.
+
+### 3. Promoted out of closure form
+
+- `restore_focus` → `ConsolePromptsController._restore_console_composer_focus`.
+  It captured only `self`; there was never a reason for it to be a closure.
+- `_resolution_identity` → module-level `_provider_resolution_identity`.
+  A pure function of its argument, capturing nothing at all.
+
+### What I deliberately did **not** do
+
+- **No new module.** The two collaborators are private to the prompt cluster
+  and are only meaningful next to the controller that builds them. A
+  `prompts_modal.py` would have split one story across two files and put the
+  module's "Zero DOM" AST test on the wrong side of a boundary.
+- **No extraction of the opening preamble.** The 30 lines before the
+  collaborators are read-once fact-gathering with two early returns; hoisting
+  them into a `_gather_open_state()` would have produced a dataclass whose
+  only consumer is twelve lines below its construction.
+- **No bundling of the five provider dependencies.** `model_display`,
+  `build_selection`, `gateway`, `blocker_copy` and `provider_recovery` look
+  like a group by name, but they are five distinct services with five distinct
+  lifetimes (one is a bare-attribute read handed on uncalled). Collapsing them
+  would have bought a smaller number at the price of a value type the screen
+  must now construct — exactly the manufactured win the brief warned against.
+
+## Per-closure verdict
+
+| Closure | Lines | Verdict |
+|---|---|---|
+| `apply_improvement_result` | 74 | → `_ConsolePromptImprovementFlow.apply_improvement_result` |
+| `activate_improvement_context` | 58 | → flow method (shares the pin) |
+| `build_improvement_snapshot` | 56 | → flow method (shares the pin) |
+| `validate_saved_recipe` | 27 | → `flow._validate_saved_recipe` (internal; only `apply` calls it) |
+| `retry_improvement_persistence` | 21 | → flow method |
+| `validate_saved_prompt` | 19 | → `flow._validate_saved_prompt` (internal) |
+| `record_applied_usage` | 18 | → `flow._record_applied_usage`; its service lookup → `_ConsolePromptSource.record_usage` |
+| `capture_manual_resolution` | 9 | → flow method (writes the pin) |
+| `_resolution_identity` | 8 | → module-level `_provider_resolution_identity` (pure) |
+| `save` | 6 | → `_ConsolePromptSource.save` |
+| `capabilities` | 5 | → `_ConsolePromptSource.capabilities` |
+| `list_page` | 5 | → `_ConsolePromptSource.list_page` |
+| `search` | 5 | → `_ConsolePromptSource.search` |
+| `detail` | 5 | → `_ConsolePromptSource.detail` (also the guards' freshness probe) |
+| `_active_system_fingerprint` | 3 | → `flow._active_system_fingerprint`, folded into `_stale_reason()` |
+| `validate_improvement` | 3 | → flow method. **Moved on membership, not size**: it reads the opening snapshot, which is flow state. Left behind it would have needed that snapshot passed in — more parameters than the body has lines. |
+| `restore_focus` | 2 | → `ConsolePromptsController._restore_console_composer_focus` |
+
+Nothing was left inline. The two shortest closures moved for opposite reasons
+and both are stated above.
+
+## Numbers
+
+| | before | after |
+|---|---|---|
+| `_open_console_prompts_modal` | 397 lines | **82** |
+| nested closures in it | 17 | **0** |
+| `ConsolePromptsController` class | 1093 lines | 788 |
+| `prompts.py` module | 1251 lines | 1474 |
+| `prompts.py`, code-only (no docstrings/comments/blanks) | 804 | 839 |
+| constructor named dependencies | 18 | **16** |
+
+The module grew 223 lines; **188 of those are docstrings** for the two new
+classes and their 20 methods, per this repo's Google-style requirement. The
+real code cost is +35 lines — two `class` statements, thirteen field
+assignments and twenty signatures, against 17 closure headers removed. I
+consider that the honest price of the trade and flag it rather than hide it:
+the win is the 397→82 method and the 17→0 closure count, not a smaller file.
+
+## Constructor dependencies: 18 → 16
+
+The three post-apply re-sync bridges (`_sync_console_chat_core_state`,
+`_sync_console_rail_system_line`, `_sync_console_settings_summary`) were
+called **only** as an ordered trio, at exactly the two moments the store
+accepted a new System prompt, and never individually anywhere in the cluster.
+They are now one dependency, `sync_console_system_prompt_surfaces`.
+
+This is a cohesion win rather than an arithmetic one: the flow's actual need
+is "the System prompt landed — refresh the surfaces that display it", and that
+is now what it asks for. `wiring.py` supplies it as a nested function that
+resolves each screen method **by name at call time**, so the late binding that
+eleven of the sixteen dependencies rely on is untouched (verified: the wiring
+suite's late-binding tests pass, and `test_ui_responsiveness.py`, which
+replaces `_sync_console_chat_core_state` on the screen instance, passes).
+
+No other reduction was available without manufacturing one — see "What I
+deliberately did not do" above. The remaining 16 are what the cluster
+genuinely reaches for.
+
+## Behaviour evidence
+
+**AST equivalence against `HEAD~1`.** I extracted every moved body from both
+revisions, applied the rename map, and diffed. Byte-identical:
+`capture_manual_resolution`, `validate_improvement`, `validate_saved_recipe`,
+`validate_saved_prompt`, `restore_focus`. Every other difference is one of the
+four documented transformations and nothing else: `_stale_reason()` (3 sites),
+`_require()` (5 sites), the sync-trio collapse (2 sites), and `self.` field
+prefixes.
+
+Call order is preserved end to end, including the two separate
+`_console_provider_blocker_copy()` reads (one into the disclosure context, one
+into the modal kwargs) and the modal's kwarg evaluation order. The controller
+still contains zero `query_one`/`query` (the module's own AST test asserts it).
+
+**One deliberate non-identity, disclosed.** `record_prompt_usage`'s
+availability lookup now happens inside `_ConsolePromptSource.record_usage`,
+which the caller invokes inside its `try`. Previously the lookup sat outside
+it. This differs only if attribute *access* on the scope service raises — no
+such service exists in the codebase or the suite — and the new behaviour is
+strictly safer if one ever did: the user gets the "usage could not be
+recorded" warning instead of an exception escaping into an apply that has
+already landed (the old `apply_improvement_result` did not wrap that call).
+
+## Test evidence
+
+Characterisation was written, mutation-checked and pushed **green before**
+any production change (`d635a862a`): 7 new tests in
+`Tests/UI/test_console_prompts_controller.py` covering the exact prompt-source
+contract each data callable forwards, the per-callable refusal copy, the
+dismissal focus restore, the pinned-target lifecycle shared between
+`activate_improvement_context` and `capture_manual_resolution`, the
+moved-System-prompt activation guard, the unpinned-target snapshot refusal,
+and `validate_improvement`'s captured-vs-opening snapshot preference.
+
+Two mutations confirm they bite: `per_page` 10→11 and dropping the
+capture-once guard each failed exactly one of the new tests, and only that one.
+
+| Suite | Baseline | After |
+|---|---|---|
+| `test_console_prompts_controller.py` + `test_console_controller_wiring.py` | 21 + 16 = 37 (+7 new) | **44 passed** |
+| `test_console_native_chat_flow.py` (13 real modal-open drives, the whole improvement sub-flow) | 304 passed | **304 passed** |
+| prompt-cluster batch (workbench contract, composer menu, prompts modal, system prompt, command composer, composer history, prompt picker, system prompt chip) | — | **268 passed** |
+| `test_ui_responsiveness.py`, `test_console_agent_swap.py`, `test_console_internals_decomposition.py` | — | **195 passed** |
+| `Tests/Architecture/` + `test_application_state_ownership.py` + `test_console_model_section.py` | — | **89 passed, 1 failed** |
+| `Tests/UI` collect-only sweep | — | **9073 collected, no errors** |
+| `ruff check` on all three changed files | — | clean |
+
+The single failure is `Tests/Architecture/test_persistent_diagnostic_inventory.py`
+— the pre-existing task-2768 failure. I ran the underlying checker directly:
+its report names neither `prompts.py` nor `wiring.py`.
+
+## Concerns
+
+- **Module length.** `prompts.py` is now 1474 lines. That is a docstring-heavy
+  1474, and the largest method in it is 82 lines, but if the programme wants
+  the file itself smaller, `_ConsolePromptSource` and
+  `_ConsolePromptImprovementFlow` are the natural seam for a later move — they
+  have no dependency on the controller at all, only on values it passes them.
+- **`_ConsolePromptImprovementFlow` is 402 lines** (about 210 code-only). It is
+  a genuine unit — every method touches the pin or the opening disclosure — but
+  it is the next-largest thing in the cluster, and a future reviewer should
+  measure it before assuming it is fine.
+- The improvement flow's constructor takes 13 arguments. That is the per-open
+  state the closures shared, made visible rather than added; I did not try to
+  reduce it, because bundling it would hide exactly what this task set out to
+  expose.

--- a/tldw_chatbook/UI/Console_Modules/prompts.py
+++ b/tldw_chatbook/UI/Console_Modules/prompts.py
@@ -2,8 +2,10 @@
 
 Extracted out of `ChatScreen` (wave-3 console decomposition, task 3): the
 Console shell's PROMPT cluster -- the source-aware Prompt Library modal
-(`_open_console_prompts_modal`, 397 lines, the largest non-`__init__`
-method the pre-move class had), `/prompt` and `/system` name resolution
+(`_open_console_prompts_modal`, 397 lines at the time of the move and the
+largest non-`__init__` method the pre-move class had; 82 since task 2766
+split its 17 nested closures into the two collaborators below), `/prompt`
+and `/system` name resolution
 and their shared refuse-a-Recipe guard, both prompt-picker launches, the
 system-prompt editor and its save-to-Library flow, the Library "Use in
 Console" staged-insert handoff, and the shared prompt-history store.
@@ -23,7 +25,7 @@ fan-in; restated briefly here):
    matters concretely here: `Tests/UI/test_console_workbench_contract.py`
    replaces `_open_console_provider_recovery` and `_console_provider_
    blocker_copy` on the SCREEN INSTANCE and then calls the modal opener,
-   and eleven of the eighteen dependencies below are monkeypatched by name
+   and eleven of the sixteen dependencies below are monkeypatched by name
    somewhere in the pre-existing suite. A constructor snapshot would
    silently stop observing every one of those.
 3. `app_instance` is a plain snapshot, for the same reason `dictation.py`
@@ -34,7 +36,7 @@ fan-in; restated briefly here):
 **Zero DOM.** No `query_one`/`query` traffic reaches through `screen` here.
 That is why `_insert_prompt_text_into_composer` -- which does a raw
 `self.query_one("#console-native-composer", ConsoleComposerBar)` -- did NOT
-move and is instead one of the eighteen injected callables, even though it
+move and is instead one of the sixteen injected callables, even though it
 is the single most prompt-shaped helper on the screen. (Six pre-existing
 test sites also replace it on the screen by name, so it has to keep
 resolving through the screen either way.)
@@ -156,6 +158,532 @@ CONSOLE_SYSTEM_PROMPT_SAVE_STATUS_COPY = {
 CONSOLE_SYSTEM_PROMPT_NO_SYSTEM_PART_TEMPLATE = 'Prompt "{name}" has no system part.'
 
 
+def _provider_resolution_identity(resolution: Any) -> tuple[str, str, str, str, str]:
+    """The five fields that decide whether two resolutions are one target.
+
+    Equal identities mean the user is still spending against the target the
+    modal disclosed; any difference means they were shown one thing and would
+    get another, which every guard in the improvement flow treats as stale.
+
+    Args:
+        resolution: A `ConsoleProviderResolution`, or anything shaped like
+            one -- the guards compare whatever the gateway handed back.
+
+    Returns:
+        tuple[str, str, str, str, str]: provider, model, base URL, readiness
+        key and execution key, each coerced to `str` (missing fields empty).
+    """
+    return (
+        str(getattr(resolution, "provider", "")),
+        str(getattr(resolution, "model", "")),
+        str(getattr(resolution, "base_url", "")),
+        str(getattr(resolution, "readiness_key", "")),
+        str(getattr(resolution, "execution_key", "")),
+    )
+
+
+class _ConsolePromptSource:
+    """The Prompt Library modal's data adapter over one prompt scope service.
+
+    Five of `_open_console_prompts_modal`'s closures captured exactly one
+    thing -- `app_instance.prompt_scope_service` -- and did exactly one thing
+    with it: look up a method, refuse in user-visible copy when the source
+    cannot serve, and forward the call with this cluster's own contract
+    (browse pages of 10, searches capped at 25, `save`'s `source` routed into
+    the service's `mode`). That is a collaborator with one field, so it is
+    one here rather than five closures over a 397-line scope (task 2766).
+
+    One instance per modal open; its bound methods are what
+    `ConsolePromptsModal` receives, and `detail`/`record_usage` are also what
+    the improvement flow's saved-artifact guards run against.
+
+    The service is duck-typed deliberately: `getattr` + `callable` per call,
+    so an absent or partially-implemented source degrades into the refusal
+    copy the modal has always rendered instead of an `AttributeError`.
+    """
+
+    def __init__(self, service: Any) -> None:
+        """Bind the scope service this modal open will read.
+
+        Args:
+            service: `app_instance.prompt_scope_service`, or `None` when the
+                app exposes none -- every method below then refuses.
+        """
+        self._service = service
+
+    def _require(self, attribute: str, unavailable_copy: str) -> Any:
+        """Return a callable service method, or refuse in user-visible copy.
+
+        Args:
+            attribute: The scope-service method name to resolve.
+            unavailable_copy: What the user is told when it is missing.
+
+        Returns:
+            Any: The bound service method.
+
+        Raises:
+            ValueError: When the service has no callable under that name.
+        """
+        method = getattr(self._service, attribute, None)
+        if not callable(method):
+            raise ValueError(unavailable_copy)
+        return method
+
+    async def capabilities(self, source: str) -> Any:
+        """Report what `source` can store, so the editor can gate its kinds."""
+        method = self._require(
+            "get_capabilities", f"{source.title()} Prompt source is unavailable."
+        )
+        return await method(mode=source)
+
+    async def list_page(self, source: str, page: int) -> Any:
+        """Return one browse page of `source` at this cluster's page size."""
+        method = self._require(
+            "list_prompts", f"{source.title()} Prompt source is unavailable."
+        )
+        return await method(mode=source, page=page, per_page=10)
+
+    async def search(self, source: str, query: str) -> Any:
+        """Search `source`, bounded to the modal's 25-row contract."""
+        method = self._require(
+            "search_prompts", f"{source.title()} Prompt search is unavailable."
+        )
+        return await method(mode=source, query=query, limit=25)
+
+    async def detail(self, source: str, identifier: str) -> Any:
+        """Fetch one record -- also the freshness probe the apply guards use."""
+        method = self._require(
+            "get_prompt", f"{source.title()} Prompt source is unavailable."
+        )
+        return await method(mode=source, prompt_identifier=identifier)
+
+    async def save(self, **payload: Any) -> Any:
+        """Persist the editor's working copy to the payload's own source."""
+        method = self._require("save_prompt", "The selected Prompt source cannot save.")
+        source = str(payload.pop("source", "local"))
+        return await method(mode=source, **payload)
+
+    async def record_usage(self, source: str, identifier: str) -> None:
+        """Record one Library usage, skipping a source that cannot track it.
+
+        A source with no recorder is not a failure -- it is a source that
+        does not count usage -- so this returns quietly. A recorder that
+        raises propagates: the caller owns what the user is told about it.
+
+        Args:
+            source: The scope the applied record came from.
+            identifier: That record's source-scoped identity.
+        """
+        recorder = getattr(self._service, "record_prompt_usage", None)
+        if not callable(recorder):
+            return
+        await recorder(mode=source, prompt_identifier=identifier)
+
+
+class _ConsolePromptImprovementFlow:
+    """The Prompt Library modal's improvement sub-flow, scoped to ONE open.
+
+    Eleven of `_open_console_prompts_modal`'s closures were a single
+    stateful conversation: pin and disclose a provider target, build a
+    request snapshot against it, validate a reviewed result against the
+    artifact it came from, apply it to the live session, and retry a
+    System-prompt persist that failed. They shared eight captured values
+    plus one `nonlocal` -- the pinned resolution -- that nothing else in that
+    scope touched. That is an object with state, so it is one here
+    (task 2766); the `nonlocal` becomes `self._pinned_resolution`.
+
+    One instance per modal open, built by
+    `ConsolePromptsController._open_console_prompts_modal`; six of its bound
+    methods are what `ConsolePromptsModal` receives. Everything it needs from
+    outside this cluster arrives as a named constructor argument and stays a
+    CALLABLE, following the rule the controller itself follows (see the
+    module docstring), so a screen-level replacement made after the modal
+    opened is still observed.
+    """
+
+    def __init__(
+        self,
+        *,
+        source: _ConsolePromptSource,
+        store: Any,
+        session_id: Any,
+        composer: Any,
+        composer_snapshot: Any,
+        current_system: str,
+        current_system_fingerprint: str,
+        gateway: Any,
+        improvement_context: Any,
+        app_instance: Any,
+        active_session_settings: Callable[[], Any],
+        build_provider_selection: Callable[[], Any],
+        sync_system_prompt_surfaces: Callable[[], None],
+    ) -> None:
+        """Capture the facts this open was disclosed against.
+
+        Args:
+            source: The open's `_ConsolePromptSource`; the saved-artifact
+                guards re-fetch through it and usage is recorded through it.
+            store: The Console chat store, live -- `active_session_id` is
+                re-read on every guard, never trusted from open time.
+            session_id: The session the modal was opened over.
+            composer: The Console composer widget the draft belongs to.
+            composer_snapshot: That draft, captured at open, and the thing
+                every projection and validation runs against.
+            current_system: The System prompt as disclosed at open.
+            current_system_fingerprint: Its fingerprint, the guard the live
+                System prompt is re-checked against.
+            gateway: The Console provider gateway that resolves targets.
+            improvement_context: The opening disclosure the activation
+                returns a `replace`d copy of.
+            app_instance: Held (not snapshotted into a bound `notify`) so a
+                later `app.notify` replacement is still observed.
+            active_session_settings: Returns the LIVE session settings --
+                `ConsoleSessionController._ensure_active_console_session_
+                settings`, through the controller's own named dependency.
+            build_provider_selection: Rebuilds the provider selection per
+                resolve, so staleness compares against a LIVE selection.
+            sync_system_prompt_surfaces: Re-syncs the three screen surfaces
+                that display the System prompt, after it is persisted.
+        """
+        self._source = source
+        self._store = store
+        self._session_id = session_id
+        self._composer = composer
+        self._composer_snapshot = composer_snapshot
+        self._current_system = current_system
+        self._current_system_fingerprint = current_system_fingerprint
+        self._gateway = gateway
+        self._improvement_context = improvement_context
+        self._app_instance = app_instance
+        self._active_session_settings = active_session_settings
+        self._build_provider_selection = build_provider_selection
+        self._sync_system_prompt_surfaces = sync_system_prompt_surfaces
+        #: The disclosed target, pinned by `activate_improvement_context` (or
+        #: by a model-free `capture_manual_resolution`) and compared against a
+        #: freshly resolved one before anything is sent or applied.
+        self._pinned_resolution: Any | None = None
+
+    # -- Staleness -----------------------------------------------------------
+
+    def _active_system_fingerprint(self) -> str:
+        """Fingerprint the LIVE System prompt, re-read on every guard."""
+        live_settings = self._active_session_settings()
+        return fingerprint_text(str(live_settings.system_prompt or ""))
+
+    def _stale_reason(self) -> str:
+        """Why this open can no longer act, or `""` while it still can.
+
+        Both facts were fixed when the modal opened -- the session it was
+        opened over and the System prompt it disclosed. Either moving means
+        the user is deciding about a state that no longer exists.
+
+        Returns:
+            str: User-visible copy naming what moved, or `""`.
+        """
+        if self._store.active_session_id != self._session_id:
+            return "The active Console session changed."
+        if self._active_system_fingerprint() != self._current_system_fingerprint:
+            return "The Console System prompt changed."
+        return ""
+
+    # -- Pinning the disclosed target ---------------------------------------
+
+    async def activate_improvement_context(self) -> Any:
+        """Pin and disclose the exact target before any model path can run."""
+
+        stale = self._stale_reason()
+        if stale:
+            raise ValueError(stale)
+        projection = None
+        projection_blocker = ""
+        try:
+            projection = self._composer.project_snapshot_for_model(
+                self._composer_snapshot,
+                request_nonce=f"prompt-preview-{uuid.uuid4().hex}",
+            )
+        except ValueError:
+            projection_blocker = (
+                "Model improvement is unavailable because the draft contains "
+                "reserved protected-placeholder text. Remove or rename that "
+                "literal token, then reopen Improve."
+            )
+        try:
+            resolution = await self._gateway.resolve_for_send(
+                self._build_provider_selection()
+            )
+        except Exception:
+            self._pinned_resolution = None
+            return replace(
+                self._improvement_context,
+                current_user_projection=projection,
+                endpoint_label="Unavailable",
+                model_unavailable_reason=(
+                    projection_blocker
+                    or "Prompt improvement could not resolve the current provider "
+                    "target. Review Console provider settings and reopen Improve."
+                ),
+            )
+        self._pinned_resolution = resolution
+        blocker = projection_blocker
+        if not blocker and (
+            not resolution.ready or not str(resolution.model or "").strip()
+        ):
+            blocker = str(
+                resolution.visible_copy
+                or "Choose a ready provider and model, then reopen Improve."
+            )
+        return replace(
+            self._improvement_context,
+            current_user_projection=projection,
+            provider_label=str(resolution.provider or "Not configured"),
+            model_label=str(resolution.model or "Not configured"),
+            endpoint_label=(
+                safe_endpoint_display(resolution.base_url) or "Provider default"
+            ),
+            model_unavailable_reason=blocker,
+            pinned_resolution=resolution,
+        )
+
+    async def capture_manual_resolution(self) -> Any:
+        """Capture the effective target once for a later model-free Apply."""
+
+        if self._pinned_resolution is None:
+            self._pinned_resolution = await self._gateway.resolve_for_send(
+                self._build_provider_selection()
+            )
+        return self._pinned_resolution
+
+    async def build_improvement_snapshot(self, **values: Any) -> Any:
+        """Build the request snapshot, against the pinned target only."""
+        stale = self._stale_reason()
+        if stale:
+            raise ValueError(stale)
+        request_id = str(values["request_id"])
+        projection = self._composer.project_snapshot_for_model(
+            self._composer_snapshot,
+            request_nonce=request_id,
+        )
+        self._composer.validate_improvement(self._composer_snapshot, projection.text)
+        pinned_resolution = self._pinned_resolution
+        if pinned_resolution is None:
+            raise ValueError(
+                "The provider target is no longer pinned. Reopen Improve to refresh disclosure."
+            )
+        live_resolution = await self._gateway.resolve_for_send(
+            self._build_provider_selection()
+        )
+        if _provider_resolution_identity(
+            live_resolution
+        ) != _provider_resolution_identity(pinned_resolution):
+            raise ValueError(
+                "The provider, model, or endpoint changed. Reopen Improve to refresh disclosure."
+            )
+        if not pinned_resolution.ready or not str(pinned_resolution.model or "").strip():
+            raise ValueError(pinned_resolution.visible_copy or "Provider is unavailable.")
+        include_system = bool(values.get("include_system"))
+        recipe_definition = values.get("recipe_definition")
+        return PromptImprovementRequestSnapshot(
+            request_id=request_id,
+            mode=values["mode"],
+            session_id=self._session_id,
+            composer_snapshot=self._composer_snapshot,
+            projection=projection,
+            system_prompt=self._current_system if include_system else None,
+            system_fingerprint=(
+                self._current_system_fingerprint if include_system else None
+            ),
+            resolution=pinned_resolution,
+            provider_label=pinned_resolution.provider,
+            model_label=str(pinned_resolution.model),
+            recipe_source=values.get("recipe_source"),
+            recipe_source_id=values.get("recipe_source_id"),
+            recipe_version=values.get("recipe_version"),
+            recipe_definition=recipe_definition,
+            recipe_fingerprint=(
+                fingerprint_block_definition(recipe_definition)
+                if recipe_definition is not None
+                else None
+            ),
+        )
+
+    # -- Validating what came back ------------------------------------------
+
+    def validate_improvement(self, captured: Any, text: str) -> None:
+        """Validate reviewed text against the snapshot the request captured."""
+        snapshot = getattr(captured, "composer_snapshot", self._composer_snapshot)
+        self._composer.validate_improvement(snapshot, text)
+
+    async def _validate_saved_recipe(self, captured: Any) -> None:
+        """Refuse to apply a Recipe that moved since it was selected.
+
+        Raises:
+            ValueError: Naming what drifted -- source, identity, version,
+                compatibility or content.
+        """
+        recipe_source_id = str(getattr(captured, "recipe_source_id", "") or "")
+        if not recipe_source_id or recipe_source_id.startswith("builtin:"):
+            return
+        source = getattr(captured, "recipe_source", None)
+        if source not in {"local", "server"}:
+            raise ValueError("The selected Recipe source changed.")
+        latest = await self._source.detail(source, recipe_source_id)
+        if not isinstance(latest, Mapping):
+            raise ValueError("The selected Recipe is no longer available.")
+        latest_identity = (
+            latest.get("source_id") or latest.get("id") or latest.get("uuid")
+        )
+        if str(latest_identity or "") != recipe_source_id:
+            raise ValueError("The selected Recipe identity changed.")
+        latest_version = latest.get("version", latest.get("optimistic_version"))
+        if latest_version != getattr(captured, "recipe_version", None):
+            raise ValueError("The selected Recipe version changed.")
+        decoded = decode_prompt_artifact(latest)
+        if decoded.artifact_type != "recipe" or decoded.definition is None:
+            raise ValueError("The selected Recipe is no longer compatible.")
+        if fingerprint_block_definition(decoded.definition) != getattr(
+            captured, "recipe_fingerprint", None
+        ):
+            raise ValueError("The selected Recipe changed.")
+
+    async def _validate_saved_prompt(self, captured: Any) -> None:
+        """Refuse to apply a saved Prompt that moved since it was selected.
+
+        Raises:
+            ValueError: Naming what drifted -- availability, identity,
+                version, compatibility or content.
+        """
+        if not isinstance(captured, ConsoleSavedPromptApplyGuard):
+            return
+        latest = await self._source.detail(captured.source, captured.prompt_source_id)
+        if not isinstance(latest, Mapping):
+            raise ValueError("The selected Prompt is no longer available.")
+        latest_identity = (
+            latest.get("source_id") or latest.get("id") or latest.get("uuid")
+        )
+        if str(latest_identity or "") != captured.prompt_source_id:
+            raise ValueError("The selected Prompt identity changed.")
+        latest_version = latest.get("version", latest.get("optimistic_version"))
+        if latest_version != captured.prompt_version:
+            raise ValueError("The selected Prompt version changed.")
+        decoded = decode_prompt_artifact(latest)
+        if decoded.artifact_type != "prompt" or decoded.definition is None:
+            raise ValueError("The selected Prompt is no longer compatible.")
+        if fingerprint_block_definition(decoded.definition) != captured.prompt_fingerprint:
+            raise ValueError("The selected Prompt changed.")
+
+    async def _record_applied_usage(self, captured: Any) -> None:
+        """Record Library usage for an applied saved Prompt, never fatally.
+
+        The apply already landed by the time this runs, so a recorder failure
+        is a warning about bookkeeping -- never a rollback.
+        """
+        if (
+            not isinstance(captured, ConsoleSavedPromptApplyGuard)
+            or not captured.record_usage
+        ):
+            return
+        try:
+            await self._source.record_usage(
+                captured.source,
+                captured.prompt_source_id,
+            )
+        except Exception:
+            self._app_instance.notify(
+                "The prompt was applied, but Library usage could not be recorded.",
+                severity="warning",
+            )
+
+    # -- Applying it --------------------------------------------------------
+
+    async def apply_improvement_result(
+        self, result: ConsolePromptsResult, captured: Any
+    ) -> ConsolePromptsApplyOutcome:
+        """Apply a reviewed result to the live session, or refuse as stale."""
+        stale = self._stale_reason()
+        if stale:
+            return ConsolePromptsApplyOutcome("stale", stale)
+        if isinstance(captured, PromptImprovementRequestSnapshot):
+            live_resolution = await self._gateway.resolve_for_send(
+                self._build_provider_selection()
+            )
+            if _provider_resolution_identity(
+                live_resolution
+            ) != _provider_resolution_identity(captured.resolution):
+                return ConsolePromptsApplyOutcome(
+                    "stale", "The provider, model, or endpoint changed."
+                )
+        elif isinstance(
+            captured, (ConsoleRecipeApplyGuard, ConsoleSavedPromptApplyGuard)
+        ):
+            captured_resolution = captured.provider_resolution
+            if captured_resolution is None:
+                return ConsolePromptsApplyOutcome(
+                    "stale",
+                    "The provider target was not captured. Reopen the Prompt and retry.",
+                )
+            live_resolution = await self._gateway.resolve_for_send(
+                self._build_provider_selection()
+            )
+            if _provider_resolution_identity(
+                live_resolution
+            ) != _provider_resolution_identity(captured_resolution):
+                return ConsolePromptsApplyOutcome(
+                    "stale", "The provider, model, or endpoint changed."
+                )
+        try:
+            await self._validate_saved_recipe(captured)
+            await self._validate_saved_prompt(captured)
+            if result.apply_user:
+                if result.user_text is None:
+                    raise ValueError("The reviewed User prompt is missing.")
+                self._composer.validate_improvement(
+                    result.composer_snapshot, result.user_text
+                )
+            elif self._composer.capture_draft_snapshot() != result.composer_snapshot:
+                raise ValueError("The Console draft changed.")
+        except Exception:
+            return ConsolePromptsApplyOutcome(
+                "stale",
+                "The draft or Recipe changed. Review the working copy and retry.",
+            )
+
+        if result.apply_user and result.user_text is not None:
+            self._composer.apply_improvement(
+                result.composer_snapshot,
+                result.user_text,
+            )
+            self._store.set_session_draft(self._session_id, self._composer.draft_text())
+        persisted = True
+        if result.apply_system:
+            _session, persisted = self._store.set_session_system_prompt(
+                self._session_id, result.system_text
+            )
+            self._sync_system_prompt_surfaces()
+        await self._record_applied_usage(captured)
+        if not persisted:
+            return ConsolePromptsApplyOutcome("persistence_failed")
+        return ConsolePromptsApplyOutcome("applied")
+
+    async def retry_improvement_persistence(
+        self, result: ConsolePromptsResult
+    ) -> ConsolePromptsApplyOutcome:
+        """Re-attempt a System-prompt persist that failed, and only that."""
+        if self._store.active_session_id != self._session_id or not result.apply_system:
+            return ConsolePromptsApplyOutcome(
+                "stale", "The active Console session changed."
+            )
+        live_settings = self._active_session_settings()
+        if str(live_settings.system_prompt or "") != str(result.system_text or ""):
+            return ConsolePromptsApplyOutcome("stale", "The live System prompt changed.")
+        _session, persisted = self._store.set_session_system_prompt(
+            self._session_id, result.system_text
+        )
+        self._sync_system_prompt_surfaces()
+        return ConsolePromptsApplyOutcome(
+            "applied" if persisted else "persistence_failed"
+        )
+
+
 class ConsolePromptsController:
     """Owns the Console shell's prompt cluster: the Prompt Library modal,
     `/prompt` + `/system` resolution and their pickers, the system-prompt
@@ -198,25 +726,27 @@ class ConsolePromptsController:
         insert_prompt_text_into_composer: Callable[..., bool],
         clear_console_composer_draft: Callable[[], None],
         append_native_console_system_message: Callable[[str], Any],
-        sync_console_chat_core_state: Callable[[], None],
-        sync_console_rail_system_line: Callable[[], None],
-        sync_console_settings_summary: Callable[[], None],
+        sync_console_system_prompt_surfaces: Callable[[], None],
     ) -> None:
         """Build the controller and bind everything its moved bodies need.
 
-        Every one of the 13 method bodies below is a byte-for-byte copy of
-        the pre-extraction `ChatScreen` method, EXCEPT the three documented
+        Every one of the method bodies below is a byte-for-byte copy of the
+        pre-extraction `ChatScreen` method, EXCEPT the three documented
         `self._session.X(...)` seam call sites (dropping that prefix for a
         same-named property here, per the module docstring's
-        "Controller-to-controller seam" section) and every
+        "Controller-to-controller seam" section), every
         `self.app.push_screen(...)` call site (dropping the `.app.` for the
         `push_screen` framework property below, the same transformation
-        `session.py` and `message.py`'s own moved bodies already made).
+        `session.py` and `message.py`'s own moved bodies already made), and
+        `_open_console_prompts_modal`, whose closures task 2766 moved into
+        `_ConsolePromptSource` and `_ConsolePromptImprovementFlow`.
 
-        Eighteen named dependencies is squarely in the band waves 1-3 have
-        established (dictation: 12; message: 19). Fifteen of the eighteen
+        Sixteen named dependencies is squarely in the band waves 1-3 have
+        established (dictation: 12; message: 19). Thirteen of the sixteen
         are needed by `_open_console_prompts_modal` alone -- it is the
-        cluster's whole fan-in, not a sprawl across many methods.
+        cluster's whole fan-in, not a sprawl across many methods. The count
+        was eighteen until task 2766 collapsed the post-apply re-sync trio
+        (see `sync_console_system_prompt_surfaces` below).
 
         Args:
             screen: The Console screen. Used ONLY for the framework
@@ -287,13 +817,16 @@ class ConsolePromptsController:
             append_native_console_system_message: `ChatScreen._append_
                 native_console_system_message` -- the inline transcript
                 error channel both command handlers use to refuse a Recipe.
-            sync_console_chat_core_state: `ChatScreen._sync_console_chat_
-                core_state`, one of the three post-apply re-sync bridges
-                (all DOM-adjacent, all staying screen-owned).
-            sync_console_rail_system_line: `ChatScreen._sync_console_rail_
-                system_line`, ditto.
-            sync_console_settings_summary: `ChatScreen._sync_console_
-                settings_summary`, ditto.
+            sync_console_system_prompt_surfaces: The post-apply re-sync
+                bridge. Three separate screen methods (`_sync_console_chat_
+                core_state`, `_sync_console_rail_system_line`, `_sync_
+                console_settings_summary`, all DOM-adjacent and all staying
+                screen-owned) sit behind ONE dependency because this cluster
+                only ever needs the trio, in that order, at the two moments
+                the store accepted a new System prompt -- never any of them
+                individually. Task 2766 collapsed them; `wiring.py` still
+                reaches each screen method by name at CALL time, so the
+                late-binding property every one of them had is unchanged.
         """
         self._screen = screen
         self.app_instance = app_instance
@@ -322,9 +855,9 @@ class ConsolePromptsController:
         self._append_native_console_system_message_fn = (
             append_native_console_system_message
         )
-        self._sync_console_chat_core_state_fn = sync_console_chat_core_state
-        self._sync_console_rail_system_line_fn = sync_console_rail_system_line
-        self._sync_console_settings_summary_fn = sync_console_settings_summary
+        self._sync_console_system_prompt_surfaces_fn = (
+            sync_console_system_prompt_surfaces
+        )
 
         # This cluster's own state, moved verbatim from `ChatScreen.__init__`.
         # Nothing outside this cluster ever read the attribute directly (only
@@ -423,16 +956,8 @@ class ConsolePromptsController:
         return self._append_native_console_system_message_fn
 
     @property
-    def _sync_console_chat_core_state(self) -> Any:
-        return self._sync_console_chat_core_state_fn
-
-    @property
-    def _sync_console_rail_system_line(self) -> Any:
-        return self._sync_console_rail_system_line_fn
-
-    @property
-    def _sync_console_settings_summary(self) -> Any:
-        return self._sync_console_settings_summary_fn
+    def _sync_console_system_prompt_surfaces(self) -> Any:
+        return self._sync_console_system_prompt_surfaces_fn
 
     # -- Moved bodies -------------------------------------------------------
 
@@ -457,9 +982,33 @@ class ConsolePromptsController:
             self._console_prompt_history = history
         return history
 
+    def _restore_console_composer_focus(
+        self, _result: ConsolePromptsResult | None = None
+    ) -> None:
+        """Return focus to the composer when a prompt modal closes.
+
+        The `push_screen` callback for the Prompt Library modal: the modal's
+        result is irrelevant to focus, so it is accepted and ignored.
+
+        Args:
+            _result: Whatever the modal dismissed with; unused.
+        """
+        self._focus_console_composer_if_needed(force=True)
+
     def _open_console_prompts_modal(self) -> None:
-        """Open the source-aware Prompt Library without changing the draft."""
-        service = getattr(self.app_instance, "prompt_scope_service", None)
+        """Open the source-aware Prompt Library without changing the draft.
+
+        Builds the modal's two collaborators for this one open -- a
+        `_ConsolePromptSource` over the app's prompt scope service, and a
+        `_ConsolePromptImprovementFlow` holding everything the improvement
+        sub-flow was disclosed against -- and hands their bound methods to
+        `ConsolePromptsModal`. Before task 2766 those were 17 closures over
+        this method's scope; see each class's docstring for why they split
+        where they do.
+        """
+        source = _ConsolePromptSource(
+            getattr(self.app_instance, "prompt_scope_service", None)
+        )
         composer = self._console_composer_or_none()
         if composer is None:
             return
@@ -477,7 +1026,6 @@ class ConsolePromptsController:
         opening_selection = self._build_console_provider_selection()
         gateway = self._ensure_console_provider_gateway()
         improvement_service = PromptImprovementService(gateway=gateway)
-        pinned_improvement_resolution: Any | None = None
         improvement_context = ConsolePromptImprovementContext(
             session_id=session_id,
             composer_snapshot=composer_snapshot,
@@ -493,366 +1041,41 @@ class ConsolePromptsController:
             model_unavailable_reason=self._console_provider_blocker_copy(),
         )
 
-        async def capabilities(source: str) -> Any:
-            method = getattr(service, "get_capabilities", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt source is unavailable.")
-            return await method(mode=source)
-
-        async def list_page(source: str, page: int) -> Any:
-            method = getattr(service, "list_prompts", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt source is unavailable.")
-            return await method(mode=source, page=page, per_page=10)
-
-        async def search(source: str, query: str) -> Any:
-            method = getattr(service, "search_prompts", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt search is unavailable.")
-            return await method(mode=source, query=query, limit=25)
-
-        async def detail(source: str, identifier: str) -> Any:
-            method = getattr(service, "get_prompt", None)
-            if not callable(method):
-                raise ValueError(f"{source.title()} Prompt source is unavailable.")
-            return await method(mode=source, prompt_identifier=identifier)
-
-        async def save(**payload: Any) -> Any:
-            method = getattr(service, "save_prompt", None)
-            if not callable(method):
-                raise ValueError("The selected Prompt source cannot save.")
-            source = str(payload.pop("source", "local"))
-            return await method(mode=source, **payload)
-
-        def _active_system_fingerprint() -> str:
-            live_settings = self._ensure_active_console_session_settings()
-            return fingerprint_text(str(live_settings.system_prompt or ""))
-
-        def _resolution_identity(resolution: Any) -> tuple[str, str, str, str, str]:
-            return (
-                str(getattr(resolution, "provider", "")),
-                str(getattr(resolution, "model", "")),
-                str(getattr(resolution, "base_url", "")),
-                str(getattr(resolution, "readiness_key", "")),
-                str(getattr(resolution, "execution_key", "")),
-            )
-
-        async def activate_improvement_context() -> Any:
-            """Pin and disclose the exact target before any model path can run."""
-
-            nonlocal pinned_improvement_resolution
-            if store.active_session_id != session_id:
-                raise ValueError("The active Console session changed.")
-            if _active_system_fingerprint() != current_system_fingerprint:
-                raise ValueError("The Console System prompt changed.")
-            projection = None
-            projection_blocker = ""
-            try:
-                projection = composer.project_snapshot_for_model(
-                    composer_snapshot,
-                    request_nonce=f"prompt-preview-{uuid.uuid4().hex}",
-                )
-            except ValueError:
-                projection_blocker = (
-                    "Model improvement is unavailable because the draft contains "
-                    "reserved protected-placeholder text. Remove or rename that "
-                    "literal token, then reopen Improve."
-                )
-            try:
-                resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-            except Exception:
-                pinned_improvement_resolution = None
-                return replace(
-                    improvement_context,
-                    current_user_projection=projection,
-                    endpoint_label="Unavailable",
-                    model_unavailable_reason=(
-                        projection_blocker
-                        or "Prompt improvement could not resolve the current provider "
-                        "target. Review Console provider settings and reopen Improve."
-                    ),
-                )
-            pinned_improvement_resolution = resolution
-            blocker = projection_blocker
-            if not blocker and (
-                not resolution.ready or not str(resolution.model or "").strip()
-            ):
-                blocker = str(
-                    resolution.visible_copy
-                    or "Choose a ready provider and model, then reopen Improve."
-                )
-            return replace(
-                improvement_context,
-                current_user_projection=projection,
-                provider_label=str(resolution.provider or "Not configured"),
-                model_label=str(resolution.model or "Not configured"),
-                endpoint_label=(
-                    safe_endpoint_display(resolution.base_url)
-                    or "Provider default"
-                ),
-                model_unavailable_reason=blocker,
-                pinned_resolution=resolution,
-            )
-
-        async def capture_manual_resolution() -> Any:
-            """Capture the effective target once for a later model-free Apply."""
-
-            nonlocal pinned_improvement_resolution
-            if pinned_improvement_resolution is None:
-                pinned_improvement_resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-            return pinned_improvement_resolution
-
-        async def build_improvement_snapshot(**values: Any) -> Any:
-            if store.active_session_id != session_id:
-                raise ValueError("The active Console session changed.")
-            if _active_system_fingerprint() != current_system_fingerprint:
-                raise ValueError("The Console System prompt changed.")
-            request_id = str(values["request_id"])
-            projection = composer.project_snapshot_for_model(
-                composer_snapshot,
-                request_nonce=request_id,
-            )
-            composer.validate_improvement(composer_snapshot, projection.text)
-            pinned_resolution = pinned_improvement_resolution
-            if pinned_resolution is None:
-                raise ValueError(
-                    "The provider target is no longer pinned. Reopen Improve to refresh disclosure."
-                )
-            live_resolution = await gateway.resolve_for_send(
-                self._build_console_provider_selection()
-            )
-            if _resolution_identity(live_resolution) != _resolution_identity(
-                pinned_resolution
-            ):
-                raise ValueError(
-                    "The provider, model, or endpoint changed. Reopen Improve to refresh disclosure."
-                )
-            if not pinned_resolution.ready or not str(
-                pinned_resolution.model or ""
-            ).strip():
-                raise ValueError(
-                    pinned_resolution.visible_copy or "Provider is unavailable."
-                )
-            include_system = bool(values.get("include_system"))
-            recipe_definition = values.get("recipe_definition")
-            return PromptImprovementRequestSnapshot(
-                request_id=request_id,
-                mode=values["mode"],
-                session_id=session_id,
-                composer_snapshot=composer_snapshot,
-                projection=projection,
-                system_prompt=current_system if include_system else None,
-                system_fingerprint=(
-                    current_system_fingerprint if include_system else None
-                ),
-                resolution=pinned_resolution,
-                provider_label=pinned_resolution.provider,
-                model_label=str(pinned_resolution.model),
-                recipe_source=values.get("recipe_source"),
-                recipe_source_id=values.get("recipe_source_id"),
-                recipe_version=values.get("recipe_version"),
-                recipe_definition=recipe_definition,
-                recipe_fingerprint=(
-                    fingerprint_block_definition(recipe_definition)
-                    if recipe_definition is not None
-                    else None
-                ),
-            )
-
-        def validate_improvement(captured: Any, text: str) -> None:
-            snapshot = getattr(captured, "composer_snapshot", composer_snapshot)
-            composer.validate_improvement(snapshot, text)
-
-        async def validate_saved_recipe(captured: Any) -> None:
-            recipe_source_id = str(
-                getattr(captured, "recipe_source_id", "") or ""
-            )
-            if not recipe_source_id or recipe_source_id.startswith("builtin:"):
-                return
-            source = getattr(captured, "recipe_source", None)
-            if source not in {"local", "server"}:
-                raise ValueError("The selected Recipe source changed.")
-            latest = await detail(source, recipe_source_id)
-            if not isinstance(latest, Mapping):
-                raise ValueError("The selected Recipe is no longer available.")
-            latest_identity = (
-                latest.get("source_id") or latest.get("id") or latest.get("uuid")
-            )
-            if str(latest_identity or "") != recipe_source_id:
-                raise ValueError("The selected Recipe identity changed.")
-            latest_version = latest.get("version", latest.get("optimistic_version"))
-            if latest_version != getattr(captured, "recipe_version", None):
-                raise ValueError("The selected Recipe version changed.")
-            decoded = decode_prompt_artifact(latest)
-            if decoded.artifact_type != "recipe" or decoded.definition is None:
-                raise ValueError("The selected Recipe is no longer compatible.")
-            if fingerprint_block_definition(decoded.definition) != getattr(
-                captured, "recipe_fingerprint", None
-            ):
-                raise ValueError("The selected Recipe changed.")
-
-        async def validate_saved_prompt(captured: Any) -> None:
-            if not isinstance(captured, ConsoleSavedPromptApplyGuard):
-                return
-            latest = await detail(captured.source, captured.prompt_source_id)
-            if not isinstance(latest, Mapping):
-                raise ValueError("The selected Prompt is no longer available.")
-            latest_identity = (
-                latest.get("source_id") or latest.get("id") or latest.get("uuid")
-            )
-            if str(latest_identity or "") != captured.prompt_source_id:
-                raise ValueError("The selected Prompt identity changed.")
-            latest_version = latest.get("version", latest.get("optimistic_version"))
-            if latest_version != captured.prompt_version:
-                raise ValueError("The selected Prompt version changed.")
-            decoded = decode_prompt_artifact(latest)
-            if decoded.artifact_type != "prompt" or decoded.definition is None:
-                raise ValueError("The selected Prompt is no longer compatible.")
-            if fingerprint_block_definition(decoded.definition) != captured.prompt_fingerprint:
-                raise ValueError("The selected Prompt changed.")
-
-        async def record_applied_usage(captured: Any) -> None:
-            if not isinstance(
-                captured, ConsoleSavedPromptApplyGuard
-            ) or not captured.record_usage:
-                return
-            recorder = getattr(service, "record_prompt_usage", None)
-            if not callable(recorder):
-                return
-            try:
-                await recorder(
-                    mode=captured.source,
-                    prompt_identifier=captured.prompt_source_id,
-                )
-            except Exception:
-                self.app_instance.notify(
-                    "The prompt was applied, but Library usage could not be recorded.",
-                    severity="warning",
-                )
-
-        async def apply_improvement_result(
-            result: ConsolePromptsResult, captured: Any
-        ) -> ConsolePromptsApplyOutcome:
-            if store.active_session_id != session_id:
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The active Console session changed."
-                )
-            if _active_system_fingerprint() != current_system_fingerprint:
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The Console System prompt changed."
-                )
-            if isinstance(captured, PromptImprovementRequestSnapshot):
-                live_resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-                if _resolution_identity(live_resolution) != _resolution_identity(
-                    captured.resolution
-                ):
-                    return ConsolePromptsApplyOutcome(
-                        "stale", "The provider, model, or endpoint changed."
-                    )
-            elif isinstance(
-                captured, (ConsoleRecipeApplyGuard, ConsoleSavedPromptApplyGuard)
-            ):
-                captured_resolution = captured.provider_resolution
-                if captured_resolution is None:
-                    return ConsolePromptsApplyOutcome(
-                        "stale",
-                        "The provider target was not captured. Reopen the Prompt and retry.",
-                    )
-                live_resolution = await gateway.resolve_for_send(
-                    self._build_console_provider_selection()
-                )
-                if _resolution_identity(live_resolution) != _resolution_identity(
-                    captured_resolution
-                ):
-                    return ConsolePromptsApplyOutcome(
-                        "stale", "The provider, model, or endpoint changed."
-                    )
-            try:
-                await validate_saved_recipe(captured)
-                await validate_saved_prompt(captured)
-                if result.apply_user:
-                    if result.user_text is None:
-                        raise ValueError("The reviewed User prompt is missing.")
-                    composer.validate_improvement(
-                        result.composer_snapshot, result.user_text
-                    )
-                elif composer.capture_draft_snapshot() != result.composer_snapshot:
-                    raise ValueError("The Console draft changed.")
-            except Exception:
-                return ConsolePromptsApplyOutcome(
-                    "stale",
-                    "The draft or Recipe changed. Review the working copy and retry.",
-                )
-
-            if result.apply_user and result.user_text is not None:
-                composer.apply_improvement(
-                    result.composer_snapshot,
-                    result.user_text,
-                )
-                store.set_session_draft(session_id, composer.draft_text())
-            persisted = True
-            if result.apply_system:
-                _session, persisted = store.set_session_system_prompt(
-                    session_id, result.system_text
-                )
-                self._sync_console_chat_core_state()
-                self._sync_console_rail_system_line()
-                self._sync_console_settings_summary()
-            await record_applied_usage(captured)
-            if not persisted:
-                return ConsolePromptsApplyOutcome("persistence_failed")
-            return ConsolePromptsApplyOutcome("applied")
-
-        async def retry_improvement_persistence(
-            result: ConsolePromptsResult,
-        ) -> ConsolePromptsApplyOutcome:
-            if store.active_session_id != session_id or not result.apply_system:
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The active Console session changed."
-                )
-            live_settings = self._ensure_active_console_session_settings()
-            if str(live_settings.system_prompt or "") != str(result.system_text or ""):
-                return ConsolePromptsApplyOutcome(
-                    "stale", "The live System prompt changed."
-                )
-            _session, persisted = store.set_session_system_prompt(
-                session_id, result.system_text
-            )
-            self._sync_console_chat_core_state()
-            self._sync_console_rail_system_line()
-            self._sync_console_settings_summary()
-            return ConsolePromptsApplyOutcome(
-                "applied" if persisted else "persistence_failed"
-            )
-
-        def restore_focus(_result: ConsolePromptsResult | None) -> None:
-            self._focus_console_composer_if_needed(force=True)
+        flow = _ConsolePromptImprovementFlow(
+            source=source,
+            store=store,
+            session_id=session_id,
+            composer=composer,
+            composer_snapshot=composer_snapshot,
+            current_system=current_system,
+            current_system_fingerprint=current_system_fingerprint,
+            gateway=gateway,
+            improvement_context=improvement_context,
+            app_instance=self.app_instance,
+            active_session_settings=self._ensure_active_console_session_settings,
+            build_provider_selection=self._build_console_provider_selection,
+            sync_system_prompt_surfaces=self._sync_console_system_prompt_surfaces,
+        )
 
         self.push_screen(
             ConsolePromptsModal(
-                capabilities=capabilities,
-                list_page=list_page,
-                search=search,
-                detail=detail,
-                save=save,
+                capabilities=source.capabilities,
+                list_page=source.list_page,
+                search=source.search,
+                detail=source.detail,
+                save=source.save,
                 improve_unavailable_reason=self._console_provider_blocker_copy(),
                 configure_provider=self._open_console_provider_recovery,
                 improvement_context=improvement_context,
-                activate_improvement_context=activate_improvement_context,
-                capture_manual_resolution=capture_manual_resolution,
-                build_improvement_snapshot=build_improvement_snapshot,
+                activate_improvement_context=flow.activate_improvement_context,
+                capture_manual_resolution=flow.capture_manual_resolution,
+                build_improvement_snapshot=flow.build_improvement_snapshot,
                 improve=improvement_service.improve,
-                validate_improvement=validate_improvement,
-                apply_improvement_result=apply_improvement_result,
-                retry_improvement_persistence=retry_improvement_persistence,
+                validate_improvement=flow.validate_improvement,
+                apply_improvement_result=flow.apply_improvement_result,
+                retry_improvement_persistence=flow.retry_improvement_persistence,
             ),
-            callback=restore_focus,
+            callback=self._restore_console_composer_focus,
         )
 
     @staticmethod

--- a/tldw_chatbook/UI/Console_Modules/prompts.py
+++ b/tldw_chatbook/UI/Console_Modules/prompts.py
@@ -135,6 +135,16 @@ from ...Widgets.Console.console_prompts_modal import (
 )
 from ...Widgets.Console.console_system_prompt_modal import ConsoleSystemPromptModal
 
+#: One browse page of the Console prompt picker. Behaviour-defining: the
+#: modal's paging controls, its "no more results" state, and the Library's
+#: own page size are all in terms of this number.
+CONSOLE_PROMPT_PAGE_SIZE = 10
+
+#: Row cap for a prompt SEARCH, as distinct from a browse page. The modal
+#: renders a single unpaged result list for a search, so this bounds what a
+#: user can be shown at once rather than what one page holds.
+CONSOLE_PROMPT_SEARCH_LIMIT = 25
+
 if TYPE_CHECKING:
     from ..Screens.chat_screen import ChatScreen
 
@@ -237,18 +247,18 @@ class _ConsolePromptSource:
         return await method(mode=source)
 
     async def list_page(self, source: str, page: int) -> Any:
-        """Return one browse page of `source` at this cluster's page size."""
+        """Return one browse page of `source` at `CONSOLE_PROMPT_PAGE_SIZE`."""
         method = self._require(
             "list_prompts", f"{source.title()} Prompt source is unavailable."
         )
-        return await method(mode=source, page=page, per_page=10)
+        return await method(mode=source, page=page, per_page=CONSOLE_PROMPT_PAGE_SIZE)
 
     async def search(self, source: str, query: str) -> Any:
-        """Search `source`, bounded to the modal's 25-row contract."""
+        """Search `source`, bounded to `CONSOLE_PROMPT_SEARCH_LIMIT`."""
         method = self._require(
             "search_prompts", f"{source.title()} Prompt search is unavailable."
         )
-        return await method(mode=source, query=query, limit=25)
+        return await method(mode=source, query=query, limit=CONSOLE_PROMPT_SEARCH_LIMIT)
 
     async def detail(self, source: str, identifier: str) -> Any:
         """Fetch one record -- also the freshness probe the apply guards use."""

--- a/tldw_chatbook/UI/Console_Modules/prompts.py
+++ b/tldw_chatbook/UI/Console_Modules/prompts.py
@@ -142,7 +142,9 @@ CONSOLE_PROMPT_PAGE_SIZE = 10
 
 #: Row cap for a prompt SEARCH, as distinct from a browse page. The modal
 #: renders a single unpaged result list for a search, so this bounds what a
-#: user can be shown at once rather than what one page holds.
+#: user can be shown at once rather than what one page holds. The controller
+#: aliases this as `_CONSOLE_PROMPT_SEARCH_LIMIT` for `/prompt` resolution --
+#: one number, two readers.
 CONSOLE_PROMPT_SEARCH_LIMIT = 25
 
 if TYPE_CHECKING:
@@ -707,8 +709,11 @@ class ConsolePromptsController:
 
     # Bounded prompt-search page size for `/prompt` resolution and the
     # picker's own search callable -- mirrors Task 11's picker contract
-    # (PromptScopeService.search_prompts, FTS-ranked, <= 25 rows).
-    _CONSOLE_PROMPT_SEARCH_LIMIT = 25
+    # (PromptScopeService.search_prompts, FTS-ranked, <= 25 rows). Aliases
+    # the module-level constant rather than repeating the number: the two
+    # were briefly separate copies, which is one tuning edit away from the
+    # picker and `/prompt` disagreeing about how many rows a search returns.
+    _CONSOLE_PROMPT_SEARCH_LIMIT = CONSOLE_PROMPT_SEARCH_LIMIT
 
     _LIBRARY_PROMPT_INSERT_BLOCKED_COPY = "Finish provider setup to insert prompts."
     _RECIPE_EXECUTION_BLOCKED_COPY = (

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -520,12 +520,27 @@ def build_console_controllers(screen: "ChatScreen") -> None:
     #: resolution and their pickers, the system-prompt editor and its
     #: save-to-Library flow, the Library staged-insert handoff, and the
     #: shared prompt-history store (wave-3 console decomposition, task
-    #: 3). Every dependency below is a LATE-BINDING lambda, never a
-    #: bound method: eleven of the eighteen are replaced by name on the
-    #: screen instance somewhere in the pre-existing suite, and a
-    #: constructor snapshot would silently stop observing every one of
-    #: those. See `Console_Modules/prompts.py`'s `__init__` docstring
+    #: 3). Every dependency below is a LATE-BINDING lambda (or, for the
+    #: post-apply re-sync trio, a nested function that reads the same
+    #: way), never a bound method: eleven of the sixteen are replaced by
+    #: name on the screen instance somewhere in the pre-existing suite,
+    #: and a constructor snapshot would silently stop observing every one
+    #: of those. See `Console_Modules/prompts.py`'s `__init__` docstring
     #: for the per-parameter rationale.
+
+    def _sync_console_system_prompt_surfaces() -> None:
+        """Re-sync the three surfaces that display the System prompt.
+
+        One dependency rather than three because the prompt cluster only
+        ever needs the trio, in this order, at the two moments the store
+        accepted a new System prompt (task 2766). Each name is still
+        resolved on the screen at CALL time, so the instance-level
+        replacements the suite makes are observed exactly as before.
+        """
+        screen._sync_console_chat_core_state()
+        screen._sync_console_rail_system_line()
+        screen._sync_console_settings_summary()
+
     screen._prompts = ConsolePromptsController(
         screen,
         app_instance=screen.app_instance,
@@ -589,15 +604,7 @@ def build_console_controllers(screen: "ChatScreen") -> None:
         append_native_console_system_message=(
             lambda text: screen._append_native_console_system_message(text)
         ),
-        sync_console_chat_core_state=(
-            lambda: screen._sync_console_chat_core_state()
-        ),
-        sync_console_rail_system_line=(
-            lambda: screen._sync_console_rail_system_line()
-        ),
-        sync_console_settings_summary=(
-            lambda: screen._sync_console_settings_summary()
-        ),
+        sync_console_system_prompt_surfaces=_sync_console_system_prompt_surfaces,
     )
     #: The agent runtime's screen-side cluster -- the lazily-built
     #: `ConsoleAgentBridge`, the Agent rail section's text derivation, the


### PR DESCRIPTION
Closes task-2766.

`ConsolePromptsController._open_console_prompts_modal` was the Console's
largest non-`__init__` method: **397 lines holding 17 nested closures**, each
capturing one dependency out of a scope no reader could hold in their head.
Wave 3 moved it verbatim; two reviews since judged the controller boundary
right and the *method* the problem. It is now **82 lines with zero closures**.

## The split follows what the closures captured

**`_ConsolePromptSource`** (5 closures) — `capabilities`/`list_page`/`search`/
`detail`/`save` captured exactly one thing, `app_instance.prompt_scope_
service`, and did one thing with it. The cluster's whole source contract now
lives in one place: pages of 10, searches capped at 25, `save`'s `source`
routed into the service's `mode`, and one `_require` helper carrying the
per-callable refusal copy a duck-typed source triggers.
`record_prompt_usage` joined it, since the improvement flow read the same
service.

**`_ConsolePromptImprovementFlow`** (11 closures) — the stateful half. The
`nonlocal pinned_improvement_resolution` is the tell: one closure wrote it,
three read it, nothing else in 397 lines touched it. It becomes a field, and
the eight values the closures each re-captured become named constructor
arguments. The session/System-prompt guard pair, duplicated verbatim across
three call sites, collapses into `_stale_reason()` — same order, same copy.

**Promoted out of closure form** — `restore_focus` (captured only `self`) is
now a controller method; `_resolution_identity` (pure) is module-level.
Nothing was left inline; the two shortest closures moved for opposite reasons,
both stated in the report.

## Constructor 18 → 16 named dependencies

The three post-apply re-sync bridges were only ever called as an ordered trio,
at the two moments the store accepted a new System prompt, never individually.
`sync_console_system_prompt_surfaces` replaces them. `wiring.py` still
resolves each screen method **by name at call time**, so the late binding
eleven of the sixteen dependencies rely on is untouched. No other reduction
was available without manufacturing an abstraction — the five provider
dependencies are five distinct services, and the report says so rather than
inventing a win.

## Zero behaviour change, checked structurally

An AST equivalence pass against the parent commit shows `capture_manual_
resolution`, `validate_improvement`, both saved-artifact guards and
`restore_focus` **byte-identical**, and every other difference to be one of
four documented transformations (`_stale_reason`, `_require`, the trio
collapse, `self.` prefixes) and nothing else. Call order, the two separate
`_console_provider_blocker_copy()` reads and the modal's kwarg evaluation
order are unchanged. The controller still owns zero DOM.

One deliberate non-identity is disclosed in the report: `record_prompt_usage`'s
availability lookup now sits inside the caller's `try`, which differs only if
attribute *access* on a scope service raises — unreachable for any plain
object, and strictly safer if it ever happened.

## Test evidence

Characterisation was written, mutation-checked and pushed **green before** any
production change (`d635a862a`): 7 new live-path tests over the source
contract, the refusal copy, the focus restore, the pinned-target lifecycle,
the activation guard, the unpinned-snapshot refusal and the captured-snapshot
preference. Two mutations (`per_page` 10→11; dropping the capture-once guard)
each failed exactly one of them.

- 44 passed — prompts controller + controller wiring
- **304 passed — `test_console_native_chat_flow.py`, identical to the baseline** (13 real modal-open drives covering the whole improvement sub-flow)
- 268 passed — prompt-cluster batch (workbench contract, composer menu, prompts modal, system prompt, command composer, composer history, picker, chip)
- 195 passed — responsiveness, agent swap, console internals
- 89 passed / 1 failed — Architecture + state ownership; the failure is the pre-existing `test_persistent_diagnostic_inventory` (task-2768), whose checker names neither changed file
- 9073 collected clean over `Tests/UI`; `ruff` clean

`chat_screen.py` is untouched, so its size ratchet is unaffected.

Full rationale, the per-closure verdict table, before/after numbers and the
concerns I am leaving on the record are in `task-2766-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor for task-2766: decomposed `_open_console_prompts_modal` into `_ConsolePromptSource` and `_ConsolePromptImprovementFlow`, named the page size and search cap, and collapsed post-apply syncs into one; method shrinks 397→82 lines with no behavior changes.

- **Refactors**
  - Extracted `_ConsolePromptSource` (data adapter over `app_instance.prompt_scope_service`) and `_ConsolePromptImprovementFlow` (stateful improvement flow with a pinned resolution).
  - Named `CONSOLE_PROMPT_PAGE_SIZE` (10) and `CONSOLE_PROMPT_SEARCH_LIMIT` (25); class now aliases `_CONSOLE_PROMPT_SEARCH_LIMIT` to avoid duplication. Preserved source contract: per-page=10, search limit=25, and `save` routes `source`→`mode`.
  - Deduped guards with `_stale_reason()` and added module `_provider_resolution_identity`; promoted `ConsolePromptsController._restore_console_composer_focus`.
  - Added 7 characterization tests for the modal callbacks and a test pinning `_stale_reason` order (session before system); verified pinned-target lifecycle, refusal copy, focus restore, and saved-artifact guards.

- **Dependencies**
  - Replaced three screen sync dependencies with one: `sync_console_system_prompt_surfaces` in `wiring.py`, which calls `screen._sync_console_chat_core_state()`, `screen._sync_console_rail_system_line()`, and `screen._sync_console_settings_summary()`; late binding preserved.

<sup>Written for commit 635df617c8c8b1582507bb619692354ada8f65c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

