### PR TITLE
feat(tools): enforce robots.txt for web_fetch and web_crawl (task-2833)

### DIFF
--- a/Docs/superpowers/specs/2026-08-07-robots-txt-enforcement-design.md
+++ b/Docs/superpowers/specs/2026-08-07-robots-txt-enforcement-design.md
@@ -1,0 +1,51 @@
+# robots.txt enforcement for web tools — design (task-2833)
+
+- Date: 2026-08-07
+- Backlog: task-2833 (Enforce robots.txt for web-tools)
+- Owner directive: "finish the web-tools arc" — rulings below made by the controller and recorded for review; the spec's adversarial review gate replaces the interactive design Q&A.
+- Reference: tldw_server2's `Web_Scraping/filters.py` `RobotsFilter` (stdlib `urllib.robotparser.RobotFileParser`, per-host TTL cache incl. negative caching, fail-open "compat" default). Chatbook has NO robots code today and NO `[webfetch]` config section — both are introduced here.
+
+## Rulings (decisions an interactive brainstorm would have surfaced)
+
+1. **Default ON.** `[webfetch] respect_robots_txt` defaults to `true` for both `web_fetch` and `web_crawl`. These are agent-driven, automated fetchers — exactly what robots.txt governs — and this arc's own spec called the 1 s/domain rate limiter "the politeness floor". The off switch exists for the user who needs it.
+2. **Fail-open on unreachable robots.txt** (server "compat" semantics): a robots.txt that can't be fetched or parsed (network error, non-2xx, garbage) is cached as `None` = no restrictions, same TTL. A "strict" fail-closed mode is a recorded non-goal. Failure to fetch robots must be caught with a broad `except Exception` — in the shipped code this is what makes the feature backward-compatible (a route-less robots fetch in existing tests fails → fail-open → old behavior), and in production a robots outage must not brick fetching.
+3. **Per-hop checks.** Robots is consulted at the same position as `_validate_hop`, for every hop of every content fetch — a redirect into a disallowed path is a disallowed fetch. Cache-hit path in `web_fetch` re-checks robots exactly like it re-runs `_validate_hop` (rules may have changed since the body was cached).
+4. **Everything content-shaped is checked**: `web_fetch` hops, `web_crawl` BFS pages, sitemap XML fetches (root + children — the server checks them like any URL; a site that disallows `/sitemap-secret.xml` means it). The robots.txt fetch itself is exempt (never self-checked) and uses a dedicated byte cap, not the page cap.
+5. **The robots.txt fetch is rate-limited** through the existing `_enforce_rate_limit` like any other request to the host — politeness applies to the politeness probe too. Cost: up to +1 s on the first fetch from a new domain while enforcement is on. Recorded, not hidden.
+6. **User agent**: `can_fetch()` is called with the exact User-Agent string the tools already send (module constant; the implementation reads it from the existing request-header code, not a new literal). RobotFileParser's own specific-UA-then-`*` fallback does the rest.
+
+## Mechanism
+
+New module-level machinery in `Tools/web_tool_impls.py` (beside the existing cache idiom; NOT in `Utils/egress.py` — web_tool_impls deliberately owns its own guard stack pending task-609 consolidation):
+
+- `ROBOTS_MAX_BYTES = 64 * 1024` (dedicated cap for the robots.txt body), `ROBOTS_CACHE_TTL_SECONDS = 1800.0` (server parity), `ROBOTS_CACHE_MAX_ENTRIES = 128`.
+- `_robots_cache: dict[str, tuple[float, RobotFileParser | None]]` keyed by `scheme://netloc` — value `(expires_at_monotonic, parser_or_None)`; `None` = unreachable → allow (ruling 2). Earliest-expiry eviction at capacity (mirror `_cache_put`). Registered in `_reset_state_for_tests()`.
+- `_robots_allows(client, url, ua) -> bool`: cache lookup → on miss, `_enforce_rate_limit(host)` + fetch `{scheme}://{netloc}/robots.txt` via `_fetch_once` with `ROBOTS_MAX_BYTES` (broad try/except → cache `None`) → `RobotFileParser.parse(text.splitlines())` → `can_fetch(ua, url)`. Synchronous, no locks — matches the module's idiom (single-threaded per tool call; a cross-call stampede costs one duplicate robots fetch, accepted). The UA is a PARAMETER (spec review, Important 3): the two tools send different agents (`_USER_AGENT` = tldw-chatbook-web-fetch/1.0 for web_fetch; `_CRAWL_USER_AGENT` = tldw-chatbook-web-crawl/1.0 for web_crawl and all sitemap fetches), and `can_fetch()` must be called with the requesting tool's actual string. The cached parser is shared per-host; only the query is per-UA.
+- Injection sites, named (spec review, Minor 8): `web_fetch`'s inline redirect loop (web_tool_impls.py ~:454-463, beside `_validate_hop`) and `_crawl_fetch_page`'s hop loop (~:801-829) — the latter is also the path every sitemap fetch takes, which is how ruling 4 falls out for free. The constructed robots.txt URL itself goes through `_validate_hop` before being fetched (Minor 9 — symmetry with every other request).
+- A robots.txt body that comes back TRUNCATED at `ROBOTS_MAX_BYTES` is treated as a fetch failure → cached `None` → fail-open (spec review, Minor 7): a half-file could silently drop trailing Disallow lines and parse permissively; refusing to trust a truncated policy is the honest reading.
+- Gate read: `_webfetch_settings()` reader following the `_deep_search_settings()` idiom (local import of config helpers, strict `_bool` coercion — `"false"` string must disable; the deep-search gate's fail-open lesson applies here in the opposite direction: this flag defaults TRUE, and a `"true"` string must not read as disabled either). Read once per tool invocation, not per hop.
+
+## Behavior
+
+- `web_fetch`: a disallowed hop returns the structured refusal `[robots-disallowed] {url} — {host}/robots.txt disallows this path for this tool's user agent; set [webfetch] respect_robots_txt = false to override` (error contract style of `[ssrf]`/`[invalid-url]`). Cache hits re-check (ruling 3).
+- `web_crawl`: a disallowed page/sitemap is SKIPPED, not fatal — the existing two-way exception dispatch (`[ssrf]` → blocked, else → failed) gains an explicit THIRD branch (`str(exc).startswith("[robots-disallowed]")` → `robots_disallowed` counter; spec review, Important 4), surfaced by `_format_crawl_result` as its own clause alongside failed/blocked. The crawl continues with allowed URLs. A disallowed SEED (start URL or root sitemap) flows through the existing unconditional wrap and therefore returns the DOUBLE-WRAPPED string `[crawl-failed] start URL could not be fetched: [robots-disallowed] …` (or `sitemap could not be fetched:` — amended per spec review, Critical 2: the wrap is how every other seed-failure type reads today; tests assert the `[robots-disallowed]` substring inside the `[crawl-failed]` message, not a bare prefix).
+- Config template: new commented `[webfetch]` block in `CONFIG_TOML_CONTENT` with `# respect_robots_txt = true` and a comment stating scope (web_fetch + web_crawl), default, and the fail-open semantics.
+- Tool descriptions (`local_tool_provider.py`): one clause added to web_fetch's and web_crawl's descriptions — "honors robots.txt (configurable)". Static text; accurate for the default.
+
+## Testing (MockTransport route idiom; `_reset_state_for_tests` isolation)
+
+**Existing-suite compatibility (spec review, Critical 1 — the original "backward compatible" claim was FALSE):** with the default ON, robots pre-fetches add transport-call entries and an extra `_enforce_rate_limit` hit that break at least seven existing exact-list/count/sleep assertions across `test_web_tool_impls.py` and `test_web_crawl.py` (reviewer traced them individually; e.g. `test_fetch_rate_limits_per_domain`'s `sleeps == []` becomes `[1.0]`). RULING: the shared `fetch_env`/`crawl_env` fixtures monkeypatch the `_webfetch_settings` seam to `respect_robots_txt = False` as part of their existing isolation duties, preserving every old test's semantics; robots tests opt in explicitly. This is a TEST-FIXTURE default only — the shipped config default remains true.
+
+- Disallowed path refused (web_fetch) with the exact `[robots-disallowed]` prefix; allowed path proceeds.
+- Specific-UA vs `*` precedence honored (fixture robots.txt with both groups). Fixture-authoring caveat (spec review, Minor 6): stdlib `RobotFileParser` is FIRST-MATCH-WINS in file order, not longest-path — `Disallow: /search` before `Allow: /search/public` refuses `/search/public`; write fixtures (and expected results) with that ordering rule in mind.
+- Unreachable robots.txt (missing route / 500 / garbage) → fetch proceeds (fail-open) — and this is also the existing-suite-compat proof.
+- Robots cache: second fetch to same host does NOT re-fetch robots.txt (route hit counter); TTL expiry re-fetches (fake clock); negative cache holds for TTL.
+- Redirect into a disallowed path refused mid-chain.
+- web_crawl: disallowed pages skipped + counted in footer; disallowed child sitemap skipped; disallowed seed → structured refusal.
+- Toggle off (`respect_robots_txt = false`, monkeypatched settings seam) → no robots fetch at all (route counter zero).
+- Cache-hit re-check: cached body + newly-disallowing robots → refusal on the cached path.
+- Mutation checks at implementation time: disable the `can_fetch` consult → allowed/disallowed tests discriminate; drop the footer count → crawl-count test red.
+
+## Non-goals (recorded)
+
+Strict fail-closed mode; per-call `respect_robots` argument (config-only — keeps the `_fetch_cache` key robots-free; a per-call override would have to join the cache key, the exact poisoning class PR #1376's review caught); Crawl-delay/Sitemap directive honoring; robots enforcement for `web_search` provider APIs (fixed HTTPS endpoints — robots is inapplicable) or `web_deep_search`'s scrape path — recorded HONESTLY (spec review, Important 5): this leaves an inconsistency where a path that web_fetch/web_crawl refuse can still be scraped by web_deep_search, and the codebase's own precedent (`is_public_http_url` was bolted onto `scrape_article` for exactly this kind of parity) shows the right fix is a follow-up patch on that path, not an architectural exemption — follow-up task to be filed at implementation; consolidating with `Utils/egress.py` (task-609).

--- a/Tests/Tools/test_web_crawl.py
+++ b/Tests/Tools/test_web_crawl.py
@@ -201,6 +201,17 @@ def crawl_env(monkeypatch):
     monkeypatch.setattr(web_tool_impls, "_transport", httpx.MockTransport(handler))
     clock = _FakeClock()
     monkeypatch.setattr(web_tool_impls, "time", clock)
+    # robots.txt enforcement (task-2833) defaults to ON in shipped config,
+    # but every existing test in this module was written against a world
+    # with no robots machinery at all: with the real default, a robots
+    # pre-fetch would add transport-call entries and an extra
+    # _enforce_rate_limit hit that break exact-list/count/sleep assertions
+    # across this file (design doc, Critical 1). This is a TEST-FIXTURE
+    # default only -- the shipped config default remains true. Robots
+    # tests opt back in explicitly via their own monkeypatch.
+    monkeypatch.setattr(
+        web_tool_impls, "_webfetch_settings", lambda: {"respect_robots_txt": False}
+    )
     web_tool_impls._reset_state_for_tests()
     yield SimpleNamespace(routes=routes, calls=calls, clock=clock)
     web_tool_impls._reset_state_for_tests()
@@ -1061,3 +1072,111 @@ def test_sitemap_seed_deadline_and_budget_both_hit_deadline_wins(crawl_env):
     assert out.endswith("Stopped: deadline reached.")
     page_calls = [c for c in crawl_env.calls if "/p" in c]
     assert page_calls == []  # deadline hit before the seeded pages get their own attempt
+
+
+# ---------------------------------------------------------------------------
+# robots.txt enforcement (task-2833)
+# ---------------------------------------------------------------------------
+#
+# crawl_env's own fixture default sets respect_robots_txt=False (existing-
+# suite compatibility, design doc Critical 1) -- every test below opts back
+# in explicitly via _enable_robots().
+
+def _enable_robots(monkeypatch, respect: bool = True) -> None:
+    monkeypatch.setattr(
+        web_tool_impls, "_webfetch_settings", lambda: {"respect_robots_txt": respect}
+    )
+
+
+def _robots_txt(body: bytes, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, content=body, headers={"content-type": "text/plain"})
+
+
+def test_crawl_disallowed_page_skipped_and_counted(crawl_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    crawl_env.routes["http://example.com/robots.txt"] = _robots_txt(b"User-agent: *\nDisallow: /private\n")
+    _site(crawl_env, {
+        "http://example.com/": ("root", ["/private", "/ok"]),
+        "http://example.com/ok": ("fine words", []),
+    })
+    out = web_crawl("http://example.com/")
+    assert "1 robots-disallowed" in out
+    assert "fine words" in out
+    assert "http://example.com/private" not in crawl_env.calls  # blocked before the hop
+
+
+def test_crawl_disallowed_child_sitemap_skipped(crawl_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    crawl_env.routes["http://example.com/robots.txt"] = _robots_txt(b"User-agent: *\nDisallow: /bad.xml\n")
+    index = (
+        b'<?xml version="1.0"?>'
+        b'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        b"<sitemap><loc>http://example.com/bad.xml</loc></sitemap>"
+        b"<sitemap><loc>http://example.com/good.xml</loc></sitemap>"
+        b"</sitemapindex>"
+    )
+    good = (
+        b'<?xml version="1.0"?>'
+        b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        b"<url><loc>http://example.com/page</loc></url></urlset>"
+    )
+    crawl_env.routes["http://example.com/sitemap.xml"] = _sitemap_response(index)
+    crawl_env.routes["http://example.com/bad.xml"] = _sitemap_response(good)  # would succeed IF fetched
+    crawl_env.routes["http://example.com/good.xml"] = _sitemap_response(good)
+    _site(crawl_env, {"http://example.com/page": ("still works", [])})
+    out = web_crawl("http://example.com/", sitemap_url="http://example.com/sitemap.xml")
+    assert "still works" in out
+    assert "1 child sitemaps skipped" in out
+    assert "http://example.com/bad.xml" not in crawl_env.calls  # blocked before the hop
+
+
+def test_crawl_disallowed_start_url_returns_structured_refusal(crawl_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    crawl_env.routes["http://example.com/robots.txt"] = _robots_txt(b"User-agent: *\nDisallow: /\n")
+    crawl_env.routes["http://example.com/"] = _html("root", [])
+    with pytest.raises(LocalToolError) as exc_info:
+        web_crawl("http://example.com/")
+    msg = str(exc_info.value)
+    # Double-wrapped (design doc): the disallowed seed flows through the
+    # existing unconditional start-URL wrap, same as any other seed failure.
+    assert msg.startswith("[crawl-failed] start URL could not be fetched: ")
+    assert "[robots-disallowed]" in msg
+    assert "http://example.com/" not in crawl_env.calls  # blocked before the hop
+
+
+def test_crawl_disallowed_root_sitemap_returns_structured_refusal(crawl_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    crawl_env.routes["http://example.com/robots.txt"] = _robots_txt(b"User-agent: *\nDisallow: /sitemap.xml\n")
+    crawl_env.routes["http://example.com/sitemap.xml"] = _sitemap_response(
+        b'<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
+    )
+    with pytest.raises(LocalToolError) as exc_info:
+        web_crawl("http://example.com/", sitemap_url="http://example.com/sitemap.xml")
+    msg = str(exc_info.value)
+    assert msg.startswith("[crawl-failed] sitemap could not be fetched: ")
+    assert "[robots-disallowed]" in msg
+    assert "http://example.com/sitemap.xml" not in crawl_env.calls  # blocked before the hop
+
+
+def test_crawl_robots_uses_crawl_user_agent(crawl_env, monkeypatch):
+    """Disallow the web_fetch UA but allow the crawl UA -- proves web_crawl
+    checks robots.txt against _CRAWL_USER_AGENT, not _USER_AGENT."""
+    _enable_robots(monkeypatch)
+    crawl_env.routes["http://example.com/robots.txt"] = _robots_txt(
+        b"User-agent: tldw-chatbook-web-fetch\nDisallow: /\n\n"
+        b"User-agent: tldw-chatbook-web-crawl\nAllow: /\n"
+    )
+    _site(crawl_env, {"http://example.com/": ("root words", [])})
+    out = web_crawl("http://example.com/")
+    assert "root words" in out
+
+
+def test_crawl_toggle_off_makes_no_robots_fetch(crawl_env):
+    # crawl_env's own fixture default is respect_robots_txt=False; this
+    # test proves a PRESENT, fully-disallowing robots.txt is never even
+    # fetched while the toggle is off.
+    crawl_env.routes["http://example.com/robots.txt"] = _robots_txt(b"User-agent: *\nDisallow: /\n")
+    _site(crawl_env, {"http://example.com/": ("root words", [])})
+    out = web_crawl("http://example.com/")
+    assert "root words" in out
+    assert "http://example.com/robots.txt" not in crawl_env.calls

--- a/Tests/Tools/test_web_tool_impls.py
+++ b/Tests/Tools/test_web_tool_impls.py
@@ -895,3 +895,49 @@ def test_webfetch_default_on_end_to_end_refuses_without_patching_seam(fetch_env_
     env.routes["http://example.com/page"] = _text_page(b"hello")
     with pytest.raises(LocalToolError, match=r"\[robots-disallowed\]"):
         web_fetch("http://example.com/page")
+
+
+# ---------------------------------------------------------------------------
+# robots.txt enforcement -- fix round 2 (Qodo PR review finding)
+# ---------------------------------------------------------------------------
+
+# 2606:4700::1111 (Cloudflare anycast), not a 2001:db8::/32 documentation
+# address: Python's ipaddress module classifies the documentation range as
+# is_private=True, so it would never even reach the robots check -- the
+# ordinary SSRF guard (_validate_hop, shared by every hop) would refuse it
+# first. This is a literal-IP URL either way: validate_outbound_url's
+# literal-IP branch handles it directly (ipaddress.ip_address(host)
+# succeeds), so no DNS resolution happens at all -- fetch_env's IPv4-only
+# fake getaddrinfo is irrelevant to these two tests.
+_IPV6_LITERAL = "2606:4700::1111"
+
+
+def test_fetch_robots_ipv6_literal_host_disallowed_refused(fetch_env, monkeypatch):
+    """Qodo finding: urlsplit(...).hostname strips the [...] brackets an
+    IPv6 literal needs in a URL. Without re-bracketing it for the
+    constructed robots.txt URL, the assembled string is malformed,
+    _validate_hop rejects it inside _fetch_robots_parser, and the broad
+    fail-open catch there silently disables robots enforcement for EVERY
+    IPv6-literal host -- an input class validate_outbound_url explicitly
+    supports."""
+    _enable_robots(monkeypatch)
+    fetch_env.routes[f"http://[{_IPV6_LITERAL}]/robots.txt"] = _text_page(
+        b"User-agent: *\nDisallow: /\n"
+    )
+    fetch_env.routes[f"http://[{_IPV6_LITERAL}]/page"] = _text_page(b"hello")
+    with pytest.raises(LocalToolError, match=r"\[robots-disallowed\]"):
+        web_fetch(f"http://[{_IPV6_LITERAL}]/page")
+    # The robots.txt URL was actually well-formed and fetched -- not
+    # silently skipped via the fail-open path.
+    assert f"http://[{_IPV6_LITERAL}]/robots.txt" in fetch_env.calls
+
+
+def test_fetch_robots_ipv6_literal_host_allowed_proceeds(fetch_env, monkeypatch):
+    """Control for the test above: an ALLOWING robots.txt on the same
+    IPv6-literal host must let the fetch proceed normally."""
+    _enable_robots(monkeypatch)
+    fetch_env.routes[f"http://[{_IPV6_LITERAL}]/robots.txt"] = _text_page(
+        b"User-agent: *\nAllow: /\n"
+    )
+    fetch_env.routes[f"http://[{_IPV6_LITERAL}]/page"] = _text_page(b"hello")
+    assert web_fetch(f"http://[{_IPV6_LITERAL}]/page") == "hello"

--- a/Tests/Tools/test_web_tool_impls.py
+++ b/Tests/Tools/test_web_tool_impls.py
@@ -772,3 +772,126 @@ def test_fetch_robots_txt_fetch_is_itself_rate_limited(fetch_env, monkeypatch):
     fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
     web_fetch("http://example.com/page")
     assert fetch_env.clock.sleeps == [pytest.approx(1.0)]
+
+
+# ---------------------------------------------------------------------------
+# robots.txt enforcement -- fix round 1 (review findings)
+# ---------------------------------------------------------------------------
+
+def test_fetch_robots_txt_redirect_is_followed_and_enforced(fetch_env, monkeypatch):
+    """Important 1: a redirecting robots.txt (e.g. HTTP canonicalization)
+    must be FOLLOWED, not treated as an unreachable fetch -- the latter
+    negative-caches the host (fail open) for ROBOTS_CACHE_TTL_SECONDS,
+    silently disabling enforcement for any host whose robots.txt 3xxs."""
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = httpx.Response(
+        301, headers={"location": "http://example.com/static/robots.txt"}
+    )
+    fetch_env.routes["http://example.com/static/robots.txt"] = _text_page(
+        b"User-agent: *\nDisallow: /\n"
+    )
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    with pytest.raises(LocalToolError, match=r"\[robots-disallowed\]"):
+        web_fetch("http://example.com/page")
+    # The redirect target must have actually been followed and consulted,
+    # not just the initial 301 response.
+    assert "http://example.com/robots.txt" in fetch_env.calls
+    assert "http://example.com/static/robots.txt" in fetch_env.calls
+
+
+def test_fetch_robots_txt_redirect_loop_exhausts_cap_and_fails_open(fetch_env, monkeypatch):
+    """A robots.txt redirect chain that never resolves must still fail open
+    once the bounded hop cap is exhausted, not raise or hang."""
+    _enable_robots(monkeypatch)
+    for i in range(FETCH_MAX_REDIRECTS + 2):
+        fetch_env.routes[f"http://example.com/robots{i}.txt"] = httpx.Response(
+            301, headers={"location": f"http://example.com/robots{i + 1}.txt"}
+        )
+    # The FIRST hop must be at the well-known /robots.txt location.
+    fetch_env.routes["http://example.com/robots.txt"] = httpx.Response(
+        301, headers={"location": "http://example.com/robots0.txt"}
+    )
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    assert web_fetch("http://example.com/page") == "hello"
+
+
+def test_webfetch_settings_defaults_to_true_with_no_config_override():
+    """Important 2a: _webfetch_settings() itself is otherwise exercised by
+    ZERO tests -- every fixture/helper in this file replaces the whole
+    seam, so a section-name typo or a flipped default in the real function
+    would ship robots-off with every other test green. This calls the REAL
+    function against the per-test sandboxed config (autouse
+    isolate_test_environment in Tests/conftest.py provides a fresh
+    per-test config dir with no [webfetch] respect_robots_txt override
+    present, i.e. the shipped default)."""
+    assert web_tool_impls._webfetch_settings() == {"respect_robots_txt": True}
+
+
+def test_webfetch_settings_raw_string_false_disables(monkeypatch):
+    """Important 2b."""
+    import tldw_chatbook.config as config_module
+
+    def fake_get_cli_setting(section, key, default):
+        if (section, key) == ("webfetch", "respect_robots_txt"):
+            return "false"
+        return default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
+    assert web_tool_impls._webfetch_settings() == {"respect_robots_txt": False}
+
+
+def test_webfetch_settings_raw_string_true_uppercase_stays_enabled(monkeypatch):
+    """Important 2c: an uppercase "TRUE" must not be misread as disabled --
+    the same lesson _deep_search_settings recorded, applied to a flag whose
+    default is already True."""
+    import tldw_chatbook.config as config_module
+
+    def fake_get_cli_setting(section, key, default):
+        if (section, key) == ("webfetch", "respect_robots_txt"):
+            return "TRUE"
+        return default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
+    assert web_tool_impls._webfetch_settings() == {"respect_robots_txt": True}
+
+
+@pytest.fixture
+def fetch_env_default_settings(monkeypatch):
+    """Like fetch_env, but deliberately does NOT monkeypatch
+    _webfetch_settings -- used for the one composition test (Important 2d)
+    that proves the REAL, unpatched settings seam defaults robots
+    enforcement ON end-to-end against the per-test sandboxed config."""
+    routes: dict[str, object] = {}
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        calls.append(url)
+        item = routes[url]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(
+        socket, "getaddrinfo", lambda *a, **k: [(2, 1, 6, "", (_PUBLIC_IP, 80))]
+    )
+    monkeypatch.setattr(
+        web_tool_impls, "_transport", httpx.MockTransport(handler)
+    )
+    clock = _FakeClock()
+    monkeypatch.setattr(web_tool_impls, "time", clock)
+    web_tool_impls._reset_state_for_tests()
+    yield SimpleNamespace(routes=routes, calls=calls, clock=clock)
+    web_tool_impls._reset_state_for_tests()
+
+
+def test_webfetch_default_on_end_to_end_refuses_without_patching_seam(fetch_env_default_settings):
+    """Important 2d: composition test -- sandboxed default config (no
+    monkeypatch of _webfetch_settings anywhere in this test) plus a
+    disallowing robots route means web_fetch must refuse, proving the
+    real default really is on end-to-end, not just at the unit level."""
+    env = fetch_env_default_settings
+    env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nDisallow: /\n")
+    env.routes["http://example.com/page"] = _text_page(b"hello")
+    with pytest.raises(LocalToolError, match=r"\[robots-disallowed\]"):
+        web_fetch("http://example.com/page")

--- a/Tests/Tools/test_web_tool_impls.py
+++ b/Tests/Tools/test_web_tool_impls.py
@@ -129,6 +129,17 @@ def fetch_env(monkeypatch):
     )
     clock = _FakeClock()
     monkeypatch.setattr(web_tool_impls, "time", clock)
+    # robots.txt enforcement (task-2833) defaults to ON in shipped config,
+    # but every existing test in this module was written against a world
+    # with no robots machinery at all: with the real default, a robots
+    # pre-fetch would add transport-call entries and an extra
+    # _enforce_rate_limit hit that break exact-list/count/sleep assertions
+    # across this file (design doc, Critical 1). This is a TEST-FIXTURE
+    # default only -- the shipped config default remains true. Robots
+    # tests opt back in explicitly via their own monkeypatch.
+    monkeypatch.setattr(
+        web_tool_impls, "_webfetch_settings", lambda: {"respect_robots_txt": False}
+    )
     web_tool_impls._reset_state_for_tests()
     yield SimpleNamespace(routes=routes, calls=calls, clock=clock)
     web_tool_impls._reset_state_for_tests()
@@ -579,3 +590,185 @@ def test_fetch_short_body_under_pdf_magic_length_extracts_as_text(fetch_env):
     )
     result = web_fetch("http://example.com/short")
     assert result == "abc"
+
+
+# ---------------------------------------------------------------------------
+# robots.txt enforcement (task-2833)
+# ---------------------------------------------------------------------------
+#
+# fetch_env's own fixture default sets respect_robots_txt=False (existing-
+# suite compatibility, design doc Critical 1) -- every test below opts back
+# in explicitly via _enable_robots().
+
+def _enable_robots(monkeypatch, respect: bool = True) -> None:
+    monkeypatch.setattr(
+        web_tool_impls, "_webfetch_settings", lambda: {"respect_robots_txt": respect}
+    )
+
+
+def test_fetch_robots_disallowed_path_refused(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nDisallow: /private\n")
+    fetch_env.routes["http://example.com/private/page"] = _text_page(b"secret")
+    with pytest.raises(LocalToolError) as exc_info:
+        web_fetch("http://example.com/private/page")
+    assert str(exc_info.value).startswith("[robots-disallowed] http://example.com/private/page")
+    assert "http://example.com/private/page" not in fetch_env.calls  # blocked before the hop
+
+
+def test_fetch_robots_allowed_path_proceeds(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nDisallow: /private\n")
+    fetch_env.routes["http://example.com/public"] = _text_page(b"hello public")
+    assert web_fetch("http://example.com/public") == "hello public"
+
+
+def test_fetch_robots_specific_ua_beats_wildcard(fetch_env, monkeypatch):
+    """Fixture-authoring caveat (design doc Minor 6): stdlib RobotFileParser
+    is first-match-wins in FILE order, not longest-path -- irrelevant here
+    since each group has exactly one rule, but the file deliberately puts
+    the wildcard group's Disallow SECOND to prove it is our own specific
+    group (declared first) that actually governs us, not file order."""
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(
+        b"User-agent: tldw-chatbook-web-fetch\n"
+        b"Disallow: /secret\n"
+        b"\n"
+        b"User-agent: *\n"
+        b"Disallow: /forbidden\n"
+    )
+    fetch_env.routes["http://example.com/secret"] = _text_page(b"nope")
+    fetch_env.routes["http://example.com/forbidden"] = _text_page(b"actually ours")
+    with pytest.raises(LocalToolError, match=r"\[robots-disallowed\]"):
+        web_fetch("http://example.com/secret")
+    fetch_env.clock.now += 2.0  # clear the per-domain rate-limit interval
+    # Our specific-UA group applies and does NOT disallow /forbidden -- the
+    # wildcard-only rule is never even consulted for our own user agent.
+    assert web_fetch("http://example.com/forbidden") == "actually ours"
+
+
+def test_fetch_robots_missing_route_fails_open(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    # No robots.txt route registered at all -> fetch fails -> fail open.
+    assert web_fetch("http://example.com/page") == "hello"
+
+
+def test_fetch_robots_500_fails_open(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = httpx.Response(500)
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    assert web_fetch("http://example.com/page") == "hello"
+
+
+def test_fetch_robots_garbage_body_fails_open(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(
+        b"\x00\x01 not remotely robots.txt syntax \xff\xfe"
+    )
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    assert web_fetch("http://example.com/page") == "hello"
+
+
+def test_fetch_robots_truncated_body_fails_open(fetch_env, monkeypatch):
+    """A body truncated at ROBOTS_MAX_BYTES must not be trusted (design doc
+    Minor 7): a half-file could silently drop trailing Disallow lines. This
+    robots.txt, if read in FULL, would disallow everything -- truncation
+    must still fail the fetch open."""
+    _enable_robots(monkeypatch)
+    huge = b"User-agent: *\nDisallow: /\n" + b"# padding\n" * web_tool_impls.ROBOTS_MAX_BYTES
+    assert len(huge) > web_tool_impls.ROBOTS_MAX_BYTES
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(huge)
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    assert web_fetch("http://example.com/page") == "hello"
+
+
+def test_fetch_robots_cache_not_refetched_on_second_request(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nAllow: /\n")
+    fetch_env.routes["http://example.com/a"] = _text_page(b"page a")
+    fetch_env.routes["http://example.com/b"] = _text_page(b"page b")
+    web_fetch("http://example.com/a")
+    assert fetch_env.calls.count("http://example.com/robots.txt") == 1
+    fetch_env.clock.now += 2.0  # clear the per-domain rate-limit interval
+    web_fetch("http://example.com/b")
+    assert fetch_env.calls.count("http://example.com/robots.txt") == 1  # cached, no re-fetch
+
+
+def test_fetch_robots_cache_ttl_expiry_refetches(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nAllow: /\n")
+    fetch_env.routes["http://example.com/a"] = _text_page(b"page a")
+    fetch_env.routes["http://example.com/b"] = _text_page(b"page b")
+    web_fetch("http://example.com/a")
+    assert fetch_env.calls.count("http://example.com/robots.txt") == 1
+    fetch_env.clock.now += web_tool_impls.ROBOTS_CACHE_TTL_SECONDS + 1
+    web_fetch("http://example.com/b")
+    assert fetch_env.calls.count("http://example.com/robots.txt") == 2  # TTL expired, re-fetched
+
+
+def test_fetch_robots_negative_cache_holds_for_ttl(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    # No robots.txt route registered: the fetch fails (KeyError inside the
+    # mock handler), caught broadly, cached as None (fail open).
+    fetch_env.routes["http://example.com/a"] = _text_page(b"page a")
+    fetch_env.routes["http://example.com/b"] = _text_page(b"page b")
+    web_fetch("http://example.com/a")
+    first_attempts = fetch_env.calls.count("http://example.com/robots.txt")
+    assert first_attempts == 1
+    fetch_env.clock.now += 2.0  # well under ROBOTS_CACHE_TTL_SECONDS
+    web_fetch("http://example.com/b")
+    assert fetch_env.calls.count("http://example.com/robots.txt") == first_attempts  # negative cache held
+
+
+def test_fetch_robots_redirect_into_disallowed_path_refused_mid_chain(fetch_env, monkeypatch):
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nDisallow: /private\n")
+    fetch_env.routes["http://example.com/start"] = httpx.Response(
+        302, headers={"location": "http://example.com/private/page"}
+    )
+    with pytest.raises(LocalToolError, match=r"\[robots-disallowed\]"):
+        web_fetch("http://example.com/start")
+    assert "http://example.com/private/page" not in fetch_env.calls  # blocked before the hop
+
+
+def test_fetch_robots_toggle_off_makes_no_robots_fetch(fetch_env):
+    # fetch_env's own fixture default is respect_robots_txt=False; this
+    # test proves a PRESENT, disallowing robots.txt is never even fetched
+    # while the toggle is off.
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nDisallow: /\n")
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    assert web_fetch("http://example.com/page") == "hello"
+    assert "http://example.com/robots.txt" not in fetch_env.calls
+
+
+def test_fetch_robots_cache_hit_rechecks_and_refuses(fetch_env, monkeypatch):
+    """Ruling 3: a cache-hit web_fetch re-checks robots the same way it
+    re-checks SSRF policy -- a cached body plus a newly-disallowing
+    robots.txt must refuse, not silently hand back the cached text."""
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nAllow: /\n")
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    assert web_fetch("http://example.com/page") == "hello"
+
+    # Robots policy changes; force the next call to see it by clearing only
+    # the robots cache (the fetch/body cache stays warm and TTL-valid).
+    web_tool_impls._robots_cache.clear()
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nDisallow: /\n")
+    fetch_env.clock.now += 2.0  # clear the per-domain rate-limit interval
+    with pytest.raises(LocalToolError, match=r"\[robots-disallowed\]"):
+        web_fetch("http://example.com/page")
+    # The page body itself was fetched only once -- the refusal came from
+    # the CACHE-HIT path's robots re-check, not a second real fetch.
+    assert fetch_env.calls.count("http://example.com/page") == 1
+
+
+def test_fetch_robots_txt_fetch_is_itself_rate_limited(fetch_env, monkeypatch):
+    """Ruling 5: the robots.txt fetch goes through the same per-domain rate
+    limiter as any other request -- two back-to-back rate-limited requests
+    to a brand-new host (robots.txt, then the page) cost one sleep."""
+    _enable_robots(monkeypatch)
+    fetch_env.routes["http://example.com/robots.txt"] = _text_page(b"User-agent: *\nAllow: /\n")
+    fetch_env.routes["http://example.com/page"] = _text_page(b"hello")
+    web_fetch("http://example.com/page")
+    assert fetch_env.clock.sleeps == [pytest.approx(1.0)]

--- a/backlog/tasks/task-2833 - Enforce-robots.txt-for-web-tools.md
+++ b/backlog/tasks/task-2833 - Enforce-robots.txt-for-web-tools.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-2833
 title: Enforce robots.txt for web tools
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-05 06:05'
+updated_date: '2026-08-07 20:44'
 labels:
   - web-tools
 dependencies:
@@ -19,5 +21,31 @@ v1 documents but does not enforce robots.txt. Add per-domain robots fetch+cache 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 robots.txt fetched+cached per domain,Disallow honored for web_fetch/web_crawl,[webfetch] respect_robots_txt toggle; fixture-based tests
+- [x] #1 robots.txt fetched+cached per domain,Disallow honored for web_fetch/web_crawl,[webfetch] respect_robots_txt toggle; fixture-based tests
 <!-- AC:END -->
+
+## Implementation Notes
+
+Implemented per `Docs/superpowers/specs/2026-08-07-robots-txt-enforcement-design.md` (rulings 1-6, injection sites, error contract, and test list are binding and were followed as written).
+
+**Approach.** New module-level machinery in `tldw_chatbook/Tools/web_tool_impls.py`, beside the existing `_fetch_cache` idiom:
+- `ROBOTS_MAX_BYTES` (64 KiB), `ROBOTS_CACHE_TTL_SECONDS` (1800.0), `ROBOTS_CACHE_MAX_ENTRIES` (128), `_robots_cache` (keyed by `scheme://netloc`, value `(expires_at, RobotFileParser | None)`, earliest-expiry eviction via `_robots_cache_put`, cleared by `_reset_state_for_tests`).
+- `_webfetch_settings()` resolves `[webfetch] respect_robots_txt` via `get_cli_setting`, mirroring `_deep_search_settings()`'s `_bool` true-set coercion (a raw bool passes through; a string coerces via `"true"`/`"1"` membership) — read once per tool invocation, not per hop.
+- `_robots_allows(client, url, user_agent)`: cache lookup by host; on miss, rate-limits via the existing `_enforce_rate_limit`, fetches `{scheme}://{netloc}/robots.txt` through `_fetch_once` under the dedicated byte cap, and parses with stdlib `RobotFileParser`. One broad `except Exception` makes any fetch/parse failure — including a body TRUNCATED at the byte cap — fail OPEN (cached `None` = no restrictions), matching ruling 2's "compat" semantics.
+- `_robots_disallowed_message(url)` builds the exact `[robots-disallowed] {url} — {host}/robots.txt disallows this path for this tool's user agent; set [webfetch] respect_robots_txt = false to override` string.
+
+**Injection sites** (exactly as named in the design doc): `web_fetch`'s cache-hit re-check and its redirect-loop hop, both right beside `_validate_hop`; `_crawl_fetch_page`'s hop loop (shared by web_crawl's BFS pages AND every sitemap fetch — root + children — for free), always checked against `_CRAWL_USER_AGENT`. `_crawl_fetch_page` and `_seed_from_sitemap` gained a `respect_robots: bool` parameter threaded from `web_crawl`'s single settings read.
+
+**Behavior.** `web_fetch` raises the structured refusal per disallowed hop (cache-hit path re-checks the same way it re-checks SSRF policy). `web_crawl` gained a third exception-dispatch branch (`str(exc).startswith("[robots-disallowed]")` → `robots_disallowed` counter, alongside the existing `[ssrf]`→blocked / else→failed split) and `_format_crawl_result` gained an additive `robots_disallowed: int = 0` parameter rendered as `"; N robots-disallowed"` in the footer's parenthetical — additive-only (omitted when zero) so every pre-existing exact-string footer assertion (e.g. `test_format_blocks_footer_and_marker`'s `endswith`) stays byte-identical. A disallowed BFS seed or root sitemap flows through the existing unconditional wrap unchanged, producing the double-wrapped `[crawl-failed] start URL could not be fetched: [robots-disallowed] …` (or `sitemap could not be fetched:`); a disallowed child sitemap is caught by the existing broad `except (LocalToolError, _CrawlDeadline)` and counted in `children_skipped`, no new counter needed there.
+
+**Existing-suite compatibility (design doc Critical 1).** With the shipped default ON, a robots pre-fetch would add transport calls and an extra `_enforce_rate_limit` hit that break several pre-existing exact-list/count/sleep assertions. Per the RULING, `fetch_env` (test_web_tool_impls.py) and `crawl_env` (test_web_crawl.py) now monkeypatch `_webfetch_settings` to `{"respect_robots_txt": False}` as part of their existing isolation duties — a TEST-FIXTURE default only; the shipped config default remains `true`. New robots tests opt back in via a local `_enable_robots(monkeypatch)` helper added to each file.
+
+**Config + descriptions.** Added a commented `[webfetch]` block to `CONFIG_TOML_CONTENT` in `config.py` (documents scope, default, and fail-open semantics). Added a one-clause "Honors robots.txt (configurable)" mention to both `web_fetch` and `web_crawl`'s tool descriptions in `Agents/local_tool_provider.py`.
+
+**Deviations from the design doc:** none — the mechanism, injection sites, error strings, config key, and test-fixture ruling were all implemented as specified.
+
+**Tests.** 14 new tests in `Tests/Tools/test_web_tool_impls.py` (disallow/allow, specific-UA-vs-wildcard precedence with the first-match-wins fixture caveat, fail-open on missing/500/garbage/truncated robots.txt, cache hit/TTL-expiry/negative-cache, redirect-into-disallowed mid-chain, cache-hit re-check refusal, toggle-off, robots.txt's own rate-limiting) and 6 in `Tests/Tools/test_web_crawl.py` (disallowed page skipped+counted, disallowed child sitemap skipped, disallowed BFS seed and disallowed root sitemap both structured-refuse double-wrapped, crawl UA correctness, toggle-off). Full suite: `Tests/Tools/test_web_tool_impls.py Tests/Tools/test_web_crawl.py` 127 passed (107 pre-existing + 20 new); `Tests/Tools/ Tests/Web_Scraping/` 543 passed, 3 skipped (pre-existing live-search skips, `TLDW_LIVE_SEARCH_TESTS` gate, unrelated); full-repo `pytest --collect-only` shows 32223 tests collected, no new collection errors. Both spec-mandated mutation checks performed by hand (Edit-based, restored immediately after): (1) `_robots_allows` forced to always `return True` past the cache lookup → 8 disallow-path tests failed (`DID NOT RAISE`) as expected, then restored and reconfirmed green; (2) the `robots_disallowed` footer clause dropped from `_format_crawl_result` → `test_crawl_disallowed_page_skipped_and_counted` failed (footer silently omitted the count) as expected, then restored and reconfirmed green.
+
+**Follow-up filed:** task-3260 (deep-search's scrape path does not honor robots.txt — recorded non-goal in the design doc's rulings; the same inconsistency `is_public_http_url`/`scrape_article` closed for SSRF).
+
+**Modified files:** `tldw_chatbook/Tools/web_tool_impls.py`, `tldw_chatbook/config.py`, `tldw_chatbook/Agents/local_tool_provider.py`, `Tests/Tools/test_web_tool_impls.py`, `Tests/Tools/test_web_crawl.py`. **Added:** `backlog/tasks/task-3260 - Deep-search-scrape-path-ignores-robots-txt.md`.

--- a/backlog/tasks/task-2833 - Enforce-robots.txt-for-web-tools.md
+++ b/backlog/tasks/task-2833 - Enforce-robots.txt-for-web-tools.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-2833
 title: Enforce robots.txt for web tools
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-05 06:05'
-updated_date: '2026-08-07 20:44'
+updated_date: '2026-08-07 21:43'
 labels:
   - web-tools
 dependencies:
@@ -26,6 +26,7 @@ v1 documents but does not enforce robots.txt. Add per-domain robots fetch+cache 
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 Implemented per `Docs/superpowers/specs/2026-08-07-robots-txt-enforcement-design.md` (rulings 1-6, injection sites, error contract, and test list are binding and were followed as written).
 
 **Approach.** New module-level machinery in `tldw_chatbook/Tools/web_tool_impls.py`, beside the existing `_fetch_cache` idiom:
@@ -49,3 +50,4 @@ Implemented per `Docs/superpowers/specs/2026-08-07-robots-txt-enforcement-design
 **Follow-up filed:** task-3260 (deep-search's scrape path does not honor robots.txt — recorded non-goal in the design doc's rulings; the same inconsistency `is_public_http_url`/`scrape_article` closed for SSRF).
 
 **Modified files:** `tldw_chatbook/Tools/web_tool_impls.py`, `tldw_chatbook/config.py`, `tldw_chatbook/Agents/local_tool_provider.py`, `Tests/Tools/test_web_tool_impls.py`, `Tests/Tools/test_web_crawl.py`. **Added:** `backlog/tasks/task-3260 - Deep-search-scrape-path-ignores-robots-txt.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3260 - Deep-search-scrape-path-ignores-robots-txt.md
+++ b/backlog/tasks/task-3260 - Deep-search-scrape-path-ignores-robots-txt.md
@@ -1,0 +1,27 @@
+---
+id: TASK-3260
+title: Deep-search scrape path ignores robots.txt
+status: To Do
+assignee: []
+created_date: '2026-08-07 21:15'
+labels:
+  - web-tools
+dependencies:
+  - TASK-2833
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+task-2833 added robots.txt enforcement for web_fetch and web_crawl (per-domain fetch+cache, Disallow honored, `[webfetch] respect_robots_txt` toggle), but its design doc recorded a non-goal: web_deep_search's scrape path (`Web_Scraping.WebSearch_APIs`'s per-result relevance/summarization scraping, invoked from `analyze_and_aggregate`) was left out of scope.
+
+This leaves an inconsistency: a path that web_fetch/web_crawl now refuse to fetch (per that host's robots.txt) can still be scraped by web_deep_search, because its scrape path never consults robots.txt at all. The codebase already has precedent for closing exactly this kind of gap — `is_public_http_url`'s SSRF check was bolted onto `scrape_article` after the same shape of inconsistency was noticed between the SSRF-guarded tools and the deep-search scrape path — so the fix shape here is the same: thread a robots.txt consult into the scrape path rather than carving out a permanent architectural exemption.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 web_deep_search's scrape path (the per-result fetch inside `analyze_and_aggregate`/its scraping helper) is refused for a URL disallowed by that host's robots.txt, under the same `[webfetch] respect_robots_txt` toggle task-2833 introduced (default on, fail-open on an unreachable/unparsable robots.txt)
+- [ ] #2 A robots-disallowed result is skipped (not fatal to the overall deep-search run), mirroring web_crawl's skip-and-count behavior rather than web_fetch's hard refusal
+- [ ] #3 Fixture-based tests (MockTransport, no live network) cover: a disallowed scrape URL is skipped, an allowed one proceeds, and the toggle-off path makes no robots.txt fetch at all
+<!-- AC:END -->

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -977,7 +977,8 @@ def _default_specs(
                 "Fetch a web page and return its extracted text; PDFs are "
                 "text-extracted too (up to 20 MB, ephemeral — nothing is "
                 "ingested). SSRF-guarded (public http(s) only), "
-                "redirect-capped, byte-capped, cached."
+                "redirect-capped, byte-capped, cached. Honors robots.txt "
+                "(configurable)."
             ),
             parameters={
                 "type": "object",
@@ -1018,9 +1019,9 @@ def _default_specs(
                 "bounded page list (URL, title, short excerpt per page) — "
                 "follow up with web_fetch on pages that matter. Same-host "
                 "only, SSRF-guarded, rate-limited (~1 page/sec), wall-clock "
-                "capped (120s). Optional sitemap_url seeds the page list "
-                "from a sitemap instead of link discovery (max_depth is "
-                "ignored in that mode)."
+                "capped (120s). Honors robots.txt (configurable). Optional "
+                "sitemap_url seeds the page list from a sitemap instead of "
+                "link discovery (max_depth is ignored in that mode)."
             ),
             parameters={
                 "type": "object",

--- a/tldw_chatbook/Tools/web_tool_impls.py
+++ b/tldw_chatbook/Tools/web_tool_impls.py
@@ -539,12 +539,26 @@ def _robots_allows(client: httpx.Client, url: str, user_agent: str) -> bool:
     in the original ``url``. Fetch/parse/redirect-following and fail-open
     semantics live in ``_fetch_robots_parser``.
 
+    IPv6 literals (fix round 2, Qodo finding): ``urlsplit(...).hostname``
+    strips the ``[...]`` brackets an IPv6 literal needs in a URL, returning
+    the bare address (e.g. ``2606:4700::1111``). Re-bracketing it here is
+    NOT cosmetic -- without it, the colons land straight in the assembled
+    ``scheme://host:port`` string, ``urljoin``/``urlsplit`` misparse the
+    result downstream in ``_fetch_robots_parser``, ``_validate_hop`` on the
+    constructed robots.txt URL raises, and the broad fail-open catch there
+    silently disables robots enforcement for every IPv6-literal host --
+    an input class ``validate_outbound_url`` explicitly supports (checked
+    directly, no DNS) and that ``_robots_allows`` must therefore support
+    too.
+
     Synchronous, no locks -- matches the module's existing idiom (single
     call per tool invocation; a cross-call stampede costs at most one
     duplicate robots.txt fetch, accepted).
     """
     parts = urlsplit(url)
     host = (parts.hostname or "").lower()
+    if ":" in host:  # IPv6 literal: bracket it back for URL assembly
+        host = f"[{host}]"
     port = f":{parts.port}" if parts.port else ""
     cache_key = f"{parts.scheme.lower()}://{host}{port}"
     cached = _robots_cache.get(cache_key)

--- a/tldw_chatbook/Tools/web_tool_impls.py
+++ b/tldw_chatbook/Tools/web_tool_impls.py
@@ -442,56 +442,133 @@ def _robots_disallowed_message(url: str) -> str:
     )
 
 
+def _fetch_robots_parser(client: httpx.Client, cache_key: str) -> "RobotFileParser | None":
+    """Fetch+parse the robots.txt at ``cache_key`` (``scheme://host[:port]``).
+
+    Own bounded redirect loop (fix round 1, Important 1): a 3xx robots.txt
+    response must not be treated as an unreachable fetch. ``_fetch_once``
+    never follows redirects itself, so a bare non-2xx check previously
+    negative-cached (i.e. DISABLED enforcement for) any host whose
+    robots.txt redirects, for the full ``ROBOTS_CACHE_TTL_SECONDS`` --
+    silently defeating the feature for exactly the hosts (CDN-fronted,
+    HTTP->HTTPS canonicalized) most likely to redirect it. Up to
+    ``FETCH_MAX_REDIRECTS`` hops, each hop re-validated (SSRF) before the
+    GET; a chain that exhausts the cap still fails open, same as any other
+    unreachable-robots outcome.
+
+    Fail-open (design doc ruling 2, "compat" semantics): anything short of
+    a clean 2xx fetch under the byte cap -- network error, non-2xx status
+    after following redirects, a body TRUNCATED at ROBOTS_MAX_BYTES (a
+    half-file could silently drop trailing Disallow lines -- refusing to
+    trust a truncated policy is the honest reading), or a parse failure --
+    returns ``None`` (no restrictions), via broad ``except Exception``
+    around each network step: a robots.txt outage must not brick fetching,
+    and in the shipped code this same broad catch is what keeps every
+    pre-existing route-less-robots test passing unchanged once the fixture
+    opts back into enforcement. Every genuine fail-open exit logs a debug
+    line (fix round 1, Minor 5) so operators can distinguish "allowed
+    because the site's policy says so" from "allowed because robots.txt
+    was unreachable".
+
+    Rate-limited per hop like any other request to that hop's host (design
+    doc ruling 5 -- the politeness probe is itself polite), and — unlike
+    the network/parse steps above — a ``[rate-limited]`` LocalToolError
+    (pathological frozen clock) is NOT caught here: it propagates out of
+    this function exactly like it does for an ordinary page fetch, instead
+    of being swallowed into an accidental ``ROBOTS_CACHE_TTL_SECONDS``
+    enforcement-off window (fix round 1, Minor 5).
+    """
+    current = f"{cache_key}/robots.txt"
+    for _hop in range(FETCH_MAX_REDIRECTS + 1):
+        try:
+            _validate_hop(current)  # symmetry with every other request (design doc Minor 9)
+        except Exception as exc:  # noqa: BLE001 - broad by design: fails open
+            logger.debug(f"robots.txt unreachable for {cache_key}: {exc} — failing open")
+            return None
+        _enforce_rate_limit(urlsplit(current).hostname or "unknown")  # propagates; see docstring
+        try:
+            status, headers, body, truncated, _is_pdf = _fetch_once(client, current, ROBOTS_MAX_BYTES)
+        except Exception as exc:  # noqa: BLE001 - broad by design: fails open
+            logger.debug(f"robots.txt unreachable for {cache_key}: {exc} — failing open")
+            return None
+        if status in _REDIRECT_STATUSES:
+            location = headers.get("location")
+            if not location:
+                logger.debug(
+                    f"robots.txt unreachable for {cache_key}: "
+                    f"redirect (status {status}) without a Location header — failing open"
+                )
+                return None
+            try:
+                current = urljoin(current, location)
+            except ValueError as exc:
+                logger.debug(
+                    f"robots.txt unreachable for {cache_key}: "
+                    f"malformed redirect Location {location!r}: {exc} — failing open"
+                )
+                return None
+            continue
+        if not (200 <= status < 300) or truncated:
+            reason = "truncated body" if truncated else f"status {status}"
+            logger.debug(f"robots.txt unreachable for {cache_key}: {reason} — failing open")
+            return None
+        try:
+            text = _decode_body(body, headers.get("content-type", ""))
+            parser = RobotFileParser()
+            parser.parse(text.splitlines())
+        except Exception as exc:  # noqa: BLE001 - broad by design: fails open
+            logger.debug(f"robots.txt for {cache_key} could not be parsed: {exc} — failing open")
+            return None
+        return parser
+    logger.debug(
+        f"robots.txt unreachable for {cache_key}: "
+        f"exceeded {FETCH_MAX_REDIRECTS} redirects — failing open"
+    )
+    return None
+
+
 def _robots_allows(client: httpx.Client, url: str, user_agent: str) -> bool:
     """True if ``user_agent`` may fetch ``url`` per its host's robots.txt.
 
-    Cache lookup keyed by ``scheme://netloc`` (host-level; the UA is only a
-    parameter to the *query*, ``can_fetch()``, not the cache key -- the
-    fetched policy is shared across callers). On a miss, rate-limits like
-    any other request to the host (design doc ruling 5 -- the politeness
-    probe is itself polite), fetches ``{scheme}://{netloc}/robots.txt``
-    through ``_fetch_once`` under a dedicated ``ROBOTS_MAX_BYTES`` cap (not
-    the page cap), and parses it with the stdlib ``RobotFileParser``.
-
-    Fail-open (design doc ruling 2, "compat" semantics): anything short of
-    a clean 2xx fetch under the byte cap -- network error, non-2xx status,
-    a body TRUNCATED at ROBOTS_MAX_BYTES (a half-file could silently drop
-    trailing Disallow lines -- refusing to trust a truncated policy is the
-    honest reading), or a parse failure -- is cached as ``None`` (no
-    restrictions) for the same TTL as a successful fetch, via one broad
-    ``except Exception``: a robots.txt outage must not brick fetching, and
-    in the shipped code this same broad catch is what keeps every
-    pre-existing route-less-robots test passing unchanged once the fixture
-    opts back into enforcement.
+    Cache lookup keyed by a NORMALIZED ``scheme://host[:port]`` (fix round
+    1, Minor 4 -- lowercase host, no userinfo, matching the per-domain rate
+    limiter's own normalization via ``urlsplit(...).hostname``): the UA is
+    only a parameter to the *query*, ``can_fetch()``, not the cache key --
+    the fetched policy is shared across callers, and the constructed
+    robots.txt URL must never carry credentials that happened to be present
+    in the original ``url``. Fetch/parse/redirect-following and fail-open
+    semantics live in ``_fetch_robots_parser``.
 
     Synchronous, no locks -- matches the module's existing idiom (single
     call per tool invocation; a cross-call stampede costs at most one
     duplicate robots.txt fetch, accepted).
     """
     parts = urlsplit(url)
-    cache_key = f"{parts.scheme}://{parts.netloc}"
+    host = (parts.hostname or "").lower()
+    port = f":{parts.port}" if parts.port else ""
+    cache_key = f"{parts.scheme.lower()}://{host}{port}"
     cached = _robots_cache.get(cache_key)
     now = time.monotonic()
     if cached is not None and now < cached[0]:
         parser = cached[1]
     else:
-        robots_url = f"{cache_key}/robots.txt"
-        parser = None
-        try:
-            _validate_hop(robots_url)  # symmetry with every other request (design doc Minor 9)
-            _enforce_rate_limit(parts.hostname or "unknown")
-            status, headers, body, truncated, _is_pdf = _fetch_once(client, robots_url, ROBOTS_MAX_BYTES)
-            if 200 <= status < 300 and not truncated:
-                text = _decode_body(body, headers.get("content-type", ""))
-                candidate = RobotFileParser()
-                candidate.parse(text.splitlines())
-                parser = candidate
-        except Exception:  # noqa: BLE001 - broad by design: any robots fetch/parse failure fails open
-            parser = None
+        parser = _fetch_robots_parser(client, cache_key)
         _robots_cache_put(cache_key, parser)
     if parser is None:
         return True
     return parser.can_fetch(user_agent, url)
+
+
+def _new_web_fetch_client() -> httpx.Client:
+    return httpx.Client(
+        follow_redirects=False,
+        timeout=FETCH_TIMEOUT_SECONDS,
+        headers={"User-Agent": _USER_AGENT},
+        transport=_transport,
+        # trust_env=False: with HTTP(S)_PROXY set, the proxy does its own DNS
+        # and connects on our behalf, bypassing the SSRF guard entirely.
+        trust_env=False,
+    )
 
 
 def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
@@ -551,15 +628,11 @@ def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
     # Read once per invocation, not per hop (design doc ruling 6).
     respect_robots = _webfetch_settings()["respect_robots_txt"]
 
-    client = httpx.Client(
-        follow_redirects=False,
-        timeout=FETCH_TIMEOUT_SECONDS,
-        headers={"User-Agent": _USER_AGENT},
-        transport=_transport,
-        # trust_env=False: with HTTP(S)_PROXY set, the proxy does its own DNS
-        # and connects on our behalf, bypassing the SSRF guard entirely.
-        trust_env=False,
-    )
+    # Lazy client (fix round 1, Minor 6): a warm cache hit with robots
+    # enforcement OFF must do zero client setup, same as before robots.txt
+    # support existed -- httpx.Client() is built only where first actually
+    # needed (a robots.txt consult on a cache hit, or the real fetch below).
+    client: "httpx.Client | None" = None
     try:
         cached = _fetch_cache.get((url, max_bytes))
         if cached is not None:
@@ -568,12 +641,19 @@ def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
                 _validate_hop(url)  # re-check policy on cache hits (cheap, no body)
                 # Robots re-checked exactly like _validate_hop above: rules
                 # may have changed since the body was cached (design doc
-                # ruling 3).
-                if respect_robots and not _robots_allows(client, url, _USER_AGENT):
-                    raise LocalToolError(_robots_disallowed_message(url))
+                # ruling 3). Known hole shared with the _validate_hop check
+                # right above (fix round 1, Minor 3): this judges the
+                # REQUESTED url only -- a cached body that was actually
+                # fetched via a redirect is keyed and re-checked here under
+                # the ORIGINAL start url, not the final redirect target.
+                if respect_robots:
+                    client = _new_web_fetch_client()
+                    if not _robots_allows(client, url, _USER_AGENT):
+                        raise LocalToolError(_robots_disallowed_message(url))
                 return text
             _fetch_cache.pop((url, max_bytes), None)
 
+        client = _new_web_fetch_client()
         # Probed ONCE per call, not per redirect hop: a mid-call sys.modules
         # mutation could otherwise make the pre-fetch cap decision and the
         # post-fetch [missing-dep]-vs-[too-large] verdict disagree with each
@@ -614,7 +694,8 @@ def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
     except httpx.HTTPError as exc:
         raise LocalToolError(f"[fetch-failed] {exc}") from exc
     finally:
-        client.close()
+        if client is not None:
+            client.close()
 
     if status >= 400:
         raise LocalToolError(f"[http-{status}] upstream returned status {status} for {url!r}")

--- a/tldw_chatbook/Tools/web_tool_impls.py
+++ b/tldw_chatbook/Tools/web_tool_impls.py
@@ -26,6 +26,7 @@ from collections import deque
 from html.parser import HTMLParser
 from typing import NamedTuple, Optional
 from urllib.parse import urljoin, urlsplit
+from urllib.robotparser import RobotFileParser
 
 import httpx
 from loguru import logger
@@ -156,14 +157,26 @@ _BLANKLINES_RE = re.compile(r"\n{3,}")
 _fetch_cache: dict[tuple[str, int], tuple[float, str]] = {}
 _domain_last_fetch: dict[str, float] = {}
 
+# robots.txt cache (task-2833 design doc §Mechanism), keyed by
+# scheme://netloc -- host-level, not per-UA: only the can_fetch() *query*
+# is per-caller-UA, the fetched/parsed policy is shared. Value is
+# (expires_at_monotonic, parser_or_None); None means "unreachable or
+# unparsable" -> fail open (ruling 2).
+ROBOTS_MAX_BYTES = 64 * 1024
+ROBOTS_CACHE_TTL_SECONDS = 1800.0
+ROBOTS_CACHE_MAX_ENTRIES = 128
+
+_robots_cache: dict[str, tuple[float, "RobotFileParser | None"]] = {}
+
 # Test seam: tests set this to an httpx.MockTransport.
 _transport: "httpx.BaseTransport | None" = None
 
 
 def _reset_state_for_tests() -> None:
-    """Clear the module-level fetch cache and rate-limit state."""
+    """Clear the module-level fetch cache, rate-limit state, and robots cache."""
     _fetch_cache.clear()
     _domain_last_fetch.clear()
+    _robots_cache.clear()
 
 
 def _cache_put(key: tuple[str, int], text: str) -> None:
@@ -172,6 +185,14 @@ def _cache_put(key: tuple[str, int], text: str) -> None:
         oldest = min(_fetch_cache, key=lambda k: _fetch_cache[k][0])
         _fetch_cache.pop(oldest)
     _fetch_cache[key] = (time.monotonic() + FETCH_CACHE_TTL_SECONDS, text)
+
+
+def _robots_cache_put(key: str, parser: "RobotFileParser | None") -> None:
+    """Insert into the robots cache, evicting earliest-expiry entry at capacity."""
+    if key not in _robots_cache and len(_robots_cache) >= ROBOTS_CACHE_MAX_ENTRIES:
+        oldest = min(_robots_cache, key=lambda k: _robots_cache[k][0])
+        _robots_cache.pop(oldest)
+    _robots_cache[key] = (time.monotonic() + ROBOTS_CACHE_TTL_SECONDS, parser)
 
 
 def _validate_hop(url: str) -> None:
@@ -379,6 +400,100 @@ def _extract_pdf_text(body: bytes, max_bytes: int) -> str:
     return joined
 
 
+def _webfetch_settings() -> dict:
+    """Resolve the ``[webfetch]`` config keys web_fetch/web_crawl need for
+    robots.txt enforcement.
+
+    A dedicated module function (mirroring ``_deep_search_settings()``
+    below) so tests can monkeypatch config resolution wholesale rather than
+    stubbing individual keys. ``_bool`` uses the same strict true-set
+    coercion as ``_deep_search_settings``'s own helper: an actual bool
+    value (the common case -- TOML parses `true`/`false` natively) passes
+    through unchanged; a string coerces via ``"true"``/``"1"`` membership,
+    so a stray quoted ``"false"`` reliably disables and a stray quoted
+    ``"true"`` is never misread as disabled -- the same lesson
+    ``_deep_search_settings`` recorded, applied in the opposite direction
+    since THIS flag defaults to True rather than False. Anything else
+    (missing key, wrong type) falls back to ``default``.
+
+    Read once per tool invocation, not per hop (design doc ruling 6): both
+    ``web_fetch`` and ``web_crawl`` call this exactly once at the top of
+    the public function and thread the resolved flag through every hop.
+    """
+    from ..config import get_cli_setting  # local import: keep module import cheap
+
+    def _bool(key: str, default: bool) -> bool:
+        raw = get_cli_setting("webfetch", key, default)
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            return raw.strip().lower() in ("true", "1")
+        return default
+
+    return {"respect_robots_txt": _bool("respect_robots_txt", True)}
+
+
+def _robots_disallowed_message(url: str) -> str:
+    """Structured refusal string (error contract style of [ssrf]/[invalid-url])."""
+    host = urlsplit(url).hostname or url
+    return (
+        f"[robots-disallowed] {url} — {host}/robots.txt disallows this path "
+        "for this tool's user agent; set [webfetch] respect_robots_txt = false to override"
+    )
+
+
+def _robots_allows(client: httpx.Client, url: str, user_agent: str) -> bool:
+    """True if ``user_agent`` may fetch ``url`` per its host's robots.txt.
+
+    Cache lookup keyed by ``scheme://netloc`` (host-level; the UA is only a
+    parameter to the *query*, ``can_fetch()``, not the cache key -- the
+    fetched policy is shared across callers). On a miss, rate-limits like
+    any other request to the host (design doc ruling 5 -- the politeness
+    probe is itself polite), fetches ``{scheme}://{netloc}/robots.txt``
+    through ``_fetch_once`` under a dedicated ``ROBOTS_MAX_BYTES`` cap (not
+    the page cap), and parses it with the stdlib ``RobotFileParser``.
+
+    Fail-open (design doc ruling 2, "compat" semantics): anything short of
+    a clean 2xx fetch under the byte cap -- network error, non-2xx status,
+    a body TRUNCATED at ROBOTS_MAX_BYTES (a half-file could silently drop
+    trailing Disallow lines -- refusing to trust a truncated policy is the
+    honest reading), or a parse failure -- is cached as ``None`` (no
+    restrictions) for the same TTL as a successful fetch, via one broad
+    ``except Exception``: a robots.txt outage must not brick fetching, and
+    in the shipped code this same broad catch is what keeps every
+    pre-existing route-less-robots test passing unchanged once the fixture
+    opts back into enforcement.
+
+    Synchronous, no locks -- matches the module's existing idiom (single
+    call per tool invocation; a cross-call stampede costs at most one
+    duplicate robots.txt fetch, accepted).
+    """
+    parts = urlsplit(url)
+    cache_key = f"{parts.scheme}://{parts.netloc}"
+    cached = _robots_cache.get(cache_key)
+    now = time.monotonic()
+    if cached is not None and now < cached[0]:
+        parser = cached[1]
+    else:
+        robots_url = f"{cache_key}/robots.txt"
+        parser = None
+        try:
+            _validate_hop(robots_url)  # symmetry with every other request (design doc Minor 9)
+            _enforce_rate_limit(parts.hostname or "unknown")
+            status, headers, body, truncated, _is_pdf = _fetch_once(client, robots_url, ROBOTS_MAX_BYTES)
+            if 200 <= status < 300 and not truncated:
+                text = _decode_body(body, headers.get("content-type", ""))
+                candidate = RobotFileParser()
+                candidate.parse(text.splitlines())
+                parser = candidate
+        except Exception:  # noqa: BLE001 - broad by design: any robots fetch/parse failure fails open
+            parser = None
+        _robots_cache_put(cache_key, parser)
+    if parser is None:
+        return True
+    return parser.can_fetch(user_agent, url)
+
+
 def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
     """Fetch ``url`` and return extracted text (trafilatura for HTML, PyMuPDF for PDF).
 
@@ -392,6 +507,11 @@ def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
     rate-limited per domain, cached in-memory by (url, max_bytes) key
     (256-entry bound, earliest-expiry eviction, FETCH_CACHE_TTL_SECONDS expiry).
 
+    Robots-guarded per hop too (task-2833): each hop's host robots.txt is
+    checked for ``_USER_AGENT``, honoring ``[webfetch] respect_robots_txt``
+    (default true, fail-open on an unreachable/unparsable robots.txt). A
+    cache hit re-checks robots the same way it re-checks SSRF policy.
+
     HTML/plain-text extracted via trafilatura with fallback tag-strip;
     script/style tags removed. Result ends with a truncation marker when
     capped at max_bytes (default FETCH_MAX_BYTES=1 MiB).
@@ -404,8 +524,8 @@ def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
     max_bytes; the result includes page count.
 
     All failures raise LocalToolError with structured reasons:
-        - "invalid-url", "ssrf", "redirect-limit", "timeout",
-          "http-<status>", "rate-limited", "fetch-failed" (general fetch)
+        - "invalid-url", "ssrf", "robots-disallowed", "redirect-limit",
+          "timeout", "http-<status>", "rate-limited", "fetch-failed" (general fetch)
         - "empty-content" (unextractable HTML/text/PDF)
         - "missing-dep" (PDF requires pymupdf extra)
         - "pdf-error" (PyMuPDF extraction or encryption failure)
@@ -428,13 +548,8 @@ def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
     except (TypeError, ValueError) as exc:
         raise LocalToolError(f"[invalid-url] max_bytes must be an integer: {max_bytes!r}") from exc
 
-    cached = _fetch_cache.get((url, max_bytes))
-    if cached is not None:
-        expires_at, text = cached
-        if time.monotonic() < expires_at:
-            _validate_hop(url)  # re-check policy on cache hits (cheap, no body)
-            return text
-        _fetch_cache.pop((url, max_bytes), None)
+    # Read once per invocation, not per hop (design doc ruling 6).
+    respect_robots = _webfetch_settings()["respect_robots_txt"]
 
     client = httpx.Client(
         follow_redirects=False,
@@ -445,17 +560,35 @@ def web_fetch(url: str, *, max_bytes: int = FETCH_MAX_BYTES) -> str:
         # and connects on our behalf, bypassing the SSRF guard entirely.
         trust_env=False,
     )
-    # Probed ONCE per call, not per redirect hop: a mid-call sys.modules
-    # mutation could otherwise make the pre-fetch cap decision and the
-    # post-fetch [missing-dep]-vs-[too-large] verdict disagree with each
-    # other (and find_spec gains nothing from re-probing every hop).
-    pymupdf_ok = _pymupdf_available()
     try:
+        cached = _fetch_cache.get((url, max_bytes))
+        if cached is not None:
+            expires_at, text = cached
+            if time.monotonic() < expires_at:
+                _validate_hop(url)  # re-check policy on cache hits (cheap, no body)
+                # Robots re-checked exactly like _validate_hop above: rules
+                # may have changed since the body was cached (design doc
+                # ruling 3).
+                if respect_robots and not _robots_allows(client, url, _USER_AGENT):
+                    raise LocalToolError(_robots_disallowed_message(url))
+                return text
+            _fetch_cache.pop((url, max_bytes), None)
+
+        # Probed ONCE per call, not per redirect hop: a mid-call sys.modules
+        # mutation could otherwise make the pre-fetch cap decision and the
+        # post-fetch [missing-dep]-vs-[too-large] verdict disagree with each
+        # other (and find_spec gains nothing from re-probing every hop).
+        pymupdf_ok = _pymupdf_available()
         current_url = url
         for _hop in range(FETCH_MAX_REDIRECTS + 1):
             # Policy re-checked on EVERY hop: a permitted URL must not be able
             # to redirect into private/denied address space.
             _validate_hop(current_url)
+            # Robots consulted at the same position as _validate_hop, for
+            # every hop (design doc ruling 3): a redirect into a disallowed
+            # path is a disallowed fetch.
+            if respect_robots and not _robots_allows(client, current_url, _USER_AGENT):
+                raise LocalToolError(_robots_disallowed_message(current_url))
             _enforce_rate_limit(urlsplit(current_url).hostname or "unknown")
             status, headers, body, truncated, is_pdf = _fetch_once(
                 client, current_url, max_bytes,
@@ -768,6 +901,7 @@ def _format_crawl_result(
     stop_reason: str,
     children_skipped: int = 0,
     duplicates_skipped: int = 0,
+    robots_disallowed: int = 0,
 ) -> str:
     blocks: list[str] = []
     total = 0
@@ -786,6 +920,8 @@ def _format_crawl_result(
         blocks.append(block)
         total += block_bytes
     counts = f"{failed} failed, {blocked} blocked"
+    if robots_disallowed > 0:
+        counts += f"; {robots_disallowed} robots-disallowed"
     if children_skipped > 0:
         counts += f"; {children_skipped} child sitemaps skipped"
     if duplicates_skipped > 0:
@@ -805,6 +941,7 @@ def _crawl_fetch_page(
     *,
     max_bytes: int = FETCH_MAX_BYTES,
     html_only: bool = True,
+    respect_robots: bool = True,
 ) -> tuple[str, "httpx.Headers", bytes, bool, bool]:
     """Guarded, rate-limited GET with the crawl's redirect loop.
 
@@ -816,12 +953,22 @@ def _crawl_fetch_page(
     text/html must not fall through to HTML extraction, or its raw bytes
     become the page excerpt and its garbage "extracted text" warm-writes
     the shared web_fetch cache (see web_crawl's marker branch).
+
+    This is also the path every sitemap fetch takes (task-2833 design doc
+    ruling 4: root + child sitemap fetches go through this same loop), so
+    the ``respect_robots`` check below covers those for free -- always
+    against ``_CRAWL_USER_AGENT``, the one UA this whole module uses for
+    crawl-initiated fetches including sitemaps.
     """
     current = url
     for _hop in range(FETCH_MAX_REDIRECTS + 1):
         if time.monotonic() >= deadline:
             raise _CrawlDeadline()
         _validate_hop(current)
+        # Robots consulted at the same position as _validate_hop, for every
+        # hop (design doc ruling 3).
+        if respect_robots and not _robots_allows(client, current, _CRAWL_USER_AGENT):
+            raise LocalToolError(_robots_disallowed_message(current))
         _enforce_rate_limit(urlsplit(current).hostname or "unknown")
         try:
             status, headers, body, truncated, is_pdf = _fetch_once(
@@ -880,6 +1027,7 @@ def _seed_from_sitemap(
     scope_host: str,
     max_pages: int,
     deadline: float,
+    respect_robots: bool = True,
 ) -> _SitemapSeed:
     """Collect up to max_pages same-host page URLs from a sitemap.
 
@@ -887,9 +1035,20 @@ def _seed_from_sitemap(
     budget; the deadline bounds a pathological index (spec §2). Host rules:
     child sitemaps must share sitemap_url's host; page URLs must share the
     crawl scope host.
+
+    ``respect_robots`` is threaded into every ``_crawl_fetch_page`` call
+    below (root sitemap and each child sitemap) -- a robots-disallowed
+    root sitemap propagates uncaught out of this function (the caller
+    wraps it into the structured ``[crawl-failed] sitemap could not be
+    fetched: [robots-disallowed] ...`` refusal, matching every other
+    seed-failure type); a disallowed child sitemap is caught by the
+    existing broad ``except (LocalToolError, _CrawlDeadline)`` below and
+    simply counted in ``children_skipped``, same as any other child
+    fetch failure.
     """
     final_url, _headers, body, truncated, _is_pdf = _crawl_fetch_page(
-        client, sitemap_url, deadline, max_bytes=SITEMAP_MAX_BYTES, html_only=False
+        client, sitemap_url, deadline, max_bytes=SITEMAP_MAX_BYTES, html_only=False,
+        respect_robots=respect_robots,
     )
     if truncated:
         raise LocalToolError(f"[crawl-failed] sitemap exceeds {SITEMAP_MAX_BYTES} bytes: {sitemap_url!r}")
@@ -945,7 +1104,8 @@ def _seed_from_sitemap(
         children_fetched += 1
         try:
             _f, _h, child_body, child_truncated, _is_pdf = _crawl_fetch_page(
-                client, child, deadline, max_bytes=SITEMAP_MAX_BYTES, html_only=False
+                client, child, deadline, max_bytes=SITEMAP_MAX_BYTES, html_only=False,
+                respect_robots=respect_robots,
             )
         except (LocalToolError, _CrawlDeadline):
             children_skipped += 1
@@ -975,6 +1135,14 @@ def web_crawl(
     expected to follow up with web_fetch on pages that matter (spec §2).
     Every URL is egress-guarded; budgets bound fetch ATTEMPTS; a wall-clock
     deadline bounds the whole crawl. Ephemeral: no database writes.
+
+    Robots-guarded (task-2833): every hop -- BFS pages, and sitemap fetches
+    (root + children) since they share the same fetch loop -- is checked
+    against its host's robots.txt for ``_CRAWL_USER_AGENT``, honoring
+    ``[webfetch] respect_robots_txt`` (default true). A disallowed page or
+    child sitemap is SKIPPED and counted (footer's "robots-disallowed"
+    clause), not fatal; a disallowed start URL or root sitemap is fatal,
+    same as any other seed-fetch failure (see Raises below).
 
     Attempt/row invariant: A row-less attempt arises two ways: a redirect
     that lands on an already-listed final URL, or a plain fetch of a URL
@@ -1019,12 +1187,16 @@ def web_crawl(
     if not scope_host:
         raise LocalToolError(f"[invalid-args] url has no host: {url!r}")
 
+    # Read once per invocation, not per hop (design doc ruling 6).
+    respect_robots = _webfetch_settings()["respect_robots_txt"]
+
     deadline = time.monotonic() + CRAWL_DEADLINE_SECONDS
     queue: "deque[tuple[str, int]]" = deque([(url, 0)])
     visited = {_normalize_crawl_url(url)}
     listed: set[str] = set()  # normalized final URLs actually appended to `pages`
     pages: list[dict] = []
     failed = blocked = 0
+    robots_disallowed = 0
     attempts = 0
     stop_reason = "no more links within depth"
     children_skipped = 0
@@ -1044,7 +1216,8 @@ def web_crawl(
                 raise LocalToolError("[invalid-args] sitemap_url must be a non-empty string")
             try:
                 seed = _seed_from_sitemap(
-                    client, sitemap_url.strip(), scope_host, max_pages, deadline
+                    client, sitemap_url.strip(), scope_host, max_pages, deadline,
+                    respect_robots=respect_robots,
                 )
             except _CrawlDeadline:
                 seed = _SitemapSeed(urls=[], children_capped=False, budget_truncated=False, children_skipped=0)
@@ -1087,20 +1260,25 @@ def web_crawl(
             is_start = attempts == 0
             attempts += 1
             try:
-                final_url, headers, body, truncated, is_pdf = _crawl_fetch_page(client, current, deadline)
+                final_url, headers, body, truncated, is_pdf = _crawl_fetch_page(
+                    client, current, deadline, respect_robots=respect_robots
+                )
             except _CrawlDeadline:
                 stop_reason = "deadline reached"
                 break
             except LocalToolError as exc:
                 if is_start and sitemap_url is None:
                     raise LocalToolError(f"[crawl-failed] start URL could not be fetched: {exc}") from exc
-                # Prefix check, not substring: _validate_hop puts the reason
-                # at position 0 of ITS message, but a URL echoed into an
-                # unrelated error (e.g. an http-404 message quoting the
-                # failing URL) can contain the literal text "[ssrf]"
-                # anywhere in the string without being an SSRF refusal.
+                # Prefix check, not substring: _validate_hop/_robots_allows put
+                # the reason at position 0 of THEIR message, but a URL echoed
+                # into an unrelated error (e.g. an http-404 message quoting
+                # the failing URL) can contain the literal text "[ssrf]" or
+                # "[robots-disallowed]" anywhere in the string without being
+                # that kind of refusal.
                 if str(exc).startswith("[ssrf]"):
                     blocked += 1
+                elif str(exc).startswith("[robots-disallowed]"):
+                    robots_disallowed += 1
                 else:
                     failed += 1
                 continue
@@ -1207,7 +1385,9 @@ def web_crawl(
         client.close()
 
     return _format_crawl_result(
-        pages, failed, blocked, stop_reason, children_skipped=children_skipped, duplicates_skipped=duplicates_skipped
+        pages, failed, blocked, stop_reason,
+        children_skipped=children_skipped, duplicates_skipped=duplicates_skipped,
+        robots_disallowed=robots_disallowed,
     )
 
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3762,6 +3762,17 @@ log_unknown_models = true      # Whether to log when an unknown model is queried
 # relevance_scrape_timeout_s = 30
 # deep_search_timeout_s = 240   # the agent runtime automatically allots this tool its own per-call timeout of this value plus ~50s slack (wait_for grace + thread-join + scheduling jitter), via LocalToolProvider.timeout_for -- independent of max_tool_call_seconds, any value here is safe
 
+[webfetch]
+# Governs the web_fetch and web_crawl tools (task-2833). When true (the
+# default), every hop -- web_fetch redirects, web_crawl pages, and sitemap
+# fetches -- is checked against its host's robots.txt before being
+# fetched; a disallowed web_fetch hop is refused, a disallowed web_crawl
+# page/sitemap is skipped and counted, not fatal. A robots.txt that can't
+# be fetched or parsed fails OPEN (no restrictions applied), so a robots
+# outage never bricks fetching. Set to false to disable enforcement
+# entirely (no robots.txt fetches are made).
+# respect_robots_txt = true
+
 # ==========================================================
 # Search Engines Configuration
 # ==========================================================


### PR DESCRIPTION
## Summary

Implements task-2833: per-domain robots.txt enforcement for the web tools, default ON via the new `[webfetch] respect_robots_txt` config key (the first `[webfetch]` section — v1 shipped constants-only).

- **Mechanism**: stdlib `RobotFileParser` behind a per-host cache (`scheme://host:port` normalized — lowercased, userinfo stripped; 1800s TTL incl. negative caching; 128-entry earliest-expiry eviction; registered in the test-reset seam). The robots.txt fetch itself is `_validate_hop`-validated, rate-limited, byte-capped (64KiB, truncation → fail-open), follows its own bounded redirect chain (≤5 hops, each SSRF-validated — review caught that a 301'd robots.txt would otherwise silently disable enforcement for the host for 30 minutes), and is exempt from self-checking.
- **Enforcement**: every content path — each `web_fetch` redirect hop (including the cache-hit re-check), every `web_crawl` BFS page, and root/child sitemap fetches — consulted with the requesting tool's actual User-Agent (the two tools send different UAs; the check is per-UA against a shared per-host parser). Fail-open on unreachable/broken robots.txt ("compat" semantics, `logger.debug`'d so outages are distinguishable from policy); `[rate-limited]` errors propagate rather than buying a fail-open window.
- **Behavior**: `web_fetch` returns a structured `[robots-disallowed]` refusal naming the override key; `web_crawl` skips disallowed pages with a dedicated third dispatch branch and a `robots-disallowed` footer count (seed/root-sitemap refusals surface inside the existing `[crawl-failed]` wrap like every other seed failure).
- **Compat**: the shared test fixtures pin robots OFF at the settings seam so all 107 pre-existing assertions are unchanged; the shipped default stays true, guarded by 4 tests that exercise the real `_webfetch_settings()` including one fully-unpatched default-on composition test (review caught that every other test replaced the seam, leaving the shipped default unguarded).

## Review process

Adversarial spec review before implementation (caught: the original backward-compat claim was false — robots pre-fetches break 7+ exact-list/sleep assertions, resolved via the fixture ruling; the seed-refusal double-wrap; per-tool UA threading; the third footer branch). Implementation + task review (opus) + one fix round + scoped re-review, all clean; 3 Edit-based mutation checks red→green (can_fetch bypass, footer clause, robots-redirect single-shot revert).

## Testing

- `Tests/Tools/test_web_tool_impls.py` + `test_web_crawl.py`: **133 passed** (107 pre-existing unchanged + 26 new)
- `Tests/Tools/ Tests/Web_Scraping/`: 549 passed, 3 skipped (live-gated)
- Repo-wide collection: 32,229 tests, 0 errors

## Follow-up filed

- task-3260 — `web_deep_search`'s scrape path still ignores robots.txt (recorded inconsistency: a path the fetch tools refuse can still be scraped; same patch-the-path precedent as `is_public_http_url`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces robots.txt across `web_fetch` and `web_crawl` (task-2833) with per-hop checks and a default-on toggle. Hardens enforcement with redirect-following, correct rate-limit handling, and IPv6 literal support.

- **New Features**
  - Per-hop checks: `web_fetch` redirects and cache hits; `web_crawl` pages and sitemap fetches (root + children), using tool-specific User-Agents.
  - `[webfetch] respect_robots_txt` toggle (default true); unreachable/unparsable or truncated robots.txt fails open.
  - Per-host robots fetch+cache (TTL + bounded size), follows redirects (bounded), SSRF-validated, byte-capped, and rate-limited.
  - Outcomes: `web_fetch` raises `[robots-disallowed]`; `web_crawl` skips and counts disallowed pages/sitemaps; disallowed seeds surface as `[crawl-failed] … [robots-disallowed] …`.
  - Config template and tool descriptions updated to note robots support; follow-up filed for `web_deep_search` parity (task-3260).

- **Bug Fixes**
  - IPv6 literals: re-bracket host in robots URL/cache key; adds regression tests.
  - Do not swallow `[rate-limited]`; normalize cache key (lowercase host, strip userinfo) to avoid bypass; lazy client creation keeps `web_fetch` cache-hit fast path.

<sup>Written for commit ffd76248ca6e2742587f440300960185e2b0d898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

